### PR TITLE
LRCI-7707 Set the PARENT_BUILD_URL on build invocations

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/ArchiveBinariesCachePortalControllerBuildRunner.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/ArchiveBinariesCachePortalControllerBuildRunner.java
@@ -66,6 +66,7 @@ public class ArchiveBinariesCachePortalControllerBuildRunner
 		invocationParameters.put(
 			"JENKINS_GITHUB_BRANCH_USERNAME",
 			buildData.getJenkinsGitHubUsername());
+		invocationParameters.put("PARENT_BUILD_URL", buildData.getBuildURL());
 		invocationParameters.put(
 			"PORTAL_GIT_COMMIT", buildData.getPortalBranchSHA());
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/DefaultBuildUpdater.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/DefaultBuildUpdater.java
@@ -351,6 +351,16 @@ public class DefaultBuildUpdater extends BaseBuildUpdater {
 
 		Build build = getBuild();
 
+		Build parentBuild = build.getParentBuild();
+
+		if (parentBuild != null) {
+			String parentBuildURL = parentBuild.getBuildURL();
+
+			if (!JenkinsResultsParserUtil.isNullOrEmpty(parentBuildURL)) {
+				build.setParameterValue("PARENT_BUILD_URL", parentBuildURL);
+			}
+		}
+
 		Map<String, String> buildParameters = new HashMap<>(
 			build.getParameters());
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GenerateReportsControllerBuildRunner.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GenerateReportsControllerBuildRunner.java
@@ -236,6 +236,10 @@ public class GenerateReportsControllerBuildRunner
 	}
 
 	private void _invoke(Map<String, String> invocationParameters) {
+		BuildData buildData = getBuildData();
+
+		invocationParameters.put("PARENT_BUILD_URL", buildData.getBuildURL());
+
 		Properties buildProperties = null;
 
 		try {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PoshiReleasePortalTopLevelBuildRunner.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PoshiReleasePortalTopLevelBuildRunner.java
@@ -263,6 +263,8 @@ public class PoshiReleasePortalTopLevelBuildRunner
 				_getGitHubBranchUsername("JENKINS_GITHUB_URL"));
 			invocationParameters.put(
 				"JENKINS_TOP_LEVEL_BUILD_URL", buildData.getBuildURL());
+			invocationParameters.put(
+				"PARENT_BUILD_URL", buildData.getBuildURL());
 
 			PullRequest pullRequest = entry.getValue();
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/QAWebsitesControllerBuildRunner.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/QAWebsitesControllerBuildRunner.java
@@ -130,6 +130,7 @@ public class QAWebsitesControllerBuildRunner
 		invocationParameters.put(
 			"JENKINS_GITHUB_BRANCH_USERNAME",
 			_getGitHubBranchUsername("JENKINS_GITHUB_URL"));
+		invocationParameters.put("PARENT_BUILD_URL", buildData.getBuildURL());
 		invocationParameters.put(
 			"TEST_QA_WEBSITES_BRANCH_NAME",
 			_getGitHubBranchName("QA_WEBSITES_GITHUB_URL"));

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SingleUpstreamPortalControllerBuildRunner.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SingleUpstreamPortalControllerBuildRunner.java
@@ -70,6 +70,7 @@ public class SingleUpstreamPortalControllerBuildRunner
 		invocationParameters.put(
 			"JENKINS_GITHUB_BRANCH_USERNAME",
 			buildData.getJenkinsGitHubUsername());
+		invocationParameters.put("PARENT_BUILD_URL", buildData.getBuildURL());
 		invocationParameters.put(
 			"PORTAL_GIT_COMMIT", buildData.getPortalBranchSHA());
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TestSuiteMultipleUpstreamPortalControllerBuildRunner.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TestSuiteMultipleUpstreamPortalControllerBuildRunner.java
@@ -92,6 +92,8 @@ public class TestSuiteMultipleUpstreamPortalControllerBuildRunner
 			invocationParameters.put(
 				"JENKINS_GITHUB_BRANCH_USERNAME",
 				buildData.getJenkinsGitHubUsername());
+			invocationParameters.put(
+				"PARENT_BUILD_URL", buildData.getBuildURL());
 			invocationParameters.put("PORTAL_GIT_COMMIT", portalBranchSHA);
 			invocationParameters.put(
 				"PORTAL_GITHUB_URL", buildData.getPortalGitHubURL());

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TopLevelBuildRunner.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TopLevelBuildRunner.java
@@ -327,6 +327,9 @@ public abstract class TopLevelBuildRunner<T extends TopLevelBuildData>
 			throw new RuntimeException(ioException);
 		}
 
+		invocationParameters.put(
+			"PARENT_BUILD_URL", _topLevelBuild.getBuildURL());
+
 		StringBuilder sb = new StringBuilder();
 
 		sb.append(getBaseInvocationURL(cohortName, jobName));

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/persistent/resource/BaseBundlePersistentResource.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/persistent/resource/BaseBundlePersistentResource.java
@@ -410,6 +410,7 @@ public abstract class BaseBundlePersistentResource
 		buildParameters.put("AXIS_VARIABLE", _getAxisVariable());
 		buildParameters.put("BUILD_PRIORITY", _BUILD_PRIORITY);
 		buildParameters.put("JOB_VARIANT", _JOB_VARIANT);
+		buildParameters.put("PARENT_BUILD_URL", getCurrentTopLevelBuildURL());
 		buildParameters.put("SLAVE_LABEL", "slave-bundle-builder");
 
 		setProducerQueueId(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7707

@brianchandotcom - This is a rebase of this pull: https://github.com/brianchandotcom/liferay-portal/pull/177276#issuecomment-4756019884

## What Is Being Fixed

Build invocations across the Jenkins results parser did not propagate a `PARENT_BUILD_URL` parameter. Child builds — build runners, the build updater, and persistent resources — had no reference back to the parent build that triggered them.

## How It Is Being Fixed

Each build-invocation path now sets a `PARENT_BUILD_URL` parameter. The controller and top-level build runners add it to their invocation parameters from the build data or the top-level build URL. `DefaultBuildUpdater` sets it from the parent build's URL when one is present. `BaseBundlePersistentResource` sets it from the current top-level build URL.

## Why Are There No Tests?

The `jenkins-results-parser` module is Jenkins build infrastructure. These changes pass through a new build parameter and are not covered by the module's automated test harness.

## PR Check

**pr-check: PASS** — tested on `dcef186bdbb565d9115a85242b84acebfb73b7f2`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "dcef186bdbb565d9115a85242b84acebfb73b7f2"} -->
