### PR TITLE
LPD-8019 Add upgrade check to replace InfoItemReference.getClassPK

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -216,6 +216,17 @@
 	},
 	{
 		"classNames": [
+			"InfoItemReference"
+		],
+		"from": "regex:(?<infoItemReference>\\w+)\\.getClassPK\\(\\)",
+		"issueKey": "LPD-8019",
+		"newImports": [
+			"com.liferay.info.item.ClassPKInfoItemIdentifier"
+		],
+		"to": "((ClassPKInfoItemIdentifier)${infoItemReference}.getInfoItemIdentifier()).getClassPK()"
+	},
+	{
+		"classNames": [
 			"HttpServletRequest"
 		],
 		"from": "regex:\t*(?s)\\b\\w+\\s*\\.setAttribute\\s*\\(\\s*InfoDisplayWebKeys\\s*\\.INFO_ITEM_FIELD_VALUES_PROVIDER\\s*,.*?\\);\n",

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_8019.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_8019.testjava
@@ -1,0 +1,19 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+import com.liferay.info.item.ClassPKInfoItemIdentifier;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class LPD_8019 {
+
+	public void method(InfoItemReference infoItemReference) {
+		((ClassPKInfoItemIdentifier)infoItemReference.getInfoItemIdentifier()).getClassPK();
+	}
+
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_8019.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_8019.testjava
@@ -1,0 +1,17 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class LPD_8019 {
+
+	public void method(InfoItemReference infoItemReference) {
+		infoItemReference.getClassPK();
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-8019

## What Is Being Fixed

`InfoItemReference.getClassPK()` is being removed, so callers must obtain the class PK through the reference's `InfoItemIdentifier` instead. There was no automated upgrade support to migrate these call sites.

## How It Is Being Fixed

A new replacement rule is added to the source formatter's `replacements.json`, consumed by the upgrade catch-all check. It matches a `<ref>.getClassPK()` call on an `InfoItemReference` and rewrites it to `((ClassPKInfoItemIdentifier)<ref>.getInfoItemIdentifier()).getClassPK()`, adding the `com.liferay.info.item.ClassPKInfoItemIdentifier` import. Input and expected fixtures for the upgrade-catch-all-check exercise the new rule.

## PR Check

**pr-check: PASS** — tested on `8c6f1a5f9847fcb240db6c7145ba63bd3070bb4a`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "8c6f1a5f9847fcb240db6c7145ba63bd3070bb4a"} -->
