### PR TITLE
LPD-94309 Keep the page user on the server-side restClient forward

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/security/auth/verifier/RESTClientHttpServletRequestWrapperAuthVerifier.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/security/auth/verifier/RESTClientHttpServletRequestWrapperAuthVerifier.java
@@ -1,0 +1,64 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.vulcan.internal.security.auth.verifier;
+
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.auth.AccessControlContext;
+import com.liferay.portal.kernel.security.auth.verifier.AuthVerifier;
+import com.liferay.portal.kernel.security.auth.verifier.AuthVerifierResult;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.vulcan.internal.template.servlet.RESTClientHttpServletRequestWrapper;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.util.Properties;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Alejandro Tardín
+ */
+@Component(
+	property = "auth.verifier.RESTClientHttpServletRequestWrapperAuthVerifier.urls.includes=/o/*",
+	service = AuthVerifier.class
+)
+public class RESTClientHttpServletRequestWrapperAuthVerifier
+	implements AuthVerifier {
+
+	@Override
+	public String getAuthType() {
+		return RESTClientHttpServletRequestWrapper.class.getName();
+	}
+
+	@Override
+	public AuthVerifierResult verify(
+		AccessControlContext accessControlContext, Properties properties) {
+
+		AuthVerifierResult authVerifierResult = new AuthVerifierResult();
+
+		HttpServletRequest httpServletRequest =
+			accessControlContext.getRequest();
+
+		Object attribute = httpServletRequest.getAttribute(
+			RESTClientHttpServletRequestWrapper.class.getName());
+
+		if (attribute == null) {
+			return authVerifierResult;
+		}
+
+		User user = (User)httpServletRequest.getAttribute(WebKeys.USER);
+
+		if ((user == null) || user.isGuestUser()) {
+			return authVerifierResult;
+		}
+
+		authVerifierResult.setState(AuthVerifierResult.State.SUCCESS);
+		authVerifierResult.setUserId(user.getUserId());
+
+		return authVerifierResult;
+	}
+
+}

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/security/auth/verifier/RESTClientHttpServletRequestWrapperAuthVerifier.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/security/auth/verifier/RESTClientHttpServletRequestWrapperAuthVerifier.java
@@ -30,7 +30,9 @@ public class RESTClientHttpServletRequestWrapperAuthVerifier
 
 	@Override
 	public String getAuthType() {
-		return RESTClientHttpServletRequestWrapper.class.getName();
+		Class<?> clazz = getClass();
+
+		return clazz.getSimpleName();
 	}
 
 	@Override

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/template/test/RESTClientTemplateContextContributorTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/template/test/RESTClientTemplateContextContributorTest.java
@@ -6,11 +6,16 @@
 package com.liferay.portal.vulcan.internal.template.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.configuration.test.util.CompanyConfigurationTemporarySwapper;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.HTTPTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.ZipFileTestUtil;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.zip.ZipWriterFactory;
 import com.liferay.portal.test.rule.Inject;
@@ -71,14 +76,24 @@ public class RESTClientTemplateContextContributorTest {
 			HTTPTestUtil.customize(
 			).withoutModulePath(
 			).apply(
-				() -> _test(friendlyUrlPath)
+				() -> _test(friendlyUrlPath, TestPropsValues.getUser())
+			);
+
+			HTTPTestUtil.customize(
+			).withoutModulePath(
+			).apply(
+				() -> HTTPTestUtil.invokeToString(
+					null, "c/portal/logout", Http.Method.GET)
 			);
 
 			HTTPTestUtil.customize(
 			).withoutModulePath(
 			).withGuest(
 			).apply(
-				() -> _test(friendlyUrlPath)
+				() -> _test(
+					friendlyUrlPath,
+					_userLocalService.getGuestUser(
+						TestPropsValues.getCompanyId()))
 			);
 		}
 		finally {
@@ -86,16 +101,29 @@ public class RESTClientTemplateContextContributorTest {
 		}
 	}
 
