### PR TITLE
LPD-94235 Center the deprecated badge label on the page type cards

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_basic_templates.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_basic_templates.jsp
@@ -66,7 +66,7 @@ SelectLayoutPageTemplateEntryDisplayContext selectLayoutPageTemplateEntryDisplay
 													<%= HtmlUtil.escape(selectBasicTemplatesNavigationCard.getTitle()) %>
 
 													<clay:badge
-														cssClass="c-ml-1 c-pl-0 text-uppercase"
+														cssClass="c-ml-1 text-uppercase"
 														displayType="warning"
 														label='<%= LanguageUtil.get(request, "deprecated") %>'
 														translucent="<%= true %>"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94235

## What Is Being Fixed

On the "Add Page" basic templates picker, the deprecated page type cards render a "Deprecated" badge whose label was not horizontally centered. The `c-pl-0` utility class zeroed only the badge's left padding while the right padding remained, pushing the "DEPRECATED" label against the left edge of the pill.

## How It Is Being Fixed

Removed `c-pl-0` from the badge so it keeps its symmetric horizontal padding and the label renders centered. The `c-ml-1` spacing from the title and `text-uppercase` are retained.

## Why Are There No Tests?

This is a presentation-only change, removing a CSS utility class from a JSP tag attribute, with no testable logic.

## PR Check

**pr-check: PASS** — tested on `47e640e9238cc190d60da6797ae779648a46bf99`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JSP Compile | PASS |

<!-- pr-check {"result": "success", "sha": "47e640e9238cc190d60da6797ae779648a46bf99"} -->