### PR TITLE
LPS-193587 Add integration tests for DB partition transaction flush

### DIFF
--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/TransactionFlushDBPartitionTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/TransactionFlushDBPartitionTest.java
@@ -1,0 +1,171 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.db.partition.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.AssumeTestRule;
+import com.liferay.portal.kernel.test.util.CompanyTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.transaction.Propagation;
+import com.liferay.portal.kernel.transaction.TransactionConfig;
+import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
+import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jorge Avalos
+ */
+@RunWith(Arquillian.class)
+public class TransactionFlushDBPartitionTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new AssumeTestRule("assume"), new LiferayIntegrationTestRule());
+
+	public static void assume() {
+		DB db = DBManagerUtil.getDB();
+
+		Assume.assumeTrue(db.isSupportsDBPartition());
+
+		Assume.assumeTrue(PropsValues.DATABASE_PARTITION_ENABLED);
+	}
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_company = CompanyTestUtil.addCompany();
+
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+					_company.getCompanyId())) {
+
+			_adminUser = UserTestUtil.getAdminUser(_company.getCompanyId());
+		}
+	}
+
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		CompanyLocalServiceUtil.deleteCompany(_company.getCompanyId());
+	}
+
+	@Test
+	public void testSetCompanyIdWithSafeCloseableFlushesSessionOnClose()
+		throws Throwable {
+
+		String roleName = RandomTestUtil.randomString();
+
+		TransactionInvokerUtil.invoke(
+			_transactionConfig,
+			() -> {
+				try (SafeCloseable safeCloseable =
+						CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+							_company.getCompanyId())) {
+
+					_roleLocalService.addRole(
+						null, _adminUser.getUserId(), null, 0, roleName, null,
+						null, RoleConstants.TYPE_REGULAR, null,
+						new ServiceContext());
+				}
+
+				return null;
+			});
+
+		Role role;
+
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+					_company.getCompanyId())) {
+
+			role = _roleLocalService.fetchRole(
+				_company.getCompanyId(), roleName);
+		}
+
+		Assert.assertNull(
+			_roleLocalService.fetchRole(
+				TestPropsValues.getCompanyId(), roleName));
+
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+					_company.getCompanyId())) {
+
+			_roleLocalService.deleteRole(role.getRoleId());
+		}
+	}
+
+	@Test
+	public void testSetCompanyIdWithSafeCloseableFlushesSessionOnEntry()
+		throws Throwable {
+
+		String roleName = RandomTestUtil.randomString();
+
+		TransactionInvokerUtil.invoke(
+			_transactionConfig,
+			() -> {
+				_roleLocalService.addRole(
+					null, TestPropsValues.getUserId(), null, 0, roleName, null,
+					null, RoleConstants.TYPE_REGULAR, null,
+					new ServiceContext());
+
+				try (SafeCloseable safeCloseable =
+						CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+							_company.getCompanyId())) {
+
+					_roleLocalService.getRoles(
+						_company.getCompanyId(),
+						new int[] {RoleConstants.TYPE_REGULAR});
+				}
+
+				return null;
+			});
+
+		Role role = _roleLocalService.fetchRole(
+			TestPropsValues.getCompanyId(), roleName);
+
+		_roleLocalService.deleteRole(role.getRoleId());
+	}
+
+	private static User _adminUser;
+	private static Company _company;
+	private static final TransactionConfig _transactionConfig;
+
+	static {
+		TransactionConfig.Builder builder = new TransactionConfig.Builder();
+
+		builder.setPropagation(Propagation.REQUIRED);
+		builder.setRollbackForClasses(Exception.class);
+
+		_transactionConfig = builder.build();
+	}
+
+	@Inject
+	private RoleLocalService _roleLocalService;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-193587

## What Is Being Fixed

LPS-185647 fixed a race condition where pending Hibernate session objects could be flushed to the wrong company's DB partition after `CompanyThreadLocal` was swapped. There was no integration test coverage verifying the flush fires at the correct moment.

## How It Is Being Fixed

`TransactionFlushDBPartitionTest` adds two integration tests inside an explicit transaction that verify `CompanyThreadLocal.setCompanyIdWithSafeCloseable` triggers the session flush at the right time:

`testSetCompanyIdWithSafeCloseableFlushesSessionOnEntry` creates a role in the default partition, then switches into a secondary company scope and executes a query there. After the transaction commits, it asserts the role landed in the default partition — confirming the pending INSERT was flushed to the correct partition before the scope switch.

`testSetCompanyIdWithSafeCloseableFlushesSessionOnClose` creates a role inside a secondary company scope, then closes the scope. After the transaction commits, it asserts the role is in the secondary partition and absent from the default partition — confirming the INSERT was flushed before the scope was released.

Both tests use `AssumeTestRule` to skip automatically when `DATABASE_PARTITION_ENABLED` is `false` or the underlying database does not support partitions.

## PR Check

**pr-check: FAIL** — tested on `3c34701190ad98076fbf5d1821d9007c569de0f9`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | FAIL |

Note: the compile failure is pre-existing in `DBPartitionUtilTest.java` (lines 560–566) — `DBPartitionUtil.incrementCounter()` does not exist on master. This branch adds only `TransactionFlushDBPartitionTest.java` and does not introduce the failure.

<!-- pr-check {"result": "failure", "sha": "3c34701190ad98076fbf5d1821d9007c569de0f9"} -->
