### PR TITLE
LPD-87600 Update liferay-one site initializer content

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/commerce-catalogs/liferay-inc.specification.options.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/commerce-catalogs/liferay-inc.specification.options.json
@@ -1,7 +1,7 @@
 [
 	{
 		"categoryKey": "app-support-and-help",
-		"description": "URL for the API Documentation",
+		"description": "This is the URL for the API documentation.",
 		"facetable": false,
 		"key": "app-api-reference-url",
 		"title": "App API Reference URL"
@@ -50,35 +50,35 @@
 	},
 	{
 		"categoryKey": "product-metadata",
-		"description": "Latest Liferay Version Supported",
+		"description": "This is the latest Liferay version supported.",
 		"facetable": false,
 		"key": "current-requirements",
 		"title": "Current Requirements"
 	},
 	{
 		"categoryKey": "product-metadata",
-		"description": "Developer Name",
+		"description": "This is the developer name.",
 		"facetable": true,
 		"key": "developer-name",
 		"title": "Developer Name"
 	},
 	{
 		"categoryKey": "pricing-licensing-terms",
-		"description": "Latest version for the app or solution.",
+		"description": "This is the latest version for the app or solution.",
 		"facetable": false,
 		"key": "latest-version",
 		"title": "Latest Version"
 	},
 	{
 		"categoryKey": "pricing-licensing-terms",
-		"description": "Length of the trial",
+		"description": "This is the length of the trial.",
 		"facetable": false,
 		"key": "license-term",
 		"title": "License Term"
 	},
 	{
 		"categoryKey": "pricing-licensing-terms",
-		"description": "License Type",
+		"description": "This is the license type.",
 		"facetable": false,
 		"key": "license-type",
 		"title": "License Type"
@@ -99,21 +99,21 @@
 	},
 	{
 		"categoryKey": "product-metadata",
-		"description": "Compatible Liferay Release Version",
+		"description": "This is the compatible Liferay release version.",
 		"facetable": true,
 		"key": "liferay-version",
 		"title": "Liferay Version"
 	},
 	{
 		"categoryKey": "pricing-licensing-terms",
-		"description": "Lifetime license offered?",
+		"description": "This indicates whether a lifetime license is offered.",
 		"facetable": false,
 		"key": "lifetime-license",
 		"title": "Lifetime License"
 	},
 	{
 		"categoryKey": "resource-requirements",
-		"description": "Number of CPUs to Resource Requirements",
+		"description": "This is the number of CPUs for the resource requirements.",
 		"facetable": true,
 		"key": "number-of-cpus",
 		"title": "Number of CPUs"
@@ -127,35 +127,35 @@
 	},
 	{
 		"categoryKey": "product-metadata",
-		"description": "Past Versions this product has worked with",
+		"description": "These are the past versions this product has worked with.",
 		"facetable": false,
 		"key": "past-versions-work-with",
 		"title": "Past Versions Work With"
 	},
 	{
 		"categoryKey": "pricing-licensing-terms",
-		"description": "Whether the app is Free, Paid or Bundled",
+		"description": "This indicates whether the app is free, paid, or bundled.",
 		"facetable": true,
 		"key": "price-model",
 		"title": "Price Model"
 	},
 	{
 		"categoryKey": "product-metadata",
-		"description": "Total number of downloads for this product",
+		"description": "This is the total number of downloads for this product.",
 		"facetable": false,
 		"key": "product-downloads",
 		"title": "Product Downloads"
 	},
 	{
 		"categoryKey": "product-metadata",
-		"description": "General notes about the app or solution.",
+		"description": "These are general notes about the app or solution.",
 		"facetable": false,
 		"key": "product-notes",
 		"title": "Product Notes"
 	},
 	{
 		"categoryKey": "product-metadata",
-		"description": "Name of the primary app publisher",
+		"description": "This is the name of the primary app publisher.",
 		"facetable": false,
 		"key": "publisher-name",
 		"title": "Publisher Name"
@@ -169,91 +169,91 @@
 	},
 	{
 		"categoryKey": "resource-requirements",
-		"description": "RAM in GB to Resource Requirements",
+		"description": "This is the RAM in GB for the resource requirements.",
 		"facetable": true,
 		"key": "ram-in-gb",
 		"title": "RAM in GB"
 	},
 	{
 		"categoryKey": "solution-metadata",
-		"description": "Solution company description",
+		"description": "This is the solution company description.",
 		"facetable": true,
 		"key": "solution-company-description",
 		"title": "Solution Company Description"
 	},
 	{
 		"categoryKey": "solution-metadata",
-		"description": "Solution company email",
+		"description": "This is the solution company email.",
 		"facetable": true,
 		"key": "solution-company-email",
 		"title": "Solution Company Email"
 	},
 	{
 		"categoryKey": "solution-metadata",
-		"description": "Solution company phone",
+		"description": "This is the solution company phone.",
 		"facetable": true,
 		"key": "solution-company-phone",
 		"title": "Solution Company Phone"
 	},
 	{
 		"categoryKey": "solution-metadata",
-		"description": "Solution company website",
+		"description": "This is the solution company website.",
 		"facetable": true,
 		"key": "solution-company-website",
 		"title": "Solution Company Website"
 	},
 	{
 		"categoryKey": "solution-metadata",
-		"description": "Solution contact email",
+		"description": "This is the solution contact email.",
 		"facetable": true,
 		"key": "solution-contact-email",
 		"title": "Solution Contact Email"
 	},
 	{
 		"categoryKey": "solution-metadata",
-		"description": "Solution details blocks",
+		"description": "These are the solution details blocks.",
 		"facetable": true,
 		"key": "solution-details-blocks",
 		"title": "Solution Details Blocks"
 	},
 	{
 		"categoryKey": "solution-metadata",
-		"description": "Solution header description",
+		"description": "This is the solution header description.",
 		"facetable": true,
 		"key": "solution-header-description",
 		"title": "Solution Header Description"
 	},
 	{
 		"categoryKey": "solution-metadata",
-		"description": "Solution header title",
+		"description": "This is the solution header title.",
 		"facetable": true,
 		"key": "solution-header-title",
 		"title": "Solution Header Title"
 	},
 	{
 		"categoryKey": "solution-metadata",
-		"description": "Solution header video description",
+		"description": "This is the solution header video description.",
 		"facetable": true,
 		"key": "solution-header-video-description",
 		"title": "Solution Header Video Description"
 	},
 	{
 		"categoryKey": "solution-metadata",
-		"description": "Solution header video url",
+		"description": "This is the solution header video URL.",
 		"facetable": true,
 		"key": "solution-header-video-url",
 		"title": "Solution Header Video URL"
 	},
 	{
 		"categoryKey": "solution-metadata",
-		"description": "Solution header title",
+		"description": "This is the solution type.",
 		"facetable": false,
 		"key": "solution-type",
 		"title": "Solution Type"
 	},
 	{
 		"categoryKey": "app-support-and-help",
-		"description": "URL of source code",
+		"description": "This is the URL of the source code.",
 		"facetable": false,
 		"key": "source-code-url",
 		"title": "Source Code URL"

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/commerce-catalogs/salesforce.products.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/commerce-catalogs/salesforce.products.json
@@ -36,7 +36,7 @@
 			},
 			{
 				"key": "liferay-products-capabilities",
-				"value": "Generative AI-powered search"
+				"value": "Generative AI powered search"
 			},
 			{
 				"key": "liferay-products-capabilities",

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/commerce-catalogs/salesforce.specification.options.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/commerce-catalogs/salesforce.specification.options.json
@@ -1,7 +1,7 @@
 [
 	{
 		"categoryKey": "app-support-and-help",
-		"description": "URL for the API Documentation",
+		"description": "This is the URL for the API documentation.",
 		"facetable": false,
 		"key": "app-api-reference-url",
 		"title": "App API Reference URL"
@@ -50,35 +50,35 @@
 	},
 	{
 		"categoryKey": "product-metadata",
-		"description": "Latest Liferay Version Supported",
+		"description": "This is the latest Liferay version supported.",
 		"facetable": false,
 		"key": "current-requirements",
 		"title": "Current Requirements"
 	},
 	{
 		"categoryKey": "product-metadata",
-		"description": "Developer Name",
+		"description": "This is the developer name.",
 		"facetable": true,
 		"key": "developer-name",
 		"title": "Developer Name"
 	},
 	{
 		"categoryKey": "pricing-licensing-terms",
-		"description": "Latest version for the app or solution.",
+		"description": "This is the latest version for the app or solution.",
 		"facetable": false,
 		"key": "latest-version",
 		"title": "Latest Version"
 	},
 	{
 		"categoryKey": "pricing-licensing-terms",
-		"description": "Length of the trial",
+		"description": "This is the length of the trial.",
 		"facetable": false,
 		"key": "license-term",
 		"title": "License Term"
 	},
 	{
 		"categoryKey": "pricing-licensing-terms",
-		"description": "License Type",
+		"description": "This is the license type.",
 		"facetable": false,
 		"key": "license-type",
 		"title": "License Type"
@@ -99,21 +99,21 @@
 	},
 	{
 		"categoryKey": "product-metadata",
-		"description": "Compatible Liferay Release Version",
+		"description": "This is the compatible Liferay release version.",
 		"facetable": true,
 		"key": "liferay-version",
 		"title": "Liferay Version"
 	},
 	{
 		"categoryKey": "pricing-licensing-terms",
-		"description": "Lifetime license offered?",
+		"description": "This indicates whether a lifetime license is offered.",
 		"facetable": false,
 		"key": "lifetime-license",
 		"title": "Lifetime License"
 	},
 	{
 		"categoryKey": "resource-requirements",
-		"description": "Number of CPUs to Resource Requirements",
+		"description": "This is the number of CPUs for the resource requirements.",
 		"facetable": true,
 		"key": "number-of-cpus",
 		"title": "Number of CPUs"
@@ -127,35 +127,35 @@
 	},
 	{
 		"categoryKey": "product-metadata",
-		"description": "Past Versions this product has worked with",
+		"description": "These are the past versions this product has worked with.",
 		"facetable": false,
 		"key": "past-versions-work-with",
 		"title": "Past Versions Work With"
 	},
 	{
 		"categoryKey": "pricing-licensing-terms",
-		"description": "Whether the app is Free, Paid or Bundled",
+		"description": "This indicates whether the app is free, paid, or bundled.",
 		"facetable": true,
 		"key": "price-model",
 		"title": "Price Model"
 	},
 	{
 		"categoryKey": "product-metadata",
-		"description": "Total number of downloads for this product",
+		"description": "This is the total number of downloads for this product.",
 		"facetable": false,
 		"key": "product-downloads",
 		"title": "Product Downloads"
 	},
 	{
 		"categoryKey": "product-metadata",
-		"description": "General notes about the app or solution.",
+		"description": "These are general notes about the app or solution.",
 		"facetable": false,
 		"key": "product-notes",
 		"title": "Product Notes"
 	},
 	{
 		"categoryKey": "product-metadata",
-		"description": "Name of the primary app publisher",
+		"description": "This is the name of the primary app publisher.",
 		"facetable": false,
 		"key": "publisher-name",
 		"title": "Publisher Name"
@@ -169,91 +169,91 @@
 	},
 	{
 		"categoryKey": "resource-requirements",
-		"description": "RAM in GB to Resource Requirements",
+		"description": "This is the RAM in GB for the resource requirements.",
 		"facetable": true,
 		"key": "ram-in-gb",
 		"title": "RAM in GB"
 	},
 	{
 		"categoryKey": "solution-metadata",
-		"description": "Solution company description",
+		"description": "This is the solution company description.",
 		"facetable": true,
 		"key": "solution-company-description",
 		"title": "Solution Company Description"
 	},
 	{
 		"categoryKey": "solution-metadata",
-		"description": "Solution company email",
+		"description": "This is the solution company email.",
 		"facetable": true,
 		"key": "solution-company-email",
 		"title": "Solution Company Email"
 	},
 	{
 		"categoryKey": "solution-metadata",
-		"description": "Solution company phone",
+		"description": "This is the solution company phone.",
 		"facetable": true,
 		"key": "solution-company-phone",
 		"title": "Solution Company Phone"
 	},
 	{
 		"categoryKey": "solution-metadata",
-		"description": "Solution company website",
+		"description": "This is the solution company website.",
 		"facetable": true,
 		"key": "solution-company-website",
 		"title": "Solution Company Website"
 	},
 	{
 		"categoryKey": "solution-metadata",
-		"description": "Solution contact email",
+		"description": "This is the solution contact email.",
 		"facetable": true,
 		"key": "solution-contact-email",
 		"title": "Solution Contact Email"
 	},
 	{
 		"categoryKey": "solution-metadata",
-		"description": "Solution details blocks",
+		"description": "These are the solution details blocks.",
 		"facetable": true,
 		"key": "solution-details-blocks",
 		"title": "Solution Details Blocks"
 	},
 	{
 		"categoryKey": "solution-metadata",
-		"description": "Solution header description",
+		"description": "This is the solution header description.",
 		"facetable": true,
 		"key": "solution-header-description",
 		"title": "Solution Header Description"
 	},
 	{
 		"categoryKey": "solution-metadata",
-		"description": "Solution header title",
+		"description": "This is the solution header title.",
 		"facetable": true,
 		"key": "solution-header-title",
 		"title": "Solution Header Title"
 	},
 	{
 		"categoryKey": "solution-metadata",
-		"description": "Solution header video description",
+		"description": "This is the solution header video description.",
 		"facetable": true,
 		"key": "solution-header-video-description",
 		"title": "Solution Header Video Description"
 	},
 	{
 		"categoryKey": "solution-metadata",
-		"description": "Solution header video url",
+		"description": "This is the solution header video URL.",
 		"facetable": true,
 		"key": "solution-header-video-url",
 		"title": "Solution Header Video URL"
 	},
 	{
 		"categoryKey": "solution-metadata",
-		"description": "Solution header title",
+		"description": "This is the solution type.",
 		"facetable": false,
 		"key": "solution-type",
 		"title": "Solution Type"
 	},
 	{
 		"categoryKey": "app-support-and-help",
-		"description": "URL of source code",
+		"description": "This is the URL of the source code.",
 		"facetable": false,
 		"key": "source-code-url",
 		"title": "Source Code URL"

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/commerce-catalogs/test-supplier.specification.options.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/commerce-catalogs/test-supplier.specification.options.json
@@ -1,7 +1,7 @@
 [
 	{
 		"categoryKey": "app-support-and-help",
-		"description": "URL for the API Documentation",
+		"description": "This is the URL for the API documentation.",
 		"facetable": false,
 		"key": "app-api-reference-url",
 		"title": "App API Reference URL"
@@ -50,35 +50,35 @@
 	},
 	{
 		"categoryKey": "product-metadata",
-		"description": "Latest Liferay Version Supported",
+		"description": "This is the latest Liferay version supported.",
 		"facetable": false,
 		"key": "current-requirements",
 		"title": "Current Requirements"
 	},
 	{
 		"categoryKey": "product-metadata",
-		"description": "Developer Name",
+		"description": "This is the developer name.",
 		"facetable": true,
 		"key": "developer-name",
 		"title": "Developer Name"
 	},
 	{
 		"categoryKey": "pricing-licensing-terms",
-		"description": "Latest version for the app or solution.",
+		"description": "This is the latest version for the app or solution.",
 		"facetable": false,
 		"key": "latest-version",
 		"title": "Latest Version"
 	},
 	{
 		"categoryKey": "pricing-licensing-terms",
-		"description": "Length of the trial",
+		"description": "This is the length of the trial.",
 		"facetable": false,
 		"key": "license-term",
 		"title": "License Term"
 	},
 	{
 		"categoryKey": "pricing-licensing-terms",
-		"description": "License Type",
+		"description": "This is the license type.",
 		"facetable": false,
 		"key": "license-type",
 		"title": "License Type"
@@ -99,21 +99,21 @@
 	},
 	{
 		"categoryKey": "product-metadata",
-		"description": "Compatible Liferay Release Version",
+		"description": "This is the compatible Liferay release version.",
 		"facetable": true,
 		"key": "liferay-version",
 		"title": "Liferay Version"
 	},
 	{
 		"categoryKey": "pricing-licensing-terms",
-		"description": "Lifetime license offered?",
+		"description": "This indicates whether a lifetime license is offered.",
 		"facetable": false,
 		"key": "lifetime-license",
 		"title": "Lifetime License"
 	},
 	{
 		"categoryKey": "resource-requirements",
-		"description": "Number of CPUs to Resource Requirements",
+		"description": "This is the number of CPUs for the resource requirements.",
 		"facetable": true,
 		"key": "number-of-cpus",
 		"title": "Number of CPUs"
@@ -127,35 +127,35 @@
 	},
 	{
 		"categoryKey": "product-metadata",
-		"description": "Past Versions this product has worked with",
+		"description": "These are the past versions this product has worked with.",
 		"facetable": false,
 		"key": "past-versions-work-with",
 		"title": "Past Versions Work With"
 	},
 	{
 		"categoryKey": "pricing-licensing-terms",
-		"description": "Whether the app is Free, Paid or Bundled",
+		"description": "This indicates whether the app is free, paid, or bundled.",
 		"facetable": true,
 		"key": "price-model",
 		"title": "Price Model"
 	},
 	{
 		"categoryKey": "product-metadata",
-		"description": "Total number of downloads for this product",
+		"description": "This is the total number of downloads for this product.",
 		"facetable": false,
 		"key": "product-downloads",
 		"title": "Product Downloads"
 	},
 	{
 		"categoryKey": "product-metadata",
-		"description": "General notes about the app or solution.",
+		"description": "These are general notes about the app or solution.",
 		"facetable": false,
 		"key": "product-notes",
 		"title": "Product Notes"
 	},
 	{
 		"categoryKey": "product-metadata",
-		"description": "Name of the primary app publisher",
+		"description": "This is the name of the primary app publisher.",
 		"facetable": false,
 		"key": "publisher-name",
 		"title": "Publisher Name"
@@ -169,91 +169,91 @@
 	},
 	{
 		"categoryKey": "resource-requirements",
-		"description": "RAM in GB to Resource Requirements",
+		"description": "This is the RAM in GB for the resource requirements.",
 		"facetable": true,
 		"key": "ram-in-gb",
 		"title": "RAM in GB"
 	},
 	{
 		"categoryKey": "solution-metadata",
-		"description": "Solution company description",
+		"description": "This is the solution company description.",
 		"facetable": true,
 		"key": "solution-company-description",
 		"title": "Solution Company Description"
 	},
 	{
 		"categoryKey": "solution-metadata",
-		"description": "Solution company email",
+		"description": "This is the solution company email.",
 		"facetable": true,
 		"key": "solution-company-email",
 		"title": "Solution Company Email"
 	},
 	{
 		"categoryKey": "solution-metadata",
-		"description": "Solution company phone",
+		"description": "This is the solution company phone.",
 		"facetable": true,
 		"key": "solution-company-phone",
 		"title": "Solution Company Phone"
 	},
 	{
 		"categoryKey": "solution-metadata",
-		"description": "Solution company website",
+		"description": "This is the solution company website.",
 		"facetable": true,
 		"key": "solution-company-website",
 		"title": "Solution Company Website"
 	},
 	{
 		"categoryKey": "solution-metadata",
-		"description": "Solution contact email",
+		"description": "This is the solution contact email.",
 		"facetable": true,
 		"key": "solution-contact-email",
 		"title": "Solution Contact Email"
 	},
 	{
 		"categoryKey": "solution-metadata",
-		"description": "Solution details blocks",
+		"description": "These are the solution details blocks.",
 		"facetable": true,
 		"key": "solution-details-blocks",
 		"title": "Solution Details Blocks"
 	},
 	{
 		"categoryKey": "solution-metadata",
-		"description": "Solution header description",
+		"description": "This is the solution header description.",
 		"facetable": true,
 		"key": "solution-header-description",
 		"title": "Solution Header Description"
 	},
 	{
 		"categoryKey": "solution-metadata",
-		"description": "Solution header title",
+		"description": "This is the solution header title.",
 		"facetable": true,
 		"key": "solution-header-title",
 		"title": "Solution Header Title"
 	},
 	{
 		"categoryKey": "solution-metadata",
-		"description": "Solution header video description",
+		"description": "This is the solution header video description.",
 		"facetable": true,
 		"key": "solution-header-video-description",
 		"title": "Solution Header Video Description"
 	},
 	{
 		"categoryKey": "solution-metadata",
-		"description": "Solution header video url",
+		"description": "This is the solution header video URL.",
 		"facetable": true,
 		"key": "solution-header-video-url",
 		"title": "Solution Header Video URL"
 	},
 	{
 		"categoryKey": "solution-metadata",
-		"description": "Solution header title",
+		"description": "This is the solution type.",
 		"facetable": false,
 		"key": "solution-type",
 		"title": "Solution Type"
 	},
 	{
 		"categoryKey": "app-support-and-help",
-		"description": "URL of source code",
+		"description": "This is the URL of the source code.",
 		"facetable": false,
 		"key": "source-code-url",
 		"title": "Source Code URL"

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/expando-values.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/expando-values.json
@@ -264,7 +264,7 @@
 		"classPk": "[#SITE_NAVIGATION_MENU_ITEM_ID:LO_NAV_SUPPORT_SECURITY_VULNERABILITIES#]",
 		"columnName": "Menu Item Description",
 		"data": {
-			"en_US": "Information and fixes for known vulnerabilities.",
+			"en_US": "Find information and fixes for known vulnerabilities.",
 			"es_ES": "Información y correcciones para vulnerabilidades conocidas.",
 			"ja_JP": "既知の脆弱性に関する情報と修正。",
 			"pt_BR": "Informações e correções para vulnerabilidades conhecidas."
@@ -506,6 +506,17 @@
 	{
 		"className": "com.liferay.site.navigation.model.SiteNavigationMenuItem",
 		"classPk": "[#SITE_NAVIGATION_MENU_ITEM_ID:LO_NAV_MY_ACCOUNT_PROJECTS#]",
+		"columnName": "Menu Item Description",
+		"data": {
+			"en_US": "View and manage your projects and licenses.",
+			"es_ES": "View and manage your projects and licenses.",
+			"ja_JP": "View and manage your projects and licenses.",
+			"pt_BR": "View and manage your projects and licenses."
+		}
+	},
+	{
+		"className": "com.liferay.site.navigation.model.SiteNavigationMenuItem",
+		"classPk": "[#SITE_NAVIGATION_MENU_ITEM_ID:LO_NAV_MY_ACCOUNT_PROJECTS#]",
 		"columnName": "Menu Item Image URL",
 		"data": {
 			"en_US": "/documents/d/one/projects-svg",
@@ -517,30 +528,8 @@
 	{
 		"className": "com.liferay.site.navigation.model.SiteNavigationMenuItem",
 		"classPk": "[#SITE_NAVIGATION_MENU_ITEM_ID:LO_NAV_MY_ACCOUNT_PROJECTS#]",
-		"columnName": "Menu Item Description",
-		"data": {
-			"en_US": "View and manage your projects and licences.",
-			"es_ES": "View and manage your projects and licences.",
-			"ja_JP": "View and manage your projects and licences.",
-			"pt_BR": "View and manage your projects and licences."
-		}
-	},
-	{
-		"className": "com.liferay.site.navigation.model.SiteNavigationMenuItem",
-		"classPk": "[#SITE_NAVIGATION_MENU_ITEM_ID:LO_NAV_MY_ACCOUNT_PROJECTS#]",
 		"columnName": "Menu Item Type",
 		"data": "Image"
-	},
-	{
-		"className": "com.liferay.site.navigation.model.SiteNavigationMenuItem",
-		"classPk": "[#SITE_NAVIGATION_MENU_ITEM_ID:LO_NAV_MY_ACCOUNT_ORDERS#]",
-		"columnName": "Menu Item Image URL",
-		"data": {
-			"en_US": "/documents/d/one/orders-svg",
-			"es_ES": "/documents/d/one/orders-svg",
-			"ja_JP": "/documents/d/one/orders-svg",
-			"pt_BR": "/documents/d/one/orders-svg"
-		}
 	},
 	{
 		"className": "com.liferay.site.navigation.model.SiteNavigationMenuItem",
@@ -556,8 +545,30 @@
 	{
 		"className": "com.liferay.site.navigation.model.SiteNavigationMenuItem",
 		"classPk": "[#SITE_NAVIGATION_MENU_ITEM_ID:LO_NAV_MY_ACCOUNT_ORDERS#]",
+		"columnName": "Menu Item Image URL",
+		"data": {
+			"en_US": "/documents/d/one/orders-svg",
+			"es_ES": "/documents/d/one/orders-svg",
+			"ja_JP": "/documents/d/one/orders-svg",
+			"pt_BR": "/documents/d/one/orders-svg"
+		}
+	},
+	{
+		"className": "com.liferay.site.navigation.model.SiteNavigationMenuItem",
+		"classPk": "[#SITE_NAVIGATION_MENU_ITEM_ID:LO_NAV_MY_ACCOUNT_ORDERS#]",
 		"columnName": "Menu Item Type",
 		"data": "Image"
+	},
+	{
+		"className": "com.liferay.site.navigation.model.SiteNavigationMenuItem",
+		"classPk": "[#SITE_NAVIGATION_MENU_ITEM_ID:LO_NAV_MY_ACCOUNT_ACCOUNT_DETAILS#]",
+		"columnName": "Menu Item Description",
+		"data": {
+			"en_US": "Update your organizations and contact information.",
+			"es_ES": "Update your organizations and contact information.",
+			"ja_JP": "Update your organizations and contact information.",
+			"pt_BR": "Update your organizations and contact information."
+		}
 	},
 	{
 		"className": "com.liferay.site.navigation.model.SiteNavigationMenuItem",
@@ -573,30 +584,8 @@
 	{
 		"className": "com.liferay.site.navigation.model.SiteNavigationMenuItem",
 		"classPk": "[#SITE_NAVIGATION_MENU_ITEM_ID:LO_NAV_MY_ACCOUNT_ACCOUNT_DETAILS#]",
-		"columnName": "Menu Item Description",
-		"data": {
-			"en_US": "Update your organisations and contact information.",
-			"es_ES": "Update your organisations and contact information.",
-			"ja_JP": "Update your organisations and contact information.",
-			"pt_BR": "Update your organisations and contact information."
-		}
-	},
-	{
-		"className": "com.liferay.site.navigation.model.SiteNavigationMenuItem",
-		"classPk": "[#SITE_NAVIGATION_MENU_ITEM_ID:LO_NAV_MY_ACCOUNT_ACCOUNT_DETAILS#]",
 		"columnName": "Menu Item Type",
 		"data": "Image"
-	},
-	{
-		"className": "com.liferay.site.navigation.model.SiteNavigationMenuItem",
-		"classPk": "[#SITE_NAVIGATION_MENU_ITEM_ID:LO_NAV_MY_ACCOUNT_ACCOUNT_MEMBERS#]",
-		"columnName": "Menu Item Image URL",
-		"data": {
-			"en_US": "/documents/d/one/account_members-svg",
-			"es_ES": "/documents/d/one/account_members-svg",
-			"ja_JP": "/documents/d/one/account_members-svg",
-			"pt_BR": "/documents/d/one/account_members-svg"
-		}
 	},
 	{
 		"className": "com.liferay.site.navigation.model.SiteNavigationMenuItem",
@@ -607,6 +596,17 @@
 			"es_ES": "Manage account members, roles, and support access.",
 			"ja_JP": "Manage account members, roles, and support access.",
 			"pt_BR": "Manage account members, roles, and support access."
+		}
+	},
+	{
+		"className": "com.liferay.site.navigation.model.SiteNavigationMenuItem",
+		"classPk": "[#SITE_NAVIGATION_MENU_ITEM_ID:LO_NAV_MY_ACCOUNT_ACCOUNT_MEMBERS#]",
+		"columnName": "Menu Item Image URL",
+		"data": {
+			"en_US": "/documents/d/one/account_members-svg",
+			"es_ES": "/documents/d/one/account_members-svg",
+			"ja_JP": "/documents/d/one/account_members-svg",
+			"pt_BR": "/documents/d/one/account_members-svg"
 		}
 	},
 	{

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/journal-articles/support-articles/journal_article_01.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/journal-articles/support-articles/journal_article_01.json
@@ -5,5 +5,5 @@
 	],
 	"ddmStructureKey": "ANNOUNCEMENT",
 	"folder": "Support Articles",
-	"name": "Liferay support service level agreement"
+	"name": "Liferay Support Service Level Agreement"
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/journal-articles/support-articles/journal_article_01.xml
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/journal-articles/support-articles/journal_article_01.xml
@@ -3,7 +3,7 @@
 <root available-locales="en_US" default-locale="en_US" version="1.0">
 	<dynamic-element field-reference="content" index-type="text" instance-id="lo0b0001" name="content" type="rich_text">
 		<dynamic-content language-id="en_US">
-			<![CDATA[<p>Liferay's standard support service level agreement defines target response times based on the severity of each reported issue. Critical production-down incidents receive the fastest response, while lower-severity questions are handled during regular business hours. Response times, coverage windows, and escalation paths vary by subscription tier; consult your subscription agreement for the commitments that apply to your organization.</p>]]>
+			<![CDATA[<p>Liferay's standard support service level agreement defines target response times based on the severity of each reported issue. Critical production down incidents receive the fastest response, while lower severity questions are handled during regular business hours. Response times, coverage windows, and escalation paths vary by subscription tier; consult your subscription agreement for the commitments that apply to your organization.</p>]]>
 		</dynamic-content>
 	</dynamic-element>
 </root>

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/journal-articles/support-articles/journal_article_02.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/journal-articles/support-articles/journal_article_02.json
@@ -5,5 +5,5 @@
 	],
 	"ddmStructureKey": "ANNOUNCEMENT",
 	"folder": "Support Articles",
-	"name": "Understanding support ticket severity levels"
+	"name": "Understanding Support Ticket Severity Levels"
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/journal-articles/support-articles/journal_article_03.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/journal-articles/support-articles/journal_article_03.json
@@ -5,5 +5,5 @@
 	],
 	"ddmStructureKey": "ANNOUNCEMENT",
 	"folder": "Support Articles",
-	"name": "Getting Started with the Liferay Customer Portal"
+	"name": "Getting Started With the Liferay Customer Portal"
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/journal-articles/support-articles/journal_article_03.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/journal-articles/support-articles/journal_article_03.json
@@ -5,5 +5,5 @@
 	],
 	"ddmStructureKey": "ANNOUNCEMENT",
 	"folder": "Support Articles",
-	"name": "Getting started with the Liferay customer portal"
+	"name": "Getting Started with the Liferay Customer Portal"
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/layouts/01_home/page-definition.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/layouts/01_home/page-definition.json
@@ -1736,7 +1736,7 @@
 										"cardSize": "large",
 										"hideRatingInfo": true,
 										"pageSize": "4",
-										"sectionDescription": "Fragments and client extensions to foster your productivity.",
+										"sectionDescription": "Fragments and client extensions help foster your productivity.",
 										"sectionTitle": "What Is New on Marketplace",
 										"specificationFilterValue": "true"
 									},

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/layouts/01_home/page-definition.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/layouts/01_home/page-definition.json
@@ -1723,7 +1723,7 @@
 							"indexed": true,
 							"layout": {
 							},
-							"name": "What's New on Marketplace"
+							"name": "What Is New on Marketplace"
 						},
 						"pageElements": [
 							{
@@ -1736,8 +1736,8 @@
 										"cardSize": "large",
 										"hideRatingInfo": true,
 										"pageSize": "4",
-										"sectionDescription": "Fragments and client extensions to foster your productivity",
-										"sectionTitle": "What's New on Marketplace",
+										"sectionDescription": "Fragments and client extensions to foster your productivity.",
+										"sectionTitle": "What Is New on Marketplace",
 										"specificationFilterValue": "true"
 									},
 									"indexed": true

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/layouts/04_marketplace/page-definition.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/layouts/04_marketplace/page-definition.json
@@ -127,7 +127,7 @@
 							"indexed": true,
 							"layout": {
 							},
-							"name": "What's New"
+							"name": "What Is New"
 						},
 						"pageElements": [
 							{
@@ -140,8 +140,8 @@
 										"cardSize": "large",
 										"hideRatingInfo": true,
 										"pageSize": "4",
-										"sectionDescription": "The latest features and extensions are growing the Marketplace ecosystem",
-										"sectionTitle": "What's New",
+										"sectionDescription": "The latest features and extensions are growing the Marketplace ecosystem.",
+										"sectionTitle": "What Is New",
 										"specificationFilterValue": "true"
 									},
 									"indexed": true
@@ -173,7 +173,7 @@
 										"cardSize": "large",
 										"hideRatingInfo": true,
 										"pageSize": "4",
-										"sectionDescription": "Hand-picked apps and extensions curated to help you get the most out of Liferay",
+										"sectionDescription": "Handpicked apps and extensions curated to help you get the most out of Liferay.",
 										"sectionTitle": "Highlights",
 										"specificationFilterValue": "true"
 									},
@@ -206,7 +206,7 @@
 										"cardSize": "large",
 										"hideRatingInfo": true,
 										"pageSize": "4",
-										"sectionDescription": "Explore the most popular apps chosen by businesses worldwide to power their digital experiences",
+										"sectionDescription": "Explore the most popular apps chosen by businesses worldwide to power their digital experiences.",
 										"sectionTitle": "Most Popular",
 										"specificationFilterValue": "true"
 									},
@@ -273,7 +273,7 @@
 												},
 												"text": {
 													"value_i18n": {
-														"en_US": "Engineers and bold extenders keeping the Liferay ecosystem thriving"
+														"en_US": "Engineers and bold extenders keeping the Liferay ecosystem thriving."
 													}
 												}
 											}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/layouts/04_marketplace/page-definition.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/layouts/04_marketplace/page-definition.json
@@ -173,7 +173,7 @@
 										"cardSize": "large",
 										"hideRatingInfo": true,
 										"pageSize": "4",
-										"sectionDescription": "Handpicked apps and extensions curated to help you get the most out of Liferay.",
+										"sectionDescription": "These handpicked apps and extensions are curated to help you get the most out of Liferay.",
 										"sectionTitle": "Highlights",
 										"specificationFilterValue": "true"
 									},
@@ -273,7 +273,7 @@
 												},
 												"text": {
 													"value_i18n": {
-														"en_US": "Engineers and bold extenders keeping the Liferay ecosystem thriving."
+														"en_US": "Engineers and bold extenders keep the Liferay ecosystem thriving."
 													}
 												}
 											}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/notification-templates/license-key-expiration-warning/en-US.html
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/notification-templates/license-key-expiration-warning/en-US.html
@@ -324,7 +324,7 @@
 					You received this email because you subscribed to expiration notifications for this activation key. To modify these notifications, please visit: Customer Portal > Product Activation.
 				</p>
 
-				<a href="https://one.liferay.com/">Go to Projects</a><br />
+				<a href="https://one.liferay.com">Go to Projects</a><br />
 				<a href="[%ACCOUNT_URL%]">Go to Product's Activation Keys</a>
 
 				<p>
@@ -350,7 +350,7 @@
 				<div class="footer-navigation">
 					<a href="mailto:customer-service@liferay.com">Contact Support</a> |
 					<a href="https://learn.liferay.com">Documentation</a> |
-					<a href="https://one.liferay.com/">Customer Portal</a> |
+					<a href="https://one.liferay.com">Customer Portal</a> |
 					<a href="https://www.subscribepage.com/liferay">Announcements</a> |
 					<a href="https://status.liferay.cloud/">Uptime Status</a>
 				</div>

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/notification-templates/license-key-expiration-warning/es-ES.html
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/notification-templates/license-key-expiration-warning/es-ES.html
@@ -324,7 +324,7 @@
 					Recibes este email porque estas suscrito a las notificaciones de las expiraciones de este código de activación. Para modificar estas notificaciones visita el Portal de cliente > Activación de productos.
 				</p>
 
-				<a href="https://one.liferay.com/">Ir a proyectos</a><br />
+				<a href="https://one.liferay.com">Ir a proyectos</a><br />
 				<a href="[%ACCOUNT_URL%]">Ir a los códigos de activación de productos</a>
 
 				<p>
@@ -350,7 +350,7 @@
 				<div class="footer-navigation">
 					<a href="mailto:customer-service@liferay.com">Contacta con Soporte</a> |
 					<a href="https://learn.liferay.com">Documentación</a> |
-					<a href="https://one.liferay.com/">Portal del Cliente</a> |
+					<a href="https://one.liferay.com">Portal del Cliente</a> |
 					<a href="https://www.subscribepage.com/liferay">Anuncios</a> |
 					<a href="https://status.liferay.cloud/">Estado de disponibilidad</a>
 				</div>

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/notification-templates/license-key-expiration-warning/ja-JP.html
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/notification-templates/license-key-expiration-warning/ja-JP.html
@@ -324,7 +324,7 @@
 					このアクティベーションキー有効期限の通知を購読しているため、本メールを受信しました。 これらの通知を変更するには、カスタマーポータル > 製品のアクティベーション にアクセスしてください。
 				</p>
 
-				<a href="https://one.liferay.com/">プロジェクトに移動</a><br />
+				<a href="https://one.liferay.com">プロジェクトに移動</a><br />
 				<a href="[%ACCOUNT_URL%]">製品のアクティベーションキーに移動</a>
 
 				<p>
@@ -350,7 +350,7 @@
 				<div class="footer-navigation">
 					<a href="mailto:customer-service@liferay.com">サポートに連絡</a> |
 					<a href="https://learn.liferay.com">ドキュメント</a> |
-					<a href="https://one.liferay.com/">カスタマーポータル</a> |
+					<a href="https://one.liferay.com">カスタマーポータル</a> |
 					<a href="https://www.subscribepage.com/liferay">お知らせ</a> |
 					<a href="https://status.liferay.cloud/">稼働時間ステータス</a>
 				</div>

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/notification-templates/license-key-expiration-warning/pt-BR.html
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/notification-templates/license-key-expiration-warning/pt-BR.html
@@ -324,7 +324,7 @@
 					Você recebeu este e-mail porque se inscreveu para receber notificações de expiração desta chave de ativação. Para modificar essas notificações, visite: Portal do cliente > Ativação do produto.
 				</p>
 
-				<a href="https://one.liferay.com/">Ir para Projetos</a><br />
+				<a href="https://one.liferay.com">Ir para Projetos</a><br />
 				<a href="[%ACCOUNT_URL%]">Ir para Chaves de Ativação do Produto</a>
 
 				<p>
@@ -350,7 +350,7 @@
 				<div class="footer-navigation">
 					<a href="mailto:customer-service@liferay.com">Contatar Suporte</a> |
 					<a href="https://learn.liferay.com">Documentação</a> |
-					<a href="https://one.liferay.com/">Portal do Cliente</a> |
+					<a href="https://one.liferay.com">Portal do Cliente</a> |
 					<a href="https://www.subscribepage.com/liferay">Anúncios</a> |
 					<a href="https://status.liferay.cloud/">Status de disponibilidade</a>
 				</div>

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/object-entries/07_publisher-account-request.object-entries.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/object-entries/07_publisher-account-request.object-entries.json
@@ -19,7 +19,7 @@
 			"lastName": "Bianchi",
 			"phoneNumber": "5125550188",
 			"publisherType": "appPublisher",
-			"requestDescription": "FormFlow Labs requests publisher access to distribute form-building applications.",
+			"requestDescription": "FormFlow Labs requests publisher access to distribute form building applications.",
 			"requestStatus": "open"
 		},
 		{
@@ -41,7 +41,7 @@
 			"lastName": "Sharma",
 			"phoneNumber": "2079460205",
 			"publisherType": "appPublisher, solutionPublisher",
-			"requestDescription": "NimbusWorks wants to publish both apps and solutions targeting cloud-native deployments.",
+			"requestDescription": "NimbusWorks wants to publish both apps and solutions targeting cloud native deployments.",
 			"requestStatus": "open"
 		}
 	],

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/object-entries/09_publisher-details.object-entries.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/object-entries/09_publisher-details.object-entries.json
@@ -16,7 +16,7 @@
 			"websiteURL": "https://www.liferay.com"
 		},
 		{
-			"description": "Liferay, Inc. publishes first-party apps and solutions that extend the Liferay platform.",
+			"description": "Liferay, Inc. publishes first party apps and solutions that extend the Liferay platform.",
 			"email": "info@liferay.com",
 			"externalReferenceCode": "PUBDET-LIFERAY-INC",
 			"fullName": "Liferay, Inc.",

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/site-navigation-menus.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/site-navigation-menus.json
@@ -209,7 +209,7 @@
 								},
 								"type": "url",
 								"url": "/web/one/my-account",
