### PR TITLE
LPD-93208 Check package.json when node-scripts.config.js changes

### DIFF
--- a/modules/apps/frontend-js/frontend-js-audiences-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-audiences-web/package.json
@@ -2,7 +2,7 @@
 	"dependencies": {
 		"ua-parser-js": "2.0.9"
 	},
-	"main": "index.ts",
+	"main": "main/index.ts",
 	"name": "@liferay/frontend-js-audiences-web",
 	"scripts": {
 		"build": "node-scripts build",

--- a/modules/frontend-sdk/node-scripts/package.json
+++ b/modules/frontend-sdk/node-scripts/package.json
@@ -4,7 +4,7 @@
 		"node-scripts": "./bin.js"
 	},
 	"com.liferay": {
-		"sha256": "8b19e4f51121e207957707744010d702067438ed3a52c3dc170f7849bc877a2b"
+		"sha256": "f110ce98d2199c53fae9cc129ae77107a51288636a5a3404fb4b6dbcb22d10a4"
 	},
 	"dependencies": {
 		"@babel/preset-env": "7.24.7",

--- a/modules/frontend-sdk/node-scripts/util/format/formatPortal.mjs
+++ b/modules/frontend-sdk/node-scripts/util/format/formatPortal.mjs
@@ -63,7 +63,9 @@ export default async function formatPortal(check, files) {
 	}
 
 	if (
-		(!files || !!files.find((file) => file.endsWith('/package.json'))) &&
+		(!files ||
+			!!files.find((file) => file.endsWith('/package.json')) ||
+			!!files.find((file) => file.endsWith('/node-scripts.config.js'))) &&
 		!(await formatPackageJSONFiles())
 	) {
 		checksPassed = false;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93208

## What Is Being Fixed

The node-scripts formatter only re-ran the package.json checks when a package.json file was itself in the changed set. A change to a node-scripts.config.js file — which can affect how package.json files are validated and formatted — did not trigger those checks, so package.json drift introduced by a config change could slip through.

## How It Is Being Fixed

formatPortal now also fires the package.json checks when any node-scripts.config.js file is in the changed file set, alongside the existing package.json trigger. The node-scripts hash was regenerated, and frontend-js-audiences-web's package.json main entry was corrected to the path the updated checks expect.

## Why Are There No Tests?

The node-scripts package has no test script or unit-test harness; the formatter logic is exercised by running the formatter itself. This change was verified by running the branch formatter (node-scripts format --current-branch), which reported everything correctly formatted, and by deploying frontend-js-audiences-web to confirm the corrected main entry builds.

## PR Check

**pr-check: PASS** — tested on `d32771854bd1866fc01d13cf975a4dd3dbad1949`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |

<!-- pr-check {"result": "success", "sha": "d32771854bd1866fc01d13cf975a4dd3dbad1949"} -->
