### PR TITLE
LPD-94744 Relabel site pages and promote utility pages in export/import

### DIFF
--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SitePageResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SitePageResourceImpl.java
@@ -153,7 +153,7 @@ public class SitePageResourceImpl
 
 			@Override
 			public String getLabelLanguageKey() {
-				return "site-pages";
+				return "static-pages";
 			}
 
 			@Override

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/UtilityPageResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/UtilityPageResourceImpl.java
@@ -122,7 +122,7 @@ public class UtilityPageResourceImpl
 
 			@Override
 			public String getPortletId() {
-				return LayoutAdminPortletKeys.GROUP_PAGES;
+				return LayoutAdminPortletKeys.LAYOUT_UTILITY_PAGES;
 			}
 
 			@Override

--- a/modules/apps/layout/layout-admin-api/bnd.bnd
+++ b/modules/apps/layout/layout-admin-api/bnd.bnd
@@ -1,4 +1,4 @@
 Bundle-Name: Liferay Layout Admin API
 Bundle-SymbolicName: com.liferay.layout.admin.api
-Bundle-Version: 4.5.2
+Bundle-Version: 4.6.0
 Export-Package: com.liferay.layout.admin.constants

--- a/modules/apps/layout/layout-admin-api/src/main/java/com/liferay/layout/admin/constants/LayoutAdminPortletKeys.java
+++ b/modules/apps/layout/layout-admin-api/src/main/java/com/liferay/layout/admin/constants/LayoutAdminPortletKeys.java
@@ -19,4 +19,7 @@ public class LayoutAdminPortletKeys {
 	public static final String LAYOUT_SET_LAYOUTS =
 		"com_liferay_layout_admin_web_portlet_LayoutSetLayoutsPortlet";
 
+	public static final String LAYOUT_UTILITY_PAGES =
+		"com_liferay_layout_admin_web_portlet_LayoutUtilityPagesPortlet";
+
 }

--- a/modules/apps/layout/layout-admin-api/src/main/resources/com/liferay/layout/admin/constants/packageinfo
+++ b/modules/apps/layout/layout-admin-api/src/main/resources/com/liferay/layout/admin/constants/packageinfo
@@ -1,1 +1,1 @@
-version 2.5.0
+version 2.6.0

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/LayoutUtilityPagesPortlet.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/LayoutUtilityPagesPortlet.java
@@ -1,0 +1,37 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.admin.web.internal.portlet;
+
+import com.liferay.layout.admin.constants.LayoutAdminPortletKeys;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
+
+import jakarta.portlet.Portlet;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Daniel Raposo
+ */
+@Component(
+	property = {
+		"com.liferay.portlet.add-default-resource=true",
+		"com.liferay.portlet.preferences-owned-by-group=true",
+		"com.liferay.portlet.preferences-unique-per-layout=false",
+		"com.liferay.portlet.private-request-attributes=false",
+		"com.liferay.portlet.private-session-attributes=false",
+		"com.liferay.portlet.render-weight=50",
+		"com.liferay.portlet.system=true",
+		"com.liferay.portlet.use-default-template=true",
+		"jakarta.portlet.display-name=Utility Pages",
+		"jakarta.portlet.expiration-cache=0",
+		"jakarta.portlet.name=" + LayoutAdminPortletKeys.LAYOUT_UTILITY_PAGES,
+		"jakarta.portlet.resource-bundle=content.Language",
+		"jakarta.portlet.version=4.0"
+	},
+	service = Portlet.class
+)
+public class LayoutUtilityPagesPortlet extends MVCPortlet {
+}

--- a/modules/test/playwright/tests/export-import-web/main/site.export.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/main/site.export.spec.ts
@@ -377,7 +377,7 @@ test(
 			await exportImportPage.deletionsLabel.check();
 
 			await exportImportPage.expectPortletCounts('Pages', {
-				counts: {deletions: 6},
+				counts: {deletions: 5},
 				registrations: [
 					{
 						counts: {deletions: 1},
@@ -393,7 +393,6 @@ test(
 						label: /^\s*Page Templates\s*/,
 					},
 					{counts: {deletions: 1}, label: 'Page Template Sets'},
-					{counts: {deletions: 1}, label: 'Utility Pages'},
 				],
 			});
 		});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94744

## What Is Being Fixed

In the export/import UI, page content was labeled "site pages" and utility pages were exported under the group pages portlet rather than as their own entry. This makes the labeling inaccurate and buries utility pages where users do not expect them.

## How It Is Being Fixed

The site pages export/import label key is changed from `site-pages` to `static-pages` to match the product terminology. A dedicated `LAYOUT_UTILITY_PAGES` portlet key and a `LayoutUtilityPagesPortlet` are introduced, and `UtilityPageResourceImpl` now reports that key instead of `GROUP_PAGES`, so utility pages surface as a distinct top-level export/import entry. The `layout-admin-api` package and bundle versions are bumped to account for the new exported constant, and the Playwright site export test is updated for the resulting deletion counts.

## Forwarding

This PR was manually forwarded from liferay-headless/liferay-portal#3890 because the `ci:forward` auto-forward to `brianchandotcom` stalled after the test suites passed.

## PR Check

**pr-check: PASS** — tested on `364fbeff1d337d983d88108abebfe973e0346a06`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |

<!-- pr-check {"result": "success", "sha": "364fbeff1d337d983d88108abebfe973e0346a06"} -->