-	private void _test(String friendlyUrlPath) throws Exception {
-		Assert.assertThat(
-			HTTPTestUtil.invokeToString(
-				null,
-				"web" + friendlyUrlPath + "/portal-vulcan-test?pageSize=2",
-				Http.Method.GET),
-			CoreMatchers.allOf(
-				CoreMatchers.containsString("Name: spain."),
-				CoreMatchers.containsString("Page Size (default): 20."),
-				CoreMatchers.containsString("Page Size (query): 1.")));
+	private void _test(String friendlyUrlPath, User user) throws Exception {
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						TestPropsValues.getCompanyId(),
+						"com.liferay.portal.security.auto.login.basic.auth." +
+							"header",
+						HashMapDictionaryBuilder.<String, Object>put(
+							"enabled", true
+						).build())) {
+
+			Assert.assertThat(
+				HTTPTestUtil.invokeToString(
+					null,
+					"web" + friendlyUrlPath + "/portal-vulcan-test?pageSize=2",
+					Http.Method.GET),
+				CoreMatchers.allOf(
+					CoreMatchers.containsString("Name: spain."),
+					CoreMatchers.containsString("Page Size (default): 20."),
+					CoreMatchers.containsString("Page Size (query): 1."),
+					CoreMatchers.containsString(
+						"User: " + user.getScreenName() + ".")));
+		}
 	}
 
 	private InputStream _toInputStream() throws Exception {
@@ -109,6 +137,9 @@ public class RESTClientTemplateContextContributorTest {
 				RESTClientTemplateContextContributorTest.class),
 			_zipWriterFactory.getZipWriter());
 	}
+
+	@Inject
+	private UserLocalService _userLocalService;
 
 	@Inject
 	private ZipWriterFactory _zipWriterFactory;

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/resources/com/liferay/portal/vulcan/internal/template/test/dependencies/site-initializer/site-initializer/fragments/group/country/index.html
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/resources/com/liferay/portal/vulcan/internal/template/test/dependencies/site-initializer/site-initializer/fragments/group/country/index.html
@@ -1,3 +1,4 @@
 Name: ${restClient.get("/headless-admin-address/v1.0/countries/by-name/spain").name}.
 Page Size (default): ${restClient.get("/headless-admin-address/v1.0/countries").pageSize}.
 Page Size (query): ${restClient.get("/headless-admin-address/v1.0/countries?pageSize=1").pageSize}.
+User: ${restClient.get("/headless-admin-user/v1.0/my-user-account").alternateName!"GUEST"}.


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94309

## What Is Being Fixed

The server-side restClient helper exposed to FreeMarker fragments (RESTClientTemplateContextContributor) forwards into the Vulcan REST layer to fetch data during page rendering. On that internal forward the authenticated page user was downgraded to the guest user, so identity and permission scoped REST data — such as accountEntryRestricted object entries — came back empty for an authenticated user, even though a direct browser REST call worked. This surfaced in LPP-64348 as an empty "Active Project" banner after an upgrade. It is a regression from LPD-66204.

## How It Is Being Fixed

On the forward the OSGi HTTP whiteboard re-runs AuthVerifierFilter, and because RESTClientHttpServletRequestWrapper masks the original credentials the auth verifier pipeline falls back to the guest user and AccessControlUtil.initContextUser overwrites the page's authenticated principal. LPD-66204 turned the forwarded request from a dynamic proxy that the infrastructure never re-verified into a real HttpServletRequestWrapper that is re-verified, which is what exposed the downgrade. This adds a dedicated AuthVerifier in portal-vulcan-impl that recognizes the restClient forward by the wrapper's marker request attribute and authenticates it as the user the wrapper already carries through WebKeys.USER, restoring the authenticated principal for the forwarded request. An integration test renders a fragment that calls restClient.get on an authenticated content page and asserts the resolved user is the page user, and also asserts that a guest render resolves the guest user.

## Forwarding

This PR was manually forwarded from liferay-headless/liferay-portal#3868 because CI is currently down — neither the `ci:forward` auto-forward nor `ci:test:sf` is running.

## PR Check

**pr-check: PASS** — tested on `39d7c235f192096352617062890d7c8a62da0519`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

_Java Unit Tests matched the diff but had no parallel-name counterpart to run; the behavior fix is covered by `RESTClientTemplateContextContributorTest` (testIntegration, out of pr-check scope). No drift validations fired._

<!-- pr-check {"result": "success", "sha": "39d7c235f192096352617062890d7c8a62da0519"} -->
