### PR TITLE
LPD-94207 Hide filtered role types across roles and permissions UI

### DIFF
--- a/modules/apps/portal/portal-default-permissions-web/src/main/java/com/liferay/portal/defaultpermissions/web/internal/display/context/EditPortalDefaultPermissionsConfigurationDisplayContext.java
+++ b/modules/apps/portal/portal-default-permissions-web/src/main/java/com/liferay/portal/defaultpermissions/web/internal/display/context/EditPortalDefaultPermissionsConfigurationDisplayContext.java
@@ -23,10 +23,12 @@ import com.liferay.portal.kernel.portlet.LiferayWindowState;
 import com.liferay.portal.kernel.portlet.PortletQName;
 import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -34,6 +36,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.roles.admin.role.type.contributor.RoleTypeContributor;
+import com.liferay.roles.admin.role.type.contributor.RoleTypeContributorShowFilterRegistryUtil;
 import com.liferay.roles.admin.role.type.contributor.provider.RoleTypeContributorProvider;
 import com.liferay.roles.admin.search.RoleSearch;
 import com.liferay.roles.admin.search.RoleSearchTerms;
@@ -45,6 +48,7 @@ import jakarta.portlet.RenderRequest;
 
 import jakarta.servlet.http.HttpServletRequest;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -334,6 +338,27 @@ public class EditPortalDefaultPermissionsConfigurationDisplayContext {
 		).buildString();
 	}
 
