### PR TITLE
LPD-93935 Hide SEO Studio account entry from the account list

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/search/spi/model/query/contributor/AccountEntryModelPreFilterContributor.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/search/spi/model/query/contributor/AccountEntryModelPreFilterContributor.java
@@ -21,7 +21,7 @@ import org.osgi.service.component.annotations.Component;
 	property = "indexer.class.name=com.liferay.account.model.AccountEntry",
 	service = ModelPreFilterContributor.class
 )
-public class AIHubAccountEntryModelPreFilterContributor
+public class AccountEntryModelPreFilterContributor
 	implements ModelPreFilterContributor {
 
 	@Override
@@ -31,6 +31,9 @@ public class AIHubAccountEntryModelPreFilterContributor
 
 		booleanFilter.add(
 			new TermFilter("externalReferenceCode", "L_AI_HUB"),
+			BooleanClauseOccur.MUST_NOT);
+		booleanFilter.add(
+			new TermFilter("externalReferenceCode", "L_SEO_STUDIO"),
 			BooleanClauseOccur.MUST_NOT);
 	}
 

--- a/modules/dxp/apps/ai-hub/ai-hub-test/src/testIntegration/java/com/liferay/ai/hub/internal/search/spi/model/query/contributor/test/AccountEntryModelPreFilterContributorTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-test/src/testIntegration/java/com/liferay/ai/hub/internal/search/spi/model/query/contributor/test/AccountEntryModelPreFilterContributorTest.java
@@ -37,7 +37,7 @@ import org.junit.runner.RunWith;
  */
 @FeatureFlag("LPD-62272")
 @RunWith(Arquillian.class)
-public class AIHubAccountEntryModelPreFilterContributorTest {
+public class AccountEntryModelPreFilterContributorTest {
 
 	@ClassRule
 	@Rule
@@ -48,13 +48,8 @@ public class AIHubAccountEntryModelPreFilterContributorTest {
 
 	@Before
 	public void setUp() throws Exception {
-		_accountEntry =
-			_accountEntryLocalService.fetchAccountEntryByExternalReferenceCode(
-				"L_AI_HUB", TestPropsValues.getCompanyId());
-
-		if (_accountEntry == null) {
-			_accountEntry = _addAccountEntry("L_AI_HUB");
-		}
+		_aiHubAccountEntry = _fetchOrAddAccountEntry("L_AI_HUB");
+		_seoStudioAccountEntry = _fetchOrAddAccountEntry("L_SEO_STUDIO");
 	}
 
 	@Test
@@ -73,7 +68,11 @@ public class AIHubAccountEntryModelPreFilterContributorTest {
 		Assert.assertTrue(
 			accountEntries.toString(), accountEntries.contains(accountEntry));
 		Assert.assertFalse(
-			accountEntries.toString(), accountEntries.contains(_accountEntry));
+			accountEntries.toString(),
+			accountEntries.contains(_aiHubAccountEntry));
+		Assert.assertFalse(
+			accountEntries.toString(),
+			accountEntries.contains(_seoStudioAccountEntry));
 	}
 
 	@Rule
@@ -91,9 +90,24 @@ public class AIHubAccountEntryModelPreFilterContributorTest {
 			ServiceContextTestUtil.getServiceContext());
 	}
 
-	private AccountEntry _accountEntry;
+	private AccountEntry _fetchOrAddAccountEntry(String externalReferenceCode)
+		throws Exception {
+
+		AccountEntry accountEntry =
+			_accountEntryLocalService.fetchAccountEntryByExternalReferenceCode(
+				externalReferenceCode, TestPropsValues.getCompanyId());
+
+		if (accountEntry == null) {
+			accountEntry = _addAccountEntry(externalReferenceCode);
+		}
+
+		return accountEntry;
+	}
 
 	@Inject
 	private AccountEntryLocalService _accountEntryLocalService;
+
+	private AccountEntry _aiHubAccountEntry;
+	private AccountEntry _seoStudioAccountEntry;
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93935

## What Is Being Fixed

The AI Hub account entry search pre-filter excluded only the internal AI Hub account (external reference code `L_AI_HUB`) from results. The SEO Studio internal account (`L_SEO_STUDIO`) was still surfacing in the account list, where it should not be visible.

## How It Is Being Fixed

The contributor (renamed from `AIHubAccountEntryModelPreFilterContributor` to `AccountEntryModelPreFilterContributor`, since it now guards more than the AI Hub account) adds a second `MUST_NOT` term filter on `externalReferenceCode` for `L_SEO_STUDIO`, so both internal accounts are excluded from the indexer results. The integration test now sets up both accounts and asserts that neither appears in the filtered list.

## PR Check

**pr-check: PASS** — tested on `162ba754ce8e1bedb88278abbbc225862bbd72d6`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "162ba754ce8e1bedb88278abbbc225862bbd72d6"} -->
