### PR TITLE
LPD-92125 Check the search response status before parsing the body

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/langchain4j/rag/content/retriever/LiferayWebSearchContentRetriever.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/langchain4j/rag/content/retriever/LiferayWebSearchContentRetriever.java
@@ -8,6 +8,7 @@ package com.liferay.ai.hub.internal.langchain4j.rag.content.retriever;
 import com.liferay.oauth2.provider.model.OAuth2Application;
 import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalServiceUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -92,8 +93,6 @@ public class LiferayWebSearchContentRetriever extends BaseContentRetriever {
 				"Local links are not allowed: " + urlObject);
 		}
 
-		List<Content> contents = new ArrayList<>();
-
 		String location = _homePageURL + "/o/search/v1.0/search";
 
 		if (!Validator.isBlank(_blueprintExternalReferenceCode)) {
@@ -111,8 +110,22 @@ public class LiferayWebSearchContentRetriever extends BaseContentRetriever {
 
 		options.setMethod(Http.Method.GET);
 
-		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
-			HttpUtil.URLtoString(options));
+		String responseBody = HttpUtil.URLtoString(options);
+
+		Http.Response response = options.getResponse();
+
+		if ((response.getResponseCode() < 200) ||
+			(response.getResponseCode() >= 300)) {
+
+			throw new PortalException(
+				StringBundler.concat(
+					"Search request to ", location,
+					" failed with response code ", response.getResponseCode()));
+		}
+
+		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(responseBody);
+
+		List<Content> contents = new ArrayList<>();
 
 		for (JSONObject itemJSONObject :
 				(Iterable<JSONObject>)jsonObject.getJSONArray("items")) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92125

## What Is Being Fixed

The web search content retriever parsed the search endpoint's response body as JSON without first checking the HTTP status. When the `/o/search/v1.0/search` request returned a non-success status, the retriever tried to parse an error or empty body as the expected payload, surfacing a confusing parse failure instead of a clear error.

## How It Is Being Fixed

`LiferayWebSearchContentRetriever` now captures the response and inspects its HTTP status code before parsing. When the code falls outside the 2xx range, it throws a `PortalException` naming the search request URL and the failing response code. Only on a successful response does it parse the body into JSON and build the content list.

## Why Are There No Tests?

This is a follow-up hardening change to LPD-92125; the existing unit coverage for the retriever (`LiferayWebSearchContentRetrieverTest`) covers the retriever path.

## PR Check

**pr-check: PASS** — tested on `32f49ce4de0bf57d5112e0c1590086bbbfd02839`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "32f49ce4de0bf57d5112e0c1590086bbbfd02839"} -->