+	private int[] _filterRoleTypes(int[] roleTypes) {
+		PermissionChecker permissionChecker =
+			_themeDisplay.getPermissionChecker();
+
+		List<Integer> roleTypesList = new ArrayList<>();
+
+		for (int roleType : roleTypes) {
+			RoleTypeContributor roleTypeContributor =
+				_roleTypeContributorProvider.getRoleTypeContributor(roleType);
+
+			if ((roleTypeContributor != null) &&
+				RoleTypeContributorShowFilterRegistryUtil.isShow(
+					roleTypeContributor, permissionChecker)) {
+
+				roleTypesList.add(roleType);
+			}
+		}
+
+		return ArrayUtil.toIntArray(roleTypesList);
+	}
+
 	private Map<String, String[]> _getDefaultPermissions() {
 		if (_defaultPermissions != null) {
 			return _defaultPermissions;
@@ -405,6 +430,8 @@ public class EditPortalDefaultPermissionsConfigurationDisplayContext {
 		}
 
 		if (_roleTypes != null) {
+			_roleTypes = _filterRoleTypes(_roleTypes);
+
 			return _roleTypes;
 		}
 
@@ -429,10 +456,14 @@ public class EditPortalDefaultPermissionsConfigurationDisplayContext {
 				_roleTypes = RoleConstants.TYPES_REGULAR;
 			}
 
+			_roleTypes = _filterRoleTypes(_roleTypes);
+
 			return _roleTypes;
 		}
 
 		if (_group == null) {
+			_roleTypes = _filterRoleTypes(_roleTypes);
+
 			return _roleTypes;
 		}
 
@@ -449,6 +480,8 @@ public class EditPortalDefaultPermissionsConfigurationDisplayContext {
 		else {
 			_roleTypes = _getGroupRoleTypes(_group, _roleTypes);
 		}
+
+		_roleTypes = _filterRoleTypes(_roleTypes);
 
 		return _roleTypes;
 	}

--- a/modules/apps/portal/portal-default-permissions-web/src/main/java/com/liferay/portal/defaultpermissions/web/internal/display/context/EditPortalDefaultPermissionsConfigurationDisplayContext.java
+++ b/modules/apps/portal/portal-default-permissions-web/src/main/java/com/liferay/portal/defaultpermissions/web/internal/display/context/EditPortalDefaultPermissionsConfigurationDisplayContext.java
@@ -23,7 +23,6 @@ import com.liferay.portal.kernel.portlet.LiferayWindowState;
 import com.liferay.portal.kernel.portlet.PortletQName;
 import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
-import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
@@ -48,7 +47,6 @@ import jakarta.portlet.RenderRequest;
 
 import jakarta.servlet.http.HttpServletRequest;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -339,24 +337,18 @@ public class EditPortalDefaultPermissionsConfigurationDisplayContext {
 	}
 
 	private int[] _filterRoleTypes(int[] roleTypes) {
-		PermissionChecker permissionChecker =
-			_themeDisplay.getPermissionChecker();
+		return ArrayUtil.filter(
+			roleTypes,
+			roleType -> {
+				RoleTypeContributor roleTypeContributor =
+					_roleTypeContributorProvider.getRoleTypeContributor(
+						roleType);
 
-		List<Integer> roleTypesList = new ArrayList<>();
-
-		for (int roleType : roleTypes) {
-			RoleTypeContributor roleTypeContributor =
-				_roleTypeContributorProvider.getRoleTypeContributor(roleType);
-
-			if ((roleTypeContributor != null) &&
-				RoleTypeContributorShowFilterRegistryUtil.isShow(
-					roleTypeContributor, permissionChecker)) {
-
-				roleTypesList.add(roleType);
-			}
-		}
-
-		return ArrayUtil.toIntArray(roleTypesList);
+				return (roleTypeContributor == null) ||
+					   RoleTypeContributorShowFilterRegistryUtil.isShow(
+						   _themeDisplay.getPermissionChecker(),
+						   roleTypeContributor);
+			});
 	}
 
 	private Map<String, String[]> _getDefaultPermissions() {

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/java/com/liferay/portlet/configuration/web/internal/display/context/PortletConfigurationPermissionsDisplayContext.java
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/java/com/liferay/portlet/configuration/web/internal/display/context/PortletConfigurationPermissionsDisplayContext.java
@@ -530,24 +530,18 @@ public class PortletConfigurationPermissionsDisplayContext {
 	}
 
 	public int[] getRoleTypes() {
-		PermissionChecker permissionChecker =
-			_themeDisplay.getPermissionChecker();
+		return ArrayUtil.filter(
+			_getRoleTypes(),
+			roleType -> {
+				RoleTypeContributor roleTypeContributor =
+					_roleTypeContributorProvider.getRoleTypeContributor(
+						roleType);
 
-		List<Integer> roleTypes = new ArrayList<>();
-
-		for (int roleType : _getRoleTypes()) {
-			RoleTypeContributor roleTypeContributor =
-				_roleTypeContributorProvider.getRoleTypeContributor(roleType);
-
-			if ((roleTypeContributor == null) ||
-				RoleTypeContributorShowFilterRegistryUtil.isShow(
-					roleTypeContributor, permissionChecker)) {
-
-				roleTypes.add(roleType);
-			}
-		}
-
-		return ArrayUtil.toIntArray(roleTypes);
+				return (roleTypeContributor == null) ||
+					   RoleTypeContributorShowFilterRegistryUtil.isShow(
+						   _themeDisplay.getPermissionChecker(),
+						   roleTypeContributor);
+			});
 	}
 
 	public String getSearchActionURL() throws Exception {

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/java/com/liferay/portlet/configuration/web/internal/display/context/PortletConfigurationPermissionsDisplayContext.java
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/java/com/liferay/portlet/configuration/web/internal/display/context/PortletConfigurationPermissionsDisplayContext.java
@@ -54,6 +54,7 @@ import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portlet.configuration.web.internal.configuration.RoleVisibilityConfiguration;
 import com.liferay.portlet.configuration.web.internal.constants.PortletConfigurationPortletKeys;
 import com.liferay.roles.admin.role.type.contributor.RoleTypeContributor;
+import com.liferay.roles.admin.role.type.contributor.RoleTypeContributorShowFilterRegistryUtil;
 import com.liferay.roles.admin.role.type.contributor.provider.RoleTypeContributorProvider;
 import com.liferay.roles.admin.search.RoleSearch;
 import com.liferay.roles.admin.search.RoleSearchTerms;
@@ -529,59 +530,24 @@ public class PortletConfigurationPermissionsDisplayContext {
 	}
 
 	public int[] getRoleTypes() {
-		if (_roleTypes != null) {
-			return _roleTypes;
-		}
+		PermissionChecker permissionChecker =
+			_themeDisplay.getPermissionChecker();
 
-		String roleTypesParam = _getRoleTypesParam();
+		List<Integer> roleTypes = new ArrayList<>();
 
-		if (Validator.isNotNull(roleTypesParam)) {
-			_roleTypes = StringUtil.split(roleTypesParam, 0);
-		}
+		for (int roleType : _getRoleTypes()) {
+			RoleTypeContributor roleTypeContributor =
+				_roleTypeContributorProvider.getRoleTypeContributor(roleType);
 
-		if (_roleTypes != null) {
-			return _roleTypes;
-		}
+			if ((roleTypeContributor == null) ||
+				RoleTypeContributorShowFilterRegistryUtil.isShow(
+					roleTypeContributor, permissionChecker)) {
 
-		_roleTypes = RoleConstants.TYPES_REGULAR_AND_SITE;
-
-		if ((_group != null) && _group.isDepot()) {
-			_roleTypes = _TYPES_DEPOT_AND_REGULAR;
-		}
-
-		if (ResourceActionsUtil.isPortalModelResource(getModelResource())) {
-			if (Objects.equals(
-					getModelResource(), Organization.class.getName()) ||
-				Objects.equals(getModelResource(), User.class.getName())) {
-
-				_roleTypes = RoleConstants.TYPES_ORGANIZATION_AND_REGULAR;
+				roleTypes.add(roleType);
 			}
-			else {
-				_roleTypes = RoleConstants.TYPES_REGULAR;
-			}
-
-			return _roleTypes;
 		}
 
-		if (_group == null) {
-			return _roleTypes;
-		}
-
-		Group parentGroup = null;
-
-		if (_group.isLayout()) {
-			parentGroup = GroupLocalServiceUtil.fetchGroup(
-				_group.getParentGroupId());
-		}
-
-		if (parentGroup != null) {
-			_roleTypes = _getGroupRoleTypes(parentGroup, _roleTypes);
-		}
-		else {
-			_roleTypes = _getGroupRoleTypes(_group, _roleTypes);
-		}
-
-		return _roleTypes;
+		return ArrayUtil.toIntArray(roleTypes);
 	}
 
 	public String getSearchActionURL() throws Exception {
@@ -727,6 +693,62 @@ public class PortletConfigurationPermissionsDisplayContext {
 			_httpServletRequest, "returnToFullPageURL");
 
 		return _returnToFullPageURL;
+	}
+
+	private int[] _getRoleTypes() {
+		if (_roleTypes != null) {
+			return _roleTypes;
+		}
+
+		String roleTypesParam = _getRoleTypesParam();
+
+		if (Validator.isNotNull(roleTypesParam)) {
+			_roleTypes = StringUtil.split(roleTypesParam, 0);
+		}
+
+		if (_roleTypes != null) {
+			return _roleTypes;
+		}
+
+		_roleTypes = RoleConstants.TYPES_REGULAR_AND_SITE;
+
+		if ((_group != null) && _group.isDepot()) {
+			_roleTypes = _TYPES_DEPOT_AND_REGULAR;
+		}
+
+		if (ResourceActionsUtil.isPortalModelResource(getModelResource())) {
+			if (Objects.equals(
+					getModelResource(), Organization.class.getName()) ||
+				Objects.equals(getModelResource(), User.class.getName())) {
+
+				_roleTypes = RoleConstants.TYPES_ORGANIZATION_AND_REGULAR;
+			}
+			else {
+				_roleTypes = RoleConstants.TYPES_REGULAR;
+			}
+
+			return _roleTypes;
+		}
+
+		if (_group == null) {
+			return _roleTypes;
+		}
+
+		Group parentGroup = null;
+
+		if (_group.isLayout()) {
+			parentGroup = GroupLocalServiceUtil.fetchGroup(
+				_group.getParentGroupId());
+		}
+
+		if (parentGroup != null) {
+			_roleTypes = _getGroupRoleTypes(parentGroup, _roleTypes);
+		}
+		else {
+			_roleTypes = _getGroupRoleTypes(_group, _roleTypes);
+		}
+
+		return _roleTypes;
 	}
 
 	private String _getRoleTypesParam() {

--- a/modules/apps/roles/roles-admin-api/bnd.bnd
+++ b/modules/apps/roles/roles-admin-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Roles Admin API
 Bundle-SymbolicName: com.liferay.roles.admin.api
-Bundle-Version: 7.0.2
+Bundle-Version: 7.1.0
 Export-Package:\
 	com.liferay.roles.admin.constants,\
 	com.liferay.roles.admin.group.type.contributor,\

--- a/modules/apps/roles/roles-admin-api/build.gradle
+++ b/modules/apps/roles/roles-admin-api/build.gradle
@@ -3,6 +3,8 @@ dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "jakarta.servlet", name: "jakarta.servlet-api", version: "6.0.0"
+	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
+	compileOnly project(":core:osgi-service-tracker-collections")
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-string")
 }

--- a/modules/apps/roles/roles-admin-api/src/main/java/com/liferay/roles/admin/role/type/contributor/RoleTypeContributorShowFilter.java
+++ b/modules/apps/roles/roles-admin-api/src/main/java/com/liferay/roles/admin/role/type/contributor/RoleTypeContributorShowFilter.java
@@ -1,0 +1,21 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.roles.admin.role.type.contributor;
+
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+
+/**
+ * @author Adolfo Pérez
+ */
+public interface RoleTypeContributorShowFilter {
+
+	public boolean isShow(
+			RoleTypeContributor roleTypeContributor,
+			PermissionChecker permissionChecker)
+		throws PortalException;
+
+}

--- a/modules/apps/roles/roles-admin-api/src/main/java/com/liferay/roles/admin/role/type/contributor/RoleTypeContributorShowFilter.java
+++ b/modules/apps/roles/roles-admin-api/src/main/java/com/liferay/roles/admin/role/type/contributor/RoleTypeContributorShowFilter.java
@@ -14,8 +14,8 @@ import com.liferay.portal.kernel.security.permission.PermissionChecker;
 public interface RoleTypeContributorShowFilter {
 
 	public boolean isShow(
-			RoleTypeContributor roleTypeContributor,
-			PermissionChecker permissionChecker)
+			PermissionChecker permissionChecker,
+			RoleTypeContributor roleTypeContributor)
 		throws PortalException;
 
 }

--- a/modules/apps/roles/roles-admin-api/src/main/java/com/liferay/roles/admin/role/type/contributor/RoleTypeContributorShowFilterRegistryUtil.java
+++ b/modules/apps/roles/roles-admin-api/src/main/java/com/liferay/roles/admin/role/type/contributor/RoleTypeContributorShowFilterRegistryUtil.java
@@ -1,0 +1,61 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.roles.admin.role.type.contributor;
+
+import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerList;
+import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerListFactory;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
+
+/**
+ * @author Adolfo Pérez
+ */
+public class RoleTypeContributorShowFilterRegistryUtil {
+
+	public static boolean isShow(
+		RoleTypeContributor roleTypeContributor,
+		PermissionChecker permissionChecker) {
+
+		for (RoleTypeContributorShowFilter roleTypeContributorShowFilter :
+				_serviceTrackerList) {
+
+			try {
+				if (!roleTypeContributorShowFilter.isShow(
+						roleTypeContributor, permissionChecker)) {
+
+					return false;
+				}
+			}
+			catch (PortalException portalException) {
+				_log.error(portalException);
+
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		RoleTypeContributorShowFilterRegistryUtil.class);
+
+	private static final ServiceTrackerList<RoleTypeContributorShowFilter>
+		_serviceTrackerList;
+
+	static {
+		Bundle bundle = FrameworkUtil.getBundle(
+			RoleTypeContributorShowFilterRegistryUtil.class);
+
+		_serviceTrackerList = ServiceTrackerListFactory.open(
+			bundle.getBundleContext(), RoleTypeContributorShowFilter.class);
+	}
+
+}

--- a/modules/apps/roles/roles-admin-api/src/main/java/com/liferay/roles/admin/role/type/contributor/RoleTypeContributorShowFilterRegistryUtil.java
+++ b/modules/apps/roles/roles-admin-api/src/main/java/com/liferay/roles/admin/role/type/contributor/RoleTypeContributorShowFilterRegistryUtil.java
@@ -21,15 +21,15 @@ import org.osgi.framework.FrameworkUtil;
 public class RoleTypeContributorShowFilterRegistryUtil {
 
 	public static boolean isShow(
-		RoleTypeContributor roleTypeContributor,
-		PermissionChecker permissionChecker) {
+		PermissionChecker permissionChecker,
+		RoleTypeContributor roleTypeContributor) {
 
 		for (RoleTypeContributorShowFilter roleTypeContributorShowFilter :
 				_serviceTrackerList) {
 
 			try {
 				if (!roleTypeContributorShowFilter.isShow(
-						roleTypeContributor, permissionChecker)) {
+						permissionChecker, roleTypeContributor)) {
 
 					return false;
 				}

--- a/modules/apps/roles/roles-admin-api/src/main/resources/com/liferay/roles/admin/role/type/contributor/packageinfo
+++ b/modules/apps/roles/roles-admin-api/src/main/resources/com/liferay/roles/admin/role/type/contributor/packageinfo
@@ -1,1 +1,1 @@
-version 1.2.0
+version 1.3.0

--- a/modules/apps/roles/roles-admin-web/src/main/java/com/liferay/roles/admin/web/internal/portlet/RolesAdminPortlet.java
+++ b/modules/apps/roles/roles-admin-web/src/main/java/com/liferay/roles/admin/web/internal/portlet/RolesAdminPortlet.java
@@ -555,9 +555,6 @@ public class RolesAdminPortlet extends MVCPortlet {
 	protected void checkPermissions(PortletRequest portletRequest)
 		throws Exception {
 
-		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
-			WebKeys.THEME_DISPLAY);
-
 		long roleId = ParamUtil.getLong(portletRequest, "roleId");
 		int roleType = ParamUtil.getInteger(
 			portletRequest, "roleType", RoleConstants.TYPE_REGULAR);
@@ -571,9 +568,12 @@ public class RolesAdminPortlet extends MVCPortlet {
 		RoleTypeContributor roleTypeContributor =
 			_roleTypeContributorProvider.getRoleTypeContributor(roleType);
 
+		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
 		if ((roleTypeContributor == null) ||
 			!RoleTypeContributorShowFilterRegistryUtil.isShow(
-				roleTypeContributor, themeDisplay.getPermissionChecker())) {
+				themeDisplay.getPermissionChecker(), roleTypeContributor)) {
 
 			throw new PrincipalException();
 		}
@@ -737,26 +737,27 @@ public class RolesAdminPortlet extends MVCPortlet {
 			type = role.getType();
 		}
 
-		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
-			WebKeys.THEME_DISPLAY);
-
 		portletRequest.setAttribute(
 			RolesAdminWebKeys.CURRENT_ROLE_TYPE,
 			_roleTypeContributorProvider.getRoleTypeContributor(type));
 		portletRequest.setAttribute(
 			RolesAdminWebKeys.ITEM_SELECTOR, _itemSelector);
+
+		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
 		portletRequest.setAttribute(
 			RolesAdminWebKeys.ROLE_TYPES,
 			ListUtil.filter(
 				_roleTypeContributorProvider.getRoleTypeContributors(),
-				curRoleTypeContributor -> {
-					if (curRoleTypeContributor == null) {
+				roleTypeContributor -> {
+					if (roleTypeContributor == null) {
 						return false;
 					}
 
 					return RoleTypeContributorShowFilterRegistryUtil.isShow(
-						curRoleTypeContributor,
-						themeDisplay.getPermissionChecker());
+						themeDisplay.getPermissionChecker(),
+						roleTypeContributor);
 				}));
 
 		String mvcPath = ParamUtil.getString(portletRequest, "mvcPath");

--- a/modules/apps/roles/roles-admin-web/src/main/java/com/liferay/roles/admin/web/internal/portlet/RolesAdminPortlet.java
+++ b/modules/apps/roles/roles-admin-web/src/main/java/com/liferay/roles/admin/web/internal/portlet/RolesAdminPortlet.java
@@ -66,6 +66,7 @@ import com.liferay.roles.admin.constants.RolesAdminWebKeys;
 import com.liferay.roles.admin.panel.category.role.type.mapper.PanelCategoryRoleTypeMapper;
 import com.liferay.roles.admin.panel.category.role.type.mapper.PanelCategoryRoleTypeMapperRegistry;
 import com.liferay.roles.admin.role.type.contributor.RoleTypeContributor;
+import com.liferay.roles.admin.role.type.contributor.RoleTypeContributorShowFilterRegistryUtil;
 import com.liferay.roles.admin.role.type.contributor.provider.RoleTypeContributorProvider;
 import com.liferay.segments.service.SegmentsEntryRoleLocalService;
 
@@ -554,13 +555,32 @@ public class RolesAdminPortlet extends MVCPortlet {
 	protected void checkPermissions(PortletRequest portletRequest)
 		throws Exception {
 
+		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		long roleId = ParamUtil.getLong(portletRequest, "roleId");
+		int roleType = ParamUtil.getInteger(
+			portletRequest, "roleType", RoleConstants.TYPE_REGULAR);
+
+		Role role = _roleLocalService.fetchRole(roleId);
+
+		if (role != null) {
+			roleType = role.getType();
+		}
+
+		RoleTypeContributor roleTypeContributor =
+			_roleTypeContributorProvider.getRoleTypeContributor(roleType);
+
+		if ((roleTypeContributor == null) ||
+			!RoleTypeContributorShowFilterRegistryUtil.isShow(
+				roleTypeContributor, themeDisplay.getPermissionChecker())) {
+
+			throw new PrincipalException();
+		}
+
 		String mvcPath = ParamUtil.getString(portletRequest, "mvcPath");
 
 		if (Objects.equals(mvcPath, "/edit_role_assignments.jsp")) {
-			ThemeDisplay themeDisplay =
-				(ThemeDisplay)portletRequest.getAttribute(
-					WebKeys.THEME_DISPLAY);
-
 			RolePermissionUtil.check(
 				themeDisplay.getPermissionChecker(),
 				ParamUtil.getLong(portletRequest, "roleId"),
@@ -717,6 +737,9 @@ public class RolesAdminPortlet extends MVCPortlet {
 			type = role.getType();
 		}
 
+		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
 		portletRequest.setAttribute(
 			RolesAdminWebKeys.CURRENT_ROLE_TYPE,
 			_roleTypeContributorProvider.getRoleTypeContributor(type));
@@ -724,7 +747,17 @@ public class RolesAdminPortlet extends MVCPortlet {
 			RolesAdminWebKeys.ITEM_SELECTOR, _itemSelector);
 		portletRequest.setAttribute(
 			RolesAdminWebKeys.ROLE_TYPES,
-			_roleTypeContributorProvider.getRoleTypeContributors());
+			ListUtil.filter(
+				_roleTypeContributorProvider.getRoleTypeContributors(),
+				curRoleTypeContributor -> {
+					if (curRoleTypeContributor == null) {
+						return false;
+					}
+
+					return RoleTypeContributorShowFilterRegistryUtil.isShow(
+						curRoleTypeContributor,
+						themeDisplay.getPermissionChecker());
+				}));
 
 		String mvcPath = ParamUtil.getString(portletRequest, "mvcPath");
 

--- a/modules/apps/site/site-cms-standalone-site-initializer/build.gradle
+++ b/modules/apps/site/site-cms-standalone-site-initializer/build.gradle
@@ -37,6 +37,7 @@ dependencies {
 	compileOnly project(":apps:portal-workflow:portal-workflow-api")
 	compileOnly project(":apps:portal:portal-instance-lifecycle-api")
 	compileOnly project(":apps:push-notifications:push-notifications-api")
+	compileOnly project(":apps:roles:roles-admin-api")
 	compileOnly project(":apps:segments:segments-api")
 	compileOnly project(":apps:sharing:sharing-api")
 	compileOnly project(":apps:site-navigation:site-navigation-admin-api")

--- a/modules/apps/site/site-cms-standalone-site-initializer/src/main/java/com/liferay/site/cms/standalone/site/initializer/internal/role/type/contributor/CMSRoleTypeContributorShowFilter.java
+++ b/modules/apps/site/site-cms-standalone-site-initializer/src/main/java/com/liferay/site/cms/standalone/site/initializer/internal/role/type/contributor/CMSRoleTypeContributorShowFilter.java
@@ -1,0 +1,36 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.standalone.site.initializer.internal.role.type.contributor;
+
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.roles.admin.role.type.contributor.RoleTypeContributor;
+import com.liferay.roles.admin.role.type.contributor.RoleTypeContributorShowFilter;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Adolfo Pérez
+ */
+@Component(service = RoleTypeContributorShowFilter.class)
+public class CMSRoleTypeContributorShowFilter
+	implements RoleTypeContributorShowFilter {
+
+	@Override
+	public boolean isShow(
+		RoleTypeContributor roleTypeContributor,
+		PermissionChecker permissionChecker) {
+
+		if ((roleTypeContributor.getType() == RoleConstants.TYPE_ACCOUNT) ||
+			(roleTypeContributor.getType() == RoleConstants.TYPE_SITE)) {
+
+			return false;
+		}
+
+		return true;
+	}
+
+}

--- a/modules/apps/site/site-cms-standalone-site-initializer/src/main/java/com/liferay/site/cms/standalone/site/initializer/internal/role/type/contributor/CMSRoleTypeContributorShowFilter.java
+++ b/modules/apps/site/site-cms-standalone-site-initializer/src/main/java/com/liferay/site/cms/standalone/site/initializer/internal/role/type/contributor/CMSRoleTypeContributorShowFilter.java
@@ -21,8 +21,8 @@ public class CMSRoleTypeContributorShowFilter
 
 	@Override
 	public boolean isShow(
-		RoleTypeContributor roleTypeContributor,
-		PermissionChecker permissionChecker) {
+		PermissionChecker permissionChecker,
+		RoleTypeContributor roleTypeContributor) {
 
 		if ((roleTypeContributor.getType() == RoleConstants.TYPE_ACCOUNT) ||
 			(roleTypeContributor.getType() == RoleConstants.TYPE_SITE)) {

--- a/modules/apps/users-admin/users-admin-web/build.gradle
+++ b/modules/apps/users-admin/users-admin-web/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	compileOnly project(":apps:portal-configuration:portal-configuration-upgrade-api")
 	compileOnly project(":apps:portal:portal-aop-api")
 	compileOnly project(":apps:product-navigation:product-navigation-personal-menu-api")
+	compileOnly project(":apps:roles:roles-admin-api")
 	compileOnly project(":apps:site-navigation:site-navigation-taglib")
 	compileOnly project(":apps:site:site-item-selector-api")
 	compileOnly project(":apps:site:site-taglib")

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/display/context/UserDisplayContext.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/display/context/UserDisplayContext.java
@@ -429,7 +429,7 @@ public class UserDisplayContext {
 		}
 
 		return RoleTypeContributorShowFilterRegistryUtil.isShow(
-			roleTypeContributor, _permissionChecker);
+			_permissionChecker, roleTypeContributor);
 	}
 
 	private static final Snapshot<RoleTypeContributorProvider>

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/display/context/UserDisplayContext.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/display/context/UserDisplayContext.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.model.UserGroup;
 import com.liferay.portal.kernel.model.UserGroupGroupRole;
 import com.liferay.portal.kernel.model.UserGroupRole;
 import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.module.service.Snapshot;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
@@ -44,6 +45,9 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.security.membershippolicy.RoleMembershipPolicyUtil;
 import com.liferay.portlet.usersadmin.util.UsersAdminUtil;
+import com.liferay.roles.admin.role.type.contributor.RoleTypeContributor;
+import com.liferay.roles.admin.role.type.contributor.RoleTypeContributorShowFilterRegistryUtil;
+import com.liferay.roles.admin.role.type.contributor.provider.RoleTypeContributorProvider;
 import com.liferay.site.item.selector.SiteItemSelectorCriterion;
 import com.liferay.user.groups.admin.item.selector.UserGroupItemSelectorCriterion;
 
@@ -320,6 +324,18 @@ public class UserDisplayContext {
 		return true;
 	}
 
+	public boolean isShowOrganizationRoles() {
+		return _isShowRoleType(RoleConstants.TYPE_ORGANIZATION);
+	}
+
+	public boolean isShowRegularRoles() {
+		return _isShowRoleType(RoleConstants.TYPE_REGULAR);
+	}
+
+	public boolean isShowSiteRoles() {
+		return _isShowRoleType(RoleConstants.TYPE_SITE);
+	}
+
 	private List<Group> _getAllGroups() throws PortalException {
 		List<Group> allGroups = new ArrayList<>();
 
@@ -396,6 +412,29 @@ public class UserDisplayContext {
 		return UsersAdminUtil.filterUserGroupRoles(
 			_permissionChecker, userGroupRoles);
 	}
+
+	private boolean _isShowRoleType(int type) {
+		RoleTypeContributorProvider roleTypeContributorProvider =
+			_roleTypeContributorProviderSnapshot.get();
+
+		if (roleTypeContributorProvider == null) {
+			return true;
+		}
+
+		RoleTypeContributor roleTypeContributor =
+			roleTypeContributorProvider.getRoleTypeContributor(type);
+
+		if (roleTypeContributor == null) {
+			return true;
+		}
+
+		return RoleTypeContributorShowFilterRegistryUtil.isShow(
+			roleTypeContributor, _permissionChecker);
+	}
+
+	private static final Snapshot<RoleTypeContributorProvider>
+		_roleTypeContributorProviderSnapshot = new Snapshot<>(
+			UserDisplayContext.class, RoleTypeContributorProvider.class);
 
 	private final HttpServletRequest _httpServletRequest;
 	private final InitDisplayContext _initDisplayContext;

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/memberships.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/memberships.jsp
@@ -9,9 +9,11 @@
 
 <liferay-util:dynamic-include key="com.liferay.users.admin.web#/user/memberships.jsp#pre" />
 
-<clay:sheet-section>
-	<liferay-util:include page="/user/sites.jsp" servletContext="<%= application %>" />
-</clay:sheet-section>
+<c:if test="<%= userDisplayContext.isShowSiteRoles() %>">
+	<clay:sheet-section>
+		<liferay-util:include page="/user/sites.jsp" servletContext="<%= application %>" />
+	</clay:sheet-section>
+</c:if>
 
 <clay:sheet-section>
 	<liferay-util:include page="/user/user_groups.jsp" servletContext="<%= application %>" />

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/roles.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/roles.jsp
@@ -549,8 +549,8 @@ currentURLObj.setParameter("historyKey", liferayPortletResponse.getNamespace() +
 	</clay:sheet-section>
 </c:if>
 
-<clay:sheet-section>
-	<c:if test="<%= userDisplayContext.isShowSiteRoles() %>">
+<c:if test="<%= userDisplayContext.isShowSiteRoles() %>">
+	<clay:sheet-section>
 		<clay:content-row
 			containerElement="div"
 			cssClass="sheet-subtitle"
@@ -862,48 +862,130 @@ currentURLObj.setParameter("historyKey", liferayPortletResponse.getNamespace() +
 				/>
 			</liferay-ui:search-container>
 		</c:if>
-	</c:if>
+	</clay:sheet-section>
+</c:if>
 
-	<c:if test="<%= !portletName.equals(myAccountPortletId) %>">
-		<aui:script>
-			var <portlet:namespace />addRoleIds = [];
-			var <portlet:namespace />deleteRoleIds = [];
+<c:if test="<%= !portletName.equals(myAccountPortletId) %>">
+	<aui:script>
+		var <portlet:namespace />addRoleIds = [];
+		var <portlet:namespace />deleteRoleIds = [];
 
-			var <portlet:namespace />addGroupRolesGroupIds = [];
-			var <portlet:namespace />addGroupRolesRoleIds = [];
-			var <portlet:namespace />deleteGroupRolesGroupIds = [];
-			var <portlet:namespace />deleteGroupRolesRoleIds = [];
+		var <portlet:namespace />addGroupRolesGroupIds = [];
+		var <portlet:namespace />addGroupRolesRoleIds = [];
+		var <portlet:namespace />deleteGroupRolesGroupIds = [];
+		var <portlet:namespace />deleteGroupRolesRoleIds = [];
 
-			function <portlet:namespace />deleteRegularRole(roleId) {
-				<portlet:namespace />addRoleIds = <portlet:namespace />addRoleIds.filter(
-					(addRoleId) => {
-						return addRoleId !== roleId;
-					}
-				);
+		function <portlet:namespace />deleteRegularRole(roleId) {
+			<portlet:namespace />addRoleIds = <portlet:namespace />addRoleIds.filter(
+				(addRoleId) => {
+					return addRoleId !== roleId;
+				}
+			);
 
-				<portlet:namespace />deleteRoleIds.push(roleId);
+			<portlet:namespace />deleteRoleIds.push(roleId);
 
-				document.<portlet:namespace />fm.<portlet:namespace />addRoleIds.value =
-					<portlet:namespace />addRoleIds.join(',');
-				document.<portlet:namespace />fm.<portlet:namespace />deleteRoleIds.value =
-					<portlet:namespace />deleteRoleIds.join(',');
+			document.<portlet:namespace />fm.<portlet:namespace />addRoleIds.value =
+				<portlet:namespace />addRoleIds.join(',');
+			document.<portlet:namespace />fm.<portlet:namespace />deleteRoleIds.value =
+				<portlet:namespace />deleteRoleIds.join(',');
+		}
+
+		function <portlet:namespace />deleteGroupRole(roleId, groupId) {
+			for (var i = 0; i < <portlet:namespace />addGroupRolesRoleIds.length; i++) {
+				if (
+					<portlet:namespace />addGroupRolesGroupIds[i] === groupId &&
+					<portlet:namespace />addGroupRolesRoleIds[i] === roleId
+				) {
+					<portlet:namespace />addGroupRolesGroupIds.splice(i, 1);
+					<portlet:namespace />addGroupRolesRoleIds.splice(i, 1);
+
+					break;
+				}
 			}
 
-			function <portlet:namespace />deleteGroupRole(roleId, groupId) {
-				for (var i = 0; i < <portlet:namespace />addGroupRolesRoleIds.length; i++) {
+			<portlet:namespace />deleteGroupRolesGroupIds.push(groupId);
+			<portlet:namespace />deleteGroupRolesRoleIds.push(roleId);
+
+			document.<portlet:namespace />fm.<portlet:namespace />addGroupRolesGroupIds.value =
+				<portlet:namespace />addGroupRolesGroupIds.join(',');
+			document.<portlet:namespace />fm.<portlet:namespace />addGroupRolesRoleIds.value =
+				<portlet:namespace />addGroupRolesRoleIds.join(',');
+			document.<portlet:namespace />fm.<portlet:namespace />deleteGroupRolesGroupIds.value =
+				<portlet:namespace />deleteGroupRolesGroupIds.join(',');
+			document.<portlet:namespace />fm.<portlet:namespace />deleteGroupRolesRoleIds.value =
+				<portlet:namespace />deleteGroupRolesRoleIds.join(',');
+		}
+
+		function <portlet:namespace />searchContainerUpdateDataStore(searchContainer) {
+			searchContainer.updateDataStore(
+				searchContainer
+					.get('contentBox')
+					.all('.modify-link')
+					.getData()
+					.map((data) => {
+						return data.groupid + '-' + data.rowid;
+					})
+			);
+		}
+
+		window['<portlet:namespace />selectRole'] = function (
+			roleId,
+			name,
+			searchContainer,
+			groupName,
+			groupId,
+			iconCssClass
+		) {
+			var searchContainerName =
+				'<portlet:namespace />' + searchContainer + 'SearchContainer';
+
+			searchContainer = Liferay.SearchContainer.get(searchContainerName);
+
+			var rowColumns = [];
+
+			rowColumns.push(
+				'<i class="' + iconCssClass + '"></i> ' + Liferay.Util.escapeHTML(name)
+			);
+
+			if (groupName) {
+				rowColumns.push(Liferay.Util.escapeHTML(groupName));
+			}
+
+			var removeRoleButton = '<%= UnicodeFormatter.toString(removeRoleIcon) %>';
+
+			removeRoleButton = removeRoleButton
+				.replace('TOKEN_DATA_ROWID', roleId)
+				.replace(
+					'TOKEN_TITLE',
+					Liferay.Util.sub('<liferay-ui:message key="remove-x" />', name)
+				);
+
+			if (groupId) {
+				removeRoleButton = removeRoleButton.replace(
+					'TOKEN_DATA_GROUPID',
+					groupId
+				);
+
+				rowColumns.push(removeRoleButton);
+
+				for (
+					var i = 0;
+					i < <portlet:namespace />deleteGroupRolesRoleIds.length;
+					i++
+				) {
 					if (
-						<portlet:namespace />addGroupRolesGroupIds[i] === groupId &&
-						<portlet:namespace />addGroupRolesRoleIds[i] === roleId
+						<portlet:namespace />deleteGroupRolesGroupIds[i] === groupId &&
+						<portlet:namespace />deleteGroupRolesRoleIds[i] === roleId
 					) {
-						<portlet:namespace />addGroupRolesGroupIds.splice(i, 1);
-						<portlet:namespace />addGroupRolesRoleIds.splice(i, 1);
+						<portlet:namespace />deleteGroupRolesGroupIds.splice(i, 1);
+						<portlet:namespace />deleteGroupRolesRoleIds.splice(i, 1);
 
 						break;
 					}
 				}
 
-				<portlet:namespace />deleteGroupRolesGroupIds.push(groupId);
-				<portlet:namespace />deleteGroupRolesRoleIds.push(roleId);
+				<portlet:namespace />addGroupRolesGroupIds.push(groupId);
+				<portlet:namespace />addGroupRolesRoleIds.push(roleId);
 
 				document.<portlet:namespace />fm.<portlet:namespace />addGroupRolesGroupIds.value =
 					<portlet:namespace />addGroupRolesGroupIds.join(',');
@@ -913,157 +995,75 @@ currentURLObj.setParameter("historyKey", liferayPortletResponse.getNamespace() +
 					<portlet:namespace />deleteGroupRolesGroupIds.join(',');
 				document.<portlet:namespace />fm.<portlet:namespace />deleteGroupRolesRoleIds.value =
 					<portlet:namespace />deleteGroupRolesRoleIds.join(',');
+
+				searchContainer.addRow(rowColumns, groupId + '-' + roleId);
 			}
-
-			function <portlet:namespace />searchContainerUpdateDataStore(searchContainer) {
-				searchContainer.updateDataStore(
-					searchContainer
-						.get('contentBox')
-						.all('.modify-link')
-						.getData()
-						.map((data) => {
-							return data.groupid + '-' + data.rowid;
-						})
-				);
-			}
-
-			window['<portlet:namespace />selectRole'] = function (
-				roleId,
-				name,
-				searchContainer,
-				groupName,
-				groupId,
-				iconCssClass
-			) {
-				var searchContainerName =
-					'<portlet:namespace />' + searchContainer + 'SearchContainer';
-
-				searchContainer = Liferay.SearchContainer.get(searchContainerName);
-
-				var rowColumns = [];
-
-				rowColumns.push(
-					'<i class="' + iconCssClass + '"></i> ' + Liferay.Util.escapeHTML(name)
+			else {
+				removeRoleButton = removeRoleButton.replace(
+					'data-groupId="TOKEN_DATA_GROUPID"',
+					''
 				);
 
-				if (groupName) {
-					rowColumns.push(Liferay.Util.escapeHTML(groupName));
-				}
+				rowColumns.push(removeRoleButton);
 
-				var removeRoleButton = '<%= UnicodeFormatter.toString(removeRoleIcon) %>';
+				<portlet:namespace />deleteRoleIds =
+					<portlet:namespace />deleteRoleIds.filter((deleteRoleId) => {
+						return deleteRoleId !== roleId;
+					});
 
-				removeRoleButton = removeRoleButton
-					.replace('TOKEN_DATA_ROWID', roleId)
-					.replace(
-						'TOKEN_TITLE',
-						Liferay.Util.sub('<liferay-ui:message key="remove-x" />', name)
+				<portlet:namespace />addRoleIds.push(roleId);
+
+				document.<portlet:namespace />fm.<portlet:namespace />addRoleIds.value =
+					<portlet:namespace />addRoleIds.join(',');
+				document.<portlet:namespace />fm.<portlet:namespace />deleteRoleIds.value =
+					<portlet:namespace />deleteRoleIds.join(',');
+
+				searchContainer.addRow(rowColumns, roleId);
+			}
+
+			searchContainer.updateDataStore();
+		};
+	</aui:script>
+
+	<c:if test="<%= userDisplayContext.isShowRegularRoles() %>">
+		<aui:script use="liferay-search-container">
+			var Util = Liferay.Util;
+
+			var searchContainer = Liferay.SearchContainer.get(
+				'<portlet:namespace />rolesSearchContainer'
+			);
+
+			var searchContainerContentBox = searchContainer.get('contentBox');
+
+			searchContainerContentBox.delegate(
+				'click',
+				(event) => {
+					var link = event.currentTarget;
+
+					var rowId = link.attr('data-rowId');
+
+					var tr = link.ancestor('tr');
+
+					var selectRegularRole = Util.getWindow(
+						'<portlet:namespace />selectRegularRole'
 					);
 
-				if (groupId) {
-					removeRoleButton = removeRoleButton.replace(
-						'TOKEN_DATA_GROUPID',
-						groupId
-					);
+					if (selectRegularRole) {
+						var selectButton = selectRegularRole.iframe.node
+							.get('contentWindow.document')
+							.one('.selector-button[data-entityid="' + rowId + '"]');
 
-					rowColumns.push(removeRoleButton);
-
-					for (
-						var i = 0;
-						i < <portlet:namespace />deleteGroupRolesRoleIds.length;
-						i++
-					) {
-						if (
-							<portlet:namespace />deleteGroupRolesGroupIds[i] === groupId &&
-							<portlet:namespace />deleteGroupRolesRoleIds[i] === roleId
-						) {
-							<portlet:namespace />deleteGroupRolesGroupIds.splice(i, 1);
-							<portlet:namespace />deleteGroupRolesRoleIds.splice(i, 1);
-
-							break;
-						}
+						Util.toggleDisabled(selectButton, false);
 					}
 
-					<portlet:namespace />addGroupRolesGroupIds.push(groupId);
-					<portlet:namespace />addGroupRolesRoleIds.push(roleId);
+					searchContainer.deleteRow(tr, link.getAttribute('data-rowId'));
 
-					document.<portlet:namespace />fm.<portlet:namespace />addGroupRolesGroupIds.value =
-						<portlet:namespace />addGroupRolesGroupIds.join(',');
-					document.<portlet:namespace />fm.<portlet:namespace />addGroupRolesRoleIds.value =
-						<portlet:namespace />addGroupRolesRoleIds.join(',');
-					document.<portlet:namespace />fm.<portlet:namespace />deleteGroupRolesGroupIds.value =
-						<portlet:namespace />deleteGroupRolesGroupIds.join(',');
-					document.<portlet:namespace />fm.<portlet:namespace />deleteGroupRolesRoleIds.value =
-						<portlet:namespace />deleteGroupRolesRoleIds.join(',');
-
-					searchContainer.addRow(rowColumns, groupId + '-' + roleId);
-				}
-				else {
-					removeRoleButton = removeRoleButton.replace(
-						'data-groupId="TOKEN_DATA_GROUPID"',
-						''
-					);
-
-					rowColumns.push(removeRoleButton);
-
-					<portlet:namespace />deleteRoleIds =
-						<portlet:namespace />deleteRoleIds.filter((deleteRoleId) => {
-							return deleteRoleId !== roleId;
-						});
-
-					<portlet:namespace />addRoleIds.push(roleId);
-
-					document.<portlet:namespace />fm.<portlet:namespace />addRoleIds.value =
-						<portlet:namespace />addRoleIds.join(',');
-					document.<portlet:namespace />fm.<portlet:namespace />deleteRoleIds.value =
-						<portlet:namespace />deleteRoleIds.join(',');
-
-					searchContainer.addRow(rowColumns, roleId);
-				}
-
-				searchContainer.updateDataStore();
-			};
+					<portlet:namespace />deleteRegularRole(rowId);
+				},
+				'.modify-link'
+			);
 		</aui:script>
-
-		<c:if test="<%= userDisplayContext.isShowRegularRoles() %>">
-			<aui:script use="liferay-search-container">
-				var Util = Liferay.Util;
-
-				var searchContainer = Liferay.SearchContainer.get(
-					'<portlet:namespace />rolesSearchContainer'
-				);
-
-				var searchContainerContentBox = searchContainer.get('contentBox');
-
-				searchContainerContentBox.delegate(
-					'click',
-					(event) => {
-						var link = event.currentTarget;
-
-						var rowId = link.attr('data-rowId');
-
-						var tr = link.ancestor('tr');
-
-						var selectRegularRole = Util.getWindow(
-							'<portlet:namespace />selectRegularRole'
-						);
-
-						if (selectRegularRole) {
-							var selectButton = selectRegularRole.iframe.node
-								.get('contentWindow.document')
-								.one('.selector-button[data-entityid="' + rowId + '"]');
-
-							Util.toggleDisabled(selectButton, false);
-						}
-
-						searchContainer.deleteRow(tr, link.getAttribute('data-rowId'));
-
-						<portlet:namespace />deleteRegularRole(rowId);
-					},
-					'.modify-link'
-				);
-			</aui:script>
-		</c:if>
 	</c:if>
-</clay:sheet-section>
+</c:if>
 
 <liferay-util:dynamic-include key="com.liferay.users.admin.web#/user/roles.jsp#post" />

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/roles.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/roles.jsp
@@ -58,275 +58,52 @@ currentURLObj.setParameter("historyKey", liferayPortletResponse.getNamespace() +
 <aui:input name="deleteGroupRolesRoleIds" type="hidden" />
 <aui:input name="deleteRoleIds" type="hidden" />
 
-<clay:sheet-section>
-	<clay:content-row
-		containerElement="div"
-		cssClass="sheet-subtitle"
-	>
-		<clay:content-col
-			expand="<%= true %>"
+<c:if test="<%= userDisplayContext.isShowRegularRoles() %>">
+	<clay:sheet-section>
+		<clay:content-row
+			containerElement="div"
+			cssClass="sheet-subtitle"
 		>
-			<span class="heading-text"><liferay-ui:message key="regular-roles" /></span>
-		</clay:content-col>
-
-		<c:if test="<%= !portletName.equals(myAccountPortletId) %>">
-			<clay:content-col>
-				<clay:button
-					aria-label='<%= LanguageUtil.format(request, "select-x", "regular-roles") %>'
-					cssClass="heading-end modify-link"
-					displayType="secondary"
-					id='<%= liferayPortletResponse.getNamespace() + "selectRegularRoleLink" %>'
-					label='<%= LanguageUtil.get(request, "select") %>'
-					small="<%= true %>"
-				/>
+			<clay:content-col
+				expand="<%= true %>"
+			>
+				<span class="heading-text"><liferay-ui:message key="regular-roles" /></span>
 			</clay:content-col>
-		</c:if>
-	</clay:content-row>
 
-	<liferay-ui:search-container
-		compactEmptyResultsMessage="<%= true %>"
-		cssClass="lfr-search-container-roles"
-		curParam="regularRolesCur"
-		emptyResultsMessage="this-user-is-not-assigned-any-regular-roles"
-		headerNames="title,null"
-		id="rolesSearchContainer"
-		iteratorURL="<%= currentURLObj %>"
-		total="<%= roles.size() %>"
-	>
-		<liferay-ui:search-container-results
-			calculateStartAndEnd="<%= true %>"
-			results="<%= roles %>"
-		/>
-
-		<liferay-ui:search-container-row
-			className="com.liferay.portal.kernel.model.Role"
-			keyProperty="roleId"
-			modelVar="role"
-		>
-			<liferay-ui:search-container-column-text
-				cssClass="table-cell-expand"
-				name="title"
-			>
-				<liferay-ui:icon
-					iconCssClass="<%= role.getIconCssClass() %>"
-					label="<%= true %>"
-					message="<%= HtmlUtil.escape(role.getTitle(locale)) %>"
-				/>
-			</liferay-ui:search-container-column-text>
-
-			<liferay-ui:search-container-column-text
-				cssClass="table-cell-expand"
-				name="status"
-			>
-				<clay:label
-					displayType="<%= WorkflowConstants.getStatusStyle(role.getStatus()) %>"
-					label="<%= WorkflowConstants.getStatusLabel(role.getStatus()) %>"
-				/>
-			</liferay-ui:search-container-column-text>
-
-			<liferay-ui:search-container-column-text>
-				<c:if test="<%= !portletName.equals(myAccountPortletId) && userDisplayContext.isAllowRemoveRole(role) %>">
+			<c:if test="<%= !portletName.equals(myAccountPortletId) %>">
+				<clay:content-col>
 					<clay:button
-						cssClass="lfr-portal-tooltip modify-link"
-						data-rowId="<%= role.getRoleId() %>"
-						displayType="null"
-						icon="times-circle"
+						aria-label='<%= LanguageUtil.format(request, "select-x", "regular-roles") %>'
+						cssClass="heading-end modify-link"
+						displayType="secondary"
+						id='<%= liferayPortletResponse.getNamespace() + "selectRegularRoleLink" %>'
+						label='<%= LanguageUtil.get(request, "select") %>'
 						small="<%= true %>"
-						title='<%= LanguageUtil.format(request, "remove-x", HtmlUtil.escape(role.getTitle(locale))) %>'
 					/>
-				</c:if>
-			</liferay-ui:search-container-column-text>
-		</liferay-ui:search-container-row>
+				</clay:content-col>
+			</c:if>
+		</clay:content-row>
 
-		<liferay-ui:search-iterator
-			markupView="lexicon"
-		/>
-	</liferay-ui:search-container>
-
-	<c:if test="<%= !portletName.equals(myAccountPortletId) %>">
-		<aui:script sandbox="<%= true %>" use="liferay-search-container">
-			var selectRegularRoleLink = document.getElementById(
-				'<portlet:namespace />selectRegularRoleLink'
-			);
-
-			if (selectRegularRoleLink) {
-				selectRegularRoleLink.addEventListener('click', (event) => {
-					var searchContainerName = '<portlet:namespace />rolesSearchContainer';
-
-					var searchContainer = Liferay.SearchContainer.get(searchContainerName);
-
-					let searchContainerData = searchContainer.getData(true);
-
-					<%
-					String[] roleIds = new String[0];
-
-					if (selUser != null) {
-						roleIds = ArrayUtil.toStringArray(selUser.getRoleIds());
-					}
-
-					JSONArray roleIdsJSONArray = JSONFactoryUtil.createJSONArray(roleIds);
-					%>
-
-					if (searchContainerData.length < <%= roleIds.length %>) {
-						searchContainerData = [
-							...new Set([
-								...<%= roleIdsJSONArray.toString() %>,
-								...searchContainerData,
-							]),
-						];
-					}
-
-					Liferay.Util.openSelectionModal({
-						onSelect: function (event) {
-							<portlet:namespace />selectRole(
-								event.entityid,
-								event.entityname,
-								event.searchcontainername,
-								event.groupdescriptivename,
-								event.groupid,
-								event.iconcssclass
-							);
-						},
-
-						<%
-						String regularRoleEventName = liferayPortletResponse.getNamespace() + "selectRegularRole";
-						%>
-
-						selectEventName: '<%= regularRoleEventName %>',
-						selectedData: searchContainerData,
-						title: '<liferay-ui:message arguments="regular-role" key="select-x" />',
-
-						<%
-						PortletURL selectRegularRoleURL = PortletURLBuilder.create(
-							PortletProviderUtil.getPortletURL(request, Role.class.getName(), PortletProvider.Action.BROWSE)
-						).setParameter(
-							"eventName", regularRoleEventName
-						).setParameter(
-							"p_u_i_d", (selUser == null) ? "0" : String.valueOf(selUser.getUserId())
-						).setWindowState(
-							LiferayWindowState.POP_UP
-						).buildPortletURL();
-						%>
-
-						url: '<%= selectRegularRoleURL.toString() %>',
-					});
-				});
-			}
-		</aui:script>
-	</c:if>
-
-	<c:if test="<%= !roleGroups.isEmpty() %>">
-		<span class="sheet-tertiary-title"><liferay-ui:message key="inherited-regular-roles" /></span>
-
-		<liferay-ui:search-container
-			cssClass="lfr-search-container-inherited-regular-roles"
-			curParam="inheritedRegularRolesCur"
-			headerNames="title,group"
-			id="inheritedRolesSearchContainer"
-			iteratorURL="<%= currentURLObj %>"
-			total="<%= roleGroups.size() %>"
-		>
-			<liferay-ui:search-container-results
-				calculateStartAndEnd="<%= true %>"
-				results="<%= roleGroups %>"
-			/>
-
-			<liferay-ui:search-container-row
-				className="com.liferay.portal.kernel.model.Group"
-				keyProperty="groupId"
-				modelVar="group"
-				rowIdProperty="friendlyURL"
-			>
-
-				<%
-				List<Role> groupRoles = RoleLocalServiceUtil.getGroupRoles(group.getGroupId());
-				%>
-
-				<liferay-ui:search-container-column-text
-					cssClass="table-cell-expand"
-					name="title"
-					value="<%= HtmlUtil.escape(ListUtil.toString(groupRoles, Role.TITLE_ACCESSOR)) %>"
-				>
-
-					<%
-					Role groupRole = groupRoles.get(0);
-					%>
-
-					<liferay-ui:icon
-						iconCssClass="<%= groupRole.getIconCssClass() %>"
-						label="<%= true %>"
-						message="<%= HtmlUtil.escape(ListUtil.toString(groupRoles, Role.NAME_ACCESSOR)) %>"
-					/>
-				</liferay-ui:search-container-column-text>
-
-				<liferay-ui:search-container-column-text
-					name="group"
-					value="<%= HtmlUtil.escape(group.getDescriptiveName(locale)) %>"
-				/>
-			</liferay-ui:search-container-row>
-
-			<liferay-ui:search-iterator
-				markupView="lexicon"
-			/>
-		</liferay-ui:search-container>
-	</c:if>
-</clay:sheet-section>
-
-<clay:sheet-section>
-	<clay:content-row
-		containerElement="div"
-		cssClass="sheet-subtitle"
-	>
-		<clay:content-col
-			expand="<%= true %>"
-		>
-			<span class="heading-text"><liferay-ui:message key="organization-roles" /></span>
-		</clay:content-col>
-
-		<c:if test="<%= !portletName.equals(myAccountPortletId) && (!organizations.isEmpty() || !organizationRoles.isEmpty()) %>">
-			<clay:content-col>
-				<clay:button
-					aria-label='<%= LanguageUtil.format(request, "select-x", "organization-roles") %>'
-					cssClass="heading-end modify-link"
-					displayType="secondary"
-					id='<%= liferayPortletResponse.getNamespace() + "selectOrganizationRoleLink" %>'
-					label='<%= LanguageUtil.get(request, "select") %>'
-					small="<%= true %>"
-				/>
-			</clay:content-col>
-		</c:if>
-	</clay:content-row>
-
-	<c:if test="<%= organizations.isEmpty() && organizationRoles.isEmpty() %>">
-		<div class="sheet-text"><liferay-ui:message key="this-user-does-not-belong-to-an-organization-to-which-an-organization-role-can-be-assigned" /></div>
-	</c:if>
-
-	<c:if test="<%= !organizations.isEmpty() %>">
 		<liferay-ui:search-container
 			compactEmptyResultsMessage="<%= true %>"
-			cssClass="lfr-search-container-organization-roles"
-			curParam="organizationRolesCur"
-			emptyResultsMessage="this-user-is-not-assigned-any-organization-roles"
-			headerNames="title,organization,null"
-			id="organizationRolesSearchContainer"
+			cssClass="lfr-search-container-roles"
+			curParam="regularRolesCur"
+			emptyResultsMessage="this-user-is-not-assigned-any-regular-roles"
+			headerNames="title,null"
+			id="rolesSearchContainer"
 			iteratorURL="<%= currentURLObj %>"
-			total="<%= organizationRoles.size() %>"
+			total="<%= roles.size() %>"
 		>
 			<liferay-ui:search-container-results
 				calculateStartAndEnd="<%= true %>"
-				results="<%= organizationRoles %>"
+				results="<%= roles %>"
 			/>
 
 			<liferay-ui:search-container-row
-				className="com.liferay.portal.kernel.model.UserGroupRole"
+				className="com.liferay.portal.kernel.model.Role"
 				keyProperty="roleId"
-				modelVar="userGroupRole"
+				modelVar="role"
 			>
-
-				<%
-				Role role = userGroupRole.getRole();
-				%>
-
 				<liferay-ui:search-container-column-text
 					cssClass="table-cell-expand"
 					name="title"
@@ -340,12 +117,6 @@ currentURLObj.setParameter("historyKey", liferayPortletResponse.getNamespace() +
 
 				<liferay-ui:search-container-column-text
 					cssClass="table-cell-expand"
-					name="organization"
-					value="<%= HtmlUtil.escape(userGroupRole.getGroup().getDescriptiveName(locale)) %>"
-				/>
-
-				<liferay-ui:search-container-column-text
-					cssClass="table-cell-expand"
 					name="status"
 				>
 					<clay:label
@@ -354,32 +125,18 @@ currentURLObj.setParameter("historyKey", liferayPortletResponse.getNamespace() +
 					/>
 				</liferay-ui:search-container-column-text>
 
-				<%
-				boolean membershipProtected = false;
-
-				Group group = userGroupRole.getGroup();
-
-				if (role.getType() == RoleConstants.TYPE_ORGANIZATION) {
-					membershipProtected = OrganizationMembershipPolicyUtil.isMembershipProtected(permissionChecker, userGroupRole.getUserId(), group.getOrganizationId());
-				}
-				else {
-					membershipProtected = SiteMembershipPolicyUtil.isMembershipProtected(permissionChecker, userGroupRole.getUserId(), group.getGroupId());
-				}
-				%>
-
-				<c:if test="<%= !portletName.equals(myAccountPortletId) && !membershipProtected %>">
-					<liferay-ui:search-container-column-text>
+				<liferay-ui:search-container-column-text>
+					<c:if test="<%= !portletName.equals(myAccountPortletId) && userDisplayContext.isAllowRemoveRole(role) %>">
 						<clay:button
 							cssClass="lfr-portal-tooltip modify-link"
-							data-groupId="<%= userGroupRole.getGroupId() %>"
-							data-rowId="<%= userGroupRole.getRoleId() %>"
+							data-rowId="<%= role.getRoleId() %>"
 							displayType="null"
 							icon="times-circle"
 							small="<%= true %>"
-							title='<%= LanguageUtil.format(request, "remove-x", HtmlUtil.escape(userGroupRole.getGroup().getDescriptiveName(locale))) %>'
+							title='<%= LanguageUtil.format(request, "remove-x", HtmlUtil.escape(role.getTitle(locale))) %>'
 						/>
-					</liferay-ui:search-container-column-text>
-				</c:if>
+					</c:if>
+				</liferay-ui:search-container-column-text>
 			</liferay-ui:search-container-row>
 
 			<liferay-ui:search-iterator
@@ -388,449 +145,698 @@ currentURLObj.setParameter("historyKey", liferayPortletResponse.getNamespace() +
 		</liferay-ui:search-container>
 
 		<c:if test="<%= !portletName.equals(myAccountPortletId) %>">
-			<aui:script use="liferay-search-container">
-				var Util = Liferay.Util;
+			<aui:script sandbox="<%= true %>" use="liferay-search-container">
+				var selectRegularRoleLink = document.getElementById(
+					'<portlet:namespace />selectRegularRoleLink'
+				);
 
-				var searchContainerName =
-					'<portlet:namespace />organizationRolesSearchContainer';
+				if (selectRegularRoleLink) {
+					selectRegularRoleLink.addEventListener('click', (event) => {
+						var searchContainerName = '<portlet:namespace />rolesSearchContainer';
 
-				var searchContainer = Liferay.SearchContainer.get(searchContainerName);
+						var searchContainer = Liferay.SearchContainer.get(searchContainerName);
 
-				<portlet:namespace />searchContainerUpdateDataStore(searchContainer);
+						let searchContainerData = searchContainer.getData(true);
 
-				var searchContainerContentBox = searchContainer.get('contentBox');
+						<%
+						String[] roleIds = new String[0];
 
-				searchContainerContentBox.delegate(
-					'click',
-					(event) => {
-						var link = event.currentTarget;
-						var tr = link.ancestor('tr');
-
-						var groupId = link.getAttribute('data-groupId');
-						var rowId = link.getAttribute('data-rowId');
-						var id = groupId + '-' + rowId;
-
-						var selectOrganizationRole = Util.getWindow(
-							'<portlet:namespace />selectOrganizationRole'
-						);
-
-						if (selectOrganizationRole) {
-							var selectButton = selectOrganizationRole.iframe.node
-								.get('contentWindow.document')
-								.one(
-									'.selector-button[data-groupid="' +
-										groupId +
-										'"][data-entityid="' +
-										rowId +
-										'"]'
-								);
-
-							Util.toggleDisabled(selectButton, false);
+						if (selUser != null) {
+							roleIds = ArrayUtil.toStringArray(selUser.getRoleIds());
 						}
 
-						searchContainer.deleteRow(tr, id);
+						JSONArray roleIdsJSONArray = JSONFactoryUtil.createJSONArray(roleIds);
+						%>
 
-						<portlet:namespace />deleteGroupRole(rowId, groupId);
-					},
-					'.modify-link'
-				);
+						if (searchContainerData.length < <%= roleIds.length %>) {
+							searchContainerData = [
+								...new Set([
+									...<%= roleIdsJSONArray.toString() %>,
+									...searchContainerData,
+								]),
+							];
+						}
+
+						Liferay.Util.openSelectionModal({
+							onSelect: function (event) {
+								<portlet:namespace />selectRole(
+									event.entityid,
+									event.entityname,
+									event.searchcontainername,
+									event.groupdescriptivename,
+									event.groupid,
+									event.iconcssclass
+								);
+							},
+
+							<%
+							String regularRoleEventName = liferayPortletResponse.getNamespace() + "selectRegularRole";
+							%>
+
+							selectEventName: '<%= regularRoleEventName %>',
+							selectedData: searchContainerData,
+							title: '<liferay-ui:message arguments="regular-role" key="select-x" />',
+
+							<%
+							PortletURL selectRegularRoleURL = PortletURLBuilder.create(
+								PortletProviderUtil.getPortletURL(request, Role.class.getName(), PortletProvider.Action.BROWSE)
+							).setParameter(
+								"eventName", regularRoleEventName
+							).setParameter(
+								"p_u_i_d", (selUser == null) ? "0" : String.valueOf(selUser.getUserId())
+							).setWindowState(
+								LiferayWindowState.POP_UP
+							).buildPortletURL();
+							%>
+
+							url: '<%= selectRegularRoleURL.toString() %>',
+						});
+					});
+				}
 			</aui:script>
 		</c:if>
-	</c:if>
 
-	<c:if test="<%= !organizations.isEmpty() && !portletName.equals(myAccountPortletId) %>">
-		<aui:script sandbox="<%= true %>" use="liferay-search-container">
-			var selectOrganizationRoleLink = document.getElementById(
-				'<portlet:namespace />selectOrganizationRoleLink'
-			);
+		<c:if test="<%= !roleGroups.isEmpty() %>">
+			<span class="sheet-tertiary-title"><liferay-ui:message key="inherited-regular-roles" /></span>
 
-			if (selectOrganizationRoleLink) {
-				selectOrganizationRoleLink.addEventListener('click', (event) => {
+			<liferay-ui:search-container
+				cssClass="lfr-search-container-inherited-regular-roles"
+				curParam="inheritedRegularRolesCur"
+				headerNames="title,group"
+				id="inheritedRolesSearchContainer"
+				iteratorURL="<%= currentURLObj %>"
+				total="<%= roleGroups.size() %>"
+			>
+				<liferay-ui:search-container-results
+					calculateStartAndEnd="<%= true %>"
+					results="<%= roleGroups %>"
+				/>
+
+				<liferay-ui:search-container-row
+					className="com.liferay.portal.kernel.model.Group"
+					keyProperty="groupId"
+					modelVar="group"
+					rowIdProperty="friendlyURL"
+				>
+
+					<%
+					List<Role> groupRoles = RoleLocalServiceUtil.getGroupRoles(group.getGroupId());
+					%>
+
+					<liferay-ui:search-container-column-text
+						cssClass="table-cell-expand"
+						name="title"
+						value="<%= HtmlUtil.escape(ListUtil.toString(groupRoles, Role.TITLE_ACCESSOR)) %>"
+					>
+
+						<%
+						Role groupRole = groupRoles.get(0);
+						%>
+
+						<liferay-ui:icon
+							iconCssClass="<%= groupRole.getIconCssClass() %>"
+							label="<%= true %>"
+							message="<%= HtmlUtil.escape(ListUtil.toString(groupRoles, Role.NAME_ACCESSOR)) %>"
+						/>
+					</liferay-ui:search-container-column-text>
+
+					<liferay-ui:search-container-column-text
+						name="group"
+						value="<%= HtmlUtil.escape(group.getDescriptiveName(locale)) %>"
+					/>
+				</liferay-ui:search-container-row>
+
+				<liferay-ui:search-iterator
+					markupView="lexicon"
+				/>
+			</liferay-ui:search-container>
+		</c:if>
+	</clay:sheet-section>
+</c:if>
+
+<c:if test="<%= userDisplayContext.isShowOrganizationRoles() %>">
+	<clay:sheet-section>
+		<clay:content-row
+			containerElement="div"
+			cssClass="sheet-subtitle"
+		>
+			<clay:content-col
+				expand="<%= true %>"
+			>
+				<span class="heading-text"><liferay-ui:message key="organization-roles" /></span>
+			</clay:content-col>
+
+			<c:if test="<%= !portletName.equals(myAccountPortletId) && (!organizations.isEmpty() || !organizationRoles.isEmpty()) %>">
+				<clay:content-col>
+					<clay:button
+						aria-label='<%= LanguageUtil.format(request, "select-x", "organization-roles") %>'
+						cssClass="heading-end modify-link"
+						displayType="secondary"
+						id='<%= liferayPortletResponse.getNamespace() + "selectOrganizationRoleLink" %>'
+						label='<%= LanguageUtil.get(request, "select") %>'
+						small="<%= true %>"
+					/>
+				</clay:content-col>
+			</c:if>
+		</clay:content-row>
+
+		<c:if test="<%= organizations.isEmpty() && organizationRoles.isEmpty() %>">
+			<div class="sheet-text"><liferay-ui:message key="this-user-does-not-belong-to-an-organization-to-which-an-organization-role-can-be-assigned" /></div>
+		</c:if>
+
+		<c:if test="<%= !organizations.isEmpty() %>">
+			<liferay-ui:search-container
+				compactEmptyResultsMessage="<%= true %>"
+				cssClass="lfr-search-container-organization-roles"
+				curParam="organizationRolesCur"
+				emptyResultsMessage="this-user-is-not-assigned-any-organization-roles"
+				headerNames="title,organization,null"
+				id="organizationRolesSearchContainer"
+				iteratorURL="<%= currentURLObj %>"
+				total="<%= organizationRoles.size() %>"
+			>
+				<liferay-ui:search-container-results
+					calculateStartAndEnd="<%= true %>"
+					results="<%= organizationRoles %>"
+				/>
+
+				<liferay-ui:search-container-row
+					className="com.liferay.portal.kernel.model.UserGroupRole"
+					keyProperty="roleId"
+					modelVar="userGroupRole"
+				>
+
+					<%
+					Role role = userGroupRole.getRole();
+					%>
+
+					<liferay-ui:search-container-column-text
+						cssClass="table-cell-expand"
+						name="title"
+					>
+						<liferay-ui:icon
+							iconCssClass="<%= role.getIconCssClass() %>"
+							label="<%= true %>"
+							message="<%= HtmlUtil.escape(role.getTitle(locale)) %>"
+						/>
+					</liferay-ui:search-container-column-text>
+
+					<liferay-ui:search-container-column-text
+						cssClass="table-cell-expand"
+						name="organization"
+						value="<%= HtmlUtil.escape(userGroupRole.getGroup().getDescriptiveName(locale)) %>"
+					/>
+
+					<liferay-ui:search-container-column-text
+						cssClass="table-cell-expand"
+						name="status"
+					>
+						<clay:label
+							displayType="<%= WorkflowConstants.getStatusStyle(role.getStatus()) %>"
+							label="<%= WorkflowConstants.getStatusLabel(role.getStatus()) %>"
+						/>
+					</liferay-ui:search-container-column-text>
+
+					<%
+					boolean membershipProtected = false;
+
+					Group group = userGroupRole.getGroup();
+
+					if (role.getType() == RoleConstants.TYPE_ORGANIZATION) {
+						membershipProtected = OrganizationMembershipPolicyUtil.isMembershipProtected(permissionChecker, userGroupRole.getUserId(), group.getOrganizationId());
+					}
+					else {
+						membershipProtected = SiteMembershipPolicyUtil.isMembershipProtected(permissionChecker, userGroupRole.getUserId(), group.getGroupId());
+					}
+					%>
+
+					<c:if test="<%= !portletName.equals(myAccountPortletId) && !membershipProtected %>">
+						<liferay-ui:search-container-column-text>
+							<clay:button
+								cssClass="lfr-portal-tooltip modify-link"
+								data-groupId="<%= userGroupRole.getGroupId() %>"
+								data-rowId="<%= userGroupRole.getRoleId() %>"
+								displayType="null"
+								icon="times-circle"
+								small="<%= true %>"
+								title='<%= LanguageUtil.format(request, "remove-x", HtmlUtil.escape(userGroupRole.getGroup().getDescriptiveName(locale))) %>'
+							/>
+						</liferay-ui:search-container-column-text>
+					</c:if>
+				</liferay-ui:search-container-row>
+
+				<liferay-ui:search-iterator
+					markupView="lexicon"
+				/>
+			</liferay-ui:search-container>
+
+			<c:if test="<%= !portletName.equals(myAccountPortletId) %>">
+				<aui:script use="liferay-search-container">
+					var Util = Liferay.Util;
+
 					var searchContainerName =
 						'<portlet:namespace />organizationRolesSearchContainer';
 
 					var searchContainer = Liferay.SearchContainer.get(searchContainerName);
 
-					Liferay.Util.openSelectionModal({
-						onSelect: function (event) {
-							<portlet:namespace />selectRole(
-								event.entityid,
-								event.entityname,
-								event.searchcontainername,
-								event.groupdescriptivename,
-								event.groupid,
-								event.iconcssclass
+					<portlet:namespace />searchContainerUpdateDataStore(searchContainer);
+
+					var searchContainerContentBox = searchContainer.get('contentBox');
+
+					searchContainerContentBox.delegate(
+						'click',
+						(event) => {
+							var link = event.currentTarget;
+							var tr = link.ancestor('tr');
+
+							var groupId = link.getAttribute('data-groupId');
+							var rowId = link.getAttribute('data-rowId');
+							var id = groupId + '-' + rowId;
+
+							var selectOrganizationRole = Util.getWindow(
+								'<portlet:namespace />selectOrganizationRole'
 							);
+
+							if (selectOrganizationRole) {
+								var selectButton = selectOrganizationRole.iframe.node
+									.get('contentWindow.document')
+									.one(
+										'.selector-button[data-groupid="' +
+											groupId +
+											'"][data-entityid="' +
+											rowId +
+											'"]'
+									);
+
+								Util.toggleDisabled(selectButton, false);
+							}
+
+							searchContainer.deleteRow(tr, id);
+
+							<portlet:namespace />deleteGroupRole(rowId, groupId);
 						},
-
-						<%
-						String groupEventName = liferayPortletResponse.getNamespace() + "selectOrganization";
-						String organizationRoleEventName = liferayPortletResponse.getNamespace() + "selectOrganizationRole";
-						%>
-
-						selectEventName: '<%= organizationRoleEventName %>',
-						title: '<liferay-ui:message arguments="organization-role" key="select-x" />',
-
-						<%
-						PortletURL selectOrganizationRoleURL = PortletURLBuilder.create(
-							PortletProviderUtil.getPortletURL(request, Role.class.getName(), PortletProvider.Action.BROWSE)
-						).setParameter(
-							"eventName", organizationRoleEventName
-						).setParameter(
-							"groupEventName", groupEventName
-						).setParameter(
-							"organizationId", ((organizationIds != null) && (organizationIds.length == 1)) ? String.valueOf(organizationIds[0]) : null
-						).setParameter(
-							"organizationIds", StringUtil.merge(organizationIds)
-						).setParameter(
-							"p_u_i_d", (selUser == null) ? "0" : String.valueOf(selUser.getUserId())
-						).setParameter(
-							"roleType", RoleConstants.TYPE_ORGANIZATION
-						).setParameter(
-							"step", ((organizationIds != null) && (organizationIds.length == 1)) ? "2" : "1"
-						).setWindowState(
-							LiferayWindowState.POP_UP
-						).buildPortletURL();
-						%>
-
-						url: '<%= selectOrganizationRoleURL.toString() %>',
-					});
-
-					Liferay.on('<%= groupEventName %>', () => {
-						const iframe = document.querySelector('.liferay-modal iframe');
-
-						if (iframe) {
-							const iframeDocument = iframe.contentWindow.document;
-
-							const selectedDataSet = new Set(searchContainer.getData(true));
-
-							const selectButtons =
-								iframeDocument.querySelectorAll('.selector-button');
-
-							selectButtons.forEach((selectButton) => {
-								const selectButtonId =
-									selectButton.dataset.groupid +
-									'-' +
-									selectButton.dataset.entityid;
-
-								if (selectedDataSet.has(selectButtonId)) {
-									selectButton.disabled = true;
-									selectButton.classList.add('disabled');
-								}
-								else {
-									selectButton.disabled = false;
-									selectButton.classList.remove('disabled');
-								}
-							});
-						}
-					});
-				});
-			}
-		</aui:script>
-	</c:if>
-</clay:sheet-section>
-
-<clay:sheet-section>
-	<clay:content-row
-		containerElement="div"
-		cssClass="sheet-subtitle"
-	>
-		<clay:content-col
-			expand="<%= true %>"
-		>
-			<span class="heading-text"><liferay-ui:message key="site-roles" /></span>
-		</clay:content-col>
-
-		<c:if test="<%= !portletName.equals(myAccountPortletId) && (!groups.isEmpty() || !siteRoles.isEmpty()) %>">
-			<clay:content-col>
-				<clay:button
-					aria-label='<%= LanguageUtil.format(request, "select-x", "site-roles") %>'
-					cssClass="heading-end modify-link"
-					displayType="secondary"
-					id='<%= liferayPortletResponse.getNamespace() + "selectSiteRoleLink" %>'
-					label='<%= LanguageUtil.get(request, "select") %>'
-					small="<%= true %>"
-				/>
-			</clay:content-col>
+						'.modify-link'
+					);
+				</aui:script>
+			</c:if>
 		</c:if>
-	</clay:content-row>
 
-	<c:if test="<%= groups.isEmpty() && siteRoles.isEmpty() %>">
-		<div class="sheet-text"><liferay-ui:message key="this-user-does-not-belong-to-a-site-to-which-a-site-role-can-be-assigned" /></div>
-	</c:if>
-
-	<c:if test="<%= !groups.isEmpty() %>">
-		<liferay-ui:search-container
-			compactEmptyResultsMessage="<%= true %>"
-			cssClass="lfr-search-container-site-roles"
-			curParam="siteRolesCur"
-			emptyResultsMessage="this-user-is-not-assigned-any-site-roles"
-			headerNames="title,site,null"
-			id="siteRolesSearchContainer"
-			iteratorURL="<%= currentURLObj %>"
-			total="<%= siteRoles.size() %>"
-		>
-			<liferay-ui:search-container-results
-				calculateStartAndEnd="<%= true %>"
-				results="<%= siteRoles %>"
-			/>
-
-			<liferay-ui:search-container-row
-				className="com.liferay.portal.kernel.model.UserGroupRole"
-				keyProperty="roleId"
-				modelVar="userGroupRole"
-			>
-
-				<%
-				Role role = userGroupRole.getRole();
-				%>
-
-				<liferay-ui:search-container-column-text
-					cssClass="table-cell-expand"
-					name="title"
-				>
-					<liferay-ui:icon
-						iconCssClass="<%= role.getIconCssClass() %>"
-						label="<%= true %>"
-						message="<%= HtmlUtil.escape(role.getTitle(locale)) %>"
-					/>
-				</liferay-ui:search-container-column-text>
-
-				<liferay-ui:search-container-column-text
-					cssClass="table-cell-expand"
-					name="site"
-				>
-					<liferay-staging:descriptive-name
-						group="<%= userGroupRole.getGroup() %>"
-					/>
-				</liferay-ui:search-container-column-text>
-
-				<liferay-ui:search-container-column-text
-					cssClass="table-cell-expand"
-					name="status"
-				>
-					<clay:label
-						displayType="<%= WorkflowConstants.getStatusStyle(role.getStatus()) %>"
-						label="<%= WorkflowConstants.getStatusLabel(role.getStatus()) %>"
-					/>
-				</liferay-ui:search-container-column-text>
-
-				<%
-				boolean membershipProtected = false;
-
-				Group group = userGroupRole.getGroup();
-
-				if (role.getType() == RoleConstants.TYPE_ORGANIZATION) {
-					membershipProtected = OrganizationMembershipPolicyUtil.isMembershipProtected(permissionChecker, userGroupRole.getUserId(), group.getOrganizationId());
-				}
-				else {
-					membershipProtected = SiteMembershipPolicyUtil.isMembershipProtected(permissionChecker, userGroupRole.getUserId(), group.getGroupId());
-				}
-				%>
-
-				<c:if test="<%= !portletName.equals(myAccountPortletId) && !membershipProtected %>">
-					<liferay-ui:search-container-column-text>
-						<clay:button
-							cssClass="lfr-portal-tooltip modify-link"
-							data-groupId="<%= userGroupRole.getGroupId() %>"
-							data-rowId="<%= userGroupRole.getRoleId() %>"
-							displayType="null"
-							icon="times-circle"
-							small="<%= true %>"
-							title='<%= LanguageUtil.format(request, "remove-x", HtmlUtil.escape(userGroupRole.getRole().getTitle(locale))) %>'
-						/>
-					</liferay-ui:search-container-column-text>
-				</c:if>
-			</liferay-ui:search-container-row>
-
-			<liferay-ui:search-iterator
-				markupView="lexicon"
-			/>
-		</liferay-ui:search-container>
-
-		<c:if test="<%= !portletName.equals(myAccountPortletId) %>">
-			<aui:script use="liferay-search-container">
-				var Util = Liferay.Util;
-
-				var searchContainerName = '<portlet:namespace />siteRolesSearchContainer';
-
-				var searchContainer = Liferay.SearchContainer.get(searchContainerName);
-
-				<portlet:namespace />searchContainerUpdateDataStore(searchContainer);
-
-				var searchContainerContentBox = searchContainer.get('contentBox');
-
-				searchContainerContentBox.delegate(
-					'click',
-					(event) => {
-						var link = event.currentTarget;
-						var tr = link.ancestor('tr');
-
-						var groupId = link.getAttribute('data-groupId');
-						var rowId = link.getAttribute('data-rowId');
-						var id = groupId + '-' + rowId;
-
-						var selectSiteRole = Util.getWindow(
-							'<portlet:namespace />selectSiteRole'
-						);
-
-						if (selectSiteRole) {
-							var selectButton = selectSiteRole.iframe.node
-								.get('contentWindow.document')
-								.one(
-									'.selector-button[data-groupid="' +
-										groupId +
-										'"][data-entityid="' +
-										rowId +
-										'"]'
-								);
-
-							Util.toggleDisabled(selectButton, false);
-						}
-
-						searchContainer.deleteRow(tr, id);
-
-						<portlet:namespace />deleteGroupRole(rowId, groupId);
-					},
-					'.modify-link'
+		<c:if test="<%= !organizations.isEmpty() && !portletName.equals(myAccountPortletId) %>">
+			<aui:script sandbox="<%= true %>" use="liferay-search-container">
+				var selectOrganizationRoleLink = document.getElementById(
+					'<portlet:namespace />selectOrganizationRoleLink'
 				);
 
-				const selectSiteRoleLink = document.getElementById(
-					'<portlet:namespace />selectSiteRoleLink'
-				);
+				if (selectOrganizationRoleLink) {
+					selectOrganizationRoleLink.addEventListener('click', (event) => {
+						var searchContainerName =
+							'<portlet:namespace />organizationRolesSearchContainer';
 
-				if (selectSiteRoleLink) {
-					selectSiteRoleLink.addEventListener('click', (event) => {
-						Util.openSelectionModal({
-							onSelect: (selectedItem) => {
+						var searchContainer = Liferay.SearchContainer.get(searchContainerName);
+
+						Liferay.Util.openSelectionModal({
+							onSelect: function (event) {
 								<portlet:namespace />selectRole(
-									selectedItem.entityid,
-									selectedItem.entityname,
-									selectedItem.searchcontainername,
-									selectedItem.groupdescriptivename,
-									selectedItem.groupid,
-									selectedItem.iconcssclass
+									event.entityid,
+									event.entityname,
+									event.searchcontainername,
+									event.groupdescriptivename,
+									event.groupid,
+									event.iconcssclass
 								);
 							},
 
 							<%
-							String groupEventName = liferayPortletResponse.getNamespace() + "selectSite";
-							String siteRoleEventName = liferayPortletResponse.getNamespace() + "selectSiteRole";
+							String groupEventName = liferayPortletResponse.getNamespace() + "selectOrganization";
+							String organizationRoleEventName = liferayPortletResponse.getNamespace() + "selectOrganizationRole";
 							%>
 
-							selectEventName: '<%= siteRoleEventName %>',
+							selectEventName: '<%= organizationRoleEventName %>',
+							title: '<liferay-ui:message arguments="organization-role" key="select-x" />',
 
-							title: '<liferay-ui:message arguments="site-role" key="select-x" />',
-							url: '<%=
-								PortletURLBuilder.create(
-									PortletProviderUtil.getPortletURL(request, Role.class.getName(), PortletProvider.Action.BROWSE)
-								).setParameter(
-									"eventName", siteRoleEventName
-								).setParameter(
-									"groupEventName", groupEventName
-								).setParameter(
-									"p_u_i_d", (selUser == null) ? "0" : String.valueOf(selUser.getUserId())
-								).setParameter(
-									"roleType", RoleConstants.TYPE_SITE
-								).setParameter(
-									"step", "1"
-								).setWindowState(
-									LiferayWindowState.POP_UP
-								).buildPortletURL()
-								%>',
+							<%
+							PortletURL selectOrganizationRoleURL = PortletURLBuilder.create(
+								PortletProviderUtil.getPortletURL(request, Role.class.getName(), PortletProvider.Action.BROWSE)
+							).setParameter(
+								"eventName", organizationRoleEventName
+							).setParameter(
+								"groupEventName", groupEventName
+							).setParameter(
+								"organizationId", ((organizationIds != null) && (organizationIds.length == 1)) ? String.valueOf(organizationIds[0]) : null
+							).setParameter(
+								"organizationIds", StringUtil.merge(organizationIds)
+							).setParameter(
+								"p_u_i_d", (selUser == null) ? "0" : String.valueOf(selUser.getUserId())
+							).setParameter(
+								"roleType", RoleConstants.TYPE_ORGANIZATION
+							).setParameter(
+								"step", ((organizationIds != null) && (organizationIds.length == 1)) ? "2" : "1"
+							).setWindowState(
+								LiferayWindowState.POP_UP
+							).buildPortletURL();
+							%>
+
+							url: '<%= selectOrganizationRoleURL.toString() %>',
 						});
-					});
 
-					Liferay.on('<%= groupEventName %>', () => {
-						const iframe = document.querySelector('.liferay-modal iframe');
+						Liferay.on('<%= groupEventName %>', () => {
+							const iframe = document.querySelector('.liferay-modal iframe');
 
-						if (iframe) {
-							const iframeDocument = iframe.contentWindow.document;
+							if (iframe) {
+								const iframeDocument = iframe.contentWindow.document;
 
-							const selectedDataSet = new Set(searchContainer.getData(true));
+								const selectedDataSet = new Set(searchContainer.getData(true));
 
-							const selectButtons =
-								iframeDocument.querySelectorAll('.selector-button');
+								const selectButtons =
+									iframeDocument.querySelectorAll('.selector-button');
 
-							selectButtons.forEach((selectButton) => {
-								const selectButtonId =
-									selectButton.dataset.groupid +
-									'-' +
-									selectButton.dataset.entityid;
+								selectButtons.forEach((selectButton) => {
+									const selectButtonId =
+										selectButton.dataset.groupid +
+										'-' +
+										selectButton.dataset.entityid;
 
-								if (selectedDataSet.has(selectButtonId)) {
-									selectButton.disabled = true;
-									selectButton.classList.add('disabled');
-								}
-								else {
-									selectButton.disabled = false;
-									selectButton.classList.remove('disabled');
-								}
-							});
-						}
+									if (selectedDataSet.has(selectButtonId)) {
+										selectButton.disabled = true;
+										selectButton.classList.add('disabled');
+									}
+									else {
+										selectButton.disabled = false;
+										selectButton.classList.remove('disabled');
+									}
+								});
+							}
+						});
 					});
 				}
 			</aui:script>
 		</c:if>
-	</c:if>
+	</clay:sheet-section>
+</c:if>
 
-	<c:if test="<%= !inheritedSiteRoles.isEmpty() %>">
-		<span class="sheet-tertiary-title"><liferay-ui:message key="inherited-site-roles" /></span>
-
-		<liferay-ui:search-container
-			cssClass="lfr-search-container-inherited-site-roles"
-			curParam="inheritedSiteRolesCur"
-			headerNames="title,site,user-group"
-			id="inheritedSiteRolesSearchContainer"
-			iteratorURL="<%= currentURLObj %>"
-			total="<%= inheritedSiteRoles.size() %>"
+<clay:sheet-section>
+	<c:if test="<%= userDisplayContext.isShowSiteRoles() %>">
+		<clay:content-row
+			containerElement="div"
+			cssClass="sheet-subtitle"
 		>
-			<liferay-ui:search-container-results
-				calculateStartAndEnd="<%= true %>"
-				results="<%= inheritedSiteRoles %>"
-			/>
-
-			<liferay-ui:search-container-row
-				className="com.liferay.portal.kernel.model.UserGroupGroupRole"
-				keyProperty="roleId"
-				modelVar="userGroupGroupRole"
+			<clay:content-col
+				expand="<%= true %>"
 			>
-				<liferay-ui:search-container-column-text
-					cssClass="table-cell-expand"
-					name="title"
+				<span class="heading-text"><liferay-ui:message key="site-roles" /></span>
+			</clay:content-col>
+
+			<c:if test="<%= !portletName.equals(myAccountPortletId) && (!groups.isEmpty() || !siteRoles.isEmpty()) %>">
+				<clay:content-col>
+					<clay:button
+						aria-label='<%= LanguageUtil.format(request, "select-x", "site-roles") %>'
+						cssClass="heading-end modify-link"
+						displayType="secondary"
+						id='<%= liferayPortletResponse.getNamespace() + "selectSiteRoleLink" %>'
+						label='<%= LanguageUtil.get(request, "select") %>'
+						small="<%= true %>"
+					/>
+				</clay:content-col>
+			</c:if>
+		</clay:content-row>
+
+		<c:if test="<%= groups.isEmpty() && siteRoles.isEmpty() %>">
+			<div class="sheet-text"><liferay-ui:message key="this-user-does-not-belong-to-a-site-to-which-a-site-role-can-be-assigned" /></div>
+		</c:if>
+
+		<c:if test="<%= !groups.isEmpty() %>">
+			<liferay-ui:search-container
+				compactEmptyResultsMessage="<%= true %>"
+				cssClass="lfr-search-container-site-roles"
+				curParam="siteRolesCur"
+				emptyResultsMessage="this-user-is-not-assigned-any-site-roles"
+				headerNames="title,site,null"
+				id="siteRolesSearchContainer"
+				iteratorURL="<%= currentURLObj %>"
+				total="<%= siteRoles.size() %>"
+			>
+				<liferay-ui:search-container-results
+					calculateStartAndEnd="<%= true %>"
+					results="<%= siteRoles %>"
+				/>
+
+				<liferay-ui:search-container-row
+					className="com.liferay.portal.kernel.model.UserGroupRole"
+					keyProperty="roleId"
+					modelVar="userGroupRole"
 				>
 
 					<%
-					Role role = userGroupGroupRole.getRole();
+					Role role = userGroupRole.getRole();
 					%>
 
-					<liferay-ui:icon
-						iconCssClass="<%= role.getIconCssClass() %>"
-						label="<%= true %>"
-						message="<%= HtmlUtil.escape(role.getTitle(locale)) %>"
-					/>
-				</liferay-ui:search-container-column-text>
+					<liferay-ui:search-container-column-text
+						cssClass="table-cell-expand"
+						name="title"
+					>
+						<liferay-ui:icon
+							iconCssClass="<%= role.getIconCssClass() %>"
+							label="<%= true %>"
+							message="<%= HtmlUtil.escape(role.getTitle(locale)) %>"
+						/>
+					</liferay-ui:search-container-column-text>
 
-				<liferay-ui:search-container-column-text
-					cssClass="table-cell-expand"
-					name="site"
-				>
-					<liferay-staging:descriptive-name
-						group="<%= userGroupGroupRole.getGroup() %>"
-					/>
-				</liferay-ui:search-container-column-text>
+					<liferay-ui:search-container-column-text
+						cssClass="table-cell-expand"
+						name="site"
+					>
+						<liferay-staging:descriptive-name
+							group="<%= userGroupRole.getGroup() %>"
+						/>
+					</liferay-ui:search-container-column-text>
 
-				<liferay-ui:search-container-column-text
-					cssClass="table-cell-expand"
-					name="user-group"
-					value="<%= HtmlUtil.escape(userGroupGroupRole.getUserGroup().getName()) %>"
+					<liferay-ui:search-container-column-text
+						cssClass="table-cell-expand"
+						name="status"
+					>
+						<clay:label
+							displayType="<%= WorkflowConstants.getStatusStyle(role.getStatus()) %>"
+							label="<%= WorkflowConstants.getStatusLabel(role.getStatus()) %>"
+						/>
+					</liferay-ui:search-container-column-text>
+
+					<%
+					boolean membershipProtected = false;
+
+					Group group = userGroupRole.getGroup();
+
+					if (role.getType() == RoleConstants.TYPE_ORGANIZATION) {
+						membershipProtected = OrganizationMembershipPolicyUtil.isMembershipProtected(permissionChecker, userGroupRole.getUserId(), group.getOrganizationId());
+					}
+					else {
+						membershipProtected = SiteMembershipPolicyUtil.isMembershipProtected(permissionChecker, userGroupRole.getUserId(), group.getGroupId());
+					}
+					%>
+
+					<c:if test="<%= !portletName.equals(myAccountPortletId) && !membershipProtected %>">
+						<liferay-ui:search-container-column-text>
+							<clay:button
+								cssClass="lfr-portal-tooltip modify-link"
+								data-groupId="<%= userGroupRole.getGroupId() %>"
+								data-rowId="<%= userGroupRole.getRoleId() %>"
+								displayType="null"
+								icon="times-circle"
+								small="<%= true %>"
+								title='<%= LanguageUtil.format(request, "remove-x", HtmlUtil.escape(userGroupRole.getRole().getTitle(locale))) %>'
+							/>
+						</liferay-ui:search-container-column-text>
+					</c:if>
+				</liferay-ui:search-container-row>
+
+				<liferay-ui:search-iterator
+					markupView="lexicon"
 				/>
-			</liferay-ui:search-container-row>
+			</liferay-ui:search-container>
 
-			<liferay-ui:search-iterator
-				markupView="lexicon"
-			/>
-		</liferay-ui:search-container>
+			<c:if test="<%= !portletName.equals(myAccountPortletId) %>">
+				<aui:script use="liferay-search-container">
+					var Util = Liferay.Util;
+
+					var searchContainerName = '<portlet:namespace />siteRolesSearchContainer';
+
+					var searchContainer = Liferay.SearchContainer.get(searchContainerName);
+
+					<portlet:namespace />searchContainerUpdateDataStore(searchContainer);
+
+					var searchContainerContentBox = searchContainer.get('contentBox');
+
+					searchContainerContentBox.delegate(
+						'click',
+						(event) => {
+							var link = event.currentTarget;
+							var tr = link.ancestor('tr');
+
+							var groupId = link.getAttribute('data-groupId');
+							var rowId = link.getAttribute('data-rowId');
+							var id = groupId + '-' + rowId;
+
+							var selectSiteRole = Util.getWindow(
+								'<portlet:namespace />selectSiteRole'
+							);
+
+							if (selectSiteRole) {
+								var selectButton = selectSiteRole.iframe.node
+									.get('contentWindow.document')
+									.one(
+										'.selector-button[data-groupid="' +
+											groupId +
+											'"][data-entityid="' +
+											rowId +
+											'"]'
+									);
+
+								Util.toggleDisabled(selectButton, false);
+							}
+
+							searchContainer.deleteRow(tr, id);
+
+							<portlet:namespace />deleteGroupRole(rowId, groupId);
+						},
+						'.modify-link'
+					);
+
+					const selectSiteRoleLink = document.getElementById(
+						'<portlet:namespace />selectSiteRoleLink'
+					);
+
+					if (selectSiteRoleLink) {
+						selectSiteRoleLink.addEventListener('click', (event) => {
+							Util.openSelectionModal({
+								onSelect: (selectedItem) => {
+									<portlet:namespace />selectRole(
+										selectedItem.entityid,
+										selectedItem.entityname,
+										selectedItem.searchcontainername,
+										selectedItem.groupdescriptivename,
+										selectedItem.groupid,
+										selectedItem.iconcssclass
+									);
+								},
+
+								<%
+								String groupEventName = liferayPortletResponse.getNamespace() + "selectSite";
+								String siteRoleEventName = liferayPortletResponse.getNamespace() + "selectSiteRole";
+								%>
+
+								selectEventName: '<%= siteRoleEventName %>',
+
+								title: '<liferay-ui:message arguments="site-role" key="select-x" />',
+								url: '<%=
+									PortletURLBuilder.create(
+										PortletProviderUtil.getPortletURL(request, Role.class.getName(), PortletProvider.Action.BROWSE)
+									).setParameter(
+										"eventName", siteRoleEventName
+									).setParameter(
+										"groupEventName", groupEventName
+									).setParameter(
+										"p_u_i_d", (selUser == null) ? "0" : String.valueOf(selUser.getUserId())
+									).setParameter(
+										"roleType", RoleConstants.TYPE_SITE
+									).setParameter(
+										"step", "1"
+									).setWindowState(
+										LiferayWindowState.POP_UP
+									).buildPortletURL()
+									%>',
+							});
+						});
+
+						Liferay.on('<%= groupEventName %>', () => {
+							const iframe = document.querySelector('.liferay-modal iframe');
+
+							if (iframe) {
+								const iframeDocument = iframe.contentWindow.document;
+
+								const selectedDataSet = new Set(searchContainer.getData(true));
+
+								const selectButtons =
+									iframeDocument.querySelectorAll('.selector-button');
+
+								selectButtons.forEach((selectButton) => {
+									const selectButtonId =
+										selectButton.dataset.groupid +
+										'-' +
+										selectButton.dataset.entityid;
+
+									if (selectedDataSet.has(selectButtonId)) {
+										selectButton.disabled = true;
+										selectButton.classList.add('disabled');
+									}
+									else {
+										selectButton.disabled = false;
+										selectButton.classList.remove('disabled');
+									}
+								});
+							}
+						});
+					}
+				</aui:script>
+			</c:if>
+		</c:if>
+
+		<c:if test="<%= !inheritedSiteRoles.isEmpty() %>">
+			<span class="sheet-tertiary-title"><liferay-ui:message key="inherited-site-roles" /></span>
+
+			<liferay-ui:search-container
+				cssClass="lfr-search-container-inherited-site-roles"
+				curParam="inheritedSiteRolesCur"
+				headerNames="title,site,user-group"
+				id="inheritedSiteRolesSearchContainer"
+				iteratorURL="<%= currentURLObj %>"
+				total="<%= inheritedSiteRoles.size() %>"
+			>
+				<liferay-ui:search-container-results
+					calculateStartAndEnd="<%= true %>"
+					results="<%= inheritedSiteRoles %>"
+				/>
+
+				<liferay-ui:search-container-row
+					className="com.liferay.portal.kernel.model.UserGroupGroupRole"
+					keyProperty="roleId"
+					modelVar="userGroupGroupRole"
+				>
+					<liferay-ui:search-container-column-text
+						cssClass="table-cell-expand"
+						name="title"
+					>
+
+						<%
+						Role role = userGroupGroupRole.getRole();
+						%>
+
+						<liferay-ui:icon
+							iconCssClass="<%= role.getIconCssClass() %>"
+							label="<%= true %>"
+							message="<%= HtmlUtil.escape(role.getTitle(locale)) %>"
+						/>
+					</liferay-ui:search-container-column-text>
+
+					<liferay-ui:search-container-column-text
+						cssClass="table-cell-expand"
+						name="site"
+					>
+						<liferay-staging:descriptive-name
+							group="<%= userGroupGroupRole.getGroup() %>"
+						/>
+					</liferay-ui:search-container-column-text>
+
+					<liferay-ui:search-container-column-text
+						cssClass="table-cell-expand"
+						name="user-group"
+						value="<%= HtmlUtil.escape(userGroupGroupRole.getUserGroup().getName()) %>"
+					/>
+				</liferay-ui:search-container-row>
+
+				<liferay-ui:search-iterator
+					markupView="lexicon"
+				/>
+			</liferay-ui:search-container>
+		</c:if>
 	</c:if>
 
 	<c:if test="<%= !portletName.equals(myAccountPortletId) %>">
@@ -993,43 +999,45 @@ currentURLObj.setParameter("historyKey", liferayPortletResponse.getNamespace() +
 			};
 		</aui:script>
 
-		<aui:script use="liferay-search-container">
-			var Util = Liferay.Util;
+		<c:if test="<%= userDisplayContext.isShowRegularRoles() %>">
+			<aui:script use="liferay-search-container">
+				var Util = Liferay.Util;
 
-			var searchContainer = Liferay.SearchContainer.get(
-				'<portlet:namespace />rolesSearchContainer'
-			);
+				var searchContainer = Liferay.SearchContainer.get(
+					'<portlet:namespace />rolesSearchContainer'
+				);
 
-			var searchContainerContentBox = searchContainer.get('contentBox');
+				var searchContainerContentBox = searchContainer.get('contentBox');
 
-			searchContainerContentBox.delegate(
-				'click',
-				(event) => {
-					var link = event.currentTarget;
+				searchContainerContentBox.delegate(
+					'click',
+					(event) => {
+						var link = event.currentTarget;
 
-					var rowId = link.attr('data-rowId');
+						var rowId = link.attr('data-rowId');
 
-					var tr = link.ancestor('tr');
+						var tr = link.ancestor('tr');
 
-					var selectRegularRole = Util.getWindow(
-						'<portlet:namespace />selectRegularRole'
-					);
+						var selectRegularRole = Util.getWindow(
+							'<portlet:namespace />selectRegularRole'
+						);
 
-					if (selectRegularRole) {
-						var selectButton = selectRegularRole.iframe.node
-							.get('contentWindow.document')
-							.one('.selector-button[data-entityid="' + rowId + '"]');
+						if (selectRegularRole) {
+							var selectButton = selectRegularRole.iframe.node
+								.get('contentWindow.document')
+								.one('.selector-button[data-entityid="' + rowId + '"]');
 
-						Util.toggleDisabled(selectButton, false);
-					}
+							Util.toggleDisabled(selectButton, false);
+						}
 
-					searchContainer.deleteRow(tr, link.getAttribute('data-rowId'));
+						searchContainer.deleteRow(tr, link.getAttribute('data-rowId'));
 
-					<portlet:namespace />deleteRegularRole(rowId);
-				},
-				'.modify-link'
-			);
-		</aui:script>
+						<portlet:namespace />deleteRegularRole(rowId);
+					},
+					'.modify-link'
+				);
+			</aui:script>
+		</c:if>
 	</c:if>
 </clay:sheet-section>
 

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/roles.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/roles.jsp
@@ -108,11 +108,16 @@ currentURLObj.setParameter("historyKey", liferayPortletResponse.getNamespace() +
 					cssClass="table-cell-expand"
 					name="title"
 				>
-					<liferay-ui:icon
-						iconCssClass="<%= role.getIconCssClass() %>"
-						label="<%= true %>"
-						message="<%= HtmlUtil.escape(role.getTitle(locale)) %>"
-					/>
+					<span>
+						<span class="inline-item inline-item-before">
+							<clay:icon
+								symbol="<%= role.getIconCssClass() %>"
+							/>
+						</span>
+						<span class="taglib-text">
+							<%= HtmlUtil.escape(role.getTitle(locale)) %>
+						</span>
+					</span>
 				</liferay-ui:search-container-column-text>
 
 				<liferay-ui:search-container-column-text
@@ -253,11 +258,16 @@ currentURLObj.setParameter("historyKey", liferayPortletResponse.getNamespace() +
 						Role groupRole = groupRoles.get(0);
 						%>
 
-						<liferay-ui:icon
-							iconCssClass="<%= groupRole.getIconCssClass() %>"
-							label="<%= true %>"
-							message="<%= HtmlUtil.escape(ListUtil.toString(groupRoles, Role.NAME_ACCESSOR)) %>"
-						/>
+						<span>
+							<span class="inline-item inline-item-before">
+								<clay:icon
+									symbol="<%= groupRole.getIconCssClass() %>"
+								/>
+							</span>
+							<span class="taglib-text">
+								<%= HtmlUtil.escape(ListUtil.toString(groupRoles, Role.NAME_ACCESSOR)) %>
+							</span>
+						</span>
 					</liferay-ui:search-container-column-text>
 
 					<liferay-ui:search-container-column-text
@@ -334,11 +344,16 @@ currentURLObj.setParameter("historyKey", liferayPortletResponse.getNamespace() +
 						cssClass="table-cell-expand"
 						name="title"
 					>
-						<liferay-ui:icon
-							iconCssClass="<%= role.getIconCssClass() %>"
-							label="<%= true %>"
-							message="<%= HtmlUtil.escape(role.getTitle(locale)) %>"
-						/>
+						<span>
+							<span class="inline-item inline-item-before">
+								<clay:icon
+									symbol="<%= role.getIconCssClass() %>"
+								/>
+							</span>
+							<span class="taglib-text">
+								<%= HtmlUtil.escape(role.getTitle(locale)) %>
+							</span>
+						</span>
 					</liferay-ui:search-container-column-text>
 
 					<liferay-ui:search-container-column-text
@@ -594,11 +609,16 @@ currentURLObj.setParameter("historyKey", liferayPortletResponse.getNamespace() +
 						cssClass="table-cell-expand"
 						name="title"
 					>
-						<liferay-ui:icon
-							iconCssClass="<%= role.getIconCssClass() %>"
-							label="<%= true %>"
-							message="<%= HtmlUtil.escape(role.getTitle(locale)) %>"
-						/>
+						<span>
+							<span class="inline-item inline-item-before">
+								<clay:icon
+									symbol="<%= role.getIconCssClass() %>"
+								/>
+							</span>
+							<span class="taglib-text">
+								<%= HtmlUtil.escape(role.getTitle(locale)) %>
+							</span>
+						</span>
 					</liferay-ui:search-container-column-text>
 
 					<liferay-ui:search-container-column-text
@@ -809,11 +829,16 @@ currentURLObj.setParameter("historyKey", liferayPortletResponse.getNamespace() +
 						Role role = userGroupGroupRole.getRole();
 						%>
 
-						<liferay-ui:icon
-							iconCssClass="<%= role.getIconCssClass() %>"
-							label="<%= true %>"
-							message="<%= HtmlUtil.escape(role.getTitle(locale)) %>"
-						/>
+						<span>
+							<span class="inline-item inline-item-before">
+								<clay:icon
+									symbol="<%= role.getIconCssClass() %>"
+								/>
+							</span>
+							<span class="taglib-text">
+								<%= HtmlUtil.escape(role.getTitle(locale)) %>
+							</span>
+						</span>
 					</liferay-ui:search-container-column-text>
 
 					<liferay-ui:search-container-column-text


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94207

Resends #177250 (auto-closed on update) with the latest bchan-bot review feedback addressed. Two findings were valid and applied; one was a false positive:

- **Rule 203 (declare next to first use):** in `RolesAdminPortlet._setAttributes`, the `themeDisplay` local is now declared immediately above the `ROLE_TYPES` `setAttribute` call that consumes it (inside the filter lambda), rather than above the unrelated `CURRENT_ROLE_TYPE`/`ITEM_SELECTOR` calls.
- **Rule 304 (list-building filter loop):** `EditPortalDefaultPermissionsConfigurationDisplayContext._filterRoleTypes` and `PortletConfigurationPermissionsDisplayContext.getRoleTypes` now use `ArrayUtil.filter(int[], Predicate<Integer>)` instead of a hand-rolled `ArrayList` + for-loop + `ArrayUtil.toIntArray`.
- **False positive (not changed):** the alleged redundant double-filtering in `_getRoleTypes` — the cache-hit branch returns `_roleTypes` without re-filtering; the branch that filters runs only on first computation.

## What Is Being Fixed

In the standalone CMS bundle, account and site roles are irrelevant to the deployment yet still surface throughout the roles and permissions UI — the Roles Admin portlet, the role item/selector pickers, the permissions matrices, and a user's roles and site memberships screens. There was no mechanism to hide role types that do not apply to a given deployment.

## How It Is Being Fixed

A `RoleTypeContributorShowFilter` SPI is introduced in `roles-admin-api`, queried through `RoleTypeContributorShowFilterRegistryUtil`. Each UI surface — `RolesAdminPortlet`, the portlet-configuration and portal-default-permissions display contexts, and the users-admin display context and its JSPs — consults the registry to drop role types that should not be shown, hiding the surrounding sections when they become empty. The standalone CMS site initializer registers a `CMSRoleTypeContributorShowFilter` that hides account and site roles. The change also swaps a `liferay-ui:icon` for `clay:icon` and bumps the semantic version of the new API package.

## Why Are There No Tests?

The change is UI-level role-type filtering with no testable business logic; behavior is covered by existing role/permission integration tests and verified manually in the standalone CMS bundle.

## PR Check

**pr-check: PASS** — tested on `6e335b999f2bf06b7f89ceb35de8631d26ae295a`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| JSP Compile | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "6e335b999f2bf06b7f89ceb35de8631d26ae295a"} -->
