### PR TITLE
LPD-94487 Enable LPD-76864 feature flag in staging use case tests

### DIFF
--- a/modules/test/playwright/tests/export-import-web/main/stagingUseCase.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/main/stagingUseCase.spec.ts
@@ -43,6 +43,7 @@ const test = mergeTests(
 	featureFlagsTest({
 		'LPD-35443': {enabled: true},
 		'LPD-39304': {enabled: true},
+		'LPD-76864': {enabled: true},
 	}),
 	loginTest(),
 	assetPublisherPagesTest,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94487

## What Is Being Fixed

Two Playwright tests in `export-import-web/main/stagingUseCase.spec.ts` — "A page created in staging is published to live" and "Content selection is empty after initial publication to live when using the From Last Publish Date option" — were failing. Both create pages of type WidgetPage through the headless-admin-site API, and that endpoint rejects WidgetPage creation unless the "Deprecation of Widget Pages" feature flag (LPD-76864) is enabled, returning `400 — Feature flag LPD-76864 is disabled for company`. The spec's featureFlagsTest fixture only enabled LPD-35443 and LPD-39304, so the flag was off. This is the common root cause behind LPD-94358 and LPD-94359.

## How It Is Being Fixed

Add `'LPD-76864': {enabled: true}` to the spec's featureFlagsTest fixture alongside the flags it already enables. The fixture enables the flag before each test and restores its prior state afterward, so other tests are unaffected. Both tests pass locally after the change.

## Forwarding

This PR was manually forwarded from liferay-headless/liferay-portal#3877 because the `ci:forward` auto-forward to `brianchandotcom` stalled after the test suites passed.

## PR Check

**pr-check: PASS** — tested on `e67f462e341f6f0936d7ccc5c86bae87bb2dbe12`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "e67f462e341f6f0936d7ccc5c86bae87bb2dbe12"} -->
