### PR TITLE
LPD-94235 Hide the deprecated widget page templates panel app entry

### DIFF
--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/application/list/LayoutPageTemplatesPanelApp.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/application/list/LayoutPageTemplatesPanelApp.java
@@ -9,7 +9,11 @@ import com.liferay.application.list.BasePanelApp;
 import com.liferay.application.list.PanelApp;
 import com.liferay.application.list.constants.PanelCategoryKeys;
 import com.liferay.layout.page.template.admin.constants.LayoutPageTemplateAdminPortletKeys;
+import com.liferay.layout.page.template.constants.LayoutPageTemplateConstants;
+import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
+import com.liferay.layout.page.template.service.LayoutPageTemplateEntryService;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Portlet;
@@ -76,6 +80,23 @@ public class LayoutPageTemplatesPanelApp extends BasePanelApp {
 			return false;
 		}
 
+		if (group.isCompany() &&
+			!FeatureFlagManagerUtil.isEnabled(
+				group.getCompanyId(), "LPD-76864")) {
+
+			int layoutPageTemplateEntriesCountByType =
+				_layoutPageTemplateEntryService.
+					getLayoutPageTemplateEntriesCountByType(
+						group.getGroupId(),
+						LayoutPageTemplateConstants.
+							PARENT_LAYOUT_PAGE_TEMPLATE_COLLECTION_ID_DEFAULT,
+						LayoutPageTemplateEntryTypeConstants.WIDGET_PAGE);
+
+			if (layoutPageTemplateEntriesCountByType == 0) {
+				return false;
+			}
+		}
+
 		return super.isShow(permissionChecker, group);
 	}
 
