### PR TITLE
LPD-95679 Scope the NewExport test's referenced content assertion

### DIFF
--- a/modules/apps/export-import/export-import-web/test/revamp/js/pages/export/NewExport.test.tsx
+++ b/modules/apps/export-import/export-import-web/test/revamp/js/pages/export/NewExport.test.tsx
@@ -679,14 +679,18 @@ describe('NewExport', () => {
 		}
 
 		expect(
-			screen.getByText('Referenced Content Behavior')
+			screen.getByText('Referenced Content Behavior', {
+				selector: 'label[for="_journal_referenced-content-behavior"]',
+			})
 		).toBeInTheDocument();
 
 		await userEvent.click(referencedContentCheckbox);
 
 		expect(referencedContentCheckbox).not.toBeChecked();
 		expect(
-			screen.queryByText('Referenced Content Behavior')
+			screen.queryByText('Referenced Content Behavior', {
+				selector: 'label[for="_journal_referenced-content-behavior"]',
+			})
 		).not.toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95679

## What Is Being Fixed

The NewExport export-revamp unit test asserted on the visible "Referenced Content Behavior" text using a bare `getByText` / `queryByText`. More than one element can carry that text, so the query was ambiguous and the assertion could resolve against the wrong node rather than the journal portlet's control.

## How It Is Being Fixed

Both assertions now pass a `selector` option that scopes the match to the journal portlet's label (`label[for="_journal_referenced-content-behavior"]`). The test now targets the specific Referenced Content Behavior control, correctly verifying it is present before the checkbox toggle and absent after.

## PR Check

**pr-check: PASS** — tested on `e6f72f600874fb53121f59bfab5e7568fe24a46b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "e6f72f600874fb53121f59bfab5e7568fe24a46b"} -->
