### PR TITLE
LPD-94608 Regenerate compat740 Service Builder output

### DIFF
--- a/modules/util/portal-tools-service-builder-test-compat740-service/src/main/java/com/liferay/portal/tools/service/builder/test/compat740/service/persistence/impl/LazyBlobEntryPersistenceImpl.java
+++ b/modules/util/portal-tools-service-builder-test-compat740-service/src/main/java/com/liferay/portal/tools/service/builder/test/compat740/service/persistence/impl/LazyBlobEntryPersistenceImpl.java
@@ -439,7 +439,7 @@ public class LazyBlobEntryPersistenceImpl
 				new String[] {String.class.getName()}, new String[] {"uuid_"},
 				0, 1, false, null),
 			_SQL_SELECT_LAZYBLOBENTRY_WHERE, _SQL_COUNT_LAZYBLOBENTRY_WHERE,
-			LazyBlobEntryModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+			LazyBlobEntryModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "", "",
 			new FinderColumn<>(
 				"lazyBlobEntry.", "uuid", "uuid_", FinderColumn.Type.STRING,
 				"=", true, true, LazyBlobEntry::getUuid));
@@ -529,4 +529,4 @@ public class LazyBlobEntryPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1428404629
+// LIFERAY-SERVICE-BUILDER-HASH:1898084269

--- a/modules/util/portal-tools-service-builder-test-compat740-service/src/main/resources/META-INF/module-hbm.xml
+++ b/modules/util/portal-tools-service-builder-test-compat740-service/src/main/resources/META-INF/module-hbm.xml
@@ -126,8 +126,8 @@
 		</id>
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" column="uuid_" name="uuid" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="groupId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
-		<one-to-one access="com.liferay.portal.dao.orm.hibernate.PrivateFieldPropertyAccessor" cascade="merge, persist, save-update" class="com.liferay.portal.tools.service.builder.test.compat740.model.LazyBlobEntryBlob1BlobModel" constrained="false" name="blob1BlobModel" outer-join="false" />
-		<one-to-one access="com.liferay.portal.dao.orm.hibernate.PrivateFieldPropertyAccessor" cascade="merge, persist, save-update" class="com.liferay.portal.tools.service.builder.test.compat740.model.LazyBlobEntryBlob2BlobModel" constrained="false" name="blob2BlobModel" outer-join="false" />
+		<one-to-one access="com.liferay.portal.dao.orm.hibernate.PrivateFieldPropertyAccessor" cascade="merge,persist,save-update" class="com.liferay.portal.tools.service.builder.test.compat740.model.LazyBlobEntryBlob1BlobModel" constrained="false" name="blob1BlobModel" outer-join="false" />
+		<one-to-one access="com.liferay.portal.dao.orm.hibernate.PrivateFieldPropertyAccessor" cascade="merge,persist,save-update" class="com.liferay.portal.tools.service.builder.test.compat740.model.LazyBlobEntryBlob2BlobModel" constrained="false" name="blob2BlobModel" outer-join="false" />
 	</class>
 	<class lazy="true" name="com.liferay.portal.tools.service.builder.test.compat740.model.LazyBlobEntryBlob1BlobModel" table="LazyBlobEntry">
 		<id column="lazyBlobEntryId" name="lazyBlobEntryId">


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94608

## What Is Being Fixed

The `portal-tools-service-builder-test-compat740-service` module's generated output was stale, likely from LPD-90640.

## How It Is Being Fixed

Regenerated the module so its `@generated` output is back in sync.

## Why Are There No Tests?

The change is only regenerated `@generated` Service Builder output, which carries no independently testable behavior.

## PR Check

**pr-check: SKIPPED** — Diff baseline mismatch: local master lags brianchandotcom/master by 1605 files, so pr-check would validate the entire unrelated delta rather than this PR. The actual change is a 2-file Service Builder regeneration.

<!-- pr-check {"reason": "Diff baseline mismatch: local master lags brianchandotcom/master by 1605 files, so pr-check would validate the entire unrelated delta rather than this PR. The actual change is a 2-file Service Builder regeneration.", "result": "skipped", "sha": "18827fb8b02d14152b33f48163a49481fcc0b4ce"} -->
