### PR TITLE
LPD-60899 Migrate getParameterValues71 to getParameterValues

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -5460,6 +5460,14 @@
 	},
 	{
 		"classNames": [
+			"PortletSharedSearchSettings"
+		],
+		"from": "getParameterValues71",
+		"issueKey": "LPD-60899",
+		"to": "getParameterValues"
+	},
+	{
+		"classNames": [
 			"CPCompareHelperUtil"
 		],
 		"from": "addCompareProduct(long paramName, long paramName, long paramName, HttpSession paramName)",

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_60899.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_60899.testjava
@@ -1,0 +1,19 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class LPD_60899 {
+
+	public void method(
+		PortletSharedSearchSettings portletSharedSearchSettings) {
+
+		portletSharedSearchSettings.getParameterValues("key");
+	}
+
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_60899.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_60899.testjava
@@ -1,0 +1,19 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class LPD_60899 {
+
+	public void method(
+		PortletSharedSearchSettings portletSharedSearchSettings) {
+
+		portletSharedSearchSettings.getParameterValues71("key");
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-60899

## What Is Being Fixed

The `getParameterValues71` method on `PortletSharedSearchSettings` was renamed to `getParameterValues`. Consumer code still calling the old method needs to be migrated automatically during a Liferay upgrade.

## How It Is Being Fixed

A new entry was added to the source formatter's `replacements.json` so the upgrade catch-all check rewrites any `PortletSharedSearchSettings.getParameterValues71(...)` call to `getParameterValues(...)`. Matching input and expected `.testjava` fixtures under `upgrade-catch-all-check` were added so `UpgradeCatchAllCheckTest` verifies the rewrite.

## PR Check

**pr-check: PASS** — tested on `4b695ea9425b072fe8a132945e1517a2e116133e`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "4b695ea9425b072fe8a132945e1517a2e116133e"} -->
