### PR TITLE
LPD-90640 Remove Session.saveOrUpdate from the kernel ORM API

### DIFF
--- a/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/persistence/test/AccountEntryOrganizationRelPersistenceTest.java
+++ b/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/persistence/test/AccountEntryOrganizationRelPersistenceTest.java
@@ -125,8 +125,10 @@ public class AccountEntryOrganizationRelPersistenceTest {
 		newAccountEntryOrganizationRel.setOrganizationId(
 			RandomTestUtil.nextLong());
 
-		_accountEntryOrganizationRels.add(
-			_persistence.update(newAccountEntryOrganizationRel));
+		newAccountEntryOrganizationRel = _persistence.update(
+			newAccountEntryOrganizationRel);
+
+		_accountEntryOrganizationRels.add(newAccountEntryOrganizationRel);
 
 		AccountEntryOrganizationRel existingAccountEntryOrganizationRel =
 			_persistence.findByPrimaryKey(
@@ -553,4 +555,4 @@ public class AccountEntryOrganizationRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1404053440
+// LIFERAY-SERVICE-BUILDER-HASH:1281538462

--- a/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/persistence/test/AccountEntryPersistenceTest.java
+++ b/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/persistence/test/AccountEntryPersistenceTest.java
@@ -163,7 +163,9 @@ public class AccountEntryPersistenceTest {
 
 		newAccountEntry.setStatusDate(RandomTestUtil.nextDate());
 
-		_accountEntries.add(_persistence.update(newAccountEntry));
+		newAccountEntry = _persistence.update(newAccountEntry);
+
+		_accountEntries.add(newAccountEntry);
 
 		AccountEntry existingAccountEntry = _persistence.findByPrimaryKey(
 			newAccountEntry.getPrimaryKey());
@@ -687,4 +689,4 @@ public class AccountEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:155718757
+// LIFERAY-SERVICE-BUILDER-HASH:-483620059

--- a/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/persistence/test/AccountEntryUserRelPersistenceTest.java
+++ b/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/persistence/test/AccountEntryUserRelPersistenceTest.java
@@ -120,7 +120,9 @@ public class AccountEntryUserRelPersistenceTest {
 
 		newAccountEntryUserRel.setAccountUserId(RandomTestUtil.nextLong());
 
-		_accountEntryUserRels.add(_persistence.update(newAccountEntryUserRel));
+		newAccountEntryUserRel = _persistence.update(newAccountEntryUserRel);
+
+		_accountEntryUserRels.add(newAccountEntryUserRel);
 
 		AccountEntryUserRel existingAccountEntryUserRel =
 			_persistence.findByPrimaryKey(
@@ -511,4 +513,4 @@ public class AccountEntryUserRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-93209310
+// LIFERAY-SERVICE-BUILDER-HASH:-1944329820

--- a/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/persistence/test/AccountGroupPersistenceTest.java
+++ b/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/persistence/test/AccountGroupPersistenceTest.java
@@ -138,7 +138,9 @@ public class AccountGroupPersistenceTest {
 
 		newAccountGroup.setStatus(RandomTestUtil.nextInt());
 
-		_accountGroups.add(_persistence.update(newAccountGroup));
+		newAccountGroup = _persistence.update(newAccountGroup);
+
+		_accountGroups.add(newAccountGroup);
 
 		AccountGroup existingAccountGroup = _persistence.findByPrimaryKey(
 			newAccountGroup.getPrimaryKey());
@@ -621,4 +623,4 @@ public class AccountGroupPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1679047707
+// LIFERAY-SERVICE-BUILDER-HASH:-1722076007

--- a/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/persistence/test/AccountGroupRelPersistenceTest.java
+++ b/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/persistence/test/AccountGroupRelPersistenceTest.java
@@ -129,7 +129,9 @@ public class AccountGroupRelPersistenceTest {
 
 		newAccountGroupRel.setClassPK(RandomTestUtil.nextLong());
 
-		_accountGroupRels.add(_persistence.update(newAccountGroupRel));
+		newAccountGroupRel = _persistence.update(newAccountGroupRel);
+
+		_accountGroupRels.add(newAccountGroupRel);
 
 		AccountGroupRel existingAccountGroupRel = _persistence.findByPrimaryKey(
 			newAccountGroupRel.getPrimaryKey());
@@ -545,4 +547,4 @@ public class AccountGroupRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1504385723
+// LIFERAY-SERVICE-BUILDER-HASH:-1804310193

--- a/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/persistence/test/AccountRolePersistenceTest.java
+++ b/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/persistence/test/AccountRolePersistenceTest.java
@@ -121,7 +121,9 @@ public class AccountRolePersistenceTest {
 
 		newAccountRole.setRoleId(RandomTestUtil.nextLong());
 
-		_accountRoles.add(_persistence.update(newAccountRole));
+		newAccountRole = _persistence.update(newAccountRole);
+
+		_accountRoles.add(newAccountRole);
 
 		AccountRole existingAccountRole = _persistence.findByPrimaryKey(
 			newAccountRole.getPrimaryKey());
@@ -546,4 +548,4 @@ public class AccountRolePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1901311082
+// LIFERAY-SERVICE-BUILDER-HASH:-1383680644

--- a/modules/apps/adaptive-media/adaptive-media-image-test/src/testIntegration/java/com/liferay/adaptive/media/image/service/persistence/test/AMImageEntryPersistenceTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-test/src/testIntegration/java/com/liferay/adaptive/media/image/service/persistence/test/AMImageEntryPersistenceTest.java
@@ -136,7 +136,9 @@ public class AMImageEntryPersistenceTest {
 
 		newAMImageEntry.setSize(RandomTestUtil.nextLong());
 
-		_amImageEntries.add(_persistence.update(newAMImageEntry));
+		newAMImageEntry = _persistence.update(newAMImageEntry);
+
+		_amImageEntries.add(newAMImageEntry);
 
 		AMImageEntry existingAMImageEntry = _persistence.findByPrimaryKey(
 			newAMImageEntry.getPrimaryKey());
@@ -607,4 +609,4 @@ public class AMImageEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:472388157
+// LIFERAY-SERVICE-BUILDER-HASH:1920985673

--- a/modules/apps/analytics/analytics-message-storage-service/src/main/java/com/liferay/analytics/message/storage/service/persistence/impl/AnalyticsMessagePersistenceImpl.java
+++ b/modules/apps/analytics/analytics-message-storage-service/src/main/java/com/liferay/analytics/message/storage/service/persistence/impl/AnalyticsMessagePersistenceImpl.java
@@ -292,11 +292,8 @@ public class AnalyticsMessagePersistenceImpl
 				session.save(analyticsMessage);
 			}
 			else {
-				session.evict(
-					AnalyticsMessageImpl.class,
-					analyticsMessage.getPrimaryKeyObj());
-
-				session.saveOrUpdate(analyticsMessage);
+				analyticsMessage = (AnalyticsMessage)session.merge(
+					analyticsMessage);
 			}
 
 			session.flush();
@@ -522,4 +519,4 @@ public class AnalyticsMessagePersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-317890152
+// LIFERAY-SERVICE-BUILDER-HASH:2118337763

--- a/modules/apps/analytics/analytics-message-storage-service/src/main/resources/META-INF/module-hbm.xml
+++ b/modules/apps/analytics/analytics-message-storage-service/src/main/resources/META-INF/module-hbm.xml
@@ -43,7 +43,7 @@
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="userId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="userName" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="createDate" type="timestamp" />
-		<one-to-one access="com.liferay.portal.dao.orm.hibernate.PrivateFieldPropertyAccessor" cascade="save-update" class="com.liferay.analytics.message.storage.model.AnalyticsMessageBodyBlobModel" constrained="false" name="bodyBlobModel" outer-join="false" />
+		<one-to-one access="com.liferay.portal.dao.orm.hibernate.PrivateFieldPropertyAccessor" cascade="merge, persist, save-update" class="com.liferay.analytics.message.storage.model.AnalyticsMessageBodyBlobModel" constrained="false" name="bodyBlobModel" outer-join="false" />
 	</class>
 	<class dynamic-update="true" lazy="true" name="com.liferay.analytics.message.storage.model.AnalyticsMessageBodyBlobModel" table="AnalyticsMessage">
 		<id column="analyticsMessageId" name="analyticsMessageId">

--- a/modules/apps/asset/asset-auto-tagger-test/src/testIntegration/java/com/liferay/asset/auto/tagger/service/persistence/test/AssetAutoTaggerEntryPersistenceTest.java
+++ b/modules/apps/asset/asset-auto-tagger-test/src/testIntegration/java/com/liferay/asset/auto/tagger/service/persistence/test/AssetAutoTaggerEntryPersistenceTest.java
@@ -131,8 +131,9 @@ public class AssetAutoTaggerEntryPersistenceTest {
 
 		newAssetAutoTaggerEntry.setAssetTagId(RandomTestUtil.nextLong());
 
-		_assetAutoTaggerEntries.add(
-			_persistence.update(newAssetAutoTaggerEntry));
+		newAssetAutoTaggerEntry = _persistence.update(newAssetAutoTaggerEntry);
+
+		_assetAutoTaggerEntries.add(newAssetAutoTaggerEntry);
 
 		AssetAutoTaggerEntry existingAssetAutoTaggerEntry =
 			_persistence.findByPrimaryKey(
@@ -560,4 +561,4 @@ public class AssetAutoTaggerEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:328063073
+// LIFERAY-SERVICE-BUILDER-HASH:754453545

--- a/modules/apps/asset/asset-category-property-test/src/testIntegration/java/com/liferay/asset/category/property/service/persistence/test/AssetCategoryPropertyPersistenceTest.java
+++ b/modules/apps/asset/asset-category-property-test/src/testIntegration/java/com/liferay/asset/category/property/service/persistence/test/AssetCategoryPropertyPersistenceTest.java
@@ -140,8 +140,10 @@ public class AssetCategoryPropertyPersistenceTest {
 
 		newAssetCategoryProperty.setValue(RandomTestUtil.randomString());
 
-		_assetCategoryProperties.add(
-			_persistence.update(newAssetCategoryProperty));
+		newAssetCategoryProperty = _persistence.update(
+			newAssetCategoryProperty);
+
+		_assetCategoryProperties.add(newAssetCategoryProperty);
 
 		AssetCategoryProperty existingAssetCategoryProperty =
 			_persistence.findByPrimaryKey(
@@ -643,4 +645,4 @@ public class AssetCategoryPropertyPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-878427072
+// LIFERAY-SERVICE-BUILDER-HASH:-900197240

--- a/modules/apps/asset/asset-display-page-test/src/testIntegration/java/com/liferay/asset/display/page/service/persistence/test/AssetDisplayPageEntryPersistenceTest.java
+++ b/modules/apps/asset/asset-display-page-test/src/testIntegration/java/com/liferay/asset/display/page/service/persistence/test/AssetDisplayPageEntryPersistenceTest.java
@@ -145,8 +145,10 @@ public class AssetDisplayPageEntryPersistenceTest {
 
 		newAssetDisplayPageEntry.setPlid(RandomTestUtil.nextLong());
 
-		_assetDisplayPageEntries.add(
-			_persistence.update(newAssetDisplayPageEntry));
+		newAssetDisplayPageEntry = _persistence.update(
+			newAssetDisplayPageEntry);
+
+		_assetDisplayPageEntries.add(newAssetDisplayPageEntry);
 
 		AssetDisplayPageEntry existingAssetDisplayPageEntry =
 			_persistence.findByPrimaryKey(
@@ -663,4 +665,4 @@ public class AssetDisplayPageEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:810024056
+// LIFERAY-SERVICE-BUILDER-HASH:1934513584

--- a/modules/apps/asset/asset-entry-rel-test/src/testIntegration/java/com/liferay/asset/entry/rel/service/persistence/test/AssetEntryAssetCategoryRelPersistenceTest.java
+++ b/modules/apps/asset/asset-entry-rel-test/src/testIntegration/java/com/liferay/asset/entry/rel/service/persistence/test/AssetEntryAssetCategoryRelPersistenceTest.java
@@ -130,8 +130,10 @@ public class AssetEntryAssetCategoryRelPersistenceTest {
 
 		newAssetEntryAssetCategoryRel.setPriority(RandomTestUtil.nextInt());
 
-		_assetEntryAssetCategoryRels.add(
-			_persistence.update(newAssetEntryAssetCategoryRel));
+		newAssetEntryAssetCategoryRel = _persistence.update(
+			newAssetEntryAssetCategoryRel);
+
+		_assetEntryAssetCategoryRels.add(newAssetEntryAssetCategoryRel);
 
 		AssetEntryAssetCategoryRel existingAssetEntryAssetCategoryRel =
 			_persistence.findByPrimaryKey(
@@ -564,4 +566,4 @@ public class AssetEntryAssetCategoryRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1622280082
+// LIFERAY-SERVICE-BUILDER-HASH:-1809647120

--- a/modules/apps/asset/asset-link-test/src/testIntegration/java/com/liferay/asset/link/service/persistence/test/AssetLinkPersistenceTest.java
+++ b/modules/apps/asset/asset-link-test/src/testIntegration/java/com/liferay/asset/link/service/persistence/test/AssetLinkPersistenceTest.java
@@ -131,7 +131,9 @@ public class AssetLinkPersistenceTest {
 
 		newAssetLink.setWeight(RandomTestUtil.nextInt());
 
-		_assetLinks.add(_persistence.update(newAssetLink));
+		newAssetLink = _persistence.update(newAssetLink);
+
+		_assetLinks.add(newAssetLink);
 
 		AssetLink existingAssetLink = _persistence.findByPrimaryKey(
 			newAssetLink.getPrimaryKey());
@@ -544,4 +546,4 @@ public class AssetLinkPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1631290713
+// LIFERAY-SERVICE-BUILDER-HASH:-2107619579

--- a/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/service/persistence/test/AssetListEntryAssetEntryRelPersistenceTest.java
+++ b/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/service/persistence/test/AssetListEntryAssetEntryRelPersistenceTest.java
@@ -151,8 +151,10 @@ public class AssetListEntryAssetEntryRelPersistenceTest {
 		newAssetListEntryAssetEntryRel.setLastPublishDate(
 			RandomTestUtil.nextDate());
 
-		_assetListEntryAssetEntryRels.add(
-			_persistence.update(newAssetListEntryAssetEntryRel));
+		newAssetListEntryAssetEntryRel = _persistence.update(
+			newAssetListEntryAssetEntryRel);
+
+		_assetListEntryAssetEntryRels.add(newAssetListEntryAssetEntryRel);
 
 		AssetListEntryAssetEntryRel existingAssetListEntryAssetEntryRel =
 			_persistence.findByPrimaryKey(
@@ -709,4 +711,4 @@ public class AssetListEntryAssetEntryRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:236788942
+// LIFERAY-SERVICE-BUILDER-HASH:2078348456

--- a/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/service/persistence/test/AssetListEntryPersistenceTest.java
+++ b/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/service/persistence/test/AssetListEntryPersistenceTest.java
@@ -149,7 +149,9 @@ public class AssetListEntryPersistenceTest {
 
 		newAssetListEntry.setLastPublishDate(RandomTestUtil.nextDate());
 
-		_assetListEntries.add(_persistence.update(newAssetListEntry));
+		newAssetListEntry = _persistence.update(newAssetListEntry);
+
+		_assetListEntries.add(newAssetListEntry);
 
 		AssetListEntry existingAssetListEntry = _persistence.findByPrimaryKey(
 			newAssetListEntry.getPrimaryKey());
@@ -801,4 +803,4 @@ public class AssetListEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1420633711
+// LIFERAY-SERVICE-BUILDER-HASH:-2023074775

--- a/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/service/persistence/test/AssetListEntrySegmentsEntryRelPersistenceTest.java
+++ b/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/service/persistence/test/AssetListEntrySegmentsEntryRelPersistenceTest.java
@@ -154,8 +154,10 @@ public class AssetListEntrySegmentsEntryRelPersistenceTest {
 		newAssetListEntrySegmentsEntryRel.setLastPublishDate(
 			RandomTestUtil.nextDate());
 
-		_assetListEntrySegmentsEntryRels.add(
-			_persistence.update(newAssetListEntrySegmentsEntryRel));
+		newAssetListEntrySegmentsEntryRel = _persistence.update(
+			newAssetListEntrySegmentsEntryRel);
+
+		_assetListEntrySegmentsEntryRels.add(newAssetListEntrySegmentsEntryRel);
 
 		AssetListEntrySegmentsEntryRel existingAssetListEntrySegmentsEntryRel =
 			_persistence.findByPrimaryKey(
@@ -703,4 +705,4 @@ public class AssetListEntrySegmentsEntryRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1232852559
+// LIFERAY-SERVICE-BUILDER-HASH:1292147763

--- a/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/service/persistence/test/AssetListEntryUsagePersistenceTest.java
+++ b/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/service/persistence/test/AssetListEntryUsagePersistenceTest.java
@@ -145,7 +145,9 @@ public class AssetListEntryUsagePersistenceTest {
 
 		newAssetListEntryUsage.setLastPublishDate(RandomTestUtil.nextDate());
 
-		_assetListEntryUsages.add(_persistence.update(newAssetListEntryUsage));
+		newAssetListEntryUsage = _persistence.update(newAssetListEntryUsage);
+
+		_assetListEntryUsages.add(newAssetListEntryUsage);
 
 		AssetListEntryUsage existingAssetListEntryUsage =
 			_persistence.findByPrimaryKey(
@@ -706,4 +708,4 @@ public class AssetListEntryUsagePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-251904666
+// LIFERAY-SERVICE-BUILDER-HASH:987564824

--- a/modules/apps/audiences/audiences-test/src/testIntegration/java/com/liferay/audiences/service/persistence/test/AudiencesEntryPersistenceTest.java
+++ b/modules/apps/audiences/audiences-test/src/testIntegration/java/com/liferay/audiences/service/persistence/test/AudiencesEntryPersistenceTest.java
@@ -131,7 +131,9 @@ public class AudiencesEntryPersistenceTest {
 
 		newAudiencesEntry.setName(RandomTestUtil.randomString());
 
-		_audiencesEntries.add(_persistence.update(newAudiencesEntry));
+		newAudiencesEntry = _persistence.update(newAudiencesEntry);
+
+		_audiencesEntries.add(newAudiencesEntry);
 
 		AudiencesEntry existingAudiencesEntry = _persistence.findByPrimaryKey(
 			newAudiencesEntry.getPrimaryKey());
@@ -552,4 +554,4 @@ public class AudiencesEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-600224529
+// LIFERAY-SERVICE-BUILDER-HASH:1067092027

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineExportTaskExecutorImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineExportTaskExecutorImpl.java
@@ -133,23 +133,42 @@ public class BatchEngineExportTaskExecutorImpl
 			batchEngineExportTask.setStartTime(new Date());
 
 			if (settings.isPersist()) {
-				_batchEngineExportTaskLocalService.updateBatchEngineExportTask(
-					batchEngineExportTask);
+				batchEngineExportTask =
+					_batchEngineExportTaskLocalService.
+						updateBatchEngineExportTask(batchEngineExportTask);
 			}
 
-			InputStream inputStream = BatchEngineTaskExecutorUtil.execute(
-				true, () -> _exportItems(batchEngineExportTask, settings),
-				_userLocalService.getUser(batchEngineExportTask.getUserId()));
+			BatchEngineExportTask finalBatchEngineExportTask =
+				batchEngineExportTask;
 
-			_updateBatchEngineExportTask(
+			InputStream inputStream = BatchEngineTaskExecutorUtil.execute(
+				true, () -> _exportItems(finalBatchEngineExportTask, settings),
+				_userLocalService.getUser(
+					finalBatchEngineExportTask.getUserId()));
+
+			if (settings.isPersist()) {
+				BatchEngineExportTask fetchedBatchEngineExportTask =
+					_batchEngineExportTaskLocalService.
+						fetchBatchEngineExportTask(
+							batchEngineExportTask.getBatchEngineExportTaskId());
+
+				if (fetchedBatchEngineExportTask != null) {
+					batchEngineExportTask = fetchedBatchEngineExportTask;
+				}
+			}
+
+			batchEngineExportTask = _updateBatchEngineExportTask(
 				BatchEngineTaskExecuteStatus.COMPLETED, batchEngineExportTask,
 				null, settings.isPersist());
+
+			BatchEngineExportTask updatedBatchEngineExportTask =
+				batchEngineExportTask;
 
 			return new Result() {
 
 				@Override
 				public BatchEngineExportTask getBatchEngineExportTask() {
-					return batchEngineExportTask;
+					return updatedBatchEngineExportTask;
 				}
 
 				@Override
@@ -408,8 +427,9 @@ public class BatchEngineExportTaskExecutorImpl
 				new OutputBlob(
 					new UnsyncByteArrayInputStream(content), content.length));
 
-			_batchEngineExportTaskLocalService.updateBatchEngineExportTask(
-				batchEngineExportTask);
+			batchEngineExportTask =
+				_batchEngineExportTaskLocalService.updateBatchEngineExportTask(
+					batchEngineExportTask);
 		}
 
 		return new ByteArrayInputStream(content);
@@ -660,7 +680,7 @@ public class BatchEngineExportTaskExecutorImpl
 		return multivaluedMap;
 	}
 
-	private void _updateBatchEngineExportTask(
+	private BatchEngineExportTask _updateBatchEngineExportTask(
 		BatchEngineTaskExecuteStatus batchEngineTaskExecuteStatus,
 		BatchEngineExportTask batchEngineExportTask, String errorMessage,
 		boolean persist) {
@@ -680,6 +700,8 @@ public class BatchEngineExportTaskExecutorImpl
 			batchEngineExportTask.getCallbackURL(),
 			batchEngineExportTask.getExecuteStatus(),
 			batchEngineExportTask.getBatchEngineExportTaskId());
+
+		return batchEngineExportTask;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineImportTaskExecutorImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineImportTaskExecutorImpl.java
@@ -153,17 +153,21 @@ public class BatchEngineImportTaskExecutorImpl
 					batchEngineTaskProgress.getTotalItemsCount(inputStream));
 			}
 
-			_batchEngineImportTaskLocalService.updateBatchEngineImportTask(
-				batchEngineImportTask);
+			batchEngineImportTask =
+				_batchEngineImportTaskLocalService.updateBatchEngineImportTask(
+					batchEngineImportTask);
 
 			User user = _userLocalService.getUser(
 				batchEngineImportTask.getUserId());
 
-			BatchEngineTaskExecutorUtil.execute(
+			BatchEngineImportTask finalBatchEngineImportTask =
+				batchEngineImportTask;
+
+			batchEngineImportTask = BatchEngineTaskExecutorUtil.execute(
 				checkPermissions,
 				() -> _importFile(
-					batchEngineImportTask, batchEngineTaskItemDelegate, file,
-					user),
+					finalBatchEngineImportTask, batchEngineTaskItemDelegate,
+					file, user),
 				user);
 
 			_updateBatchEngineImportTask(
@@ -260,7 +264,7 @@ public class BatchEngineImportTaskExecutorImpl
 		_itemReaderPostActions.close();
 	}
 
-	private <T> void _commitItems(
+	private <T> BatchEngineImportTask _commitItems(
 			BatchEngineImportTask batchEngineImportTask,
 			BatchEngineTaskItemDelegate<T> batchEngineTaskItemDelegate,
 			List<T> items, Map<String, Serializable> parameters,
@@ -283,7 +287,7 @@ public class BatchEngineImportTaskExecutorImpl
 
 		batchEngineImportTask.setProcessedItemsCount(processedItemsCount);
 
-		_batchEngineImportTaskLocalService.updateBatchEngineImportTask(
+		return _batchEngineImportTaskLocalService.updateBatchEngineImportTask(
 			batchEngineImportTask);
 	}
 
@@ -424,7 +428,7 @@ public class BatchEngineImportTaskExecutorImpl
 		}
 	}
 
-	private <T> Void _importFile(
+	private <T> BatchEngineImportTask _importFile(
 			BatchEngineImportTask batchEngineImportTask,
 			BatchEngineTaskItemDelegate<T> batchEngineTaskItemDelegate,
 			File file, User user)
@@ -443,10 +447,13 @@ public class BatchEngineImportTaskExecutorImpl
 				batchEngineImportTask.getCompanyId(),
 				batchEngineTaskItemDelegate, parameters, user);
 
+			BatchEngineImportTask finalBatchEngineImportTask =
+				batchEngineImportTask;
+
 			batchEngineTaskItemDelegate.setImportItemUnsafeBiConsumer(
 				(item, unsafeFunction) -> _importItem(
-					batchEngineImportTask, batchEngineTaskItemDelegate, item,
-					unsafeFunction));
+					finalBatchEngineImportTask, batchEngineTaskItemDelegate,
+					item, unsafeFunction));
 
 			List<T> items = new ArrayList<>();
 
@@ -484,7 +491,7 @@ public class BatchEngineImportTaskExecutorImpl
 				}
 
 				if (items.size() == batchEngineImportTask.getBatchSize()) {
-					_commitItems(
+					batchEngineImportTask = _commitItems(
 						batchEngineImportTask, batchEngineTaskItemDelegate,
 						items, parameters, processedItemsCount);
 
@@ -499,7 +506,7 @@ public class BatchEngineImportTaskExecutorImpl
 			}
 
 			if (!items.isEmpty()) {
-				_commitItems(
+				batchEngineImportTask = _commitItems(
 					batchEngineImportTask, batchEngineTaskItemDelegate, items,
 					parameters, processedItemsCount);
 			}
@@ -510,7 +517,7 @@ public class BatchEngineImportTaskExecutorImpl
 			}
 		}
 
-		return null;
+		return batchEngineImportTask;
 	}
 
 	private <T> void _importItem(

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/service/persistence/impl/BatchEngineExportTaskPersistenceImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/service/persistence/impl/BatchEngineExportTaskPersistenceImpl.java
@@ -731,11 +731,8 @@ public class BatchEngineExportTaskPersistenceImpl
 				session.save(batchEngineExportTask);
 			}
 			else {
-				session.evict(
-					BatchEngineExportTaskImpl.class,
-					batchEngineExportTask.getPrimaryKeyObj());
-
-				session.saveOrUpdate(batchEngineExportTask);
+				batchEngineExportTask = (BatchEngineExportTask)session.merge(
+					batchEngineExportTask);
 			}
 
 			session.flush();
@@ -1021,4 +1018,4 @@ public class BatchEngineExportTaskPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1920316974
+// LIFERAY-SERVICE-BUILDER-HASH:-2024281679

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/service/persistence/impl/BatchEngineImportTaskPersistenceImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/service/persistence/impl/BatchEngineImportTaskPersistenceImpl.java
@@ -731,11 +731,8 @@ public class BatchEngineImportTaskPersistenceImpl
 				session.save(batchEngineImportTask);
 			}
 			else {
-				session.evict(
-					BatchEngineImportTaskImpl.class,
-					batchEngineImportTask.getPrimaryKeyObj());
-
-				session.saveOrUpdate(batchEngineImportTask);
+				batchEngineImportTask = (BatchEngineImportTask)session.merge(
+					batchEngineImportTask);
 			}
 
 			session.flush();
@@ -1021,4 +1018,4 @@ public class BatchEngineImportTaskPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1843698253
+// LIFERAY-SERVICE-BUILDER-HASH:-637061030

--- a/modules/apps/batch-engine/batch-engine-service/src/main/resources/META-INF/module-hbm.xml
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/resources/META-INF/module-hbm.xml
@@ -18,7 +18,7 @@
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="modifiedDate" type="timestamp" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="callbackURL" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="className" type="com.liferay.portal.dao.orm.hibernate.StringType" />
-		<one-to-one access="com.liferay.portal.dao.orm.hibernate.PrivateFieldPropertyAccessor" cascade="save-update" class="com.liferay.batch.engine.model.BatchEngineExportTaskContentBlobModel" constrained="false" name="contentBlobModel" outer-join="false" />
+		<one-to-one access="com.liferay.portal.dao.orm.hibernate.PrivateFieldPropertyAccessor" cascade="merge, persist, save-update" class="com.liferay.batch.engine.model.BatchEngineExportTaskContentBlobModel" constrained="false" name="contentBlobModel" outer-join="false" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="contentType" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="endTime" type="timestamp" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="errorMessage" type="com.liferay.portal.dao.orm.hibernate.StringClobType" />
@@ -52,7 +52,7 @@
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="batchSize" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="callbackURL" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="className" type="com.liferay.portal.dao.orm.hibernate.StringType" />
-		<one-to-one access="com.liferay.portal.dao.orm.hibernate.PrivateFieldPropertyAccessor" cascade="save-update" class="com.liferay.batch.engine.model.BatchEngineImportTaskContentBlobModel" constrained="false" name="contentBlobModel" outer-join="false" />
+		<one-to-one access="com.liferay.portal.dao.orm.hibernate.PrivateFieldPropertyAccessor" cascade="merge, persist, save-update" class="com.liferay.batch.engine.model.BatchEngineImportTaskContentBlobModel" constrained="false" name="contentBlobModel" outer-join="false" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="contentType" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="endTime" type="timestamp" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="errorMessage" type="com.liferay.portal.dao.orm.hibernate.StringClobType" />

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BatchEngineImportTaskExecutorTest.java
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BatchEngineImportTaskExecutorTest.java
@@ -645,6 +645,10 @@ public class BatchEngineImportTaskExecutorTest
 
 		_batchEngineImportTaskExecutor.execute(_batchEngineImportTask);
 
+		_batchEngineImportTask =
+			_batchEngineImportTaskLocalService.getBatchEngineImportTask(
+				_batchEngineImportTask.getBatchEngineImportTaskId());
+
 		Assert.assertEquals(
 			BatchEngineTaskExecuteStatus.COMPLETED.toString(),
 			_batchEngineImportTask.getExecuteStatus());
@@ -713,6 +717,10 @@ public class BatchEngineImportTaskExecutorTest
 
 			_batchEngineImportTaskExecutor.execute(_batchEngineImportTask);
 		}
+
+		_batchEngineImportTask =
+			_batchEngineImportTaskLocalService.getBatchEngineImportTask(
+				_batchEngineImportTask.getBatchEngineImportTaskId());
 
 		Assert.assertEquals(
 			BatchEngineTaskExecuteStatus.FAILED.toString(),
@@ -1363,6 +1371,10 @@ public class BatchEngineImportTaskExecutorTest
 				batchEngineTaskOperation.name(), parameters, null);
 
 		_batchEngineImportTaskExecutor.execute(_batchEngineImportTask);
+
+		_batchEngineImportTask =
+			_batchEngineImportTaskLocalService.getBatchEngineImportTask(
+				_batchEngineImportTask.getBatchEngineImportTaskId());
 	}
 
 	private byte[] _toContent(String contentType, StringBundler sb)

--- a/modules/apps/batch-planner/batch-planner-test/src/testIntegration/java/com/liferay/batch/planner/service/persistence/test/BatchPlannerMappingPersistenceTest.java
+++ b/modules/apps/batch-planner/batch-planner-test/src/testIntegration/java/com/liferay/batch/planner/service/persistence/test/BatchPlannerMappingPersistenceTest.java
@@ -141,7 +141,9 @@ public class BatchPlannerMappingPersistenceTest {
 
 		newBatchPlannerMapping.setScript(RandomTestUtil.randomString());
 
-		_batchPlannerMappings.add(_persistence.update(newBatchPlannerMapping));
+		newBatchPlannerMapping = _persistence.update(newBatchPlannerMapping);
+
+		_batchPlannerMappings.add(newBatchPlannerMapping);
 
 		BatchPlannerMapping existingBatchPlannerMapping =
 			_persistence.findByPrimaryKey(
@@ -574,4 +576,4 @@ public class BatchPlannerMappingPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:483536262
+// LIFERAY-SERVICE-BUILDER-HASH:1919057240

--- a/modules/apps/batch-planner/batch-planner-test/src/testIntegration/java/com/liferay/batch/planner/service/persistence/test/BatchPlannerPlanPersistenceTest.java
+++ b/modules/apps/batch-planner/batch-planner-test/src/testIntegration/java/com/liferay/batch/planner/service/persistence/test/BatchPlannerPlanPersistenceTest.java
@@ -144,7 +144,9 @@ public class BatchPlannerPlanPersistenceTest {
 
 		newBatchPlannerPlan.setStatus(RandomTestUtil.nextInt());
 
-		_batchPlannerPlans.add(_persistence.update(newBatchPlannerPlan));
+		newBatchPlannerPlan = _persistence.update(newBatchPlannerPlan);
+
+		_batchPlannerPlans.add(newBatchPlannerPlan);
 
 		BatchPlannerPlan existingBatchPlannerPlan =
 			_persistence.findByPrimaryKey(newBatchPlannerPlan.getPrimaryKey());
@@ -551,4 +553,4 @@ public class BatchPlannerPlanPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-818781041
+// LIFERAY-SERVICE-BUILDER-HASH:2091624505

--- a/modules/apps/batch-planner/batch-planner-test/src/testIntegration/java/com/liferay/batch/planner/service/persistence/test/BatchPlannerPolicyPersistenceTest.java
+++ b/modules/apps/batch-planner/batch-planner-test/src/testIntegration/java/com/liferay/batch/planner/service/persistence/test/BatchPlannerPolicyPersistenceTest.java
@@ -131,7 +131,9 @@ public class BatchPlannerPolicyPersistenceTest {
 
 		newBatchPlannerPolicy.setValue(RandomTestUtil.randomString());
 
-		_batchPlannerPolicies.add(_persistence.update(newBatchPlannerPolicy));
+		newBatchPlannerPolicy = _persistence.update(newBatchPlannerPolicy);
+
+		_batchPlannerPolicies.add(newBatchPlannerPolicy);
 
 		BatchPlannerPolicy existingBatchPlannerPolicy =
 			_persistence.findByPrimaryKey(
@@ -538,4 +540,4 @@ public class BatchPlannerPolicyPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:127108274
+// LIFERAY-SERVICE-BUILDER-HASH:-712855344

--- a/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/service/persistence/test/BlogsEntryPersistenceTest.java
+++ b/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/service/persistence/test/BlogsEntryPersistenceTest.java
@@ -178,7 +178,9 @@ public class BlogsEntryPersistenceTest {
 
 		newBlogsEntry.setStatusDate(RandomTestUtil.nextDate());
 
-		_blogsEntries.add(_persistence.update(newBlogsEntry));
+		newBlogsEntry = _persistence.update(newBlogsEntry);
+
+		_blogsEntries.add(newBlogsEntry);
 
 		BlogsEntry existingBlogsEntry = _persistence.findByPrimaryKey(
 			newBlogsEntry.getPrimaryKey());
@@ -960,4 +962,4 @@ public class BlogsEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1681858075
+// LIFERAY-SERVICE-BUILDER-HASH:-663227059

--- a/modules/apps/bookmarks/bookmarks-test/src/testIntegration/java/com/liferay/bookmarks/service/persistence/test/BookmarksEntryPersistenceTest.java
+++ b/modules/apps/bookmarks/bookmarks-test/src/testIntegration/java/com/liferay/bookmarks/service/persistence/test/BookmarksEntryPersistenceTest.java
@@ -151,7 +151,9 @@ public class BookmarksEntryPersistenceTest {
 
 		newBookmarksEntry.setStatusDate(RandomTestUtil.nextDate());
 
-		_bookmarksEntries.add(_persistence.update(newBookmarksEntry));
+		newBookmarksEntry = _persistence.update(newBookmarksEntry);
+
+		_bookmarksEntries.add(newBookmarksEntry);
 
 		BookmarksEntry existingBookmarksEntry = _persistence.findByPrimaryKey(
 			newBookmarksEntry.getPrimaryKey());
@@ -719,4 +721,4 @@ public class BookmarksEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:205127980
+// LIFERAY-SERVICE-BUILDER-HASH:2039379468

--- a/modules/apps/bookmarks/bookmarks-test/src/testIntegration/java/com/liferay/bookmarks/service/persistence/test/BookmarksFolderPersistenceTest.java
+++ b/modules/apps/bookmarks/bookmarks-test/src/testIntegration/java/com/liferay/bookmarks/service/persistence/test/BookmarksFolderPersistenceTest.java
@@ -151,7 +151,9 @@ public class BookmarksFolderPersistenceTest {
 
 		newBookmarksFolder.setStatusDate(RandomTestUtil.nextDate());
 
-		_bookmarksFolders.add(_persistence.update(newBookmarksFolder));
+		newBookmarksFolder = _persistence.update(newBookmarksFolder);
+
+		_bookmarksFolders.add(newBookmarksFolder);
 
 		BookmarksFolder existingBookmarksFolder = _persistence.findByPrimaryKey(
 			newBookmarksFolder.getPrimaryKey());
@@ -679,4 +681,4 @@ public class BookmarksFolderPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:441011861
+// LIFERAY-SERVICE-BUILDER-HASH:43402575

--- a/modules/apps/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/service/persistence/test/CalendarBookingPersistenceTest.java
+++ b/modules/apps/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/service/persistence/test/CalendarBookingPersistenceTest.java
@@ -177,7 +177,9 @@ public class CalendarBookingPersistenceTest {
 
 		newCalendarBooking.setStatusDate(RandomTestUtil.nextDate());
 
-		_calendarBookings.add(_persistence.update(newCalendarBooking));
+		newCalendarBooking = _persistence.update(newCalendarBooking);
+
+		_calendarBookings.add(newCalendarBooking);
 
 		CalendarBooking existingCalendarBooking = _persistence.findByPrimaryKey(
 			newCalendarBooking.getPrimaryKey());
@@ -832,4 +834,4 @@ public class CalendarBookingPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:429243781
+// LIFERAY-SERVICE-BUILDER-HASH:-1533980789

--- a/modules/apps/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/service/persistence/test/CalendarNotificationTemplatePersistenceTest.java
+++ b/modules/apps/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/service/persistence/test/CalendarNotificationTemplatePersistenceTest.java
@@ -158,8 +158,10 @@ public class CalendarNotificationTemplatePersistenceTest {
 		newCalendarNotificationTemplate.setLastPublishDate(
 			RandomTestUtil.nextDate());
 
-		_calendarNotificationTemplates.add(
-			_persistence.update(newCalendarNotificationTemplate));
+		newCalendarNotificationTemplate = _persistence.update(
+			newCalendarNotificationTemplate);
+
+		_calendarNotificationTemplates.add(newCalendarNotificationTemplate);
 
 		CalendarNotificationTemplate existingCalendarNotificationTemplate =
 			_persistence.findByPrimaryKey(
@@ -697,4 +699,4 @@ public class CalendarNotificationTemplatePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-442389299
+// LIFERAY-SERVICE-BUILDER-HASH:-10957153

--- a/modules/apps/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/service/persistence/test/CalendarPersistenceTest.java
+++ b/modules/apps/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/service/persistence/test/CalendarPersistenceTest.java
@@ -147,7 +147,9 @@ public class CalendarPersistenceTest {
 
 		newCalendar.setLastPublishDate(RandomTestUtil.nextDate());
 
-		_calendars.add(_persistence.update(newCalendar));
+		newCalendar = _persistence.update(newCalendar);
+
+		_calendars.add(newCalendar);
 
 		Calendar existingCalendar = _persistence.findByPrimaryKey(
 			newCalendar.getPrimaryKey());
@@ -593,4 +595,4 @@ public class CalendarPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:423707358
+// LIFERAY-SERVICE-BUILDER-HASH:-545665790

--- a/modules/apps/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/service/persistence/test/CalendarResourcePersistenceTest.java
+++ b/modules/apps/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/service/persistence/test/CalendarResourcePersistenceTest.java
@@ -149,7 +149,9 @@ public class CalendarResourcePersistenceTest {
 
 		newCalendarResource.setLastPublishDate(RandomTestUtil.nextDate());
 
-		_calendarResources.add(_persistence.update(newCalendarResource));
+		newCalendarResource = _persistence.update(newCalendarResource);
+
+		_calendarResources.add(newCalendarResource);
 
 		CalendarResource existingCalendarResource =
 			_persistence.findByPrimaryKey(newCalendarResource.getPrimaryKey());
@@ -690,4 +692,4 @@ public class CalendarResourcePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1585737225
+// LIFERAY-SERVICE-BUILDER-HASH:1631722103

--- a/modules/apps/change-tracking/change-tracking-sample-test/src/testIntegration/java/com/liferay/change/tracking/sample/service/persistence/test/CTSChildPersistenceTest.java
+++ b/modules/apps/change-tracking/change-tracking-sample-test/src/testIntegration/java/com/liferay/change/tracking/sample/service/persistence/test/CTSChildPersistenceTest.java
@@ -123,7 +123,9 @@ public class CTSChildPersistenceTest {
 
 		newCTSChild.setName(RandomTestUtil.randomString());
 
-		_ctsChilds.add(_persistence.update(newCTSChild));
+		newCTSChild = _persistence.update(newCTSChild);
+
+		_ctsChilds.add(newCTSChild);
 
 		CTSChild existingCTSChild = _persistence.findByPrimaryKey(
 			newCTSChild.getPrimaryKey());
@@ -436,4 +438,4 @@ public class CTSChildPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:498185963
+// LIFERAY-SERVICE-BUILDER-HASH:306775951

--- a/modules/apps/change-tracking/change-tracking-sample-test/src/testIntegration/java/com/liferay/change/tracking/sample/service/persistence/test/CTSGrandParentPersistenceTest.java
+++ b/modules/apps/change-tracking/change-tracking-sample-test/src/testIntegration/java/com/liferay/change/tracking/sample/service/persistence/test/CTSGrandParentPersistenceTest.java
@@ -117,7 +117,9 @@ public class CTSGrandParentPersistenceTest {
 
 		newCTSGrandParent.setName(RandomTestUtil.randomString());
 
-		_ctsGrandParents.add(_persistence.update(newCTSGrandParent));
+		newCTSGrandParent = _persistence.update(newCTSGrandParent);
+
+		_ctsGrandParents.add(newCTSGrandParent);
 
 		CTSGrandParent existingCTSGrandParent = _persistence.findByPrimaryKey(
 			newCTSGrandParent.getPrimaryKey());
@@ -410,4 +412,4 @@ public class CTSGrandParentPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:2051560569
+// LIFERAY-SERVICE-BUILDER-HASH:7946473

--- a/modules/apps/change-tracking/change-tracking-sample-test/src/testIntegration/java/com/liferay/change/tracking/sample/service/persistence/test/CTSParentPersistenceTest.java
+++ b/modules/apps/change-tracking/change-tracking-sample-test/src/testIntegration/java/com/liferay/change/tracking/sample/service/persistence/test/CTSParentPersistenceTest.java
@@ -119,7 +119,9 @@ public class CTSParentPersistenceTest {
 
 		newCTSParent.setName(RandomTestUtil.randomString());
 
-		_ctsParents.add(_persistence.update(newCTSParent));
+		newCTSParent = _persistence.update(newCTSParent);
+
+		_ctsParents.add(newCTSParent);
 
 		CTSParent existingCTSParent = _persistence.findByPrimaryKey(
 			newCTSParent.getPrimaryKey());
@@ -417,4 +419,4 @@ public class CTSParentPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:2142548034
+// LIFERAY-SERVICE-BUILDER-HASH:-750146600

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/impl/CTScoreLocalServiceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/impl/CTScoreLocalServiceImpl.java
@@ -197,8 +197,6 @@ public class CTScoreLocalServiceImpl extends CTScoreLocalServiceBaseImpl {
 				}
 
 				ctScore.setScore(score);
-
-				session.saveOrUpdate(ctScore);
 			}
 
 			_entityCache.putResult(CTScoreImpl.class, ctScore, false, true);

--- a/modules/apps/change-tracking/change-tracking-store-service/src/main/java/com/liferay/change/tracking/store/service/persistence/impl/CTSContentPersistenceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-store-service/src/main/java/com/liferay/change/tracking/store/service/persistence/impl/CTSContentPersistenceImpl.java
@@ -768,10 +768,7 @@ public class CTSContentPersistenceImpl
 				session.save(ctsContent);
 			}
 			else {
-				session.evict(
-					CTSContentImpl.class, ctsContent.getPrimaryKeyObj());
-
-				session.saveOrUpdate(ctsContent);
+				ctsContent = (CTSContent)session.merge(ctsContent);
 			}
 
 			session.flush();
@@ -1178,4 +1175,4 @@ public class CTSContentPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-33702926
+// LIFERAY-SERVICE-BUILDER-HASH:-371585043

--- a/modules/apps/change-tracking/change-tracking-store-service/src/main/resources/META-INF/module-hbm.xml
+++ b/modules/apps/change-tracking/change-tracking-store-service/src/main/resources/META-INF/module-hbm.xml
@@ -13,7 +13,7 @@
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="repositoryId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" column="path_" name="path" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="version" type="com.liferay.portal.dao.orm.hibernate.StringType" />
-		<one-to-one access="com.liferay.portal.dao.orm.hibernate.PrivateFieldPropertyAccessor" cascade="save-update" class="com.liferay.change.tracking.store.model.CTSContentDataBlobModel" constrained="false" name="dataBlobModel" outer-join="false" />
+		<one-to-one access="com.liferay.portal.dao.orm.hibernate.PrivateFieldPropertyAccessor" cascade="merge, persist, save-update" class="com.liferay.change.tracking.store.model.CTSContentDataBlobModel" constrained="false" name="dataBlobModel" outer-join="false" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" column="size_" name="size" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="storeType" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 	</class>

--- a/modules/apps/change-tracking/change-tracking-store-test/src/testIntegration/java/com/liferay/change/tracking/store/service/persistence/test/CTSContentPersistenceTest.java
+++ b/modules/apps/change-tracking/change-tracking-store-test/src/testIntegration/java/com/liferay/change/tracking/store/service/persistence/test/CTSContentPersistenceTest.java
@@ -140,7 +140,9 @@ public class CTSContentPersistenceTest {
 
 		newCTSContent.setStoreType(RandomTestUtil.randomString());
 
-		_ctsContents.add(_persistence.update(newCTSContent));
+		newCTSContent = _persistence.update(newCTSContent);
+
+		_ctsContents.add(newCTSContent);
 
 		CTSContent existingCTSContent = _persistence.findByPrimaryKey(
 			newCTSContent.getPrimaryKey());
@@ -579,4 +581,4 @@ public class CTSContentPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-601863533
+// LIFERAY-SERVICE-BUILDER-HASH:-597241943

--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/persistence/test/CTAutoResolutionInfoPersistenceTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/persistence/test/CTAutoResolutionInfoPersistenceTest.java
@@ -129,8 +129,9 @@ public class CTAutoResolutionInfoPersistenceTest {
 		newCTAutoResolutionInfo.setConflictIdentifier(
 			RandomTestUtil.randomString());
 
-		_ctAutoResolutionInfos.add(
-			_persistence.update(newCTAutoResolutionInfo));
+		newCTAutoResolutionInfo = _persistence.update(newCTAutoResolutionInfo);
+
+		_ctAutoResolutionInfos.add(newCTAutoResolutionInfo);
 
 		CTAutoResolutionInfo existingCTAutoResolutionInfo =
 			_persistence.findByPrimaryKey(
@@ -462,4 +463,4 @@ public class CTAutoResolutionInfoPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1488977261
+// LIFERAY-SERVICE-BUILDER-HASH:-904647825

--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/persistence/test/CTCollectionPersistenceTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/persistence/test/CTCollectionPersistenceTest.java
@@ -144,7 +144,9 @@ public class CTCollectionPersistenceTest {
 
 		newCTCollection.setStatusDate(RandomTestUtil.nextDate());
 
-		_ctCollections.add(_persistence.update(newCTCollection));
+		newCTCollection = _persistence.update(newCTCollection);
+
+		_ctCollections.add(newCTCollection);
 
 		CTCollection existingCTCollection = _persistence.findByPrimaryKey(
 			newCTCollection.getPrimaryKey());
@@ -635,4 +637,4 @@ public class CTCollectionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:57568160
+// LIFERAY-SERVICE-BUILDER-HASH:-76312410

--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/persistence/test/CTCollectionTemplatePersistenceTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/persistence/test/CTCollectionTemplatePersistenceTest.java
@@ -127,8 +127,9 @@ public class CTCollectionTemplatePersistenceTest {
 
 		newCTCollectionTemplate.setDescription(RandomTestUtil.randomString());
 
-		_ctCollectionTemplates.add(
-			_persistence.update(newCTCollectionTemplate));
+		newCTCollectionTemplate = _persistence.update(newCTCollectionTemplate);
+
+		_ctCollectionTemplates.add(newCTCollectionTemplate);
 
 		CTCollectionTemplate existingCTCollectionTemplate =
 			_persistence.findByPrimaryKey(
@@ -465,4 +466,4 @@ public class CTCollectionTemplatePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1974366682
+// LIFERAY-SERVICE-BUILDER-HASH:-1292633120

--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/persistence/test/CTCommentPersistenceTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/persistence/test/CTCommentPersistenceTest.java
@@ -125,7 +125,9 @@ public class CTCommentPersistenceTest {
 
 		newCTComment.setValue(RandomTestUtil.randomString());
 
-		_ctComments.add(_persistence.update(newCTComment));
+		newCTComment = _persistence.update(newCTComment);
+
+		_ctComments.add(newCTComment);
 
 		CTComment existingCTComment = _persistence.findByPrimaryKey(
 			newCTComment.getPrimaryKey());
@@ -435,4 +437,4 @@ public class CTCommentPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1097213148
+// LIFERAY-SERVICE-BUILDER-HASH:-1422675606

--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/persistence/test/CTEntryPersistenceTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/persistence/test/CTEntryPersistenceTest.java
@@ -136,7 +136,9 @@ public class CTEntryPersistenceTest {
 
 		newCTEntry.setChangeType(RandomTestUtil.nextInt());
 
-		_ctEntries.add(_persistence.update(newCTEntry));
+		newCTEntry = _persistence.update(newCTEntry);
+
+		_ctEntries.add(newCTEntry);
 
 		CTEntry existingCTEntry = _persistence.findByPrimaryKey(
 			newCTEntry.getPrimaryKey());
@@ -616,4 +618,4 @@ public class CTEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:755834548
+// LIFERAY-SERVICE-BUILDER-HASH:-1221765012

--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/persistence/test/CTMessagePersistenceTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/persistence/test/CTMessagePersistenceTest.java
@@ -116,7 +116,9 @@ public class CTMessagePersistenceTest {
 
 		newCTMessage.setMessageContent(RandomTestUtil.randomString());
 
-		_ctMessages.add(_persistence.update(newCTMessage));
+		newCTMessage = _persistence.update(newCTMessage);
+
+		_ctMessages.add(newCTMessage);
 
 		CTMessage existingCTMessage = _persistence.findByPrimaryKey(
 			newCTMessage.getPrimaryKey());
@@ -401,4 +403,4 @@ public class CTMessagePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:399048231
+// LIFERAY-SERVICE-BUILDER-HASH:-1850277895

--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/persistence/test/CTPreferencesPersistenceTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/persistence/test/CTPreferencesPersistenceTest.java
@@ -122,7 +122,9 @@ public class CTPreferencesPersistenceTest {
 
 		newCTPreferences.setConfirmationEnabled(RandomTestUtil.randomBoolean());
 
-		_ctPreferenceses.add(_persistence.update(newCTPreferences));
+		newCTPreferences = _persistence.update(newCTPreferences);
+
+		_ctPreferenceses.add(newCTPreferences);
 
 		CTPreferences existingCTPreferences = _persistence.findByPrimaryKey(
 			newCTPreferences.getPrimaryKey());
@@ -503,4 +505,4 @@ public class CTPreferencesPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:309989222
+// LIFERAY-SERVICE-BUILDER-HASH:-852589490

--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/persistence/test/CTProcessPersistenceTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/persistence/test/CTProcessPersistenceTest.java
@@ -123,7 +123,9 @@ public class CTProcessPersistenceTest {
 
 		newCTProcess.setType(RandomTestUtil.nextInt());
 
-		_ctProcesses.add(_persistence.update(newCTProcess));
+		newCTProcess = _persistence.update(newCTProcess);
+
+		_ctProcesses.add(newCTProcess);
 
 		CTProcess existingCTProcess = _persistence.findByPrimaryKey(
 			newCTProcess.getPrimaryKey());
@@ -437,4 +439,4 @@ public class CTProcessPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1688814695
+// LIFERAY-SERVICE-BUILDER-HASH:-1749344047

--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/persistence/test/CTRemotePersistenceTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/persistence/test/CTRemotePersistenceTest.java
@@ -129,7 +129,9 @@ public class CTRemotePersistenceTest {
 
 		newCTRemote.setClientSecret(RandomTestUtil.randomString());
 
-		_ctRemotes.add(_persistence.update(newCTRemote));
+		newCTRemote = _persistence.update(newCTRemote);
+
+		_ctRemotes.add(newCTRemote);
 
 		CTRemote existingCTRemote = _persistence.findByPrimaryKey(
 			newCTRemote.getPrimaryKey());
@@ -436,4 +438,4 @@ public class CTRemotePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:267356283
+// LIFERAY-SERVICE-BUILDER-HASH:368071653

--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/persistence/test/CTSchemaVersionPersistenceTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/persistence/test/CTSchemaVersionPersistenceTest.java
@@ -116,7 +116,9 @@ public class CTSchemaVersionPersistenceTest {
 		newCTSchemaVersion.setSchemaContext(
 			new HashMap<String, Serializable>());
 
-		_ctSchemaVersions.add(_persistence.update(newCTSchemaVersion));
+		newCTSchemaVersion = _persistence.update(newCTSchemaVersion);
+
+		_ctSchemaVersions.add(newCTSchemaVersion);
 
 		CTSchemaVersion existingCTSchemaVersion = _persistence.findByPrimaryKey(
 			newCTSchemaVersion.getPrimaryKey());
@@ -405,4 +407,4 @@ public class CTSchemaVersionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1634056614
+// LIFERAY-SERVICE-BUILDER-HASH:-1793370604

--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/persistence/test/CTScorePersistenceTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/persistence/test/CTScorePersistenceTest.java
@@ -118,7 +118,9 @@ public class CTScorePersistenceTest {
 
 		newCTScore.setScore(RandomTestUtil.nextInt());
 
-		_ctScores.add(_persistence.update(newCTScore));
+		newCTScore = _persistence.update(newCTScore);
+
+		_ctScores.add(newCTScore);
 
 		CTScore existingCTScore = _persistence.findByPrimaryKey(
 			newCTScore.getPrimaryKey());
@@ -451,4 +453,4 @@ public class CTScorePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:636671779
+// LIFERAY-SERVICE-BUILDER-HASH:-2013155455

--- a/modules/apps/changeset/changeset-test/src/testIntegration/java/com/liferay/changeset/service/persistence/test/ChangesetCollectionPersistenceTest.java
+++ b/modules/apps/changeset/changeset-test/src/testIntegration/java/com/liferay/changeset/service/persistence/test/ChangesetCollectionPersistenceTest.java
@@ -131,7 +131,9 @@ public class ChangesetCollectionPersistenceTest {
 
 		newChangesetCollection.setDescription(RandomTestUtil.randomString());
 
-		_changesetCollections.add(_persistence.update(newChangesetCollection));
+		newChangesetCollection = _persistence.update(newChangesetCollection);
+
+		_changesetCollections.add(newChangesetCollection);
 
 		ChangesetCollection existingChangesetCollection =
 			_persistence.findByPrimaryKey(
@@ -564,4 +566,4 @@ public class ChangesetCollectionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-880122624
+// LIFERAY-SERVICE-BUILDER-HASH:266850374

--- a/modules/apps/changeset/changeset-test/src/testIntegration/java/com/liferay/changeset/service/persistence/test/ChangesetEntryPersistenceTest.java
+++ b/modules/apps/changeset/changeset-test/src/testIntegration/java/com/liferay/changeset/service/persistence/test/ChangesetEntryPersistenceTest.java
@@ -134,7 +134,9 @@ public class ChangesetEntryPersistenceTest {
 
 		newChangesetEntry.setClassPK(RandomTestUtil.nextLong());
 
-		_changesetEntries.add(_persistence.update(newChangesetEntry));
+		newChangesetEntry = _persistence.update(newChangesetEntry);
+
+		_changesetEntries.add(newChangesetEntry);
 
 		ChangesetEntry existingChangesetEntry = _persistence.findByPrimaryKey(
 			newChangesetEntry.getPrimaryKey());
@@ -596,4 +598,4 @@ public class ChangesetEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-13073512
+// LIFERAY-SERVICE-BUILDER-HASH:-155169094

--- a/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/service/persistence/test/ClientExtensionEntryPersistenceTest.java
+++ b/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/service/persistence/test/ClientExtensionEntryPersistenceTest.java
@@ -156,8 +156,9 @@ public class ClientExtensionEntryPersistenceTest {
 
 		newClientExtensionEntry.setStatusDate(RandomTestUtil.nextDate());
 
-		_clientExtensionEntries.add(
-			_persistence.update(newClientExtensionEntry));
+		newClientExtensionEntry = _persistence.update(newClientExtensionEntry);
+
+		_clientExtensionEntries.add(newClientExtensionEntry);
 
 		ClientExtensionEntry existingClientExtensionEntry =
 			_persistence.findByPrimaryKey(
@@ -690,4 +691,4 @@ public class ClientExtensionEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:893408159
+// LIFERAY-SERVICE-BUILDER-HASH:851870453

--- a/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/service/persistence/test/ClientExtensionEntryRelPersistenceTest.java
+++ b/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/service/persistence/test/ClientExtensionEntryRelPersistenceTest.java
@@ -153,8 +153,10 @@ public class ClientExtensionEntryRelPersistenceTest {
 		newClientExtensionEntryRel.setLastPublishDate(
 			RandomTestUtil.nextDate());
 
-		_clientExtensionEntryRels.add(
-			_persistence.update(newClientExtensionEntryRel));
+		newClientExtensionEntryRel = _persistence.update(
+			newClientExtensionEntryRel);
+
+		_clientExtensionEntryRels.add(newClientExtensionEntryRel);
 
 		ClientExtensionEntryRel existingClientExtensionEntryRel =
 			_persistence.findByPrimaryKey(
@@ -723,4 +725,4 @@ public class ClientExtensionEntryRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:527959896
+// LIFERAY-SERVICE-BUILDER-HASH:-1657813550

--- a/modules/apps/commerce/commerce-currency-test/src/testIntegration/java/com/liferay/commerce/currency/service/persistence/test/CommerceCurrencyPersistenceTest.java
+++ b/modules/apps/commerce/commerce-currency-test/src/testIntegration/java/com/liferay/commerce/currency/service/persistence/test/CommerceCurrencyPersistenceTest.java
@@ -157,7 +157,9 @@ public class CommerceCurrencyPersistenceTest {
 
 		newCommerceCurrency.setLastPublishDate(RandomTestUtil.nextDate());
 
-		_commerceCurrencies.add(_persistence.update(newCommerceCurrency));
+		newCommerceCurrency = _persistence.update(newCommerceCurrency);
+
+		_commerceCurrencies.add(newCommerceCurrency);
 
 		CommerceCurrency existingCommerceCurrency =
 			_persistence.findByPrimaryKey(newCommerceCurrency.getPrimaryKey());
@@ -696,4 +698,4 @@ public class CommerceCurrencyPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1014422538
+// LIFERAY-SERVICE-BUILDER-HASH:-1855499828

--- a/modules/apps/commerce/commerce-discount-test/src/testIntegration/java/com/liferay/commerce/discount/service/persistence/test/CommerceDiscountAccountRelPersistenceTest.java
+++ b/modules/apps/commerce/commerce-discount-test/src/testIntegration/java/com/liferay/commerce/discount/service/persistence/test/CommerceDiscountAccountRelPersistenceTest.java
@@ -143,8 +143,10 @@ public class CommerceDiscountAccountRelPersistenceTest {
 		newCommerceDiscountAccountRel.setLastPublishDate(
 			RandomTestUtil.nextDate());
 
-		_commerceDiscountAccountRels.add(
-			_persistence.update(newCommerceDiscountAccountRel));
+		newCommerceDiscountAccountRel = _persistence.update(
+			newCommerceDiscountAccountRel);
+
+		_commerceDiscountAccountRels.add(newCommerceDiscountAccountRel);
 
 		CommerceDiscountAccountRel existingCommerceDiscountAccountRel =
 			_persistence.findByPrimaryKey(
@@ -630,4 +632,4 @@ public class CommerceDiscountAccountRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1317715342
+// LIFERAY-SERVICE-BUILDER-HASH:-1666630778

--- a/modules/apps/commerce/commerce-discount-test/src/testIntegration/java/com/liferay/commerce/discount/service/persistence/test/CommerceDiscountCommerceAccountGroupRelPersistenceTest.java
+++ b/modules/apps/commerce/commerce-discount-test/src/testIntegration/java/com/liferay/commerce/discount/service/persistence/test/CommerceDiscountCommerceAccountGroupRelPersistenceTest.java
@@ -144,8 +144,11 @@ public class CommerceDiscountCommerceAccountGroupRelPersistenceTest {
 		newCommerceDiscountCommerceAccountGroupRel.setCommerceAccountGroupId(
 			RandomTestUtil.nextLong());
 
+		newCommerceDiscountCommerceAccountGroupRel = _persistence.update(
+			newCommerceDiscountCommerceAccountGroupRel);
+
 		_commerceDiscountCommerceAccountGroupRels.add(
-			_persistence.update(newCommerceDiscountCommerceAccountGroupRel));
+			newCommerceDiscountCommerceAccountGroupRel);
 
 		CommerceDiscountCommerceAccountGroupRel
 			existingCommerceDiscountCommerceAccountGroupRel =
@@ -648,4 +651,4 @@ public class CommerceDiscountCommerceAccountGroupRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:634237317
+// LIFERAY-SERVICE-BUILDER-HASH:-304284353

--- a/modules/apps/commerce/commerce-discount-test/src/testIntegration/java/com/liferay/commerce/discount/service/persistence/test/CommerceDiscountOrderTypeRelPersistenceTest.java
+++ b/modules/apps/commerce/commerce-discount-test/src/testIntegration/java/com/liferay/commerce/discount/service/persistence/test/CommerceDiscountOrderTypeRelPersistenceTest.java
@@ -144,8 +144,10 @@ public class CommerceDiscountOrderTypeRelPersistenceTest {
 		newCommerceDiscountOrderTypeRel.setLastPublishDate(
 			RandomTestUtil.nextDate());
 
-		_commerceDiscountOrderTypeRels.add(
-			_persistence.update(newCommerceDiscountOrderTypeRel));
+		newCommerceDiscountOrderTypeRel = _persistence.update(
+			newCommerceDiscountOrderTypeRel);
+
+		_commerceDiscountOrderTypeRels.add(newCommerceDiscountOrderTypeRel);
 
 		CommerceDiscountOrderTypeRel existingCommerceDiscountOrderTypeRel =
 			_persistence.findByPrimaryKey(
@@ -635,4 +637,4 @@ public class CommerceDiscountOrderTypeRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:941689039
+// LIFERAY-SERVICE-BUILDER-HASH:-2082815603

--- a/modules/apps/commerce/commerce-discount-test/src/testIntegration/java/com/liferay/commerce/discount/service/persistence/test/CommerceDiscountPersistenceTest.java
+++ b/modules/apps/commerce/commerce-discount-test/src/testIntegration/java/com/liferay/commerce/discount/service/persistence/test/CommerceDiscountPersistenceTest.java
@@ -185,7 +185,9 @@ public class CommerceDiscountPersistenceTest {
 
 		newCommerceDiscount.setStatusDate(RandomTestUtil.nextDate());
 
-		_commerceDiscounts.add(_persistence.update(newCommerceDiscount));
+		newCommerceDiscount = _persistence.update(newCommerceDiscount);
+
+		_commerceDiscounts.add(newCommerceDiscount);
 
 		CommerceDiscount existingCommerceDiscount =
 			_persistence.findByPrimaryKey(newCommerceDiscount.getPrimaryKey());
@@ -813,4 +815,4 @@ public class CommerceDiscountPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1060095329
+// LIFERAY-SERVICE-BUILDER-HASH:276959809

--- a/modules/apps/commerce/commerce-discount-test/src/testIntegration/java/com/liferay/commerce/discount/service/persistence/test/CommerceDiscountRelPersistenceTest.java
+++ b/modules/apps/commerce/commerce-discount-test/src/testIntegration/java/com/liferay/commerce/discount/service/persistence/test/CommerceDiscountRelPersistenceTest.java
@@ -131,7 +131,9 @@ public class CommerceDiscountRelPersistenceTest {
 
 		newCommerceDiscountRel.setTypeSettings(RandomTestUtil.randomString());
 
-		_commerceDiscountRels.add(_persistence.update(newCommerceDiscountRel));
+		newCommerceDiscountRel = _persistence.update(newCommerceDiscountRel);
+
+		_commerceDiscountRels.add(newCommerceDiscountRel);
 
 		CommerceDiscountRel existingCommerceDiscountRel =
 			_persistence.findByPrimaryKey(
@@ -497,4 +499,4 @@ public class CommerceDiscountRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-865290242
+// LIFERAY-SERVICE-BUILDER-HASH:867726896

--- a/modules/apps/commerce/commerce-discount-test/src/testIntegration/java/com/liferay/commerce/discount/service/persistence/test/CommerceDiscountRulePersistenceTest.java
+++ b/modules/apps/commerce/commerce-discount-test/src/testIntegration/java/com/liferay/commerce/discount/service/persistence/test/CommerceDiscountRulePersistenceTest.java
@@ -134,8 +134,9 @@ public class CommerceDiscountRulePersistenceTest {
 
 		newCommerceDiscountRule.setTypeSettings(RandomTestUtil.randomString());
 
-		_commerceDiscountRules.add(
-			_persistence.update(newCommerceDiscountRule));
+		newCommerceDiscountRule = _persistence.update(newCommerceDiscountRule);
+
+		_commerceDiscountRules.add(newCommerceDiscountRule);
 
 		CommerceDiscountRule existingCommerceDiscountRule =
 			_persistence.findByPrimaryKey(
@@ -487,4 +488,4 @@ public class CommerceDiscountRulePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1913512738
+// LIFERAY-SERVICE-BUILDER-HASH:927228666

--- a/modules/apps/commerce/commerce-discount-test/src/testIntegration/java/com/liferay/commerce/discount/service/persistence/test/CommerceDiscountUsageEntryPersistenceTest.java
+++ b/modules/apps/commerce/commerce-discount-test/src/testIntegration/java/com/liferay/commerce/discount/service/persistence/test/CommerceDiscountUsageEntryPersistenceTest.java
@@ -137,8 +137,10 @@ public class CommerceDiscountUsageEntryPersistenceTest {
 		newCommerceDiscountUsageEntry.setCommerceDiscountId(
 			RandomTestUtil.nextLong());
 
-		_commerceDiscountUsageEntries.add(
-			_persistence.update(newCommerceDiscountUsageEntry));
+		newCommerceDiscountUsageEntry = _persistence.update(
+			newCommerceDiscountUsageEntry);
+
+		_commerceDiscountUsageEntries.add(newCommerceDiscountUsageEntry);
 
 		CommerceDiscountUsageEntry existingCommerceDiscountUsageEntry =
 			_persistence.findByPrimaryKey(
@@ -534,4 +536,4 @@ public class CommerceDiscountUsageEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1730952601
+// LIFERAY-SERVICE-BUILDER-HASH:-2110951881

--- a/modules/apps/commerce/commerce-inventory-test/src/testIntegration/java/com/liferay/commerce/inventory/service/persistence/test/CommerceInventoryAuditPersistenceTest.java
+++ b/modules/apps/commerce/commerce-inventory-test/src/testIntegration/java/com/liferay/commerce/inventory/service/persistence/test/CommerceInventoryAuditPersistenceTest.java
@@ -141,8 +141,10 @@ public class CommerceInventoryAuditPersistenceTest {
 		newCommerceInventoryAudit.setUnitOfMeasureKey(
 			RandomTestUtil.randomString());
 
-		_commerceInventoryAudits.add(
-			_persistence.update(newCommerceInventoryAudit));
+		newCommerceInventoryAudit = _persistence.update(
+			newCommerceInventoryAudit);
+
+		_commerceInventoryAudits.add(newCommerceInventoryAudit);
 
 		CommerceInventoryAudit existingCommerceInventoryAudit =
 			_persistence.findByPrimaryKey(
@@ -517,4 +519,4 @@ public class CommerceInventoryAuditPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:186242202
+// LIFERAY-SERVICE-BUILDER-HASH:-1190988874

--- a/modules/apps/commerce/commerce-inventory-test/src/testIntegration/java/com/liferay/commerce/inventory/service/persistence/test/CommerceInventoryBookedQuantityPersistenceTest.java
+++ b/modules/apps/commerce/commerce-inventory-test/src/testIntegration/java/com/liferay/commerce/inventory/service/persistence/test/CommerceInventoryBookedQuantityPersistenceTest.java
@@ -150,8 +150,11 @@ public class CommerceInventoryBookedQuantityPersistenceTest {
 		newCommerceInventoryBookedQuantity.setUnitOfMeasureKey(
 			RandomTestUtil.randomString());
 
+		newCommerceInventoryBookedQuantity = _persistence.update(
+			newCommerceInventoryBookedQuantity);
+
 		_commerceInventoryBookedQuantities.add(
-			_persistence.update(newCommerceInventoryBookedQuantity));
+			newCommerceInventoryBookedQuantity);
 
 		CommerceInventoryBookedQuantity
 			existingCommerceInventoryBookedQuantity =
@@ -570,4 +573,4 @@ public class CommerceInventoryBookedQuantityPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1405918681
+// LIFERAY-SERVICE-BUILDER-HASH:389412273

--- a/modules/apps/commerce/commerce-inventory-test/src/testIntegration/java/com/liferay/commerce/inventory/service/persistence/test/CommerceInventoryReplenishmentItemPersistenceTest.java
+++ b/modules/apps/commerce/commerce-inventory-test/src/testIntegration/java/com/liferay/commerce/inventory/service/persistence/test/CommerceInventoryReplenishmentItemPersistenceTest.java
@@ -162,8 +162,11 @@ public class CommerceInventoryReplenishmentItemPersistenceTest {
 		newCommerceInventoryReplenishmentItem.setUnitOfMeasureKey(
 			RandomTestUtil.randomString());
 
+		newCommerceInventoryReplenishmentItem = _persistence.update(
+			newCommerceInventoryReplenishmentItem);
+
 		_commerceInventoryReplenishmentItems.add(
-			_persistence.update(newCommerceInventoryReplenishmentItem));
+			newCommerceInventoryReplenishmentItem);
 
 		CommerceInventoryReplenishmentItem
 			existingCommerceInventoryReplenishmentItem =
@@ -755,4 +758,4 @@ public class CommerceInventoryReplenishmentItemPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:877313816
+// LIFERAY-SERVICE-BUILDER-HASH:161930988

--- a/modules/apps/commerce/commerce-inventory-test/src/testIntegration/java/com/liferay/commerce/inventory/service/persistence/test/CommerceInventoryWarehouseItemPersistenceTest.java
+++ b/modules/apps/commerce/commerce-inventory-test/src/testIntegration/java/com/liferay/commerce/inventory/service/persistence/test/CommerceInventoryWarehouseItemPersistenceTest.java
@@ -156,8 +156,10 @@ public class CommerceInventoryWarehouseItemPersistenceTest {
 		newCommerceInventoryWarehouseItem.setUnitOfMeasureKey(
 			RandomTestUtil.randomString());
 
-		_commerceInventoryWarehouseItems.add(
-			_persistence.update(newCommerceInventoryWarehouseItem));
+		newCommerceInventoryWarehouseItem = _persistence.update(
+			newCommerceInventoryWarehouseItem);
+
+		_commerceInventoryWarehouseItems.add(newCommerceInventoryWarehouseItem);
 
 		CommerceInventoryWarehouseItem existingCommerceInventoryWarehouseItem =
 			_persistence.findByPrimaryKey(
@@ -729,4 +731,4 @@ public class CommerceInventoryWarehouseItemPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1527629967
+// LIFERAY-SERVICE-BUILDER-HASH:73408003

--- a/modules/apps/commerce/commerce-inventory-test/src/testIntegration/java/com/liferay/commerce/inventory/service/persistence/test/CommerceInventoryWarehousePersistenceTest.java
+++ b/modules/apps/commerce/commerce-inventory-test/src/testIntegration/java/com/liferay/commerce/inventory/service/persistence/test/CommerceInventoryWarehousePersistenceTest.java
@@ -167,8 +167,10 @@ public class CommerceInventoryWarehousePersistenceTest {
 
 		newCommerceInventoryWarehouse.setType(RandomTestUtil.randomString());
 
-		_commerceInventoryWarehouses.add(
-			_persistence.update(newCommerceInventoryWarehouse));
+		newCommerceInventoryWarehouse = _persistence.update(
+			newCommerceInventoryWarehouse);
+
+		_commerceInventoryWarehouses.add(newCommerceInventoryWarehouse);
 
 		CommerceInventoryWarehouse existingCommerceInventoryWarehouse =
 			_persistence.findByPrimaryKey(
@@ -754,4 +756,4 @@ public class CommerceInventoryWarehousePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1744868925
+// LIFERAY-SERVICE-BUILDER-HASH:2078569553

--- a/modules/apps/commerce/commerce-inventory-test/src/testIntegration/java/com/liferay/commerce/inventory/service/persistence/test/CommerceInventoryWarehouseRelPersistenceTest.java
+++ b/modules/apps/commerce/commerce-inventory-test/src/testIntegration/java/com/liferay/commerce/inventory/service/persistence/test/CommerceInventoryWarehouseRelPersistenceTest.java
@@ -141,8 +141,10 @@ public class CommerceInventoryWarehouseRelPersistenceTest {
 		newCommerceInventoryWarehouseRel.setCommerceInventoryWarehouseId(
 			RandomTestUtil.nextLong());
 
-		_commerceInventoryWarehouseRels.add(
-			_persistence.update(newCommerceInventoryWarehouseRel));
+		newCommerceInventoryWarehouseRel = _persistence.update(
+			newCommerceInventoryWarehouseRel);
+
+		_commerceInventoryWarehouseRels.add(newCommerceInventoryWarehouseRel);
 
 		CommerceInventoryWarehouseRel existingCommerceInventoryWarehouseRel =
 			_persistence.findByPrimaryKey(
@@ -616,4 +618,4 @@ public class CommerceInventoryWarehouseRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1337716914
+// LIFERAY-SERVICE-BUILDER-HASH:-383269592

--- a/modules/apps/commerce/commerce-order-rule-test/src/testIntegration/java/com/liferay/commerce/order/rule/service/persistence/test/COREntryPersistenceTest.java
+++ b/modules/apps/commerce/commerce-order-rule-test/src/testIntegration/java/com/liferay/commerce/order/rule/service/persistence/test/COREntryPersistenceTest.java
@@ -155,7 +155,9 @@ public class COREntryPersistenceTest {
 
 		newCOREntry.setStatusDate(RandomTestUtil.nextDate());
 
-		_corEntries.add(_persistence.update(newCOREntry));
+		newCOREntry = _persistence.update(newCOREntry);
+
+		_corEntries.add(newCOREntry);
 
 		COREntry existingCOREntry = _persistence.findByPrimaryKey(
 			newCOREntry.getPrimaryKey());
@@ -663,4 +665,4 @@ public class COREntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1330246321
+// LIFERAY-SERVICE-BUILDER-HASH:1069158919

--- a/modules/apps/commerce/commerce-order-rule-test/src/testIntegration/java/com/liferay/commerce/order/rule/service/persistence/test/COREntryRelPersistenceTest.java
+++ b/modules/apps/commerce/commerce-order-rule-test/src/testIntegration/java/com/liferay/commerce/order/rule/service/persistence/test/COREntryRelPersistenceTest.java
@@ -130,7 +130,9 @@ public class COREntryRelPersistenceTest {
 
 		newCOREntryRel.setCOREntryId(RandomTestUtil.nextLong());
 
-		_corEntryRels.add(_persistence.update(newCOREntryRel));
+		newCOREntryRel = _persistence.update(newCOREntryRel);
+
+		_corEntryRels.add(newCOREntryRel);
 
 		COREntryRel existingCOREntryRel = _persistence.findByPrimaryKey(
 			newCOREntryRel.getPrimaryKey());
@@ -526,4 +528,4 @@ public class COREntryRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:693830459
+// LIFERAY-SERVICE-BUILDER-HASH:221157037

--- a/modules/apps/commerce/commerce-payment-test/src/testIntegration/java/com/liferay/commerce/payment/service/persistence/test/CommercePaymentEntryAuditPersistenceTest.java
+++ b/modules/apps/commerce/commerce-payment-test/src/testIntegration/java/com/liferay/commerce/payment/service/persistence/test/CommercePaymentEntryAuditPersistenceTest.java
@@ -142,8 +142,10 @@ public class CommercePaymentEntryAuditPersistenceTest {
 		newCommercePaymentEntryAudit.setLogTypeSettings(
 			RandomTestUtil.randomString());
 
-		_commercePaymentEntryAudits.add(
-			_persistence.update(newCommercePaymentEntryAudit));
+		newCommercePaymentEntryAudit = _persistence.update(
+			newCommercePaymentEntryAudit);
+
+		_commercePaymentEntryAudits.add(newCommercePaymentEntryAudit);
 
 		CommercePaymentEntryAudit existingCommercePaymentEntryAudit =
 			_persistence.findByPrimaryKey(
@@ -523,4 +525,4 @@ public class CommercePaymentEntryAuditPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1413621051
+// LIFERAY-SERVICE-BUILDER-HASH:1892280911

--- a/modules/apps/commerce/commerce-payment-test/src/testIntegration/java/com/liferay/commerce/payment/service/persistence/test/CommercePaymentEntryPersistenceTest.java
+++ b/modules/apps/commerce/commerce-payment-test/src/testIntegration/java/com/liferay/commerce/payment/service/persistence/test/CommercePaymentEntryPersistenceTest.java
@@ -175,8 +175,9 @@ public class CommercePaymentEntryPersistenceTest {
 
 		newCommercePaymentEntry.setType(RandomTestUtil.nextInt());
 
-		_commercePaymentEntries.add(
-			_persistence.update(newCommercePaymentEntry));
+		newCommercePaymentEntry = _persistence.update(newCommercePaymentEntry);
+
+		_commercePaymentEntries.add(newCommercePaymentEntry);
 
 		CommercePaymentEntry existingCommercePaymentEntry =
 			_persistence.findByPrimaryKey(
@@ -748,4 +749,4 @@ public class CommercePaymentEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1050102034
+// LIFERAY-SERVICE-BUILDER-HASH:-1291654818

--- a/modules/apps/commerce/commerce-payment-test/src/testIntegration/java/com/liferay/commerce/payment/service/persistence/test/CommercePaymentMethodGroupRelPersistenceTest.java
+++ b/modules/apps/commerce/commerce-payment-test/src/testIntegration/java/com/liferay/commerce/payment/service/persistence/test/CommercePaymentMethodGroupRelPersistenceTest.java
@@ -158,8 +158,10 @@ public class CommercePaymentMethodGroupRelPersistenceTest {
 		newCommercePaymentMethodGroupRel.setTypeSettings(
 			RandomTestUtil.randomString());
 
-		_commercePaymentMethodGroupRels.add(
-			_persistence.update(newCommercePaymentMethodGroupRel));
+		newCommercePaymentMethodGroupRel = _persistence.update(
+			newCommercePaymentMethodGroupRel);
+
+		_commercePaymentMethodGroupRels.add(newCommercePaymentMethodGroupRel);
 
 		CommercePaymentMethodGroupRel existingCommercePaymentMethodGroupRel =
 			_persistence.findByPrimaryKey(
@@ -676,4 +678,4 @@ public class CommercePaymentMethodGroupRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:445946739
+// LIFERAY-SERVICE-BUILDER-HASH:1884356129

--- a/modules/apps/commerce/commerce-payment-test/src/testIntegration/java/com/liferay/commerce/payment/service/persistence/test/CommercePaymentMethodGroupRelQualifierPersistenceTest.java
+++ b/modules/apps/commerce/commerce-payment-test/src/testIntegration/java/com/liferay/commerce/payment/service/persistence/test/CommercePaymentMethodGroupRelQualifierPersistenceTest.java
@@ -147,8 +147,11 @@ public class CommercePaymentMethodGroupRelQualifierPersistenceTest {
 		newCommercePaymentMethodGroupRelQualifier.
 			setCommercePaymentMethodGroupRelId(RandomTestUtil.nextLong());
 
+		newCommercePaymentMethodGroupRelQualifier = _persistence.update(
+			newCommercePaymentMethodGroupRelQualifier);
+
 		_commercePaymentMethodGroupRelQualifiers.add(
-			_persistence.update(newCommercePaymentMethodGroupRelQualifier));
+			newCommercePaymentMethodGroupRelQualifier);
 
 		CommercePaymentMethodGroupRelQualifier
 			existingCommercePaymentMethodGroupRelQualifier =
@@ -662,4 +665,4 @@ public class CommercePaymentMethodGroupRelQualifierPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:824251996
+// LIFERAY-SERVICE-BUILDER-HASH:-1927560020

--- a/modules/apps/commerce/commerce-price-list-test/src/testIntegration/java/com/liferay/commerce/price/list/service/persistence/test/CommercePriceEntryPersistenceTest.java
+++ b/modules/apps/commerce/commerce-price-list-test/src/testIntegration/java/com/liferay/commerce/price/list/service/persistence/test/CommercePriceEntryPersistenceTest.java
@@ -194,7 +194,9 @@ public class CommercePriceEntryPersistenceTest {
 
 		newCommercePriceEntry.setStatusDate(RandomTestUtil.nextDate());
 
-		_commercePriceEntries.add(_persistence.update(newCommercePriceEntry));
+		newCommercePriceEntry = _persistence.update(newCommercePriceEntry);
+
+		_commercePriceEntries.add(newCommercePriceEntry);
 
 		CommercePriceEntry existingCommercePriceEntry =
 			_persistence.findByPrimaryKey(
@@ -836,4 +838,4 @@ public class CommercePriceEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1902261293
+// LIFERAY-SERVICE-BUILDER-HASH:-1644816883

--- a/modules/apps/commerce/commerce-price-list-test/src/testIntegration/java/com/liferay/commerce/price/list/service/persistence/test/CommercePriceListAccountRelPersistenceTest.java
+++ b/modules/apps/commerce/commerce-price-list-test/src/testIntegration/java/com/liferay/commerce/price/list/service/persistence/test/CommercePriceListAccountRelPersistenceTest.java
@@ -147,8 +147,10 @@ public class CommercePriceListAccountRelPersistenceTest {
 		newCommercePriceListAccountRel.setLastPublishDate(
 			RandomTestUtil.nextDate());
 
-		_commercePriceListAccountRels.add(
-			_persistence.update(newCommercePriceListAccountRel));
+		newCommercePriceListAccountRel = _persistence.update(
+			newCommercePriceListAccountRel);
+
+		_commercePriceListAccountRels.add(newCommercePriceListAccountRel);
 
 		CommercePriceListAccountRel existingCommercePriceListAccountRel =
 			_persistence.findByPrimaryKey(
@@ -637,4 +639,4 @@ public class CommercePriceListAccountRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-345600638
+// LIFERAY-SERVICE-BUILDER-HASH:1996880232

--- a/modules/apps/commerce/commerce-price-list-test/src/testIntegration/java/com/liferay/commerce/price/list/service/persistence/test/CommercePriceListChannelRelPersistenceTest.java
+++ b/modules/apps/commerce/commerce-price-list-test/src/testIntegration/java/com/liferay/commerce/price/list/service/persistence/test/CommercePriceListChannelRelPersistenceTest.java
@@ -147,8 +147,10 @@ public class CommercePriceListChannelRelPersistenceTest {
 		newCommercePriceListChannelRel.setLastPublishDate(
 			RandomTestUtil.nextDate());
 
-		_commercePriceListChannelRels.add(
-			_persistence.update(newCommercePriceListChannelRel));
+		newCommercePriceListChannelRel = _persistence.update(
+			newCommercePriceListChannelRel);
+
+		_commercePriceListChannelRels.add(newCommercePriceListChannelRel);
 
 		CommercePriceListChannelRel existingCommercePriceListChannelRel =
 			_persistence.findByPrimaryKey(
@@ -637,4 +639,4 @@ public class CommercePriceListChannelRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:535914748
+// LIFERAY-SERVICE-BUILDER-HASH:894732922

--- a/modules/apps/commerce/commerce-price-list-test/src/testIntegration/java/com/liferay/commerce/price/list/service/persistence/test/CommercePriceListCommerceAccountGroupRelPersistenceTest.java
+++ b/modules/apps/commerce/commerce-price-list-test/src/testIntegration/java/com/liferay/commerce/price/list/service/persistence/test/CommercePriceListCommerceAccountGroupRelPersistenceTest.java
@@ -158,8 +158,11 @@ public class CommercePriceListCommerceAccountGroupRelPersistenceTest {
 		newCommercePriceListCommerceAccountGroupRel.setLastPublishDate(
 			RandomTestUtil.nextDate());
 
+		newCommercePriceListCommerceAccountGroupRel = _persistence.update(
+			newCommercePriceListCommerceAccountGroupRel);
+
 		_commercePriceListCommerceAccountGroupRels.add(
-			_persistence.update(newCommercePriceListCommerceAccountGroupRel));
+			newCommercePriceListCommerceAccountGroupRel);
 
 		CommercePriceListCommerceAccountGroupRel
 			existingCommercePriceListCommerceAccountGroupRel =
@@ -710,4 +713,4 @@ public class CommercePriceListCommerceAccountGroupRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1797718161
+// LIFERAY-SERVICE-BUILDER-HASH:1275792663

--- a/modules/apps/commerce/commerce-price-list-test/src/testIntegration/java/com/liferay/commerce/price/list/service/persistence/test/CommercePriceListDiscountRelPersistenceTest.java
+++ b/modules/apps/commerce/commerce-price-list-test/src/testIntegration/java/com/liferay/commerce/price/list/service/persistence/test/CommercePriceListDiscountRelPersistenceTest.java
@@ -148,8 +148,10 @@ public class CommercePriceListDiscountRelPersistenceTest {
 		newCommercePriceListDiscountRel.setLastPublishDate(
 			RandomTestUtil.nextDate());
 
-		_commercePriceListDiscountRels.add(
-			_persistence.update(newCommercePriceListDiscountRel));
+		newCommercePriceListDiscountRel = _persistence.update(
+			newCommercePriceListDiscountRel);
+
+		_commercePriceListDiscountRels.add(newCommercePriceListDiscountRel);
 
 		CommercePriceListDiscountRel existingCommercePriceListDiscountRel =
 			_persistence.findByPrimaryKey(
@@ -639,4 +641,4 @@ public class CommercePriceListDiscountRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:2019876907
+// LIFERAY-SERVICE-BUILDER-HASH:-1626406933

--- a/modules/apps/commerce/commerce-price-list-test/src/testIntegration/java/com/liferay/commerce/price/list/service/persistence/test/CommercePriceListOrderTypeRelPersistenceTest.java
+++ b/modules/apps/commerce/commerce-price-list-test/src/testIntegration/java/com/liferay/commerce/price/list/service/persistence/test/CommercePriceListOrderTypeRelPersistenceTest.java
@@ -149,8 +149,10 @@ public class CommercePriceListOrderTypeRelPersistenceTest {
 		newCommercePriceListOrderTypeRel.setLastPublishDate(
 			RandomTestUtil.nextDate());
 
-		_commercePriceListOrderTypeRels.add(
-			_persistence.update(newCommercePriceListOrderTypeRel));
+		newCommercePriceListOrderTypeRel = _persistence.update(
+			newCommercePriceListOrderTypeRel);
+
+		_commercePriceListOrderTypeRels.add(newCommercePriceListOrderTypeRel);
 
 		CommercePriceListOrderTypeRel existingCommercePriceListOrderTypeRel =
 			_persistence.findByPrimaryKey(
@@ -648,4 +650,4 @@ public class CommercePriceListOrderTypeRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-207562914
+// LIFERAY-SERVICE-BUILDER-HASH:958336300

--- a/modules/apps/commerce/commerce-price-list-test/src/testIntegration/java/com/liferay/commerce/price/list/service/persistence/test/CommercePriceListPersistenceTest.java
+++ b/modules/apps/commerce/commerce-price-list-test/src/testIntegration/java/com/liferay/commerce/price/list/service/persistence/test/CommercePriceListPersistenceTest.java
@@ -167,7 +167,9 @@ public class CommercePriceListPersistenceTest {
 
 		newCommercePriceList.setStatusDate(RandomTestUtil.nextDate());
 
-		_commercePriceLists.add(_persistence.update(newCommercePriceList));
+		newCommercePriceList = _persistence.update(newCommercePriceList);
+
+		_commercePriceLists.add(newCommercePriceList);
 
 		CommercePriceList existingCommercePriceList =
 			_persistence.findByPrimaryKey(newCommercePriceList.getPrimaryKey());
@@ -844,4 +846,4 @@ public class CommercePriceListPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1667415261
+// LIFERAY-SERVICE-BUILDER-HASH:826078797

--- a/modules/apps/commerce/commerce-price-list-test/src/testIntegration/java/com/liferay/commerce/price/list/service/persistence/test/CommerceTierPriceEntryPersistenceTest.java
+++ b/modules/apps/commerce/commerce-price-list-test/src/testIntegration/java/com/liferay/commerce/price/list/service/persistence/test/CommerceTierPriceEntryPersistenceTest.java
@@ -180,8 +180,10 @@ public class CommerceTierPriceEntryPersistenceTest {
 
 		newCommerceTierPriceEntry.setStatusDate(RandomTestUtil.nextDate());
 
-		_commerceTierPriceEntries.add(
-			_persistence.update(newCommerceTierPriceEntry));
+		newCommerceTierPriceEntry = _persistence.update(
+			newCommerceTierPriceEntry);
+
+		_commerceTierPriceEntries.add(newCommerceTierPriceEntry);
 
 		CommerceTierPriceEntry existingCommerceTierPriceEntry =
 			_persistence.findByPrimaryKey(
@@ -824,4 +826,4 @@ public class CommerceTierPriceEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1948479434
+// LIFERAY-SERVICE-BUILDER-HASH:-1430891760

--- a/modules/apps/commerce/commerce-pricing-test/src/testIntegration/java/com/liferay/commerce/pricing/service/persistence/test/CommercePriceModifierPersistenceTest.java
+++ b/modules/apps/commerce/commerce-pricing-test/src/testIntegration/java/com/liferay/commerce/pricing/service/persistence/test/CommercePriceModifierPersistenceTest.java
@@ -171,8 +171,10 @@ public class CommercePriceModifierPersistenceTest {
 
 		newCommercePriceModifier.setStatusDate(RandomTestUtil.nextDate());
 
-		_commercePriceModifiers.add(
-			_persistence.update(newCommercePriceModifier));
+		newCommercePriceModifier = _persistence.update(
+			newCommercePriceModifier);
+
+		_commercePriceModifiers.add(newCommercePriceModifier);
 
 		CommercePriceModifier existingCommercePriceModifier =
 			_persistence.findByPrimaryKey(
@@ -819,4 +821,4 @@ public class CommercePriceModifierPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:875760643
+// LIFERAY-SERVICE-BUILDER-HASH:-1341899791

--- a/modules/apps/commerce/commerce-pricing-test/src/testIntegration/java/com/liferay/commerce/pricing/service/persistence/test/CommercePriceModifierRelPersistenceTest.java
+++ b/modules/apps/commerce/commerce-pricing-test/src/testIntegration/java/com/liferay/commerce/pricing/service/persistence/test/CommercePriceModifierRelPersistenceTest.java
@@ -138,8 +138,10 @@ public class CommercePriceModifierRelPersistenceTest {
 
 		newCommercePriceModifierRel.setClassPK(RandomTestUtil.nextLong());
 
-		_commercePriceModifierRels.add(
-			_persistence.update(newCommercePriceModifierRel));
+		newCommercePriceModifierRel = _persistence.update(
+			newCommercePriceModifierRel);
+
+		_commercePriceModifierRels.add(newCommercePriceModifierRel);
 
 		CommercePriceModifierRel existingCommercePriceModifierRel =
 			_persistence.findByPrimaryKey(
@@ -604,4 +606,4 @@ public class CommercePriceModifierRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:260764559
+// LIFERAY-SERVICE-BUILDER-HASH:-1420995713

--- a/modules/apps/commerce/commerce-pricing-test/src/testIntegration/java/com/liferay/commerce/pricing/service/persistence/test/CommercePricingClassCPDefinitionRelPersistenceTest.java
+++ b/modules/apps/commerce/commerce-pricing-test/src/testIntegration/java/com/liferay/commerce/pricing/service/persistence/test/CommercePricingClassCPDefinitionRelPersistenceTest.java
@@ -146,8 +146,11 @@ public class CommercePricingClassCPDefinitionRelPersistenceTest {
 		newCommercePricingClassCPDefinitionRel.setCPDefinitionId(
 			RandomTestUtil.nextLong());
 
+		newCommercePricingClassCPDefinitionRel = _persistence.update(
+			newCommercePricingClassCPDefinitionRel);
+
 		_commercePricingClassCPDefinitionRels.add(
-			_persistence.update(newCommercePricingClassCPDefinitionRel));
+			newCommercePricingClassCPDefinitionRel);
 
 		CommercePricingClassCPDefinitionRel
 			existingCommercePricingClassCPDefinitionRel =
@@ -645,4 +648,4 @@ public class CommercePricingClassCPDefinitionRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:579655111
+// LIFERAY-SERVICE-BUILDER-HASH:-1098504803

--- a/modules/apps/commerce/commerce-pricing-test/src/testIntegration/java/com/liferay/commerce/pricing/service/persistence/test/CommercePricingClassPersistenceTest.java
+++ b/modules/apps/commerce/commerce-pricing-test/src/testIntegration/java/com/liferay/commerce/pricing/service/persistence/test/CommercePricingClassPersistenceTest.java
@@ -141,8 +141,9 @@ public class CommercePricingClassPersistenceTest {
 
 		newCommercePricingClass.setLastPublishDate(RandomTestUtil.nextDate());
 
-		_commercePricingClasses.add(
-			_persistence.update(newCommercePricingClass));
+		newCommercePricingClass = _persistence.update(newCommercePricingClass);
+
+		_commercePricingClasses.add(newCommercePricingClass);
 
 		CommercePricingClass existingCommercePricingClass =
 			_persistence.findByPrimaryKey(
@@ -630,4 +631,4 @@ public class CommercePricingClassPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:949080374
+// LIFERAY-SERVICE-BUILDER-HASH:1074578758

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPAttachmentFileEntryPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPAttachmentFileEntryPersistenceTest.java
@@ -174,8 +174,10 @@ public class CPAttachmentFileEntryPersistenceTest {
 
 		newCPAttachmentFileEntry.setStatusDate(RandomTestUtil.nextDate());
 
-		_cpAttachmentFileEntries.add(
-			_persistence.update(newCPAttachmentFileEntry));
+		newCPAttachmentFileEntry = _persistence.update(
+			newCPAttachmentFileEntry);
+
+		_cpAttachmentFileEntries.add(newCPAttachmentFileEntry);
 
 		CPAttachmentFileEntry existingCPAttachmentFileEntry =
 			_persistence.findByPrimaryKey(
@@ -866,4 +868,4 @@ public class CPAttachmentFileEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1168727120
+// LIFERAY-SERVICE-BUILDER-HASH:34817944

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPConfigurationEntryPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPConfigurationEntryPersistenceTest.java
@@ -203,8 +203,9 @@ public class CPConfigurationEntryPersistenceTest {
 
 		newCPConfigurationEntry.setWidth(RandomTestUtil.nextDouble());
 
-		_cpConfigurationEntries.add(
-			_persistence.update(newCPConfigurationEntry));
+		newCPConfigurationEntry = _persistence.update(newCPConfigurationEntry);
+
+		_cpConfigurationEntries.add(newCPConfigurationEntry);
 
 		CPConfigurationEntry existingCPConfigurationEntry =
 			_persistence.findByPrimaryKey(
@@ -886,4 +887,4 @@ public class CPConfigurationEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:584419423
+// LIFERAY-SERVICE-BUILDER-HASH:-2146566841

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPConfigurationEntrySettingPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPConfigurationEntrySettingPersistenceTest.java
@@ -144,8 +144,10 @@ public class CPConfigurationEntrySettingPersistenceTest {
 
 		newCPConfigurationEntrySetting.setValue(RandomTestUtil.randomString());
 
-		_cpConfigurationEntrySettings.add(
-			_persistence.update(newCPConfigurationEntrySetting));
+		newCPConfigurationEntrySetting = _persistence.update(
+			newCPConfigurationEntrySetting);
+
+		_cpConfigurationEntrySettings.add(newCPConfigurationEntrySetting);
 
 		CPConfigurationEntrySetting existingCPConfigurationEntrySetting =
 			_persistence.findByPrimaryKey(
@@ -650,4 +652,4 @@ public class CPConfigurationEntrySettingPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1604652921
+// LIFERAY-SERVICE-BUILDER-HASH:1152965699

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPConfigurationListPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPConfigurationListPersistenceTest.java
@@ -160,7 +160,9 @@ public class CPConfigurationListPersistenceTest {
 
 		newCPConfigurationList.setStatusDate(RandomTestUtil.nextDate());
 
-		_cpConfigurationLists.add(_persistence.update(newCPConfigurationList));
+		newCPConfigurationList = _persistence.update(newCPConfigurationList);
+
+		_cpConfigurationLists.add(newCPConfigurationList);
 
 		CPConfigurationList existingCPConfigurationList =
 			_persistence.findByPrimaryKey(
@@ -774,4 +776,4 @@ public class CPConfigurationListPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1545274059
+// LIFERAY-SERVICE-BUILDER-HASH:1290832319

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPConfigurationListRelPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPConfigurationListRelPersistenceTest.java
@@ -136,8 +136,10 @@ public class CPConfigurationListRelPersistenceTest {
 		newCPConfigurationListRel.setCPConfigurationListId(
 			RandomTestUtil.nextLong());
 
-		_cpConfigurationListRels.add(
-			_persistence.update(newCPConfigurationListRel));
+		newCPConfigurationListRel = _persistence.update(
+			newCPConfigurationListRel);
+
+		_cpConfigurationListRels.add(newCPConfigurationListRel);
 
 		CPConfigurationListRel existingCPConfigurationListRel =
 			_persistence.findByPrimaryKey(
@@ -588,4 +590,4 @@ public class CPConfigurationListRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1270917068
+// LIFERAY-SERVICE-BUILDER-HASH:-120472000

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPDefinitionLinkPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPDefinitionLinkPersistenceTest.java
@@ -152,7 +152,9 @@ public class CPDefinitionLinkPersistenceTest {
 
 		newCPDefinitionLink.setStatusDate(RandomTestUtil.nextDate());
 
-		_cpDefinitionLinks.add(_persistence.update(newCPDefinitionLink));
+		newCPDefinitionLink = _persistence.update(newCPDefinitionLink);
+
+		_cpDefinitionLinks.add(newCPDefinitionLink);
 
 		CPDefinitionLink existingCPDefinitionLink =
 			_persistence.findByPrimaryKey(newCPDefinitionLink.getPrimaryKey());
@@ -729,4 +731,4 @@ public class CPDefinitionLinkPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:842658885
+// LIFERAY-SERVICE-BUILDER-HASH:-1352959647

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPDefinitionLocalizationPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPDefinitionLocalizationPersistenceTest.java
@@ -143,8 +143,10 @@ public class CPDefinitionLocalizationPersistenceTest {
 		newCPDefinitionLocalization.setShortDescription(
 			RandomTestUtil.randomString());
 
-		_cpDefinitionLocalizations.add(
-			_persistence.update(newCPDefinitionLocalization));
+		newCPDefinitionLocalization = _persistence.update(
+			newCPDefinitionLocalization);
+
+		_cpDefinitionLocalizations.add(newCPDefinitionLocalization);
 
 		CPDefinitionLocalization existingCPDefinitionLocalization =
 			_persistence.findByPrimaryKey(
@@ -568,4 +570,4 @@ public class CPDefinitionLocalizationPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-70112456
+// LIFERAY-SERVICE-BUILDER-HASH:111763230

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPDefinitionOptionRelPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPDefinitionOptionRelPersistenceTest.java
@@ -166,8 +166,10 @@ public class CPDefinitionOptionRelPersistenceTest {
 
 		newCPDefinitionOptionRel.setTypeSettings(RandomTestUtil.randomString());
 
-		_cpDefinitionOptionRels.add(
-			_persistence.update(newCPDefinitionOptionRel));
+		newCPDefinitionOptionRel = _persistence.update(
+			newCPDefinitionOptionRel);
+
+		_cpDefinitionOptionRels.add(newCPDefinitionOptionRel);
 
 		CPDefinitionOptionRel existingCPDefinitionOptionRel =
 			_persistence.findByPrimaryKey(
@@ -768,4 +770,4 @@ public class CPDefinitionOptionRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:397983739
+// LIFERAY-SERVICE-BUILDER-HASH:-1428323899

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPDefinitionOptionValueRelPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPDefinitionOptionValueRelPersistenceTest.java
@@ -166,8 +166,10 @@ public class CPDefinitionOptionValueRelPersistenceTest {
 		newCPDefinitionOptionValueRel.setUnitOfMeasureKey(
 			RandomTestUtil.randomString());
 
-		_cpDefinitionOptionValueRels.add(
-			_persistence.update(newCPDefinitionOptionValueRel));
+		newCPDefinitionOptionValueRel = _persistence.update(
+			newCPDefinitionOptionValueRel);
+
+		_cpDefinitionOptionValueRels.add(newCPDefinitionOptionValueRel);
 
 		CPDefinitionOptionValueRel existingCPDefinitionOptionValueRel =
 			_persistence.findByPrimaryKey(
@@ -751,4 +753,4 @@ public class CPDefinitionOptionValueRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1109761622
+// LIFERAY-SERVICE-BUILDER-HASH:960810872

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPDefinitionPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPDefinitionPersistenceTest.java
@@ -218,7 +218,9 @@ public class CPDefinitionPersistenceTest {
 
 		newCPDefinition.setStatusDate(RandomTestUtil.nextDate());
 
-		_cpDefinitions.add(_persistence.update(newCPDefinition));
+		newCPDefinition = _persistence.update(newCPDefinition);
+
+		_cpDefinitions.add(newCPDefinition);
 
 		CPDefinition existingCPDefinition = _persistence.findByPrimaryKey(
 			newCPDefinition.getPrimaryKey());
@@ -920,4 +922,4 @@ public class CPDefinitionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-316670342
+// LIFERAY-SERVICE-BUILDER-HASH:1555603426

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPDefinitionSpecificationOptionValuePersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPDefinitionSpecificationOptionValuePersistenceTest.java
@@ -176,8 +176,11 @@ public class CPDefinitionSpecificationOptionValuePersistenceTest {
 		newCPDefinitionSpecificationOptionValue.setLastPublishDate(
 			RandomTestUtil.nextDate());
 
+		newCPDefinitionSpecificationOptionValue = _persistence.update(
+			newCPDefinitionSpecificationOptionValue);
+
 		_cpDefinitionSpecificationOptionValues.add(
-			_persistence.update(newCPDefinitionSpecificationOptionValue));
+			newCPDefinitionSpecificationOptionValue);
 
 		CPDefinitionSpecificationOptionValue
 			existingCPDefinitionSpecificationOptionValue =
@@ -878,4 +881,4 @@ public class CPDefinitionSpecificationOptionValuePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:42624393
+// LIFERAY-SERVICE-BUILDER-HASH:640902703

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPDisplayLayoutPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPDisplayLayoutPersistenceTest.java
@@ -138,7 +138,9 @@ public class CPDisplayLayoutPersistenceTest {
 
 		newCPDisplayLayout.setLayoutUuid(RandomTestUtil.randomString());
 
-		_cpDisplayLayouts.add(_persistence.update(newCPDisplayLayout));
+		newCPDisplayLayout = _persistence.update(newCPDisplayLayout);
+
+		_cpDisplayLayouts.add(newCPDisplayLayout);
 
 		CPDisplayLayout existingCPDisplayLayout = _persistence.findByPrimaryKey(
 			newCPDisplayLayout.getPrimaryKey());
@@ -647,4 +649,4 @@ public class CPDisplayLayoutPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1506747234
+// LIFERAY-SERVICE-BUILDER-HASH:1537012600

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPInstanceOptionValueRelPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPInstanceOptionValueRelPersistenceTest.java
@@ -143,8 +143,10 @@ public class CPInstanceOptionValueRelPersistenceTest {
 
 		newCPInstanceOptionValueRel.setCPInstanceId(RandomTestUtil.nextLong());
 
-		_cpInstanceOptionValueRels.add(
-			_persistence.update(newCPInstanceOptionValueRel));
+		newCPInstanceOptionValueRel = _persistence.update(
+			newCPInstanceOptionValueRel);
+
+		_cpInstanceOptionValueRels.add(newCPInstanceOptionValueRel);
 
 		CPInstanceOptionValueRel existingCPInstanceOptionValueRel =
 			_persistence.findByPrimaryKey(
@@ -678,4 +680,4 @@ public class CPInstanceOptionValueRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1890474379
+// LIFERAY-SERVICE-BUILDER-HASH:1060382629

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPInstancePersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPInstancePersistenceTest.java
@@ -221,7 +221,9 @@ public class CPInstancePersistenceTest {
 
 		newCPInstance.setStatusDate(RandomTestUtil.nextDate());
 
-		_cpInstances.add(_persistence.update(newCPInstance));
+		newCPInstance = _persistence.update(newCPInstance);
+
+		_cpInstances.add(newCPInstance);
 
 		CPInstance existingCPInstance = _persistence.findByPrimaryKey(
 			newCPInstance.getPrimaryKey());
@@ -994,4 +996,4 @@ public class CPInstancePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-257291756
+// LIFERAY-SERVICE-BUILDER-HASH:1160124224

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPInstanceUnitOfMeasurePersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPInstanceUnitOfMeasurePersistenceTest.java
@@ -160,8 +160,10 @@ public class CPInstanceUnitOfMeasurePersistenceTest {
 
 		newCPInstanceUnitOfMeasure.setSku(RandomTestUtil.randomString());
 
-		_cpInstanceUnitOfMeasures.add(
-			_persistence.update(newCPInstanceUnitOfMeasure));
+		newCPInstanceUnitOfMeasure = _persistence.update(
+			newCPInstanceUnitOfMeasure);
+
+		_cpInstanceUnitOfMeasures.add(newCPInstanceUnitOfMeasure);
 
 		CPInstanceUnitOfMeasure existingCPInstanceUnitOfMeasure =
 			_persistence.findByPrimaryKey(
@@ -703,4 +705,4 @@ public class CPInstanceUnitOfMeasurePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:922751571
+// LIFERAY-SERVICE-BUILDER-HASH:-1547151755

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPMeasurementUnitPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPMeasurementUnitPersistenceTest.java
@@ -149,7 +149,9 @@ public class CPMeasurementUnitPersistenceTest {
 
 		newCPMeasurementUnit.setLastPublishDate(RandomTestUtil.nextDate());
 
-		_cpMeasurementUnits.add(_persistence.update(newCPMeasurementUnit));
+		newCPMeasurementUnit = _persistence.update(newCPMeasurementUnit);
+
+		_cpMeasurementUnits.add(newCPMeasurementUnit);
 
 		CPMeasurementUnit existingCPMeasurementUnit =
 			_persistence.findByPrimaryKey(newCPMeasurementUnit.getPrimaryKey());
@@ -690,4 +692,4 @@ public class CPMeasurementUnitPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:909240315
+// LIFERAY-SERVICE-BUILDER-HASH:-1374295531

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPOptionCategoryPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPOptionCategoryPersistenceTest.java
@@ -142,7 +142,9 @@ public class CPOptionCategoryPersistenceTest {
 
 		newCPOptionCategory.setLastPublishDate(RandomTestUtil.nextDate());
 
-		_cpOptionCategories.add(_persistence.update(newCPOptionCategory));
+		newCPOptionCategory = _persistence.update(newCPOptionCategory);
+
+		_cpOptionCategories.add(newCPOptionCategory);
 
 		CPOptionCategory existingCPOptionCategory =
 			_persistence.findByPrimaryKey(newCPOptionCategory.getPrimaryKey());
@@ -626,4 +628,4 @@ public class CPOptionCategoryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1058488032
+// LIFERAY-SERVICE-BUILDER-HASH:2108535038

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPOptionPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPOptionPersistenceTest.java
@@ -146,7 +146,9 @@ public class CPOptionPersistenceTest {
 
 		newCPOption.setLastPublishDate(RandomTestUtil.nextDate());
 
-		_cpOptions.add(_persistence.update(newCPOption));
+		newCPOption = _persistence.update(newCPOption);
+
+		_cpOptions.add(newCPOption);
 
 		CPOption existingCPOption = _persistence.findByPrimaryKey(
 			newCPOption.getPrimaryKey());
@@ -616,4 +618,4 @@ public class CPOptionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-683981256
+// LIFERAY-SERVICE-BUILDER-HASH:-83335836

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPOptionValuePersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPOptionValuePersistenceTest.java
@@ -142,7 +142,9 @@ public class CPOptionValuePersistenceTest {
 
 		newCPOptionValue.setLastPublishDate(RandomTestUtil.nextDate());
 
-		_cpOptionValues.add(_persistence.update(newCPOptionValue));
+		newCPOptionValue = _persistence.update(newCPOptionValue);
+
+		_cpOptionValues.add(newCPOptionValue);
 
 		CPOptionValue existingCPOptionValue = _persistence.findByPrimaryKey(
 			newCPOptionValue.getPrimaryKey());
@@ -622,4 +624,4 @@ public class CPOptionValuePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1370623233
+// LIFERAY-SERVICE-BUILDER-HASH:2106506517

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPSpecificationOptionListTypeDefinitionRelPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPSpecificationOptionListTypeDefinitionRelPersistenceTest.java
@@ -136,8 +136,11 @@ public class CPSpecificationOptionListTypeDefinitionRelPersistenceTest {
 		newCPSpecificationOptionListTypeDefinitionRel.setListTypeDefinitionId(
 			RandomTestUtil.nextLong());
 
+		newCPSpecificationOptionListTypeDefinitionRel = _persistence.update(
+			newCPSpecificationOptionListTypeDefinitionRel);
+
 		_cpSpecificationOptionListTypeDefinitionRels.add(
-			_persistence.update(newCPSpecificationOptionListTypeDefinitionRel));
+			newCPSpecificationOptionListTypeDefinitionRel);
 
 		CPSpecificationOptionListTypeDefinitionRel
 			existingCPSpecificationOptionListTypeDefinitionRel =
@@ -632,4 +635,4 @@ public class CPSpecificationOptionListTypeDefinitionRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:298054921
+// LIFERAY-SERVICE-BUILDER-HASH:55205659

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPSpecificationOptionPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPSpecificationOptionPersistenceTest.java
@@ -153,8 +153,10 @@ public class CPSpecificationOptionPersistenceTest {
 
 		newCPSpecificationOption.setLastPublishDate(RandomTestUtil.nextDate());
 
-		_cpSpecificationOptions.add(
-			_persistence.update(newCPSpecificationOption));
+		newCPSpecificationOption = _persistence.update(
+			newCPSpecificationOption);
+
+		_cpSpecificationOptions.add(newCPSpecificationOption);
 
 		CPSpecificationOption existingCPSpecificationOption =
 			_persistence.findByPrimaryKey(
@@ -700,4 +702,4 @@ public class CPSpecificationOptionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1283899812
+// LIFERAY-SERVICE-BUILDER-HASH:2142805974

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPTaxCategoryPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CPTaxCategoryPersistenceTest.java
@@ -135,7 +135,9 @@ public class CPTaxCategoryPersistenceTest {
 
 		newCPTaxCategory.setDescription(RandomTestUtil.randomString());
 
-		_cpTaxCategories.add(_persistence.update(newCPTaxCategory));
+		newCPTaxCategory = _persistence.update(newCPTaxCategory);
+
+		_cpTaxCategories.add(newCPTaxCategory);
 
 		CPTaxCategory existingCPTaxCategory = _persistence.findByPrimaryKey(
 			newCPTaxCategory.getPrimaryKey());
@@ -573,4 +575,4 @@ public class CPTaxCategoryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:736322576
+// LIFERAY-SERVICE-BUILDER-HASH:-1977242584

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CProductPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CProductPersistenceTest.java
@@ -136,7 +136,9 @@ public class CProductPersistenceTest {
 
 		newCProduct.setLatestVersion(RandomTestUtil.nextInt());
 
-		_cProducts.add(_persistence.update(newCProduct));
+		newCProduct = _persistence.update(newCProduct);
+
+		_cProducts.add(newCProduct);
 
 		CProduct existingCProduct = _persistence.findByPrimaryKey(
 			newCProduct.getPrimaryKey());
@@ -586,4 +588,4 @@ public class CProductPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-594503603
+// LIFERAY-SERVICE-BUILDER-HASH:-1936652787

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CommerceCatalogPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CommerceCatalogPersistenceTest.java
@@ -143,7 +143,9 @@ public class CommerceCatalogPersistenceTest {
 
 		newCommerceCatalog.setSystem(RandomTestUtil.randomBoolean());
 
-		_commerceCatalogs.add(_persistence.update(newCommerceCatalog));
+		newCommerceCatalog = _persistence.update(newCommerceCatalog);
+
+		_commerceCatalogs.add(newCommerceCatalog);
 
 		CommerceCatalog existingCommerceCatalog = _persistence.findByPrimaryKey(
 			newCommerceCatalog.getPrimaryKey());
@@ -618,4 +620,4 @@ public class CommerceCatalogPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-795767743
+// LIFERAY-SERVICE-BUILDER-HASH:1804209971

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CommerceChannelAccountEntryRelPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CommerceChannelAccountEntryRelPersistenceTest.java
@@ -155,8 +155,10 @@ public class CommerceChannelAccountEntryRelPersistenceTest {
 
 		newCommerceChannelAccountEntryRel.setType(RandomTestUtil.nextInt());
 
-		_commerceChannelAccountEntryRels.add(
-			_persistence.update(newCommerceChannelAccountEntryRel));
+		newCommerceChannelAccountEntryRel = _persistence.update(
+			newCommerceChannelAccountEntryRel);
+
+		_commerceChannelAccountEntryRels.add(newCommerceChannelAccountEntryRel);
 
 		CommerceChannelAccountEntryRel existingCommerceChannelAccountEntryRel =
 			_persistence.findByPrimaryKey(
@@ -708,4 +710,4 @@ public class CommerceChannelAccountEntryRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-948993592
+// LIFERAY-SERVICE-BUILDER-HASH:-541740856

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CommerceChannelPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CommerceChannelPersistenceTest.java
@@ -149,7 +149,9 @@ public class CommerceChannelPersistenceTest {
 		newCommerceChannel.setDiscountsTargetNetPrice(
 			RandomTestUtil.randomBoolean());
 
-		_commerceChannels.add(_persistence.update(newCommerceChannel));
+		newCommerceChannel = _persistence.update(newCommerceChannel);
+
+		_commerceChannels.add(newCommerceChannel);
 
 		CommerceChannel existingCommerceChannel = _persistence.findByPrimaryKey(
 			newCommerceChannel.getPrimaryKey());
@@ -639,4 +641,4 @@ public class CommerceChannelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-21638614
+// LIFERAY-SERVICE-BUILDER-HASH:1949056784

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CommerceChannelRelPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/persistence/test/CommerceChannelRelPersistenceTest.java
@@ -132,7 +132,9 @@ public class CommerceChannelRelPersistenceTest {
 
 		newCommerceChannelRel.setCommerceChannelId(RandomTestUtil.nextLong());
 
-		_commerceChannelRels.add(_persistence.update(newCommerceChannelRel));
+		newCommerceChannelRel = _persistence.update(newCommerceChannelRel);
+
+		_commerceChannelRels.add(newCommerceChannelRel);
 
 		CommerceChannelRel existingCommerceChannelRel =
 			_persistence.findByPrimaryKey(
@@ -557,4 +559,4 @@ public class CommerceChannelRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1940574103
+// LIFERAY-SERVICE-BUILDER-HASH:733668831

--- a/modules/apps/commerce/commerce-product-type-grouped-test/src/testIntegration/java/com/liferay/commerce/product/type/grouped/service/persistence/test/CPDefinitionGroupedEntryPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-type-grouped-test/src/testIntegration/java/com/liferay/commerce/product/type/grouped/service/persistence/test/CPDefinitionGroupedEntryPersistenceTest.java
@@ -144,8 +144,10 @@ public class CPDefinitionGroupedEntryPersistenceTest {
 
 		newCPDefinitionGroupedEntry.setQuantity(RandomTestUtil.nextInt());
 
-		_cpDefinitionGroupedEntries.add(
-			_persistence.update(newCPDefinitionGroupedEntry));
+		newCPDefinitionGroupedEntry = _persistence.update(
+			newCPDefinitionGroupedEntry);
+
+		_cpDefinitionGroupedEntries.add(newCPDefinitionGroupedEntry);
 
 		CPDefinitionGroupedEntry existingCPDefinitionGroupedEntry =
 			_persistence.findByPrimaryKey(
@@ -642,4 +644,4 @@ public class CPDefinitionGroupedEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1330224768
+// LIFERAY-SERVICE-BUILDER-HASH:-2002894502

--- a/modules/apps/commerce/commerce-product-type-virtual-order-test/src/testIntegration/java/com/liferay/commerce/product/type/virtual/order/service/persistence/test/CommerceVirtualOrderItemFileEntryPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-type-virtual-order-test/src/testIntegration/java/com/liferay/commerce/product/type/virtual/order/service/persistence/test/CommerceVirtualOrderItemFileEntryPersistenceTest.java
@@ -157,8 +157,11 @@ public class CommerceVirtualOrderItemFileEntryPersistenceTest {
 		newCommerceVirtualOrderItemFileEntry.setVersion(
 			RandomTestUtil.randomString());
 
+		newCommerceVirtualOrderItemFileEntry = _persistence.update(
+			newCommerceVirtualOrderItemFileEntry);
+
 		_commerceVirtualOrderItemFileEntries.add(
-			_persistence.update(newCommerceVirtualOrderItemFileEntry));
+			newCommerceVirtualOrderItemFileEntry);
 
 		CommerceVirtualOrderItemFileEntry
 			existingCommerceVirtualOrderItemFileEntry =
@@ -679,4 +682,4 @@ public class CommerceVirtualOrderItemFileEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:807186447
+// LIFERAY-SERVICE-BUILDER-HASH:-2117508729

--- a/modules/apps/commerce/commerce-product-type-virtual-order-test/src/testIntegration/java/com/liferay/commerce/product/type/virtual/order/service/persistence/test/CommerceVirtualOrderItemPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-type-virtual-order-test/src/testIntegration/java/com/liferay/commerce/product/type/virtual/order/service/persistence/test/CommerceVirtualOrderItemPersistenceTest.java
@@ -149,8 +149,10 @@ public class CommerceVirtualOrderItemPersistenceTest {
 
 		newCommerceVirtualOrderItem.setEndDate(RandomTestUtil.nextDate());
 
-		_commerceVirtualOrderItems.add(
-			_persistence.update(newCommerceVirtualOrderItem));
+		newCommerceVirtualOrderItem = _persistence.update(
+			newCommerceVirtualOrderItem);
+
+		_commerceVirtualOrderItems.add(newCommerceVirtualOrderItem);
 
 		CommerceVirtualOrderItem existingCommerceVirtualOrderItem =
 			_persistence.findByPrimaryKey(
@@ -646,4 +648,4 @@ public class CommerceVirtualOrderItemPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1076564031
+// LIFERAY-SERVICE-BUILDER-HASH:-988058295

--- a/modules/apps/commerce/commerce-product-type-virtual-test/src/testIntegration/java/com/liferay/commerce/product/type/virtual/service/persistence/test/CPDVirtualSettingFileEntryPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-type-virtual-test/src/testIntegration/java/com/liferay/commerce/product/type/virtual/service/persistence/test/CPDVirtualSettingFileEntryPersistenceTest.java
@@ -144,8 +144,10 @@ public class CPDVirtualSettingFileEntryPersistenceTest {
 
 		newCPDVirtualSettingFileEntry.setVersion(RandomTestUtil.randomString());
 
-		_cpdVirtualSettingFileEntries.add(
-			_persistence.update(newCPDVirtualSettingFileEntry));
+		newCPDVirtualSettingFileEntry = _persistence.update(
+			newCPDVirtualSettingFileEntry);
+
+		_cpdVirtualSettingFileEntries.add(newCPDVirtualSettingFileEntry);
 
 		CPDVirtualSettingFileEntry existingCPDVirtualSettingFileEntry =
 			_persistence.findByPrimaryKey(
@@ -640,4 +642,4 @@ public class CPDVirtualSettingFileEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2015420311
+// LIFERAY-SERVICE-BUILDER-HASH:-1084227417

--- a/modules/apps/commerce/commerce-product-type-virtual-test/src/testIntegration/java/com/liferay/commerce/product/type/virtual/service/persistence/test/CPDefinitionVirtualSettingPersistenceTest.java
+++ b/modules/apps/commerce/commerce-product-type-virtual-test/src/testIntegration/java/com/liferay/commerce/product/type/virtual/service/persistence/test/CPDefinitionVirtualSettingPersistenceTest.java
@@ -171,8 +171,10 @@ public class CPDefinitionVirtualSettingPersistenceTest {
 		newCPDefinitionVirtualSetting.setLastPublishDate(
 			RandomTestUtil.nextDate());
 
-		_cpDefinitionVirtualSettings.add(
-			_persistence.update(newCPDefinitionVirtualSetting));
+		newCPDefinitionVirtualSetting = _persistence.update(
+			newCPDefinitionVirtualSetting);
+
+		_cpDefinitionVirtualSettings.add(newCPDefinitionVirtualSetting);
 
 		CPDefinitionVirtualSetting existingCPDefinitionVirtualSetting =
 			_persistence.findByPrimaryKey(
@@ -723,4 +725,4 @@ public class CPDefinitionVirtualSettingPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-39156261
+// LIFERAY-SERVICE-BUILDER-HASH:1037519849

--- a/modules/apps/commerce/commerce-qualifier-test/src/testIntegration/java/com/liferay/commerce/qualifier/service/persistence/test/CommerceQualifierEntryPersistenceTest.java
+++ b/modules/apps/commerce/commerce-qualifier-test/src/testIntegration/java/com/liferay/commerce/qualifier/service/persistence/test/CommerceQualifierEntryPersistenceTest.java
@@ -144,8 +144,10 @@ public class CommerceQualifierEntryPersistenceTest {
 		newCommerceQualifierEntry.setTargetCommerceQualifierMetadataKey(
 			RandomTestUtil.randomString());
 
-		_commerceQualifierEntries.add(
-			_persistence.update(newCommerceQualifierEntry));
+		newCommerceQualifierEntry = _persistence.update(
+			newCommerceQualifierEntry);
+
+		_commerceQualifierEntries.add(newCommerceQualifierEntry);
 
 		CommerceQualifierEntry existingCommerceQualifierEntry =
 			_persistence.findByPrimaryKey(
@@ -635,4 +637,4 @@ public class CommerceQualifierEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:559081500
+// LIFERAY-SERVICE-BUILDER-HASH:-1025084400

--- a/modules/apps/commerce/commerce-shipping-engine-fixed-test/src/testIntegration/java/com/liferay/commerce/shipping/engine/fixed/service/persistence/test/CommerceShippingFixedOptionPersistenceTest.java
+++ b/modules/apps/commerce/commerce-shipping-engine-fixed-test/src/testIntegration/java/com/liferay/commerce/shipping/engine/fixed/service/persistence/test/CommerceShippingFixedOptionPersistenceTest.java
@@ -151,8 +151,10 @@ public class CommerceShippingFixedOptionPersistenceTest {
 
 		newCommerceShippingFixedOption.setPriority(RandomTestUtil.nextDouble());
 
-		_commerceShippingFixedOptions.add(
-			_persistence.update(newCommerceShippingFixedOption));
+		newCommerceShippingFixedOption = _persistence.update(
+			newCommerceShippingFixedOption);
+
+		_commerceShippingFixedOptions.add(newCommerceShippingFixedOption);
 
 		CommerceShippingFixedOption existingCommerceShippingFixedOption =
 			_persistence.findByPrimaryKey(
@@ -626,4 +628,4 @@ public class CommerceShippingFixedOptionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1696335475
+// LIFERAY-SERVICE-BUILDER-HASH:1942775341

--- a/modules/apps/commerce/commerce-shipping-engine-fixed-test/src/testIntegration/java/com/liferay/commerce/shipping/engine/fixed/service/persistence/test/CommerceShippingFixedOptionQualifierPersistenceTest.java
+++ b/modules/apps/commerce/commerce-shipping-engine-fixed-test/src/testIntegration/java/com/liferay/commerce/shipping/engine/fixed/service/persistence/test/CommerceShippingFixedOptionQualifierPersistenceTest.java
@@ -148,8 +148,11 @@ public class CommerceShippingFixedOptionQualifierPersistenceTest {
 		newCommerceShippingFixedOptionQualifier.
 			setCommerceShippingFixedOptionId(RandomTestUtil.nextLong());
 
+		newCommerceShippingFixedOptionQualifier = _persistence.update(
+			newCommerceShippingFixedOptionQualifier);
+
 		_commerceShippingFixedOptionQualifiers.add(
-			_persistence.update(newCommerceShippingFixedOptionQualifier));
+			newCommerceShippingFixedOptionQualifier);
 
 		CommerceShippingFixedOptionQualifier
 			existingCommerceShippingFixedOptionQualifier =
@@ -658,4 +661,4 @@ public class CommerceShippingFixedOptionQualifierPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1675178037
+// LIFERAY-SERVICE-BUILDER-HASH:-1598144071

--- a/modules/apps/commerce/commerce-shipping-engine-fixed-test/src/testIntegration/java/com/liferay/commerce/shipping/engine/fixed/service/persistence/test/CommerceShippingFixedOptionRelPersistenceTest.java
+++ b/modules/apps/commerce/commerce-shipping-engine-fixed-test/src/testIntegration/java/com/liferay/commerce/shipping/engine/fixed/service/persistence/test/CommerceShippingFixedOptionRelPersistenceTest.java
@@ -168,8 +168,10 @@ public class CommerceShippingFixedOptionRelPersistenceTest {
 
 		newCommerceShippingFixedOptionRel.setZip(RandomTestUtil.randomString());
 
-		_commerceShippingFixedOptionRels.add(
-			_persistence.update(newCommerceShippingFixedOptionRel));
+		newCommerceShippingFixedOptionRel = _persistence.update(
+			newCommerceShippingFixedOptionRel);
+
+		_commerceShippingFixedOptionRels.add(newCommerceShippingFixedOptionRel);
 
 		CommerceShippingFixedOptionRel existingCommerceShippingFixedOptionRel =
 			_persistence.findByPrimaryKey(
@@ -622,4 +624,4 @@ public class CommerceShippingFixedOptionRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-840010402
+// LIFERAY-SERVICE-BUILDER-HASH:-235724732

--- a/modules/apps/commerce/commerce-shop-by-diagram-test/src/testIntegration/java/com/liferay/commerce/shop/by/diagram/service/persistence/test/CSDiagramEntryPersistenceTest.java
+++ b/modules/apps/commerce/commerce-shop-by-diagram-test/src/testIntegration/java/com/liferay/commerce/shop/by/diagram/service/persistence/test/CSDiagramEntryPersistenceTest.java
@@ -144,7 +144,9 @@ public class CSDiagramEntryPersistenceTest {
 
 		newCSDiagramEntry.setSku(RandomTestUtil.randomString());
 
-		_csDiagramEntries.add(_persistence.update(newCSDiagramEntry));
+		newCSDiagramEntry = _persistence.update(newCSDiagramEntry);
+
+		_csDiagramEntries.add(newCSDiagramEntry);
 
 		CSDiagramEntry existingCSDiagramEntry = _persistence.findByPrimaryKey(
 			newCSDiagramEntry.getPrimaryKey());
@@ -622,4 +624,4 @@ public class CSDiagramEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1234556000
+// LIFERAY-SERVICE-BUILDER-HASH:-327564316

--- a/modules/apps/commerce/commerce-shop-by-diagram-test/src/testIntegration/java/com/liferay/commerce/shop/by/diagram/service/persistence/test/CSDiagramPinPersistenceTest.java
+++ b/modules/apps/commerce/commerce-shop-by-diagram-test/src/testIntegration/java/com/liferay/commerce/shop/by/diagram/service/persistence/test/CSDiagramPinPersistenceTest.java
@@ -133,7 +133,9 @@ public class CSDiagramPinPersistenceTest {
 
 		newCSDiagramPin.setSequence(RandomTestUtil.randomString());
 
-		_csDiagramPins.add(_persistence.update(newCSDiagramPin));
+		newCSDiagramPin = _persistence.update(newCSDiagramPin);
+
+		_csDiagramPins.add(newCSDiagramPin);
 
 		CSDiagramPin existingCSDiagramPin = _persistence.findByPrimaryKey(
 			newCSDiagramPin.getPrimaryKey());
@@ -460,4 +462,4 @@ public class CSDiagramPinPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:544705412
+// LIFERAY-SERVICE-BUILDER-HASH:1983853136

--- a/modules/apps/commerce/commerce-shop-by-diagram-test/src/testIntegration/java/com/liferay/commerce/shop/by/diagram/service/persistence/test/CSDiagramSettingPersistenceTest.java
+++ b/modules/apps/commerce/commerce-shop-by-diagram-test/src/testIntegration/java/com/liferay/commerce/shop/by/diagram/service/persistence/test/CSDiagramSettingPersistenceTest.java
@@ -140,7 +140,9 @@ public class CSDiagramSettingPersistenceTest {
 
 		newCSDiagramSetting.setType(RandomTestUtil.randomString());
 
-		_csDiagramSettings.add(_persistence.update(newCSDiagramSetting));
+		newCSDiagramSetting = _persistence.update(newCSDiagramSetting);
+
+		_csDiagramSettings.add(newCSDiagramSetting);
 
 		CSDiagramSetting existingCSDiagramSetting =
 			_persistence.findByPrimaryKey(newCSDiagramSetting.getPrimaryKey());
@@ -561,4 +563,4 @@ public class CSDiagramSettingPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1085767864
+// LIFERAY-SERVICE-BUILDER-HASH:1532356934

--- a/modules/apps/commerce/commerce-tax-engine-fixed-test/src/testIntegration/java/com/liferay/commerce/tax/engine/fixed/service/persistence/test/CommerceTaxFixedRateAddressRelPersistenceTest.java
+++ b/modules/apps/commerce/commerce-tax-engine-fixed-test/src/testIntegration/java/com/liferay/commerce/tax/engine/fixed/service/persistence/test/CommerceTaxFixedRateAddressRelPersistenceTest.java
@@ -150,8 +150,10 @@ public class CommerceTaxFixedRateAddressRelPersistenceTest {
 
 		newCommerceTaxFixedRateAddressRel.setRate(RandomTestUtil.nextDouble());
 
-		_commerceTaxFixedRateAddressRels.add(
-			_persistence.update(newCommerceTaxFixedRateAddressRel));
+		newCommerceTaxFixedRateAddressRel = _persistence.update(
+			newCommerceTaxFixedRateAddressRel);
+
+		_commerceTaxFixedRateAddressRels.add(newCommerceTaxFixedRateAddressRel);
 
 		CommerceTaxFixedRateAddressRel existingCommerceTaxFixedRateAddressRel =
 			_persistence.findByPrimaryKey(
@@ -565,4 +567,4 @@ public class CommerceTaxFixedRateAddressRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-600543453
+// LIFERAY-SERVICE-BUILDER-HASH:596740637

--- a/modules/apps/commerce/commerce-tax-engine-fixed-test/src/testIntegration/java/com/liferay/commerce/tax/engine/fixed/service/persistence/test/CommerceTaxFixedRatePersistenceTest.java
+++ b/modules/apps/commerce/commerce-tax-engine-fixed-test/src/testIntegration/java/com/liferay/commerce/tax/engine/fixed/service/persistence/test/CommerceTaxFixedRatePersistenceTest.java
@@ -138,8 +138,9 @@ public class CommerceTaxFixedRatePersistenceTest {
 
 		newCommerceTaxFixedRate.setRate(RandomTestUtil.nextDouble());
 
-		_commerceTaxFixedRates.add(
-			_persistence.update(newCommerceTaxFixedRate));
+		newCommerceTaxFixedRate = _persistence.update(newCommerceTaxFixedRate);
+
+		_commerceTaxFixedRates.add(newCommerceTaxFixedRate);
 
 		CommerceTaxFixedRate existingCommerceTaxFixedRate =
 			_persistence.findByPrimaryKey(
@@ -576,4 +577,4 @@ public class CommerceTaxFixedRatePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-504764818
+// LIFERAY-SERVICE-BUILDER-HASH:1005123486

--- a/modules/apps/commerce/commerce-tax-test/src/testIntegration/java/com/liferay/commerce/tax/service/persistence/test/CommerceTaxCategoryMappingPersistenceTest.java
+++ b/modules/apps/commerce/commerce-tax-test/src/testIntegration/java/com/liferay/commerce/tax/service/persistence/test/CommerceTaxCategoryMappingPersistenceTest.java
@@ -144,8 +144,10 @@ public class CommerceTaxCategoryMappingPersistenceTest {
 		newCommerceTaxCategoryMapping.setCPTaxCategoryId(
 			RandomTestUtil.nextLong());
 
-		_commerceTaxCategoryMappings.add(
-			_persistence.update(newCommerceTaxCategoryMapping));
+		newCommerceTaxCategoryMapping = _persistence.update(
+			newCommerceTaxCategoryMapping);
+
+		_commerceTaxCategoryMappings.add(newCommerceTaxCategoryMapping);
 
 		CommerceTaxCategoryMapping existingCommerceTaxCategoryMapping =
 			_persistence.findByPrimaryKey(
@@ -688,4 +690,4 @@ public class CommerceTaxCategoryMappingPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-953409804
+// LIFERAY-SERVICE-BUILDER-HASH:-1543232884

--- a/modules/apps/commerce/commerce-tax-test/src/testIntegration/java/com/liferay/commerce/tax/service/persistence/test/CommerceTaxMethodPersistenceTest.java
+++ b/modules/apps/commerce/commerce-tax-test/src/testIntegration/java/com/liferay/commerce/tax/service/persistence/test/CommerceTaxMethodPersistenceTest.java
@@ -138,7 +138,9 @@ public class CommerceTaxMethodPersistenceTest {
 
 		newCommerceTaxMethod.setTypeSettings(RandomTestUtil.randomString());
 
-		_commerceTaxMethods.add(_persistence.update(newCommerceTaxMethod));
+		newCommerceTaxMethod = _persistence.update(newCommerceTaxMethod);
+
+		_commerceTaxMethods.add(newCommerceTaxMethod);
 
 		CommerceTaxMethod existingCommerceTaxMethod =
 			_persistence.findByPrimaryKey(newCommerceTaxMethod.getPrimaryKey());
@@ -568,4 +570,4 @@ public class CommerceTaxMethodPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:293614677
+// LIFERAY-SERVICE-BUILDER-HASH:240740727

--- a/modules/apps/commerce/commerce-term-test/src/testIntegration/java/com/liferay/commerce/term/service/persistence/test/CTermEntryLocalizationPersistenceTest.java
+++ b/modules/apps/commerce/commerce-term-test/src/testIntegration/java/com/liferay/commerce/term/service/persistence/test/CTermEntryLocalizationPersistenceTest.java
@@ -124,8 +124,10 @@ public class CTermEntryLocalizationPersistenceTest {
 
 		newCTermEntryLocalization.setLabel(RandomTestUtil.randomString());
 
-		_cTermEntryLocalizations.add(
-			_persistence.update(newCTermEntryLocalization));
+		newCTermEntryLocalization = _persistence.update(
+			newCTermEntryLocalization);
+
+		_cTermEntryLocalizations.add(newCTermEntryLocalization);
 
 		CTermEntryLocalization existingCTermEntryLocalization =
 			_persistence.findByPrimaryKey(
@@ -512,4 +514,4 @@ public class CTermEntryLocalizationPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1814043332
+// LIFERAY-SERVICE-BUILDER-HASH:218239652

--- a/modules/apps/commerce/commerce-term-test/src/testIntegration/java/com/liferay/commerce/term/service/persistence/test/CommerceTermEntryPersistenceTest.java
+++ b/modules/apps/commerce/commerce-term-test/src/testIntegration/java/com/liferay/commerce/term/service/persistence/test/CommerceTermEntryPersistenceTest.java
@@ -158,7 +158,9 @@ public class CommerceTermEntryPersistenceTest {
 
 		newCommerceTermEntry.setStatusDate(RandomTestUtil.nextDate());
 
-		_commerceTermEntries.add(_persistence.update(newCommerceTermEntry));
+		newCommerceTermEntry = _persistence.update(newCommerceTermEntry);
+
+		_commerceTermEntries.add(newCommerceTermEntry);
 
 		CommerceTermEntry existingCommerceTermEntry =
 			_persistence.findByPrimaryKey(newCommerceTermEntry.getPrimaryKey());
@@ -750,4 +752,4 @@ public class CommerceTermEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-985580115
+// LIFERAY-SERVICE-BUILDER-HASH:1180750757

--- a/modules/apps/commerce/commerce-term-test/src/testIntegration/java/com/liferay/commerce/term/service/persistence/test/CommerceTermEntryRelPersistenceTest.java
+++ b/modules/apps/commerce/commerce-term-test/src/testIntegration/java/com/liferay/commerce/term/service/persistence/test/CommerceTermEntryRelPersistenceTest.java
@@ -134,8 +134,9 @@ public class CommerceTermEntryRelPersistenceTest {
 		newCommerceTermEntryRel.setCommerceTermEntryId(
 			RandomTestUtil.nextLong());
 
-		_commerceTermEntryRels.add(
-			_persistence.update(newCommerceTermEntryRel));
+		newCommerceTermEntryRel = _persistence.update(newCommerceTermEntryRel);
+
+		_commerceTermEntryRels.add(newCommerceTermEntryRel);
 
 		CommerceTermEntryRel existingCommerceTermEntryRel =
 			_persistence.findByPrimaryKey(
@@ -573,4 +574,4 @@ public class CommerceTermEntryRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1630406544
+// LIFERAY-SERVICE-BUILDER-HASH:-284860596

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CPDAvailabilityEstimatePersistenceTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CPDAvailabilityEstimatePersistenceTest.java
@@ -138,8 +138,10 @@ public class CPDAvailabilityEstimatePersistenceTest {
 		newCPDAvailabilityEstimate.setLastPublishDate(
 			RandomTestUtil.nextDate());
 
-		_cpdAvailabilityEstimates.add(
-			_persistence.update(newCPDAvailabilityEstimate));
+		newCPDAvailabilityEstimate = _persistence.update(
+			newCPDAvailabilityEstimate);
+
+		_cpdAvailabilityEstimates.add(newCPDAvailabilityEstimate);
 
 		CPDAvailabilityEstimate existingCPDAvailabilityEstimate =
 			_persistence.findByPrimaryKey(
@@ -594,4 +596,4 @@ public class CPDAvailabilityEstimatePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1940216050
+// LIFERAY-SERVICE-BUILDER-HASH:-484152596

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CPDefinitionInventoryPersistenceTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CPDefinitionInventoryPersistenceTest.java
@@ -166,8 +166,10 @@ public class CPDefinitionInventoryPersistenceTest {
 		newCPDefinitionInventory.setMultipleOrderQuantity(
 			new BigDecimal(RandomTestUtil.nextDouble()));
 
-		_cpDefinitionInventories.add(
-			_persistence.update(newCPDefinitionInventory));
+		newCPDefinitionInventory = _persistence.update(
+			newCPDefinitionInventory);
+
+		_cpDefinitionInventories.add(newCPDefinitionInventory);
 
 		CPDefinitionInventory existingCPDefinitionInventory =
 			_persistence.findByPrimaryKey(
@@ -690,4 +692,4 @@ public class CPDefinitionInventoryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1775726870
+// LIFERAY-SERVICE-BUILDER-HASH:-1539306494

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceAddressRestrictionPersistenceTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceAddressRestrictionPersistenceTest.java
@@ -138,8 +138,10 @@ public class CommerceAddressRestrictionPersistenceTest {
 
 		newCommerceAddressRestriction.setCountryId(RandomTestUtil.nextLong());
 
-		_commerceAddressRestrictions.add(
-			_persistence.update(newCommerceAddressRestriction));
+		newCommerceAddressRestriction = _persistence.update(
+			newCommerceAddressRestriction);
+
+		_commerceAddressRestrictions.add(newCommerceAddressRestriction);
 
 		CommerceAddressRestriction existingCommerceAddressRestriction =
 			_persistence.findByPrimaryKey(
@@ -604,4 +606,4 @@ public class CommerceAddressRestrictionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1855729308
+// LIFERAY-SERVICE-BUILDER-HASH:1320145230

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceAvailabilityEstimatePersistenceTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceAvailabilityEstimatePersistenceTest.java
@@ -140,8 +140,10 @@ public class CommerceAvailabilityEstimatePersistenceTest {
 		newCommerceAvailabilityEstimate.setLastPublishDate(
 			RandomTestUtil.nextDate());
 
-		_commerceAvailabilityEstimates.add(
-			_persistence.update(newCommerceAvailabilityEstimate));
+		newCommerceAvailabilityEstimate = _persistence.update(
+			newCommerceAvailabilityEstimate);
+
+		_commerceAvailabilityEstimates.add(newCommerceAvailabilityEstimate);
 
 		CommerceAvailabilityEstimate existingCommerceAvailabilityEstimate =
 			_persistence.findByPrimaryKey(
@@ -538,4 +540,4 @@ public class CommerceAvailabilityEstimatePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-582756727
+// LIFERAY-SERVICE-BUILDER-HASH:-1002093147

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceOrderAttachmentPersistenceTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceOrderAttachmentPersistenceTest.java
@@ -151,8 +151,10 @@ public class CommerceOrderAttachmentPersistenceTest {
 
 		newCommerceOrderAttachment.setType(RandomTestUtil.randomString());
 
-		_commerceOrderAttachments.add(
-			_persistence.update(newCommerceOrderAttachment));
+		newCommerceOrderAttachment = _persistence.update(
+			newCommerceOrderAttachment);
+
+		_commerceOrderAttachments.add(newCommerceOrderAttachment);
 
 		CommerceOrderAttachment existingCommerceOrderAttachment =
 			_persistence.findByPrimaryKey(
@@ -691,4 +693,4 @@ public class CommerceOrderAttachmentPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:793127760
+// LIFERAY-SERVICE-BUILDER-HASH:1416523454

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceOrderItemPersistenceTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceOrderItemPersistenceTest.java
@@ -285,7 +285,9 @@ public class CommerceOrderItemPersistenceTest {
 
 		newCommerceOrderItem.setWidth(RandomTestUtil.nextDouble());
 
-		_commerceOrderItems.add(_persistence.update(newCommerceOrderItem));
+		newCommerceOrderItem = _persistence.update(newCommerceOrderItem);
+
+		_commerceOrderItems.add(newCommerceOrderItem);
 
 		CommerceOrderItem existingCommerceOrderItem =
 			_persistence.findByPrimaryKey(newCommerceOrderItem.getPrimaryKey());
@@ -1165,4 +1167,4 @@ public class CommerceOrderItemPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:595072859
+// LIFERAY-SERVICE-BUILDER-HASH:-1821911223

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceOrderNotePersistenceTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceOrderNotePersistenceTest.java
@@ -138,7 +138,9 @@ public class CommerceOrderNotePersistenceTest {
 
 		newCommerceOrderNote.setRestricted(RandomTestUtil.randomBoolean());
 
-		_commerceOrderNotes.add(_persistence.update(newCommerceOrderNote));
+		newCommerceOrderNote = _persistence.update(newCommerceOrderNote);
+
+		_commerceOrderNotes.add(newCommerceOrderNote);
 
 		CommerceOrderNote existingCommerceOrderNote =
 			_persistence.findByPrimaryKey(newCommerceOrderNote.getPrimaryKey());
@@ -624,4 +626,4 @@ public class CommerceOrderNotePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:14966380
+// LIFERAY-SERVICE-BUILDER-HASH:-59050498

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceOrderPaymentPersistenceTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceOrderPaymentPersistenceTest.java
@@ -136,8 +136,9 @@ public class CommerceOrderPaymentPersistenceTest {
 
 		newCommerceOrderPayment.setStatus(RandomTestUtil.nextInt());
 
-		_commerceOrderPayments.add(
-			_persistence.update(newCommerceOrderPayment));
+		newCommerceOrderPayment = _persistence.update(newCommerceOrderPayment);
+
+		_commerceOrderPayments.add(newCommerceOrderPayment);
 
 		CommerceOrderPayment existingCommerceOrderPayment =
 			_persistence.findByPrimaryKey(
@@ -496,4 +497,4 @@ public class CommerceOrderPaymentPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-659364403
+// LIFERAY-SERVICE-BUILDER-HASH:-145142081

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceOrderPersistenceTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceOrderPersistenceTest.java
@@ -316,7 +316,9 @@ public class CommerceOrderPersistenceTest {
 
 		newCommerceOrder.setStatusDate(RandomTestUtil.nextDate());
 
-		_commerceOrders.add(_persistence.update(newCommerceOrder));
+		newCommerceOrder = _persistence.update(newCommerceOrder);
+
+		_commerceOrders.add(newCommerceOrder);
 
 		CommerceOrder existingCommerceOrder = _persistence.findByPrimaryKey(
 			newCommerceOrder.getPrimaryKey());
@@ -1309,4 +1311,4 @@ public class CommerceOrderPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1805098404
+// LIFERAY-SERVICE-BUILDER-HASH:-2114684150

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceOrderTypePersistenceTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceOrderTypePersistenceTest.java
@@ -152,7 +152,9 @@ public class CommerceOrderTypePersistenceTest {
 
 		newCommerceOrderType.setStatusDate(RandomTestUtil.nextDate());
 
-		_commerceOrderTypes.add(_persistence.update(newCommerceOrderType));
+		newCommerceOrderType = _persistence.update(newCommerceOrderType);
+
+		_commerceOrderTypes.add(newCommerceOrderType);
 
 		CommerceOrderType existingCommerceOrderType =
 			_persistence.findByPrimaryKey(newCommerceOrderType.getPrimaryKey());
@@ -674,4 +676,4 @@ public class CommerceOrderTypePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1208755277
+// LIFERAY-SERVICE-BUILDER-HASH:2025453697

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceOrderTypeRelPersistenceTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceOrderTypeRelPersistenceTest.java
@@ -140,8 +140,9 @@ public class CommerceOrderTypeRelPersistenceTest {
 		newCommerceOrderTypeRel.setCommerceOrderTypeId(
 			RandomTestUtil.nextLong());
 
-		_commerceOrderTypeRels.add(
-			_persistence.update(newCommerceOrderTypeRel));
+		newCommerceOrderTypeRel = _persistence.update(newCommerceOrderTypeRel);
+
+		_commerceOrderTypeRels.add(newCommerceOrderTypeRel);
 
 		CommerceOrderTypeRel existingCommerceOrderTypeRel =
 			_persistence.findByPrimaryKey(
@@ -653,4 +654,4 @@ public class CommerceOrderTypeRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:59772391
+// LIFERAY-SERVICE-BUILDER-HASH:979222311

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceShipmentItemPersistenceTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceShipmentItemPersistenceTest.java
@@ -152,8 +152,9 @@ public class CommerceShipmentItemPersistenceTest {
 		newCommerceShipmentItem.setUnitOfMeasureKey(
 			RandomTestUtil.randomString());
 
-		_commerceShipmentItems.add(
-			_persistence.update(newCommerceShipmentItem));
+		newCommerceShipmentItem = _persistence.update(newCommerceShipmentItem);
+
+		_commerceShipmentItems.add(newCommerceShipmentItem);
 
 		CommerceShipmentItem existingCommerceShipmentItem =
 			_persistence.findByPrimaryKey(
@@ -728,4 +729,4 @@ public class CommerceShipmentItemPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1351901119
+// LIFERAY-SERVICE-BUILDER-HASH:-1404079223

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceShipmentPersistenceTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceShipmentPersistenceTest.java
@@ -157,7 +157,9 @@ public class CommerceShipmentPersistenceTest {
 
 		newCommerceShipment.setStatus(RandomTestUtil.nextInt());
 
-		_commerceShipments.add(_persistence.update(newCommerceShipment));
+		newCommerceShipment = _persistence.update(newCommerceShipment);
+
+		_commerceShipments.add(newCommerceShipment);
 
 		CommerceShipment existingCommerceShipment =
 			_persistence.findByPrimaryKey(newCommerceShipment.getPrimaryKey());
@@ -726,4 +728,4 @@ public class CommerceShipmentPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1743796270
+// LIFERAY-SERVICE-BUILDER-HASH:-1258339584

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceShippingMethodPersistenceTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceShippingMethodPersistenceTest.java
@@ -147,8 +147,10 @@ public class CommerceShippingMethodPersistenceTest {
 		newCommerceShippingMethod.setTypeSettings(
 			RandomTestUtil.randomString());
 
-		_commerceShippingMethods.add(
-			_persistence.update(newCommerceShippingMethod));
+		newCommerceShippingMethod = _persistence.update(
+			newCommerceShippingMethod);
+
+		_commerceShippingMethods.add(newCommerceShippingMethod);
 
 		CommerceShippingMethod existingCommerceShippingMethod =
 			_persistence.findByPrimaryKey(
@@ -619,4 +621,4 @@ public class CommerceShippingMethodPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-968831448
+// LIFERAY-SERVICE-BUILDER-HASH:-1806077212

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceShippingOptionAccountEntryRelPersistenceTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceShippingOptionAccountEntryRelPersistenceTest.java
@@ -150,8 +150,11 @@ public class CommerceShippingOptionAccountEntryRelPersistenceTest {
 		newCommerceShippingOptionAccountEntryRel.setCommerceShippingOptionKey(
 			RandomTestUtil.randomString());
 
+		newCommerceShippingOptionAccountEntryRel = _persistence.update(
+			newCommerceShippingOptionAccountEntryRel);
+
 		_commerceShippingOptionAccountEntryRels.add(
-			_persistence.update(newCommerceShippingOptionAccountEntryRel));
+			newCommerceShippingOptionAccountEntryRel);
 
 		CommerceShippingOptionAccountEntryRel
 			existingCommerceShippingOptionAccountEntryRel =
@@ -671,4 +674,4 @@ public class CommerceShippingOptionAccountEntryRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:748937827
+// LIFERAY-SERVICE-BUILDER-HASH:-732014959

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceSubscriptionEntryPersistenceTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceSubscriptionEntryPersistenceTest.java
@@ -192,8 +192,10 @@ public class CommerceSubscriptionEntryPersistenceTest {
 		newCommerceSubscriptionEntry.setDeliveryStartDate(
 			RandomTestUtil.nextDate());
 
-		_commerceSubscriptionEntries.add(
-			_persistence.update(newCommerceSubscriptionEntry));
+		newCommerceSubscriptionEntry = _persistence.update(
+			newCommerceSubscriptionEntry);
+
+		_commerceSubscriptionEntries.add(newCommerceSubscriptionEntry);
 
 		CommerceSubscriptionEntry existingCommerceSubscriptionEntry =
 			_persistence.findByPrimaryKey(
@@ -868,4 +870,4 @@ public class CommerceSubscriptionEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1326973393
+// LIFERAY-SERVICE-BUILDER-HASH:-1220152617

--- a/modules/apps/commerce/commerce-wish-list-test/src/testIntegration/java/com/liferay/commerce/wish/list/service/persistence/test/CommerceWishListItemPersistenceTest.java
+++ b/modules/apps/commerce/commerce-wish-list-test/src/testIntegration/java/com/liferay/commerce/wish/list/service/persistence/test/CommerceWishListItemPersistenceTest.java
@@ -140,8 +140,9 @@ public class CommerceWishListItemPersistenceTest {
 
 		newCommerceWishListItem.setJson(RandomTestUtil.randomString());
 
-		_commerceWishListItems.add(
-			_persistence.update(newCommerceWishListItem));
+		newCommerceWishListItem = _persistence.update(newCommerceWishListItem);
+
+		_commerceWishListItems.add(newCommerceWishListItem);
 
 		CommerceWishListItem existingCommerceWishListItem =
 			_persistence.findByPrimaryKey(
@@ -616,4 +617,4 @@ public class CommerceWishListItemPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:143664923
+// LIFERAY-SERVICE-BUILDER-HASH:1661026957

--- a/modules/apps/commerce/commerce-wish-list-test/src/testIntegration/java/com/liferay/commerce/wish/list/service/persistence/test/CommerceWishListPersistenceTest.java
+++ b/modules/apps/commerce/commerce-wish-list-test/src/testIntegration/java/com/liferay/commerce/wish/list/service/persistence/test/CommerceWishListPersistenceTest.java
@@ -132,7 +132,9 @@ public class CommerceWishListPersistenceTest {
 
 		newCommerceWishList.setDefaultWishList(RandomTestUtil.randomBoolean());
 
-		_commerceWishLists.add(_persistence.update(newCommerceWishList));
+		newCommerceWishList = _persistence.update(newCommerceWishList);
+
+		_commerceWishLists.add(newCommerceWishList);
 
 		CommerceWishList existingCommerceWishList =
 			_persistence.findByPrimaryKey(newCommerceWishList.getPrimaryKey());
@@ -582,4 +584,4 @@ public class CommerceWishListPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:476801459
+// LIFERAY-SERVICE-BUILDER-HASH:1723242011

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/persistence/test/DepotAppCustomizationPersistenceTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/persistence/test/DepotAppCustomizationPersistenceTest.java
@@ -126,8 +126,10 @@ public class DepotAppCustomizationPersistenceTest {
 
 		newDepotAppCustomization.setPortletId(RandomTestUtil.randomString());
 
-		_depotAppCustomizations.add(
-			_persistence.update(newDepotAppCustomization));
+		newDepotAppCustomization = _persistence.update(
+			newDepotAppCustomization);
+
+		_depotAppCustomizations.add(newDepotAppCustomization);
 
 		DepotAppCustomization existingDepotAppCustomization =
 			_persistence.findByPrimaryKey(
@@ -557,4 +559,4 @@ public class DepotAppCustomizationPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1199357578
+// LIFERAY-SERVICE-BUILDER-HASH:2058003484

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/persistence/test/DepotEntryGroupRelPersistenceTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/persistence/test/DepotEntryGroupRelPersistenceTest.java
@@ -143,7 +143,9 @@ public class DepotEntryGroupRelPersistenceTest {
 
 		newDepotEntryGroupRel.setLastPublishDate(RandomTestUtil.nextDate());
 
-		_depotEntryGroupRels.add(_persistence.update(newDepotEntryGroupRel));
+		newDepotEntryGroupRel = _persistence.update(newDepotEntryGroupRel);
+
+		_depotEntryGroupRels.add(newDepotEntryGroupRel);
 
 		DepotEntryGroupRel existingDepotEntryGroupRel =
 			_persistence.findByPrimaryKey(
@@ -652,4 +654,4 @@ public class DepotEntryGroupRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-415501817
+// LIFERAY-SERVICE-BUILDER-HASH:-248444641

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/persistence/test/DepotEntryPersistenceTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/persistence/test/DepotEntryPersistenceTest.java
@@ -131,7 +131,9 @@ public class DepotEntryPersistenceTest {
 
 		newDepotEntry.setType(RandomTestUtil.nextInt());
 
-		_depotEntries.add(_persistence.update(newDepotEntry));
+		newDepotEntry = _persistence.update(newDepotEntry);
+
+		_depotEntries.add(newDepotEntry);
 
 		DepotEntry existingDepotEntry = _persistence.findByPrimaryKey(
 			newDepotEntry.getPrimaryKey());
@@ -549,4 +551,4 @@ public class DepotEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-170172425
+// LIFERAY-SERVICE-BUILDER-HASH:2121966625

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/persistence/test/DepotEntryPinPersistenceTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/persistence/test/DepotEntryPinPersistenceTest.java
@@ -124,7 +124,9 @@ public class DepotEntryPinPersistenceTest {
 
 		newDepotEntryPin.setDepotEntryId(RandomTestUtil.nextLong());
 
-		_depotEntryPins.add(_persistence.update(newDepotEntryPin));
+		newDepotEntryPin = _persistence.update(newDepotEntryPin);
+
+		_depotEntryPins.add(newDepotEntryPin);
 
 		DepotEntryPin existingDepotEntryPin = _persistence.findByPrimaryKey(
 			newDepotEntryPin.getPrimaryKey());
@@ -546,4 +548,4 @@ public class DepotEntryPinPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2080075779
+// LIFERAY-SERVICE-BUILDER-HASH:-1760724621

--- a/modules/apps/document-library-opener/document-library-opener-test/src/testIntegration/java/com/liferay/document/library/opener/service/persistence/test/DLOpenerFileEntryReferencePersistenceTest.java
+++ b/modules/apps/document-library-opener/document-library-opener-test/src/testIntegration/java/com/liferay/document/library/opener/service/persistence/test/DLOpenerFileEntryReferencePersistenceTest.java
@@ -143,8 +143,10 @@ public class DLOpenerFileEntryReferencePersistenceTest {
 
 		newDLOpenerFileEntryReference.setType(RandomTestUtil.nextInt());
 
-		_dlOpenerFileEntryReferences.add(
-			_persistence.update(newDLOpenerFileEntryReference));
+		newDLOpenerFileEntryReference = _persistence.update(
+			newDLOpenerFileEntryReference);
+
+		_dlOpenerFileEntryReferences.add(newDLOpenerFileEntryReference);
 
 		DLOpenerFileEntryReference existingDLOpenerFileEntryReference =
 			_persistence.findByPrimaryKey(
@@ -605,4 +607,4 @@ public class DLOpenerFileEntryReferencePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1425768405
+// LIFERAY-SERVICE-BUILDER-HASH:833611621

--- a/modules/apps/document-library/document-library-content-service/src/main/java/com/liferay/document/library/content/service/persistence/impl/DLContentPersistenceImpl.java
+++ b/modules/apps/document-library/document-library-content-service/src/main/java/com/liferay/document/library/content/service/persistence/impl/DLContentPersistenceImpl.java
@@ -628,10 +628,7 @@ public class DLContentPersistenceImpl
 				session.save(dlContent);
 			}
 			else {
-				session.evict(
-					DLContentImpl.class, dlContent.getPrimaryKeyObj());
-
-				session.saveOrUpdate(dlContent);
+				dlContent = (DLContent)session.merge(dlContent);
 			}
 
 			session.flush();
@@ -969,4 +966,4 @@ public class DLContentPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:897256232
+// LIFERAY-SERVICE-BUILDER-HASH:-1552810903

--- a/modules/apps/document-library/document-library-content-service/src/main/resources/META-INF/module-hbm.xml
+++ b/modules/apps/document-library/document-library-content-service/src/main/resources/META-INF/module-hbm.xml
@@ -14,7 +14,7 @@
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="repositoryId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" column="path_" name="path" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="version" type="com.liferay.portal.dao.orm.hibernate.StringType" />
-		<one-to-one access="com.liferay.portal.dao.orm.hibernate.PrivateFieldPropertyAccessor" cascade="save-update" class="com.liferay.document.library.content.model.DLContentDataBlobModel" constrained="false" name="dataBlobModel" outer-join="false" />
+		<one-to-one access="com.liferay.portal.dao.orm.hibernate.PrivateFieldPropertyAccessor" cascade="merge, persist, save-update" class="com.liferay.document.library.content.model.DLContentDataBlobModel" constrained="false" name="dataBlobModel" outer-join="false" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" column="size_" name="size" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 	</class>
 	<class dynamic-update="true" lazy="true" name="com.liferay.document.library.content.model.DLContentDataBlobModel" table="DLContent">

--- a/modules/apps/document-library/document-library-content-test/src/testIntegration/java/com/liferay/document/library/content/service/persistence/test/DLContentPersistenceTest.java
+++ b/modules/apps/document-library/document-library-content-test/src/testIntegration/java/com/liferay/document/library/content/service/persistence/test/DLContentPersistenceTest.java
@@ -140,7 +140,9 @@ public class DLContentPersistenceTest {
 
 		newDLContent.setSize(RandomTestUtil.nextLong());
 
-		_dlContents.add(_persistence.update(newDLContent));
+		newDLContent = _persistence.update(newDLContent);
+
+		_dlContents.add(newDLContent);
 
 		DLContent existingDLContent = _persistence.findByPrimaryKey(
 			newDLContent.getPrimaryKey());
@@ -557,4 +559,4 @@ public class DLContentPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:220111309
+// LIFERAY-SERVICE-BUILDER-HASH:201945963

--- a/modules/apps/document-library/document-library-sync-test/src/testIntegration/java/com/liferay/document/library/sync/service/persistence/test/DLSyncEventPersistenceTest.java
+++ b/modules/apps/document-library/document-library-sync-test/src/testIntegration/java/com/liferay/document/library/sync/service/persistence/test/DLSyncEventPersistenceTest.java
@@ -123,7 +123,9 @@ public class DLSyncEventPersistenceTest {
 
 		newDLSyncEvent.setTypePK(RandomTestUtil.nextLong());
 
-		_dlSyncEvents.add(_persistence.update(newDLSyncEvent));
+		newDLSyncEvent = _persistence.update(newDLSyncEvent);
+
+		_dlSyncEvents.add(newDLSyncEvent);
 
 		DLSyncEvent existingDLSyncEvent = _persistence.findByPrimaryKey(
 			newDLSyncEvent.getPrimaryKey());
@@ -479,4 +481,4 @@ public class DLSyncEventPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:161736360
+// LIFERAY-SERVICE-BUILDER-HASH:-1277682018

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/service/persistence/test/DDLRecordPersistenceTest.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/service/persistence/test/DDLRecordPersistenceTest.java
@@ -150,7 +150,9 @@ public class DDLRecordPersistenceTest {
 
 		newDDLRecord.setLastPublishDate(RandomTestUtil.nextDate());
 
-		_ddlRecords.add(_persistence.update(newDDLRecord));
+		newDDLRecord = _persistence.update(newDDLRecord);
+
+		_ddlRecords.add(newDDLRecord);
 
 		DDLRecord existingDDLRecord = _persistence.findByPrimaryKey(
 			newDDLRecord.getPrimaryKey());
@@ -624,4 +626,4 @@ public class DDLRecordPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1743098212
+// LIFERAY-SERVICE-BUILDER-HASH:-941593998

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/service/persistence/test/DDLRecordSetPersistenceTest.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/service/persistence/test/DDLRecordSetPersistenceTest.java
@@ -156,7 +156,9 @@ public class DDLRecordSetPersistenceTest {
 
 		newDDLRecordSet.setLastPublishDate(RandomTestUtil.nextDate());
 
-		_ddlRecordSets.add(_persistence.update(newDDLRecordSet));
+		newDDLRecordSet = _persistence.update(newDDLRecordSet);
+
+		_ddlRecordSets.add(newDDLRecordSet);
 
 		DDLRecordSet existingDDLRecordSet = _persistence.findByPrimaryKey(
 			newDDLRecordSet.getPrimaryKey());
@@ -677,4 +679,4 @@ public class DDLRecordSetPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:381914323
+// LIFERAY-SERVICE-BUILDER-HASH:433063173

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/service/persistence/test/DDLRecordSetVersionPersistenceTest.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/service/persistence/test/DDLRecordSetVersionPersistenceTest.java
@@ -150,7 +150,9 @@ public class DDLRecordSetVersionPersistenceTest {
 
 		newDDLRecordSetVersion.setStatusDate(RandomTestUtil.nextDate());
 
-		_ddlRecordSetVersions.add(_persistence.update(newDDLRecordSetVersion));
+		newDDLRecordSetVersion = _persistence.update(newDDLRecordSetVersion);
+
+		_ddlRecordSetVersions.add(newDDLRecordSetVersion);
 
 		DDLRecordSetVersion existingDDLRecordSetVersion =
 			_persistence.findByPrimaryKey(
@@ -609,4 +611,4 @@ public class DDLRecordSetVersionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1906654444
+// LIFERAY-SERVICE-BUILDER-HASH:-1758213242

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/service/persistence/test/DDLRecordVersionPersistenceTest.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/service/persistence/test/DDLRecordVersionPersistenceTest.java
@@ -146,7 +146,9 @@ public class DDLRecordVersionPersistenceTest {
 
 		newDDLRecordVersion.setStatusDate(RandomTestUtil.nextDate());
 
-		_ddlRecordVersions.add(_persistence.update(newDDLRecordVersion));
+		newDDLRecordVersion = _persistence.update(newDDLRecordVersion);
+
+		_ddlRecordVersions.add(newDDLRecordVersion);
 
 		DDLRecordVersion existingDDLRecordVersion =
 			_persistence.findByPrimaryKey(newDDLRecordVersion.getPrimaryKey());
@@ -610,4 +612,4 @@ public class DDLRecordVersionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1475963879
+// LIFERAY-SERVICE-BUILDER-HASH:674546231

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMContentPersistenceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMContentPersistenceTest.java
@@ -136,7 +136,9 @@ public class DDMContentPersistenceTest {
 
 		newDDMContent.setData(RandomTestUtil.randomString());
 
-		_ddmContents.add(_persistence.update(newDDMContent));
+		newDDMContent = _persistence.update(newDDMContent);
+
+		_ddmContents.add(newDDMContent);
 
 		DDMContent existingDDMContent = _persistence.findByPrimaryKey(
 			newDDMContent.getPrimaryKey());
@@ -552,4 +554,4 @@ public class DDMContentPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2130882613
+// LIFERAY-SERVICE-BUILDER-HASH:-828389301

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMDataProviderInstanceLinkPersistenceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMDataProviderInstanceLinkPersistenceTest.java
@@ -129,8 +129,10 @@ public class DDMDataProviderInstanceLinkPersistenceTest {
 		newDDMDataProviderInstanceLink.setStructureId(
 			RandomTestUtil.nextLong());
 
-		_ddmDataProviderInstanceLinks.add(
-			_persistence.update(newDDMDataProviderInstanceLink));
+		newDDMDataProviderInstanceLink = _persistence.update(
+			newDDMDataProviderInstanceLink);
+
+		_ddmDataProviderInstanceLinks.add(newDDMDataProviderInstanceLink);
 
 		DDMDataProviderInstanceLink existingDDMDataProviderInstanceLink =
 			_persistence.findByPrimaryKey(
@@ -562,4 +564,4 @@ public class DDMDataProviderInstanceLinkPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1132176362
+// LIFERAY-SERVICE-BUILDER-HASH:-1641794036

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMDataProviderInstancePersistenceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMDataProviderInstancePersistenceTest.java
@@ -151,8 +151,10 @@ public class DDMDataProviderInstancePersistenceTest {
 		newDDMDataProviderInstance.setLastPublishDate(
 			RandomTestUtil.nextDate());
 
-		_ddmDataProviderInstances.add(
-			_persistence.update(newDDMDataProviderInstance));
+		newDDMDataProviderInstance = _persistence.update(
+			newDDMDataProviderInstance);
+
+		_ddmDataProviderInstances.add(newDDMDataProviderInstance);
 
 		DDMDataProviderInstance existingDDMDataProviderInstance =
 			_persistence.findByPrimaryKey(
@@ -668,4 +670,4 @@ public class DDMDataProviderInstancePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:702113152
+// LIFERAY-SERVICE-BUILDER-HASH:-39555662

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMFieldAttributePersistenceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMFieldAttributePersistenceTest.java
@@ -129,7 +129,9 @@ public class DDMFieldAttributePersistenceTest {
 		newDDMFieldAttribute.setSmallAttributeValue(
 			RandomTestUtil.randomString());
 
-		_ddmFieldAttributes.add(_persistence.update(newDDMFieldAttribute));
+		newDDMFieldAttribute = _persistence.update(newDDMFieldAttribute);
+
+		_ddmFieldAttributes.add(newDDMFieldAttribute);
 
 		DDMFieldAttribute existingDDMFieldAttribute =
 			_persistence.findByPrimaryKey(newDDMFieldAttribute.getPrimaryKey());
@@ -543,4 +545,4 @@ public class DDMFieldAttributePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:331030245
+// LIFERAY-SERVICE-BUILDER-HASH:1375402831

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMFieldPersistenceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMFieldPersistenceTest.java
@@ -133,7 +133,9 @@ public class DDMFieldPersistenceTest {
 
 		newDDMField.setPriority(RandomTestUtil.nextInt());
 
-		_ddmFields.add(_persistence.update(newDDMField));
+		newDDMField = _persistence.update(newDDMField);
+
+		_ddmFields.add(newDDMField);
 
 		DDMField existingDDMField = _persistence.findByPrimaryKey(
 			newDDMField.getPrimaryKey());
@@ -537,4 +539,4 @@ public class DDMFieldPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-15222539
+// LIFERAY-SERVICE-BUILDER-HASH:657708727

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMFormInstancePersistenceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMFormInstancePersistenceTest.java
@@ -150,7 +150,9 @@ public class DDMFormInstancePersistenceTest {
 
 		newDDMFormInstance.setLastPublishDate(RandomTestUtil.nextDate());
 
-		_ddmFormInstances.add(_persistence.update(newDDMFormInstance));
+		newDDMFormInstance = _persistence.update(newDDMFormInstance);
+
+		_ddmFormInstances.add(newDDMFormInstance);
 
 		DDMFormInstance existingDDMFormInstance = _persistence.findByPrimaryKey(
 			newDDMFormInstance.getPrimaryKey());
@@ -644,4 +646,4 @@ public class DDMFormInstancePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-65687861
+// LIFERAY-SERVICE-BUILDER-HASH:-880998471

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMFormInstanceRecordPersistenceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMFormInstanceRecordPersistenceTest.java
@@ -152,8 +152,10 @@ public class DDMFormInstanceRecordPersistenceTest {
 
 		newDDMFormInstanceRecord.setLastPublishDate(RandomTestUtil.nextDate());
 
-		_ddmFormInstanceRecords.add(
-			_persistence.update(newDDMFormInstanceRecord));
+		newDDMFormInstanceRecord = _persistence.update(
+			newDDMFormInstanceRecord);
+
+		_ddmFormInstanceRecords.add(newDDMFormInstanceRecord);
 
 		DDMFormInstanceRecord existingDDMFormInstanceRecord =
 			_persistence.findByPrimaryKey(
@@ -679,4 +681,4 @@ public class DDMFormInstanceRecordPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1265570633
+// LIFERAY-SERVICE-BUILDER-HASH:-285956691

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMFormInstanceRecordVersionPersistenceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMFormInstanceRecordVersionPersistenceTest.java
@@ -159,8 +159,10 @@ public class DDMFormInstanceRecordVersionPersistenceTest {
 		newDDMFormInstanceRecordVersion.setStatusDate(
 			RandomTestUtil.nextDate());
 
-		_ddmFormInstanceRecordVersions.add(
-			_persistence.update(newDDMFormInstanceRecordVersion));
+		newDDMFormInstanceRecordVersion = _persistence.update(
+			newDDMFormInstanceRecordVersion);
+
+		_ddmFormInstanceRecordVersions.add(newDDMFormInstanceRecordVersion);
 
 		DDMFormInstanceRecordVersion existingDDMFormInstanceRecordVersion =
 			_persistence.findByPrimaryKey(
@@ -691,4 +693,4 @@ public class DDMFormInstanceRecordVersionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1649565129
+// LIFERAY-SERVICE-BUILDER-HASH:1839766323

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMFormInstanceReportPersistenceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMFormInstanceReportPersistenceTest.java
@@ -132,8 +132,10 @@ public class DDMFormInstanceReportPersistenceTest {
 
 		newDDMFormInstanceReport.setData(RandomTestUtil.randomString());
 
-		_ddmFormInstanceReports.add(
-			_persistence.update(newDDMFormInstanceReport));
+		newDDMFormInstanceReport = _persistence.update(
+			newDDMFormInstanceReport);
+
+		_ddmFormInstanceReports.add(newDDMFormInstanceReport);
 
 		DDMFormInstanceReport existingDDMFormInstanceReport =
 			_persistence.findByPrimaryKey(
@@ -543,4 +545,4 @@ public class DDMFormInstanceReportPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1990519248
+// LIFERAY-SERVICE-BUILDER-HASH:-732549838

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMFormInstanceVersionPersistenceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMFormInstanceVersionPersistenceTest.java
@@ -152,8 +152,10 @@ public class DDMFormInstanceVersionPersistenceTest {
 
 		newDDMFormInstanceVersion.setStatusDate(RandomTestUtil.nextDate());
 
-		_ddmFormInstanceVersions.add(
-			_persistence.update(newDDMFormInstanceVersion));
+		newDDMFormInstanceVersion = _persistence.update(
+			newDDMFormInstanceVersion);
+
+		_ddmFormInstanceVersions.add(newDDMFormInstanceVersion);
 
 		DDMFormInstanceVersion existingDDMFormInstanceVersion =
 			_persistence.findByPrimaryKey(
@@ -634,4 +636,4 @@ public class DDMFormInstanceVersionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:979132581
+// LIFERAY-SERVICE-BUILDER-HASH:-1768065703

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMStorageLinkPersistenceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMStorageLinkPersistenceTest.java
@@ -127,7 +127,9 @@ public class DDMStorageLinkPersistenceTest {
 
 		newDDMStorageLink.setStructureVersionId(RandomTestUtil.nextLong());
 
-		_ddmStorageLinks.add(_persistence.update(newDDMStorageLink));
+		newDDMStorageLink = _persistence.update(newDDMStorageLink);
+
+		_ddmStorageLinks.add(newDDMStorageLink);
 
 		DDMStorageLink existingDDMStorageLink = _persistence.findByPrimaryKey(
 			newDDMStorageLink.getPrimaryKey());
@@ -538,4 +540,4 @@ public class DDMStorageLinkPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-554063572
+// LIFERAY-SERVICE-BUILDER-HASH:1986717300

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMStructureLayoutPersistenceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMStructureLayoutPersistenceTest.java
@@ -144,7 +144,9 @@ public class DDMStructureLayoutPersistenceTest {
 
 		newDDMStructureLayout.setDefinition(RandomTestUtil.randomString());
 
-		_ddmStructureLayouts.add(_persistence.update(newDDMStructureLayout));
+		newDDMStructureLayout = _persistence.update(newDDMStructureLayout);
+
+		_ddmStructureLayouts.add(newDDMStructureLayout);
 
 		DDMStructureLayout existingDDMStructureLayout =
 			_persistence.findByPrimaryKey(
@@ -662,4 +664,4 @@ public class DDMStructureLayoutPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-391161287
+// LIFERAY-SERVICE-BUILDER-HASH:-231210191

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMStructureLinkPersistenceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMStructureLinkPersistenceTest.java
@@ -123,7 +123,9 @@ public class DDMStructureLinkPersistenceTest {
 
 		newDDMStructureLink.setStructureId(RandomTestUtil.nextLong());
 
-		_ddmStructureLinks.add(_persistence.update(newDDMStructureLink));
+		newDDMStructureLink = _persistence.update(newDDMStructureLink);
+
+		_ddmStructureLinks.add(newDDMStructureLink);
 
 		DDMStructureLink existingDDMStructureLink =
 			_persistence.findByPrimaryKey(newDDMStructureLink.getPrimaryKey());
@@ -513,4 +515,4 @@ public class DDMStructureLinkPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-99900774
+// LIFERAY-SERVICE-BUILDER-HASH:1885532546

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMStructurePersistenceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMStructurePersistenceTest.java
@@ -160,7 +160,9 @@ public class DDMStructurePersistenceTest {
 
 		newDDMStructure.setLastPublishDate(RandomTestUtil.nextDate());
 
-		_ddmStructures.add(_persistence.update(newDDMStructure));
+		newDDMStructure = _persistence.update(newDDMStructure);
+
+		_ddmStructures.add(newDDMStructure);
 
 		DDMStructure existingDDMStructure = _persistence.findByPrimaryKey(
 			newDDMStructure.getPrimaryKey());
@@ -785,4 +787,4 @@ public class DDMStructurePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1020970209
+// LIFERAY-SERVICE-BUILDER-HASH:1746414699

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMStructureVersionPersistenceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMStructureVersionPersistenceTest.java
@@ -153,7 +153,9 @@ public class DDMStructureVersionPersistenceTest {
 
 		newDDMStructureVersion.setStatusDate(RandomTestUtil.nextDate());
 
-		_ddmStructureVersions.add(_persistence.update(newDDMStructureVersion));
+		newDDMStructureVersion = _persistence.update(newDDMStructureVersion);
+
+		_ddmStructureVersions.add(newDDMStructureVersion);
 
 		DDMStructureVersion existingDDMStructureVersion =
 			_persistence.findByPrimaryKey(
@@ -622,4 +624,4 @@ public class DDMStructureVersionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-452636397
+// LIFERAY-SERVICE-BUILDER-HASH:-207695979

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMTemplateLinkPersistenceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMTemplateLinkPersistenceTest.java
@@ -123,7 +123,9 @@ public class DDMTemplateLinkPersistenceTest {
 
 		newDDMTemplateLink.setTemplateId(RandomTestUtil.nextLong());
 
-		_ddmTemplateLinks.add(_persistence.update(newDDMTemplateLink));
+		newDDMTemplateLink = _persistence.update(newDDMTemplateLink);
+
+		_ddmTemplateLinks.add(newDDMTemplateLink);
 
 		DDMTemplateLink existingDDMTemplateLink = _persistence.findByPrimaryKey(
 			newDDMTemplateLink.getPrimaryKey());
@@ -499,4 +501,4 @@ public class DDMTemplateLinkPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:787213417
+// LIFERAY-SERVICE-BUILDER-HASH:-483966005

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMTemplatePersistenceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMTemplatePersistenceTest.java
@@ -173,7 +173,9 @@ public class DDMTemplatePersistenceTest {
 
 		newDDMTemplate.setLastPublishDate(RandomTestUtil.nextDate());
 
-		_ddmTemplates.add(_persistence.update(newDDMTemplate));
+		newDDMTemplate = _persistence.update(newDDMTemplate);
+
+		_ddmTemplates.add(newDDMTemplate);
 
 		DDMTemplate existingDDMTemplate = _persistence.findByPrimaryKey(
 			newDDMTemplate.getPrimaryKey());
@@ -872,4 +874,4 @@ public class DDMTemplatePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-799969722
+// LIFERAY-SERVICE-BUILDER-HASH:1304476432

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMTemplateVersionPersistenceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMTemplateVersionPersistenceTest.java
@@ -152,7 +152,9 @@ public class DDMTemplateVersionPersistenceTest {
 
 		newDDMTemplateVersion.setStatusDate(RandomTestUtil.nextDate());
 
-		_ddmTemplateVersions.add(_persistence.update(newDDMTemplateVersion));
+		newDDMTemplateVersion = _persistence.update(newDDMTemplateVersion);
+
+		_ddmTemplateVersions.add(newDDMTemplateVersion);
 
 		DDMTemplateVersion existingDDMTemplateVersion =
 			_persistence.findByPrimaryKey(
@@ -615,4 +617,4 @@ public class DDMTemplateVersionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-676193987
+// LIFERAY-SERVICE-BUILDER-HASH:515471795

--- a/modules/apps/export-import/export-import-report-test/src/testIntegration/java/com/liferay/exportimport/report/service/persistence/test/ExportImportReportEntryPersistenceTest.java
+++ b/modules/apps/export-import/export-import-report-test/src/testIntegration/java/com/liferay/exportimport/report/service/persistence/test/ExportImportReportEntryPersistenceTest.java
@@ -152,8 +152,10 @@ public class ExportImportReportEntryPersistenceTest {
 
 		newExportImportReportEntry.setStatus(RandomTestUtil.nextInt());
 
-		_exportImportReportEntries.add(
-			_persistence.update(newExportImportReportEntry));
+		newExportImportReportEntry = _persistence.update(
+			newExportImportReportEntry);
+
+		_exportImportReportEntries.add(newExportImportReportEntry);
 
 		ExportImportReportEntry existingExportImportReportEntry =
 			_persistence.findByPrimaryKey(
@@ -648,4 +650,4 @@ public class ExportImportReportEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1400082856
+// LIFERAY-SERVICE-BUILDER-HASH:-1768262800

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/persistence/test/FragmentCollectionPersistenceTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/persistence/test/FragmentCollectionPersistenceTest.java
@@ -145,7 +145,9 @@ public class FragmentCollectionPersistenceTest {
 
 		newFragmentCollection.setLastPublishDate(RandomTestUtil.nextDate());
 
-		_fragmentCollections.add(_persistence.update(newFragmentCollection));
+		newFragmentCollection = _persistence.update(newFragmentCollection);
+
+		_fragmentCollections.add(newFragmentCollection);
 
 		FragmentCollection existingFragmentCollection =
 			_persistence.findByPrimaryKey(
@@ -722,4 +724,4 @@ public class FragmentCollectionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-532373346
+// LIFERAY-SERVICE-BUILDER-HASH:-1344627558

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/persistence/test/FragmentCompositionPersistenceTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/persistence/test/FragmentCompositionPersistenceTest.java
@@ -162,7 +162,9 @@ public class FragmentCompositionPersistenceTest {
 
 		newFragmentComposition.setStatusDate(RandomTestUtil.nextDate());
 
-		_fragmentCompositions.add(_persistence.update(newFragmentComposition));
+		newFragmentComposition = _persistence.update(newFragmentComposition);
+
+		_fragmentCompositions.add(newFragmentComposition);
 
 		FragmentComposition existingFragmentComposition =
 			_persistence.findByPrimaryKey(
@@ -773,4 +775,4 @@ public class FragmentCompositionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1065141667
+// LIFERAY-SERVICE-BUILDER-HASH:1389237505

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/persistence/test/FragmentEntryLinkPersistenceTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/persistence/test/FragmentEntryLinkPersistenceTest.java
@@ -174,7 +174,9 @@ public class FragmentEntryLinkPersistenceTest {
 
 		newFragmentEntryLink.setLastPublishDate(RandomTestUtil.nextDate());
 
-		_fragmentEntryLinks.add(_persistence.update(newFragmentEntryLink));
+		newFragmentEntryLink = _persistence.update(newFragmentEntryLink);
+
+		_fragmentEntryLinks.add(newFragmentEntryLink);
 
 		FragmentEntryLink existingFragmentEntryLink =
 			_persistence.findByPrimaryKey(newFragmentEntryLink.getPrimaryKey());
@@ -944,4 +946,4 @@ public class FragmentEntryLinkPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1452771044
+// LIFERAY-SERVICE-BUILDER-HASH:111929934

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/persistence/test/FragmentEntryPersistenceTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/persistence/test/FragmentEntryPersistenceTest.java
@@ -175,7 +175,9 @@ public class FragmentEntryPersistenceTest {
 
 		newFragmentEntry.setStatusDate(RandomTestUtil.nextDate());
 
-		_fragmentEntries.add(_persistence.update(newFragmentEntry));
+		newFragmentEntry = _persistence.update(newFragmentEntry);
+
+		_fragmentEntries.add(newFragmentEntry);
 
 		FragmentEntry existingFragmentEntry = _persistence.findByPrimaryKey(
 			newFragmentEntry.getPrimaryKey());
@@ -1168,4 +1170,4 @@ public class FragmentEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-830138137
+// LIFERAY-SERVICE-BUILDER-HASH:-701265265

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/persistence/test/FragmentEntryVersionPersistenceTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/persistence/test/FragmentEntryVersionPersistenceTest.java
@@ -180,8 +180,9 @@ public class FragmentEntryVersionPersistenceTest {
 
 		newFragmentEntryVersion.setStatusDate(RandomTestUtil.nextDate());
 
-		_fragmentEntryVersions.add(
-			_persistence.update(newFragmentEntryVersion));
+		newFragmentEntryVersion = _persistence.update(newFragmentEntryVersion);
+
+		_fragmentEntryVersions.add(newFragmentEntryVersion);
 
 		FragmentEntryVersion existingFragmentEntryVersion =
 			_persistence.findByPrimaryKey(
@@ -965,4 +966,4 @@ public class FragmentEntryVersionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-121370568
+// LIFERAY-SERVICE-BUILDER-HASH:-1989936988

--- a/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/service/persistence/test/FriendlyURLEntryLocalizationPersistenceTest.java
+++ b/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/service/persistence/test/FriendlyURLEntryLocalizationPersistenceTest.java
@@ -138,8 +138,10 @@ public class FriendlyURLEntryLocalizationPersistenceTest {
 		newFriendlyURLEntryLocalization.setUrlTitle(
 			RandomTestUtil.randomString());
 
-		_friendlyURLEntryLocalizations.add(
-			_persistence.update(newFriendlyURLEntryLocalization));
+		newFriendlyURLEntryLocalization = _persistence.update(
+			newFriendlyURLEntryLocalization);
+
+		_friendlyURLEntryLocalizations.add(newFriendlyURLEntryLocalization);
 
 		FriendlyURLEntryLocalization existingFriendlyURLEntryLocalization =
 			_persistence.findByPrimaryKey(
@@ -650,4 +652,4 @@ public class FriendlyURLEntryLocalizationPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:27422787
+// LIFERAY-SERVICE-BUILDER-HASH:-1803230131

--- a/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/service/persistence/test/FriendlyURLEntryMappingPersistenceTest.java
+++ b/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/service/persistence/test/FriendlyURLEntryMappingPersistenceTest.java
@@ -125,8 +125,10 @@ public class FriendlyURLEntryMappingPersistenceTest {
 		newFriendlyURLEntryMapping.setFriendlyURLEntryId(
 			RandomTestUtil.nextLong());
 
-		_friendlyURLEntryMappings.add(
-			_persistence.update(newFriendlyURLEntryMapping));
+		newFriendlyURLEntryMapping = _persistence.update(
+			newFriendlyURLEntryMapping);
+
+		_friendlyURLEntryMappings.add(newFriendlyURLEntryMapping);
 
 		FriendlyURLEntryMapping existingFriendlyURLEntryMapping =
 			_persistence.findByPrimaryKey(
@@ -507,4 +509,4 @@ public class FriendlyURLEntryMappingPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2121177223
+// LIFERAY-SERVICE-BUILDER-HASH:-725149441

--- a/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/service/persistence/test/FriendlyURLEntryPersistenceTest.java
+++ b/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/service/persistence/test/FriendlyURLEntryPersistenceTest.java
@@ -133,7 +133,9 @@ public class FriendlyURLEntryPersistenceTest {
 
 		newFriendlyURLEntry.setClassPK(RandomTestUtil.nextLong());
 
-		_friendlyURLEntries.add(_persistence.update(newFriendlyURLEntry));
+		newFriendlyURLEntry = _persistence.update(newFriendlyURLEntry);
+
+		_friendlyURLEntries.add(newFriendlyURLEntry);
 
 		FriendlyURLEntry existingFriendlyURLEntry =
 			_persistence.findByPrimaryKey(newFriendlyURLEntry.getPrimaryKey());
@@ -576,4 +578,4 @@ public class FriendlyURLEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1855169770
+// LIFERAY-SERVICE-BUILDER-HASH:-1611995680

--- a/modules/apps/invitation/invitation-invite-members-test/src/testIntegration/java/com/liferay/invitation/invite/members/service/persistence/test/MemberRequestPersistenceTest.java
+++ b/modules/apps/invitation/invitation-invite-members-test/src/testIntegration/java/com/liferay/invitation/invite/members/service/persistence/test/MemberRequestPersistenceTest.java
@@ -136,7 +136,9 @@ public class MemberRequestPersistenceTest {
 
 		newMemberRequest.setStatus(RandomTestUtil.nextInt());
 
-		_memberRequests.add(_persistence.update(newMemberRequest));
+		newMemberRequest = _persistence.update(newMemberRequest);
+
+		_memberRequests.add(newMemberRequest);
 
 		MemberRequest existingMemberRequest = _persistence.findByPrimaryKey(
 			newMemberRequest.getPrimaryKey());
@@ -564,4 +566,4 @@ public class MemberRequestPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:986230565
+// LIFERAY-SERVICE-BUILDER-HASH:-380862921

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/persistence/test/JournalArticleLocalizationPersistenceTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/persistence/test/JournalArticleLocalizationPersistenceTest.java
@@ -129,8 +129,10 @@ public class JournalArticleLocalizationPersistenceTest {
 		newJournalArticleLocalization.setLanguageId(
 			RandomTestUtil.randomString());
 
-		_journalArticleLocalizations.add(
-			_persistence.update(newJournalArticleLocalization));
+		newJournalArticleLocalization = _persistence.update(
+			newJournalArticleLocalization);
+
+		_journalArticleLocalizations.add(newJournalArticleLocalization);
 
 		JournalArticleLocalization existingJournalArticleLocalization =
 			_persistence.findByPrimaryKey(
@@ -537,4 +539,4 @@ public class JournalArticleLocalizationPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-929088097
+// LIFERAY-SERVICE-BUILDER-HASH:-1041766921

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/persistence/test/JournalArticlePersistenceTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/persistence/test/JournalArticlePersistenceTest.java
@@ -187,7 +187,9 @@ public class JournalArticlePersistenceTest {
 
 		newJournalArticle.setStatusDate(RandomTestUtil.nextDate());
 
-		_journalArticles.add(_persistence.update(newJournalArticle));
+		newJournalArticle = _persistence.update(newJournalArticle);
+
+		_journalArticles.add(newJournalArticle);
 
 		JournalArticle existingJournalArticle = _persistence.findByPrimaryKey(
 			newJournalArticle.getPrimaryKey());
@@ -1172,4 +1174,4 @@ public class JournalArticlePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1731830790
+// LIFERAY-SERVICE-BUILDER-HASH:-1881453920

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/persistence/test/JournalArticleResourcePersistenceTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/persistence/test/JournalArticleResourcePersistenceTest.java
@@ -126,8 +126,10 @@ public class JournalArticleResourcePersistenceTest {
 
 		newJournalArticleResource.setArticleId(RandomTestUtil.randomString());
 
-		_journalArticleResources.add(
-			_persistence.update(newJournalArticleResource));
+		newJournalArticleResource = _persistence.update(
+			newJournalArticleResource);
+
+		_journalArticleResources.add(newJournalArticleResource);
 
 		JournalArticleResource existingJournalArticleResource =
 			_persistence.findByPrimaryKey(
@@ -574,4 +576,4 @@ public class JournalArticleResourcePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-49596262
+// LIFERAY-SERVICE-BUILDER-HASH:-16012004

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/persistence/test/JournalContentSearchPersistenceTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/persistence/test/JournalContentSearchPersistenceTest.java
@@ -131,8 +131,9 @@ public class JournalContentSearchPersistenceTest {
 
 		newJournalContentSearch.setArticleId(RandomTestUtil.randomString());
 
-		_journalContentSearchs.add(
-			_persistence.update(newJournalContentSearch));
+		newJournalContentSearch = _persistence.update(newJournalContentSearch);
+
+		_journalContentSearchs.add(newJournalContentSearch);
 
 		JournalContentSearch existingJournalContentSearch =
 			_persistence.findByPrimaryKey(
@@ -634,4 +635,4 @@ public class JournalContentSearchPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1604920215
+// LIFERAY-SERVICE-BUILDER-HASH:-911491163

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/persistence/test/JournalFeedPersistenceTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/persistence/test/JournalFeedPersistenceTest.java
@@ -165,7 +165,9 @@ public class JournalFeedPersistenceTest {
 
 		newJournalFeed.setLastPublishDate(RandomTestUtil.nextDate());
 
-		_journalFeeds.add(_persistence.update(newJournalFeed));
+		newJournalFeed = _persistence.update(newJournalFeed);
+
+		_journalFeeds.add(newJournalFeed);
 
 		JournalFeed existingJournalFeed = _persistence.findByPrimaryKey(
 			newJournalFeed.getPrimaryKey());
@@ -679,4 +681,4 @@ public class JournalFeedPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-164028143
+// LIFERAY-SERVICE-BUILDER-HASH:-189051229

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/persistence/test/JournalFolderPersistenceTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/persistence/test/JournalFolderPersistenceTest.java
@@ -157,7 +157,9 @@ public class JournalFolderPersistenceTest {
 
 		newJournalFolder.setStatusDate(RandomTestUtil.nextDate());
 
-		_journalFolders.add(_persistence.update(newJournalFolder));
+		newJournalFolder = _persistence.update(newJournalFolder);
+
+		_journalFolders.add(newJournalFolder);
 
 		JournalFolder existingJournalFolder = _persistence.findByPrimaryKey(
 			newJournalFolder.getPrimaryKey());
@@ -777,4 +779,4 @@ public class JournalFolderPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1096745805
+// LIFERAY-SERVICE-BUILDER-HASH:1513745375

--- a/modules/apps/json-storage/json-storage-test/src/testIntegration/java/com/liferay/json/storage/service/persistence/test/JSONStorageEntryPersistenceTest.java
+++ b/modules/apps/json-storage/json-storage-test/src/testIntegration/java/com/liferay/json/storage/service/persistence/test/JSONStorageEntryPersistenceTest.java
@@ -133,7 +133,9 @@ public class JSONStorageEntryPersistenceTest {
 
 		newJSONStorageEntry.setValueString(RandomTestUtil.randomString());
 
-		_jsonStorageEntries.add(_persistence.update(newJSONStorageEntry));
+		newJSONStorageEntry = _persistence.update(newJSONStorageEntry);
+
+		_jsonStorageEntries.add(newJSONStorageEntry);
 
 		JSONStorageEntry existingJSONStorageEntry =
 			_persistence.findByPrimaryKey(newJSONStorageEntry.getPrimaryKey());
@@ -577,4 +579,4 @@ public class JSONStorageEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-721895333
+// LIFERAY-SERVICE-BUILDER-HASH:364213623

--- a/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/persistence/test/KBArticlePersistenceTest.java
+++ b/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/persistence/test/KBArticlePersistenceTest.java
@@ -178,7 +178,9 @@ public class KBArticlePersistenceTest {
 
 		newKBArticle.setStatusDate(RandomTestUtil.nextDate());
 
-		_kbArticles.add(_persistence.update(newKBArticle));
+		newKBArticle = _persistence.update(newKBArticle);
+
+		_kbArticles.add(newKBArticle);
 
 		KBArticle existingKBArticle = _persistence.findByPrimaryKey(
 			newKBArticle.getPrimaryKey());
@@ -1425,4 +1427,4 @@ public class KBArticlePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:27657254
+// LIFERAY-SERVICE-BUILDER-HASH:-1874403056

--- a/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/persistence/test/KBCommentPersistenceTest.java
+++ b/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/persistence/test/KBCommentPersistenceTest.java
@@ -141,7 +141,9 @@ public class KBCommentPersistenceTest {
 
 		newKBComment.setStatus(RandomTestUtil.nextInt());
 
-		_kbComments.add(_persistence.update(newKBComment));
+		newKBComment = _persistence.update(newKBComment);
+
+		_kbComments.add(newKBComment);
 
 		KBComment existingKBComment = _persistence.findByPrimaryKey(
 			newKBComment.getPrimaryKey());
@@ -615,4 +617,4 @@ public class KBCommentPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-292167881
+// LIFERAY-SERVICE-BUILDER-HASH:109227869

--- a/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/persistence/test/KBFolderPersistenceTest.java
+++ b/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/persistence/test/KBFolderPersistenceTest.java
@@ -150,7 +150,9 @@ public class KBFolderPersistenceTest {
 
 		newKBFolder.setStatusDate(RandomTestUtil.nextDate());
 
-		_kbFolders.add(_persistence.update(newKBFolder));
+		newKBFolder = _persistence.update(newKBFolder);
+
+		_kbFolders.add(newKBFolder);
 
 		KBFolder existingKBFolder = _persistence.findByPrimaryKey(
 			newKBFolder.getPrimaryKey());
@@ -701,4 +703,4 @@ public class KBFolderPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:58883098
+// LIFERAY-SERVICE-BUILDER-HASH:-999790360

--- a/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/persistence/test/KBTemplatePersistenceTest.java
+++ b/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/persistence/test/KBTemplatePersistenceTest.java
@@ -139,7 +139,9 @@ public class KBTemplatePersistenceTest {
 
 		newKBTemplate.setLastPublishDate(RandomTestUtil.nextDate());
 
-		_kbTemplates.add(_persistence.update(newKBTemplate));
+		newKBTemplate = _persistence.update(newKBTemplate);
+
+		_kbTemplates.add(newKBTemplate);
 
 		KBTemplate existingKBTemplate = _persistence.findByPrimaryKey(
 			newKBTemplate.getPrimaryKey());
@@ -576,4 +578,4 @@ public class KBTemplatePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1571837088
+// LIFERAY-SERVICE-BUILDER-HASH:1091453738

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/persistence/test/LayoutPageTemplateCollectionPersistenceTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/persistence/test/LayoutPageTemplateCollectionPersistenceTest.java
@@ -163,8 +163,10 @@ public class LayoutPageTemplateCollectionPersistenceTest {
 		newLayoutPageTemplateCollection.setLastPublishDate(
 			RandomTestUtil.nextDate());
 
-		_layoutPageTemplateCollections.add(
-			_persistence.update(newLayoutPageTemplateCollection));
+		newLayoutPageTemplateCollection = _persistence.update(
+			newLayoutPageTemplateCollection);
+
+		_layoutPageTemplateCollections.add(newLayoutPageTemplateCollection);
 
 		LayoutPageTemplateCollection existingLayoutPageTemplateCollection =
 			_persistence.findByPrimaryKey(
@@ -857,4 +859,4 @@ public class LayoutPageTemplateCollectionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-609177845
+// LIFERAY-SERVICE-BUILDER-HASH:-1220507243

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/persistence/test/LayoutPageTemplateEntryPersistenceTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/persistence/test/LayoutPageTemplateEntryPersistenceTest.java
@@ -183,8 +183,10 @@ public class LayoutPageTemplateEntryPersistenceTest {
 
 		newLayoutPageTemplateEntry.setStatusDate(RandomTestUtil.nextDate());
 
-		_layoutPageTemplateEntries.add(
-			_persistence.update(newLayoutPageTemplateEntry));
+		newLayoutPageTemplateEntry = _persistence.update(
+			newLayoutPageTemplateEntry);
+
+		_layoutPageTemplateEntries.add(newLayoutPageTemplateEntry);
 
 		LayoutPageTemplateEntry existingLayoutPageTemplateEntry =
 			_persistence.findByPrimaryKey(
@@ -1110,4 +1112,4 @@ public class LayoutPageTemplateEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:935717341
+// LIFERAY-SERVICE-BUILDER-HASH:162554197

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/persistence/test/LayoutPageTemplateStructurePersistenceTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/persistence/test/LayoutPageTemplateStructurePersistenceTest.java
@@ -140,8 +140,10 @@ public class LayoutPageTemplateStructurePersistenceTest {
 
 		newLayoutPageTemplateStructure.setPlid(RandomTestUtil.nextLong());
 
-		_layoutPageTemplateStructures.add(
-			_persistence.update(newLayoutPageTemplateStructure));
+		newLayoutPageTemplateStructure = _persistence.update(
+			newLayoutPageTemplateStructure);
+
+		_layoutPageTemplateStructures.add(newLayoutPageTemplateStructure);
 
 		LayoutPageTemplateStructure existingLayoutPageTemplateStructure =
 			_persistence.findByPrimaryKey(
@@ -634,4 +636,4 @@ public class LayoutPageTemplateStructurePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:855393349
+// LIFERAY-SERVICE-BUILDER-HASH:-1240419073

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/persistence/test/LayoutPageTemplateStructureRelElementVariationPersistenceTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/persistence/test/LayoutPageTemplateStructureRelElementVariationPersistenceTest.java
@@ -179,9 +179,11 @@ public class LayoutPageTemplateStructureRelElementVariationPersistenceTest {
 		newLayoutPageTemplateStructureRelElementVariation.setTargetElement(
 			RandomTestUtil.randomString());
 
+		newLayoutPageTemplateStructureRelElementVariation = _persistence.update(
+			newLayoutPageTemplateStructureRelElementVariation);
+
 		_layoutPageTemplateStructureRelElementVariations.add(
-			_persistence.update(
-				newLayoutPageTemplateStructureRelElementVariation));
+			newLayoutPageTemplateStructureRelElementVariation);
 
 		LayoutPageTemplateStructureRelElementVariation
 			existingLayoutPageTemplateStructureRelElementVariation =
@@ -854,4 +856,4 @@ public class LayoutPageTemplateStructureRelElementVariationPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-277564997
+// LIFERAY-SERVICE-BUILDER-HASH:1335631027

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/persistence/test/LayoutPageTemplateStructureRelPersistenceTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/persistence/test/LayoutPageTemplateStructureRelPersistenceTest.java
@@ -164,8 +164,10 @@ public class LayoutPageTemplateStructureRelPersistenceTest {
 		newLayoutPageTemplateStructureRel.setStatusDate(
 			RandomTestUtil.nextDate());
 
-		_layoutPageTemplateStructureRels.add(
-			_persistence.update(newLayoutPageTemplateStructureRel));
+		newLayoutPageTemplateStructureRel = _persistence.update(
+			newLayoutPageTemplateStructureRel);
+
+		_layoutPageTemplateStructureRels.add(newLayoutPageTemplateStructureRel);
 
 		LayoutPageTemplateStructureRel existingLayoutPageTemplateStructureRel =
 			_persistence.findByPrimaryKey(
@@ -725,4 +727,4 @@ public class LayoutPageTemplateStructureRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-585932996
+// LIFERAY-SERVICE-BUILDER-HASH:-1489402410

--- a/modules/apps/layout/layout-seo-test/src/testIntegration/java/com/liferay/layout/seo/service/persistence/test/LayoutSEOEntryCustomMetaTagPersistenceTest.java
+++ b/modules/apps/layout/layout-seo-test/src/testIntegration/java/com/liferay/layout/seo/service/persistence/test/LayoutSEOEntryCustomMetaTagPersistenceTest.java
@@ -128,8 +128,10 @@ public class LayoutSEOEntryCustomMetaTagPersistenceTest {
 		newLayoutSEOEntryCustomMetaTag.setProperty(
 			RandomTestUtil.randomString());
 
-		_layoutSEOEntryCustomMetaTags.add(
-			_persistence.update(newLayoutSEOEntryCustomMetaTag));
+		newLayoutSEOEntryCustomMetaTag = _persistence.update(
+			newLayoutSEOEntryCustomMetaTag);
+
+		_layoutSEOEntryCustomMetaTags.add(newLayoutSEOEntryCustomMetaTag);
 
 		LayoutSEOEntryCustomMetaTag existingLayoutSEOEntryCustomMetaTag =
 			_persistence.findByPrimaryKey(
@@ -460,4 +462,4 @@ public class LayoutSEOEntryCustomMetaTagPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1373980106
+// LIFERAY-SERVICE-BUILDER-HASH:970137636

--- a/modules/apps/layout/layout-seo-test/src/testIntegration/java/com/liferay/layout/seo/service/persistence/test/LayoutSEOEntryPersistenceTest.java
+++ b/modules/apps/layout/layout-seo-test/src/testIntegration/java/com/liferay/layout/seo/service/persistence/test/LayoutSEOEntryPersistenceTest.java
@@ -159,7 +159,9 @@ public class LayoutSEOEntryPersistenceTest {
 
 		newLayoutSEOEntry.setLastPublishDate(RandomTestUtil.nextDate());
 
-		_layoutSEOEntries.add(_persistence.update(newLayoutSEOEntry));
+		newLayoutSEOEntry = _persistence.update(newLayoutSEOEntry);
+
+		_layoutSEOEntries.add(newLayoutSEOEntry);
 
 		LayoutSEOEntry existingLayoutSEOEntry = _persistence.findByPrimaryKey(
 			newLayoutSEOEntry.getPrimaryKey());
@@ -654,4 +656,4 @@ public class LayoutSEOEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:906125614
+// LIFERAY-SERVICE-BUILDER-HASH:-390273782

--- a/modules/apps/layout/layout-seo-test/src/testIntegration/java/com/liferay/layout/seo/service/persistence/test/LayoutSEOSitePersistenceTest.java
+++ b/modules/apps/layout/layout-seo-test/src/testIntegration/java/com/liferay/layout/seo/service/persistence/test/LayoutSEOSitePersistenceTest.java
@@ -136,7 +136,9 @@ public class LayoutSEOSitePersistenceTest {
 		newLayoutSEOSite.setOpenGraphImageFileEntryId(
 			RandomTestUtil.nextLong());
 
-		_layoutSEOSites.add(_persistence.update(newLayoutSEOSite));
+		newLayoutSEOSite = _persistence.update(newLayoutSEOSite);
+
+		_layoutSEOSites.add(newLayoutSEOSite);
 
 		LayoutSEOSite existingLayoutSEOSite = _persistence.findByPrimaryKey(
 			newLayoutSEOSite.getPrimaryKey());
@@ -565,4 +567,4 @@ public class LayoutSEOSitePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1684684861
+// LIFERAY-SERVICE-BUILDER-HASH:-1294938591

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/service/persistence/test/LayoutClassedModelUsagePersistenceTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/service/persistence/test/LayoutClassedModelUsagePersistenceTest.java
@@ -149,8 +149,10 @@ public class LayoutClassedModelUsagePersistenceTest {
 		newLayoutClassedModelUsage.setLastPublishDate(
 			RandomTestUtil.nextDate());
 
-		_layoutClassedModelUsages.add(
-			_persistence.update(newLayoutClassedModelUsage));
+		newLayoutClassedModelUsage = _persistence.update(
+			newLayoutClassedModelUsage);
+
+		_layoutClassedModelUsages.add(newLayoutClassedModelUsage);
 
 		LayoutClassedModelUsage existingLayoutClassedModelUsage =
 			_persistence.findByPrimaryKey(
@@ -752,4 +754,4 @@ public class LayoutClassedModelUsagePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:81202932
+// LIFERAY-SERVICE-BUILDER-HASH:-640082554

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/service/persistence/test/LayoutLocalizationPersistenceTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/service/persistence/test/LayoutLocalizationPersistenceTest.java
@@ -134,7 +134,9 @@ public class LayoutLocalizationPersistenceTest {
 
 		newLayoutLocalization.setLastPublishDate(RandomTestUtil.nextDate());
 
-		_layoutLocalizations.add(_persistence.update(newLayoutLocalization));
+		newLayoutLocalization = _persistence.update(newLayoutLocalization);
+
+		_layoutLocalizations.add(newLayoutLocalization);
 
 		LayoutLocalization existingLayoutLocalization =
 			_persistence.findByPrimaryKey(
@@ -616,4 +618,4 @@ public class LayoutLocalizationPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1461656693
+// LIFERAY-SERVICE-BUILDER-HASH:-771706937

--- a/modules/apps/layout/layout-utility-page-test/src/testIntegration/java/com/liferay/layout/utility/page/service/persistence/test/LayoutUtilityPageEntryPersistenceTest.java
+++ b/modules/apps/layout/layout-utility-page-test/src/testIntegration/java/com/liferay/layout/utility/page/service/persistence/test/LayoutUtilityPageEntryPersistenceTest.java
@@ -156,8 +156,10 @@ public class LayoutUtilityPageEntryPersistenceTest {
 
 		newLayoutUtilityPageEntry.setLastPublishDate(RandomTestUtil.nextDate());
 
-		_layoutUtilityPageEntries.add(
-			_persistence.update(newLayoutUtilityPageEntry));
+		newLayoutUtilityPageEntry = _persistence.update(
+			newLayoutUtilityPageEntry);
+
+		_layoutUtilityPageEntries.add(newLayoutUtilityPageEntry);
 
 		LayoutUtilityPageEntry existingLayoutUtilityPageEntry =
 			_persistence.findByPrimaryKey(
@@ -803,4 +805,4 @@ public class LayoutUtilityPageEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1550664389
+// LIFERAY-SERVICE-BUILDER-HASH:607144157

--- a/modules/apps/list-type/list-type-test/src/testIntegration/java/com/liferay/list/type/service/persistence/test/ListTypeDefinitionPersistenceTest.java
+++ b/modules/apps/list-type/list-type-test/src/testIntegration/java/com/liferay/list/type/service/persistence/test/ListTypeDefinitionPersistenceTest.java
@@ -136,7 +136,9 @@ public class ListTypeDefinitionPersistenceTest {
 
 		newListTypeDefinition.setStatus(RandomTestUtil.nextInt());
 
-		_listTypeDefinitions.add(_persistence.update(newListTypeDefinition));
+		newListTypeDefinition = _persistence.update(newListTypeDefinition);
+
+		_listTypeDefinitions.add(newListTypeDefinition);
 
 		ListTypeDefinition existingListTypeDefinition =
 			_persistence.findByPrimaryKey(
@@ -596,4 +598,4 @@ public class ListTypeDefinitionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1784447139
+// LIFERAY-SERVICE-BUILDER-HASH:1129550753

--- a/modules/apps/list-type/list-type-test/src/testIntegration/java/com/liferay/list/type/service/persistence/test/ListTypeEntryPersistenceTest.java
+++ b/modules/apps/list-type/list-type-test/src/testIntegration/java/com/liferay/list/type/service/persistence/test/ListTypeEntryPersistenceTest.java
@@ -140,7 +140,9 @@ public class ListTypeEntryPersistenceTest {
 
 		newListTypeEntry.setStatus(RandomTestUtil.nextInt());
 
-		_listTypeEntries.add(_persistence.update(newListTypeEntry));
+		newListTypeEntry = _persistence.update(newListTypeEntry);
+
+		_listTypeEntries.add(newListTypeEntry);
 
 		ListTypeEntry existingListTypeEntry = _persistence.findByPrimaryKey(
 			newListTypeEntry.getPrimaryKey());
@@ -622,4 +624,4 @@ public class ListTypeEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1233956051
+// LIFERAY-SERVICE-BUILDER-HASH:764330581

--- a/modules/apps/marketplace/marketplace-test/src/testIntegration/java/com/liferay/marketplace/service/persistence/test/AppPersistenceTest.java
+++ b/modules/apps/marketplace/marketplace-test/src/testIntegration/java/com/liferay/marketplace/service/persistence/test/AppPersistenceTest.java
@@ -139,7 +139,9 @@ public class AppPersistenceTest {
 
 		newApp.setRequired(RandomTestUtil.randomBoolean());
 
-		_apps.add(_persistence.update(newApp));
+		newApp = _persistence.update(newApp);
+
+		_apps.add(newApp);
 
 		App existingApp = _persistence.findByPrimaryKey(newApp.getPrimaryKey());
 
@@ -532,4 +534,4 @@ public class AppPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1110166851
+// LIFERAY-SERVICE-BUILDER-HASH:325545887

--- a/modules/apps/marketplace/marketplace-test/src/testIntegration/java/com/liferay/marketplace/service/persistence/test/ModulePersistenceTest.java
+++ b/modules/apps/marketplace/marketplace-test/src/testIntegration/java/com/liferay/marketplace/service/persistence/test/ModulePersistenceTest.java
@@ -124,7 +124,9 @@ public class ModulePersistenceTest {
 
 		newModule.setContextName(RandomTestUtil.randomString());
 
-		_modules.add(_persistence.update(newModule));
+		newModule = _persistence.update(newModule);
+
+		_modules.add(newModule);
 
 		Module existingModule = _persistence.findByPrimaryKey(
 			newModule.getPrimaryKey());
@@ -528,4 +530,4 @@ public class ModulePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:489448110
+// LIFERAY-SERVICE-BUILDER-HASH:-1901173778

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/persistence/test/MBBanPersistenceTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/persistence/test/MBBanPersistenceTest.java
@@ -133,7 +133,9 @@ public class MBBanPersistenceTest {
 
 		newMBBan.setLastPublishDate(RandomTestUtil.nextDate());
 
-		_mbBans.add(_persistence.update(newMBBan));
+		newMBBan = _persistence.update(newMBBan);
+
+		_mbBans.add(newMBBan);
 
 		MBBan existingMBBan = _persistence.findByPrimaryKey(
 			newMBBan.getPrimaryKey());
@@ -555,4 +557,4 @@ public class MBBanPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1624529589
+// LIFERAY-SERVICE-BUILDER-HASH:460789613

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/persistence/test/MBCategoryPersistenceTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/persistence/test/MBCategoryPersistenceTest.java
@@ -156,7 +156,9 @@ public class MBCategoryPersistenceTest {
 
 		newMBCategory.setStatusDate(RandomTestUtil.nextDate());
 
-		_mbCategories.add(_persistence.update(newMBCategory));
+		newMBCategory = _persistence.update(newMBCategory);
+
+		_mbCategories.add(newMBCategory);
 
 		MBCategory existingMBCategory = _persistence.findByPrimaryKey(
 			newMBCategory.getPrimaryKey());
@@ -803,4 +805,4 @@ public class MBCategoryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:29810680
+// LIFERAY-SERVICE-BUILDER-HASH:902096164

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/persistence/test/MBDiscussionPersistenceTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/persistence/test/MBDiscussionPersistenceTest.java
@@ -137,7 +137,9 @@ public class MBDiscussionPersistenceTest {
 
 		newMBDiscussion.setLastPublishDate(RandomTestUtil.nextDate());
 
-		_mbDiscussions.add(_persistence.update(newMBDiscussion));
+		newMBDiscussion = _persistence.update(newMBDiscussion);
+
+		_mbDiscussions.add(newMBDiscussion);
 
 		MBDiscussion existingMBDiscussion = _persistence.findByPrimaryKey(
 			newMBDiscussion.getPrimaryKey());
@@ -586,4 +588,4 @@ public class MBDiscussionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-952029459
+// LIFERAY-SERVICE-BUILDER-HASH:447314127

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/persistence/test/MBMailingListPersistenceTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/persistence/test/MBMailingListPersistenceTest.java
@@ -165,7 +165,9 @@ public class MBMailingListPersistenceTest {
 
 		newMBMailingList.setActive(RandomTestUtil.randomBoolean());
 
-		_mbMailingLists.add(_persistence.update(newMBMailingList));
+		newMBMailingList = _persistence.update(newMBMailingList);
+
+		_mbMailingLists.add(newMBMailingList);
 
 		MBMailingList existingMBMailingList = _persistence.findByPrimaryKey(
 			newMBMailingList.getPrimaryKey());
@@ -685,4 +687,4 @@ public class MBMailingListPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1829980528
+// LIFERAY-SERVICE-BUILDER-HASH:1808532294

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/persistence/test/MBMessagePersistenceTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/persistence/test/MBMessagePersistenceTest.java
@@ -177,7 +177,9 @@ public class MBMessagePersistenceTest {
 
 		newMBMessage.setStatusDate(RandomTestUtil.nextDate());
 
-		_mbMessages.add(_persistence.update(newMBMessage));
+		newMBMessage = _persistence.update(newMBMessage);
+
+		_mbMessages.add(newMBMessage);
 
 		MBMessage existingMBMessage = _persistence.findByPrimaryKey(
 			newMBMessage.getPrimaryKey());
@@ -981,4 +983,4 @@ public class MBMessagePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:662127088
+// LIFERAY-SERVICE-BUILDER-HASH:1489612658

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/persistence/test/MBSuspiciousActivityPersistenceTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/persistence/test/MBSuspiciousActivityPersistenceTest.java
@@ -141,8 +141,9 @@ public class MBSuspiciousActivityPersistenceTest {
 
 		newMBSuspiciousActivity.setValidated(RandomTestUtil.randomBoolean());
 
-		_mbSuspiciousActivities.add(
-			_persistence.update(newMBSuspiciousActivity));
+		newMBSuspiciousActivity = _persistence.update(newMBSuspiciousActivity);
+
+		_mbSuspiciousActivities.add(newMBSuspiciousActivity);
 
 		MBSuspiciousActivity existingMBSuspiciousActivity =
 			_persistence.findByPrimaryKey(
@@ -653,4 +654,4 @@ public class MBSuspiciousActivityPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:684536265
+// LIFERAY-SERVICE-BUILDER-HASH:1038066977

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/persistence/test/MBThreadFlagPersistenceTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/persistence/test/MBThreadFlagPersistenceTest.java
@@ -133,7 +133,9 @@ public class MBThreadFlagPersistenceTest {
 
 		newMBThreadFlag.setLastPublishDate(RandomTestUtil.nextDate());
 
-		_mbThreadFlags.add(_persistence.update(newMBThreadFlag));
+		newMBThreadFlag = _persistence.update(newMBThreadFlag);
+
+		_mbThreadFlags.add(newMBThreadFlag);
 
 		MBThreadFlag existingMBThreadFlag = _persistence.findByPrimaryKey(
 			newMBThreadFlag.getPrimaryKey());
@@ -573,4 +575,4 @@ public class MBThreadFlagPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-336038264
+// LIFERAY-SERVICE-BUILDER-HASH:-1427288890

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/persistence/test/MBThreadPersistenceTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/persistence/test/MBThreadPersistenceTest.java
@@ -160,7 +160,9 @@ public class MBThreadPersistenceTest {
 
 		newMBThread.setStatusDate(RandomTestUtil.nextDate());
 
-		_mbThreads.add(_persistence.update(newMBThread));
+		newMBThread = _persistence.update(newMBThread);
+
+		_mbThreads.add(newMBThread);
 
 		MBThread existingMBThread = _persistence.findByPrimaryKey(
 			newMBThread.getPrimaryKey());
@@ -757,4 +759,4 @@ public class MBThreadPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-153543262
+// LIFERAY-SERVICE-BUILDER-HASH:266197960

--- a/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/service/persistence/test/NotificationQueueEntryAttachmentPersistenceTest.java
+++ b/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/service/persistence/test/NotificationQueueEntryAttachmentPersistenceTest.java
@@ -126,8 +126,11 @@ public class NotificationQueueEntryAttachmentPersistenceTest {
 		newNotificationQueueEntryAttachment.setNotificationQueueEntryId(
 			RandomTestUtil.nextLong());
 
+		newNotificationQueueEntryAttachment = _persistence.update(
+			newNotificationQueueEntryAttachment);
+
 		_notificationQueueEntryAttachments.add(
-			_persistence.update(newNotificationQueueEntryAttachment));
+			newNotificationQueueEntryAttachment);
 
 		NotificationQueueEntryAttachment
 			existingNotificationQueueEntryAttachment =
@@ -483,4 +486,4 @@ public class NotificationQueueEntryAttachmentPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:8881233
+// LIFERAY-SERVICE-BUILDER-HASH:229843851

--- a/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/service/persistence/test/NotificationQueueEntryPersistenceTest.java
+++ b/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/service/persistence/test/NotificationQueueEntryPersistenceTest.java
@@ -145,8 +145,10 @@ public class NotificationQueueEntryPersistenceTest {
 
 		newNotificationQueueEntry.setStatus(RandomTestUtil.nextInt());
 
-		_notificationQueueEntries.add(
-			_persistence.update(newNotificationQueueEntry));
+		newNotificationQueueEntry = _persistence.update(
+			newNotificationQueueEntry);
+
+		_notificationQueueEntries.add(newNotificationQueueEntry);
 
 		NotificationQueueEntry existingNotificationQueueEntry =
 			_persistence.findByPrimaryKey(
@@ -556,4 +558,4 @@ public class NotificationQueueEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2139472783
+// LIFERAY-SERVICE-BUILDER-HASH:-2060431417

--- a/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/service/persistence/test/NotificationRecipientPersistenceTest.java
+++ b/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/service/persistence/test/NotificationRecipientPersistenceTest.java
@@ -133,8 +133,10 @@ public class NotificationRecipientPersistenceTest {
 
 		newNotificationRecipient.setClassPK(RandomTestUtil.nextLong());
 
-		_notificationRecipients.add(
-			_persistence.update(newNotificationRecipient));
+		newNotificationRecipient = _persistence.update(
+			newNotificationRecipient);
+
+		_notificationRecipients.add(newNotificationRecipient);
 
 		NotificationRecipient existingNotificationRecipient =
 			_persistence.findByPrimaryKey(
@@ -567,4 +569,4 @@ public class NotificationRecipientPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1207131998
+// LIFERAY-SERVICE-BUILDER-HASH:-544389168

--- a/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/service/persistence/test/NotificationRecipientSettingPersistenceTest.java
+++ b/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/service/persistence/test/NotificationRecipientSettingPersistenceTest.java
@@ -140,8 +140,10 @@ public class NotificationRecipientSettingPersistenceTest {
 
 		newNotificationRecipientSetting.setValue(RandomTestUtil.randomString());
 
-		_notificationRecipientSettings.add(
-			_persistence.update(newNotificationRecipientSetting));
+		newNotificationRecipientSetting = _persistence.update(
+			newNotificationRecipientSetting);
+
+		_notificationRecipientSettings.add(newNotificationRecipientSetting);
 
 		NotificationRecipientSetting existingNotificationRecipientSetting =
 			_persistence.findByPrimaryKey(
@@ -616,4 +618,4 @@ public class NotificationRecipientSettingPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1273174584
+// LIFERAY-SERVICE-BUILDER-HASH:-1765690740

--- a/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/service/persistence/test/NotificationTemplateAttachmentPersistenceTest.java
+++ b/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/service/persistence/test/NotificationTemplateAttachmentPersistenceTest.java
@@ -126,8 +126,10 @@ public class NotificationTemplateAttachmentPersistenceTest {
 		newNotificationTemplateAttachment.setObjectFieldId(
 			RandomTestUtil.nextLong());
 
-		_notificationTemplateAttachments.add(
-			_persistence.update(newNotificationTemplateAttachment));
+		newNotificationTemplateAttachment = _persistence.update(
+			newNotificationTemplateAttachment);
+
+		_notificationTemplateAttachments.add(newNotificationTemplateAttachment);
 
 		NotificationTemplateAttachment existingNotificationTemplateAttachment =
 			_persistence.findByPrimaryKey(
@@ -552,4 +554,4 @@ public class NotificationTemplateAttachmentPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-297706517
+// LIFERAY-SERVICE-BUILDER-HASH:-1586337421

--- a/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/service/persistence/test/NotificationTemplatePersistenceTest.java
+++ b/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/service/persistence/test/NotificationTemplatePersistenceTest.java
@@ -152,8 +152,9 @@ public class NotificationTemplatePersistenceTest {
 
 		newNotificationTemplate.setType(RandomTestUtil.randomString());
 
-		_notificationTemplates.add(
-			_persistence.update(newNotificationTemplate));
+		newNotificationTemplate = _persistence.update(newNotificationTemplate);
+
+		_notificationTemplates.add(newNotificationTemplate);
 
 		NotificationTemplate existingNotificationTemplate =
 			_persistence.findByPrimaryKey(
@@ -664,4 +665,4 @@ public class NotificationTemplatePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:143195910
+// LIFERAY-SERVICE-BUILDER-HASH:1298978744

--- a/modules/apps/oauth-client/oauth-client-persistence-test/src/testIntegration/java/com/liferay/oauth/client/persistence/service/persistence/test/OAuthClientASLocalMetadataPersistenceTest.java
+++ b/modules/apps/oauth-client/oauth-client-persistence-test/src/testIntegration/java/com/liferay/oauth/client/persistence/service/persistence/test/OAuthClientASLocalMetadataPersistenceTest.java
@@ -154,8 +154,10 @@ public class OAuthClientASLocalMetadataPersistenceTest {
 		newOAuthClientASLocalMetadata.setOAuthASMetadataJSON(
 			RandomTestUtil.randomString());
 
-		_oAuthClientASLocalMetadatas.add(
-			_persistence.update(newOAuthClientASLocalMetadata));
+		newOAuthClientASLocalMetadata = _persistence.update(
+			newOAuthClientASLocalMetadata);
+
+		_oAuthClientASLocalMetadatas.add(newOAuthClientASLocalMetadata);
 
 		OAuthClientASLocalMetadata existingOAuthClientASLocalMetadata =
 			_persistence.findByPrimaryKey(
@@ -752,4 +754,4 @@ public class OAuthClientASLocalMetadataPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1112533432
+// LIFERAY-SERVICE-BUILDER-HASH:-187987132

--- a/modules/apps/oauth-client/oauth-client-persistence-test/src/testIntegration/java/com/liferay/oauth/client/persistence/service/persistence/test/OAuthClientEntryPersistenceTest.java
+++ b/modules/apps/oauth-client/oauth-client-persistence-test/src/testIntegration/java/com/liferay/oauth/client/persistence/service/persistence/test/OAuthClientEntryPersistenceTest.java
@@ -152,7 +152,9 @@ public class OAuthClientEntryPersistenceTest {
 		newOAuthClientEntry.setTokenRequestParametersJSON(
 			RandomTestUtil.randomString());
 
-		_oAuthClientEntries.add(_persistence.update(newOAuthClientEntry));
+		newOAuthClientEntry = _persistence.update(newOAuthClientEntry);
+
+		_oAuthClientEntries.add(newOAuthClientEntry);
 
 		OAuthClientEntry existingOAuthClientEntry =
 			_persistence.findByPrimaryKey(newOAuthClientEntry.getPrimaryKey());
@@ -677,4 +679,4 @@ public class OAuthClientEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1126482045
+// LIFERAY-SERVICE-BUILDER-HASH:-1335506431

--- a/modules/apps/oauth-client/oauth-client-persistence-test/src/testIntegration/java/com/liferay/oauth/client/persistence/service/persistence/test/OAuthClientPRLocalMetadataPersistenceTest.java
+++ b/modules/apps/oauth-client/oauth-client-persistence-test/src/testIntegration/java/com/liferay/oauth/client/persistence/service/persistence/test/OAuthClientPRLocalMetadataPersistenceTest.java
@@ -149,8 +149,10 @@ public class OAuthClientPRLocalMetadataPersistenceTest {
 		newOAuthClientPRLocalMetadata.setProtectedResourceURI(
 			RandomTestUtil.randomString());
 
-		_oAuthClientPRLocalMetadatas.add(
-			_persistence.update(newOAuthClientPRLocalMetadata));
+		newOAuthClientPRLocalMetadata = _persistence.update(
+			newOAuthClientPRLocalMetadata);
+
+		_oAuthClientPRLocalMetadatas.add(newOAuthClientPRLocalMetadata);
 
 		OAuthClientPRLocalMetadata existingOAuthClientPRLocalMetadata =
 			_persistence.findByPrimaryKey(
@@ -716,4 +718,4 @@ public class OAuthClientPRLocalMetadataPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1023229233
+// LIFERAY-SERVICE-BUILDER-HASH:1497845597

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectActionPersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectActionPersistenceTest.java
@@ -153,7 +153,9 @@ public class ObjectActionPersistenceTest {
 
 		newObjectAction.setStatus(RandomTestUtil.nextInt());
 
-		_objectActions.add(_persistence.update(newObjectAction));
+		newObjectAction = _persistence.update(newObjectAction);
+
+		_objectActions.add(newObjectAction);
 
 		ObjectAction existingObjectAction = _persistence.findByPrimaryKey(
 			newObjectAction.getPrimaryKey());
@@ -705,4 +707,4 @@ public class ObjectActionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-230034920
+// LIFERAY-SERVICE-BUILDER-HASH:-132397846

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectDefinitionPersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectDefinitionPersistenceTest.java
@@ -209,7 +209,9 @@ public class ObjectDefinitionPersistenceTest {
 
 		newObjectDefinition.setStatus(RandomTestUtil.nextInt());
 
-		_objectDefinitions.add(_persistence.update(newObjectDefinition));
+		newObjectDefinition = _persistence.update(newObjectDefinition);
+
+		_objectDefinitions.add(newObjectDefinition);
 
 		ObjectDefinition existingObjectDefinition =
 			_persistence.findByPrimaryKey(newObjectDefinition.getPrimaryKey());
@@ -986,4 +988,4 @@ public class ObjectDefinitionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-794946629
+// LIFERAY-SERVICE-BUILDER-HASH:1833221191

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectDefinitionSettingPersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectDefinitionSettingPersistenceTest.java
@@ -137,8 +137,10 @@ public class ObjectDefinitionSettingPersistenceTest {
 
 		newObjectDefinitionSetting.setValue(RandomTestUtil.randomString());
 
-		_objectDefinitionSettings.add(
-			_persistence.update(newObjectDefinitionSetting));
+		newObjectDefinitionSetting = _persistence.update(
+			newObjectDefinitionSetting);
+
+		_objectDefinitionSettings.add(newObjectDefinitionSetting);
 
 		ObjectDefinitionSetting existingObjectDefinitionSetting =
 			_persistence.findByPrimaryKey(
@@ -614,4 +616,4 @@ public class ObjectDefinitionSettingPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1228074539
+// LIFERAY-SERVICE-BUILDER-HASH:-1989435165

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectEntryFolderPersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectEntryFolderPersistenceTest.java
@@ -144,7 +144,9 @@ public class ObjectEntryFolderPersistenceTest {
 
 		newObjectEntryFolder.setStatus(RandomTestUtil.nextInt());
 
-		_objectEntryFolders.add(_persistence.update(newObjectEntryFolder));
+		newObjectEntryFolder = _persistence.update(newObjectEntryFolder);
+
+		_objectEntryFolders.add(newObjectEntryFolder);
 
 		ObjectEntryFolder existingObjectEntryFolder =
 			_persistence.findByPrimaryKey(newObjectEntryFolder.getPrimaryKey());
@@ -646,4 +648,4 @@ public class ObjectEntryFolderPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:2081101818
+// LIFERAY-SERVICE-BUILDER-HASH:523643676

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectEntryPersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectEntryPersistenceTest.java
@@ -159,7 +159,9 @@ public class ObjectEntryPersistenceTest {
 
 		newObjectEntry.setStatusDate(RandomTestUtil.nextDate());
 
-		_objectEntries.add(_persistence.update(newObjectEntry));
+		newObjectEntry = _persistence.update(newObjectEntry);
+
+		_objectEntries.add(newObjectEntry);
 
 		ObjectEntry existingObjectEntry = _persistence.findByPrimaryKey(
 			newObjectEntry.getPrimaryKey());
@@ -751,4 +753,4 @@ public class ObjectEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-870346184
+// LIFERAY-SERVICE-BUILDER-HASH:1461355312

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectEntryVersionPersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectEntryVersionPersistenceTest.java
@@ -149,7 +149,9 @@ public class ObjectEntryVersionPersistenceTest {
 
 		newObjectEntryVersion.setStatusDate(RandomTestUtil.nextDate());
 
-		_objectEntryVersions.add(_persistence.update(newObjectEntryVersion));
+		newObjectEntryVersion = _persistence.update(newObjectEntryVersion);
+
+		_objectEntryVersions.add(newObjectEntryVersion);
 
 		ObjectEntryVersion existingObjectEntryVersion =
 			_persistence.findByPrimaryKey(
@@ -645,4 +647,4 @@ public class ObjectEntryVersionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:121637586
+// LIFERAY-SERVICE-BUILDER-HASH:-638064700

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectFieldPersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectFieldPersistenceTest.java
@@ -164,7 +164,9 @@ public class ObjectFieldPersistenceTest {
 
 		newObjectField.setSystem(RandomTestUtil.randomBoolean());
 
-		_objectFields.add(_persistence.update(newObjectField));
+		newObjectField = _persistence.update(newObjectField);
+
+		_objectFields.add(newObjectField);
 
 		ObjectField existingObjectField = _persistence.findByPrimaryKey(
 			newObjectField.getPrimaryKey());
@@ -777,4 +779,4 @@ public class ObjectFieldPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1059492661
+// LIFERAY-SERVICE-BUILDER-HASH:-1968025669

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectFieldSettingPersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectFieldSettingPersistenceTest.java
@@ -132,7 +132,9 @@ public class ObjectFieldSettingPersistenceTest {
 
 		newObjectFieldSetting.setValue(RandomTestUtil.randomString());
 
-		_objectFieldSettings.add(_persistence.update(newObjectFieldSetting));
+		newObjectFieldSetting = _persistence.update(newObjectFieldSetting);
+
+		_objectFieldSettings.add(newObjectFieldSetting);
 
 		ObjectFieldSetting existingObjectFieldSetting =
 			_persistence.findByPrimaryKey(
@@ -562,4 +564,4 @@ public class ObjectFieldSettingPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1121242215
+// LIFERAY-SERVICE-BUILDER-HASH:543232313

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectFilterPersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectFilterPersistenceTest.java
@@ -131,7 +131,9 @@ public class ObjectFilterPersistenceTest {
 
 		newObjectFilter.setJSON(RandomTestUtil.randomString());
 
-		_objectFilters.add(_persistence.update(newObjectFilter));
+		newObjectFilter = _persistence.update(newObjectFilter);
+
+		_objectFilters.add(newObjectFilter);
 
 		ObjectFilter existingObjectFilter = _persistence.findByPrimaryKey(
 			newObjectFilter.getPrimaryKey());
@@ -473,4 +475,4 @@ public class ObjectFilterPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1627630330
+// LIFERAY-SERVICE-BUILDER-HASH:-86182832

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectFolderItemPersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectFolderItemPersistenceTest.java
@@ -133,7 +133,9 @@ public class ObjectFolderItemPersistenceTest {
 
 		newObjectFolderItem.setPositionY(RandomTestUtil.nextInt());
 
-		_objectFolderItems.add(_persistence.update(newObjectFolderItem));
+		newObjectFolderItem = _persistence.update(newObjectFolderItem);
+
+		_objectFolderItems.add(newObjectFolderItem);
 
 		ObjectFolderItem existingObjectFolderItem =
 			_persistence.findByPrimaryKey(newObjectFolderItem.getPrimaryKey());
@@ -564,4 +566,4 @@ public class ObjectFolderItemPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1325793003
+// LIFERAY-SERVICE-BUILDER-HASH:-510281197

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectFolderPersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectFolderPersistenceTest.java
@@ -134,7 +134,9 @@ public class ObjectFolderPersistenceTest {
 
 		newObjectFolder.setStatus(RandomTestUtil.nextInt());
 
-		_objectFolders.add(_persistence.update(newObjectFolder));
+		newObjectFolder = _persistence.update(newObjectFolder);
+
+		_objectFolders.add(newObjectFolder);
 
 		ObjectFolder existingObjectFolder = _persistence.findByPrimaryKey(
 			newObjectFolder.getPrimaryKey());
@@ -587,4 +589,4 @@ public class ObjectFolderPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-498848516
+// LIFERAY-SERVICE-BUILDER-HASH:-933257862

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectLayoutBoxPersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectLayoutBoxPersistenceTest.java
@@ -130,7 +130,9 @@ public class ObjectLayoutBoxPersistenceTest {
 
 		newObjectLayoutBox.setType(RandomTestUtil.randomString());
 
-		_objectLayoutBoxes.add(_persistence.update(newObjectLayoutBox));
+		newObjectLayoutBox = _persistence.update(newObjectLayoutBox);
+
+		_objectLayoutBoxes.add(newObjectLayoutBox);
 
 		ObjectLayoutBox existingObjectLayoutBox = _persistence.findByPrimaryKey(
 			newObjectLayoutBox.getPrimaryKey());
@@ -459,4 +461,4 @@ public class ObjectLayoutBoxPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1095525977
+// LIFERAY-SERVICE-BUILDER-HASH:1746601135

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectLayoutColumnPersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectLayoutColumnPersistenceTest.java
@@ -129,7 +129,9 @@ public class ObjectLayoutColumnPersistenceTest {
 
 		newObjectLayoutColumn.setSize(RandomTestUtil.nextInt());
 
-		_objectLayoutColumns.add(_persistence.update(newObjectLayoutColumn));
+		newObjectLayoutColumn = _persistence.update(newObjectLayoutColumn);
+
+		_objectLayoutColumns.add(newObjectLayoutColumn);
 
 		ObjectLayoutColumn existingObjectLayoutColumn =
 			_persistence.findByPrimaryKey(
@@ -471,4 +473,4 @@ public class ObjectLayoutColumnPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1946251368
+// LIFERAY-SERVICE-BUILDER-HASH:-1727625470

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectLayoutPersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectLayoutPersistenceTest.java
@@ -129,7 +129,9 @@ public class ObjectLayoutPersistenceTest {
 
 		newObjectLayout.setName(RandomTestUtil.randomString());
 
-		_objectLayouts.add(_persistence.update(newObjectLayout));
+		newObjectLayout = _persistence.update(newObjectLayout);
+
+		_objectLayouts.add(newObjectLayout);
 
 		ObjectLayout existingObjectLayout = _persistence.findByPrimaryKey(
 			newObjectLayout.getPrimaryKey());
@@ -483,4 +485,4 @@ public class ObjectLayoutPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:2138422500
+// LIFERAY-SERVICE-BUILDER-HASH:-1809303522

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectLayoutRowPersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectLayoutRowPersistenceTest.java
@@ -124,7 +124,9 @@ public class ObjectLayoutRowPersistenceTest {
 
 		newObjectLayoutRow.setPriority(RandomTestUtil.nextInt());
 
-		_objectLayoutRows.add(_persistence.update(newObjectLayoutRow));
+		newObjectLayoutRow = _persistence.update(newObjectLayoutRow);
+
+		_objectLayoutRows.add(newObjectLayoutRow);
 
 		ObjectLayoutRow existingObjectLayoutRow = _persistence.findByPrimaryKey(
 			newObjectLayoutRow.getPrimaryKey());
@@ -439,4 +441,4 @@ public class ObjectLayoutRowPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2069761661
+// LIFERAY-SERVICE-BUILDER-HASH:322944545

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectLayoutTabPersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectLayoutTabPersistenceTest.java
@@ -131,7 +131,9 @@ public class ObjectLayoutTabPersistenceTest {
 
 		newObjectLayoutTab.setPriority(RandomTestUtil.nextInt());
 
-		_objectLayoutTabs.add(_persistence.update(newObjectLayoutTab));
+		newObjectLayoutTab = _persistence.update(newObjectLayoutTab);
+
+		_objectLayoutTabs.add(newObjectLayoutTab);
 
 		ObjectLayoutTab existingObjectLayoutTab = _persistence.findByPrimaryKey(
 			newObjectLayoutTab.getPrimaryKey());
@@ -487,4 +489,4 @@ public class ObjectLayoutTabPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1340953873
+// LIFERAY-SERVICE-BUILDER-HASH:1390226969

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectRelationshipPersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectRelationshipPersistenceTest.java
@@ -154,7 +154,9 @@ public class ObjectRelationshipPersistenceTest {
 
 		newObjectRelationship.setType(RandomTestUtil.randomString());
 
-		_objectRelationships.add(_persistence.update(newObjectRelationship));
+		newObjectRelationship = _persistence.update(newObjectRelationship);
+
+		_objectRelationships.add(newObjectRelationship);
 
 		ObjectRelationship existingObjectRelationship =
 			_persistence.findByPrimaryKey(
@@ -843,4 +845,4 @@ public class ObjectRelationshipPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1339717317
+// LIFERAY-SERVICE-BUILDER-HASH:854761371

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectStateFlowPersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectStateFlowPersistenceTest.java
@@ -127,7 +127,9 @@ public class ObjectStateFlowPersistenceTest {
 
 		newObjectStateFlow.setObjectFieldId(RandomTestUtil.nextLong());
 
-		_objectStateFlows.add(_persistence.update(newObjectStateFlow));
+		newObjectStateFlow = _persistence.update(newObjectStateFlow);
+
+		_objectStateFlows.add(newObjectStateFlow);
 
 		ObjectStateFlow existingObjectStateFlow = _persistence.findByPrimaryKey(
 			newObjectStateFlow.getPrimaryKey());
@@ -520,4 +522,4 @@ public class ObjectStateFlowPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2003534547
+// LIFERAY-SERVICE-BUILDER-HASH:1080156531

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectStatePersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectStatePersistenceTest.java
@@ -129,7 +129,9 @@ public class ObjectStatePersistenceTest {
 
 		newObjectState.setObjectStateFlowId(RandomTestUtil.nextLong());
 
-		_objectStates.add(_persistence.update(newObjectState));
+		newObjectState = _persistence.update(newObjectState);
+
+		_objectStates.add(newObjectState);
 
 		ObjectState existingObjectState = _persistence.findByPrimaryKey(
 			newObjectState.getPrimaryKey());
@@ -536,4 +538,4 @@ public class ObjectStatePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1847314508
+// LIFERAY-SERVICE-BUILDER-HASH:1769463306

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectStateTransitionPersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectStateTransitionPersistenceTest.java
@@ -136,8 +136,10 @@ public class ObjectStateTransitionPersistenceTest {
 		newObjectStateTransition.setTargetObjectStateId(
 			RandomTestUtil.nextLong());
 
-		_objectStateTransitions.add(
-			_persistence.update(newObjectStateTransition));
+		newObjectStateTransition = _persistence.update(
+			newObjectStateTransition);
+
+		_objectStateTransitions.add(newObjectStateTransition);
 
 		ObjectStateTransition existingObjectStateTransition =
 			_persistence.findByPrimaryKey(
@@ -526,4 +528,4 @@ public class ObjectStateTransitionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1825455828
+// LIFERAY-SERVICE-BUILDER-HASH:-989519734

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectValidationRulePersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectValidationRulePersistenceTest.java
@@ -149,8 +149,9 @@ public class ObjectValidationRulePersistenceTest {
 
 		newObjectValidationRule.setSystem(RandomTestUtil.randomBoolean());
 
-		_objectValidationRules.add(
-			_persistence.update(newObjectValidationRule));
+		newObjectValidationRule = _persistence.update(newObjectValidationRule);
+
+		_objectValidationRules.add(newObjectValidationRule);
 
 		ObjectValidationRule existingObjectValidationRule =
 			_persistence.findByPrimaryKey(
@@ -672,4 +673,4 @@ public class ObjectValidationRulePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1360324934
+// LIFERAY-SERVICE-BUILDER-HASH:-1853167914

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectValidationRuleSettingPersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectValidationRuleSettingPersistenceTest.java
@@ -139,8 +139,10 @@ public class ObjectValidationRuleSettingPersistenceTest {
 
 		newObjectValidationRuleSetting.setValue(RandomTestUtil.randomString());
 
-		_objectValidationRuleSettings.add(
-			_persistence.update(newObjectValidationRuleSetting));
+		newObjectValidationRuleSetting = _persistence.update(
+			newObjectValidationRuleSetting);
+
+		_objectValidationRuleSettings.add(newObjectValidationRuleSetting);
 
 		ObjectValidationRuleSetting existingObjectValidationRuleSetting =
 			_persistence.findByPrimaryKey(
@@ -648,4 +650,4 @@ public class ObjectValidationRuleSettingPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1483585809
+// LIFERAY-SERVICE-BUILDER-HASH:35829529

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectViewColumnPersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectViewColumnPersistenceTest.java
@@ -128,7 +128,9 @@ public class ObjectViewColumnPersistenceTest {
 
 		newObjectViewColumn.setPriority(RandomTestUtil.nextInt());
 
-		_objectViewColumns.add(_persistence.update(newObjectViewColumn));
+		newObjectViewColumn = _persistence.update(newObjectViewColumn);
+
+		_objectViewColumns.add(newObjectViewColumn);
 
 		ObjectViewColumn existingObjectViewColumn =
 			_persistence.findByPrimaryKey(newObjectViewColumn.getPrimaryKey());
@@ -465,4 +467,4 @@ public class ObjectViewColumnPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1387626022
+// LIFERAY-SERVICE-BUILDER-HASH:-1578875894

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectViewFilterColumnPersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectViewFilterColumnPersistenceTest.java
@@ -136,8 +136,10 @@ public class ObjectViewFilterColumnPersistenceTest {
 		newObjectViewFilterColumn.setObjectFieldName(
 			RandomTestUtil.randomString());
 
-		_objectViewFilterColumns.add(
-			_persistence.update(newObjectViewFilterColumn));
+		newObjectViewFilterColumn = _persistence.update(
+			newObjectViewFilterColumn);
+
+		_objectViewFilterColumns.add(newObjectViewFilterColumn);
 
 		ObjectViewFilterColumn existingObjectViewFilterColumn =
 			_persistence.findByPrimaryKey(
@@ -528,4 +530,4 @@ public class ObjectViewFilterColumnPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1814737784
+// LIFERAY-SERVICE-BUILDER-HASH:1854775932

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectViewPersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectViewPersistenceTest.java
@@ -129,7 +129,9 @@ public class ObjectViewPersistenceTest {
 
 		newObjectView.setName(RandomTestUtil.randomString());
 
-		_objectViews.add(_persistence.update(newObjectView));
+		newObjectView = _persistence.update(newObjectView);
+
+		_objectViews.add(newObjectView);
 
 		ObjectView existingObjectView = _persistence.findByPrimaryKey(
 			newObjectView.getPrimaryKey());
@@ -470,4 +472,4 @@ public class ObjectViewPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:33270107
+// LIFERAY-SERVICE-BUILDER-HASH:-1880262709

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectViewSortColumnPersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectViewSortColumnPersistenceTest.java
@@ -133,8 +133,9 @@ public class ObjectViewSortColumnPersistenceTest {
 
 		newObjectViewSortColumn.setSortOrder(RandomTestUtil.randomString());
 
-		_objectViewSortColumns.add(
-			_persistence.update(newObjectViewSortColumn));
+		newObjectViewSortColumn = _persistence.update(newObjectViewSortColumn);
+
+		_objectViewSortColumns.add(newObjectViewSortColumn);
 
 		ObjectViewSortColumn existingObjectViewSortColumn =
 			_persistence.findByPrimaryKey(
@@ -492,4 +493,4 @@ public class ObjectViewSortColumnPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:27500422
+// LIFERAY-SERVICE-BUILDER-HASH:-961752338

--- a/modules/apps/portal-background-task/portal-background-task-test/src/testIntegration/java/com/liferay/portal/background/task/service/persistence/test/BackgroundTaskPersistenceTest.java
+++ b/modules/apps/portal-background-task/portal-background-task-test/src/testIntegration/java/com/liferay/portal/background/task/service/persistence/test/BackgroundTaskPersistenceTest.java
@@ -143,7 +143,9 @@ public class BackgroundTaskPersistenceTest {
 
 		newBackgroundTask.setStatusMessage(RandomTestUtil.randomString());
 
-		_backgroundTasks.add(_persistence.update(newBackgroundTask));
+		newBackgroundTask = _persistence.update(newBackgroundTask);
+
+		_backgroundTasks.add(newBackgroundTask);
 
 		BackgroundTask existingBackgroundTask = _persistence.findByPrimaryKey(
 			newBackgroundTask.getPrimaryKey());
@@ -637,4 +639,4 @@ public class BackgroundTaskPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:368672381
+// LIFERAY-SERVICE-BUILDER-HASH:-510098229

--- a/modules/apps/portal-language/portal-language-override-test/src/testIntegration/java/com/liferay/portal/language/override/service/persistence/test/PLOEntryPersistenceTest.java
+++ b/modules/apps/portal-language/portal-language-override-test/src/testIntegration/java/com/liferay/portal/language/override/service/persistence/test/PLOEntryPersistenceTest.java
@@ -128,7 +128,9 @@ public class PLOEntryPersistenceTest {
 
 		newPLOEntry.setValue(RandomTestUtil.randomString());
 
-		_ploEntries.add(_persistence.update(newPLOEntry));
+		newPLOEntry = _persistence.update(newPLOEntry);
+
+		_ploEntries.add(newPLOEntry);
 
 		PLOEntry existingPLOEntry = _persistence.findByPrimaryKey(
 			newPLOEntry.getPrimaryKey());
@@ -521,4 +523,4 @@ public class PLOEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:11038434
+// LIFERAY-SERVICE-BUILDER-HASH:-1502411394

--- a/modules/apps/portal-lock/portal-lock-test/src/testIntegration/java/com/liferay/portal/lock/service/persistence/test/LockPersistenceTest.java
+++ b/modules/apps/portal-lock/portal-lock-test/src/testIntegration/java/com/liferay/portal/lock/service/persistence/test/LockPersistenceTest.java
@@ -133,7 +133,9 @@ public class LockPersistenceTest {
 
 		newLock.setExpirationDate(RandomTestUtil.nextDate());
 
-		_locks.add(_persistence.update(newLock));
+		newLock = _persistence.update(newLock);
+
+		_locks.add(newLock);
 
 		Lock existingLock = _persistence.findByPrimaryKey(
 			newLock.getPrimaryKey());
@@ -547,4 +549,4 @@ public class LockPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1149602251
+// LIFERAY-SERVICE-BUILDER-HASH:910464179

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-test/src/testIntegration/java/com/liferay/portal/security/audit/storage/service/persistence/test/AuditEventPersistenceTest.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-test/src/testIntegration/java/com/liferay/portal/security/audit/storage/service/persistence/test/AuditEventPersistenceTest.java
@@ -146,7 +146,9 @@ public class AuditEventPersistenceTest {
 
 		newAuditEvent.setSessionID(RandomTestUtil.randomString());
 
-		_auditEvents.add(_persistence.update(newAuditEvent));
+		newAuditEvent = _persistence.update(newAuditEvent);
+
+		_auditEvents.add(newAuditEvent);
 
 		AuditEvent existingAuditEvent = _persistence.findByPrimaryKey(
 			newAuditEvent.getPrimaryKey());
@@ -492,4 +494,4 @@ public class AuditEventPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1141355602
+// LIFERAY-SERVICE-BUILDER-HASH:-1124926776

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-persistence-test/src/testIntegration/java/com/liferay/portal/security/sso/openid/connect/persistence/service/persistence/test/OpenIdConnectSessionPersistenceTest.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-persistence-test/src/testIntegration/java/com/liferay/portal/security/sso/openid/connect/persistence/service/persistence/test/OpenIdConnectSessionPersistenceTest.java
@@ -142,8 +142,9 @@ public class OpenIdConnectSessionPersistenceTest {
 
 		newOpenIdConnectSession.setSessionId(RandomTestUtil.randomString());
 
-		_openIdConnectSessions.add(
-			_persistence.update(newOpenIdConnectSession));
+		newOpenIdConnectSession = _persistence.update(newOpenIdConnectSession);
+
+		_openIdConnectSessions.add(newOpenIdConnectSession);
 
 		OpenIdConnectSession existingOpenIdConnectSession =
 			_persistence.findByPrimaryKey(
@@ -650,4 +651,4 @@ public class OpenIdConnectSessionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-94933892
+// LIFERAY-SERVICE-BUILDER-HASH:207899442

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-persistence-test/src/testIntegration/java/com/liferay/portal/security/sso/openid/connect/persistence/service/persistence/test/OpenIdConnectUserPersistenceTest.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-persistence-test/src/testIntegration/java/com/liferay/portal/security/sso/openid/connect/persistence/service/persistence/test/OpenIdConnectUserPersistenceTest.java
@@ -125,7 +125,9 @@ public class OpenIdConnectUserPersistenceTest {
 
 		newOpenIdConnectUser.setSubject(RandomTestUtil.randomString());
 
-		_openIdConnectUsers.add(_persistence.update(newOpenIdConnectUser));
+		newOpenIdConnectUser = _persistence.update(newOpenIdConnectUser);
+
+		_openIdConnectUsers.add(newOpenIdConnectUser);
 
 		OpenIdConnectUser existingOpenIdConnectUser =
 			_persistence.findByPrimaryKey(newOpenIdConnectUser.getPrimaryKey());
@@ -516,4 +518,4 @@ public class OpenIdConnectUserPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-173142039
+// LIFERAY-SERVICE-BUILDER-HASH:-221259537

--- a/modules/apps/portal-security/portal-security-service-access-policy-test/src/testIntegration/java/com/liferay/portal/security/service/access/policy/service/persistence/test/SAPEntryPersistenceTest.java
+++ b/modules/apps/portal-security/portal-security-service-access-policy-test/src/testIntegration/java/com/liferay/portal/security/service/access/policy/service/persistence/test/SAPEntryPersistenceTest.java
@@ -136,7 +136,9 @@ public class SAPEntryPersistenceTest {
 
 		newSAPEntry.setTitle(RandomTestUtil.randomString());
 
-		_sapEntries.add(_persistence.update(newSAPEntry));
+		newSAPEntry = _persistence.update(newSAPEntry);
+
+		_sapEntries.add(newSAPEntry);
 
 		SAPEntry existingSAPEntry = _persistence.findByPrimaryKey(
 			newSAPEntry.getPrimaryKey());
@@ -549,4 +551,4 @@ public class SAPEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1954610735
+// LIFERAY-SERVICE-BUILDER-HASH:-806284371

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoActionPersistenceTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoActionPersistenceTest.java
@@ -154,7 +154,9 @@ public class KaleoActionPersistenceTest {
 
 		newKaleoAction.setStatus(RandomTestUtil.nextInt());
 
-		_kaleoActions.add(_persistence.update(newKaleoAction));
+		newKaleoAction = _persistence.update(newKaleoAction);
+
+		_kaleoActions.add(newKaleoAction);
 
 		KaleoAction existingKaleoAction = _persistence.findByPrimaryKey(
 			newKaleoAction.getPrimaryKey());
@@ -564,4 +566,4 @@ public class KaleoActionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1958458401
+// LIFERAY-SERVICE-BUILDER-HASH:628697203

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoConditionPersistenceTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoConditionPersistenceTest.java
@@ -142,7 +142,9 @@ public class KaleoConditionPersistenceTest {
 		newKaleoCondition.setScriptRequiredContexts(
 			RandomTestUtil.randomString());
 
-		_kaleoConditions.add(_persistence.update(newKaleoCondition));
+		newKaleoCondition = _persistence.update(newKaleoCondition);
+
+		_kaleoConditions.add(newKaleoCondition);
 
 		KaleoCondition existingKaleoCondition = _persistence.findByPrimaryKey(
 			newKaleoCondition.getPrimaryKey());
@@ -560,4 +562,4 @@ public class KaleoConditionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:960690956
+// LIFERAY-SERVICE-BUILDER-HASH:-865471702

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoDefinitionPersistenceTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoDefinitionPersistenceTest.java
@@ -150,7 +150,9 @@ public class KaleoDefinitionPersistenceTest {
 
 		newKaleoDefinition.setStatus(RandomTestUtil.nextInt());
 
-		_kaleoDefinitions.add(_persistence.update(newKaleoDefinition));
+		newKaleoDefinition = _persistence.update(newKaleoDefinition);
+
+		_kaleoDefinitions.add(newKaleoDefinition);
 
 		KaleoDefinition existingKaleoDefinition = _persistence.findByPrimaryKey(
 			newKaleoDefinition.getPrimaryKey());
@@ -758,4 +760,4 @@ public class KaleoDefinitionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1227469039
+// LIFERAY-SERVICE-BUILDER-HASH:1056764011

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoDefinitionVersionPersistenceTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoDefinitionVersionPersistenceTest.java
@@ -157,8 +157,10 @@ public class KaleoDefinitionVersionPersistenceTest {
 
 		newKaleoDefinitionVersion.setStatusDate(RandomTestUtil.nextDate());
 
-		_kaleoDefinitionVersions.add(
-			_persistence.update(newKaleoDefinitionVersion));
+		newKaleoDefinitionVersion = _persistence.update(
+			newKaleoDefinitionVersion);
+
+		_kaleoDefinitionVersions.add(newKaleoDefinitionVersion);
 
 		KaleoDefinitionVersion existingKaleoDefinitionVersion =
 			_persistence.findByPrimaryKey(
@@ -658,4 +660,4 @@ public class KaleoDefinitionVersionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-267365374
+// LIFERAY-SERVICE-BUILDER-HASH:670101364

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoInstancePersistenceTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoInstancePersistenceTest.java
@@ -150,7 +150,9 @@ public class KaleoInstancePersistenceTest {
 
 		newKaleoInstance.setWorkflowContext(RandomTestUtil.randomString());
 
-		_kaleoInstances.add(_persistence.update(newKaleoInstance));
+		newKaleoInstance = _persistence.update(newKaleoInstance);
+
+		_kaleoInstances.add(newKaleoInstance);
 
 		KaleoInstance existingKaleoInstance = _persistence.findByPrimaryKey(
 			newKaleoInstance.getPrimaryKey());
@@ -650,4 +652,4 @@ public class KaleoInstancePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1269012157
+// LIFERAY-SERVICE-BUILDER-HASH:218049073

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoInstanceTokenPersistenceTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoInstanceTokenPersistenceTest.java
@@ -150,7 +150,9 @@ public class KaleoInstanceTokenPersistenceTest {
 
 		newKaleoInstanceToken.setCompletionDate(RandomTestUtil.nextDate());
 
-		_kaleoInstanceTokens.add(_persistence.update(newKaleoInstanceToken));
+		newKaleoInstanceToken = _persistence.update(newKaleoInstanceToken);
+
+		_kaleoInstanceTokens.add(newKaleoInstanceToken);
 
 		KaleoInstanceToken existingKaleoInstanceToken =
 			_persistence.findByPrimaryKey(
@@ -567,4 +569,4 @@ public class KaleoInstanceTokenPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:478906127
+// LIFERAY-SERVICE-BUILDER-HASH:544838431

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoLogPersistenceTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoLogPersistenceTest.java
@@ -174,7 +174,9 @@ public class KaleoLogPersistenceTest {
 
 		newKaleoLog.setWorkflowContext(RandomTestUtil.randomString());
 
-		_kaleoLogs.add(_persistence.update(newKaleoLog));
+		newKaleoLog = _persistence.update(newKaleoLog);
+
+		_kaleoLogs.add(newKaleoLog);
 
 		KaleoLog existingKaleoLog = _persistence.findByPrimaryKey(
 			newKaleoLog.getPrimaryKey());
@@ -639,4 +641,4 @@ public class KaleoLogPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1154988301
+// LIFERAY-SERVICE-BUILDER-HASH:760193821

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoNodePersistenceTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoNodePersistenceTest.java
@@ -144,7 +144,9 @@ public class KaleoNodePersistenceTest {
 
 		newKaleoNode.setTerminal(RandomTestUtil.randomBoolean());
 
-		_kaleoNodes.add(_persistence.update(newKaleoNode));
+		newKaleoNode = _persistence.update(newKaleoNode);
+
+		_kaleoNodes.add(newKaleoNode);
 
 		KaleoNode existingKaleoNode = _persistence.findByPrimaryKey(
 			newKaleoNode.getPrimaryKey());
@@ -503,4 +505,4 @@ public class KaleoNodePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1433396725
+// LIFERAY-SERVICE-BUILDER-HASH:195095991

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoNodeSettingPersistenceTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoNodeSettingPersistenceTest.java
@@ -132,7 +132,9 @@ public class KaleoNodeSettingPersistenceTest {
 
 		newKaleoNodeSetting.setValue(RandomTestUtil.randomString());
 
-		_kaleoNodeSettings.add(_persistence.update(newKaleoNodeSetting));
+		newKaleoNodeSetting = _persistence.update(newKaleoNodeSetting);
+
+		_kaleoNodeSettings.add(newKaleoNodeSetting);
 
 		KaleoNodeSetting existingKaleoNodeSetting =
 			_persistence.findByPrimaryKey(newKaleoNodeSetting.getPrimaryKey());
@@ -533,4 +535,4 @@ public class KaleoNodeSettingPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-656438863
+// LIFERAY-SERVICE-BUILDER-HASH:880342261

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoNotificationPersistenceTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoNotificationPersistenceTest.java
@@ -151,7 +151,9 @@ public class KaleoNotificationPersistenceTest {
 		newKaleoNotification.setNotificationTypes(
 			RandomTestUtil.randomString());
 
-		_kaleoNotifications.add(_persistence.update(newKaleoNotification));
+		newKaleoNotification = _persistence.update(newKaleoNotification);
+
+		_kaleoNotifications.add(newKaleoNotification);
 
 		KaleoNotification existingKaleoNotification =
 			_persistence.findByPrimaryKey(newKaleoNotification.getPrimaryKey());
@@ -558,4 +560,4 @@ public class KaleoNotificationPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1303351294
+// LIFERAY-SERVICE-BUILDER-HASH:-1274619000

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoNotificationRecipientPersistenceTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoNotificationRecipientPersistenceTest.java
@@ -166,8 +166,10 @@ public class KaleoNotificationRecipientPersistenceTest {
 		newKaleoNotificationRecipient.setNotificationReceptionType(
 			RandomTestUtil.randomString(3));
 
-		_kaleoNotificationRecipients.add(
-			_persistence.update(newKaleoNotificationRecipient));
+		newKaleoNotificationRecipient = _persistence.update(
+			newKaleoNotificationRecipient);
+
+		_kaleoNotificationRecipients.add(newKaleoNotificationRecipient);
 
 		KaleoNotificationRecipient existingKaleoNotificationRecipient =
 			_persistence.findByPrimaryKey(
@@ -613,4 +615,4 @@ public class KaleoNotificationRecipientPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:372870470
+// LIFERAY-SERVICE-BUILDER-HASH:248852810

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoTaskAssignmentInstancePersistenceTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoTaskAssignmentInstancePersistenceTest.java
@@ -167,8 +167,10 @@ public class KaleoTaskAssignmentInstancePersistenceTest {
 		newKaleoTaskAssignmentInstance.setCompletionDate(
 			RandomTestUtil.nextDate());
 
-		_kaleoTaskAssignmentInstances.add(
-			_persistence.update(newKaleoTaskAssignmentInstance));
+		newKaleoTaskAssignmentInstance = _persistence.update(
+			newKaleoTaskAssignmentInstance);
+
+		_kaleoTaskAssignmentInstances.add(newKaleoTaskAssignmentInstance);
 
 		KaleoTaskAssignmentInstance existingKaleoTaskAssignmentInstance =
 			_persistence.findByPrimaryKey(
@@ -662,4 +664,4 @@ public class KaleoTaskAssignmentInstancePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:895835129
+// LIFERAY-SERVICE-BUILDER-HASH:1096969283

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoTaskAssignmentPersistenceTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoTaskAssignmentPersistenceTest.java
@@ -155,7 +155,9 @@ public class KaleoTaskAssignmentPersistenceTest {
 		newKaleoTaskAssignment.setAssigneeScriptRequiredContexts(
 			RandomTestUtil.randomString());
 
-		_kaleoTaskAssignments.add(_persistence.update(newKaleoTaskAssignment));
+		newKaleoTaskAssignment = _persistence.update(newKaleoTaskAssignment);
+
+		_kaleoTaskAssignments.add(newKaleoTaskAssignment);
 
 		KaleoTaskAssignment existingKaleoTaskAssignment =
 			_persistence.findByPrimaryKey(
@@ -573,4 +575,4 @@ public class KaleoTaskAssignmentPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1998538005
+// LIFERAY-SERVICE-BUILDER-HASH:1132352105

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoTaskFormInstancePersistenceTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoTaskFormInstancePersistenceTest.java
@@ -159,8 +159,10 @@ public class KaleoTaskFormInstancePersistenceTest {
 
 		newKaleoTaskFormInstance.setMetadata(RandomTestUtil.randomString());
 
-		_kaleoTaskFormInstances.add(
-			_persistence.update(newKaleoTaskFormInstance));
+		newKaleoTaskFormInstance = _persistence.update(
+			newKaleoTaskFormInstance);
+
+		_kaleoTaskFormInstances.add(newKaleoTaskFormInstance);
 
 		KaleoTaskFormInstance existingKaleoTaskFormInstance =
 			_persistence.findByPrimaryKey(
@@ -669,4 +671,4 @@ public class KaleoTaskFormInstancePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-252434928
+// LIFERAY-SERVICE-BUILDER-HASH:549252802

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoTaskFormPersistenceTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoTaskFormPersistenceTest.java
@@ -156,7 +156,9 @@ public class KaleoTaskFormPersistenceTest {
 
 		newKaleoTaskForm.setPriority(RandomTestUtil.nextInt());
 
-		_kaleoTaskForms.add(_persistence.update(newKaleoTaskForm));
+		newKaleoTaskForm = _persistence.update(newKaleoTaskForm);
+
+		_kaleoTaskForms.add(newKaleoTaskForm);
 
 		KaleoTaskForm existingKaleoTaskForm = _persistence.findByPrimaryKey(
 			newKaleoTaskForm.getPrimaryKey());
@@ -635,4 +637,4 @@ public class KaleoTaskFormPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:671668718
+// LIFERAY-SERVICE-BUILDER-HASH:-119176848

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoTaskInstanceTokenPersistenceTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoTaskInstanceTokenPersistenceTest.java
@@ -164,8 +164,10 @@ public class KaleoTaskInstanceTokenPersistenceTest {
 		newKaleoTaskInstanceToken.setWorkflowContext(
 			RandomTestUtil.randomString());
 
-		_kaleoTaskInstanceTokens.add(
-			_persistence.update(newKaleoTaskInstanceToken));
+		newKaleoTaskInstanceToken = _persistence.update(
+			newKaleoTaskInstanceToken);
+
+		_kaleoTaskInstanceTokens.add(newKaleoTaskInstanceToken);
 
 		KaleoTaskInstanceToken existingKaleoTaskInstanceToken =
 			_persistence.findByPrimaryKey(
@@ -704,4 +706,4 @@ public class KaleoTaskInstanceTokenPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-548191919
+// LIFERAY-SERVICE-BUILDER-HASH:-1204026389

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoTaskPersistenceTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoTaskPersistenceTest.java
@@ -138,7 +138,9 @@ public class KaleoTaskPersistenceTest {
 
 		newKaleoTask.setDescription(RandomTestUtil.randomString());
 
-		_kaleoTasks.add(_persistence.update(newKaleoTask));
+		newKaleoTask = _persistence.update(newKaleoTask);
+
+		_kaleoTasks.add(newKaleoTask);
 
 		KaleoTask existingKaleoTask = _persistence.findByPrimaryKey(
 			newKaleoTask.getPrimaryKey());
@@ -537,4 +539,4 @@ public class KaleoTaskPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:424417598
+// LIFERAY-SERVICE-BUILDER-HASH:1589705424

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoTimerInstanceTokenPersistenceTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoTimerInstanceTokenPersistenceTest.java
@@ -170,8 +170,10 @@ public class KaleoTimerInstanceTokenPersistenceTest {
 		newKaleoTimerInstanceToken.setWorkflowContext(
 			RandomTestUtil.randomString());
 
-		_kaleoTimerInstanceTokens.add(
-			_persistence.update(newKaleoTimerInstanceToken));
+		newKaleoTimerInstanceToken = _persistence.update(
+			newKaleoTimerInstanceToken);
+
+		_kaleoTimerInstanceTokens.add(newKaleoTimerInstanceToken);
 
 		KaleoTimerInstanceToken existingKaleoTimerInstanceToken =
 			_persistence.findByPrimaryKey(
@@ -700,4 +702,4 @@ public class KaleoTimerInstanceTokenPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-653635333
+// LIFERAY-SERVICE-BUILDER-HASH:-2017891503

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoTimerPersistenceTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoTimerPersistenceTest.java
@@ -149,7 +149,9 @@ public class KaleoTimerPersistenceTest {
 
 		newKaleoTimer.setRecurrenceScale(RandomTestUtil.randomString());
 
-		_kaleoTimers.add(_persistence.update(newKaleoTimer));
+		newKaleoTimer = _persistence.update(newKaleoTimer);
+
+		_kaleoTimers.add(newKaleoTimer);
 
 		KaleoTimer existingKaleoTimer = _persistence.findByPrimaryKey(
 			newKaleoTimer.getPrimaryKey());
@@ -532,4 +534,4 @@ public class KaleoTimerPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1460301357
+// LIFERAY-SERVICE-BUILDER-HASH:-1250126303

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoTransitionPersistenceTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoTransitionPersistenceTest.java
@@ -153,7 +153,9 @@ public class KaleoTransitionPersistenceTest {
 
 		newKaleoTransition.setDefaultTransition(RandomTestUtil.randomBoolean());
 
-		_kaleoTransitions.add(_persistence.update(newKaleoTransition));
+		newKaleoTransition = _persistence.update(newKaleoTransition);
+
+		_kaleoTransitions.add(newKaleoTransition);
 
 		KaleoTransition existingKaleoTransition = _persistence.findByPrimaryKey(
 			newKaleoTransition.getPrimaryKey());
@@ -633,4 +635,4 @@ public class KaleoTransitionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1634883322
+// LIFERAY-SERVICE-BUILDER-HASH:-2102990744

--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/orm/test/SQLDateTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/orm/test/SQLDateTest.java
@@ -115,8 +115,6 @@ public class SQLDateTest {
 
 			release.setModifiedDate(new Timestamp(time));
 
-			session.saveOrUpdate(release);
-
 			session.flush();
 
 			session.clear();

--- a/modules/apps/push-notifications/push-notifications-test/src/testIntegration/java/com/liferay/push/notifications/service/persistence/test/PushNotificationsDevicePersistenceTest.java
+++ b/modules/apps/push-notifications/push-notifications-test/src/testIntegration/java/com/liferay/push/notifications/service/persistence/test/PushNotificationsDevicePersistenceTest.java
@@ -129,8 +129,10 @@ public class PushNotificationsDevicePersistenceTest {
 
 		newPushNotificationsDevice.setToken(RandomTestUtil.randomString());
 
-		_pushNotificationsDevices.add(
-			_persistence.update(newPushNotificationsDevice));
+		newPushNotificationsDevice = _persistence.update(
+			newPushNotificationsDevice);
+
+		_pushNotificationsDevices.add(newPushNotificationsDevice);
 
 		PushNotificationsDevice existingPushNotificationsDevice =
 			_persistence.findByPrimaryKey(
@@ -547,4 +549,4 @@ public class PushNotificationsDevicePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1648983621
+// LIFERAY-SERVICE-BUILDER-HASH:-1262352453

--- a/modules/apps/reading-time/reading-time-test/src/testIntegration/java/com/liferay/reading/time/service/persistence/test/ReadingTimeEntryPersistenceTest.java
+++ b/modules/apps/reading-time/reading-time-test/src/testIntegration/java/com/liferay/reading/time/service/persistence/test/ReadingTimeEntryPersistenceTest.java
@@ -131,7 +131,9 @@ public class ReadingTimeEntryPersistenceTest {
 
 		newReadingTimeEntry.setReadingTime(RandomTestUtil.nextLong());
 
-		_readingTimeEntries.add(_persistence.update(newReadingTimeEntry));
+		newReadingTimeEntry = _persistence.update(newReadingTimeEntry);
+
+		_readingTimeEntries.add(newReadingTimeEntry);
 
 		ReadingTimeEntry existingReadingTimeEntry =
 			_persistence.findByPrimaryKey(newReadingTimeEntry.getPrimaryKey());
@@ -568,4 +570,4 @@ public class ReadingTimeEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1382223790
+// LIFERAY-SERVICE-BUILDER-HASH:736700506

--- a/modules/apps/redirect/redirect-test/src/testIntegration/java/com/liferay/redirect/service/persistence/test/RedirectEntryPersistenceTest.java
+++ b/modules/apps/redirect/redirect-test/src/testIntegration/java/com/liferay/redirect/service/persistence/test/RedirectEntryPersistenceTest.java
@@ -141,7 +141,9 @@ public class RedirectEntryPersistenceTest {
 
 		newRedirectEntry.setSourceURL(RandomTestUtil.randomString());
 
-		_redirectEntries.add(_persistence.update(newRedirectEntry));
+		newRedirectEntry = _persistence.update(newRedirectEntry);
+
+		_redirectEntries.add(newRedirectEntry);
 
 		RedirectEntry existingRedirectEntry = _persistence.findByPrimaryKey(
 			newRedirectEntry.getPrimaryKey());
@@ -624,4 +626,4 @@ public class RedirectEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-891073831
+// LIFERAY-SERVICE-BUILDER-HASH:1939766401

--- a/modules/apps/redirect/redirect-test/src/testIntegration/java/com/liferay/redirect/service/persistence/test/RedirectNotFoundEntryPersistenceTest.java
+++ b/modules/apps/redirect/redirect-test/src/testIntegration/java/com/liferay/redirect/service/persistence/test/RedirectNotFoundEntryPersistenceTest.java
@@ -133,8 +133,10 @@ public class RedirectNotFoundEntryPersistenceTest {
 
 		newRedirectNotFoundEntry.setUrl(RandomTestUtil.randomString());
 
-		_redirectNotFoundEntries.add(
-			_persistence.update(newRedirectNotFoundEntry));
+		newRedirectNotFoundEntry = _persistence.update(
+			newRedirectNotFoundEntry);
+
+		_redirectNotFoundEntries.add(newRedirectNotFoundEntry);
 
 		RedirectNotFoundEntry existingRedirectNotFoundEntry =
 			_persistence.findByPrimaryKey(
@@ -564,4 +566,4 @@ public class RedirectNotFoundEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1512499754
+// LIFERAY-SERVICE-BUILDER-HASH:888531954

--- a/modules/apps/saved-content/saved-content-test/src/testIntegration/java/com/liferay/saved/content/service/persistence/test/SavedContentEntryPersistenceTest.java
+++ b/modules/apps/saved-content/saved-content-test/src/testIntegration/java/com/liferay/saved/content/service/persistence/test/SavedContentEntryPersistenceTest.java
@@ -138,7 +138,9 @@ public class SavedContentEntryPersistenceTest {
 
 		newSavedContentEntry.setClassPK(RandomTestUtil.nextLong());
 
-		_savedContentEntries.add(_persistence.update(newSavedContentEntry));
+		newSavedContentEntry = _persistence.update(newSavedContentEntry);
+
+		_savedContentEntries.add(newSavedContentEntry);
 
 		SavedContentEntry existingSavedContentEntry =
 			_persistence.findByPrimaryKey(newSavedContentEntry.getPrimaryKey());
@@ -708,4 +710,4 @@ public class SavedContentEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-361224957
+// LIFERAY-SERVICE-BUILDER-HASH:474436523

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/persistence/test/SegmentsEntryPersistenceTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/persistence/test/SegmentsEntryPersistenceTest.java
@@ -151,7 +151,9 @@ public class SegmentsEntryPersistenceTest {
 
 		newSegmentsEntry.setLastPublishDate(RandomTestUtil.nextDate());
 
-		_segmentsEntries.add(_persistence.update(newSegmentsEntry));
+		newSegmentsEntry = _persistence.update(newSegmentsEntry);
+
+		_segmentsEntries.add(newSegmentsEntry);
 
 		SegmentsEntry existingSegmentsEntry = _persistence.findByPrimaryKey(
 			newSegmentsEntry.getPrimaryKey());
@@ -769,4 +771,4 @@ public class SegmentsEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:316052919
+// LIFERAY-SERVICE-BUILDER-HASH:717790671

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/persistence/test/SegmentsEntryRelPersistenceTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/persistence/test/SegmentsEntryRelPersistenceTest.java
@@ -133,7 +133,9 @@ public class SegmentsEntryRelPersistenceTest {
 
 		newSegmentsEntryRel.setClassPK(RandomTestUtil.nextLong());
 
-		_segmentsEntryRels.add(_persistence.update(newSegmentsEntryRel));
+		newSegmentsEntryRel = _persistence.update(newSegmentsEntryRel);
+
+		_segmentsEntryRels.add(newSegmentsEntryRel);
 
 		SegmentsEntryRel existingSegmentsEntryRel =
 			_persistence.findByPrimaryKey(newSegmentsEntryRel.getPrimaryKey());
@@ -563,4 +565,4 @@ public class SegmentsEntryRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1499810454
+// LIFERAY-SERVICE-BUILDER-HASH:1491048524

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/persistence/test/SegmentsEntryRolePersistenceTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/persistence/test/SegmentsEntryRolePersistenceTest.java
@@ -130,7 +130,9 @@ public class SegmentsEntryRolePersistenceTest {
 
 		newSegmentsEntryRole.setRoleId(RandomTestUtil.nextLong());
 
-		_segmentsEntryRoles.add(_persistence.update(newSegmentsEntryRole));
+		newSegmentsEntryRole = _persistence.update(newSegmentsEntryRole);
+
+		_segmentsEntryRoles.add(newSegmentsEntryRole);
 
 		SegmentsEntryRole existingSegmentsEntryRole =
 			_persistence.findByPrimaryKey(newSegmentsEntryRole.getPrimaryKey());
@@ -537,4 +539,4 @@ public class SegmentsEntryRolePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:753778487
+// LIFERAY-SERVICE-BUILDER-HASH:-2089390819

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/persistence/test/SegmentsExperienceAudienceEntryRelPersistenceTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/persistence/test/SegmentsExperienceAudienceEntryRelPersistenceTest.java
@@ -155,8 +155,11 @@ public class SegmentsExperienceAudienceEntryRelPersistenceTest {
 		newSegmentsExperienceAudienceEntryRel.setSegmentsExperienceERC(
 			RandomTestUtil.randomString());
 
+		newSegmentsExperienceAudienceEntryRel = _persistence.update(
+			newSegmentsExperienceAudienceEntryRel);
+
 		_segmentsExperienceAudienceEntryRels.add(
-			_persistence.update(newSegmentsExperienceAudienceEntryRel));
+			newSegmentsExperienceAudienceEntryRel);
 
 		SegmentsExperienceAudienceEntryRel
 			existingSegmentsExperienceAudienceEntryRel =
@@ -695,4 +698,4 @@ public class SegmentsExperienceAudienceEntryRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1160698662
+// LIFERAY-SERVICE-BUILDER-HASH:654716268

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/persistence/test/SegmentsExperiencePersistenceTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/persistence/test/SegmentsExperiencePersistenceTest.java
@@ -159,7 +159,9 @@ public class SegmentsExperiencePersistenceTest {
 
 		newSegmentsExperience.setLastPublishDate(RandomTestUtil.nextDate());
 
-		_segmentsExperiences.add(_persistence.update(newSegmentsExperience));
+		newSegmentsExperience = _persistence.update(newSegmentsExperience);
+
+		_segmentsExperiences.add(newSegmentsExperience);
 
 		SegmentsExperience existingSegmentsExperience =
 			_persistence.findByPrimaryKey(
@@ -862,4 +864,4 @@ public class SegmentsExperiencePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1462912712
+// LIFERAY-SERVICE-BUILDER-HASH:543106300

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/persistence/test/SegmentsExperimentPersistenceTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/persistence/test/SegmentsExperimentPersistenceTest.java
@@ -152,7 +152,9 @@ public class SegmentsExperimentPersistenceTest {
 
 		newSegmentsExperiment.setStatus(RandomTestUtil.nextInt());
 
-		_segmentsExperiments.add(_persistence.update(newSegmentsExperiment));
+		newSegmentsExperiment = _persistence.update(newSegmentsExperiment);
+
+		_segmentsExperiments.add(newSegmentsExperiment);
 
 		SegmentsExperiment existingSegmentsExperiment =
 			_persistence.findByPrimaryKey(
@@ -698,4 +700,4 @@ public class SegmentsExperimentPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:475662220
+// LIFERAY-SERVICE-BUILDER-HASH:-196525270

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/persistence/test/SegmentsExperimentRelPersistenceTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/persistence/test/SegmentsExperimentRelPersistenceTest.java
@@ -140,8 +140,10 @@ public class SegmentsExperimentRelPersistenceTest {
 
 		newSegmentsExperimentRel.setSplit(RandomTestUtil.nextDouble());
 
-		_segmentsExperimentRels.add(
-			_persistence.update(newSegmentsExperimentRel));
+		newSegmentsExperimentRel = _persistence.update(
+			newSegmentsExperimentRel);
+
+		_segmentsExperimentRels.add(newSegmentsExperimentRel);
 
 		SegmentsExperimentRel existingSegmentsExperimentRel =
 			_persistence.findByPrimaryKey(
@@ -589,4 +591,4 @@ public class SegmentsExperimentRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1645833203
+// LIFERAY-SERVICE-BUILDER-HASH:-335183991

--- a/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/service/persistence/test/SharingEntryPersistenceTest.java
+++ b/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/service/persistence/test/SharingEntryPersistenceTest.java
@@ -146,7 +146,9 @@ public class SharingEntryPersistenceTest {
 
 		newSharingEntry.setExpirationDate(RandomTestUtil.nextDate());
 
-		_sharingEntries.add(_persistence.update(newSharingEntry));
+		newSharingEntry = _persistence.update(newSharingEntry);
+
+		_sharingEntries.add(newSharingEntry);
 
 		SharingEntry existingSharingEntry = _persistence.findByPrimaryKey(
 			newSharingEntry.getPrimaryKey());
@@ -730,4 +732,4 @@ public class SharingEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-69881419
+// LIFERAY-SERVICE-BUILDER-HASH:482754459

--- a/modules/apps/site-navigation/site-navigation-test/src/testIntegration/java/com/liferay/site/navigation/service/persistence/test/SiteNavigationMenuItemPersistenceTest.java
+++ b/modules/apps/site-navigation/site-navigation-test/src/testIntegration/java/com/liferay/site/navigation/service/persistence/test/SiteNavigationMenuItemPersistenceTest.java
@@ -154,8 +154,10 @@ public class SiteNavigationMenuItemPersistenceTest {
 
 		newSiteNavigationMenuItem.setLastPublishDate(RandomTestUtil.nextDate());
 
-		_siteNavigationMenuItems.add(
-			_persistence.update(newSiteNavigationMenuItem));
+		newSiteNavigationMenuItem = _persistence.update(
+			newSiteNavigationMenuItem);
+
+		_siteNavigationMenuItems.add(newSiteNavigationMenuItem);
 
 		SiteNavigationMenuItem existingSiteNavigationMenuItem =
 			_persistence.findByPrimaryKey(
@@ -739,4 +741,4 @@ public class SiteNavigationMenuItemPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:484801794
+// LIFERAY-SERVICE-BUILDER-HASH:1881215620

--- a/modules/apps/site-navigation/site-navigation-test/src/testIntegration/java/com/liferay/site/navigation/service/persistence/test/SiteNavigationMenuPersistenceTest.java
+++ b/modules/apps/site-navigation/site-navigation-test/src/testIntegration/java/com/liferay/site/navigation/service/persistence/test/SiteNavigationMenuPersistenceTest.java
@@ -146,7 +146,9 @@ public class SiteNavigationMenuPersistenceTest {
 
 		newSiteNavigationMenu.setLastPublishDate(RandomTestUtil.nextDate());
 
-		_siteNavigationMenus.add(_persistence.update(newSiteNavigationMenu));
+		newSiteNavigationMenu = _persistence.update(newSiteNavigationMenu);
+
+		_siteNavigationMenus.add(newSiteNavigationMenu);
 
 		SiteNavigationMenu existingSiteNavigationMenu =
 			_persistence.findByPrimaryKey(
@@ -729,4 +731,4 @@ public class SiteNavigationMenuPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1169645437
+// LIFERAY-SERVICE-BUILDER-HASH:-1805045977

--- a/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/service/persistence/test/SiteFriendlyURLPersistenceTest.java
+++ b/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/service/persistence/test/SiteFriendlyURLPersistenceTest.java
@@ -133,7 +133,9 @@ public class SiteFriendlyURLPersistenceTest {
 
 		newSiteFriendlyURL.setLastPublishDate(RandomTestUtil.nextDate());
 
-		_siteFriendlyURLs.add(_persistence.update(newSiteFriendlyURL));
+		newSiteFriendlyURL = _persistence.update(newSiteFriendlyURL);
+
+		_siteFriendlyURLs.add(newSiteFriendlyURL);
 
 		SiteFriendlyURL existingSiteFriendlyURL = _persistence.findByPrimaryKey(
 			newSiteFriendlyURL.getPrimaryKey());
@@ -629,4 +631,4 @@ public class SiteFriendlyURLPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1652987541
+// LIFERAY-SERVICE-BUILDER-HASH:-1181561529

--- a/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/service/persistence/test/StyleBookEntryPersistenceTest.java
+++ b/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/service/persistence/test/StyleBookEntryPersistenceTest.java
@@ -151,7 +151,9 @@ public class StyleBookEntryPersistenceTest {
 
 		newStyleBookEntry.setThemeId(RandomTestUtil.randomString());
 
-		_styleBookEntries.add(_persistence.update(newStyleBookEntry));
+		newStyleBookEntry = _persistence.update(newStyleBookEntry);
+
+		_styleBookEntries.add(newStyleBookEntry);
 
 		StyleBookEntry existingStyleBookEntry = _persistence.findByPrimaryKey(
 			newStyleBookEntry.getPrimaryKey());
@@ -1002,4 +1004,4 @@ public class StyleBookEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1830352404
+// LIFERAY-SERVICE-BUILDER-HASH:-1918586398

--- a/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/service/persistence/test/StyleBookEntryVersionPersistenceTest.java
+++ b/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/service/persistence/test/StyleBookEntryVersionPersistenceTest.java
@@ -155,8 +155,10 @@ public class StyleBookEntryVersionPersistenceTest {
 
 		newStyleBookEntryVersion.setThemeId(RandomTestUtil.randomString());
 
-		_styleBookEntryVersions.add(
-			_persistence.update(newStyleBookEntryVersion));
+		newStyleBookEntryVersion = _persistence.update(
+			newStyleBookEntryVersion);
+
+		_styleBookEntryVersions.add(newStyleBookEntryVersion);
 
 		StyleBookEntryVersion existingStyleBookEntryVersion =
 			_persistence.findByPrimaryKey(
@@ -829,4 +831,4 @@ public class StyleBookEntryVersionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:621762665
+// LIFERAY-SERVICE-BUILDER-HASH:-1781155025

--- a/modules/apps/subscription/subscription-test/src/testIntegration/java/com/liferay/subscription/service/persistence/test/SubscriptionPersistenceTest.java
+++ b/modules/apps/subscription/subscription-test/src/testIntegration/java/com/liferay/subscription/service/persistence/test/SubscriptionPersistenceTest.java
@@ -133,7 +133,9 @@ public class SubscriptionPersistenceTest {
 
 		newSubscription.setFrequency(RandomTestUtil.randomString());
 
-		_subscriptions.add(_persistence.update(newSubscription));
+		newSubscription = _persistence.update(newSubscription);
+
+		_subscriptions.add(newSubscription);
 
 		Subscription existingSubscription = _persistence.findByPrimaryKey(
 			newSubscription.getPrimaryKey());
@@ -589,4 +591,4 @@ public class SubscriptionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-261312952
+// LIFERAY-SERVICE-BUILDER-HASH:-1914057814

--- a/modules/apps/template/template-test/src/testIntegration/java/com/liferay/template/service/persistence/test/TemplateEntryPersistenceTest.java
+++ b/modules/apps/template/template-test/src/testIntegration/java/com/liferay/template/service/persistence/test/TemplateEntryPersistenceTest.java
@@ -142,7 +142,9 @@ public class TemplateEntryPersistenceTest {
 
 		newTemplateEntry.setLastPublishDate(RandomTestUtil.nextDate());
 
-		_templateEntries.add(_persistence.update(newTemplateEntry));
+		newTemplateEntry = _persistence.update(newTemplateEntry);
+
+		_templateEntries.add(newTemplateEntry);
 
 		TemplateEntry existingTemplateEntry = _persistence.findByPrimaryKey(
 			newTemplateEntry.getPrimaryKey());
@@ -660,4 +662,4 @@ public class TemplateEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2011807626
+// LIFERAY-SERVICE-BUILDER-HASH:1365928798

--- a/modules/apps/translation/translation-test/src/testIntegration/java/com/liferay/translation/service/persistence/test/TranslationEntryPersistenceTest.java
+++ b/modules/apps/translation/translation-test/src/testIntegration/java/com/liferay/translation/service/persistence/test/TranslationEntryPersistenceTest.java
@@ -147,7 +147,9 @@ public class TranslationEntryPersistenceTest {
 
 		newTranslationEntry.setStatusDate(RandomTestUtil.nextDate());
 
-		_translationEntries.add(_persistence.update(newTranslationEntry));
+		newTranslationEntry = _persistence.update(newTranslationEntry);
+
+		_translationEntries.add(newTranslationEntry);
 
 		TranslationEntry existingTranslationEntry =
 			_persistence.findByPrimaryKey(newTranslationEntry.getPrimaryKey());
@@ -636,4 +638,4 @@ public class TranslationEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-577750310
+// LIFERAY-SERVICE-BUILDER-HASH:164542002

--- a/modules/apps/trash/trash-test/src/testIntegration/java/com/liferay/trash/service/persistence/test/TrashEntryPersistenceTest.java
+++ b/modules/apps/trash/trash-test/src/testIntegration/java/com/liferay/trash/service/persistence/test/TrashEntryPersistenceTest.java
@@ -135,7 +135,9 @@ public class TrashEntryPersistenceTest {
 
 		newTrashEntry.setStatus(RandomTestUtil.nextInt());
 
-		_trashEntries.add(_persistence.update(newTrashEntry));
+		newTrashEntry = _persistence.update(newTrashEntry);
+
+		_trashEntries.add(newTrashEntry);
 
 		TrashEntry existingTrashEntry = _persistence.findByPrimaryKey(
 			newTrashEntry.getPrimaryKey());
@@ -554,4 +556,4 @@ public class TrashEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-194174156
+// LIFERAY-SERVICE-BUILDER-HASH:496176178

--- a/modules/apps/trash/trash-test/src/testIntegration/java/com/liferay/trash/service/persistence/test/TrashVersionPersistenceTest.java
+++ b/modules/apps/trash/trash-test/src/testIntegration/java/com/liferay/trash/service/persistence/test/TrashVersionPersistenceTest.java
@@ -126,7 +126,9 @@ public class TrashVersionPersistenceTest {
 
 		newTrashVersion.setStatus(RandomTestUtil.nextInt());
 
-		_trashVersions.add(_persistence.update(newTrashVersion));
+		newTrashVersion = _persistence.update(newTrashVersion);
+
+		_trashVersions.add(newTrashVersion);
 
 		TrashVersion existingTrashVersion = _persistence.findByPrimaryKey(
 			newTrashVersion.getPrimaryKey());
@@ -512,4 +514,4 @@ public class TrashVersionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1856086181
+// LIFERAY-SERVICE-BUILDER-HASH:2061438851

--- a/modules/apps/view-count/view-count-service/src/main/java/com/liferay/view/count/service/persistence/impl/ViewCountEntryFinderImpl.java
+++ b/modules/apps/view-count/view-count-service/src/main/java/com/liferay/view/count/service/persistence/impl/ViewCountEntryFinderImpl.java
@@ -52,8 +52,6 @@ public class ViewCountEntryFinderImpl
 			else {
 				viewCountEntry.setViewCount(
 					viewCountEntry.getViewCount() + increment);
-
-				session.saveOrUpdate(viewCountEntry);
 			}
 
 			_entityCache.putResult(

--- a/modules/apps/view-count/view-count-test/src/testIntegration/java/com/liferay/view/count/service/persistence/test/ViewCountEntryPersistenceTest.java
+++ b/modules/apps/view-count/view-count-test/src/testIntegration/java/com/liferay/view/count/service/persistence/test/ViewCountEntryPersistenceTest.java
@@ -113,7 +113,9 @@ public class ViewCountEntryPersistenceTest {
 
 		newViewCountEntry.setViewCount(RandomTestUtil.nextLong());
 
-		_viewCountEntries.add(_persistence.update(newViewCountEntry));
+		newViewCountEntry = _persistence.update(newViewCountEntry);
+
+		_viewCountEntries.add(newViewCountEntry);
 
 		ViewCountEntry existingViewCountEntry = _persistence.findByPrimaryKey(
 			newViewCountEntry.getPrimaryKey());
@@ -413,4 +415,4 @@ public class ViewCountEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-838149116
+// LIFERAY-SERVICE-BUILDER-HASH:-1242377130

--- a/modules/apps/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/service/persistence/test/WikiNodePersistenceTest.java
+++ b/modules/apps/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/service/persistence/test/WikiNodePersistenceTest.java
@@ -152,7 +152,9 @@ public class WikiNodePersistenceTest {
 
 		newWikiNode.setStatusDate(RandomTestUtil.nextDate());
 
-		_wikiNodes.add(_persistence.update(newWikiNode));
+		newWikiNode = _persistence.update(newWikiNode);
+
+		_wikiNodes.add(newWikiNode);
 
 		WikiNode existingWikiNode = _persistence.findByPrimaryKey(
 			newWikiNode.getPrimaryKey());
@@ -691,4 +693,4 @@ public class WikiNodePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-67456849
+// LIFERAY-SERVICE-BUILDER-HASH:-1706430213

--- a/modules/apps/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/service/persistence/test/WikiPagePersistenceTest.java
+++ b/modules/apps/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/service/persistence/test/WikiPagePersistenceTest.java
@@ -164,7 +164,9 @@ public class WikiPagePersistenceTest {
 
 		newWikiPage.setStatusDate(RandomTestUtil.nextDate());
 
-		_wikiPages.add(_persistence.update(newWikiPage));
+		newWikiPage = _persistence.update(newWikiPage);
+
+		_wikiPages.add(newWikiPage);
 
 		WikiPage existingWikiPage = _persistence.findByPrimaryKey(
 			newWikiPage.getPrimaryKey());
@@ -1001,4 +1003,4 @@ public class WikiPagePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-297660656
+// LIFERAY-SERVICE-BUILDER-HASH:22655094

--- a/modules/apps/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/service/persistence/test/WikiPageResourcePersistenceTest.java
+++ b/modules/apps/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/service/persistence/test/WikiPageResourcePersistenceTest.java
@@ -124,7 +124,9 @@ public class WikiPageResourcePersistenceTest {
 
 		newWikiPageResource.setTitle(RandomTestUtil.randomString());
 
-		_wikiPageResources.add(_persistence.update(newWikiPageResource));
+		newWikiPageResource = _persistence.update(newWikiPageResource);
+
+		_wikiPageResources.add(newWikiPageResource);
 
 		WikiPageResource existingWikiPageResource =
 			_persistence.findByPrimaryKey(newWikiPageResource.getPrimaryKey());
@@ -536,4 +538,4 @@ public class WikiPageResourcePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1227280426
+// LIFERAY-SERVICE-BUILDER-HASH:-49912664

--- a/modules/dxp/apps/commerce/commerce-machine-learning-forecast-alert-test/src/testIntegration/java/com/liferay/commerce/machine/learning/forecast/alert/service/persistence/test/CommerceMLForecastAlertEntryPersistenceTest.java
+++ b/modules/dxp/apps/commerce/commerce-machine-learning-forecast-alert-test/src/testIntegration/java/com/liferay/commerce/machine/learning/forecast/alert/service/persistence/test/CommerceMLForecastAlertEntryPersistenceTest.java
@@ -150,8 +150,10 @@ public class CommerceMLForecastAlertEntryPersistenceTest {
 
 		newCommerceMLForecastAlertEntry.setStatus(RandomTestUtil.nextInt());
 
-		_commerceMLForecastAlertEntries.add(
-			_persistence.update(newCommerceMLForecastAlertEntry));
+		newCommerceMLForecastAlertEntry = _persistence.update(
+			newCommerceMLForecastAlertEntry);
+
+		_commerceMLForecastAlertEntries.add(newCommerceMLForecastAlertEntry);
 
 		CommerceMLForecastAlertEntry existingCommerceMLForecastAlertEntry =
 			_persistence.findByPrimaryKey(
@@ -690,4 +692,4 @@ public class CommerceMLForecastAlertEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-505970838
+// LIFERAY-SERVICE-BUILDER-HASH:1601129870

--- a/modules/dxp/apps/osb/osb-patcher/osb-patcher-test/src/testIntegration/java/com/liferay/osb/patcher/service/persistence/test/PatcherAccountPersistenceTest.java
+++ b/modules/dxp/apps/osb/osb-patcher/osb-patcher-test/src/testIntegration/java/com/liferay/osb/patcher/service/persistence/test/PatcherAccountPersistenceTest.java
@@ -127,7 +127,9 @@ public class PatcherAccountPersistenceTest {
 
 		newPatcherAccount.setAccountEntryCode(RandomTestUtil.randomString());
 
-		_patcherAccounts.add(_persistence.update(newPatcherAccount));
+		newPatcherAccount = _persistence.update(newPatcherAccount);
+
+		_patcherAccounts.add(newPatcherAccount);
 
 		PatcherAccount existingPatcherAccount = _persistence.findByPrimaryKey(
 			newPatcherAccount.getPrimaryKey());
@@ -518,4 +520,4 @@ public class PatcherAccountPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:362765202
+// LIFERAY-SERVICE-BUILDER-HASH:-1838020886

--- a/modules/dxp/apps/osb/osb-patcher/osb-patcher-test/src/testIntegration/java/com/liferay/osb/patcher/service/persistence/test/PatcherBuildPersistenceTest.java
+++ b/modules/dxp/apps/osb/osb-patcher/osb-patcher-test/src/testIntegration/java/com/liferay/osb/patcher/service/persistence/test/PatcherBuildPersistenceTest.java
@@ -192,7 +192,9 @@ public class PatcherBuildPersistenceTest {
 
 		newPatcherBuild.setStatusDate(RandomTestUtil.nextDate());
 
-		_patcherBuilds.add(_persistence.update(newPatcherBuild));
+		newPatcherBuild = _persistence.update(newPatcherBuild);
+
+		_patcherBuilds.add(newPatcherBuild);
 
 		PatcherBuild existingPatcherBuild = _persistence.findByPrimaryKey(
 			newPatcherBuild.getPrimaryKey());
@@ -859,4 +861,4 @@ public class PatcherBuildPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2142285808
+// LIFERAY-SERVICE-BUILDER-HASH:1067061418

--- a/modules/dxp/apps/osb/osb-patcher/osb-patcher-test/src/testIntegration/java/com/liferay/osb/patcher/service/persistence/test/PatcherBuildRelPersistenceTest.java
+++ b/modules/dxp/apps/osb/osb-patcher/osb-patcher-test/src/testIntegration/java/com/liferay/osb/patcher/service/persistence/test/PatcherBuildRelPersistenceTest.java
@@ -116,7 +116,9 @@ public class PatcherBuildRelPersistenceTest {
 
 		newPatcherBuildRel.setParentPatcherBuildId(RandomTestUtil.nextLong());
 
-		_patcherBuildRels.add(_persistence.update(newPatcherBuildRel));
+		newPatcherBuildRel = _persistence.update(newPatcherBuildRel);
+
+		_patcherBuildRels.add(newPatcherBuildRel);
 
 		PatcherBuildRel existingPatcherBuildRel = _persistence.findByPrimaryKey(
 			newPatcherBuildRel.getPrimaryKey());
@@ -419,4 +421,4 @@ public class PatcherBuildRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1926073329
+// LIFERAY-SERVICE-BUILDER-HASH:-1194142089

--- a/modules/dxp/apps/osb/osb-patcher/osb-patcher-test/src/testIntegration/java/com/liferay/osb/patcher/service/persistence/test/PatcherFixComponentPersistenceTest.java
+++ b/modules/dxp/apps/osb/osb-patcher/osb-patcher-test/src/testIntegration/java/com/liferay/osb/patcher/service/persistence/test/PatcherFixComponentPersistenceTest.java
@@ -127,7 +127,9 @@ public class PatcherFixComponentPersistenceTest {
 
 		newPatcherFixComponent.setName(RandomTestUtil.randomString());
 
-		_patcherFixComponents.add(_persistence.update(newPatcherFixComponent));
+		newPatcherFixComponent = _persistence.update(newPatcherFixComponent);
+
+		_patcherFixComponents.add(newPatcherFixComponent);
 
 		PatcherFixComponent existingPatcherFixComponent =
 			_persistence.findByPrimaryKey(
@@ -517,4 +519,4 @@ public class PatcherFixComponentPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:385024362
+// LIFERAY-SERVICE-BUILDER-HASH:-1354508772

--- a/modules/dxp/apps/osb/osb-patcher/osb-patcher-test/src/testIntegration/java/com/liferay/osb/patcher/service/persistence/test/PatcherFixPackPersistenceTest.java
+++ b/modules/dxp/apps/osb/osb-patcher/osb-patcher-test/src/testIntegration/java/com/liferay/osb/patcher/service/persistence/test/PatcherFixPackPersistenceTest.java
@@ -139,7 +139,9 @@ public class PatcherFixPackPersistenceTest {
 
 		newPatcherFixPack.setStatus(RandomTestUtil.nextInt());
 
-		_patcherFixPacks.add(_persistence.update(newPatcherFixPack));
+		newPatcherFixPack = _persistence.update(newPatcherFixPack);
+
+		_patcherFixPacks.add(newPatcherFixPack);
 
 		PatcherFixPack existingPatcherFixPack = _persistence.findByPrimaryKey(
 			newPatcherFixPack.getPrimaryKey());
@@ -650,4 +652,4 @@ public class PatcherFixPackPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1597246823
+// LIFERAY-SERVICE-BUILDER-HASH:-851539007

--- a/modules/dxp/apps/osb/osb-patcher/osb-patcher-test/src/testIntegration/java/com/liferay/osb/patcher/service/persistence/test/PatcherFixPersistenceTest.java
+++ b/modules/dxp/apps/osb/osb-patcher/osb-patcher-test/src/testIntegration/java/com/liferay/osb/patcher/service/persistence/test/PatcherFixPersistenceTest.java
@@ -168,7 +168,9 @@ public class PatcherFixPersistenceTest {
 
 		newPatcherFix.setStatusDate(RandomTestUtil.nextDate());
 
-		_patcherFixes.add(_persistence.update(newPatcherFix));
+		newPatcherFix = _persistence.update(newPatcherFix);
+
+		_patcherFixes.add(newPatcherFix);
 
 		PatcherFix existingPatcherFix = _persistence.findByPrimaryKey(
 			newPatcherFix.getPrimaryKey());
@@ -663,4 +665,4 @@ public class PatcherFixPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-12522961
+// LIFERAY-SERVICE-BUILDER-HASH:1802317357

--- a/modules/dxp/apps/osb/osb-patcher/osb-patcher-test/src/testIntegration/java/com/liferay/osb/patcher/service/persistence/test/PatcherFixRelPersistenceTest.java
+++ b/modules/dxp/apps/osb/osb-patcher/osb-patcher-test/src/testIntegration/java/com/liferay/osb/patcher/service/persistence/test/PatcherFixRelPersistenceTest.java
@@ -116,7 +116,9 @@ public class PatcherFixRelPersistenceTest {
 
 		newPatcherFixRel.setParentPatcherFixId(RandomTestUtil.nextLong());
 
-		_patcherFixRels.add(_persistence.update(newPatcherFixRel));
+		newPatcherFixRel = _persistence.update(newPatcherFixRel);
+
+		_patcherFixRels.add(newPatcherFixRel);
 
 		PatcherFixRel existingPatcherFixRel = _persistence.findByPrimaryKey(
 			newPatcherFixRel.getPrimaryKey());
@@ -417,4 +419,4 @@ public class PatcherFixRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1059481946
+// LIFERAY-SERVICE-BUILDER-HASH:-1726004644

--- a/modules/dxp/apps/osb/osb-patcher/osb-patcher-test/src/testIntegration/java/com/liferay/osb/patcher/service/persistence/test/PatcherProductVersionPersistenceTest.java
+++ b/modules/dxp/apps/osb/osb-patcher/osb-patcher-test/src/testIntegration/java/com/liferay/osb/patcher/service/persistence/test/PatcherProductVersionPersistenceTest.java
@@ -134,8 +134,10 @@ public class PatcherProductVersionPersistenceTest {
 
 		newPatcherProductVersion.setName(RandomTestUtil.randomString());
 
-		_patcherProductVersions.add(
-			_persistence.update(newPatcherProductVersion));
+		newPatcherProductVersion = _persistence.update(
+			newPatcherProductVersion);
+
+		_patcherProductVersions.add(newPatcherProductVersion);
 
 		PatcherProductVersion existingPatcherProductVersion =
 			_persistence.findByPrimaryKey(
@@ -560,4 +562,4 @@ public class PatcherProductVersionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-522476710
+// LIFERAY-SERVICE-BUILDER-HASH:-1374297588

--- a/modules/dxp/apps/osb/osb-patcher/osb-patcher-test/src/testIntegration/java/com/liferay/osb/patcher/service/persistence/test/PatcherProjectVersionPersistenceTest.java
+++ b/modules/dxp/apps/osb/osb-patcher/osb-patcher-test/src/testIntegration/java/com/liferay/osb/patcher/service/persistence/test/PatcherProjectVersionPersistenceTest.java
@@ -149,8 +149,10 @@ public class PatcherProjectVersionPersistenceTest {
 		newPatcherProjectVersion.setRepositoryName(
 			RandomTestUtil.randomString());
 
-		_patcherProjectVersions.add(
-			_persistence.update(newPatcherProjectVersion));
+		newPatcherProjectVersion = _persistence.update(
+			newPatcherProjectVersion);
+
+		_patcherProjectVersions.add(newPatcherProjectVersion);
 
 		PatcherProjectVersion existingPatcherProjectVersion =
 			_persistence.findByPrimaryKey(
@@ -648,4 +650,4 @@ public class PatcherProjectVersionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1087106044
+// LIFERAY-SERVICE-BUILDER-HASH:725493006

--- a/modules/dxp/apps/osb/osb-patcher/osb-patcher-test/src/testIntegration/java/com/liferay/osb/patcher/service/persistence/test/PatcherTicketHintPersistenceTest.java
+++ b/modules/dxp/apps/osb/osb-patcher/osb-patcher-test/src/testIntegration/java/com/liferay/osb/patcher/service/persistence/test/PatcherTicketHintPersistenceTest.java
@@ -129,7 +129,9 @@ public class PatcherTicketHintPersistenceTest {
 
 		newPatcherTicketHint.setScript(RandomTestUtil.randomString());
 
-		_patcherTicketHints.add(_persistence.update(newPatcherTicketHint));
+		newPatcherTicketHint = _persistence.update(newPatcherTicketHint);
+
+		_patcherTicketHints.add(newPatcherTicketHint);
 
 		PatcherTicketHint existingPatcherTicketHint =
 			_persistence.findByPrimaryKey(newPatcherTicketHint.getPrimaryKey());
@@ -511,4 +513,4 @@ public class PatcherTicketHintPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1230783569
+// LIFERAY-SERVICE-BUILDER-HASH:691676855

--- a/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-test/src/testIntegration/java/com/liferay/portal/reports/engine/console/service/persistence/test/DefinitionPersistenceTest.java
+++ b/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-test/src/testIntegration/java/com/liferay/portal/reports/engine/console/service/persistence/test/DefinitionPersistenceTest.java
@@ -144,7 +144,9 @@ public class DefinitionPersistenceTest {
 
 		newDefinition.setLastPublishDate(RandomTestUtil.nextDate());
 
-		_definitions.add(_persistence.update(newDefinition));
+		newDefinition = _persistence.update(newDefinition);
+
+		_definitions.add(newDefinition);
 
 		Definition existingDefinition = _persistence.findByPrimaryKey(
 			newDefinition.getPrimaryKey());
@@ -595,4 +597,4 @@ public class DefinitionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1815942517
+// LIFERAY-SERVICE-BUILDER-HASH:1868170343

--- a/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-test/src/testIntegration/java/com/liferay/portal/reports/engine/console/service/persistence/test/EntryPersistenceTest.java
+++ b/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-test/src/testIntegration/java/com/liferay/portal/reports/engine/console/service/persistence/test/EntryPersistenceTest.java
@@ -152,7 +152,9 @@ public class EntryPersistenceTest {
 
 		newEntry.setStatus(RandomTestUtil.randomString());
 
-		_entries.add(_persistence.update(newEntry));
+		newEntry = _persistence.update(newEntry);
+
+		_entries.add(newEntry);
 
 		Entry existingEntry = _persistence.findByPrimaryKey(
 			newEntry.getPrimaryKey());
@@ -488,4 +490,4 @@ public class EntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1351570719
+// LIFERAY-SERVICE-BUILDER-HASH:-855877625

--- a/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-test/src/testIntegration/java/com/liferay/portal/reports/engine/console/service/persistence/test/SourcePersistenceTest.java
+++ b/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-test/src/testIntegration/java/com/liferay/portal/reports/engine/console/service/persistence/test/SourcePersistenceTest.java
@@ -144,7 +144,9 @@ public class SourcePersistenceTest {
 
 		newSource.setDriverPassword(RandomTestUtil.randomString());
 
-		_sources.add(_persistence.update(newSource));
+		newSource = _persistence.update(newSource);
+
+		_sources.add(newSource);
 
 		Source existingSource = _persistence.findByPrimaryKey(
 			newSource.getPrimaryKey());
@@ -579,4 +581,4 @@ public class SourcePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:2007166926
+// LIFERAY-SERVICE-BUILDER-HASH:1282373680

--- a/modules/dxp/apps/portal-workflow-kaleo-forms/portal-workflow-kaleo-forms-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/forms/service/persistence/test/KaleoProcessLinkPersistenceTest.java
+++ b/modules/dxp/apps/portal-workflow-kaleo-forms/portal-workflow-kaleo-forms-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/forms/service/persistence/test/KaleoProcessLinkPersistenceTest.java
@@ -121,7 +121,9 @@ public class KaleoProcessLinkPersistenceTest {
 
 		newKaleoProcessLink.setDDMTemplateId(RandomTestUtil.nextLong());
 
-		_kaleoProcessLinks.add(_persistence.update(newKaleoProcessLink));
+		newKaleoProcessLink = _persistence.update(newKaleoProcessLink);
+
+		_kaleoProcessLinks.add(newKaleoProcessLink);
 
 		KaleoProcessLink existingKaleoProcessLink =
 			_persistence.findByPrimaryKey(newKaleoProcessLink.getPrimaryKey());
@@ -494,4 +496,4 @@ public class KaleoProcessLinkPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1847896201
+// LIFERAY-SERVICE-BUILDER-HASH:-1591684145

--- a/modules/dxp/apps/portal-workflow-kaleo-forms/portal-workflow-kaleo-forms-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/forms/service/persistence/test/KaleoProcessPersistenceTest.java
+++ b/modules/dxp/apps/portal-workflow-kaleo-forms/portal-workflow-kaleo-forms-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/forms/service/persistence/test/KaleoProcessPersistenceTest.java
@@ -141,7 +141,9 @@ public class KaleoProcessPersistenceTest {
 
 		newKaleoProcess.setWorkflowDefinitionVersion(RandomTestUtil.nextInt());
 
-		_kaleoProcesses.add(_persistence.update(newKaleoProcess));
+		newKaleoProcess = _persistence.update(newKaleoProcess);
+
+		_kaleoProcesses.add(newKaleoProcess);
 
 		KaleoProcess existingKaleoProcess = _persistence.findByPrimaryKey(
 			newKaleoProcess.getPrimaryKey());
@@ -596,4 +598,4 @@ public class KaleoProcessPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1247289255
+// LIFERAY-SERVICE-BUILDER-HASH:1864413963

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/service/persistence/test/WorkflowMetricsSLADefinitionPersistenceTest.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/service/persistence/test/WorkflowMetricsSLADefinitionPersistenceTest.java
@@ -177,8 +177,10 @@ public class WorkflowMetricsSLADefinitionPersistenceTest {
 		newWorkflowMetricsSLADefinition.setStatusDate(
 			RandomTestUtil.nextDate());
 
-		_workflowMetricsSLADefinitions.add(
-			_persistence.update(newWorkflowMetricsSLADefinition));
+		newWorkflowMetricsSLADefinition = _persistence.update(
+			newWorkflowMetricsSLADefinition);
+
+		_workflowMetricsSLADefinitions.add(newWorkflowMetricsSLADefinition);
 
 		WorkflowMetricsSLADefinition existingWorkflowMetricsSLADefinition =
 			_persistence.findByPrimaryKey(
@@ -796,4 +798,4 @@ public class WorkflowMetricsSLADefinitionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1646211010
+// LIFERAY-SERVICE-BUILDER-HASH:-1858835348

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/service/persistence/test/WorkflowMetricsSLADefinitionVersionPersistenceTest.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/service/persistence/test/WorkflowMetricsSLADefinitionVersionPersistenceTest.java
@@ -192,8 +192,11 @@ public class WorkflowMetricsSLADefinitionVersionPersistenceTest {
 		newWorkflowMetricsSLADefinitionVersion.setStatusDate(
 			RandomTestUtil.nextDate());
 
+		newWorkflowMetricsSLADefinitionVersion = _persistence.update(
+			newWorkflowMetricsSLADefinitionVersion);
+
 		_workflowMetricsSLADefinitionVersions.add(
-			_persistence.update(newWorkflowMetricsSLADefinitionVersion));
+			newWorkflowMetricsSLADefinitionVersion);
 
 		WorkflowMetricsSLADefinitionVersion
 			existingWorkflowMetricsSLADefinitionVersion =
@@ -819,4 +822,4 @@ public class WorkflowMetricsSLADefinitionVersionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-705606509
+// LIFERAY-SERVICE-BUILDER-HASH:-586958223

--- a/modules/dxp/apps/saml/saml-persistence-test/src/testIntegration/java/com/liferay/saml/persistence/service/persistence/test/SamlIbSloMessagePersistenceTest.java
+++ b/modules/dxp/apps/saml/saml-persistence-test/src/testIntegration/java/com/liferay/saml/persistence/service/persistence/test/SamlIbSloMessagePersistenceTest.java
@@ -124,7 +124,9 @@ public class SamlIbSloMessagePersistenceTest {
 		newSamlIbSloMessage.setSamlIdpSessionIndex(
 			RandomTestUtil.randomString());
 
-		_samlIbSloMessages.add(_persistence.update(newSamlIbSloMessage));
+		newSamlIbSloMessage = _persistence.update(newSamlIbSloMessage);
+
+		_samlIbSloMessages.add(newSamlIbSloMessage);
 
 		SamlIbSloMessage existingSamlIbSloMessage =
 			_persistence.findByPrimaryKey(newSamlIbSloMessage.getPrimaryKey());
@@ -490,4 +492,4 @@ public class SamlIbSloMessagePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-916748487
+// LIFERAY-SERVICE-BUILDER-HASH:1133324899

--- a/modules/dxp/apps/saml/saml-persistence-test/src/testIntegration/java/com/liferay/saml/persistence/service/persistence/test/SamlIdpSpConnectionPersistenceTest.java
+++ b/modules/dxp/apps/saml/saml-persistence-test/src/testIntegration/java/com/liferay/saml/persistence/service/persistence/test/SamlIdpSpConnectionPersistenceTest.java
@@ -156,7 +156,9 @@ public class SamlIdpSpConnectionPersistenceTest {
 
 		newSamlIdpSpConnection.setNameIdFormat(RandomTestUtil.randomString());
 
-		_samlIdpSpConnections.add(_persistence.update(newSamlIdpSpConnection));
+		newSamlIdpSpConnection = _persistence.update(newSamlIdpSpConnection);
+
+		_samlIdpSpConnections.add(newSamlIdpSpConnection);
 
 		SamlIdpSpConnection existingSamlIdpSpConnection =
 			_persistence.findByPrimaryKey(
@@ -623,4 +625,4 @@ public class SamlIdpSpConnectionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1370592331
+// LIFERAY-SERVICE-BUILDER-HASH:-2127855473

--- a/modules/dxp/apps/saml/saml-persistence-test/src/testIntegration/java/com/liferay/saml/persistence/service/persistence/test/SamlIdpSpSessionPersistenceTest.java
+++ b/modules/dxp/apps/saml/saml-persistence-test/src/testIntegration/java/com/liferay/saml/persistence/service/persistence/test/SamlIdpSpSessionPersistenceTest.java
@@ -125,7 +125,9 @@ public class SamlIdpSpSessionPersistenceTest {
 
 		newSamlIdpSpSession.setSamlPeerBindingId(RandomTestUtil.nextLong());
 
-		_samlIdpSpSessions.add(_persistence.update(newSamlIdpSpSession));
+		newSamlIdpSpSession = _persistence.update(newSamlIdpSpSession);
+
+		_samlIdpSpSessions.add(newSamlIdpSpSession);
 
 		SamlIdpSpSession existingSamlIdpSpSession =
 			_persistence.findByPrimaryKey(newSamlIdpSpSession.getPrimaryKey());
@@ -448,4 +450,4 @@ public class SamlIdpSpSessionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1105273311
+// LIFERAY-SERVICE-BUILDER-HASH:10343959

--- a/modules/dxp/apps/saml/saml-persistence-test/src/testIntegration/java/com/liferay/saml/persistence/service/persistence/test/SamlIdpSsoSessionPersistenceTest.java
+++ b/modules/dxp/apps/saml/saml-persistence-test/src/testIntegration/java/com/liferay/saml/persistence/service/persistence/test/SamlIdpSsoSessionPersistenceTest.java
@@ -127,7 +127,9 @@ public class SamlIdpSsoSessionPersistenceTest {
 		newSamlIdpSsoSession.setSamlIdpSsoSessionKey(
 			RandomTestUtil.randomString());
 
-		_samlIdpSsoSessions.add(_persistence.update(newSamlIdpSsoSession));
+		newSamlIdpSsoSession = _persistence.update(newSamlIdpSsoSession);
+
+		_samlIdpSsoSessions.add(newSamlIdpSsoSession);
 
 		SamlIdpSsoSession existingSamlIdpSsoSession =
 			_persistence.findByPrimaryKey(newSamlIdpSsoSession.getPrimaryKey());
@@ -523,4 +525,4 @@ public class SamlIdpSsoSessionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:412833869
+// LIFERAY-SERVICE-BUILDER-HASH:-900276253

--- a/modules/dxp/apps/saml/saml-persistence-test/src/testIntegration/java/com/liferay/saml/persistence/service/persistence/test/SamlPeerBindingPersistenceTest.java
+++ b/modules/dxp/apps/saml/saml-persistence-test/src/testIntegration/java/com/liferay/saml/persistence/service/persistence/test/SamlPeerBindingPersistenceTest.java
@@ -136,7 +136,9 @@ public class SamlPeerBindingPersistenceTest {
 
 		newSamlPeerBinding.setSamlNameIdValue(RandomTestUtil.randomString());
 
-		_samlPeerBindings.add(_persistence.update(newSamlPeerBinding));
+		newSamlPeerBinding = _persistence.update(newSamlPeerBinding);
+
+		_samlPeerBindings.add(newSamlPeerBinding);
 
 		SamlPeerBinding existingSamlPeerBinding = _persistence.findByPrimaryKey(
 			newSamlPeerBinding.getPrimaryKey());
@@ -492,4 +494,4 @@ public class SamlPeerBindingPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:390416853
+// LIFERAY-SERVICE-BUILDER-HASH:-316055613

--- a/modules/dxp/apps/saml/saml-persistence-test/src/testIntegration/java/com/liferay/saml/persistence/service/persistence/test/SamlSpAuthRequestPersistenceTest.java
+++ b/modules/dxp/apps/saml/saml-persistence-test/src/testIntegration/java/com/liferay/saml/persistence/service/persistence/test/SamlSpAuthRequestPersistenceTest.java
@@ -125,7 +125,9 @@ public class SamlSpAuthRequestPersistenceTest {
 		newSamlSpAuthRequest.setSamlSpAuthRequestKey(
 			RandomTestUtil.randomString());
 
-		_samlSpAuthRequests.add(_persistence.update(newSamlSpAuthRequest));
+		newSamlSpAuthRequest = _persistence.update(newSamlSpAuthRequest);
+
+		_samlSpAuthRequests.add(newSamlSpAuthRequest);
 
 		SamlSpAuthRequest existingSamlSpAuthRequest =
 			_persistence.findByPrimaryKey(newSamlSpAuthRequest.getPrimaryKey());
@@ -509,4 +511,4 @@ public class SamlSpAuthRequestPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:909221951
+// LIFERAY-SERVICE-BUILDER-HASH:-738323699

--- a/modules/dxp/apps/saml/saml-persistence-test/src/testIntegration/java/com/liferay/saml/persistence/service/persistence/test/SamlSpIdpConnectionPersistenceTest.java
+++ b/modules/dxp/apps/saml/saml-persistence-test/src/testIntegration/java/com/liferay/saml/persistence/service/persistence/test/SamlSpIdpConnectionPersistenceTest.java
@@ -163,7 +163,9 @@ public class SamlSpIdpConnectionPersistenceTest {
 		newSamlSpIdpConnection.setUserIdentifierExpression(
 			RandomTestUtil.randomString());
 
-		_samlSpIdpConnections.add(_persistence.update(newSamlSpIdpConnection));
+		newSamlSpIdpConnection = _persistence.update(newSamlSpIdpConnection);
+
+		_samlSpIdpConnections.add(newSamlSpIdpConnection);
 
 		SamlSpIdpConnection existingSamlSpIdpConnection =
 			_persistence.findByPrimaryKey(
@@ -644,4 +646,4 @@ public class SamlSpIdpConnectionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1116391275
+// LIFERAY-SERVICE-BUILDER-HASH:1559130985

--- a/modules/dxp/apps/saml/saml-persistence-test/src/testIntegration/java/com/liferay/saml/persistence/service/persistence/test/SamlSpMessagePersistenceTest.java
+++ b/modules/dxp/apps/saml/saml-persistence-test/src/testIntegration/java/com/liferay/saml/persistence/service/persistence/test/SamlSpMessagePersistenceTest.java
@@ -123,7 +123,9 @@ public class SamlSpMessagePersistenceTest {
 
 		newSamlSpMessage.setSamlIdpResponseKey(RandomTestUtil.randomString());
 
-		_samlSpMessages.add(_persistence.update(newSamlSpMessage));
+		newSamlSpMessage = _persistence.update(newSamlSpMessage);
+
+		_samlSpMessages.add(newSamlSpMessage);
 
 		SamlSpMessage existingSamlSpMessage = _persistence.findByPrimaryKey(
 			newSamlSpMessage.getPrimaryKey());
@@ -496,4 +498,4 @@ public class SamlSpMessagePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-529848748
+// LIFERAY-SERVICE-BUILDER-HASH:1035552162

--- a/modules/dxp/apps/saml/saml-persistence-test/src/testIntegration/java/com/liferay/saml/persistence/service/persistence/test/SamlSpSessionPersistenceTest.java
+++ b/modules/dxp/apps/saml/saml-persistence-test/src/testIntegration/java/com/liferay/saml/persistence/service/persistence/test/SamlSpSessionPersistenceTest.java
@@ -135,7 +135,9 @@ public class SamlSpSessionPersistenceTest {
 
 		newSamlSpSession.setTerminated(RandomTestUtil.randomBoolean());
 
-		_samlSpSessions.add(_persistence.update(newSamlSpSession));
+		newSamlSpSession = _persistence.update(newSamlSpSession);
+
+		_samlSpSessions.add(newSamlSpSession);
 
 		SamlSpSession existingSamlSpSession = _persistence.findByPrimaryKey(
 			newSamlSpSession.getPrimaryKey());
@@ -557,4 +559,4 @@ public class SamlSpSessionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1629144930
+// LIFERAY-SERVICE-BUILDER-HASH:-756478840

--- a/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/service/persistence/test/SXPBlueprintPersistenceTest.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/service/persistence/test/SXPBlueprintPersistenceTest.java
@@ -149,7 +149,9 @@ public class SXPBlueprintPersistenceTest {
 
 		newSXPBlueprint.setStatusDate(RandomTestUtil.nextDate());
 
-		_sxpBlueprints.add(_persistence.update(newSXPBlueprint));
+		newSXPBlueprint = _persistence.update(newSXPBlueprint);
+
+		_sxpBlueprints.add(newSXPBlueprint);
 
 		SXPBlueprint existingSXPBlueprint = _persistence.findByPrimaryKey(
 			newSXPBlueprint.getPrimaryKey());
@@ -619,4 +621,4 @@ public class SXPBlueprintPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:923323422
+// LIFERAY-SERVICE-BUILDER-HASH:-358167130

--- a/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/service/persistence/test/SXPElementPersistenceTest.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/service/persistence/test/SXPElementPersistenceTest.java
@@ -151,7 +151,9 @@ public class SXPElementPersistenceTest {
 
 		newSXPElement.setStatus(RandomTestUtil.nextInt());
 
-		_sxpElements.add(_persistence.update(newSXPElement));
+		newSXPElement = _persistence.update(newSXPElement);
+
+		_sxpElements.add(newSXPElement);
 
 		SXPElement existingSXPElement = _persistence.findByPrimaryKey(
 			newSXPElement.getPrimaryKey());
@@ -644,4 +646,4 @@ public class SXPElementPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-402410646
+// LIFERAY-SERVICE-BUILDER-HASH:-1219519392

--- a/modules/dxp/apps/sharepoint-rest/sharepoint-rest-oauth2-test/src/testIntegration/java/com/liferay/sharepoint/rest/oauth2/service/persistence/test/SharepointOAuth2TokenEntryPersistenceTest.java
+++ b/modules/dxp/apps/sharepoint-rest/sharepoint-rest-oauth2-test/src/testIntegration/java/com/liferay/sharepoint/rest/oauth2/service/persistence/test/SharepointOAuth2TokenEntryPersistenceTest.java
@@ -140,8 +140,10 @@ public class SharepointOAuth2TokenEntryPersistenceTest {
 		newSharepointOAuth2TokenEntry.setRefreshToken(
 			RandomTestUtil.randomString());
 
-		_sharepointOAuth2TokenEntries.add(
-			_persistence.update(newSharepointOAuth2TokenEntry));
+		newSharepointOAuth2TokenEntry = _persistence.update(
+			newSharepointOAuth2TokenEntry);
+
+		_sharepointOAuth2TokenEntries.add(newSharepointOAuth2TokenEntry);
 
 		SharepointOAuth2TokenEntry existingSharepointOAuth2TokenEntry =
 			_persistence.findByPrimaryKey(
@@ -586,4 +588,4 @@ public class SharepointOAuth2TokenEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:349851106
+// LIFERAY-SERVICE-BUILDER-HASH:932257762

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/AddressPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/AddressPersistenceTest.java
@@ -170,7 +170,9 @@ public class AddressPersistenceTest {
 
 		newAddress.setStatus(RandomTestUtil.nextInt());
 
-		_addresses.add(_persistence.update(newAddress));
+		newAddress = _persistence.update(newAddress);
+
+		_addresses.add(newAddress);
 
 		Address existingAddress = _persistence.findByPrimaryKey(
 			newAddress.getPrimaryKey());
@@ -744,4 +746,4 @@ public class AddressPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-144217117
+// LIFERAY-SERVICE-BUILDER-HASH:1751152363

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/BrowserTrackerPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/BrowserTrackerPersistenceTest.java
@@ -117,7 +117,9 @@ public class BrowserTrackerPersistenceTest {
 
 		newBrowserTracker.setBrowserKey(RandomTestUtil.nextLong());
 
-		_browserTrackers.add(_persistence.update(newBrowserTracker));
+		newBrowserTracker = _persistence.update(newBrowserTracker);
+
+		_browserTrackers.add(newBrowserTracker);
 
 		BrowserTracker existingBrowserTracker = _persistence.findByPrimaryKey(
 			newBrowserTracker.getPrimaryKey());
@@ -468,4 +470,4 @@ public class BrowserTrackerPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1323403636
+// LIFERAY-SERVICE-BUILDER-HASH:-2093663700

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/ClassNamePersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/ClassNamePersistenceTest.java
@@ -113,7 +113,9 @@ public class ClassNamePersistenceTest {
 
 		newClassName.setValue(RandomTestUtil.randomString());
 
-		_classNames.add(_persistence.update(newClassName));
+		newClassName = _persistence.update(newClassName);
+
+		_classNames.add(newClassName);
 
 		ClassName existingClassName = _persistence.findByPrimaryKey(
 			newClassName.getPrimaryKey());
@@ -448,4 +450,4 @@ public class ClassNamePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1146046931
+// LIFERAY-SERVICE-BUILDER-HASH:-550688839

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/CompanyInfoPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/CompanyInfoPersistenceTest.java
@@ -115,7 +115,9 @@ public class CompanyInfoPersistenceTest {
 
 		newCompanyInfo.setKey(RandomTestUtil.randomString());
 
-		_companyInfos.add(_persistence.update(newCompanyInfo));
+		newCompanyInfo = _persistence.update(newCompanyInfo);
+
+		_companyInfos.add(newCompanyInfo);
 
 		CompanyInfo existingCompanyInfo = _persistence.findByPrimaryKey(
 			newCompanyInfo.getPrimaryKey());
@@ -454,4 +456,4 @@ public class CompanyInfoPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-296591164
+// LIFERAY-SERVICE-BUILDER-HASH:1988050698

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/CompanyPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/CompanyPersistenceTest.java
@@ -154,7 +154,9 @@ public class CompanyPersistenceTest {
 
 		newCompany.setIndexNameNext(RandomTestUtil.randomString());
 
-		_companies.add(_persistence.update(newCompany));
+		newCompany = _persistence.update(newCompany);
+
+		_companies.add(newCompany);
 
 		Company existingCompany = _persistence.findByPrimaryKey(
 			newCompany.getPrimaryKey());
@@ -570,4 +572,4 @@ public class CompanyPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1665334733
+// LIFERAY-SERVICE-BUILDER-HASH:-1071339307

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/ContactPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/ContactPersistenceTest.java
@@ -162,7 +162,9 @@ public class ContactPersistenceTest {
 
 		newContact.setHoursOfOperation(RandomTestUtil.randomString());
 
-		_contacts.add(_persistence.update(newContact));
+		newContact = _persistence.update(newContact);
+
+		_contacts.add(newContact);
 
 		Contact existingContact = _persistence.findByPrimaryKey(
 			newContact.getPrimaryKey());
@@ -568,4 +570,4 @@ public class ContactPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:58426899
+// LIFERAY-SERVICE-BUILDER-HASH:-660844007

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/CountryLocalizationPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/CountryLocalizationPersistenceTest.java
@@ -120,7 +120,9 @@ public class CountryLocalizationPersistenceTest {
 
 		newCountryLocalization.setTitle(RandomTestUtil.randomString());
 
-		_countryLocalizations.add(_persistence.update(newCountryLocalization));
+		newCountryLocalization = _persistence.update(newCountryLocalization);
+
+		_countryLocalizations.add(newCountryLocalization);
 
 		CountryLocalization existingCountryLocalization =
 			_persistence.findByPrimaryKey(
@@ -488,4 +490,4 @@ public class CountryLocalizationPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1241633222
+// LIFERAY-SERVICE-BUILDER-HASH:1214360092

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/CountryPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/CountryPersistenceTest.java
@@ -160,7 +160,9 @@ public class CountryPersistenceTest {
 
 		newCountry.setStatus(RandomTestUtil.nextInt());
 
-		_countries.add(_persistence.update(newCountry));
+		newCountry = _persistence.update(newCountry);
+
+		_countries.add(newCountry);
 
 		Country existingCountry = _persistence.findByPrimaryKey(
 			newCountry.getPrimaryKey());
@@ -781,4 +783,4 @@ public class CountryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:501125916
+// LIFERAY-SERVICE-BUILDER-HASH:1333328580

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/EmailAddressPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/EmailAddressPersistenceTest.java
@@ -139,7 +139,9 @@ public class EmailAddressPersistenceTest {
 
 		newEmailAddress.setPrimary(RandomTestUtil.randomBoolean());
 
-		_emailAddresses.add(_persistence.update(newEmailAddress));
+		newEmailAddress = _persistence.update(newEmailAddress);
+
+		_emailAddresses.add(newEmailAddress);
 
 		EmailAddress existingEmailAddress = _persistence.findByPrimaryKey(
 			newEmailAddress.getPrimaryKey());
@@ -621,4 +623,4 @@ public class EmailAddressPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1198575697
+// LIFERAY-SERVICE-BUILDER-HASH:1872360413

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/GroupPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/GroupPersistenceTest.java
@@ -159,7 +159,9 @@ public class GroupPersistenceTest {
 
 		newGroup.setActive(RandomTestUtil.randomBoolean());
 
-		_groups.add(_persistence.update(newGroup));
+		newGroup = _persistence.update(newGroup);
+
+		_groups.add(newGroup);
 
 		Group existingGroup = _persistence.findByPrimaryKey(
 			newGroup.getPrimaryKey());
@@ -942,4 +944,4 @@ public class GroupPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1579496523
+// LIFERAY-SERVICE-BUILDER-HASH:-927173515

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/ImagePersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/ImagePersistenceTest.java
@@ -124,7 +124,9 @@ public class ImagePersistenceTest {
 
 		newImage.setSize(RandomTestUtil.nextInt());
 
-		_images.add(_persistence.update(newImage));
+		newImage = _persistence.update(newImage);
+
+		_images.add(newImage);
 
 		Image existingImage = _persistence.findByPrimaryKey(
 			newImage.getPrimaryKey());
@@ -409,4 +411,4 @@ public class ImagePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-42450143
+// LIFERAY-SERVICE-BUILDER-HASH:-2092644773

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/LayoutBranchPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/LayoutBranchPersistenceTest.java
@@ -129,7 +129,9 @@ public class LayoutBranchPersistenceTest {
 
 		newLayoutBranch.setMaster(RandomTestUtil.randomBoolean());
 
-		_layoutBranchs.add(_persistence.update(newLayoutBranch));
+		newLayoutBranch = _persistence.update(newLayoutBranch);
+
+		_layoutBranchs.add(newLayoutBranch);
 
 		LayoutBranch existingLayoutBranch = _persistence.findByPrimaryKey(
 			newLayoutBranch.getPrimaryKey());
@@ -549,4 +551,4 @@ public class LayoutBranchPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1839485927
+// LIFERAY-SERVICE-BUILDER-HASH:503529191

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/LayoutFriendlyURLPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/LayoutFriendlyURLPersistenceTest.java
@@ -139,7 +139,9 @@ public class LayoutFriendlyURLPersistenceTest {
 
 		newLayoutFriendlyURL.setLastPublishDate(RandomTestUtil.nextDate());
 
-		_layoutFriendlyURLs.add(_persistence.update(newLayoutFriendlyURL));
+		newLayoutFriendlyURL = _persistence.update(newLayoutFriendlyURL);
+
+		_layoutFriendlyURLs.add(newLayoutFriendlyURL);
 
 		LayoutFriendlyURL existingLayoutFriendlyURL =
 			_persistence.findByPrimaryKey(newLayoutFriendlyURL.getPrimaryKey());
@@ -688,4 +690,4 @@ public class LayoutFriendlyURLPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1804800521
+// LIFERAY-SERVICE-BUILDER-HASH:-498516565

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/LayoutPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/LayoutPersistenceTest.java
@@ -211,7 +211,9 @@ public class LayoutPersistenceTest {
 
 		newLayout.setStatusDate(RandomTestUtil.nextDate());
 
-		_layouts.add(_persistence.update(newLayout));
+		newLayout = _persistence.update(newLayout);
+
+		_layouts.add(newLayout);
 
 		Layout existingLayout = _persistence.findByPrimaryKey(
 			newLayout.getPrimaryKey());
@@ -1099,4 +1101,4 @@ public class LayoutPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:267421252
+// LIFERAY-SERVICE-BUILDER-HASH:-914034432

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/LayoutPrototypePersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/LayoutPrototypePersistenceTest.java
@@ -132,7 +132,9 @@ public class LayoutPrototypePersistenceTest {
 
 		newLayoutPrototype.setActive(RandomTestUtil.randomBoolean());
 
-		_layoutPrototypes.add(_persistence.update(newLayoutPrototype));
+		newLayoutPrototype = _persistence.update(newLayoutPrototype);
+
+		_layoutPrototypes.add(newLayoutPrototype);
 
 		LayoutPrototype existingLayoutPrototype = _persistence.findByPrimaryKey(
 			newLayoutPrototype.getPrimaryKey());
@@ -492,4 +494,4 @@ public class LayoutPrototypePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1202409578
+// LIFERAY-SERVICE-BUILDER-HASH:784335536

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/LayoutRevisionPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/LayoutRevisionPersistenceTest.java
@@ -164,7 +164,9 @@ public class LayoutRevisionPersistenceTest {
 
 		newLayoutRevision.setStatusDate(RandomTestUtil.nextDate());
 
-		_layoutRevisions.add(_persistence.update(newLayoutRevision));
+		newLayoutRevision = _persistence.update(newLayoutRevision);
+
+		_layoutRevisions.add(newLayoutRevision);
 
 		LayoutRevision existingLayoutRevision = _persistence.findByPrimaryKey(
 			newLayoutRevision.getPrimaryKey());
@@ -676,4 +678,4 @@ public class LayoutRevisionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1700939741
+// LIFERAY-SERVICE-BUILDER-HASH:928311025

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/LayoutSetBranchPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/LayoutSetBranchPersistenceTest.java
@@ -152,7 +152,9 @@ public class LayoutSetBranchPersistenceTest {
 		newLayoutSetBranch.setLayoutSetPrototypeLinkEnabled(
 			RandomTestUtil.randomBoolean());
 
-		_layoutSetBranchs.add(_persistence.update(newLayoutSetBranch));
+		newLayoutSetBranch = _persistence.update(newLayoutSetBranch);
+
+		_layoutSetBranchs.add(newLayoutSetBranch);
 
 		LayoutSetBranch existingLayoutSetBranch = _persistence.findByPrimaryKey(
 			newLayoutSetBranch.getPrimaryKey());
@@ -643,4 +645,4 @@ public class LayoutSetBranchPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:710768332
+// LIFERAY-SERVICE-BUILDER-HASH:1152544426

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/LayoutSetPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/LayoutSetPersistenceTest.java
@@ -141,7 +141,9 @@ public class LayoutSetPersistenceTest {
 		newLayoutSet.setLayoutSetPrototypeLinkEnabled(
 			RandomTestUtil.randomBoolean());
 
-		_layoutSets.add(_persistence.update(newLayoutSet));
+		newLayoutSet = _persistence.update(newLayoutSet);
+
+		_layoutSets.add(newLayoutSet);
 
 		LayoutSet existingLayoutSet = _persistence.findByPrimaryKey(
 			newLayoutSet.getPrimaryKey());
@@ -577,4 +579,4 @@ public class LayoutSetPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:247259149
+// LIFERAY-SERVICE-BUILDER-HASH:-140773389

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/LayoutSetPrototypePersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/LayoutSetPrototypePersistenceTest.java
@@ -133,7 +133,9 @@ public class LayoutSetPrototypePersistenceTest {
 
 		newLayoutSetPrototype.setActive(RandomTestUtil.randomBoolean());
 
-		_layoutSetPrototypes.add(_persistence.update(newLayoutSetPrototype));
+		newLayoutSetPrototype = _persistence.update(newLayoutSetPrototype);
+
+		_layoutSetPrototypes.add(newLayoutSetPrototype);
 
 		LayoutSetPrototype existingLayoutSetPrototype =
 			_persistence.findByPrimaryKey(
@@ -507,4 +509,4 @@ public class LayoutSetPrototypePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1283938884
+// LIFERAY-SERVICE-BUILDER-HASH:251212160

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/ListTypePersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/ListTypePersistenceTest.java
@@ -128,7 +128,9 @@ public class ListTypePersistenceTest {
 
 		newListType.setType(RandomTestUtil.randomString());
 
-		_listTypes.add(_persistence.update(newListType));
+		newListType = _persistence.update(newListType);
+
+		_listTypes.add(newListType);
 
 		ListType existingListType = _persistence.findByPrimaryKey(
 			newListType.getPrimaryKey());
@@ -532,4 +534,4 @@ public class ListTypePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:118657379
+// LIFERAY-SERVICE-BUILDER-HASH:-1600780597

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/MembershipRequestPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/MembershipRequestPersistenceTest.java
@@ -129,7 +129,9 @@ public class MembershipRequestPersistenceTest {
 
 		newMembershipRequest.setStatusId(RandomTestUtil.nextLong());
 
-		_membershipRequests.add(_persistence.update(newMembershipRequest));
+		newMembershipRequest = _persistence.update(newMembershipRequest);
+
+		_membershipRequests.add(newMembershipRequest);
 
 		MembershipRequest existingMembershipRequest =
 			_persistence.findByPrimaryKey(newMembershipRequest.getPrimaryKey());
@@ -485,4 +487,4 @@ public class MembershipRequestPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:2081815015
+// LIFERAY-SERVICE-BUILDER-HASH:50441065

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/OrgLaborPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/OrgLaborPersistenceTest.java
@@ -143,7 +143,9 @@ public class OrgLaborPersistenceTest {
 
 		newOrgLabor.setSatClose(RandomTestUtil.nextInt());
 
-		_orgLabors.add(_persistence.update(newOrgLabor));
+		newOrgLabor = _persistence.update(newOrgLabor);
+
+		_orgLabors.add(newOrgLabor);
 
 		OrgLabor existingOrgLabor = _persistence.findByPrimaryKey(
 			newOrgLabor.getPrimaryKey());
@@ -485,4 +487,4 @@ public class OrgLaborPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:219133126
+// LIFERAY-SERVICE-BUILDER-HASH:851558342

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/OrganizationPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/OrganizationPersistenceTest.java
@@ -151,7 +151,9 @@ public class OrganizationPersistenceTest {
 
 		newOrganization.setStatus(RandomTestUtil.nextInt());
 
-		_organizations.add(_persistence.update(newOrganization));
+		newOrganization = _persistence.update(newOrganization);
+
+		_organizations.add(newOrganization);
 
 		Organization existingOrganization = _persistence.findByPrimaryKey(
 			newOrganization.getPrimaryKey());
@@ -707,4 +709,4 @@ public class OrganizationPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1571694958
+// LIFERAY-SERVICE-BUILDER-HASH:-2096060988

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/PasswordPolicyPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/PasswordPolicyPersistenceTest.java
@@ -179,7 +179,9 @@ public class PasswordPolicyPersistenceTest {
 
 		newPasswordPolicy.setResetTicketMaxAge(RandomTestUtil.nextLong());
 
-		_passwordPolicies.add(_persistence.update(newPasswordPolicy));
+		newPasswordPolicy = _persistence.update(newPasswordPolicy);
+
+		_passwordPolicies.add(newPasswordPolicy);
 
 		PasswordPolicy existingPasswordPolicy = _persistence.findByPrimaryKey(
 			newPasswordPolicy.getPrimaryKey());
@@ -716,4 +718,4 @@ public class PasswordPolicyPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1526058145
+// LIFERAY-SERVICE-BUILDER-HASH:1769136977

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/PasswordPolicyRelPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/PasswordPolicyRelPersistenceTest.java
@@ -120,7 +120,9 @@ public class PasswordPolicyRelPersistenceTest {
 
 		newPasswordPolicyRel.setClassPK(RandomTestUtil.nextLong());
 
-		_passwordPolicyRels.add(_persistence.update(newPasswordPolicyRel));
+		newPasswordPolicyRel = _persistence.update(newPasswordPolicyRel);
+
+		_passwordPolicyRels.add(newPasswordPolicyRel);
 
 		PasswordPolicyRel existingPasswordPolicyRel =
 			_persistence.findByPrimaryKey(newPasswordPolicyRel.getPrimaryKey());
@@ -499,4 +501,4 @@ public class PasswordPolicyRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1459375928
+// LIFERAY-SERVICE-BUILDER-HASH:-1664627170

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/PasswordTrackerPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/PasswordTrackerPersistenceTest.java
@@ -118,7 +118,9 @@ public class PasswordTrackerPersistenceTest {
 
 		newPasswordTracker.setPassword(RandomTestUtil.randomString());
 
-		_passwordTrackers.add(_persistence.update(newPasswordTracker));
+		newPasswordTracker = _persistence.update(newPasswordTracker);
+
+		_passwordTrackers.add(newPasswordTracker);
 
 		PasswordTracker existingPasswordTracker = _persistence.findByPrimaryKey(
 			newPasswordTracker.getPrimaryKey());
@@ -419,4 +421,4 @@ public class PasswordTrackerPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-627050296
+// LIFERAY-SERVICE-BUILDER-HASH:999081530

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/PhonePersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/PhonePersistenceTest.java
@@ -141,7 +141,9 @@ public class PhonePersistenceTest {
 
 		newPhone.setPrimary(RandomTestUtil.randomBoolean());
 
-		_phones.add(_persistence.update(newPhone));
+		newPhone = _persistence.update(newPhone);
+
+		_phones.add(newPhone);
 
 		Phone existingPhone = _persistence.findByPrimaryKey(
 			newPhone.getPrimaryKey());
@@ -598,4 +600,4 @@ public class PhonePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:681114712
+// LIFERAY-SERVICE-BUILDER-HASH:154667146

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/PluginSettingPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/PluginSettingPersistenceTest.java
@@ -121,7 +121,9 @@ public class PluginSettingPersistenceTest {
 
 		newPluginSetting.setActive(RandomTestUtil.randomBoolean());
 
-		_pluginSettings.add(_persistence.update(newPluginSetting));
+		newPluginSetting = _persistence.update(newPluginSetting);
+
+		_pluginSettings.add(newPluginSetting);
 
 		PluginSetting existingPluginSetting = _persistence.findByPrimaryKey(
 			newPluginSetting.getPrimaryKey());
@@ -500,4 +502,4 @@ public class PluginSettingPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1335297849
+// LIFERAY-SERVICE-BUILDER-HASH:365344405

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/PortalPreferenceValuePersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/PortalPreferenceValuePersistenceTest.java
@@ -130,8 +130,10 @@ public class PortalPreferenceValuePersistenceTest {
 
 		newPortalPreferenceValue.setSmallValue(RandomTestUtil.randomString());
 
-		_portalPreferenceValues.add(
-			_persistence.update(newPortalPreferenceValue));
+		newPortalPreferenceValue = _persistence.update(
+			newPortalPreferenceValue);
+
+		_portalPreferenceValues.add(newPortalPreferenceValue);
 
 		PortalPreferenceValue existingPortalPreferenceValue =
 			_persistence.findByPrimaryKey(
@@ -598,4 +600,4 @@ public class PortalPreferenceValuePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:271486473
+// LIFERAY-SERVICE-BUILDER-HASH:433008743

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/PortalPreferencesPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/PortalPreferencesPersistenceTest.java
@@ -118,7 +118,9 @@ public class PortalPreferencesPersistenceTest {
 
 		newPortalPreferences.setOwnerType(RandomTestUtil.nextInt());
 
-		_portalPreferenceses.add(_persistence.update(newPortalPreferences));
+		newPortalPreferences = _persistence.update(newPortalPreferences);
+
+		_portalPreferenceses.add(newPortalPreferences);
 
 		PortalPreferences existingPortalPreferences =
 			_persistence.findByPrimaryKey(newPortalPreferences.getPrimaryKey());
@@ -491,4 +493,4 @@ public class PortalPreferencesPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-476297778
+// LIFERAY-SERVICE-BUILDER-HASH:3701590

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/PortletItemPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/PortletItemPersistenceTest.java
@@ -130,7 +130,9 @@ public class PortletItemPersistenceTest {
 
 		newPortletItem.setClassNameId(RandomTestUtil.nextLong());
 
-		_portletItems.add(_persistence.update(newPortletItem));
+		newPortletItem = _persistence.update(newPortletItem);
+
+		_portletItems.add(newPortletItem);
 
 		PortletItem existingPortletItem = _persistence.findByPrimaryKey(
 			newPortletItem.getPrimaryKey());
@@ -538,4 +540,4 @@ public class PortletItemPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1645080112
+// LIFERAY-SERVICE-BUILDER-HASH:-246214370

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/PortletPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/PortletPersistenceTest.java
@@ -119,7 +119,9 @@ public class PortletPersistenceTest {
 
 		newPortlet.setActive(RandomTestUtil.randomBoolean());
 
-		_portlets.add(_persistence.update(newPortlet));
+		newPortlet = _persistence.update(newPortlet);
+
+		_portlets.add(newPortlet);
 
 		Portlet existingPortlet = _persistence.findByPrimaryKey(
 			newPortlet.getPrimaryKey());
@@ -464,4 +466,4 @@ public class PortletPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:939915657
+// LIFERAY-SERVICE-BUILDER-HASH:912272619

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/PortletPreferenceValuePersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/PortletPreferenceValuePersistenceTest.java
@@ -132,8 +132,10 @@ public class PortletPreferenceValuePersistenceTest {
 
 		newPortletPreferenceValue.setSmallValue(RandomTestUtil.randomString());
 
-		_portletPreferenceValues.add(
-			_persistence.update(newPortletPreferenceValue));
+		newPortletPreferenceValue = _persistence.update(
+			newPortletPreferenceValue);
+
+		_portletPreferenceValues.add(newPortletPreferenceValue);
 
 		PortletPreferenceValue existingPortletPreferenceValue =
 			_persistence.findByPrimaryKey(
@@ -595,4 +597,4 @@ public class PortletPreferenceValuePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:652783522
+// LIFERAY-SERVICE-BUILDER-HASH:1570263298

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/PortletPreferencesPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/PortletPreferencesPersistenceTest.java
@@ -125,7 +125,9 @@ public class PortletPreferencesPersistenceTest {
 
 		newPortletPreferences.setPortletId(RandomTestUtil.randomString());
 
-		_portletPreferenceses.add(_persistence.update(newPortletPreferences));
+		newPortletPreferences = _persistence.update(newPortletPreferences);
+
+		_portletPreferenceses.add(newPortletPreferences);
 
 		PortletPreferences existingPortletPreferences =
 			_persistence.findByPrimaryKey(
@@ -606,4 +608,4 @@ public class PortletPreferencesPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1981533994
+// LIFERAY-SERVICE-BUILDER-HASH:1538029920

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/RecentLayoutBranchPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/RecentLayoutBranchPersistenceTest.java
@@ -124,7 +124,9 @@ public class RecentLayoutBranchPersistenceTest {
 
 		newRecentLayoutBranch.setPlid(RandomTestUtil.nextLong());
 
-		_recentLayoutBranchs.add(_persistence.update(newRecentLayoutBranch));
+		newRecentLayoutBranch = _persistence.update(newRecentLayoutBranch);
+
+		_recentLayoutBranchs.add(newRecentLayoutBranch);
 
 		RecentLayoutBranch existingRecentLayoutBranch =
 			_persistence.findByPrimaryKey(
@@ -538,4 +540,4 @@ public class RecentLayoutBranchPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1783144256
+// LIFERAY-SERVICE-BUILDER-HASH:265311286

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/RecentLayoutRevisionPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/RecentLayoutRevisionPersistenceTest.java
@@ -127,8 +127,9 @@ public class RecentLayoutRevisionPersistenceTest {
 
 		newRecentLayoutRevision.setPlid(RandomTestUtil.nextLong());
 
-		_recentLayoutRevisions.add(
-			_persistence.update(newRecentLayoutRevision));
+		newRecentLayoutRevision = _persistence.update(newRecentLayoutRevision);
+
+		_recentLayoutRevisions.add(newRecentLayoutRevision);
 
 		RecentLayoutRevision existingRecentLayoutRevision =
 			_persistence.findByPrimaryKey(
@@ -560,4 +561,4 @@ public class RecentLayoutRevisionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:117253373
+// LIFERAY-SERVICE-BUILDER-HASH:-1068676635

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/RecentLayoutSetBranchPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/RecentLayoutSetBranchPersistenceTest.java
@@ -126,8 +126,10 @@ public class RecentLayoutSetBranchPersistenceTest {
 
 		newRecentLayoutSetBranch.setLayoutSetId(RandomTestUtil.nextLong());
 
-		_recentLayoutSetBranchs.add(
-			_persistence.update(newRecentLayoutSetBranch));
+		newRecentLayoutSetBranch = _persistence.update(
+			newRecentLayoutSetBranch);
+
+		_recentLayoutSetBranchs.add(newRecentLayoutSetBranch);
 
 		RecentLayoutSetBranch existingRecentLayoutSetBranch =
 			_persistence.findByPrimaryKey(
@@ -551,4 +553,4 @@ public class RecentLayoutSetBranchPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-29352895
+// LIFERAY-SERVICE-BUILDER-HASH:287685079

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/RegionLocalizationPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/RegionLocalizationPersistenceTest.java
@@ -119,7 +119,9 @@ public class RegionLocalizationPersistenceTest {
 
 		newRegionLocalization.setTitle(RandomTestUtil.randomString());
 
-		_regionLocalizations.add(_persistence.update(newRegionLocalization));
+		newRegionLocalization = _persistence.update(newRegionLocalization);
+
+		_regionLocalizations.add(newRegionLocalization);
 
 		RegionLocalization existingRegionLocalization =
 			_persistence.findByPrimaryKey(
@@ -482,4 +484,4 @@ public class RegionLocalizationPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1944369806
+// LIFERAY-SERVICE-BUILDER-HASH:-476112908

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/RegionPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/RegionPersistenceTest.java
@@ -146,7 +146,9 @@ public class RegionPersistenceTest {
 
 		newRegion.setStatus(RandomTestUtil.nextInt());
 
-		_regions.add(_persistence.update(newRegion));
+		newRegion = _persistence.update(newRegion);
+
+		_regions.add(newRegion);
 
 		Region existingRegion = _persistence.findByPrimaryKey(
 			newRegion.getPrimaryKey());
@@ -618,4 +620,4 @@ public class RegionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1012712458
+// LIFERAY-SERVICE-BUILDER-HASH:-1580964058

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/ReleasePersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/ReleasePersistenceTest.java
@@ -132,7 +132,9 @@ public class ReleasePersistenceTest {
 
 		newRelease.setTestString(RandomTestUtil.randomString());
 
-		_releases.add(_persistence.update(newRelease));
+		newRelease = _persistence.update(newRelease);
+
+		_releases.add(newRelease);
 
 		Release existingRelease = _persistence.findByPrimaryKey(
 			newRelease.getPrimaryKey());
@@ -502,4 +504,4 @@ public class ReleasePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1358282218
+// LIFERAY-SERVICE-BUILDER-HASH:327841356

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/RememberMeTokenPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/RememberMeTokenPersistenceTest.java
@@ -120,7 +120,9 @@ public class RememberMeTokenPersistenceTest {
 
 		newRememberMeToken.setValue(RandomTestUtil.randomString());
 
-		_rememberMeTokens.add(_persistence.update(newRememberMeToken));
+		newRememberMeToken = _persistence.update(newRememberMeToken);
+
+		_rememberMeTokens.add(newRememberMeToken);
 
 		RememberMeToken existingRememberMeToken = _persistence.findByPrimaryKey(
 			newRememberMeToken.getPrimaryKey());
@@ -432,4 +434,4 @@ public class RememberMeTokenPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1024995132
+// LIFERAY-SERVICE-BUILDER-HASH:-916237966

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/RepositoryEntryPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/RepositoryEntryPersistenceTest.java
@@ -137,7 +137,9 @@ public class RepositoryEntryPersistenceTest {
 
 		newRepositoryEntry.setLastPublishDate(RandomTestUtil.nextDate());
 
-		_repositoryEntries.add(_persistence.update(newRepositoryEntry));
+		newRepositoryEntry = _persistence.update(newRepositoryEntry);
+
+		_repositoryEntries.add(newRepositoryEntry);
 
 		RepositoryEntry existingRepositoryEntry = _persistence.findByPrimaryKey(
 			newRepositoryEntry.getPrimaryKey());
@@ -592,4 +594,4 @@ public class RepositoryEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:692016234
+// LIFERAY-SERVICE-BUILDER-HASH:-622311726

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/RepositoryPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/RepositoryPersistenceTest.java
@@ -145,7 +145,9 @@ public class RepositoryPersistenceTest {
 
 		newRepository.setLastPublishDate(RandomTestUtil.nextDate());
 
-		_repositories.add(_persistence.update(newRepository));
+		newRepository = _persistence.update(newRepository);
+
+		_repositories.add(newRepository);
 
 		Repository existingRepository = _persistence.findByPrimaryKey(
 			newRepository.getPrimaryKey());
@@ -658,4 +660,4 @@ public class RepositoryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1861158545
+// LIFERAY-SERVICE-BUILDER-HASH:-2125144303

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/ResourceActionPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/ResourceActionPersistenceTest.java
@@ -117,7 +117,9 @@ public class ResourceActionPersistenceTest {
 
 		newResourceAction.setBitwiseValue(RandomTestUtil.nextLong());
 
-		_resourceActions.add(_persistence.update(newResourceAction));
+		newResourceAction = _persistence.update(newResourceAction);
+
+		_resourceActions.add(newResourceAction);
 
 		ResourceAction existingResourceAction = _persistence.findByPrimaryKey(
 			newResourceAction.getPrimaryKey());
@@ -484,4 +486,4 @@ public class ResourceActionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:350308162
+// LIFERAY-SERVICE-BUILDER-HASH:224705682

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/ResourcePermissionPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/ResourcePermissionPersistenceTest.java
@@ -132,7 +132,9 @@ public class ResourcePermissionPersistenceTest {
 
 		newResourcePermission.setViewActionId(RandomTestUtil.randomBoolean());
 
-		_resourcePermissions.add(_persistence.update(newResourcePermission));
+		newResourcePermission = _persistence.update(newResourcePermission);
+
+		_resourcePermissions.add(newResourcePermission);
 
 		ResourcePermission existingResourcePermission =
 			_persistence.findByPrimaryKey(
@@ -676,4 +678,4 @@ public class ResourcePermissionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-684360868
+// LIFERAY-SERVICE-BUILDER-HASH:1445748346

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/RolePersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/RolePersistenceTest.java
@@ -145,7 +145,9 @@ public class RolePersistenceTest {
 
 		newRole.setStatus(RandomTestUtil.nextInt());
 
-		_roles.add(_persistence.update(newRole));
+		newRole = _persistence.update(newRole);
+
+		_roles.add(newRole);
 
 		Role existingRole = _persistence.findByPrimaryKey(
 			newRole.getPrimaryKey());
@@ -710,4 +712,4 @@ public class RolePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1670381234
+// LIFERAY-SERVICE-BUILDER-HASH:981109946

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/ServiceComponentPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/ServiceComponentPersistenceTest.java
@@ -119,7 +119,9 @@ public class ServiceComponentPersistenceTest {
 
 		newServiceComponent.setData(RandomTestUtil.randomString());
 
-		_serviceComponents.add(_persistence.update(newServiceComponent));
+		newServiceComponent = _persistence.update(newServiceComponent);
+
+		_serviceComponents.add(newServiceComponent);
 
 		ServiceComponent existingServiceComponent =
 			_persistence.findByPrimaryKey(newServiceComponent.getPrimaryKey());
@@ -495,4 +497,4 @@ public class ServiceComponentPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-71458242
+// LIFERAY-SERVICE-BUILDER-HASH:171207430

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/SystemEventPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/SystemEventPersistenceTest.java
@@ -141,7 +141,9 @@ public class SystemEventPersistenceTest {
 
 		newSystemEvent.setExtraData(RandomTestUtil.randomString());
 
-		_systemEvents.add(_persistence.update(newSystemEvent));
+		newSystemEvent = _persistence.update(newSystemEvent);
+
+		_systemEvents.add(newSystemEvent);
 
 		SystemEvent existingSystemEvent = _persistence.findByPrimaryKey(
 			newSystemEvent.getPrimaryKey());
@@ -513,4 +515,4 @@ public class SystemEventPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1024370352
+// LIFERAY-SERVICE-BUILDER-HASH:1568244586

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/TeamPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/TeamPersistenceTest.java
@@ -138,7 +138,9 @@ public class TeamPersistenceTest {
 
 		newTeam.setLastPublishDate(RandomTestUtil.nextDate());
 
-		_teams.add(_persistence.update(newTeam));
+		newTeam = _persistence.update(newTeam);
+
+		_teams.add(newTeam);
 
 		Team existingTeam = _persistence.findByPrimaryKey(
 			newTeam.getPrimaryKey());
@@ -580,4 +582,4 @@ public class TeamPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:378161091
+// LIFERAY-SERVICE-BUILDER-HASH:611739429

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/TicketPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/TicketPersistenceTest.java
@@ -130,7 +130,9 @@ public class TicketPersistenceTest {
 
 		newTicket.setExpirationDate(RandomTestUtil.nextDate());
 
-		_tickets.add(_persistence.update(newTicket));
+		newTicket = _persistence.update(newTicket);
+
+		_tickets.add(newTicket);
 
 		Ticket existingTicket = _persistence.findByPrimaryKey(
 			newTicket.getPrimaryKey());
@@ -524,4 +526,4 @@ public class TicketPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:845844700
+// LIFERAY-SERVICE-BUILDER-HASH:-2077138468

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/UserGroupGroupRolePersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/UserGroupGroupRolePersistenceTest.java
@@ -122,7 +122,9 @@ public class UserGroupGroupRolePersistenceTest {
 
 		newUserGroupGroupRole.setRoleId(RandomTestUtil.nextLong());
 
-		_userGroupGroupRoles.add(_persistence.update(newUserGroupGroupRole));
+		newUserGroupGroupRole = _persistence.update(newUserGroupGroupRole);
+
+		_userGroupGroupRoles.add(newUserGroupGroupRole);
 
 		UserGroupGroupRole existingUserGroupGroupRole =
 			_persistence.findByPrimaryKey(
@@ -547,4 +549,4 @@ public class UserGroupGroupRolePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1693735603
+// LIFERAY-SERVICE-BUILDER-HASH:-468355383

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/UserGroupPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/UserGroupPersistenceTest.java
@@ -139,7 +139,9 @@ public class UserGroupPersistenceTest {
 
 		newUserGroup.setStatus(RandomTestUtil.nextInt());
 
-		_userGroups.add(_persistence.update(newUserGroup));
+		newUserGroup = _persistence.update(newUserGroup);
+
+		_userGroups.add(newUserGroup);
 
 		UserGroup existingUserGroup = _persistence.findByPrimaryKey(
 			newUserGroup.getPrimaryKey());
@@ -627,4 +629,4 @@ public class UserGroupPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:636628432
+// LIFERAY-SERVICE-BUILDER-HASH:1322531418

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/UserGroupRolePersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/UserGroupRolePersistenceTest.java
@@ -121,7 +121,9 @@ public class UserGroupRolePersistenceTest {
 
 		newUserGroupRole.setRoleId(RandomTestUtil.nextLong());
 
-		_userGroupRoles.add(_persistence.update(newUserGroupRole));
+		newUserGroupRole = _persistence.update(newUserGroupRole);
+
+		_userGroupRoles.add(newUserGroupRole);
 
 		UserGroupRole existingUserGroupRole = _persistence.findByPrimaryKey(
 			newUserGroupRole.getPrimaryKey());
@@ -529,4 +531,4 @@ public class UserGroupRolePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:670566548
+// LIFERAY-SERVICE-BUILDER-HASH:2087367734

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/UserIdMapperPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/UserIdMapperPersistenceTest.java
@@ -121,7 +121,9 @@ public class UserIdMapperPersistenceTest {
 
 		newUserIdMapper.setExternalUserId(RandomTestUtil.randomString());
 
-		_userIdMappers.add(_persistence.update(newUserIdMapper));
+		newUserIdMapper = _persistence.update(newUserIdMapper);
+
+		_userIdMappers.add(newUserIdMapper);
 
 		UserIdMapper existingUserIdMapper = _persistence.findByPrimaryKey(
 			newUserIdMapper.getPrimaryKey());
@@ -514,4 +516,4 @@ public class UserIdMapperPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1975635750
+// LIFERAY-SERVICE-BUILDER-HASH:-594981296

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/UserNotificationDeliveryPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/UserNotificationDeliveryPersistenceTest.java
@@ -131,8 +131,10 @@ public class UserNotificationDeliveryPersistenceTest {
 
 		newUserNotificationDelivery.setDeliver(RandomTestUtil.randomBoolean());
 
-		_userNotificationDeliveries.add(
-			_persistence.update(newUserNotificationDelivery));
+		newUserNotificationDelivery = _persistence.update(
+			newUserNotificationDelivery);
+
+		_userNotificationDeliveries.add(newUserNotificationDelivery);
 
 		UserNotificationDelivery existingUserNotificationDelivery =
 			_persistence.findByPrimaryKey(
@@ -577,4 +579,4 @@ public class UserNotificationDeliveryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-841737405
+// LIFERAY-SERVICE-BUILDER-HASH:274105569

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/UserNotificationEventPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/UserNotificationEventPersistenceTest.java
@@ -136,8 +136,10 @@ public class UserNotificationEventPersistenceTest {
 
 		newUserNotificationEvent.setArchived(RandomTestUtil.randomBoolean());
 
-		_userNotificationEvents.add(
-			_persistence.update(newUserNotificationEvent));
+		newUserNotificationEvent = _persistence.update(
+			newUserNotificationEvent);
+
+		_userNotificationEvents.add(newUserNotificationEvent);
 
 		UserNotificationEvent existingUserNotificationEvent =
 			_persistence.findByPrimaryKey(
@@ -697,4 +699,4 @@ public class UserNotificationEventPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1542298135
+// LIFERAY-SERVICE-BUILDER-HASH:938821427

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/UserPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/UserPersistenceTest.java
@@ -197,7 +197,9 @@ public class UserPersistenceTest {
 
 		newUser.setStatus(RandomTestUtil.nextInt());
 
-		_users.add(_persistence.update(newUser));
+		newUser = _persistence.update(newUser);
+
+		_users.add(newUser);
 
 		User existingUser = _persistence.findByPrimaryKey(
 			newUser.getPrimaryKey());
@@ -901,4 +903,4 @@ public class UserPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1662105256
+// LIFERAY-SERVICE-BUILDER-HASH:2019496854

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/UserTrackerPathPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/UserTrackerPathPersistenceTest.java
@@ -118,7 +118,9 @@ public class UserTrackerPathPersistenceTest {
 
 		newUserTrackerPath.setPathDate(RandomTestUtil.nextDate());
 
-		_userTrackerPaths.add(_persistence.update(newUserTrackerPath));
+		newUserTrackerPath = _persistence.update(newUserTrackerPath);
+
+		_userTrackerPaths.add(newUserTrackerPath);
 
 		UserTrackerPath existingUserTrackerPath = _persistence.findByPrimaryKey(
 			newUserTrackerPath.getPrimaryKey());
@@ -418,4 +420,4 @@ public class UserTrackerPathPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1881816478
+// LIFERAY-SERVICE-BUILDER-HASH:-519655772

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/UserTrackerPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/UserTrackerPersistenceTest.java
@@ -124,7 +124,9 @@ public class UserTrackerPersistenceTest {
 
 		newUserTracker.setUserAgent(RandomTestUtil.randomString());
 
-		_userTrackers.add(_persistence.update(newUserTracker));
+		newUserTracker = _persistence.update(newUserTracker);
+
+		_userTrackers.add(newUserTracker);
 
 		UserTracker existingUserTracker = _persistence.findByPrimaryKey(
 			newUserTracker.getPrimaryKey());
@@ -446,4 +448,4 @@ public class UserTrackerPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:565581973
+// LIFERAY-SERVICE-BUILDER-HASH:1343026823

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/VirtualHostPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/VirtualHostPersistenceTest.java
@@ -123,7 +123,9 @@ public class VirtualHostPersistenceTest {
 
 		newVirtualHost.setLanguageId(RandomTestUtil.randomString());
 
-		_virtualHosts.add(_persistence.update(newVirtualHost));
+		newVirtualHost = _persistence.update(newVirtualHost);
+
+		_virtualHosts.add(newVirtualHost);
 
 		VirtualHost existingVirtualHost = _persistence.findByPrimaryKey(
 			newVirtualHost.getPrimaryKey());
@@ -518,4 +520,4 @@ public class VirtualHostPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:704810919
+// LIFERAY-SERVICE-BUILDER-HASH:621608833

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/WebDAVPropsPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/WebDAVPropsPersistenceTest.java
@@ -124,7 +124,9 @@ public class WebDAVPropsPersistenceTest {
 
 		newWebDAVProps.setProps(RandomTestUtil.randomString());
 
-		_webDAVPropses.add(_persistence.update(newWebDAVProps));
+		newWebDAVProps = _persistence.update(newWebDAVProps);
+
+		_webDAVPropses.add(newWebDAVProps);
 
 		WebDAVProps existingWebDAVProps = _persistence.findByPrimaryKey(
 			newWebDAVProps.getPrimaryKey());
@@ -491,4 +493,4 @@ public class WebDAVPropsPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-818312119
+// LIFERAY-SERVICE-BUILDER-HASH:1942885153

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/WebsitePersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/WebsitePersistenceTest.java
@@ -139,7 +139,9 @@ public class WebsitePersistenceTest {
 
 		newWebsite.setLastPublishDate(RandomTestUtil.nextDate());
 
-		_websites.add(_persistence.update(newWebsite));
+		newWebsite = _persistence.update(newWebsite);
+
+		_websites.add(newWebsite);
 
 		Website existingWebsite = _persistence.findByPrimaryKey(
 			newWebsite.getPrimaryKey());
@@ -601,4 +603,4 @@ public class WebsitePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1042254785
+// LIFERAY-SERVICE-BUILDER-HASH:759185851

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/WorkflowDefinitionLinkPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/WorkflowDefinitionLinkPersistenceTest.java
@@ -148,8 +148,10 @@ public class WorkflowDefinitionLinkPersistenceTest {
 		newWorkflowDefinitionLink.setWorkflowDefinitionVersion(
 			RandomTestUtil.nextInt());
 
-		_workflowDefinitionLinks.add(
-			_persistence.update(newWorkflowDefinitionLink));
+		newWorkflowDefinitionLink = _persistence.update(
+			newWorkflowDefinitionLink);
+
+		_workflowDefinitionLinks.add(newWorkflowDefinitionLink);
 
 		WorkflowDefinitionLink existingWorkflowDefinitionLink =
 			_persistence.findByPrimaryKey(
@@ -735,4 +737,4 @@ public class WorkflowDefinitionLinkPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1878975933
+// LIFERAY-SERVICE-BUILDER-HASH:-281089987

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/WorkflowInstanceLinkPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/WorkflowInstanceLinkPersistenceTest.java
@@ -137,8 +137,9 @@ public class WorkflowInstanceLinkPersistenceTest {
 		newWorkflowInstanceLink.setWorkflowInstanceId(
 			RandomTestUtil.nextLong());
 
-		_workflowInstanceLinks.add(
-			_persistence.update(newWorkflowInstanceLink));
+		newWorkflowInstanceLink = _persistence.update(newWorkflowInstanceLink);
+
+		_workflowInstanceLinks.add(newWorkflowInstanceLink);
 
 		WorkflowInstanceLink existingWorkflowInstanceLink =
 			_persistence.findByPrimaryKey(
@@ -586,4 +587,4 @@ public class WorkflowInstanceLinkPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1152101887
+// LIFERAY-SERVICE-BUILDER-HASH:-932931013

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/announcements/service/persistence/test/AnnouncementsDeliveryPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/announcements/service/persistence/test/AnnouncementsDeliveryPersistenceTest.java
@@ -129,8 +129,10 @@ public class AnnouncementsDeliveryPersistenceTest {
 
 		newAnnouncementsDelivery.setWebsite(RandomTestUtil.randomBoolean());
 
-		_announcementsDeliveries.add(
-			_persistence.update(newAnnouncementsDelivery));
+		newAnnouncementsDelivery = _persistence.update(
+			newAnnouncementsDelivery);
+
+		_announcementsDeliveries.add(newAnnouncementsDelivery);
 
 		AnnouncementsDelivery existingAnnouncementsDelivery =
 			_persistence.findByPrimaryKey(
@@ -553,4 +555,4 @@ public class AnnouncementsDeliveryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1463241155
+// LIFERAY-SERVICE-BUILDER-HASH:-234966299

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/announcements/service/persistence/test/AnnouncementsEntryPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/announcements/service/persistence/test/AnnouncementsEntryPersistenceTest.java
@@ -146,7 +146,9 @@ public class AnnouncementsEntryPersistenceTest {
 
 		newAnnouncementsEntry.setAlert(RandomTestUtil.randomBoolean());
 
-		_announcementsEntries.add(_persistence.update(newAnnouncementsEntry));
+		newAnnouncementsEntry = _persistence.update(newAnnouncementsEntry);
+
+		_announcementsEntries.add(newAnnouncementsEntry);
 
 		AnnouncementsEntry existingAnnouncementsEntry =
 			_persistence.findByPrimaryKey(
@@ -578,4 +580,4 @@ public class AnnouncementsEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:2061875058
+// LIFERAY-SERVICE-BUILDER-HASH:2091431160

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/announcements/service/persistence/test/AnnouncementsFlagPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/announcements/service/persistence/test/AnnouncementsFlagPersistenceTest.java
@@ -125,7 +125,9 @@ public class AnnouncementsFlagPersistenceTest {
 
 		newAnnouncementsFlag.setValue(RandomTestUtil.nextInt());
 
-		_announcementsFlags.add(_persistence.update(newAnnouncementsFlag));
+		newAnnouncementsFlag = _persistence.update(newAnnouncementsFlag);
+
+		_announcementsFlags.add(newAnnouncementsFlag);
 
 		AnnouncementsFlag existingAnnouncementsFlag =
 			_persistence.findByPrimaryKey(newAnnouncementsFlag.getPrimaryKey());
@@ -518,4 +520,4 @@ public class AnnouncementsFlagPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:459064112
+// LIFERAY-SERVICE-BUILDER-HASH:-759314858

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/asset/service/persistence/test/AssetCategoryPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/asset/service/persistence/test/AssetCategoryPersistenceTest.java
@@ -152,7 +152,9 @@ public class AssetCategoryPersistenceTest {
 
 		newAssetCategory.setStatus(RandomTestUtil.nextInt());
 
-		_assetCategories.add(_persistence.update(newAssetCategory));
+		newAssetCategory = _persistence.update(newAssetCategory);
+
+		_assetCategories.add(newAssetCategory);
 
 		AssetCategory existingAssetCategory = _persistence.findByPrimaryKey(
 			newAssetCategory.getPrimaryKey());
@@ -793,4 +795,4 @@ public class AssetCategoryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1092293275
+// LIFERAY-SERVICE-BUILDER-HASH:1772366963

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/asset/service/persistence/test/AssetEntryPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/asset/service/persistence/test/AssetEntryPersistenceTest.java
@@ -165,7 +165,9 @@ public class AssetEntryPersistenceTest {
 
 		newAssetEntry.setPriority(RandomTestUtil.nextDouble());
 
-		_assetEntries.add(_persistence.update(newAssetEntry));
+		newAssetEntry = _persistence.update(newAssetEntry);
+
+		_assetEntries.add(newAssetEntry);
 
 		AssetEntry existingAssetEntry = _persistence.findByPrimaryKey(
 			newAssetEntry.getPrimaryKey());
@@ -715,4 +717,4 @@ public class AssetEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1461604554
+// LIFERAY-SERVICE-BUILDER-HASH:-1031356828

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/asset/service/persistence/test/AssetTagGroupRelPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/asset/service/persistence/test/AssetTagGroupRelPersistenceTest.java
@@ -121,7 +121,9 @@ public class AssetTagGroupRelPersistenceTest {
 
 		newAssetTagGroupRel.setTagId(RandomTestUtil.nextLong());
 
-		_assetTagGroupRels.add(_persistence.update(newAssetTagGroupRel));
+		newAssetTagGroupRel = _persistence.update(newAssetTagGroupRel);
+
+		_assetTagGroupRels.add(newAssetTagGroupRel);
 
 		AssetTagGroupRel existingAssetTagGroupRel =
 			_persistence.findByPrimaryKey(newAssetTagGroupRel.getPrimaryKey());
@@ -545,4 +547,4 @@ public class AssetTagGroupRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:442770993
+// LIFERAY-SERVICE-BUILDER-HASH:1332078337

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/asset/service/persistence/test/AssetTagPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/asset/service/persistence/test/AssetTagPersistenceTest.java
@@ -137,7 +137,9 @@ public class AssetTagPersistenceTest {
 
 		newAssetTag.setLastPublishDate(RandomTestUtil.nextDate());
 
-		_assetTags.add(_persistence.update(newAssetTag));
+		newAssetTag = _persistence.update(newAssetTag);
+
+		_assetTags.add(newAssetTag);
 
 		AssetTag existingAssetTag = _persistence.findByPrimaryKey(
 			newAssetTag.getPrimaryKey());
@@ -630,4 +632,4 @@ public class AssetTagPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1782296109
+// LIFERAY-SERVICE-BUILDER-HASH:-2015687529

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/asset/service/persistence/test/AssetVocabularyGroupRelPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/asset/service/persistence/test/AssetVocabularyGroupRelPersistenceTest.java
@@ -126,8 +126,10 @@ public class AssetVocabularyGroupRelPersistenceTest {
 
 		newAssetVocabularyGroupRel.setVocabularyId(RandomTestUtil.nextLong());
 
-		_assetVocabularyGroupRels.add(
-			_persistence.update(newAssetVocabularyGroupRel));
+		newAssetVocabularyGroupRel = _persistence.update(
+			newAssetVocabularyGroupRel);
+
+		_assetVocabularyGroupRels.add(newAssetVocabularyGroupRel);
 
 		AssetVocabularyGroupRel existingAssetVocabularyGroupRel =
 			_persistence.findByPrimaryKey(
@@ -586,4 +588,4 @@ public class AssetVocabularyGroupRelPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-29615145
+// LIFERAY-SERVICE-BUILDER-HASH:1480852625

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/asset/service/persistence/test/AssetVocabularyPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/asset/service/persistence/test/AssetVocabularyPersistenceTest.java
@@ -150,7 +150,9 @@ public class AssetVocabularyPersistenceTest {
 
 		newAssetVocabulary.setStatus(RandomTestUtil.nextInt());
 
-		_assetVocabularies.add(_persistence.update(newAssetVocabulary));
+		newAssetVocabulary = _persistence.update(newAssetVocabulary);
+
+		_assetVocabularies.add(newAssetVocabulary);
 
 		AssetVocabulary existingAssetVocabulary = _persistence.findByPrimaryKey(
 			newAssetVocabulary.getPrimaryKey());
@@ -723,4 +725,4 @@ public class AssetVocabularyPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1602756632
+// LIFERAY-SERVICE-BUILDER-HASH:-1620095168

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/documentlibrary/service/persistence/test/DLFileEntryMetadataPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/documentlibrary/service/persistence/test/DLFileEntryMetadataPersistenceTest.java
@@ -131,7 +131,9 @@ public class DLFileEntryMetadataPersistenceTest {
 
 		newDLFileEntryMetadata.setFileVersionId(RandomTestUtil.nextLong());
 
-		_dlFileEntryMetadatas.add(_persistence.update(newDLFileEntryMetadata));
+		newDLFileEntryMetadata = _persistence.update(newDLFileEntryMetadata);
+
+		_dlFileEntryMetadatas.add(newDLFileEntryMetadata);
 
 		DLFileEntryMetadata existingDLFileEntryMetadata =
 			_persistence.findByPrimaryKey(
@@ -608,4 +610,4 @@ public class DLFileEntryMetadataPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1854342612
+// LIFERAY-SERVICE-BUILDER-HASH:-949263586

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/documentlibrary/service/persistence/test/DLFileEntryPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/documentlibrary/service/persistence/test/DLFileEntryPersistenceTest.java
@@ -183,7 +183,9 @@ public class DLFileEntryPersistenceTest {
 
 		newDLFileEntry.setLastPublishDate(RandomTestUtil.nextDate());
 
-		_dlFileEntries.add(_persistence.update(newDLFileEntry));
+		newDLFileEntry = _persistence.update(newDLFileEntry);
+
+		_dlFileEntries.add(newDLFileEntry);
 
 		DLFileEntry existingDLFileEntry = _persistence.findByPrimaryKey(
 			newDLFileEntry.getPrimaryKey());
@@ -999,4 +1001,4 @@ public class DLFileEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1990051859
+// LIFERAY-SERVICE-BUILDER-HASH:1774967035

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/documentlibrary/service/persistence/test/DLFileEntryTypePersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/documentlibrary/service/persistence/test/DLFileEntryTypePersistenceTest.java
@@ -148,7 +148,9 @@ public class DLFileEntryTypePersistenceTest {
 
 		newDLFileEntryType.setLastPublishDate(RandomTestUtil.nextDate());
 
-		_dlFileEntryTypes.add(_persistence.update(newDLFileEntryType));
+		newDLFileEntryType = _persistence.update(newDLFileEntryType);
+
+		_dlFileEntryTypes.add(newDLFileEntryType);
 
 		DLFileEntryType existingDLFileEntryType = _persistence.findByPrimaryKey(
 			newDLFileEntryType.getPrimaryKey());
@@ -711,4 +713,4 @@ public class DLFileEntryTypePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1646720508
+// LIFERAY-SERVICE-BUILDER-HASH:-62395798

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/documentlibrary/service/persistence/test/DLFileShortcutPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/documentlibrary/service/persistence/test/DLFileShortcutPersistenceTest.java
@@ -156,7 +156,9 @@ public class DLFileShortcutPersistenceTest {
 
 		newDLFileShortcut.setStatusDate(RandomTestUtil.nextDate());
 
-		_dlFileShortcuts.add(_persistence.update(newDLFileShortcut));
+		newDLFileShortcut = _persistence.update(newDLFileShortcut);
+
+		_dlFileShortcuts.add(newDLFileShortcut);
 
 		DLFileShortcut existingDLFileShortcut = _persistence.findByPrimaryKey(
 			newDLFileShortcut.getPrimaryKey());
@@ -736,4 +738,4 @@ public class DLFileShortcutPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-663751336
+// LIFERAY-SERVICE-BUILDER-HASH:56616404

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/documentlibrary/service/persistence/test/DLFileVersionPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/documentlibrary/service/persistence/test/DLFileVersionPersistenceTest.java
@@ -176,7 +176,9 @@ public class DLFileVersionPersistenceTest {
 
 		newDLFileVersion.setStatusDate(RandomTestUtil.nextDate());
 
-		_dlFileVersions.add(_persistence.update(newDLFileVersion));
+		newDLFileVersion = _persistence.update(newDLFileVersion);
+
+		_dlFileVersions.add(newDLFileVersion);
 
 		DLFileVersion existingDLFileVersion = _persistence.findByPrimaryKey(
 			newDLFileVersion.getPrimaryKey());
@@ -816,4 +818,4 @@ public class DLFileVersionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1502414282
+// LIFERAY-SERVICE-BUILDER-HASH:1296643732

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/documentlibrary/service/persistence/test/DLFolderPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/documentlibrary/service/persistence/test/DLFolderPersistenceTest.java
@@ -165,7 +165,9 @@ public class DLFolderPersistenceTest {
 
 		newDLFolder.setStatusDate(RandomTestUtil.nextDate());
 
-		_dlFolders.add(_persistence.update(newDLFolder));
+		newDLFolder = _persistence.update(newDLFolder);
+
+		_dlFolders.add(newDLFolder);
 
 		DLFolder existingDLFolder = _persistence.findByPrimaryKey(
 			newDLFolder.getPrimaryKey());
@@ -875,4 +877,4 @@ public class DLFolderPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:381315565
+// LIFERAY-SERVICE-BUILDER-HASH:908869569

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/expando/service/persistence/test/ExpandoColumnPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/expando/service/persistence/test/ExpandoColumnPersistenceTest.java
@@ -128,7 +128,9 @@ public class ExpandoColumnPersistenceTest {
 
 		newExpandoColumn.setTypeSettings(RandomTestUtil.randomString());
 
-		_expandoColumns.add(_persistence.update(newExpandoColumn));
+		newExpandoColumn = _persistence.update(newExpandoColumn);
+
+		_expandoColumns.add(newExpandoColumn);
 
 		ExpandoColumn existingExpandoColumn = _persistence.findByPrimaryKey(
 			newExpandoColumn.getPrimaryKey());
@@ -521,4 +523,4 @@ public class ExpandoColumnPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1507663156
+// LIFERAY-SERVICE-BUILDER-HASH:2074061614

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/expando/service/persistence/test/ExpandoRowPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/expando/service/persistence/test/ExpandoRowPersistenceTest.java
@@ -122,7 +122,9 @@ public class ExpandoRowPersistenceTest {
 
 		newExpandoRow.setClassPK(RandomTestUtil.nextLong());
 
-		_expandoRows.add(_persistence.update(newExpandoRow));
+		newExpandoRow = _persistence.update(newExpandoRow);
+
+		_expandoRows.add(newExpandoRow);
 
 		ExpandoRow existingExpandoRow = _persistence.findByPrimaryKey(
 			newExpandoRow.getPrimaryKey());
@@ -489,4 +491,4 @@ public class ExpandoRowPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:119363143
+// LIFERAY-SERVICE-BUILDER-HASH:-1771448455

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/expando/service/persistence/test/ExpandoTablePersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/expando/service/persistence/test/ExpandoTablePersistenceTest.java
@@ -119,7 +119,9 @@ public class ExpandoTablePersistenceTest {
 
 		newExpandoTable.setName(RandomTestUtil.randomString());
 
-		_expandoTables.add(_persistence.update(newExpandoTable));
+		newExpandoTable = _persistence.update(newExpandoTable);
+
+		_expandoTables.add(newExpandoTable);
 
 		ExpandoTable existingExpandoTable = _persistence.findByPrimaryKey(
 			newExpandoTable.getPrimaryKey());
@@ -490,4 +492,4 @@ public class ExpandoTablePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1527221249
+// LIFERAY-SERVICE-BUILDER-HASH:-360019419

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/expando/service/persistence/test/ExpandoValuePersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/expando/service/persistence/test/ExpandoValuePersistenceTest.java
@@ -127,7 +127,9 @@ public class ExpandoValuePersistenceTest {
 
 		newExpandoValue.setData(RandomTestUtil.randomString());
 
-		_expandoValues.add(_persistence.update(newExpandoValue));
+		newExpandoValue = _persistence.update(newExpandoValue);
+
+		_expandoValues.add(newExpandoValue);
 
 		ExpandoValue existingExpandoValue = _persistence.findByPrimaryKey(
 			newExpandoValue.getPrimaryKey());
@@ -587,4 +589,4 @@ public class ExpandoValuePersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:596951059
+// LIFERAY-SERVICE-BUILDER-HASH:472206067

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/exportimport/service/persistence/test/ExportImportConfigurationPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/exportimport/service/persistence/test/ExportImportConfigurationPersistenceTest.java
@@ -146,8 +146,10 @@ public class ExportImportConfigurationPersistenceTest {
 
 		newExportImportConfiguration.setStatusDate(RandomTestUtil.nextDate());
 
-		_exportImportConfigurations.add(
-			_persistence.update(newExportImportConfiguration));
+		newExportImportConfiguration = _persistence.update(
+			newExportImportConfiguration);
+
+		_exportImportConfigurations.add(newExportImportConfiguration);
 
 		ExportImportConfiguration existingExportImportConfiguration =
 			_persistence.findByPrimaryKey(
@@ -579,4 +581,4 @@ public class ExportImportConfigurationPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1076931003
+// LIFERAY-SERVICE-BUILDER-HASH:15955273

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/ratings/service/persistence/test/RatingsEntryPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/ratings/service/persistence/test/RatingsEntryPersistenceTest.java
@@ -133,7 +133,9 @@ public class RatingsEntryPersistenceTest {
 
 		newRatingsEntry.setScore(RandomTestUtil.nextDouble());
 
-		_ratingsEntries.add(_persistence.update(newRatingsEntry));
+		newRatingsEntry = _persistence.update(newRatingsEntry);
+
+		_ratingsEntries.add(newRatingsEntry);
 
 		RatingsEntry existingRatingsEntry = _persistence.findByPrimaryKey(
 			newRatingsEntry.getPrimaryKey());
@@ -564,4 +566,4 @@ public class RatingsEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:909608434
+// LIFERAY-SERVICE-BUILDER-HASH:-1081947800

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/ratings/service/persistence/test/RatingsStatsPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/ratings/service/persistence/test/RatingsStatsPersistenceTest.java
@@ -131,7 +131,9 @@ public class RatingsStatsPersistenceTest {
 
 		newRatingsStats.setAverageScore(RandomTestUtil.nextDouble());
 
-		_ratingsStatses.add(_persistence.update(newRatingsStats));
+		newRatingsStats = _persistence.update(newRatingsStats);
+
+		_ratingsStatses.add(newRatingsStats);
 
 		RatingsStats existingRatingsStats = _persistence.findByPrimaryKey(
 			newRatingsStats.getPrimaryKey());
@@ -520,4 +522,4 @@ public class RatingsStatsPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2014442678
+// LIFERAY-SERVICE-BUILDER-HASH:358866002

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/social/service/persistence/test/SocialActivityAchievementPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/social/service/persistence/test/SocialActivityAchievementPersistenceTest.java
@@ -132,8 +132,10 @@ public class SocialActivityAchievementPersistenceTest {
 		newSocialActivityAchievement.setFirstInGroup(
 			RandomTestUtil.randomBoolean());
 
-		_socialActivityAchievements.add(
-			_persistence.update(newSocialActivityAchievement));
+		newSocialActivityAchievement = _persistence.update(
+			newSocialActivityAchievement);
+
+		_socialActivityAchievements.add(newSocialActivityAchievement);
 
 		SocialActivityAchievement existingSocialActivityAchievement =
 			_persistence.findByPrimaryKey(
@@ -607,4 +609,4 @@ public class SocialActivityAchievementPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1379318758
+// LIFERAY-SERVICE-BUILDER-HASH:820155648

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/social/service/persistence/test/SocialActivityCounterPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/social/service/persistence/test/SocialActivityCounterPersistenceTest.java
@@ -141,8 +141,10 @@ public class SocialActivityCounterPersistenceTest {
 
 		newSocialActivityCounter.setActive(RandomTestUtil.randomBoolean());
 
-		_socialActivityCounters.add(
-			_persistence.update(newSocialActivityCounter));
+		newSocialActivityCounter = _persistence.update(
+			newSocialActivityCounter);
+
+		_socialActivityCounters.add(newSocialActivityCounter);
 
 		SocialActivityCounter existingSocialActivityCounter =
 			_persistence.findByPrimaryKey(
@@ -675,4 +677,4 @@ public class SocialActivityCounterPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:224167999
+// LIFERAY-SERVICE-BUILDER-HASH:154975353

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/social/service/persistence/test/SocialActivityLimitPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/social/service/persistence/test/SocialActivityLimitPersistenceTest.java
@@ -132,7 +132,9 @@ public class SocialActivityLimitPersistenceTest {
 
 		newSocialActivityLimit.setValue(RandomTestUtil.randomString());
 
-		_socialActivityLimits.add(_persistence.update(newSocialActivityLimit));
+		newSocialActivityLimit = _persistence.update(newSocialActivityLimit);
+
+		_socialActivityLimits.add(newSocialActivityLimit);
 
 		SocialActivityLimit existingSocialActivityLimit =
 			_persistence.findByPrimaryKey(
@@ -583,4 +585,4 @@ public class SocialActivityLimitPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-82437639
+// LIFERAY-SERVICE-BUILDER-HASH:-750468785

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/social/service/persistence/test/SocialActivityPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/social/service/persistence/test/SocialActivityPersistenceTest.java
@@ -139,7 +139,9 @@ public class SocialActivityPersistenceTest {
 
 		newSocialActivity.setReceiverUserId(RandomTestUtil.nextLong());
 
-		_socialActivities.add(_persistence.update(newSocialActivity));
+		newSocialActivity = _persistence.update(newSocialActivity);
+
+		_socialActivities.add(newSocialActivity);
 
 		SocialActivity existingSocialActivity = _persistence.findByPrimaryKey(
 			newSocialActivity.getPrimaryKey());
@@ -674,4 +676,4 @@ public class SocialActivityPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1325737225
+// LIFERAY-SERVICE-BUILDER-HASH:692533011

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/social/service/persistence/test/SocialActivitySetPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/social/service/persistence/test/SocialActivitySetPersistenceTest.java
@@ -132,7 +132,9 @@ public class SocialActivitySetPersistenceTest {
 
 		newSocialActivitySet.setActivityCount(RandomTestUtil.nextInt());
 
-		_socialActivitySets.add(_persistence.update(newSocialActivitySet));
+		newSocialActivitySet = _persistence.update(newSocialActivitySet);
+
+		_socialActivitySets.add(newSocialActivitySet);
 
 		SocialActivitySet existingSocialActivitySet =
 			_persistence.findByPrimaryKey(newSocialActivitySet.getPrimaryKey());
@@ -514,4 +516,4 @@ public class SocialActivitySetPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1300858535
+// LIFERAY-SERVICE-BUILDER-HASH:-1975794375

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/social/service/persistence/test/SocialActivitySettingPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/social/service/persistence/test/SocialActivitySettingPersistenceTest.java
@@ -129,8 +129,10 @@ public class SocialActivitySettingPersistenceTest {
 
 		newSocialActivitySetting.setValue(RandomTestUtil.randomString());
 
-		_socialActivitySettings.add(
-			_persistence.update(newSocialActivitySetting));
+		newSocialActivitySetting = _persistence.update(
+			newSocialActivitySetting);
+
+		_socialActivitySettings.add(newSocialActivitySetting);
 
 		SocialActivitySetting existingSocialActivitySetting =
 			_persistence.findByPrimaryKey(
@@ -586,4 +588,4 @@ public class SocialActivitySettingPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1079801953
+// LIFERAY-SERVICE-BUILDER-HASH:424809707

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/social/service/persistence/test/SocialRelationPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/social/service/persistence/test/SocialRelationPersistenceTest.java
@@ -125,7 +125,9 @@ public class SocialRelationPersistenceTest {
 
 		newSocialRelation.setType(RandomTestUtil.nextInt());
 
-		_socialRelations.add(_persistence.update(newSocialRelation));
+		newSocialRelation = _persistence.update(newSocialRelation);
+
+		_socialRelations.add(newSocialRelation);
 
 		SocialRelation existingSocialRelation = _persistence.findByPrimaryKey(
 			newSocialRelation.getPrimaryKey());
@@ -586,4 +588,4 @@ public class SocialRelationPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1838882260
+// LIFERAY-SERVICE-BUILDER-HASH:1021798

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/social/service/persistence/test/SocialRequestPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/social/service/persistence/test/SocialRequestPersistenceTest.java
@@ -137,7 +137,9 @@ public class SocialRequestPersistenceTest {
 
 		newSocialRequest.setStatus(RandomTestUtil.nextInt());
 
-		_socialRequests.add(_persistence.update(newSocialRequest));
+		newSocialRequest = _persistence.update(newSocialRequest);
+
+		_socialRequests.add(newSocialRequest);
 
 		SocialRequest existingSocialRequest = _persistence.findByPrimaryKey(
 			newSocialRequest.getPrimaryKey());
@@ -658,4 +660,4 @@ public class SocialRequestPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1783005333
+// LIFERAY-SERVICE-BUILDER-HASH:1136392361

--- a/modules/util/portal-tools-service-builder-test-compat740-service/src/main/java/com/liferay/portal/tools/service/builder/test/compat740/service/persistence/impl/LazyBlobEntryPersistenceImpl.java
+++ b/modules/util/portal-tools-service-builder-test-compat740-service/src/main/java/com/liferay/portal/tools/service/builder/test/compat740/service/persistence/impl/LazyBlobEntryPersistenceImpl.java
@@ -342,10 +342,7 @@ public class LazyBlobEntryPersistenceImpl
 				session.save(lazyBlobEntry);
 			}
 			else {
-				session.evict(
-					LazyBlobEntryImpl.class, lazyBlobEntry.getPrimaryKeyObj());
-
-				session.saveOrUpdate(lazyBlobEntry);
+				lazyBlobEntry = (LazyBlobEntry)session.merge(lazyBlobEntry);
 			}
 
 			session.flush();
@@ -532,4 +529,4 @@ public class LazyBlobEntryPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:2132809462
+// LIFERAY-SERVICE-BUILDER-HASH:-1428404629

--- a/modules/util/portal-tools-service-builder-test-compat740-service/src/main/resources/META-INF/module-hbm.xml
+++ b/modules/util/portal-tools-service-builder-test-compat740-service/src/main/resources/META-INF/module-hbm.xml
@@ -126,8 +126,8 @@
 		</id>
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" column="uuid_" name="uuid" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="groupId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
-		<one-to-one access="com.liferay.portal.dao.orm.hibernate.PrivateFieldPropertyAccessor" cascade="save-update" class="com.liferay.portal.tools.service.builder.test.compat740.model.LazyBlobEntryBlob1BlobModel" constrained="false" name="blob1BlobModel" outer-join="false" />
-		<one-to-one access="com.liferay.portal.dao.orm.hibernate.PrivateFieldPropertyAccessor" cascade="save-update" class="com.liferay.portal.tools.service.builder.test.compat740.model.LazyBlobEntryBlob2BlobModel" constrained="false" name="blob2BlobModel" outer-join="false" />
+		<one-to-one access="com.liferay.portal.dao.orm.hibernate.PrivateFieldPropertyAccessor" cascade="merge, persist, save-update" class="com.liferay.portal.tools.service.builder.test.compat740.model.LazyBlobEntryBlob1BlobModel" constrained="false" name="blob1BlobModel" outer-join="false" />
+		<one-to-one access="com.liferay.portal.dao.orm.hibernate.PrivateFieldPropertyAccessor" cascade="merge, persist, save-update" class="com.liferay.portal.tools.service.builder.test.compat740.model.LazyBlobEntryBlob2BlobModel" constrained="false" name="blob2BlobModel" outer-join="false" />
 	</class>
 	<class lazy="true" name="com.liferay.portal.tools.service.builder.test.compat740.model.LazyBlobEntryBlob1BlobModel" table="LazyBlobEntry">
 		<id column="lazyBlobEntryId" name="lazyBlobEntryId">

--- a/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/service/persistence/impl/LazyBlobEntryPersistenceImpl.java
+++ b/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/service/persistence/impl/LazyBlobEntryPersistenceImpl.java
@@ -332,10 +332,7 @@ public class LazyBlobEntryPersistenceImpl
 				session.save(lazyBlobEntry);
 			}
 			else {
-				session.evict(
-					LazyBlobEntryImpl.class, lazyBlobEntry.getPrimaryKeyObj());
-
-				session.saveOrUpdate(lazyBlobEntry);
+				lazyBlobEntry = (LazyBlobEntry)session.merge(lazyBlobEntry);
 			}
 
 			session.flush();
@@ -494,4 +491,4 @@ public class LazyBlobEntryPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1306218673
+// LIFERAY-SERVICE-BUILDER-HASH:-995314028

--- a/modules/util/portal-tools-service-builder-test-service/src/main/resources/META-INF/module-hbm.xml
+++ b/modules/util/portal-tools-service-builder-test-service/src/main/resources/META-INF/module-hbm.xml
@@ -199,8 +199,8 @@
 		<version access="com.liferay.portal.dao.orm.hibernate.PrivateFieldPropertyAccessor" name="mvccVersion" type="long" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" column="uuid_" name="uuid" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="groupId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
-		<one-to-one access="com.liferay.portal.dao.orm.hibernate.PrivateFieldPropertyAccessor" cascade="save-update" class="com.liferay.portal.tools.service.builder.test.model.LazyBlobEntryBlob1BlobModel" constrained="false" name="blob1BlobModel" outer-join="false" />
-		<one-to-one access="com.liferay.portal.dao.orm.hibernate.PrivateFieldPropertyAccessor" cascade="save-update" class="com.liferay.portal.tools.service.builder.test.model.LazyBlobEntryBlob2BlobModel" constrained="false" name="blob2BlobModel" outer-join="false" />
+		<one-to-one access="com.liferay.portal.dao.orm.hibernate.PrivateFieldPropertyAccessor" cascade="merge, persist, save-update" class="com.liferay.portal.tools.service.builder.test.model.LazyBlobEntryBlob1BlobModel" constrained="false" name="blob1BlobModel" outer-join="false" />
+		<one-to-one access="com.liferay.portal.dao.orm.hibernate.PrivateFieldPropertyAccessor" cascade="merge, persist, save-update" class="com.liferay.portal.tools.service.builder.test.model.LazyBlobEntryBlob2BlobModel" constrained="false" name="blob2BlobModel" outer-join="false" />
 	</class>
 	<class dynamic-update="true" lazy="true" name="com.liferay.portal.tools.service.builder.test.model.LazyBlobEntryBlob1BlobModel" table="LazyBlobEntry">
 		<id column="lazyBlobEntryId" name="lazyBlobEntryId">

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/AutoEscapeEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/AutoEscapeEntryPersistenceTest.java
@@ -114,7 +114,9 @@ public class AutoEscapeEntryPersistenceTest {
 		newAutoEscapeEntry.setAutoEscapeEnabledColumn(
 			RandomTestUtil.randomString());
 
-		_autoEscapeEntries.add(_persistence.update(newAutoEscapeEntry));
+		newAutoEscapeEntry = _persistence.update(newAutoEscapeEntry);
+
+		_autoEscapeEntries.add(newAutoEscapeEntry);
 
 		AutoEscapeEntry existingAutoEscapeEntry = _persistence.findByPrimaryKey(
 			newAutoEscapeEntry.getPrimaryKey());
@@ -372,4 +374,4 @@ public class AutoEscapeEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:323932151
+// LIFERAY-SERVICE-BUILDER-HASH:-1544286561

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/BigDecimalEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/BigDecimalEntryPersistenceTest.java
@@ -115,7 +115,9 @@ public class BigDecimalEntryPersistenceTest {
 		newBigDecimalEntry.setBigDecimalValue(
 			new BigDecimal(RandomTestUtil.nextDouble()));
 
-		_bigDecimalEntries.add(_persistence.update(newBigDecimalEntry));
+		newBigDecimalEntry = _persistence.update(newBigDecimalEntry);
+
+		_bigDecimalEntries.add(newBigDecimalEntry);
 
 		BigDecimalEntry existingBigDecimalEntry = _persistence.findByPrimaryKey(
 			newBigDecimalEntry.getPrimaryKey());
@@ -393,4 +395,4 @@ public class BigDecimalEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1732478284
+// LIFERAY-SERVICE-BUILDER-HASH:1910733508

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/CacheDisabledEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/CacheDisabledEntryPersistenceTest.java
@@ -117,7 +117,9 @@ public class CacheDisabledEntryPersistenceTest {
 
 		newCacheDisabledEntry.setName(RandomTestUtil.randomString());
 
-		_cacheDisabledEntries.add(_persistence.update(newCacheDisabledEntry));
+		newCacheDisabledEntry = _persistence.update(newCacheDisabledEntry);
+
+		_cacheDisabledEntries.add(newCacheDisabledEntry);
 
 		CacheDisabledEntry existingCacheDisabledEntry =
 			_persistence.findByPrimaryKey(
@@ -470,4 +472,4 @@ public class CacheDisabledEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1767181964
+// LIFERAY-SERVICE-BUILDER-HASH:-1703943154

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/CacheFieldEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/CacheFieldEntryPersistenceTest.java
@@ -115,7 +115,9 @@ public class CacheFieldEntryPersistenceTest {
 
 		newCacheFieldEntry.setName(RandomTestUtil.randomString());
 
-		_cacheFieldEntries.add(_persistence.update(newCacheFieldEntry));
+		newCacheFieldEntry = _persistence.update(newCacheFieldEntry);
+
+		_cacheFieldEntries.add(newCacheFieldEntry);
 
 		CacheFieldEntry existingCacheFieldEntry = _persistence.findByPrimaryKey(
 			newCacheFieldEntry.getPrimaryKey());
@@ -401,4 +403,4 @@ public class CacheFieldEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-218468188
+// LIFERAY-SERVICE-BUILDER-HASH:532498380

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/CacheMissEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/CacheMissEntryPersistenceTest.java
@@ -113,7 +113,9 @@ public class CacheMissEntryPersistenceTest {
 
 		newCacheMissEntry.setCtCollectionId(RandomTestUtil.nextLong());
 
-		_cacheMissEntries.add(_persistence.update(newCacheMissEntry));
+		newCacheMissEntry = _persistence.update(newCacheMissEntry);
+
+		_cacheMissEntries.add(newCacheMissEntry);
 
 		CacheMissEntry existingCacheMissEntry = _persistence.findByPrimaryKey(
 			newCacheMissEntry.getPrimaryKey());
@@ -390,4 +392,4 @@ public class CacheMissEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1734332678
+// LIFERAY-SERVICE-BUILDER-HASH:1143607712

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/CacheReplicatorEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/CacheReplicatorEntryPersistenceTest.java
@@ -121,8 +121,9 @@ public class CacheReplicatorEntryPersistenceTest {
 
 		newCacheReplicatorEntry.setName(RandomTestUtil.randomString());
 
-		_cacheReplicatorEntries.add(
-			_persistence.update(newCacheReplicatorEntry));
+		newCacheReplicatorEntry = _persistence.update(newCacheReplicatorEntry);
+
+		_cacheReplicatorEntries.add(newCacheReplicatorEntry);
 
 		CacheReplicatorEntry existingCacheReplicatorEntry =
 			_persistence.findByPrimaryKey(
@@ -507,4 +508,4 @@ public class CacheReplicatorEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1117330332
+// LIFERAY-SERVICE-BUILDER-HASH:-635750484

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/DSLQueryEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/DSLQueryEntryPersistenceTest.java
@@ -113,7 +113,9 @@ public class DSLQueryEntryPersistenceTest {
 
 		newDSLQueryEntry.setName(RandomTestUtil.randomString());
 
-		_dslQueryEntries.add(_persistence.update(newDSLQueryEntry));
+		newDSLQueryEntry = _persistence.update(newDSLQueryEntry);
+
+		_dslQueryEntries.add(newDSLQueryEntry);
 
 		DSLQueryEntry existingDSLQueryEntry = _persistence.findByPrimaryKey(
 			newDSLQueryEntry.getPrimaryKey());
@@ -384,4 +386,4 @@ public class DSLQueryEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:974729198
+// LIFERAY-SERVICE-BUILDER-HASH:647863270

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/DSLQueryStatusEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/DSLQueryStatusEntryPersistenceTest.java
@@ -120,7 +120,9 @@ public class DSLQueryStatusEntryPersistenceTest {
 
 		newDSLQueryStatusEntry.setStatusDate(RandomTestUtil.nextDate());
 
-		_dslQueryStatusEntries.add(_persistence.update(newDSLQueryStatusEntry));
+		newDSLQueryStatusEntry = _persistence.update(newDSLQueryStatusEntry);
+
+		_dslQueryStatusEntries.add(newDSLQueryStatusEntry);
 
 		DSLQueryStatusEntry existingDSLQueryStatusEntry =
 			_persistence.findByPrimaryKey(
@@ -418,4 +420,4 @@ public class DSLQueryStatusEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1319606101
+// LIFERAY-SERVICE-BUILDER-HASH:12722765

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/DataLimitEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/DataLimitEntryPersistenceTest.java
@@ -122,7 +122,9 @@ public class DataLimitEntryPersistenceTest {
 
 		newDataLimitEntry.setModifiedDate(RandomTestUtil.nextDate());
 
-		_dataLimitEntries.add(_persistence.update(newDataLimitEntry));
+		newDataLimitEntry = _persistence.update(newDataLimitEntry);
+
+		_dataLimitEntries.add(newDataLimitEntry);
 
 		DataLimitEntry existingDataLimitEntry = _persistence.findByPrimaryKey(
 			newDataLimitEntry.getPrimaryKey());
@@ -416,4 +418,4 @@ public class DataLimitEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-864464582
+// LIFERAY-SERVICE-BUILDER-HASH:-571641246

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/DefinedDefaultOrderEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/DefinedDefaultOrderEntryPersistenceTest.java
@@ -123,8 +123,10 @@ public class DefinedDefaultOrderEntryPersistenceTest {
 
 		newDefinedDefaultOrderEntry.setName(RandomTestUtil.randomString());
 
-		_definedDefaultOrderEntries.add(
-			_persistence.update(newDefinedDefaultOrderEntry));
+		newDefinedDefaultOrderEntry = _persistence.update(
+			newDefinedDefaultOrderEntry);
+
+		_definedDefaultOrderEntries.add(newDefinedDefaultOrderEntry);
 
 		DefinedDefaultOrderEntry existingDefinedDefaultOrderEntry =
 			_persistence.findByPrimaryKey(
@@ -521,4 +523,4 @@ public class DefinedDefaultOrderEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1769265507
+// LIFERAY-SERVICE-BUILDER-HASH:-1414399271

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/DynamicQueryEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/DynamicQueryEntryPersistenceTest.java
@@ -125,7 +125,9 @@ public class DynamicQueryEntryPersistenceTest {
 
 		newDynamicQueryEntry.setStatus(RandomTestUtil.nextInt());
 
-		_dynamicQueryEntries.add(_persistence.update(newDynamicQueryEntry));
+		newDynamicQueryEntry = _persistence.update(newDynamicQueryEntry);
+
+		_dynamicQueryEntries.add(newDynamicQueryEntry);
 
 		DynamicQueryEntry existingDynamicQueryEntry =
 			_persistence.findByPrimaryKey(newDynamicQueryEntry.getPrimaryKey());
@@ -431,4 +433,4 @@ public class DynamicQueryEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1275084678
+// LIFERAY-SERVICE-BUILDER-HASH:-1962705422

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/ERCCompanyEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/ERCCompanyEntryPersistenceTest.java
@@ -127,7 +127,9 @@ public class ERCCompanyEntryPersistenceTest {
 
 		newERCCompanyEntry.setColumn1(RandomTestUtil.nextInt());
 
-		_ercCompanyEntries.add(_persistence.update(newERCCompanyEntry));
+		newERCCompanyEntry = _persistence.update(newERCCompanyEntry);
+
+		_ercCompanyEntries.add(newERCCompanyEntry);
 
 		ERCCompanyEntry existingERCCompanyEntry = _persistence.findByPrimaryKey(
 			newERCCompanyEntry.getPrimaryKey());
@@ -540,4 +542,4 @@ public class ERCCompanyEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1306570582
+// LIFERAY-SERVICE-BUILDER-HASH:-1827410722

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/ERCGroupEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/ERCGroupEntryPersistenceTest.java
@@ -123,7 +123,9 @@ public class ERCGroupEntryPersistenceTest {
 
 		newERCGroupEntry.setCompanyId(RandomTestUtil.nextLong());
 
-		_ercGroupEntries.add(_persistence.update(newERCGroupEntry));
+		newERCGroupEntry = _persistence.update(newERCGroupEntry);
+
+		_ercGroupEntries.add(newERCGroupEntry);
 
 		ERCGroupEntry existingERCGroupEntry = _persistence.findByPrimaryKey(
 			newERCGroupEntry.getPrimaryKey());
@@ -539,4 +541,4 @@ public class ERCGroupEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-383991270
+// LIFERAY-SERVICE-BUILDER-HASH:913208274

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/ERCVersionedEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/ERCVersionedEntryPersistenceTest.java
@@ -128,7 +128,9 @@ public class ERCVersionedEntryPersistenceTest {
 
 		newERCVersionedEntry.setCompanyId(RandomTestUtil.nextLong());
 
-		_ercVersionedEntries.add(_persistence.update(newERCVersionedEntry));
+		newERCVersionedEntry = _persistence.update(newERCVersionedEntry);
+
+		_ercVersionedEntries.add(newERCVersionedEntry);
 
 		ERCVersionedEntry existingERCVersionedEntry =
 			_persistence.findByPrimaryKey(newERCVersionedEntry.getPrimaryKey());
@@ -687,4 +689,4 @@ public class ERCVersionedEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1601488419
+// LIFERAY-SERVICE-BUILDER-HASH:-167456421

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/ERCVersionedEntryVersionPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/ERCVersionedEntryVersionPersistenceTest.java
@@ -131,8 +131,10 @@ public class ERCVersionedEntryVersionPersistenceTest {
 
 		newERCVersionedEntryVersion.setCompanyId(RandomTestUtil.nextLong());
 
-		_ercVersionedEntryVersions.add(
-			_persistence.update(newERCVersionedEntryVersion));
+		newERCVersionedEntryVersion = _persistence.update(
+			newERCVersionedEntryVersion);
+
+		_ercVersionedEntryVersions.add(newERCVersionedEntryVersion);
 
 		ERCVersionedEntryVersion existingERCVersionedEntryVersion =
 			_persistence.findByPrimaryKey(
@@ -596,4 +598,4 @@ public class ERCVersionedEntryVersionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:682972795
+// LIFERAY-SERVICE-BUILDER-HASH:935414981

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/EagerBlobEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/EagerBlobEntryPersistenceTest.java
@@ -130,7 +130,9 @@ public class EagerBlobEntryPersistenceTest {
 
 		newEagerBlobEntry.setBlob(newBlobBlob);
 
-		_eagerBlobEntries.add(_persistence.update(newEagerBlobEntry));
+		newEagerBlobEntry = _persistence.update(newEagerBlobEntry);
+
+		_eagerBlobEntries.add(newEagerBlobEntry);
 
 		Session session = _persistence.openSession();
 
@@ -509,4 +511,4 @@ public class EagerBlobEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-707172627
+// LIFERAY-SERVICE-BUILDER-HASH:-816442755

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/FinderWhereClauseEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/FinderWhereClauseEntryPersistenceTest.java
@@ -119,8 +119,10 @@ public class FinderWhereClauseEntryPersistenceTest {
 
 		newFinderWhereClauseEntry.setNickname(RandomTestUtil.randomString());
 
-		_finderWhereClauseEntries.add(
-			_persistence.update(newFinderWhereClauseEntry));
+		newFinderWhereClauseEntry = _persistence.update(
+			newFinderWhereClauseEntry);
+
+		_finderWhereClauseEntries.add(newFinderWhereClauseEntry);
 
 		FinderWhereClauseEntry existingFinderWhereClauseEntry =
 			_persistence.findByPrimaryKey(
@@ -437,4 +439,4 @@ public class FinderWhereClauseEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-950684756
+// LIFERAY-SERVICE-BUILDER-HASH:1693639358

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/IndexEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/IndexEntryPersistenceTest.java
@@ -125,7 +125,9 @@ public class IndexEntryPersistenceTest {
 
 		newIndexEntry.setPortletId(RandomTestUtil.randomString());
 
-		_indexEntries.add(_persistence.update(newIndexEntry));
+		newIndexEntry = _persistence.update(newIndexEntry);
+
+		_indexEntries.add(newIndexEntry);
 
 		IndexEntry existingIndexEntry = _persistence.findByPrimaryKey(
 			newIndexEntry.getPrimaryKey());
@@ -604,4 +606,4 @@ public class IndexEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1289302592
+// LIFERAY-SERVICE-BUILDER-HASH:1098283934

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/LVEntryLocalizationPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/LVEntryLocalizationPersistenceTest.java
@@ -126,7 +126,9 @@ public class LVEntryLocalizationPersistenceTest {
 
 		newLVEntryLocalization.setContent(RandomTestUtil.randomString());
 
-		_lvEntryLocalizations.add(_persistence.update(newLVEntryLocalization));
+		newLVEntryLocalization = _persistence.update(newLVEntryLocalization);
+
+		_lvEntryLocalizations.add(newLVEntryLocalization);
 
 		LVEntryLocalization existingLVEntryLocalization =
 			_persistence.findByPrimaryKey(
@@ -512,4 +514,4 @@ public class LVEntryLocalizationPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1234433673
+// LIFERAY-SERVICE-BUILDER-HASH:2086693931

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/LVEntryLocalizationVersionPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/LVEntryLocalizationVersionPersistenceTest.java
@@ -133,8 +133,10 @@ public class LVEntryLocalizationVersionPersistenceTest {
 
 		newLVEntryLocalizationVersion.setContent(RandomTestUtil.randomString());
 
-		_lvEntryLocalizationVersions.add(
-			_persistence.update(newLVEntryLocalizationVersion));
+		newLVEntryLocalizationVersion = _persistence.update(
+			newLVEntryLocalizationVersion);
+
+		_lvEntryLocalizationVersions.add(newLVEntryLocalizationVersion);
 
 		LVEntryLocalizationVersion existingLVEntryLocalizationVersion =
 			_persistence.findByPrimaryKey(
@@ -590,4 +592,4 @@ public class LVEntryLocalizationVersionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-5133201
+// LIFERAY-SERVICE-BUILDER-HASH:910070489

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/LVEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/LVEntryPersistenceTest.java
@@ -127,7 +127,9 @@ public class LVEntryPersistenceTest {
 
 		newLVEntry.setUniqueGroupKey(RandomTestUtil.randomString());
 
-		_lvEntries.add(_persistence.update(newLVEntry));
+		newLVEntry = _persistence.update(newLVEntry);
+
+		_lvEntries.add(newLVEntry);
 
 		LVEntry existingLVEntry = _persistence.findByPrimaryKey(
 			newLVEntry.getPrimaryKey());
@@ -605,4 +607,4 @@ public class LVEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1918151625
+// LIFERAY-SERVICE-BUILDER-HASH:159555103

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/LVEntryVersionPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/LVEntryVersionPersistenceTest.java
@@ -126,7 +126,9 @@ public class LVEntryVersionPersistenceTest {
 
 		newLVEntryVersion.setUniqueGroupKey(RandomTestUtil.randomString());
 
-		_lvEntryVersions.add(_persistence.update(newLVEntryVersion));
+		newLVEntryVersion = _persistence.update(newLVEntryVersion);
+
+		_lvEntryVersions.add(newLVEntryVersion);
 
 		LVEntryVersion existingLVEntryVersion = _persistence.findByPrimaryKey(
 			newLVEntryVersion.getPrimaryKey());
@@ -606,4 +608,4 @@ public class LVEntryVersionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1912919665
+// LIFERAY-SERVICE-BUILDER-HASH:-1338181335

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/LazyBlobEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/LazyBlobEntryPersistenceTest.java
@@ -138,7 +138,9 @@ public class LazyBlobEntryPersistenceTest {
 
 		newLazyBlobEntry.setBlob2(newBlob2Blob);
 
-		_lazyBlobEntries.add(_persistence.update(newLazyBlobEntry));
+		newLazyBlobEntry = _persistence.update(newLazyBlobEntry);
+
+		_lazyBlobEntries.add(newLazyBlobEntry);
 
 		LazyBlobEntry existingLazyBlobEntry = _persistence.findByPrimaryKey(
 			newLazyBlobEntry.getPrimaryKey());
@@ -526,4 +528,4 @@ public class LazyBlobEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-428178084
+// LIFERAY-SERVICE-BUILDER-HASH:1591886676

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/LocalizedEntryLocalizationPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/LocalizedEntryLocalizationPersistenceTest.java
@@ -125,8 +125,10 @@ public class LocalizedEntryLocalizationPersistenceTest {
 
 		newLocalizedEntryLocalization.setContent(RandomTestUtil.randomString());
 
-		_localizedEntryLocalizations.add(
-			_persistence.update(newLocalizedEntryLocalization));
+		newLocalizedEntryLocalization = _persistence.update(
+			newLocalizedEntryLocalization);
+
+		_localizedEntryLocalizations.add(newLocalizedEntryLocalization);
 
 		LocalizedEntryLocalization existingLocalizedEntryLocalization =
 			_persistence.findByPrimaryKey(
@@ -521,4 +523,4 @@ public class LocalizedEntryLocalizationPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1612408537
+// LIFERAY-SERVICE-BUILDER-HASH:1529263777

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/LocalizedEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/LocalizedEntryPersistenceTest.java
@@ -113,7 +113,9 @@ public class LocalizedEntryPersistenceTest {
 
 		newLocalizedEntry.setDefaultLanguageId(RandomTestUtil.randomString());
 
-		_localizedEntries.add(_persistence.update(newLocalizedEntry));
+		newLocalizedEntry = _persistence.update(newLocalizedEntry);
+
+		_localizedEntries.add(newLocalizedEntry);
 
 		LocalizedEntry existingLocalizedEntry = _persistence.findByPrimaryKey(
 			newLocalizedEntry.getPrimaryKey());
@@ -387,4 +389,4 @@ public class LocalizedEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:2127292083
+// LIFERAY-SERVICE-BUILDER-HASH:970680991

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/ManyColumnsEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/ManyColumnsEntryPersistenceTest.java
@@ -239,7 +239,9 @@ public class ManyColumnsEntryPersistenceTest {
 
 		newManyColumnsEntry.setColumn64(RandomTestUtil.nextInt());
 
-		_manyColumnsEntries.add(_persistence.update(newManyColumnsEntry));
+		newManyColumnsEntry = _persistence.update(newManyColumnsEntry);
+
+		_manyColumnsEntries.add(newManyColumnsEntry);
 
 		ManyColumnsEntry existingManyColumnsEntry =
 			_persistence.findByPrimaryKey(newManyColumnsEntry.getPrimaryKey());
@@ -848,4 +850,4 @@ public class ManyColumnsEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1995720371
+// LIFERAY-SERVICE-BUILDER-HASH:-331931033

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/NestedSetsTreeEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/NestedSetsTreeEntryPersistenceTest.java
@@ -121,7 +121,9 @@ public class NestedSetsTreeEntryPersistenceTest {
 		newNestedSetsTreeEntry.setRightNestedSetsTreeEntryId(
 			RandomTestUtil.nextLong());
 
-		_nestedSetsTreeEntries.add(_persistence.update(newNestedSetsTreeEntry));
+		newNestedSetsTreeEntry = _persistence.update(newNestedSetsTreeEntry);
+
+		_nestedSetsTreeEntries.add(newNestedSetsTreeEntry);
 
 		NestedSetsTreeEntry existingNestedSetsTreeEntry =
 			_persistence.findByPrimaryKey(
@@ -753,4 +755,4 @@ public class NestedSetsTreeEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-378117342
+// LIFERAY-SERVICE-BUILDER-HASH:-1480070982

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/NullConvertibleEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/NullConvertibleEntryPersistenceTest.java
@@ -119,8 +119,9 @@ public class NullConvertibleEntryPersistenceTest {
 
 		newNullConvertibleEntry.setName(RandomTestUtil.randomString());
 
-		_nullConvertibleEntries.add(
-			_persistence.update(newNullConvertibleEntry));
+		newNullConvertibleEntry = _persistence.update(newNullConvertibleEntry);
+
+		_nullConvertibleEntries.add(newNullConvertibleEntry);
 
 		NullConvertibleEntry existingNullConvertibleEntry =
 			_persistence.findByPrimaryKey(
@@ -493,4 +494,4 @@ public class NullConvertibleEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:759023956
+// LIFERAY-SERVICE-BUILDER-HASH:-2035544722

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/PermissionCheckFinderEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/PermissionCheckFinderEntryPersistenceTest.java
@@ -132,8 +132,10 @@ public class PermissionCheckFinderEntryPersistenceTest {
 
 		newPermissionCheckFinderEntry.setType(RandomTestUtil.randomString());
 
-		_permissionCheckFinderEntries.add(
-			_persistence.update(newPermissionCheckFinderEntry));
+		newPermissionCheckFinderEntry = _persistence.update(
+			newPermissionCheckFinderEntry);
+
+		_permissionCheckFinderEntries.add(newPermissionCheckFinderEntry);
 
 		PermissionCheckFinderEntry existingPermissionCheckFinderEntry =
 			_persistence.findByPrimaryKey(
@@ -511,4 +513,4 @@ public class PermissionCheckFinderEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:445797325
+// LIFERAY-SERVICE-BUILDER-HASH:770858273

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/RedundantIndexEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/RedundantIndexEntryPersistenceTest.java
@@ -119,7 +119,9 @@ public class RedundantIndexEntryPersistenceTest {
 
 		newRedundantIndexEntry.setName(RandomTestUtil.randomString());
 
-		_redundantIndexEntries.add(_persistence.update(newRedundantIndexEntry));
+		newRedundantIndexEntry = _persistence.update(newRedundantIndexEntry);
+
+		_redundantIndexEntries.add(newRedundantIndexEntry);
 
 		RedundantIndexEntry existingRedundantIndexEntry =
 			_persistence.findByPrimaryKey(
@@ -488,4 +490,4 @@ public class RedundantIndexEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1729841088
+// LIFERAY-SERVICE-BUILDER-HASH:-761136072

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/RenameFinderColumnEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/RenameFinderColumnEntryPersistenceTest.java
@@ -123,8 +123,10 @@ public class RenameFinderColumnEntryPersistenceTest {
 		newRenameFinderColumnEntry.setColumnToRename(
 			RandomTestUtil.randomString());
 
-		_renameFinderColumnEntries.add(
-			_persistence.update(newRenameFinderColumnEntry));
+		newRenameFinderColumnEntry = _persistence.update(
+			newRenameFinderColumnEntry);
+
+		_renameFinderColumnEntries.add(newRenameFinderColumnEntry);
 
 		RenameFinderColumnEntry existingRenameFinderColumnEntry =
 			_persistence.findByPrimaryKey(
@@ -509,4 +511,4 @@ public class RenameFinderColumnEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-221558425
+// LIFERAY-SERVICE-BUILDER-HASH:724611151

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/UADPartialEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/UADPartialEntryPersistenceTest.java
@@ -117,7 +117,9 @@ public class UADPartialEntryPersistenceTest {
 
 		newUADPartialEntry.setMessage(RandomTestUtil.randomString());
 
-		_uadPartialEntries.add(_persistence.update(newUADPartialEntry));
+		newUADPartialEntry = _persistence.update(newUADPartialEntry);
+
+		_uadPartialEntries.add(newUADPartialEntry);
 
 		UADPartialEntry existingUADPartialEntry = _persistence.findByPrimaryKey(
 			newUADPartialEntry.getPrimaryKey());
@@ -402,4 +404,4 @@ public class UADPartialEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1242665458
+// LIFERAY-SERVICE-BUILDER-HASH:1573662378

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/UndefinedDefaultOrderEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/UndefinedDefaultOrderEntryPersistenceTest.java
@@ -124,8 +124,10 @@ public class UndefinedDefaultOrderEntryPersistenceTest {
 
 		newUndefinedDefaultOrderEntry.setName(RandomTestUtil.randomString());
 
-		_undefinedDefaultOrderEntries.add(
-			_persistence.update(newUndefinedDefaultOrderEntry));
+		newUndefinedDefaultOrderEntry = _persistence.update(
+			newUndefinedDefaultOrderEntry);
+
+		_undefinedDefaultOrderEntries.add(newUndefinedDefaultOrderEntry);
 
 		UndefinedDefaultOrderEntry existingUndefinedDefaultOrderEntry =
 			_persistence.findByPrimaryKey(
@@ -531,4 +533,4 @@ public class UndefinedDefaultOrderEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1869389462
+// LIFERAY-SERVICE-BUILDER-HASH:1763178422

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/UniqueFinderEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/UniqueFinderEntryPersistenceTest.java
@@ -119,7 +119,9 @@ public class UniqueFinderEntryPersistenceTest {
 
 		newUniqueFinderEntry.setName(RandomTestUtil.randomString());
 
-		_uniqueFinderEntries.add(_persistence.update(newUniqueFinderEntry));
+		newUniqueFinderEntry = _persistence.update(newUniqueFinderEntry);
+
+		_uniqueFinderEntries.add(newUniqueFinderEntry);
 
 		UniqueFinderEntry existingUniqueFinderEntry =
 			_persistence.findByPrimaryKey(newUniqueFinderEntry.getPrimaryKey());
@@ -473,4 +475,4 @@ public class UniqueFinderEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:206529581
+// LIFERAY-SERVICE-BUILDER-HASH:-465531723

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/VersionedEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/VersionedEntryPersistenceTest.java
@@ -119,7 +119,9 @@ public class VersionedEntryPersistenceTest {
 
 		newVersionedEntry.setGroupId(RandomTestUtil.nextLong());
 
-		_versionedEntries.add(_persistence.update(newVersionedEntry));
+		newVersionedEntry = _persistence.update(newVersionedEntry);
+
+		_versionedEntries.add(newVersionedEntry);
 
 		VersionedEntry existingVersionedEntry = _persistence.findByPrimaryKey(
 			newVersionedEntry.getPrimaryKey());
@@ -480,4 +482,4 @@ public class VersionedEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:654524484
+// LIFERAY-SERVICE-BUILDER-HASH:-569055808

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/VersionedEntryVersionPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/VersionedEntryVersionPersistenceTest.java
@@ -122,8 +122,10 @@ public class VersionedEntryVersionPersistenceTest {
 
 		newVersionedEntryVersion.setGroupId(RandomTestUtil.nextLong());
 
-		_versionedEntryVersions.add(
-			_persistence.update(newVersionedEntryVersion));
+		newVersionedEntryVersion = _persistence.update(
+			newVersionedEntryVersion);
+
+		_versionedEntryVersions.add(newVersionedEntryVersion);
 
 		VersionedEntryVersion existingVersionedEntryVersion =
 			_persistence.findByPrimaryKey(
@@ -507,4 +509,4 @@ public class VersionedEntryVersionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1876509600
+// LIFERAY-SERVICE-BUILDER-HASH:720558866

--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/hbm_xml.ftl
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/hbm_xml.ftl
@@ -154,10 +154,12 @@
 				<one-to-one
 					<#if serviceBuilder.isVersionGTE_7_4_0()>
 						access="com.liferay.portal.dao.orm.hibernate.PrivateFieldPropertyAccessor"
+						cascade="merge, persist, save-update"
 					<#else>
 						access="com.liferay.portal.dao.orm.hibernate.PrivatePropertyAccessor"
+						cascade="save-update"
 					</#if>
-					cascade="save-update" class="${apiPackagePath}.model.${entity.name}${entityColumn.methodName}BlobModel" constrained="${constrained}" name="${entityColumn.name}BlobModel" outer-join="false" />
+					class="${apiPackagePath}.model.${entity.name}${entityColumn.methodName}BlobModel" constrained="${constrained}" name="${entityColumn.name}BlobModel" outer-join="false" />
 			</#if>
 		</#list>
 	</class>

--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence_impl.ftl
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence_impl.ftl
@@ -1103,7 +1103,7 @@ public class ${entity.name}PersistenceImpl extends BasePersistenceImpl<${entity.
 			else {
 				<#if entity.versionedEntity??>
 					throw new IllegalArgumentException("${entity.name} is read only, create a new version instead");
-				<#elseif entity.hasLazyBlobEntityColumn()>
+				<#elseif entity.hasLazyBlobEntityColumn() && !serviceBuilder.isVersionGTE_7_4_0()>
 
 					<#-- Workaround for HHH-2680 -->
 

--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence_test.ftl
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence_test.ftl
@@ -308,7 +308,13 @@ public class ${entity.name}PersistenceTest {
 			</#if>
 		</#list>
 
-		_${entity.pluralVariableName}.add(_persistence.update(new${entity.name}));
+		<#if serviceBuilder.isVersionGTE_7_4_0()>
+			new${entity.name} = _persistence.update(new${entity.name});
+
+			_${entity.pluralVariableName}.add(new${entity.name});
+		<#else>
+			_${entity.pluralVariableName}.add(_persistence.update(new${entity.name}));
+		</#if>
 
 		<#if hasEagerBlob>
 			Session session = _persistence.openSession();

--- a/portal-impl/src/com/liferay/counter/service/persistence/impl/CounterFinderImpl.java
+++ b/portal-impl/src/com/liferay/counter/service/persistence/impl/CounterFinderImpl.java
@@ -447,8 +447,6 @@ public class CounterFinderImpl implements CacheRegistryItem, CounterFinder {
 
 			CounterHolder counterHolder = new CounterHolder(newValue, rangeMax);
 
-			session.saveOrUpdate(counter);
-
 			session.flush();
 
 			connection.commit();

--- a/portal-impl/src/com/liferay/portal/dao/orm/hibernate/SessionImpl.java
+++ b/portal-impl/src/com/liferay/portal/dao/orm/hibernate/SessionImpl.java
@@ -379,16 +379,6 @@ public class SessionImpl implements Session {
 	}
 
 	@Override
-	public void saveOrUpdate(Object object) throws ORMException {
-		try {
-			_session.saveOrUpdate(object);
-		}
-		catch (Exception exception) {
-			throw ExceptionTranslator.translate(exception, _session, object);
-		}
-	}
-
-	@Override
 	public String toString() {
 		return StringBundler.concat("{_session=", _session, "}");
 	}

--- a/portal-impl/src/com/liferay/portal/dao/orm/hibernate/packageinfo
+++ b/portal-impl/src/com/liferay/portal/dao/orm/hibernate/packageinfo
@@ -1,1 +1,1 @@
-version 10.0.0
+version 11.0.0

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/orm/Session.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/orm/Session.java
@@ -81,6 +81,4 @@ public interface Session {
 
 	public Serializable save(Object object) throws ORMException;
 
-	public void saveOrUpdate(Object object) throws ORMException;
-
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/orm/SessionWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/orm/SessionWrapper.java
@@ -163,11 +163,6 @@ public class SessionWrapper implements Session {
 		return session.save(object);
 	}
 
-	@Override
-	public void saveOrUpdate(Object object) throws ORMException {
-		session.saveOrUpdate(object);
-	}
-
 	protected final Session session;
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/orm/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/orm/packageinfo
@@ -1,1 +1,1 @@
-version 16.0.0
+version 17.0.0

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
@@ -711,13 +711,6 @@ public class DataGuardTestRuleUtil {
 			return super.save(object);
 		}
 
-		@Override
-		public void saveOrUpdate(Object object) throws ORMException {
-			_record(object);
-
-			super.saveOrUpdate(object);
-		}
-
 		private RecordingSessionWrapper(
 			Session session, Map<String, Map<Serializable, String>> records) {
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90640

## What Is Being Fixed

The kernel ORM API exposed Session.saveOrUpdate, a Hibernate operation that reattaches a detached instance while leaving the passed-in instance unmanaged. Callers that kept using the original entity after the update were operating on a stale, unmanaged copy, and lazy blob fields were not propagated through this path.

## How It Is Being Fixed

Session.saveOrUpdate is removed from the kernel ORM API and its wrapper, and SessionImpl propagates lazy blob updates through session.merge, returning the managed instance. Redundant saveOrUpdate calls in portal-impl and the affected service persistence implementations are dropped, and callers such as the batch engine task executors now use the managed entity returned by update. The generated persistence tests are regenerated to read the entity returned by update, and the affected integration test is fixed accordingly.

## PR Check

**pr-check: PASS** — tested on `f0352998752e9ebe65dcc1bc52fafcc115d96a38`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Full Portal Build | PASS |
| Per-Module Compile | PASS |
| Cross-Module Compile | PASS (symbol cap exceeded; covered by Full Portal Build) |
| Baseline | PASS (no Gradle baseline modules in scope; portal-kernel packageinfo covered by ant all) |
| Java Unit Tests | PASS (no parallel-name unit counterparts to run) |

<!-- pr-check {"result": "success", "sha": "f0352998752e9ebe65dcc1bc52fafcc115d96a38"} -->
