### PR TITLE
LPD-61579 Add upgrade rule for ParamAndPropertyAncestorTagImpl access

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -5531,6 +5531,27 @@
 	},
 	{
 		"classNames": [
+			"ParamAndPropertyAncestorTagImpl"
+		],
+		"classStructurePattern": true,
+		"issueKey": "LPD-61579",
+		"methodsToFormat": [
+			{
+				"from": "regex:FileAvailabilityUtil\\.isAvailable\\(servletContext, (?<page>[^)]+)\\)",
+				"to": "FileAvailabilityUtil.isAvailable(getServletContext(), ${page})"
+			},
+			{
+				"from": "servletContext = ServletContextUtil.getServletContext()",
+				"to": "setServletContext(ServletContextUtil.getServletContext())"
+			},
+			{
+				"from": "setAttributes(request)",
+				"to": "setAttributes(getRequest())"
+			}
+		]
+	},
+	{
+		"classNames": [
 			"JournalArticleLocalService",
 			"JournalArticleLocalServiceUtil",
 			"JournalArticleService",

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_61579.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_61579.testjava
@@ -1,0 +1,21 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class LPD_61579 extends ParamAndPropertyAncestorTagImpl {
+
+	public void method() {
+		setServletContext(ServletContextUtil.getServletContext());
+
+		if (FileAvailabilityUtil.isAvailable(getServletContext(), "page")) {
+			setAttributes(getRequest());
+		}
+	}
+
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_61579.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_61579.testjava
@@ -1,0 +1,21 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class LPD_61579 extends ParamAndPropertyAncestorTagImpl {
+
+	public void method() {
+		servletContext = ServletContextUtil.getServletContext();
+
+		if (FileAvailabilityUtil.isAvailable(servletContext, "page")) {
+			setAttributes(request);
+		}
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-61579

## What Is Being Fixed

Direct field access to `request` and `servletContext` was removed from `ParamAndPropertyAncestorTagImpl`; callers must now go through the accessor methods (`getRequest()`, `getServletContext()`, `setServletContext(...)`). There was no automated source-formatter rule to migrate subclasses that still referenced the fields directly.

## How It Is Being Fixed

A class-structure upgrade-catch-all-check rule is added to the source formatter's `replacements.json`, scoped to `ParamAndPropertyAncestorTagImpl`. It rewrites `servletContext = ServletContextUtil.getServletContext()` to `setServletContext(...)`, `FileAvailabilityUtil.isAvailable(servletContext, ...)` to use `getServletContext()`, and `setAttributes(request)` to `setAttributes(getRequest())`. A test fixture and its expected output cover these rewrites.

## PR Check

**pr-check: PASS** — tested on `7c2ea9cc4129c3f045f83dbaf45c3c92ac801cba`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "7c2ea9cc4129c3f045f83dbaf45c3c92ac801cba"} -->