### PR TITLE
LPD-70233 Add source formatter rule for Language pageContext calls

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -5750,6 +5750,27 @@
 	},
 	{
 		"classNames": [
+			"Language",
+			"LanguageUtil"
+		],
+		"from": "get(PageContext paramName, String paramName)",
+		"hasMessage": true,
+		"issueKey": "LPD-70233",
+		"validExtensions": [
+			"java"
+		]
+	},
+	{
+		"from": "regex:(?<class>Language(?:Util)?)\\.(?<method>format|get)\\(pageContext,",
+		"issueKey": "LPD-70233",
+		"to": "${class}.${method}(request,",
+		"validExtensions": [
+			"jsp",
+			"jspf"
+		]
+	},
+	{
+		"classNames": [
 			"FFDocumentLibraryDDMEditorConfigurationUtil"
 		],
 		"from": "useDataEngineEditor()",

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_70233.testjsp
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_70233.testjsp
@@ -1,0 +1,13 @@
+<%--
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+--%>
+
+<%
+Language.format(request, "key", (Object[])null);
+Language.get(request, "key");
+LanguageUtil.format(request, "key", (Object[])null);
+LanguageUtil.get(request, "key");
+%>

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_70233.testjspf
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_70233.testjspf
@@ -1,0 +1,13 @@
+<%--
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+--%>
+
+<%
+Language.format(request, "key", (Object[])null);
+Language.get(request, "key");
+LanguageUtil.format(request, "key", (Object[])null);
+LanguageUtil.get(request, "key");
+%>

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_70233.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_70233.testjava
@@ -1,0 +1,24 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class LPD_70233 {
+
+	public void method(PageContext pageContext, String key) {
+		LanguageUtil.get(null, key);
+		LanguageUtil.get(pageContext, key);
+		_language.get(pageContext, key);
+	}
+
+	@Reference
+	private Language _language;
+
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_70233.testjsp
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_70233.testjsp
@@ -1,0 +1,13 @@
+<%--
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+--%>
+
+<%
+Language.format(pageContext, "key", (Object[])null);
+Language.get(pageContext, "key");
+LanguageUtil.format(pageContext, "key", (Object[])null);
+LanguageUtil.get(pageContext, "key");
+%>

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_70233.testjspf
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_70233.testjspf
@@ -1,0 +1,13 @@
+<%--
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+--%>
+
+<%
+Language.format(pageContext, "key", (Object[])null);
+Language.get(pageContext, "key");
+LanguageUtil.format(pageContext, "key", (Object[])null);
+LanguageUtil.get(pageContext, "key");
+%>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-70233

## What Is Being Fixed

The `get` and `format` methods on `Language`/`LanguageUtil` are being migrated away from taking a `PageContext`, in favor of the request-based overloads. Existing call sites that pass a `pageContext` need upgrading, but there was no automated source-formatter rule to flag or rewrite them.

## How It Is Being Fixed

Two upgrade-catch-all-check replacement rules are added to the source formatter's `replacements.json`. The first targets Java sources and flags `Language`/`LanguageUtil` `get(PageContext, String)` calls with a message so the developer migrates them manually. The second targets `jsp`/`jspf` sources and rewrites `Language`/`LanguageUtil` `get`/`format` calls that pass `pageContext` to pass `request` instead. Test fixtures and their expected outputs are added for the Java, JSP, and JSPF cases.

## PR Check

**pr-check: PASS** — tested on `6b846df81071d62bb728039bbf2dcb492f0fb5ca`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "6b846df81071d62bb728039bbf2dcb492f0fb5ca"} -->