### PR TITLE
LPD-58508 Warn on use of removed COMPANY_SECURITY_AUTH_REQUIRES_HTTPS

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -5353,6 +5353,14 @@
 		"to": "updateFileEntryAndCheckIn(param#0#, param#1#, param#2#, param#3#, null, param#4#, param#5#, param#6#, param#7#, param#8#, null, null, null, param#9#)"
 	},
 	{
+		"classNames": [
+			"PropsKeys"
+		],
+		"from": "COMPANY_SECURITY_AUTH_REQUIRES_HTTPS",
+		"hasMessage": true,
+		"issueKey": "LPD-58508"
+	},
+	{
 		"ClassNames": [
 			"UserLocalService",
 			"UserLocalServiceUtil"

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_58508.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_58508.testjava
@@ -1,0 +1,19 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+import com.liferay.portal.kernel.util.PropsKeys;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class LPD_58508 {
+
+	public void method() {
+		PropsUtil.get(PropsKeys.COMPANY_SECURITY_AUTH_REQUIRES_HTTPS);
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-58508

## What Is Being Fixed

The `PropsKeys.COMPANY_SECURITY_AUTH_REQUIRES_HTTPS` constant has been removed, but code that still references it gets no upgrade guidance, leaving the breakage for developers to discover on their own.

## How It Is Being Fixed

A new entry is added to the source formatter's `replacements.json` upgrade catch-all check, mapping `PropsKeys.COMPANY_SECURITY_AUTH_REQUIRES_HTTPS` to issue key LPD-58508 and flagging it with `hasMessage` so the formatter emits a warning whenever the removed constant is referenced. A `LPD_58508.testjava` fixture exercises the new check.

## PR Check

**pr-check: PASS** — tested on `d8cae427e47cbc6087db9984167a565d23c58b61`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "d8cae427e47cbc6087db9984167a565d23c58b61"} -->
