### PR TITLE
LPD-95679 Scope NewExport test assertion to journal portlet label

### DIFF
--- a/modules/apps/export-import/export-import-web/test/revamp/js/pages/export/NewExport.test.tsx
+++ b/modules/apps/export-import/export-import-web/test/revamp/js/pages/export/NewExport.test.tsx
@@ -679,14 +679,18 @@ describe('NewExport', () => {
 		}
 
 		expect(
-			screen.getByText('Referenced Content Behavior')
+			screen.getByText('Referenced Content Behavior', {
+				selector: 'label[for="_journal_referenced-content-behavior"]',
+			})
 		).toBeInTheDocument();
 
 		await userEvent.click(referencedContentCheckbox);
 
 		expect(referencedContentCheckbox).not.toBeChecked();
 		expect(
-			screen.queryByText('Referenced Content Behavior')
+			screen.queryByText('Referenced Content Behavior', {
+				selector: 'label[for="_journal_referenced-content-behavior"]',
+			})
 		).not.toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95679

## What Is Being Fixed

The NewExport unit test asserted on the "Referenced Content Behavior" text with an unscoped query. That same label text now renders for more than one portlet in the export revamp, so the lookup matched multiple elements and made the assertion ambiguous.

## How It Is Being Fixed

The assertion now targets the journal portlet's specific label through the `label[for="_journal_referenced-content-behavior"]` selector, both for the visible-state check and for the hidden-state check after the referenced content checkbox is unchecked. This pins the test to the intended element regardless of other portlets rendering the same text.

## PR Check

**pr-check: PASS** — tested on `04b085b2b4851f1dd837b6c45418fa1591d026bf`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "04b085b2b4851f1dd837b6c45418fa1591d026bf"} -->
