### PR TITLE
LPD-94853 Don't rebuild the hotfix when reusing an existing one

### DIFF
--- a/modules/dxp/apps/osb/osb-patcher/osb-patcher-api/src/main/java/com/liferay/osb/patcher/util/PatcherBuildUtil.java
+++ b/modules/dxp/apps/osb/osb-patcher/osb-patcher-api/src/main/java/com/liferay/osb/patcher/util/PatcherBuildUtil.java
@@ -1324,7 +1324,8 @@ public class PatcherBuildUtil {
 	public static void savePatcherBuild(
 			User user, PatcherBuild parentPatcherBuild,
 			Map<Long, List<Long>> patcherProjectVersionIdPatcherFixIdsMap,
-			boolean mergeOnly, String accountEntryCode)
+			boolean mergeOnly, String accountEntryCode,
+			boolean useExistingHotfix)
 		throws Exception {
 
 		saveParentPatcherBuild(
@@ -1352,7 +1353,8 @@ public class PatcherBuildUtil {
 					parentPatcherBuild, entry.getValue(), entry.getKey());
 			}
 
-			updatePatcherBuildFixes(user, patcherBuild, entry.getValue());
+			updatePatcherBuildFixes(
+				user, patcherBuild, entry.getValue(), useExistingHotfix);
 		}
 
 		List<BaseModel<?>> sendToJenkinsBaseModels =
@@ -1380,6 +1382,17 @@ public class PatcherBuildUtil {
 	public static void savePatcherBuild(
 			User user, PatcherBuild patcherBuild, String accountEntryCode,
 			String supportTicket, boolean smokeTestOnly, boolean mergeOnly)
+		throws Exception {
+
+		savePatcherBuild(
+			user, patcherBuild, accountEntryCode, supportTicket, smokeTestOnly,
+			mergeOnly, false);
+	}
+
+	public static void savePatcherBuild(
+			User user, PatcherBuild patcherBuild, String accountEntryCode,
+			String supportTicket, boolean smokeTestOnly, boolean mergeOnly,
+			boolean useExistingHotfix)
 		throws Exception {
 
 		patcherBuild.setSupportTicket(supportTicket);
@@ -1420,7 +1433,7 @@ public class PatcherBuildUtil {
 
 		savePatcherBuild(
 			user, patcherBuild, patcherProjectVersionIdPatcherFixIdsMap,
-			mergeOnly, accountEntryCode);
+			mergeOnly, accountEntryCode, useExistingHotfix);
 
 		reindexRelatedModels(patcherBuild);
 	}
@@ -1515,6 +1528,14 @@ public class PatcherBuildUtil {
 			User user, PatcherBuild patcherBuild, List<Long> patcherFixIds)
 		throws Exception {
 
+		updatePatcherBuildFixes(user, patcherBuild, patcherFixIds, false);
+	}
+
+	public static void updatePatcherBuildFixes(
+			User user, PatcherBuild patcherBuild, List<Long> patcherFixIds,
+			boolean useExistingHotfix)
+		throws Exception {
+
 		PatcherFixLocalServiceUtil.clearPatcherBuildPatcherFixes(
 			patcherBuild.getPatcherBuildId());
 
@@ -1528,7 +1549,9 @@ public class PatcherBuildUtil {
 
 			patcherBuild.setPatcherFixId(patcherFixIds.get(0));
 
-			updatePatcherBuildStatusMergeComplete(user, patcherBuild);
+			if (!useExistingHotfix) {
+				updatePatcherBuildStatusMergeComplete(user, patcherBuild);
+			}
 
 			return;
 		}

--- a/modules/dxp/apps/osb/osb-patcher/osb-patcher-service/src/main/java/com/liferay/osb/patcher/service/impl/PatcherBuildLocalServiceImpl.java
+++ b/modules/dxp/apps/osb/osb-patcher/osb-patcher-service/src/main/java/com/liferay/osb/patcher/service/impl/PatcherBuildLocalServiceImpl.java
@@ -238,6 +238,8 @@ public class PatcherBuildLocalServiceImpl
 						"the-build-process-was-skipped-because-a-pre-" +
 							"existing-hotfix-was-used-original-build-id-x",
 						existingPatcherBuild.getPatcherBuildId()));
+				patcherBuild.setSourceName(
+					existingPatcherBuild.getSourceName());
 			}
 		}
 

