### PR TITLE
LPD-91707 Make worktree hooks work on macOS

### DIFF
--- a/.claude/hooks/_common.sh
+++ b/.claude/hooks/_common.sh
@@ -26,7 +26,7 @@ function _derive_db_name {
 		return
 	fi
 
-	suffix="$(echo "${suffix}" | tr "[:upper:]" "[:lower:]" | sed --regexp-extended "s/[^a-z0-9]+/_/g; s/^_+|_+\$//g")"
+	suffix="$(echo "${suffix}" | tr "[:upper:]" "[:lower:]" | _sed --regexp-extended "s/[^a-z0-9]+/_/g; s/^_+|_+\$//g")"
 	suffix="${suffix:0:56}"
 
 	echo "lportal_${suffix}"
@@ -79,12 +79,12 @@ function _find_app_server_parent_dir {
 
 	if [[ -f ${user_props} ]]
 	then
-		raw="$(grep --extended-regexp "^[[:space:]]*app\.server\.parent\.dir=" "${user_props}" | tail --lines=1 | sed "s/^[[:space:]]*app\.server\.parent\.dir=//")"
+		raw="$(grep --extended-regexp "^[[:space:]]*app\.server\.parent\.dir=" "${user_props}" | tail --lines=1 | _sed "s/^[[:space:]]*app\.server\.parent\.dir=//")"
 	fi
 
 	if [[ -z ${raw} && -f ${default_props} ]]
 	then
-		raw="$(grep --extended-regexp "^[[:space:]]*app\.server\.parent\.dir=" "${default_props}" | tail --lines=1 | sed "s/^[[:space:]]*app\.server\.parent\.dir=//")"
+		raw="$(grep --extended-regexp "^[[:space:]]*app\.server\.parent\.dir=" "${default_props}" | tail --lines=1 | _sed "s/^[[:space:]]*app\.server\.parent\.dir=//")"
 	fi
 
 	[[ -n ${raw} ]] || return 1
@@ -123,7 +123,7 @@ function _get_property {
 
 	if [[ -f ${file} ]] && grep --extended-regexp --quiet "^[[:space:]]*${key}=" "${file}"
 	then
-		value="$(grep --extended-regexp "^[[:space:]]*${key}=" "${file}" | tail --lines=1 | sed --regexp-extended "s/^[[:space:]]*${key}=[[:space:]]*//; s/[[:space:]]+\$//")"
+		value="$(grep --extended-regexp "^[[:space:]]*${key}=" "${file}" | tail --lines=1 | _sed --regexp-extended "s/^[[:space:]]*${key}=[[:space:]]*//; s/[[:space:]]+\$//")"
 	fi
 
 	echo "${value}"
@@ -141,11 +141,61 @@ function _get_property_from_files {
 	do
 		if [[ -f ${file} ]] && grep --extended-regexp --quiet "^[[:space:]]*${key}=" "${file}"
 		then
-			grep --extended-regexp "^[[:space:]]*${key}=" "${file}" | tail --lines=1 | sed --regexp-extended "s/^[[:space:]]*${key}=[[:space:]]*//; s/[[:space:]]+\$//"
+			grep --extended-regexp "^[[:space:]]*${key}=" "${file}" | tail --lines=1 | _sed --regexp-extended "s/^[[:space:]]*${key}=[[:space:]]*//; s/[[:space:]]+\$//"
 
 			return
 		fi
 	done
 
 	echo "${default}"
+}
+
+function _sed {
+	local arg in_place=0
+
+	for arg in "${@}"
+	do
+		[[ ${arg} == --in-place ]] && in_place=1
+	done
+
+	if [[ ${in_place} -eq 1 ]]
+	then
+		local file="${*: -1}"
+
+		if [[ -L ${file} ]]
+		then
+			local dereferenced="${file}.dereferenced"
+
+			cp "${file}" "${dereferenced}" 2>/dev/null || : > "${dereferenced}"
+
+			rm -f "${file}"
+
+			mv "${dereferenced}" "${file}"
+		fi
+	fi
+
+	if [[ $(uname) == Darwin ]]
+	then
+		local args=()
+
+		for arg in "${@}"
+		do
+			if [[ ${arg} == --expression ]]
+			then
+				args+=(-e)
+			elif [[ ${arg} == --in-place ]]
+			then
+				args+=(-i "")
+			elif [[ ${arg} == --regexp-extended ]]
+			then
+				args+=(-E)
+			else
+				args+=("${arg}")
+			fi
+		done
+
+		sed "${args[@]}"
+	else
+		sed "${@}"
+	fi
 }

--- a/.claude/hooks/worktree-create.sh
+++ b/.claude/hooks/worktree-create.sh
@@ -105,7 +105,7 @@ function _create_worktree {
 
 	local main_worktree target_path
 
-	main_worktree="$(git -C "${cwd}" worktree list --porcelain | grep --extended-regexp "^worktree " | head --lines=1 | sed "s/^worktree //")"
+	main_worktree="$(git -C "${cwd}" worktree list --porcelain | grep --extended-regexp "^worktree " | head --lines=1 | _sed "s/^worktree //")"
 
 	target_path="$(dirname "${main_worktree}")/$(basename "${main_worktree}")-${name}"
 
@@ -127,7 +127,7 @@ function _resolve_main_worktree_dir {
 
 	repo_dir="$(git -C "${WORKTREE_DIR}" rev-parse --show-toplevel)"
 
-	git -C "${repo_dir}" worktree list --porcelain | grep --extended-regexp "^worktree .*/liferay-portal\$" | head --lines=1 | sed "s/^worktree //"
+	git -C "${repo_dir}" worktree list --porcelain | grep --extended-regexp "^worktree .*/liferay-portal\$" | head --lines=1 | _sed "s/^worktree //"
 }
 
 function _reuse_worktree {
@@ -148,9 +148,14 @@ function _reuse_worktree {
 
 		if [[ -d ${MAIN_WORKTREE_DIR}/.gradle/caches && ! -e ${WORKTREE_DIR}/.gradle/caches ]]
 		then
-			mkdir --parents "${WORKTREE_DIR}/.gradle"
+			mkdir -p "${WORKTREE_DIR}/.gradle"
 
-			cp --archive --link "${MAIN_WORKTREE_DIR}/.gradle/caches" "${WORKTREE_DIR}/.gradle/caches"
+			if [[ $(uname) == Darwin ]]
+			then
+				rsync --archive --link-dest="${MAIN_WORKTREE_DIR}/.gradle/caches" "${MAIN_WORKTREE_DIR}/.gradle/caches/" "${WORKTREE_DIR}/.gradle/caches/"
+			else
+				cp --archive --link "${MAIN_WORKTREE_DIR}/.gradle/caches" "${WORKTREE_DIR}/.gradle/caches"
+			fi
 		fi
 	fi
 
@@ -164,20 +169,16 @@ function _reuse_worktree {
 
 		[[ -d ${main_bundles} ]] || _die "Main bundle directory ${main_bundles} does not exist."
 
-		mkdir --parents "${BUNDLES_DIR}"
+		mkdir -p "${BUNDLES_DIR}"
 
-		cp --archive "${main_bundles}/." "${BUNDLES_DIR}"
+		if [[ $(uname) == Darwin ]]
+		then
+			rsync --archive "${main_bundles}/" "${BUNDLES_DIR}/"
+		else
+			cp --archive "${main_bundles}/." "${BUNDLES_DIR}"
+		fi
 
 		_bundle_exists "${BUNDLES_DIR}" || _die "Bundle copy finished but no \"tomcat-*\" directory exists under ${BUNDLES_DIR}."
-	fi
-}
-
-function _sed_inplace {
-	if [[ $(uname) == Darwin ]]
-	then
-		sed -i "" "${@}"
-	else
-		sed --in-place "${@}"
 	fi
 }
 
@@ -186,7 +187,7 @@ function _set_arquillian_port {
 
 	local config_file="${BUNDLES_DIR}/osgi/configs/com.liferay.arquillian.extension.junit.bridge.connector.ArquillianConnector.config"
 
-	mkdir --parents "$(dirname "${config_file}")"
+	mkdir -p "$(dirname "${config_file}")"
 
 	_atomic_write "${config_file}" <<EOF
 port="${target}"
@@ -208,7 +209,7 @@ function _set_bundle_path {
 function _set_data_guard_port {
 	local file="${BUNDLES_DIR}/osgi/configs/com.liferay.data.guard.connector.DataGuardConnector.config"
 
-	mkdir --parents "$(dirname "${file}")"
+	mkdir -p "$(dirname "${file}")"
 
 	local target=$((42763 + OFFSET))
 
@@ -266,7 +267,7 @@ function _set_debug_port {
 function _set_elasticsearch_ports {
 	local configs_dir="${BUNDLES_DIR}/osgi/configs"
 
-	mkdir --parents "${configs_dir}"
+	mkdir -p "${configs_dir}"
 
 	local es_version=elasticsearch8
 
@@ -343,7 +344,7 @@ function _set_gradle_paths {
 
 	[[ -n ${main_bundles_literal} ]] || _die "The \"liferay.home\" property is missing from ${file}."
 
-	_sed_inplace \
+	_sed --in-place \
 		--expression "s|${main_bundles_literal}/|${BUNDLES_DIR}/|g" \
 		--expression "s|${main_bundles_literal}\$|${BUNDLES_DIR}|g" \
 		--expression "s|${main_worktree}/|${WORKTREE_DIR}/|g" \
@@ -354,7 +355,7 @@ function _set_playwright_port {
 	local file="${WORKTREE_DIR}/modules/test/playwright/.env.local"
 	local http_port=$((8080 + OFFSET))
 
-	mkdir --parents "$(dirname "${file}")"
+	mkdir -p "$(dirname "${file}")"
 
 	_atomic_write "${file}" <<EOF
 PORTAL_URL=http://localhost:${http_port}
@@ -461,7 +462,7 @@ function _set_property {
 
 	local escaped="${key//./\\.}"
 
-	_sed_inplace --regexp-extended --expression "/^[[:space:]]*${escaped}=/d" "${file}"
+	_sed --in-place --regexp-extended --expression "/^[[:space:]]*${escaped}=/d" "${file}"
 
 	if [[ -s ${file} ]] && [[ -n $(tail --bytes=1 "${file}") ]]
 	then
@@ -474,7 +475,7 @@ function _set_property {
 function _set_test_integration_port {
 	local file="${WORKTREE_DIR}/.gradle/init.d/worktree-ports.gradle"
 
-	mkdir --parents "$(dirname "${file}")"
+	mkdir -p "$(dirname "${file}")"
 
 	local http_port=$((8080 + OFFSET))
 
@@ -501,7 +502,7 @@ function _set_tomcat_ports {
 	local target_ajp=$((8009 + OFFSET))
 	local target_https=$((8443 + OFFSET))
 
-	_sed_inplace \
+	_sed --in-place \
 		--regexp-extended \
 		--expression "/<Server/s/port=\"[0-9]+\"/port=\"${target_shutdown}\"/" \
 		--expression "/protocol=\"HTTP\\/1\\.1\"/s/port=\"[0-9]+\"/port=\"${target_http}\"/" \
@@ -525,7 +526,7 @@ function _set_worktree_paths {
 
 	[[ -f ${file} ]] || return 0
 
-	_sed_inplace \
+	_sed --in-place \
 		--expression "s|${main_tomcat}/|$(_find_tomcat_dir "${BUNDLES_DIR}")/|g" \
 		--expression "s|${main_bundles}/|${BUNDLES_DIR}/|g" \
 		--expression "s|${main_worktree}/|${WORKTREE_DIR}/|g" \

--- a/.claude/hooks/worktree-remove.sh
+++ b/.claude/hooks/worktree-remove.sh
@@ -26,7 +26,7 @@ function main {
 		if bundles_dir="$(_find_app_server_parent_dir "${worktree_path}")" &&
 		   tomcat_dir="$(_find_tomcat_dir "${bundles_dir}")"
 		then
-			pkill --full --signal=KILL "catalina.base=${tomcat_dir}" >/dev/null 2>&1 || true
+			pkill -KILL -f "catalina.base=${tomcat_dir}" >/dev/null 2>&1 || true
 		fi
 	fi
 


### PR DESCRIPTION
## Review Feedback

Applying the feedback from https://github.com/brianchandotcom/liferay-portal/pull/176925#issuecomment-4732768209.

Applied all the feedback from `#bchan-bot-pr-review` except the parts that break macOS:

- `mkdir -p` / `pkill -KILL -f`: BSD rejects the long forms (`illegal option`), so they stay short.
- `rsync` trailing slash: required for "copy contents" semantics, not a typo.

Everything else (the `_sed` `if/elif` + placement, `tail`/`head` back to long form) is done.

> https://liferay.atlassian.net/browse/LPD-91707
> 
> ## What Is Being Fixed
> 
> The worktree provisioning hooks assumed a GNU userland: GNU-only `sed` long flags (`--in-place`, `--regexp-extended`, `--expression`), `head --lines`/`tail --lines`, `mkdir --parents`, and `cp --archive --link`. On macOS, whose BSD utilities reject those flags, `worktree-create.sh` and `worktree-remove.sh` failed.
> 
> ## How It Is Being Fixed
> 
> Adds a `_sed` wrapper in `_common.sh` that, on Darwin, rewrites the GNU long flags to their BSD `sed` equivalents and dereferences a symlinked target before an in-place edit, while delegating unchanged on GNU. Replaces the remaining GNU-only invocations with portable forms: `mkdir -p`, `pkill -KILL -f`, and an `rsync --archive [--link-dest]` fallback for `cp --archive [--link]` on Darwin. `head`/`tail` keep their GNU long flags, which BSD also accepts.
> 
> ## Why Are There No Tests?
> 
> The `.claude` worktree hooks are local developer tooling, outside the portal build and runtime, so the automated test layers do not apply to them.


## PR Check

**pr-check: PASS** — tested on `bf3f487bb7c0a92840b8ba60e3c2a34439bf2f92`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "bf3f487bb7c0a92840b8ba60e3c2a34439bf2f92"} -->
