### PR TITLE
LPD-89991 Reduce MCP tool token usage

### DIFF
--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
@@ -28,12 +28,15 @@ import com.liferay.portal.kernel.util.Validator;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.UUID;
 import java.util.function.Predicate;
 
@@ -73,7 +76,10 @@ public class OpenAPIUtil {
 		return options;
 	}
 
-	public static Tool getTool(JSONObject openAPIJSONObject, String toolName) {
+	public static Tool getTool(
+		boolean injectVulcanParameters, JSONObject openAPIJSONObject,
+		String toolName) {
+
 		Operation operation = _getOperation(openAPIJSONObject, toolName);
 
 		return new Tool() {
@@ -84,6 +90,7 @@ public class OpenAPIUtil {
 						operation._path));
 				setInputSchema(
 					() -> _getInputSchema(
+						injectVulcanParameters, operation._method,
 						openAPIJSONObject, operation._operationJSONObject,
 						operation._pathParametersJSONArray));
 
@@ -165,31 +172,40 @@ public class OpenAPIUtil {
 
 	private static void _addParameter(
 		JSONObject parameterJSONObject, Map<String, Object> properties,
-		List<String> requiredPropertyNames, Set<String> visitedParameterNames) {
+		List<String> requiredPropertyNames,
+		Collection<String> responseFieldNames,
+		Set<String> visitedParameterNames) {
 
 		String name = parameterJSONObject.getString("name");
 
-		if (_vulcanFieldSelectionParameterNames.contains(name) ||
-			!visitedParameterNames.add(name)) {
-
+		if (!visitedParameterNames.add(name)) {
 			return;
 		}
 
-		Map<String, Object> parameterProperties = new LinkedHashMap<>();
+		Map<String, Object> parameterSchemaMap;
 
-		JSONObject parameterSchemaJSONObject =
-			parameterJSONObject.getJSONObject("schema");
+		if (Objects.equals(name, "fields")) {
+			parameterSchemaMap = _getParameterSchemaMap(
+				_DESCRIPTION_FIELDS, responseFieldNames);
+		}
+		else {
+			parameterSchemaMap = new LinkedHashMap<>();
 
-		for (String key : parameterSchemaJSONObject.keySet()) {
-			parameterProperties.put(key, parameterSchemaJSONObject.get(key));
+			JSONObject parameterSchemaJSONObject =
+				parameterJSONObject.getJSONObject("schema");
+
+			for (String key : parameterSchemaJSONObject.keySet()) {
+				parameterSchemaMap.put(key, parameterSchemaJSONObject.get(key));
+			}
+
+			if (parameterJSONObject.has("description")) {
+				parameterSchemaMap.put(
+					"description",
+					parameterJSONObject.getString("description"));
+			}
 		}
 
-		if (parameterJSONObject.has("description")) {
-			parameterProperties.put(
-				"description", parameterJSONObject.getString("description"));
-		}
-
-		properties.put(name, parameterProperties);
+		properties.put(name, parameterSchemaMap);
 
 		if (Objects.equals(parameterJSONObject.getString("in"), "path")) {
 			requiredPropertyNames.add(name);
@@ -198,7 +214,9 @@ public class OpenAPIUtil {
 
 	private static void _addParameters(
 		JSONArray parametersJSONArray, Map<String, Object> properties,
-		List<String> requiredPropertyNames, Set<String> visitedParameterNames) {
+		List<String> requiredPropertyNames,
+		Collection<String> responseFieldNames,
+		Set<String> visitedParameterNames) {
 
 		if (parametersJSONArray == null) {
 			return;
@@ -207,7 +225,8 @@ public class OpenAPIUtil {
 		for (int i = 0; i < parametersJSONArray.length(); i++) {
 			_addParameter(
 				parametersJSONArray.getJSONObject(i), properties,
-				requiredPropertyNames, visitedParameterNames);
+				requiredPropertyNames, responseFieldNames,
+				visitedParameterNames);
 		}
 	}
 
@@ -468,6 +487,15 @@ public class OpenAPIUtil {
 		return StringUtil.toUpperCase(method) + StringPool.SPACE + path;
 	}
 
+	private static Set<String> _getFieldNames(Object value) {
+		if (value instanceof JSONArray jsonArray) {
+			return new LinkedHashSet<>(JSONUtil.toStringList(jsonArray));
+		}
+
+		return new LinkedHashSet<>(
+			Arrays.asList(StringUtil.split((String)value)));
+	}
+
 	private static Http.FilePart _getFilePart(String name, Object value) {
 		String fileName = name;
 		String contentType = ContentTypes.APPLICATION_OCTET_STREAM;
@@ -512,6 +540,7 @@ public class OpenAPIUtil {
 	}
 
 	private static Map<String, Object> _getInputSchema(
+		boolean injectVulcanParameters, String method,
 		JSONObject openAPIJSONObject, JSONObject operationJSONObject,
 		JSONArray pathParametersJSONArray) {
 
@@ -574,14 +603,26 @@ public class OpenAPIUtil {
 			}
 		}
 
+		Collection<String> responseFieldNames = _getResponseFieldNames(
+			openAPIJSONObject, operationJSONObject);
+
 		Set<String> visitedParameterNames = new HashSet<>();
 
 		_addParameters(
 			operationJSONObject.getJSONArray("parameters"), properties,
-			requiredPropertyNames, visitedParameterNames);
+			requiredPropertyNames, responseFieldNames, visitedParameterNames);
 		_addParameters(
 			pathParametersJSONArray, properties, requiredPropertyNames,
-			visitedParameterNames);
+			responseFieldNames, visitedParameterNames);
+
+		if (injectVulcanParameters && Objects.equals(method, "get") &&
+			visitedParameterNames.add("fields")) {
+
+			properties.put(
+				"fields",
+				_getParameterSchemaMap(
+					_DESCRIPTION_FIELDS, responseFieldNames));
+		}
 
 		return LinkedHashMapBuilder.<String, Object>put(
 			"properties", properties
@@ -709,6 +750,30 @@ public class OpenAPIUtil {
 			"OpenAPI document has no tool with name \"" + toolName + "\"");
 	}
 
+	private static Map<String, Object> _getParameterSchemaMap(
+		String description, Collection<String> enumFieldNames) {
+
+		return LinkedHashMapBuilder.<String, Object>put(
+			"description", description
+		).put(
+			"items",
+			LinkedHashMapBuilder.<String, Object>put(
+				"type", "string"
+			).put(
+				"enum",
+				() -> {
+					if ((enumFieldNames == null) || enumFieldNames.isEmpty()) {
+						return null;
+					}
+
+					return new ArrayList<>(enumFieldNames);
+				}
+			).build()
+		).put(
+			"type", "array"
+		).build();
+	}
+
 	private static Map<String, Object> _getParameterSchemaObjects(
 		String in, JSONObject inputJSONObject, Operation operation) {
 
@@ -799,16 +864,23 @@ public class OpenAPIUtil {
 		Map<String, Object> parameterSchemaObjects = _getParameterSchemaObjects(
 			"query", inputJSONObject, operation);
 
+		Set<String> visitedParameterNames = new HashSet<>(
+			Arrays.asList("fields", "restrictFields"));
+
 		for (Map.Entry<String, Object> entry :
 				parameterSchemaObjects.entrySet()) {
 
 			String name = entry.getKey();
 
-			if (_vulcanFieldSelectionParameterNames.contains(name)) {
-				continue;
+			if (visitedParameterNames.add(name)) {
+				_appendQueryParameter(name, sb, entry.getValue());
 			}
+		}
 
-			_appendQueryParameter(name, sb, entry.getValue());
+		Set<String> fieldNames = _getFieldNames(inputJSONObject.opt("fields"));
+
+		if (!fieldNames.isEmpty()) {
+			_appendQueryParameter("fields", sb, StringUtil.merge(fieldNames));
 		}
 
 		if (Objects.equals(operation._method, "get")) {
@@ -828,6 +900,113 @@ public class OpenAPIUtil {
 		}
 
 		return refJSONObject;
+	}
+
+	private static Collection<String> _getResponseFieldNames(
+		JSONObject openAPIJSONObject, JSONObject operationJSONObject) {
+
+		JSONObject responsesJSONObject = operationJSONObject.getJSONObject(
+			"responses");
+
+		JSONObject responseJSONObject = null;
+
+		if (responsesJSONObject != null) {
+			for (String code : responsesJSONObject.keySet()) {
+				if (code.startsWith("2")) {
+					responseJSONObject = responsesJSONObject.getJSONObject(
+						code);
+
+					break;
+				}
+			}
+
+			if (responseJSONObject == null) {
+				responseJSONObject = responsesJSONObject.getJSONObject(
+					"default");
+			}
+		}
+
+		JSONObject responseSchemaJSONObject = null;
+
+		if (responseJSONObject != null) {
+			JSONObject contentJSONObject = responseJSONObject.getJSONObject(
+				"content");
+
+			if (contentJSONObject != null) {
+				JSONObject mediaTypeJSONObject =
+					contentJSONObject.getJSONObject("application/json");
+
+				if (mediaTypeJSONObject != null) {
+					responseSchemaJSONObject =
+						mediaTypeJSONObject.getJSONObject("schema");
+				}
+			}
+		}
+
+		return _getResponseFieldNames(
+			openAPIJSONObject, responseSchemaJSONObject, new HashSet<>());
+	}
+
+	private static Set<String> _getResponseFieldNames(
+		JSONObject openAPIJSONObject, JSONObject schemaJSONObject,
+		Set<String> visitedRefs) {
+
+		Set<String> responseFieldNames = new TreeSet<>();
+
+		if (schemaJSONObject == null) {
+			return responseFieldNames;
+		}
+
+		if (schemaJSONObject.has("$ref")) {
+			String ref = schemaJSONObject.getString("$ref");
+
+			if (!visitedRefs.add(ref)) {
+				return responseFieldNames;
+			}
+
+			return _getResponseFieldNames(
+				openAPIJSONObject, _getRefJSONObject(ref, openAPIJSONObject),
+				visitedRefs);
+		}
+
+		if (Objects.equals(schemaJSONObject.getString("type"), "array")) {
+			return _getResponseFieldNames(
+				openAPIJSONObject, schemaJSONObject.getJSONObject("items"),
+				visitedRefs);
+		}
+
+		JSONObject propertiesJSONObject = schemaJSONObject.getJSONObject(
+			"properties");
+
+		if (propertiesJSONObject != null) {
+			JSONObject itemsPropertyJSONObject =
+				propertiesJSONObject.getJSONObject("items");
+
+			if ((itemsPropertyJSONObject != null) &&
+				Objects.equals(
+					itemsPropertyJSONObject.getString("type"), "array")) {
+
+				return _getResponseFieldNames(
+					openAPIJSONObject,
+					itemsPropertyJSONObject.getJSONObject("items"),
+					visitedRefs);
+			}
+
+			responseFieldNames.addAll(propertiesJSONObject.keySet());
+		}
+
+		JSONArray allOfJSONArray = schemaJSONObject.getJSONArray("allOf");
+
+		if (allOfJSONArray != null) {
+			for (int i = 0; i < allOfJSONArray.length(); i++) {
+				responseFieldNames.addAll(
+					_getResponseFieldNames(
+						openAPIJSONObject, allOfJSONArray.getJSONObject(i),
+						visitedRefs));
+			}
+		}
+
+		return responseFieldNames;
 	}
 
 	private static Object _getSchemaObject(
@@ -1005,14 +1184,16 @@ public class OpenAPIUtil {
 		}
 	}
 
+	private static final String _DESCRIPTION_FIELDS =
+		"Fields to include in the response. Pass only the fields the user " +
+			"actually needs.";
+
 	private static final String[] _METHODS = {
 		"delete", "get", "head", "options", "patch", "post", "put"
 	};
 
 	private static final Set<String> _excludedSchemaKeys = Set.of(
 		"actions", "example", "exclusiveMaximum", "exclusiveMinimum", "xml");
-	private static final Set<String> _vulcanFieldSelectionParameterNames =
-		Set.of("fields", "restrictFields");
 
 	private static class Operation {
 

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
@@ -140,8 +140,8 @@ public class OpenAPIUtil {
 	}
 
 	private static void _addMultipartParts(
-		JSONObject operationJSONObject, Map<String, Object> properties,
-		List<String> requiredPropertyNames, JSONObject openAPIJSONObject) {
+		JSONObject openAPIJSONObject, JSONObject operationJSONObject,
+		Map<String, Object> properties, List<String> requiredPropertyNames) {
 
 		Map<String, Object> bodySchemaMap =
 			(Map<String, Object>)_getSchemaObject(
@@ -550,8 +550,8 @@ public class OpenAPIUtil {
 		if (operationJSONObject.has("requestBody")) {
 			if (_isMultipartRequest(operationJSONObject)) {
 				_addMultipartParts(
-					operationJSONObject, properties, requiredPropertyNames,
-					openAPIJSONObject);
+					openAPIJSONObject, operationJSONObject, properties,
+					requiredPropertyNames);
 			}
 			else {
 				JSONObject requestBodyJSONObject =

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
@@ -16,9 +16,11 @@ import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.URLCodec;
 import com.liferay.portal.kernel.util.Validator;
@@ -33,6 +35,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.Predicate;
 
 /**
  * @author Alejandro Tardín
@@ -230,6 +233,52 @@ public class OpenAPIUtil {
 		sb.append(URLCodec.encodeURL(stringValue));
 	}
 
+	private static void _filterReadOnlyProperties(
+		Map<String, Object> schemaMap) {
+
+		Object propertiesObject = schemaMap.get("properties");
+
+		if (!(propertiesObject instanceof Map)) {
+			return;
+		}
+
+		Map<String, Object> properties = (Map<String, Object>)propertiesObject;
+
+		Set<String> readOnlyPropertyNames = new HashSet<>();
+
+		for (Map.Entry<String, Object> entry : properties.entrySet()) {
+			Object value = entry.getValue();
+
+			if (!(value instanceof Map)) {
+				continue;
+			}
+
+			Map<?, ?> propertyMap = (Map<?, ?>)value;
+
+			if (GetterUtil.getBoolean(propertyMap.get("readOnly"))) {
+				readOnlyPropertyNames.add(entry.getKey());
+			}
+		}
+
+		if (readOnlyPropertyNames.isEmpty()) {
+			return;
+		}
+
+		readOnlyPropertyNames.forEach(properties::remove);
+
+		List<Object> requiredList = (List<Object>)schemaMap.get("required");
+
+		if (requiredList == null) {
+			return;
+		}
+
+		schemaMap.put(
+			"required",
+			ListUtil.filter(
+				TransformUtil.transform(requiredList, String::valueOf),
+				Predicate.not(readOnlyPropertyNames::contains)));
+	}
+
 	private static Map<String, Object> _getAllOfSchemaMap(
 		JSONObject jsonObject, JSONObject openAPIJSONObject,
 		Set<String> visitedRefs) {
@@ -299,6 +348,8 @@ public class OpenAPIUtil {
 		if (!allOfSchemaMap.containsKey("type")) {
 			allOfSchemaMap.put("type", "object");
 		}
+
+		_filterReadOnlyProperties(allOfSchemaMap);
 
 		return allOfSchemaMap;
 	}
@@ -614,6 +665,8 @@ public class OpenAPIUtil {
 						openAPIJSONObject, jsonObject.get(key), visitedRefs));
 			}
 
+			_filterReadOnlyProperties(schemaMap);
+
 			return schemaMap;
 		}
 
@@ -826,6 +879,8 @@ public class OpenAPIUtil {
 					_getSchemaObject(
 						openAPIJSONObject, jsonObject.get(key), visitedRefs));
 			}
+
+			_filterReadOnlyProperties(schemaMap);
 
 			return schemaMap;
 		}

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
@@ -839,7 +839,7 @@ public class OpenAPIUtil {
 			if (jsonObject.has("$ref")) {
 				String ref = jsonObject.getString("$ref");
 
-				if (visitedRefs.contains(ref)) {
+				if (visitedRefs.contains(ref) || (visitedRefs.size() >= 3)) {
 					return HashMapBuilder.<String, Object>put(
 						"type", "object"
 					).build();

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/ToolSetUtil.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/ToolSetUtil.java
@@ -65,6 +65,7 @@ public class ToolSetUtil {
 		String toolSetName) {
 
 		return OpenAPIUtil.getTool(
+			!Objects.equals(toolSetName, _MCP_SERVER_TOOL_SET_NAME),
 			_getOpenAPIJSONObject(
 				_getOpenAPIBrief(toolSetName), httpServletRequest),
 			toolName);
@@ -117,7 +118,7 @@ public class ToolSetUtil {
 			inputJSONObject = JSONFactoryUtil.createJSONObject();
 		}
 
-		if (Objects.equals(toolSetName, "mcp-server-v1.0")) {
+		if (Objects.equals(toolSetName, _MCP_SERVER_TOOL_SET_NAME)) {
 			if (Objects.equals(toolName, "getToolSetToolSetNameTool")) {
 				return _getResponse(
 					getTool(
@@ -472,6 +473,8 @@ public class ToolSetUtil {
 
 		return openAPIPath.substring(0, index);
 	}
+
+	private static final String _MCP_SERVER_TOOL_SET_NAME = "mcp-server-v1.0";
 
 	private static final Log _log = LogFactoryUtil.getLog(ToolSetUtil.class);
 

--- a/modules/apps/mcp/mcp-server-rest-impl/src/test/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtilTest.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/test/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtilTest.java
@@ -226,6 +226,8 @@ public class OpenAPIUtilTest {
 		_testGetTool(
 			"POST /v1.0/items", "post_test_v1.0_items.json", "postItem");
 		_testGetTool(
+			"POST /v1.0/levels", "post_test_v1.0_levels.json", "postLevel");
+		_testGetTool(
 			"POST /v1.0/no-content", "post_test_v1.0_no-content.json",
 			"postNoContent");
 		_testGetTool(
@@ -245,37 +247,39 @@ public class OpenAPIUtilTest {
 		List<ToolSummary> toolSummaries = OpenAPIUtil.getToolSummaries(
 			_openAPIJSONObject);
 
-		Assert.assertEquals(toolSummaries.toString(), 14, toolSummaries.size());
+		Assert.assertEquals(toolSummaries.toString(), 15, toolSummaries.size());
 		_assertToolSummary(
 			"POST /v1.0/described", "postDescribed", toolSummaries.get(0));
 		_assertToolSummary(
-			"POST /v1.0/undescribed", "postUndescribed", toolSummaries.get(1));
+			"POST /v1.0/levels", "postLevel", toolSummaries.get(1));
 		_assertToolSummary(
-			"This is the description", "getItem", toolSummaries.get(2));
+			"POST /v1.0/undescribed", "postUndescribed", toolSummaries.get(2));
 		_assertToolSummary(
-			"PATCH /v1.0/items/{itemId}", "patchItem", toolSummaries.get(3));
+			"This is the description", "getItem", toolSummaries.get(3));
 		_assertToolSummary(
-			"PUT /v1.0/items/{itemId}", "putItem", toolSummaries.get(4));
+			"PATCH /v1.0/items/{itemId}", "patchItem", toolSummaries.get(4));
 		_assertToolSummary(
-			"POST /v1.0/binaries", "postBinary", toolSummaries.get(5));
+			"PUT /v1.0/items/{itemId}", "putItem", toolSummaries.get(5));
+		_assertToolSummary(
+			"POST /v1.0/binaries", "postBinary", toolSummaries.get(6));
 		_assertToolSummary(
 			"POST /v1.0/empty-content", "postEmptyContent",
-			toolSummaries.get(6));
+			toolSummaries.get(7));
 		_assertToolSummary(
-			"POST /v1.0/no-content", "postNoContent", toolSummaries.get(7));
+			"POST /v1.0/no-content", "postNoContent", toolSummaries.get(8));
 		_assertToolSummary(
-			"POST /v1.0/parents", "postParent", toolSummaries.get(8));
+			"POST /v1.0/parents", "postParent", toolSummaries.get(9));
 		_assertToolSummary(
-			"POST /v1.0/uploads", "postUpload", toolSummaries.get(9));
+			"POST /v1.0/uploads", "postUpload", toolSummaries.get(10));
 		_assertToolSummary(
 			"This is the summary. This is the description", "getItems",
-			toolSummaries.get(10));
+			toolSummaries.get(11));
 		_assertToolSummary(
-			"POST /v1.0/items", "postItem", toolSummaries.get(11));
+			"POST /v1.0/items", "postItem", toolSummaries.get(12));
 		_assertToolSummary(
-			"POST /v1.0/no-schema", "postNoSchema", toolSummaries.get(12));
+			"POST /v1.0/no-schema", "postNoSchema", toolSummaries.get(13));
 		_assertToolSummary(
-			"This is the summary", "getItemsPage", toolSummaries.get(13));
+			"This is the summary", "getItemsPage", toolSummaries.get(14));
 
 		AssertUtils.assertFailure(
 			IllegalArgumentException.class,

--- a/modules/apps/mcp/mcp-server-rest-impl/src/test/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtilTest.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/test/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtilTest.java
@@ -57,9 +57,15 @@ public class OpenAPIUtilTest {
 			JSONFactoryUtil.createJSONObject(), "getItems");
 		_testGetOptions(
 			null, null, Http.Method.GET,
-			"http://localhost/test/v1.0/items?page=1&pageSize=20" +
+			"http://localhost/test/v1.0/items?restrictFields=actions",
+			JSONUtil.put("fields", ""), "getItems");
+		_testGetOptions(
+			null, null, Http.Method.GET,
+			"http://localhost/test/v1.0/items?page=1&pageSize=20&fields=name" +
 				"&restrictFields=actions",
 			JSONUtil.put(
+				"fields", "name"
+			).put(
 				"page", "1"
 			).put(
 				"pageSize", "20"
@@ -72,12 +78,20 @@ public class OpenAPIUtilTest {
 			JSONUtil.put("filter", "name eq 'John Doe'"), "getItems");
 		_testGetOptions(
 			null, null, Http.Method.GET,
-			"http://localhost/test/v1.0/items?restrictFields=actions",
-			JSONUtil.put("fields", "name"), "getItems");
+			"http://localhost/test/v1.0/items?fields=name%2Cinteger" +
+				"&restrictFields=actions",
+			JSONUtil.put("fields", JSONUtil.putAll("name", "integer")),
+			"getItems");
 		_testGetOptions(
 			null, null, Http.Method.GET,
-			"http://localhost/test/v1.0/items?restrictFields=actions",
-			JSONUtil.put("restrictFields", "name"), "getItems");
+			"http://localhost/test/v1.0/items/123?fields=name" +
+				"&restrictFields=actions",
+			JSONUtil.put(
+				"fields", "name"
+			).put(
+				"itemId", "123"
+			),
+			"getItem");
 		_testGetOptions(
 			null, null, Http.Method.GET,
 			"http://localhost/test/v1.0/items/123?restrictFields=actions",
@@ -192,12 +206,12 @@ public class OpenAPIUtilTest {
 		AssertUtils.assertFailure(
 			IllegalArgumentException.class,
 			"OpenAPI document has no tool with name \"missing\"",
-			() -> OpenAPIUtil.getTool(_openAPIJSONObject, "missing"));
+			() -> OpenAPIUtil.getTool(true, _openAPIJSONObject, "missing"));
 		AssertUtils.assertFailure(
 			IllegalArgumentException.class,
 			"OpenAPI document has no \"paths\" object",
 			() -> OpenAPIUtil.getTool(
-				JSONFactoryUtil.createJSONObject(),
+				true, JSONFactoryUtil.createJSONObject(),
 				RandomTestUtil.randomString()));
 		AssertUtils.assertFailure(
 			IllegalArgumentException.class, "Request body has no content",
@@ -213,6 +227,9 @@ public class OpenAPIUtilTest {
 		_testGetTool(
 			"This is the summary. This is the description",
 			"get_test_v1.0_items.json", "getItems");
+		_testGetTool(
+			"This is the summary. This is the description",
+			"get_test_v1.0_items_no_inject.json", false, "getItems");
 		_testGetTool("This is the summary", "get_c_test.json", "getItemsPage");
 		_testGetTool(
 			"PATCH /v1.0/items/{itemId}", "patch_test_v1.0_items_itemId.json",
@@ -308,7 +325,7 @@ public class OpenAPIUtilTest {
 	private Map<String, ?> _getInputSchema(
 		JSONObject openAPIJSONObject, String toolName) {
 
-		Tool tool = OpenAPIUtil.getTool(openAPIJSONObject, toolName);
+		Tool tool = OpenAPIUtil.getTool(true, openAPIJSONObject, toolName);
 
 		return tool.getInputSchema();
 	}
@@ -347,10 +364,11 @@ public class OpenAPIUtilTest {
 
 	private void _testGetTool(
 			String expectedDescription, String expectedSchemaFileName,
-			String toolName)
+			boolean injectVulcanParameters, String toolName)
 		throws Exception {
 
-		Tool tool = OpenAPIUtil.getTool(_openAPIJSONObject, toolName);
+		Tool tool = OpenAPIUtil.getTool(
+			injectVulcanParameters, _openAPIJSONObject, toolName);
 
 		Assert.assertEquals(expectedDescription, tool.getDescription());
 		Assert.assertEquals(toolName, tool.getName());
@@ -362,6 +380,15 @@ public class OpenAPIUtilTest {
 				tool.getInputSchema()
 			),
 			true);
+	}
+
+	private void _testGetTool(
+			String expectedDescription, String expectedSchemaFileName,
+			String toolName)
+		throws Exception {
+
+		_testGetTool(
+			expectedDescription, expectedSchemaFileName, true, toolName);
 	}
 
 	private JSONObject _openAPIJSONObject;

--- a/modules/apps/mcp/mcp-server-rest-impl/src/test/resources/com/liferay/mcp/server/rest/internal/util/dependencies/get_c_test.json
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/test/resources/com/liferay/mcp/server/rest/internal/util/dependencies/get_c_test.json
@@ -1,5 +1,22 @@
 {
 	"properties": {
+		"fields": {
+			"description": "Fields to include in the response. Pass only the fields the user actually needs.",
+			"items": {
+				"enum": [
+					"array",
+					"boolean",
+					"integer",
+					"number",
+					"object1",
+					"object2",
+					"readOnly",
+					"string"
+				],
+				"type": "string"
+			},
+			"type": "array"
+		}
 	},
 	"required": [
 	],

--- a/modules/apps/mcp/mcp-server-rest-impl/src/test/resources/com/liferay/mcp/server/rest/internal/util/dependencies/get_test_v1.0_items.json
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/test/resources/com/liferay/mcp/server/rest/internal/util/dependencies/get_test_v1.0_items.json
@@ -1,5 +1,22 @@
 {
 	"properties": {
+		"fields": {
+			"description": "Fields to include in the response. Pass only the fields the user actually needs.",
+			"items": {
+				"enum": [
+					"array",
+					"boolean",
+					"integer",
+					"number",
+					"object1",
+					"object2",
+					"readOnly",
+					"string"
+				],
+				"type": "string"
+			},
+			"type": "array"
+		},
 		"filter": {
 			"description": "This is the description",
 			"type": "string"

--- a/modules/apps/mcp/mcp-server-rest-impl/src/test/resources/com/liferay/mcp/server/rest/internal/util/dependencies/get_test_v1.0_items_itemId.json
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/test/resources/com/liferay/mcp/server/rest/internal/util/dependencies/get_test_v1.0_items_itemId.json
@@ -4,6 +4,23 @@
 			"description": "This is the description",
 			"type": "boolean"
 		},
+		"fields": {
+			"description": "Fields to include in the response. Pass only the fields the user actually needs.",
+			"items": {
+				"enum": [
+					"array",
+					"boolean",
+					"integer",
+					"number",
+					"object1",
+					"object2",
+					"readOnly",
+					"string"
+				],
+				"type": "string"
+			},
+			"type": "array"
+		},
 		"itemId": {
 			"description": "This is the description",
 			"type": "string"

--- a/modules/apps/mcp/mcp-server-rest-impl/src/test/resources/com/liferay/mcp/server/rest/internal/util/dependencies/get_test_v1.0_items_no_inject.json
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/test/resources/com/liferay/mcp/server/rest/internal/util/dependencies/get_test_v1.0_items_no_inject.json
@@ -1,0 +1,19 @@
+{
+	"properties": {
+		"filter": {
+			"description": "This is the description",
+			"type": "string"
+		},
+		"page": {
+			"description": "This is the description",
+			"type": "integer"
+		},
+		"pageSize": {
+			"description": "This is the description",
+			"type": "integer"
+		}
+	},
+	"required": [
+	],
+	"type": "object"
+}

--- a/modules/apps/mcp/mcp-server-rest-impl/src/test/resources/com/liferay/mcp/server/rest/internal/util/dependencies/openapi.json
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/test/resources/com/liferay/mcp/server/rest/internal/util/dependencies/openapi.json
@@ -135,6 +135,23 @@
 				},
 				"type": "object"
 			},
+			"PageItem": {
+				"properties": {
+					"items": {
+						"items": {
+							"$ref": "#/components/schemas/Item"
+						},
+						"type": "array"
+					},
+					"page": {
+						"type": "integer"
+					},
+					"totalCount": {
+						"type": "integer"
+					}
+				},
+				"type": "object"
+			},
 			"Parent": {
 				"discriminator": {
 					"propertyName": "kind"
@@ -159,6 +176,17 @@
 		"/": {
 			"get": {
 				"operationId": "getItemsPage",
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/PageItem"
+								}
+							}
+						}
+					}
+				},
 				"summary": "This is the summary"
 			}
 		},
@@ -231,6 +259,20 @@
 						}
 					}
 				],
+				"responses": {
+					"200": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"items": {
+										"$ref": "#/components/schemas/Item"
+									},
+									"type": "array"
+								}
+							}
+						}
+					}
+				},
 				"summary": "This is the summary"
 			},
 			"post": {
@@ -283,7 +325,18 @@
 							"type": "integer"
 						}
 					}
-				]
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Item"
+								}
+							}
+						}
+					}
+				}
 			},
 			"parameters": [
 				{

--- a/modules/apps/mcp/mcp-server-rest-impl/src/test/resources/com/liferay/mcp/server/rest/internal/util/dependencies/openapi.json
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/test/resources/com/liferay/mcp/server/rest/internal/util/dependencies/openapi.json
@@ -76,11 +76,16 @@
 					"object2": {
 						"$ref": "#/components/schemas/Item"
 					},
+					"readOnly": {
+						"readOnly": true,
+						"type": "string"
+					},
 					"string": {
 						"type": "string"
 					}
 				},
 				"required": [
+					"readOnly",
 					"string"
 				],
 				"type": "object",

--- a/modules/apps/mcp/mcp-server-rest-impl/src/test/resources/com/liferay/mcp/server/rest/internal/util/dependencies/openapi.json
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/test/resources/com/liferay/mcp/server/rest/internal/util/dependencies/openapi.json
@@ -94,6 +94,47 @@
 					"name": "Item"
 				}
 			},
+			"LevelA": {
+				"properties": {
+					"name": {
+						"type": "string"
+					},
+					"next": {
+						"$ref": "#/components/schemas/LevelB"
+					}
+				},
+				"type": "object"
+			},
+			"LevelB": {
+				"properties": {
+					"name": {
+						"type": "string"
+					},
+					"next": {
+						"$ref": "#/components/schemas/LevelC"
+					}
+				},
+				"type": "object"
+			},
+			"LevelC": {
+				"properties": {
+					"name": {
+						"type": "string"
+					},
+					"next": {
+						"$ref": "#/components/schemas/LevelD"
+					}
+				},
+				"type": "object"
+			},
+			"LevelD": {
+				"properties": {
+					"name": {
+						"type": "string"
+					}
+				},
+				"type": "object"
+			},
 			"Parent": {
 				"discriminator": {
 					"propertyName": "kind"
@@ -293,6 +334,20 @@
 						"application/json": {
 							"schema": {
 								"$ref": "#/components/schemas/Item"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/v1.0/levels": {
+			"post": {
+				"operationId": "postLevel",
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/LevelA"
 							}
 						}
 					}

--- a/modules/apps/mcp/mcp-server-rest-impl/src/test/resources/com/liferay/mcp/server/rest/internal/util/dependencies/post_test_v1.0_levels.json
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/test/resources/com/liferay/mcp/server/rest/internal/util/dependencies/post_test_v1.0_levels.json
@@ -1,0 +1,35 @@
+{
+	"properties": {
+		"body": {
+			"properties": {
+				"name": {
+					"type": "string"
+				},
+				"next": {
+					"properties": {
+						"name": {
+							"type": "string"
+						},
+						"next": {
+							"properties": {
+								"name": {
+									"type": "string"
+								},
+								"next": {
+									"type": "object"
+								}
+							},
+							"type": "object"
+						}
+					},
+					"type": "object"
+				}
+			},
+			"type": "object"
+		}
+	},
+	"required": [
+		"body"
+	],
+	"type": "object"
+}

--- a/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/resource/v1_0/test/ToolResourceTest.java
+++ b/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/resource/v1_0/test/ToolResourceTest.java
@@ -91,6 +91,36 @@ public class ToolResourceTest extends BaseToolResourceTestCase {
 			).has(
 				"xClassName"
 			));
+
+		httpResponse =
+			toolResource.postToolSetToolSetNameToolInvokeHttpResponse(
+				"headless-delivery-v1.0", "getSiteDocumentsPage",
+				JSONUtil.put(
+					"fields", "id"
+				).put(
+					"siteId", testGroup.getGroupId()
+				).toString());
+
+		Assert.assertTrue(
+			JSONFactoryUtil.createJSONObject(
+				httpResponse.getContent()
+			).getJSONArray(
+				"items"
+			).getJSONObject(
+				0
+			).has(
+				"id"
+			));
+		Assert.assertFalse(
+			JSONFactoryUtil.createJSONObject(
+				httpResponse.getContent()
+			).getJSONArray(
+				"items"
+			).getJSONObject(
+				0
+			).has(
+				"title"
+			));
 	}
 
 }

--- a/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/resources/com/liferay/mcp/server/rest/internal/servlet/test/dependencies/post_mcp_server_profiles.json
+++ b/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/resources/com/liferay/mcp/server/rest/internal/servlet/test/dependencies/post_mcp_server_profiles.json
@@ -5,10 +5,6 @@
 				"externalReferenceCode": {
 					"type": "string"
 				},
-				"id": {
-					"format": "int64",
-					"type": "integer"
-				},
 				"name": {
 					"type": "string"
 				}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89991

## What Is Being Fixed

MCP exposes Liferay's REST APIs as tools. The generated tool input schemas mirrored the full DTOs and fully expanded every $ref, so write tools such as postSiteDocument produced schemas around 100 KB, and read tools returned the entire DTO for every record. Both flooded the model's context with fields a caller never needs.

## How It Is Being Fixed

LPD-92845 strips readOnly fields, which the server populates and a client never sends, from write tool input schemas during schema resolution.

LPD-92846 caps $ref expansion at three hops and collapses anything deeper to an opaque object, so deeply nested DTOs no longer explode the schema.

LPD-92848 exposes the Vulcan fields query parameter on GET tool input schemas, each with an enum of the response's field names, and forwards it on invocation so callers fetch only what they need. The bulky HATEOAS actions block stays stripped from every GET response.

LPD-89991 sorts the _addMultipartParts parameters alphabetically, a small consistency cleanup in the same file.

Measured against a live instance, the postSiteDocument input schema drops from about 103 KB to 6.6 KB, and "get me the object definition names" with fields=["name"] takes the getObjectDefinitionsPage response from 38,203 to 122 tokens, the whole request down about 69%.

## PR Check

**pr-check: PASS** — tested on `c67821965bdafcbf2b3231ad683ae4760939ea5c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "c67821965bdafcbf2b3231ad683ae4760939ea5c"} -->