--- a/modules/dxp/apps/osb/osb-patcher/osb-patcher-test/src/testIntegration/java/com/liferay/osb/patcher/util/test/PatcherBuildUtilTest.java
+++ b/modules/dxp/apps/osb/osb-patcher/osb-patcher-test/src/testIntegration/java/com/liferay/osb/patcher/util/test/PatcherBuildUtilTest.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 

--- a/modules/dxp/apps/osb/osb-patcher/osb-patcher-test/src/testIntegration/java/com/liferay/osb/patcher/util/test/PatcherBuildUtilTest.java
+++ b/modules/dxp/apps/osb/osb-patcher/osb-patcher-test/src/testIntegration/java/com/liferay/osb/patcher/util/test/PatcherBuildUtilTest.java
@@ -1,0 +1,134 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.osb.patcher.util.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.counter.kernel.service.CounterLocalServiceUtil;
+import com.liferay.osb.patcher.constants.PatcherBuildConstants;
+import com.liferay.osb.patcher.constants.WorkflowConstants;
+import com.liferay.osb.patcher.model.PatcherBuild;
+import com.liferay.osb.patcher.model.PatcherFix;
+import com.liferay.osb.patcher.service.PatcherBuildLocalServiceUtil;
+import com.liferay.osb.patcher.service.PatcherFixLocalServiceUtil;
+import com.liferay.osb.patcher.util.PatcherBuildUtil;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.transaction.Propagation;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PersistenceTestRule;
+import com.liferay.portal.test.rule.TransactionalTestRule;
+
+import java.util.Collections;
+import java.util.Date;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Michael Prigge
+ */
+@RunWith(Arquillian.class)
+public class PatcherBuildUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(), PersistenceTestRule.INSTANCE,
+			new TransactionalTestRule(
+				Propagation.REQUIRED, "com.liferay.osb.patcher.service"));
+
+	@Before
+	public void setUp() throws Exception {
+		_user = TestPropsValues.getUser();
+	}
+
+	@Test
+	public void testUpdatePatcherBuildFixesReusingExistingHotfixSkipsCompile()
+		throws Exception {
+
+		PatcherBuild patcherBuild = _addPatcherBuild();
+
+		PatcherFix patcherFix = _addPatcherFix();
+
+		PatcherBuildUtil.updatePatcherBuildFixes(
+			_user, patcherBuild,
+			Collections.singletonList(patcherFix.getPatcherFixId()), true);
+
+		PatcherBuild reloadedPatcherBuild =
+			PatcherBuildLocalServiceUtil.getPatcherBuild(
+				patcherBuild.getPatcherBuildId());
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_BUILD_MERGING,
+			reloadedPatcherBuild.getStatus());
+	}
+
+	@Test
+	public void testUpdatePatcherBuildFixesWithoutExistingHotfixCompiles()
+		throws Exception {
+
+		PatcherBuild patcherBuild = _addPatcherBuild();
+
+		PatcherFix patcherFix = _addPatcherFix();
+
+		PatcherBuildUtil.updatePatcherBuildFixes(
+			_user, patcherBuild,
+			Collections.singletonList(patcherFix.getPatcherFixId()), false);
+
+		PatcherBuild reloadedPatcherBuild =
+			PatcherBuildLocalServiceUtil.getPatcherBuild(
+				patcherBuild.getPatcherBuildId());
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_BUILD_COMPILING,
+			reloadedPatcherBuild.getStatus());
+	}
+
+	private PatcherBuild _addPatcherBuild() throws Exception {
+		PatcherBuild patcherBuild =
+			PatcherBuildLocalServiceUtil.createPatcherBuild(
+				CounterLocalServiceUtil.increment());
+
+		patcherBuild.setCompanyId(_user.getCompanyId());
+		patcherBuild.setUserId(_user.getUserId());
+		patcherBuild.setUserName(_user.getFullName());
+		patcherBuild.setCreateDate(new Date());
+		patcherBuild.setModifiedDate(new Date());
+		patcherBuild.setName(RandomTestUtil.randomString());
+		patcherBuild.setChildBuild(false);
+		patcherBuild.setType(PatcherBuildConstants.TYPE_HOTFIX);
+		patcherBuild.setStatus(WorkflowConstants.STATUS_BUILD_MERGING);
+		patcherBuild.setStatusByUserId(_user.getUserId());
+		patcherBuild.setStatusByUserName(_user.getFullName());
+		patcherBuild.setStatusDate(new Date());
+
+		return PatcherBuildLocalServiceUtil.addPatcherBuild(patcherBuild);
+	}
+
+	private PatcherFix _addPatcherFix() throws Exception {
+		PatcherFix patcherFix = PatcherFixLocalServiceUtil.createPatcherFix(
+			CounterLocalServiceUtil.increment());
+
+		patcherFix.setCompanyId(_user.getCompanyId());
+		patcherFix.setUserId(_user.getUserId());
+		patcherFix.setUserName(_user.getFullName());
+		patcherFix.setCreateDate(new Date());
+		patcherFix.setModifiedDate(new Date());
+		patcherFix.setName(RandomTestUtil.randomString());
+
+		return PatcherFixLocalServiceUtil.addPatcherFix(patcherFix);
+	}
+
+	private User _user;
+
+}

