### PR TITLE
LPD-91109 Resolve Jira component dynamically instead of hardcoding IDs

### DIFF
--- a/.claude/skills/jira-bug/SKILL.md
+++ b/.claude/skills/jira-bug/SKILL.md
@@ -29,13 +29,8 @@ Request any missing details from the user:
 The LPD project requires the following fields. Apply these defaults unless the user specifies otherwise:
 
 - **Affects Version**: `Master` (ID: `16660`).
-- **Component**: Select from the list below, or infer from the code area. Common components include:
-	- `Content Publishing > Resource Importer` (ID: `16131`)
-	- `Data Integration > Export/Import` (ID: `15805`)
-	- `Headless Batch Engine API` (ID: `16022`)
+- **Component**: Infer from the code area. Fetch the LPD project components and select the one whose name best matches the relevant area or keyword.
 - **Cross Cutting Properties** (`customfield_10979`): `None` (ID: `14468`).
-
-When no listed component matches, fetch the LPD project components and pick the one whose name matches the keyword.
 
 ## Create the Ticket
 

--- a/.claude/skills/jira-bug/SKILL.md
+++ b/.claude/skills/jira-bug/SKILL.md
@@ -30,8 +30,8 @@ The LPD project requires the following fields. Apply these defaults unless the u
 
 - **Affects Version**: `Master` (ID: `16660`).
 - **Component**: Select from the list below, or infer from the code area. Common components include:
-	- `Content Publishing > Resource Importer` (ID: `15805`)
-	- `Data Integration > Export/Import` (ID: `16131`)
+	- `Content Publishing > Resource Importer` (ID: `16131`)
+	- `Data Integration > Export/Import` (ID: `15805`)
 	- `Headless Batch Engine API` (ID: `16022`)
 - **Cross Cutting Properties** (`customfield_10979`): `None` (ID: `14468`).
 

--- a/.claude/skills/jira-task/SKILL.md
+++ b/.claude/skills/jira-task/SKILL.md
@@ -27,8 +27,8 @@ Request any missing details from the user:
 The LPD project requires the following fields. Apply these defaults unless the user specifies otherwise:
 
 - **Component**: Select from the list below, or infer from the code area. Common components include:
-	- `Content Publishing > Resource Importer` (ID: `15805`)
-	- `Data Integration > Export/Import` (ID: `16131`)
+	- `Content Publishing > Resource Importer` (ID: `16131`)
+	- `Data Integration > Export/Import` (ID: `15805`)
 	- `Headless Batch Engine API` (ID: `16022`)
 - **Issue Type**: `Task` (ID: `10002`).
 

--- a/.claude/skills/jira-task/SKILL.md
+++ b/.claude/skills/jira-task/SKILL.md
@@ -26,15 +26,10 @@ Request any missing details from the user:
 
 The LPD project requires the following fields. Apply these defaults unless the user specifies otherwise:
 
-- **Component**: Select from the list below, or infer from the code area. Common components include:
-	- `Content Publishing > Resource Importer` (ID: `16131`)
-	- `Data Integration > Export/Import` (ID: `15805`)
-	- `Headless Batch Engine API` (ID: `16022`)
+- **Component**: Infer from the code area. Fetch the LPD project components and select the one whose name best matches the relevant area or keyword.
 - **Issue Type**: `Task` (ID: `10002`).
 
 Note: Unlike bugs, tasks do not require the Affects Version or Cross Cutting Properties fields.
-
-When no listed component matches, fetch the LPD project components and pick the one whose name matches the keyword.
 
 ## Create the Ticket
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91109

## What Is Being Fixed

The `jira-task` and `jira-bug` skills carried a hardcoded list of Jira component names and their numeric IDs. Those IDs had drifted from the live LPD project — `Content Publishing > Resource Importer` and `Data Integration > Export/Import` were swapped — so tickets created through either skill landed in the wrong component until corrected by hand. A hardcoded list cannot be kept in sync with Jira and would drift again.

## How It Is Being Fixed

The first commit swaps the two IDs back to match Jira. The second removes the hardcoded list from both skills entirely and instead instructs the skill to fetch the LPD project components at creation time and select the one whose name best matches the relevant code area. With no IDs baked into the skill, this class of drift can no longer occur.

## Why Are There No Tests?

The change touches only skill instruction Markdown under `.claude/skills`; there is no executable code to cover.

## PR Check

**pr-check: PASS** — tested on `45255fa60649a5cc69d2c5a4e7653e047dea7f3f`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "45255fa60649a5cc69d2c5a4e7653e047dea7f3f"} -->
