### PR TITLE
LPD-95261 Prevent worktree removal from shutting down the main Tomcat

### DIFF
--- a/.claude/hooks/worktree-remove.sh
+++ b/.claude/hooks/worktree-remove.sh
@@ -24,6 +24,7 @@ function main {
 		local tomcat_dir
 
 		if bundles_dir="$(_find_app_server_parent_dir "${worktree_path}")" &&
+		   [[ ${bundles_dir} == "${worktree_path}/"* ]] &&
 		   tomcat_dir="$(_find_tomcat_dir "${bundles_dir}")"
 		then
 			pkill --full --signal=KILL "catalina.base=${tomcat_dir}" >/dev/null 2>&1 || true


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95261

## What Is Being Fixed

Removing a worktree created with `LIFERAY_PROVISION=none` shut down the main
worktree's Tomcat. A `none` worktree provisions no bundle of its own, so it never
writes an `app.server.<user>.properties` pointing at a per-worktree `bundle/`. On
removal, `worktree-remove.sh` resolved the app server parent directory via
`_find_app_server_parent_dir`, which fell back to the checked-in
`app.server.properties` and pointed at the shared main bundle. The hook then found
the Tomcat running there and killed it.

## How It Is Being Fixed

The Tomcat kill is now confined to a bundle that actually lives inside the worktree
being removed, by guarding on `[[ ${bundles_dir} == "${worktree_path}/"* ]]` before
resolving and killing the Tomcat. A correctly provisioned worktree keeps its bundle
at `${WORKTREE_DIR}/bundle`, so it still matches and is cleaned up; a `none` worktree
resolves to the shared external bundle, which no longer matches, so the main Tomcat
is left running. The database drop is unaffected — it keys off the worktree name and
is a no-op when no per-worktree database exists.

## Why Are There No Tests?

The change is a one-line guard in a Bash worktree hook. The repository has no test
harness for these `.claude/hooks` scripts (no bats, no existing hook tests), so there
is no place to add automated coverage. The fix was verified manually by removing a
`LIFERAY_PROVISION=none` worktree and confirming the main Tomcat keeps running.

## PR Check

**pr-check: PASS** — tested on `7ea41bc5adfbd7169ea611ec97619c23ddc3c148`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "7ea41bc5adfbd7169ea611ec97619c23ddc3c148"} -->
