### PR TITLE
LPD-95521 Remove old indexes

### DIFF
--- a/modules/apps/layout/layout-page-template-service/src/main/resources/META-INF/sql/indexes.sql
+++ b/modules/apps/layout/layout-page-template-service/src/main/resources/META-INF/sql/indexes.sql
@@ -2,10 +2,6 @@ create unique index IX_D4E7D564 on LPTSRelElementVariation (groupId, externalRef
 create index IX_1496EBF4 on LPTSRelElementVariation (segmentsExperienceERC[$COLUMN_LENGTH:75$], plid);
 create unique index IX_BFCB1187 on LPTSRelElementVariation (uuid_[$COLUMN_LENGTH:75$], groupId, ctCollectionId);
 
-create unique index IX_E095AB91 on LPTStructureElementVariation (groupId, externalReferenceCode[$COLUMN_LENGTH:75$], ctCollectionId);
-create index IX_A5E1D2E7 on LPTStructureElementVariation (segmentsExperienceERC[$COLUMN_LENGTH:75$], plid);
-create unique index IX_9B3CE1B4 on LPTStructureElementVariation (uuid_[$COLUMN_LENGTH:75$], groupId, ctCollectionId);
-
 create unique index IX_D22242C8 on LayoutPageTemplateCollection (groupId, externalReferenceCode[$COLUMN_LENGTH:75$], ctCollectionId);
 create index IX_5A1F4BFC on LayoutPageTemplateCollection (groupId, parentLPTCollectionId);
 create unique index IX_332638E5 on LayoutPageTemplateCollection (groupId, type_, lptCollectionKey[$COLUMN_LENGTH:75$], ctCollectionId);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95521

## What Is Being Fixed

Renaming the element variation entity to `LPTSRelElementVariation` left the old `LPTStructureElementVariation` table's index definitions behind in the module's generated `indexes.sql`, declaring indexes on a table that no longer exists.

## How It Is Being Fixed

Remove the three stale `LPTStructureElementVariation` index definitions from `indexes.sql` so the generated SQL matches the current service definition.

## Why Are There No Tests?

The change only removes obsolete generated Service Builder index definitions for a renamed entity; there is no application logic to exercise. Service Builder regeneration produces no drift, confirming the SQL matches the current service definition.

## PR Check

**pr-check: PASS** — tested on `812d15507ef796d36bbb8d86a3b9f1b0874c4cd5`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "812d15507ef796d36bbb8d86a3b9f1b0874c4cd5"} -->