@@ -84,6 +105,9 @@ public class LayoutPageTemplatesPanelApp extends BasePanelApp {
 
 	@Reference
 	private Language _language;
+
+	@Reference
+	private LayoutPageTemplateEntryService _layoutPageTemplateEntryService;
 
 	@Reference(
 		target = "(jakarta.portlet.name=" + LayoutPageTemplateAdminPortletKeys.LAYOUT_PAGE_TEMPLATES + ")"

--- a/modules/apps/layout/layout-page-template-admin-web/src/test/java/com/liferay/layout/page/template/admin/web/internal/application/list/LayoutPageTemplatesPanelAppTest.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/test/java/com/liferay/layout/page/template/admin/web/internal/application/list/LayoutPageTemplatesPanelAppTest.java
@@ -1,0 +1,243 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.page.template.admin.web.internal.application.list;
+
+import com.liferay.layout.page.template.constants.LayoutPageTemplateConstants;
+import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
+import com.liferay.layout.page.template.service.LayoutPageTemplateEntryService;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Portlet;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.service.PortletLocalService;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.staging.StagingGroupHelper;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author Georgel Pop
+ */
+public class LayoutPageTemplatesPanelAppTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testIsShow() throws Exception {
+		_testIsShowWhenFeatureFlagIsEnabled();
+		_testIsShowWithCompanyGroupAndNoWidgetPageTemplates();
+		_testIsShowWithCompanyGroupAndWidgetPageTemplates();
+		_testIsShowWithLocalLiveGroup();
+		_testIsShowWithRemoteLiveGroup();
+		_testIsShowWithSiteGroup();
+	}
+
+	private LayoutPageTemplatesPanelApp _createLayoutPageTemplatesPanelApp(
+			LayoutPageTemplateEntryService layoutPageTemplateEntryService,
+			StagingGroupHelper stagingGroupHelper)
+		throws Exception {
+
+		LayoutPageTemplatesPanelApp layoutPageTemplatesPanelApp =
+			new LayoutPageTemplatesPanelApp();
+
+		Portlet portlet = Mockito.mock(Portlet.class);
+
+		Mockito.when(
+			portlet.isActive()
+		).thenReturn(
+			true
+		);
+
+		PortletLocalService portletLocalService = Mockito.mock(
+			PortletLocalService.class);
+
+		Mockito.when(
+			portletLocalService.getPortletById(
+				Mockito.anyLong(), Mockito.anyString())
+		).thenReturn(
+			portlet
+		);
+
+		ReflectionTestUtil.setFieldValue(
+			layoutPageTemplatesPanelApp, "_layoutPageTemplateEntryService",
+			layoutPageTemplateEntryService);
+		ReflectionTestUtil.setFieldValue(
+			layoutPageTemplatesPanelApp, "_portletLocalService",
+			portletLocalService);
+		ReflectionTestUtil.setFieldValue(
+			layoutPageTemplatesPanelApp, "_stagingGroupHelper",
+			stagingGroupHelper);
+
+		return layoutPageTemplatesPanelApp;
+	}
+
+	private void _testIsShowWhenFeatureFlagIsEnabled() throws Exception {
+		Group group = Mockito.mock(Group.class);
+
+		Mockito.when(
+			group.isCompany()
+		).thenReturn(
+			true
+		);
+
+		LayoutPageTemplatesPanelApp layoutPageTemplatesPanelApp =
+			_createLayoutPageTemplatesPanelApp(
+				Mockito.mock(LayoutPageTemplateEntryService.class),
+				Mockito.mock(StagingGroupHelper.class));
+
+		try (MockedStatic<FeatureFlagManagerUtil>
+				featureFlagManagerUtilMockedStatic = Mockito.mockStatic(
+					FeatureFlagManagerUtil.class)) {
+
+			featureFlagManagerUtilMockedStatic.when(
+				() -> FeatureFlagManagerUtil.isEnabled(
+					Mockito.anyLong(), Mockito.eq("LPD-76864"))
+			).thenReturn(
+				true
+			);
+
+			Assert.assertTrue(
+				layoutPageTemplatesPanelApp.isShow(
+					Mockito.mock(PermissionChecker.class), group));
+		}
+	}
+
+	private void _testIsShowWithCompanyGroupAndNoWidgetPageTemplates()
+		throws Exception {
+
+		Group group = Mockito.mock(Group.class);
+
+		Mockito.when(
+			group.isCompany()
+		).thenReturn(
+			true
+		);
+
+		LayoutPageTemplatesPanelApp layoutPageTemplatesPanelApp =
+			_createLayoutPageTemplatesPanelApp(
+				Mockito.mock(LayoutPageTemplateEntryService.class),
+				Mockito.mock(StagingGroupHelper.class));
+
+		try (MockedStatic<FeatureFlagManagerUtil>
+				featureFlagManagerUtilMockedStatic = Mockito.mockStatic(
+					FeatureFlagManagerUtil.class)) {
+
+			Assert.assertFalse(
+				layoutPageTemplatesPanelApp.isShow(
+					Mockito.mock(PermissionChecker.class), group));
+		}
+	}
+
+	private void _testIsShowWithCompanyGroupAndWidgetPageTemplates()
+		throws Exception {
+
+		Group group = Mockito.mock(Group.class);
+
+		Mockito.when(
+			group.isCompany()
+		).thenReturn(
+			true
+		);
+
+		LayoutPageTemplateEntryService layoutPageTemplateEntryService =
+			Mockito.mock(LayoutPageTemplateEntryService.class);
+
+		Mockito.when(
+			layoutPageTemplateEntryService.
+				getLayoutPageTemplateEntriesCountByType(
+					Mockito.anyLong(),
+					Mockito.eq(
+						LayoutPageTemplateConstants.
+							PARENT_LAYOUT_PAGE_TEMPLATE_COLLECTION_ID_DEFAULT),
+					Mockito.eq(
+						LayoutPageTemplateEntryTypeConstants.WIDGET_PAGE))
+		).thenReturn(
+			RandomTestUtil.randomInt()
+		);
+
+		LayoutPageTemplatesPanelApp layoutPageTemplatesPanelApp =
+			_createLayoutPageTemplatesPanelApp(
+				layoutPageTemplateEntryService,
+				Mockito.mock(StagingGroupHelper.class));
+
+		try (MockedStatic<FeatureFlagManagerUtil>
+				featureFlagManagerUtilMockedStatic = Mockito.mockStatic(
+					FeatureFlagManagerUtil.class)) {
+
+			Assert.assertTrue(
+				layoutPageTemplatesPanelApp.isShow(
+					Mockito.mock(PermissionChecker.class), group));
+		}
+	}
+
+	private void _testIsShowWithLocalLiveGroup() throws Exception {
+		Group group = Mockito.mock(Group.class);
+
+		StagingGroupHelper stagingGroupHelper = Mockito.mock(
+			StagingGroupHelper.class);
+
+		Mockito.when(
+			stagingGroupHelper.isLocalLiveGroup(group)
+		).thenReturn(
+			true
+		);
+
+		LayoutPageTemplatesPanelApp layoutPageTemplatesPanelApp =
+			_createLayoutPageTemplatesPanelApp(
+				Mockito.mock(LayoutPageTemplateEntryService.class),
+				stagingGroupHelper);
+
+		Assert.assertFalse(
+			layoutPageTemplatesPanelApp.isShow(
+				Mockito.mock(PermissionChecker.class), group));
+	}
+
+	private void _testIsShowWithRemoteLiveGroup() throws Exception {
+		Group group = Mockito.mock(Group.class);
+
+		StagingGroupHelper stagingGroupHelper = Mockito.mock(
+			StagingGroupHelper.class);
+
+		Mockito.when(
+			stagingGroupHelper.isRemoteLiveGroup(group)
+		).thenReturn(
+			true
+		);
+
+		LayoutPageTemplatesPanelApp layoutPageTemplatesPanelApp =
+			_createLayoutPageTemplatesPanelApp(
+				Mockito.mock(LayoutPageTemplateEntryService.class),
+				stagingGroupHelper);
+
+		Assert.assertFalse(
+			layoutPageTemplatesPanelApp.isShow(
+				Mockito.mock(PermissionChecker.class), group));
+	}
+
+	private void _testIsShowWithSiteGroup() throws Exception {
+		LayoutPageTemplatesPanelApp layoutPageTemplatesPanelApp =
+			_createLayoutPageTemplatesPanelApp(
+				Mockito.mock(LayoutPageTemplateEntryService.class),
+				Mockito.mock(StagingGroupHelper.class));
+
+		Assert.assertTrue(
+			layoutPageTemplatesPanelApp.isShow(
+				Mockito.mock(PermissionChecker.class),
+				Mockito.mock(Group.class)));
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94235

## What Is Being Fixed

At the company scope, the "Widget Page Templates" entry in the Site Administration product menu (rendered by LayoutPageTemplatesPanelApp) stayed visible even when the LPD-76864 deprecation flag was disabled and no widget page templates existed. The earlier LPD-94235 work hid the deprecated content panels and tab (via the display contexts and view.jsp) but never gated the navigation entry itself, so the menu item remained.

## How It Is Being Fixed

LayoutPageTemplatesPanelApp.isShow now applies the same gate the content tab uses: at the company scope, when LPD-76864 is disabled and there are zero WIDGET_PAGE templates, the entry is hidden. The check is scoped to group.isCompany() so site-scope page templates are unaffected, and existing widget page templates keep the entry visible so administrators can still migrate them.

## PR Check

**pr-check: PASS** — tested on `70888d13d7ad1967a3a579a92b3ee5e7efcff41b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "70888d13d7ad1967a3a579a92b3ee5e7efcff41b"} -->