### PR TITLE
LRSD-12388 Add Liferay DXP Academic products to Customer Portal

### DIFF
--- a/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-site-initializer/site-initializer/accounts.json
+++ b/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-site-initializer/site-initializer/accounts.json
@@ -113,5 +113,10 @@
 		"externalReferenceCode": "ERC-023",
 		"name": "AI Hub Test Account",
 		"type": "business"
+	},
+	{
+		"externalReferenceCode": "ERC-024",
+		"name": "Liferay DXP Academic Test Account",
+		"type": "business"
 	}
 ]

--- a/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-site-initializer/site-initializer/object-entries/account-subscription-group.object-entries.json
+++ b/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-site-initializer/site-initializer/object-entries/account-subscription-group.object-entries.json
@@ -307,6 +307,17 @@
 			"name": "Liferay Cloud",
 			"r_accountEntryToAccountSubscriptionGroup_accountEntryERC": "ERC-023",
 			"tabOrder": 2
+		},
+		{
+			"accountKey": "ERC-024",
+			"activationProductName": "DXP",
+			"activationStatus": "Active",
+			"externalReferenceCode": "ERC-024_self-hosted",
+			"hasActivation": true,
+			"menuOrder": 1,
+			"name": "Self-Hosted",
+			"r_accountEntryToAccountSubscriptionGroup_accountEntryERC": "ERC-024",
+			"tabOrder": 2
 		}
 	],
 	"objectDefinitionName": "AccountSubscriptionGroup"

--- a/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-site-initializer/site-initializer/object-entries/account-subscription.object-entries.json
+++ b/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-site-initializer/site-initializer/object-entries/account-subscription.object-entries.json
@@ -587,6 +587,30 @@
 			"r_accountEntryToAccountSubscription_accountEntryERC": "ERC-023",
 			"startDate": "2023-01-01T00:00:00Z",
 			"subscriptionStatus": "Active"
+		},
+		{
+			"accountKey": "ERC-024",
+			"accountSubscriptionGroupERC": "ERC-024_self-hosted",
+			"endDate": "2026-12-31T00:00:00Z",
+			"externalReferenceCode": "ERC-024_self-hosted_academic-production",
+			"instanceSize": "1",
+			"name": "Academic Production",
+			"quantity": 1,
+			"r_accountEntryToAccountSubscription_accountEntryERC": "ERC-024",
+			"startDate": "2023-01-01T00:00:00Z",
+			"subscriptionStatus": "Active"
+		},
+		{
+			"accountKey": "ERC-024",
+			"accountSubscriptionGroupERC": "ERC-024_self-hosted",
+			"endDate": "2026-12-31T00:00:00Z",
+			"externalReferenceCode": "ERC-024_self-hosted_academic-non-production",
+			"instanceSize": "1",
+			"name": "Academic Non-Production",
+			"quantity": 1,
+			"r_accountEntryToAccountSubscription_accountEntryERC": "ERC-024",
+			"startDate": "2023-01-01T00:00:00Z",
+			"subscriptionStatus": "Active"
 		}
 	],
 	"objectDefinitionName": "AccountSubscription"

--- a/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-site-initializer/site-initializer/object-entries/koroneiki-account.object-entries.json
+++ b/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-site-initializer/site-initializer/object-entries/koroneiki-account.object-entries.json
@@ -370,6 +370,19 @@
 			"slaCurrent": "Platinum Subscription",
 			"slaCurrentEndDate": "2026-12-31 00:00:00.0",
 			"slaCurrentStartDate": "2023-01-01 00:00:00.0"
+		},
+		{
+			"accountKey": "ERC-024",
+			"code": "TESTACCOUNT24",
+			"dxpVersion": "7.4",
+			"externalReferenceCode": "ERC-024",
+			"liferayContactEmailAddress": "customer-service@liferay.com",
+			"liferayContactName": "Liferay Support",
+			"maxRequestors": -1,
+			"name": "Liferay DXP Academic Test Account",
+			"partner": false,
+			"r_accountEntryToKoroneikiAccount_accountEntryERC": "ERC-024",
+			"region": "United States"
 		}
 	],
 	"objectDefinitionName": "KoroneikiAccount"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRSD-12388

## What Is Being Fixed

The Customer Portal site initializer had no Liferay DXP Academic subscription data, so an academic customer scenario could not be represented or exercised in the portal.

## How It Is Being Fixed

Seed data is added to the liferay-customer-site-initializer for a new "Liferay DXP Academic Test Account" (ERC-024): a business account in accounts.json, a self-hosted DXP subscription group, two subscriptions (Academic Production and Academic Non-Production), and a matching Koroneiki account record. The entries mirror the structure of the existing seeded accounts.

## Why Are There No Tests?

This change only adds JSON seed data to a site initializer; there is no executable code or logic to cover with tests.

## PR Check

**pr-check: PASS** — tested on `2dac8bb8c1feadf1a307f9e49493367d53659f57`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "2dac8bb8c1feadf1a307f9e49493367d53659f57"} -->
