### PR TITLE
LPD-31312 Warn about removed RecurrenceSerializer.toCronText method

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -3502,6 +3502,14 @@
 	},
 	{
 		"classNames": [
+			"RecurrenceSerializer"
+		],
+		"from": "toCronText(Recurrence paramName)",
+		"hasMessage": true,
+		"issueKey": "LPD-31312"
+	},
+	{
+		"classNames": [
 			"CustomFacetPortletPreferences"
 		],
 		"from": "getFederatedSearchKeyOptional",

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_31312.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_31312.testjava
@@ -1,0 +1,21 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+import com.liferay.calendar.recurrence.Recurrence;
+import com.liferay.calendar.recurrence.RecurrenceSerializer;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class LPD_31312 {
+
+	public void method(Recurrence recurrence) {
+		RecurrenceSerializer.toCronText(null);
+		RecurrenceSerializer.toCronText(recurrence);
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-31312

## What Is Being Fixed

The `RecurrenceSerializer.toCronText(Recurrence)` method was removed. Code
that still calls it needs to be flagged during upgrades so developers know
the method is gone and can migrate off it.

## How It Is Being Fixed

A new entry is added to the source formatter's `replacements.json` upgrade
catch-all check for `RecurrenceSerializer.toCronText(Recurrence paramName)`,
keyed to LPD-31312 and marked with `hasMessage` so the formatter warns about
the removed method. A `LPD_31312.testjava` fixture is added to cover the new
rule.

## PR Check

**pr-check: PASS** — tested on `1424b851f56f64f0e243a9c410f970c25f8b83fb`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "1424b851f56f64f0e243a9c410f970c25f8b83fb"} -->