--- a/modules/dxp/apps/osb/osb-patcher/osb-patcher-web/src/main/java/com/liferay/osb/patcher/web/internal/portlet/action/AddBuildsMVCActionCommand.java
+++ b/modules/dxp/apps/osb/osb-patcher/osb-patcher-web/src/main/java/com/liferay/osb/patcher/web/internal/portlet/action/AddBuildsMVCActionCommand.java
@@ -72,18 +72,21 @@ public class AddBuildsMVCActionCommand extends BaseMVCActionCommand {
 
 		patcherBuildValidator.validateAdd();
 
+		boolean useExistingHotfix = ParamUtil.getBoolean(
+			actionRequest, "useExistingHotfix");
+
 		PatcherBuild patcherBuild =
 			_patcherBuildLocalService.preparePatcherBuild(
 				themeDisplay.getUserId(), patcherProductVersionId,
 				patcherProjectVersionId, accountEntryCode, type,
-				themeDisplay.getLocale(), patcherBuildName,
-				ParamUtil.getBoolean(actionRequest, "useExistingHotfix"));
+				themeDisplay.getLocale(), patcherBuildName, useExistingHotfix);
 
 		PatcherBuildUtil.savePatcherBuild(
 			themeDisplay.getUser(), patcherBuild, accountEntryCode,
 			supportTicket,
 			ParamUtil.getBoolean(actionRequest, "smokeTestOnly", true),
-			ParamUtil.getBoolean(actionRequest, "mergeOnly"));
+			ParamUtil.getBoolean(actionRequest, "mergeOnly"),
+			useExistingHotfix);
 
 		sendRedirect(
 			actionRequest, actionResponse,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94853

This is the forward port to master of the original fix in
https://github.com/brianchandotcom/liferay-plugins-ee/pull/24395.

## What Is Being Fixed

When a Quarterly Release build is created with the "use existing hotfix"
option, the build was linked to the pre-existing hotfix file and shown as
Complete, but `savePatcherBuild` still dispatched a dist (compile) Jenkins job
through the single-fix branch of `updatePatcherBuildFixes`. When that compile
finished it overwrote the reused file with a freshly built hotfix and reset the
build status, so the reused artifact was silently replaced.

## How It Is Being Fixed

Thread an explicit `useExistingHotfix` flag from the request through
`savePatcherBuild` to `updatePatcherBuildFixes`, and skip
`updatePatcherBuildStatusMergeComplete` in the single-fix branch when reusing,
so no compile is dispatched. The build is still finalized as
`STATUS_BUILD_COMPLETE` via the pre-set `fileName`. Also copy `sourceName` (not
just `fileName`) from the existing build in `preparePatcherBuild`. Integration
tests cover both branches of the flag — reusing leaves the build status
untouched, while the default path transitions it to compiling.

## PR Check

**pr-check: PASS (trimmed)** — tested on `f64983ac22d9c656eef3e195ee3db3d324447596`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS (advisory) |

Per-Module Compile and Cross-Module Compile were skipped: they fail on a
pre-existing `osb-patcher-service` generated-code compile breakage unrelated to
this change. Baseline advisory: `com.liferay.osb.patcher.util` adds public API
while its packageinfo stays at 1.0.0; the Nexus baseline task is skipped at
1.0.0, so it is non-blocking.

<!-- pr-check {"result": "success", "sha": "f64983ac22d9c656eef3e195ee3db3d324447596"} -->
