### PR TITLE
LPD-84614 Index CMS object entries by rootDescendantNode

### DIFF
--- a/modules/apps/frontend-js/frontend-js-item-selector-sample-web/src/main/resources/META-INF/resources/js/CMSFilesItemSelectorModal.tsx
+++ b/modules/apps/frontend-js/frontend-js-item-selector-sample-web/src/main/resources/META-INF/resources/js/CMSFilesItemSelectorModal.tsx
@@ -36,7 +36,7 @@ const BASE_SEARCH_PARAMS = {
 
 const CMS_ROOT_FILES_URL = `${ROOT_URL}?${new URLSearchParams({
 	...BASE_SEARCH_PARAMS,
-	filter: "cmsRoot eq true and cmsSection eq 'files' and status in (0, 2, 3)",
+	filter: "cmsRoot eq true and cmsSection eq 'files' and rootDescendantNode eq false and status in (0, 2, 3)",
 }).toString()}`;
 
 function getCMSChildFolderURL(folderId: string) {

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/openCMSFileSelectorModal.ts
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/openCMSFileSelectorModal.ts
@@ -58,7 +58,11 @@ function urlBuilder({
 
 	const scopePredicates = folderId
 		? [`(folderId eq ${folderId})`]
-		: ["(cmsSection eq 'files')", '(cmsRoot eq true)'];
+		: [
+				"(cmsSection eq 'files')",
+				'(cmsRoot eq true)',
+				'(rootDescendantNode eq false)',
+			];
 
 	const filter = [...scopePredicates, '(status in (0, 2, 3))']
 		.concat(filters.filter(Boolean))

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/test/openCMSFileSelectorModal.test.tsx
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/test/openCMSFileSelectorModal.test.tsx
@@ -133,6 +133,8 @@ describe('openCMSFileSelectorModal', () => {
 
 		expect(firstURL).toContain("(cmsSection eq 'files')");
 
+		expect(firstURL).toContain('(rootDescendantNode eq false)');
+
 		expect(firstURL).not.toContain("cmsKind eq 'object'");
 
 		expect(firstURL).not.toContain('folderId eq ');

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Attachment/AttachmentBase.tsx
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Attachment/AttachmentBase.tsx
@@ -217,7 +217,7 @@ export default function AttachmentBase({
 		else if (isVisible) {
 			searchParams.set(
 				'filter',
-				"cmsRoot eq true and cmsSection eq 'files' and status in (0)"
+				"cmsRoot eq true and cmsSection eq 'files' and rootDescendantNode eq false and status in (0)"
 			);
 		}
 

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Attachment/util/CMSFilesItemSelectorModal.tsx
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Attachment/util/CMSFilesItemSelectorModal.tsx
@@ -42,7 +42,7 @@ function getSpaceRootFilesURL(groupId: string) {
 
 	return `${ROOT_URL}?${new URLSearchParams({
 		...BASE_SEARCH_PARAMS,
-		filter: `cmsRoot eq true and cmsSection eq 'files' and status in (0) and scopeGroupId eq ${groupId}`,
+		filter: `cmsRoot eq true and cmsSection eq 'files' and rootDescendantNode eq false and status in (0) and scopeGroupId eq ${groupId}`,
 	}).toString()}`;
 }
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
@@ -506,6 +506,9 @@ public class ObjectEntryModelDocumentContributor
 			"objectFolderExternalReferenceCode",
 			objectFolder.getExternalReferenceCode(), true);
 
+		document.addKeyword(
+			"rootDescendantNode", objectEntry.isRootDescendantNode());
+
 		if (FeatureFlagManagerUtil.isEnabled(
 				objectEntry.getCompanyId(), "LPD-17564")) {
 

--- a/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/odata/entity/v1_0/SearchResultEntityModel.java
+++ b/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/odata/entity/v1_0/SearchResultEntityModel.java
@@ -25,6 +25,8 @@ public class SearchResultEntityModel implements EntityModel {
 	public SearchResultEntityModel() {
 		_entityFieldsMap = EntityModel.toEntityFieldsMap(
 			new BooleanEntityField("cmsRoot", locale -> "cms_root"),
+			new BooleanEntityField(
+				"rootDescendantNode", locale -> "rootDescendantNode"),
 			new CollectionEntityField(
 				new IntegerEntityField("groupIds", locale -> Field.GROUP_ID)),
 			new CollectionEntityField(

--- a/modules/apps/portal-search/portal-search-rest-test/src/testIntegration/java/com/liferay/portal/search/rest/resource/v1_0/test/SearchResultResourceTest.java
+++ b/modules/apps/portal-search/portal-search-rest-test/src/testIntegration/java/com/liferay/portal/search/rest/resource/v1_0/test/SearchResultResourceTest.java
@@ -1555,7 +1555,7 @@ public class SearchResultResourceTest extends BaseSearchResultResourceTestCase {
 		"cmsSection", "extension", "dateDisplay", "dateExpiration",
 		"datePublish", "dateReview", "folderId",
 		"objectDefinitionExternalReferenceCode",
-		"objectFolderExternalReferenceCode"
+		"objectFolderExternalReferenceCode", "rootDescendantNode"
 	};
 
 	private AssetCategory _assetCategory;

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewContentsSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewContentsSectionDisplayContextTest.java
@@ -255,7 +255,8 @@ public class ViewContentsSectionDisplayContextTest
 
 	@Override
 	protected String getFilterString() {
-		return "cmsRoot eq true and cmsSection eq 'contents'";
+		return "cmsRoot eq true and cmsSection eq 'contents' and " +
+			"rootDescendantNode eq false";
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewFilesSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewFilesSectionDisplayContextTest.java
@@ -144,7 +144,8 @@ public class ViewFilesSectionDisplayContextTest
 
 	@Override
 	protected String getFilterString() {
-		return "cmsRoot eq true and cmsSection eq 'files'";
+		return "cmsRoot eq true and cmsSection eq 'files' and " +
+			"rootDescendantNode eq false";
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewRecycleBinSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewRecycleBinSectionDisplayContextTest.java
@@ -248,7 +248,7 @@ public class ViewRecycleBinSectionDisplayContextTest
 	@Override
 	protected String getFilterString() {
 		return "cmsRoot eq true and (cmsSection eq 'contents' or cmsSection " +
-			"eq 'files')";
+			"eq 'files') and rootDescendantNode eq false";
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseRelatedAssetsSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseRelatedAssetsSectionDisplayContext.java
@@ -114,7 +114,8 @@ public abstract class BaseRelatedAssetsSectionDisplayContext
 		return appendStatus(
 			StringBundler.concat(
 				"(cmsSection eq 'contents' or cmsSection eq 'files') and ",
-				"keywords/any(k:k in (", keywordsFilterString, "))"));
+				"keywords/any(k:k in (", keywordsFilterString,
+				")) and rootDescendantNode eq false"));
 	}
 
 	protected abstract String[] getKeywords();

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/SectionDisplayContextUtil.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/SectionDisplayContextUtil.java
@@ -117,13 +117,14 @@ public class SectionDisplayContextUtil {
 			httpServletRequest.getAttribute(InfoDisplayWebKeys.INFO_ITEM),
 			rootObjectEntryFolderExternalReferenceCode);
 
-		StringBundler sb = new StringBundler(13);
+		StringBundler sb = new StringBundler(14);
 
 		sb.append("emptySearch=true&filter=");
 
 		if (objectEntryFolder != null) {
 			sb.append("folderId eq ");
 			sb.append(objectEntryFolder.getObjectEntryFolderId());
+			sb.append(" and rootDescendantNode eq false");
 
 			if (objectEntryFolder.getStatus() ==
 					WorkflowConstants.STATUS_IN_TRASH) {

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewContentsSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewContentsSectionDisplayContext.java
@@ -74,7 +74,9 @@ public class ViewContentsSectionDisplayContext
 	@Override
 	protected String getCMSSectionFilterString() {
 		return appendStatus(
-			appendGroupIds("cmsRoot eq true and cmsSection eq 'contents'"));
+			appendGroupIds(
+				"cmsRoot eq true and cmsSection eq 'contents' and " +
+					"rootDescendantNode eq false"));
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewFilesSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewFilesSectionDisplayContext.java
@@ -78,7 +78,9 @@ public class ViewFilesSectionDisplayContext
 	@Override
 	protected String getCMSSectionFilterString() {
 		return appendStatus(
-			appendGroupIds("cmsRoot eq true and cmsSection eq 'files'"));
+			appendGroupIds(
+				"cmsRoot eq true and cmsSection eq 'files' and " +
+					"rootDescendantNode eq false"));
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewHomeRecentAssetsSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewHomeRecentAssetsSectionDisplayContext.java
@@ -121,7 +121,7 @@ public class ViewHomeRecentAssetsSectionDisplayContext
 		return appendStatus(
 			appendGroupIds(
 				"cmsKind eq 'object' and (cmsSection eq 'contents' or " +
-					"cmsSection eq 'files')"));
+					"cmsSection eq 'files') and rootDescendantNode eq false"));
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewRecycleBinSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewRecycleBinSectionDisplayContext.java
@@ -201,7 +201,7 @@ public class ViewRecycleBinSectionDisplayContext
 	protected String getCMSSectionFilterString() {
 		String filterString =
 			"cmsRoot eq true and (cmsSection eq 'contents' or cmsSection eq " +
-				"'files')";
+				"'files') and rootDescendantNode eq false";
 
 		List<Long> groupIds = _getTrashEnabledDepotEntryGroupIds();
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewRelatedAssetsSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewRelatedAssetsSectionDisplayContext.java
@@ -100,7 +100,8 @@ public class ViewRelatedAssetsSectionDisplayContext
 									"(cmsSection eq 'contents' or cmsSection ",
 									"eq 'files') and not (keywords/any(k:k in ",
 									"(", getKeywordsFilterString(),
-									"))) and objectDefinitionId gt 0")),
+									"))) and objectDefinitionId gt 0 and ",
+									"rootDescendantNode eq false")),
 							httpServletRequest, null);
 
 					return "/o/search/v1.0/search?" +

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSpaceContentsSummarySectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSpaceContentsSummarySectionDisplayContext.java
@@ -98,7 +98,7 @@ public class ViewSpaceContentsSummarySectionDisplayContext
 	protected String getCMSSectionFilterString() {
 		return String.format(
 			"cmsRoot eq true and cmsSection eq 'contents' and groupIds/any" +
-				"(g:g eq %s)",
+				"(g:g eq %s) and rootDescendantNode eq false",
 			_groupId);
 	}
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSpaceFilesSummarySectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSpaceFilesSummarySectionDisplayContext.java
@@ -98,7 +98,7 @@ public class ViewSpaceFilesSummarySectionDisplayContext
 	protected String getCMSSectionFilterString() {
 		return String.format(
 			"cmsRoot eq true and cmsSection eq 'files' and groupIds/any" +
-				"(g:g eq %s)",
+				"(g:g eq %s) and rootDescendantNode eq false",
 			_groupId);
 	}
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/ViewAllSectionSystemFDSEntry.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/ViewAllSectionSystemFDSEntry.java
@@ -31,7 +31,7 @@ public class ViewAllSectionSystemFDSEntry implements SystemFDSEntry {
 		String filterString = SectionDisplayContextUtil.appendStatus(
 			SectionDisplayContextUtil.appendGroupIds(
 				"cmsKind eq 'object' and (cmsSection eq 'contents' or " +
-					"cmsSection eq 'files')",
+					"cmsSection eq 'files') and rootDescendantNode eq false",
 				httpServletRequest));
 
 		String additionalAPIURLParameters =

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/bulk_actions_monitor/util/index.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/bulk_actions_monitor/util/index.ts
@@ -63,7 +63,7 @@ export function composeCreateTaskURL(
 		const {folderId, groupIds} =
 			getFolderIdAndGroupIdsFromFilter(scopeFilter);
 
-		scopeFilter = `cmsRoot eq true and cmsSection eq 'contents' and status in (0, 2, 3)`;
+		scopeFilter = `cmsRoot eq true and cmsSection eq 'contents' and rootDescendantNode eq false and status in (0, 2, 3)`;
 
 		if (folderId) {
 			scopeFilter += ` and folderId eq ${folderId}`;

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/modal/EmptyRecycleBinModalContent.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/modal/EmptyRecycleBinModalContent.tsx
@@ -10,7 +10,7 @@ import React from 'react';
 import {triggerAssetBulkAction} from '../props_transformer/actions/triggerAssetBulkAction';
 
 const CMS_RECYCLE_BIN_FILTER =
-	"cmsRoot eq true and (cmsSection eq 'contents' or cmsSection eq 'files') and status eq 8";
+	"cmsRoot eq true and (cmsSection eq 'contents' or cmsSection eq 'files') and rootDescendantNode eq false and status eq 8";
 
 export default function EmptyRecycleBinModalContent({
 	closeModal,

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/modal/FolderItemSelectorModalContent.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/modal/FolderItemSelectorModalContent.tsx
@@ -105,7 +105,7 @@ const getDuplicateItemCheckPromise = (item: ItemData, folder: Folder) => {
 };
 
 const getSpaceFoldersURL = (cmsSection: string, scopeId: number) => {
-	return `${window.location.origin}/o/search/v1.0/search?emptySearch=true&entryClassNames=${OBJECT_ENTRY_FOLDER_CLASS_NAME}&filter=((title eq '${cmsSection}' and folderId eq 0) or (cmsRoot eq true and cmsSection eq '${cmsSection}')) and (status in (0, 2, 3))&nestedFields=description,embedded,file.thumbnailURL&scope=${scopeId}`;
+	return `${window.location.origin}/o/search/v1.0/search?emptySearch=true&entryClassNames=${OBJECT_ENTRY_FOLDER_CLASS_NAME}&filter=((title eq '${cmsSection}' and folderId eq 0) or (cmsRoot eq true and cmsSection eq '${cmsSection}' and rootDescendantNode eq false)) and (status in (0, 2, 3))&nestedFields=description,embedded,file.thumbnailURL&scope=${scopeId}`;
 };
 
 const getChildFoldersURL = (folderId: number, scopeId: number) => {

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/bulk_action_task/util/index.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/bulk_action_task/util/index.test.tsx
@@ -106,7 +106,7 @@ describe('Bulk Actions Monitor Utils', () => {
 			);
 
 			expect(taskUrl).toBe(
-				`${Liferay.ThemeDisplay.getPortalURL()}/o/cms/translations?type=ExportTranslationBulkAction&emptySearch=true&filter=cmsRoot+eq+true+and+cmsSection+eq+%27contents%27+and+status+in+%280%2C+2%2C+3%29+and+folderId+eq+123+and+groupIds%2Fany%28g%3Ag+in+%28456%29%29`
+				`${Liferay.ThemeDisplay.getPortalURL()}/o/cms/translations?type=ExportTranslationBulkAction&emptySearch=true&filter=cmsRoot+eq+true+and+cmsSection+eq+%27contents%27+and+rootDescendantNode+eq+false+and+status+in+%280%2C+2%2C+3%29+and+folderId+eq+123+and+groupIds%2Fany%28g%3Ag+in+%28456%29%29`
 			);
 		});
 	});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-84614

## What Is Being Fixed

CMS structures nest their content as object entries in a tree. There was no way to distinguish a nested (descendant) entry from a root entry at search time, so nested children appeared in the CMS content, files, and recycle-bin lists, in the attachment item selector, and in the bulk-action and empty-recycle-bin flows — even though only roots should be listed there.

## How It Is Being Fixed

The object entry indexer writes a `rootDescendantNode` keyword to each entry's search document, registered as a filterable search property so it can be used in OData filters. Every CMS list filter (display contexts, attachment item selector, bulk-action monitor, empty-recycle-bin) now includes `rootDescendantNode eq false` to exclude nested children, with each filter's properties kept in alphabetical order. The CMS list display context tests are updated to expect the new filter, `rootDescendantNode` is added to the search REST resource test's ignored entity fields, and a test covers the CMS file selector excluding nested children.

## PR Check

**pr-check: PASS** — tested on `639d39f0115a6413b3efb3c865133932756eb5c0`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "639d39f0115a6413b3efb3c865133932756eb5c0"} -->