-								"useNewTab": "false"
+								"useNewTab": false
 							},
 							{
 								"externalReferenceCode": "LO_NAV_MY_ACCOUNT_ORDERS",
@@ -218,7 +218,7 @@
 								},
 								"type": "url",
 								"url": "/web/one/my-account/#/orders",
-								"useNewTab": "false"
+								"useNewTab": false
 							}
 						],
 						"name_i18n": {
@@ -237,7 +237,7 @@
 								},
 								"type": "url",
 								"url": "/web/one/my-account/#/account-details",
-								"useNewTab": "false"
+								"useNewTab": false
 							},
 							{
 								"externalReferenceCode": "LO_NAV_MY_ACCOUNT_ACCOUNT_MEMBERS",
@@ -246,7 +246,7 @@
 								},
 								"type": "url",
 								"url": "/web/one/my-account/#/account-members",
-								"useNewTab": "false"
+								"useNewTab": false
 							},
 							{
 								"externalReferenceCode": "LO_NAV_MY_ACCOUNT_PUBLISHER_DASHBOARD",
@@ -255,7 +255,7 @@
 								},
 								"type": "url",
 								"url": "/web/one/my-account/publisher-dashboard",
-								"useNewTab": "false"
+								"useNewTab": false
 							}
 						],
 						"name_i18n": {
@@ -523,7 +523,6 @@
 			},
 			{
 				"externalReferenceCode": "LO_NAV_ADMIN",
-				"name": "Admin",
 				"name_i18n": {
 					"en_US": "Admin"
 				},


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87600

## What Is Being Fixed

The liferay-one site initializer shipped content with inconsistent copy: terse
fragment and specification-option descriptions, a mix of British and American
spelling, inconsistent hyphenation, contractions, and missing end punctuation.
It also carried a couple of data issues — `useNewTab` stored as the string
`"false"` instead of a boolean, and a stray `Admin` navigation entry.

## How It Is Being Fixed

This polishes the site initializer content across the commerce catalog
specification options, expando values, support journal articles, the home and
marketplace page definitions, the license-key-expiration notification
templates, publisher object entries, and the navigation menus. Specification
and section descriptions become complete sentences, spelling is normalized to
American English, hyphenated phrases and contractions are regularized, titles
follow APA title case, trailing slashes are dropped from notification-template
links, `useNewTab` values become proper booleans, and the obsolete `Admin`
navigation item is removed.

## Why Are There No Tests?

The change touches only static site initializer data (JSON, HTML, XML) consumed
by the platform at site-creation time; there is no code path to exercise with a
unit or integration test. The Workspace Build in pr-check confirms the site
initializer client extension still assembles with the updated content.

## PR Check

**pr-check: PASS** — tested on `dee909ecfb3510c0bd30bd79a9734350e38742c0`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "dee909ecfb3510c0bd30bd79a9734350e38742c0"} -->
