### PR TITLE
LRCI-7727 Avoid null pointer when webhook JSON arrays are missing

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
@@ -539,7 +539,11 @@ public class JenkinsCohort {
 	private void _addNodeData(
 		JSONObject jsonObject, int recordCount, String key, long value) {
 
-		JSONArray jsonArray = jsonObject.optJSONArray(key, new JSONArray());
+		JSONArray jsonArray = jsonObject.optJSONArray(key);
+
+		if (jsonArray == null) {
+			jsonArray = new JSONArray();
+		}
 
 		while (jsonArray.length() < recordCount) {
 			jsonArray.put(0);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
@@ -320,6 +320,10 @@ public abstract class SecretsUtil {
 				JenkinsResultsParserUtil.combine(
 					"/v1/vaults/", _vault.getId(), "/items/", getId()));
 
+			if (itemJSONObject == null) {
+				return;
+			}
+
 			JSONArray fieldsJSONArray = itemJSONObject.getJSONArray("fields");
 
 			_itemFields = new ArrayList<>(fieldsJSONArray.length());
@@ -361,8 +365,11 @@ public abstract class SecretsUtil {
 				}
 			}
 
-			JSONArray filesJSONArray = itemJSONObject.optJSONArray(
-				"files", new JSONArray());
+			JSONArray filesJSONArray = itemJSONObject.optJSONArray("files");
+
+			if (filesJSONArray == null) {
+				filesJSONArray = new JSONArray();
+			}
 
 			_itemFiles = new ArrayList<>(filesJSONArray.length());
 


### PR DESCRIPTION
## What Is Being Fixed

While processing webhook payloads, the parser called the two-argument `JSONObject.optJSONArray(key, default)` overload and dereferenced an item JSON object without a null guard. The two-argument overload is not available in the org.json version used at runtime, so it returns null rather than the supplied default, and the item object can itself be null. Either path throws a NullPointerException.

## How It Is Being Fixed

The two-argument `optJSONArray` calls in `JenkinsCohort` and `SecretsUtil` are replaced with the single-argument form followed by an explicit null check that substitutes an empty `JSONArray`. `SecretsUtil` also returns early when the item JSON object is null before dereferencing it.

## Why Are There No Tests?

This change is in `jenkins-results-parser`, CI tooling for the webhook. The defensive null-handling is verified by the running webhook against live payloads rather than a unit test.

## PR Check

**pr-check: PASS** — tested on `c434ff81ca59444926ba383a047b4dfd3ab8b815`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Cross-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "c434ff81ca59444926ba383a047b4dfd3ab8b815"} -->
