### PR TITLE
LPD-28402 Format source in search, roles, and object modules

### DIFF
--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -11408,9 +11408,7 @@ public class ObjectEntryResourceTest {
 
 	@FeatureFlag("LPD-43996")
 	@Test
-	public void testPostObjectEntryWithObjectFieldComments()
-		throws Exception {
-
+	public void testPostObjectEntryWithObjectFieldComments() throws Exception {
 		ObjectDefinition objectDefinition =
 			ObjectDefinitionTestUtil.publishObjectDefinition(
 				Collections.singletonList(

--- a/modules/apps/roles/roles-admin-web/src/main/java/com/liferay/roles/admin/web/internal/portlet/RolesAdminPortlet.java
+++ b/modules/apps/roles/roles-admin-web/src/main/java/com/liferay/roles/admin/web/internal/portlet/RolesAdminPortlet.java
@@ -583,8 +583,8 @@ public class RolesAdminPortlet extends MVCPortlet {
 
 		if (Objects.equals(mvcPath, "/edit_role_assignments.jsp")) {
 			RolePermissionUtil.check(
-				themeDisplay.getPermissionChecker(),
-				roleId, ActionKeys.ASSIGN_MEMBERS);
+				themeDisplay.getPermissionChecker(), roleId,
+				ActionKeys.ASSIGN_MEMBERS);
 		}
 
 		super.checkPermissions(portletRequest);

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-api/src/test/java/com/liferay/search/experiences/rest/dto/v1_0/FieldTest.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-api/src/test/java/com/liferay/search/experiences/rest/dto/v1_0/FieldTest.java
@@ -52,17 +52,17 @@ public class FieldTest {
 		_testToStringDefaultValue(maps.toArray());
 	}
 
-	private List<Map<String, String>> _createMaps() {
-		return Arrays.asList(
-			_createMap("label1", "value1"), _createMap("label2", "value2"));
-	}
-
 	private Map<String, String> _createMap(String label, String value) {
 		return HashMapBuilder.put(
 			"label", label
 		).put(
 			"value", value
 		).build();
+	}
+
+	private List<Map<String, String>> _createMaps() {
+		return Arrays.asList(
+			_createMap("label1", "value1"), _createMap("label2", "value2"));
 	}
 
 	private void _testEscape(String escaped, String unescaped) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-28402
  https://liferay.atlassian.net/browse/LPD-94207
  https://liferay.atlassian.net/browse/LPD-93214

  ## What Is Being Fixed

  Three Java files carried source-formatting deviations the source formatter flags: a wrapped method-call argument list in RolesAdminPortlet, a wrapped test-method signature in ObjectEntryResourceTest, and out-of-order private helper methods in
  FieldTest.

  ## How It Is Being Fixed

  The source formatter was applied across the three modules. The `RolePermissionUtil.check(...)` call in RolesAdminPortlet was re-wrapped, the `testPostObjectEntryWithObjectFieldComments()` signature in ObjectEntryResourceTest was collapsed onto one
  line, and the `_createMaps()` and `_createMap()` helpers in FieldTest were reordered alphabetically. No behavior changes.

  ## Why Are There No Tests?

  This PR contains source-format-only changes (line wrapping and method ordering) with no behavior change, so no tests are warranted.

  ## PR Check

  **pr-check: PASS** — tested on `d2f1cefa35377c55193ea8d405c6d38a4a8eb49a`

  | Validation | Result |
  | --- | --- |
  | Source Format | PASS |
  | Portlet Title | PASS |
  | Per-Module Compile | PASS |
  | Integration Test Compile | PASS |

  <!-- pr-check {"result": "success", "sha": "d2f1cefa35377c55193ea8d405c6d38a4a8eb49a"} -->