### PR TITLE
LPD-94853 Reuse an existing hotfix instead of rebuilding it

### DIFF
--- a/modules/dxp/apps/osb/osb-patcher/osb-patcher-api/src/main/java/com/liferay/osb/patcher/util/PatcherBuildUtil.java
+++ b/modules/dxp/apps/osb/osb-patcher/osb-patcher-api/src/main/java/com/liferay/osb/patcher/util/PatcherBuildUtil.java
@@ -1381,16 +1381,6 @@ public class PatcherBuildUtil {
 
 	public static void savePatcherBuild(
 			User user, PatcherBuild patcherBuild, String accountEntryCode,
-			String supportTicket, boolean smokeTestOnly, boolean mergeOnly)
-		throws Exception {
-
-		savePatcherBuild(
-			user, patcherBuild, accountEntryCode, supportTicket, smokeTestOnly,
-			mergeOnly, false);
-	}
-
-	public static void savePatcherBuild(
-			User user, PatcherBuild patcherBuild, String accountEntryCode,
 			String supportTicket, boolean smokeTestOnly, boolean mergeOnly,
 			boolean useExistingHotfix)
 		throws Exception {

--- a/modules/dxp/apps/osb/osb-patcher/osb-patcher-api/src/main/java/com/liferay/osb/patcher/util/PatcherBuildUtil.java
+++ b/modules/dxp/apps/osb/osb-patcher/osb-patcher-api/src/main/java/com/liferay/osb/patcher/util/PatcherBuildUtil.java
@@ -1324,7 +1324,8 @@ public class PatcherBuildUtil {
 	public static void savePatcherBuild(
 			User user, PatcherBuild parentPatcherBuild,
 			Map<Long, List<Long>> patcherProjectVersionIdPatcherFixIdsMap,
-			boolean mergeOnly, String accountEntryCode)
+			boolean mergeOnly, String accountEntryCode,
+			boolean useExistingHotfix)
 		throws Exception {
 
 		saveParentPatcherBuild(
@@ -1352,7 +1353,8 @@ public class PatcherBuildUtil {
 					parentPatcherBuild, entry.getValue(), entry.getKey());
 			}
 
-			updatePatcherBuildFixes(user, patcherBuild, entry.getValue());
+			updatePatcherBuildFixes(
+				user, patcherBuild, entry.getValue(), useExistingHotfix);
 		}
 
 		List<BaseModel<?>> sendToJenkinsBaseModels =
@@ -1380,6 +1382,17 @@ public class PatcherBuildUtil {
 	public static void savePatcherBuild(
 			User user, PatcherBuild patcherBuild, String accountEntryCode,
 			String supportTicket, boolean smokeTestOnly, boolean mergeOnly)
+		throws Exception {
+
+		savePatcherBuild(
+			user, patcherBuild, accountEntryCode, supportTicket, smokeTestOnly,
+			mergeOnly, false);
+	}
+
+	public static void savePatcherBuild(
+			User user, PatcherBuild patcherBuild, String accountEntryCode,
+			String supportTicket, boolean smokeTestOnly, boolean mergeOnly,
+			boolean useExistingHotfix)
 		throws Exception {
 
 		patcherBuild.setSupportTicket(supportTicket);
@@ -1420,7 +1433,7 @@ public class PatcherBuildUtil {
 
 		savePatcherBuild(
 			user, patcherBuild, patcherProjectVersionIdPatcherFixIdsMap,
-			mergeOnly, accountEntryCode);
+			mergeOnly, accountEntryCode, useExistingHotfix);
 
 		reindexRelatedModels(patcherBuild);
 	}
@@ -1515,6 +1528,14 @@ public class PatcherBuildUtil {
 			User user, PatcherBuild patcherBuild, List<Long> patcherFixIds)
 		throws Exception {
 
+		updatePatcherBuildFixes(user, patcherBuild, patcherFixIds, false);
+	}
+
+	public static void updatePatcherBuildFixes(
+			User user, PatcherBuild patcherBuild, List<Long> patcherFixIds,
+			boolean useExistingHotfix)
+		throws Exception {
+
 		PatcherFixLocalServiceUtil.clearPatcherBuildPatcherFixes(
 			patcherBuild.getPatcherBuildId());
 
@@ -1528,7 +1549,9 @@ public class PatcherBuildUtil {
 
 			patcherBuild.setPatcherFixId(patcherFixIds.get(0));
 
-			updatePatcherBuildStatusMergeComplete(user, patcherBuild);
+			if (!useExistingHotfix) {
+				updatePatcherBuildStatusMergeComplete(user, patcherBuild);
+			}
 
 			return;
 		}

--- a/modules/dxp/apps/osb/osb-patcher/osb-patcher-service/src/main/java/com/liferay/osb/patcher/service/impl/PatcherBuildLocalServiceImpl.java
+++ b/modules/dxp/apps/osb/osb-patcher/osb-patcher-service/src/main/java/com/liferay/osb/patcher/service/impl/PatcherBuildLocalServiceImpl.java
@@ -238,6 +238,8 @@ public class PatcherBuildLocalServiceImpl
 						"the-build-process-was-skipped-because-a-pre-" +
 							"existing-hotfix-was-used-original-build-id-x",
 						existingPatcherBuild.getPatcherBuildId()));
+				patcherBuild.setSourceName(
+					existingPatcherBuild.getSourceName());
 			}
 		}
 

--- a/modules/dxp/apps/osb/osb-patcher/osb-patcher-test/src/testIntegration/java/com/liferay/osb/patcher/util/test/PatcherBuildUtilTest.java
+++ b/modules/dxp/apps/osb/osb-patcher/osb-patcher-test/src/testIntegration/java/com/liferay/osb/patcher/util/test/PatcherBuildUtilTest.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 

--- a/modules/dxp/apps/osb/osb-patcher/osb-patcher-test/src/testIntegration/java/com/liferay/osb/patcher/util/test/PatcherBuildUtilTest.java
+++ b/modules/dxp/apps/osb/osb-patcher/osb-patcher-test/src/testIntegration/java/com/liferay/osb/patcher/util/test/PatcherBuildUtilTest.java
@@ -1,0 +1,134 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.osb.patcher.util.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.counter.kernel.service.CounterLocalServiceUtil;
+import com.liferay.osb.patcher.constants.PatcherBuildConstants;
+import com.liferay.osb.patcher.constants.WorkflowConstants;
+import com.liferay.osb.patcher.model.PatcherBuild;
+import com.liferay.osb.patcher.model.PatcherFix;
+import com.liferay.osb.patcher.service.PatcherBuildLocalServiceUtil;
+import com.liferay.osb.patcher.service.PatcherFixLocalServiceUtil;
+import com.liferay.osb.patcher.util.PatcherBuildUtil;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.transaction.Propagation;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PersistenceTestRule;
+import com.liferay.portal.test.rule.TransactionalTestRule;
+
+import java.util.Collections;
+import java.util.Date;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Michael Prigge
+ */
+@RunWith(Arquillian.class)
+public class PatcherBuildUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(), PersistenceTestRule.INSTANCE,
+			new TransactionalTestRule(
+				Propagation.REQUIRED, "com.liferay.osb.patcher.service"));
+
+	@Before
+	public void setUp() throws Exception {
+		_user = TestPropsValues.getUser();
+	}
+
+	@Test
+	public void testUpdatePatcherBuildFixesReusingExistingHotfixSkipsCompile()
+		throws Exception {
+
+		PatcherBuild patcherBuild = _addPatcherBuild();
+
+		PatcherFix patcherFix = _addPatcherFix();
+
+		PatcherBuildUtil.updatePatcherBuildFixes(
+			_user, patcherBuild,
+			Collections.singletonList(patcherFix.getPatcherFixId()), true);
+
+		PatcherBuild reloadedPatcherBuild =
+			PatcherBuildLocalServiceUtil.getPatcherBuild(
+				patcherBuild.getPatcherBuildId());
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_BUILD_MERGING,
+			reloadedPatcherBuild.getStatus());
+	}
+
+	@Test
+	public void testUpdatePatcherBuildFixesWithoutExistingHotfixCompiles()
+		throws Exception {
+
+		PatcherBuild patcherBuild = _addPatcherBuild();
+
+		PatcherFix patcherFix = _addPatcherFix();
+
+		PatcherBuildUtil.updatePatcherBuildFixes(
+			_user, patcherBuild,
+			Collections.singletonList(patcherFix.getPatcherFixId()), false);
+
+		PatcherBuild reloadedPatcherBuild =
+			PatcherBuildLocalServiceUtil.getPatcherBuild(
+				patcherBuild.getPatcherBuildId());
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_BUILD_COMPILING,
+			reloadedPatcherBuild.getStatus());
+	}
+
+	private PatcherBuild _addPatcherBuild() throws Exception {
+		PatcherBuild patcherBuild =
+			PatcherBuildLocalServiceUtil.createPatcherBuild(
+				CounterLocalServiceUtil.increment());
+
+		patcherBuild.setCompanyId(_user.getCompanyId());
+		patcherBuild.setUserId(_user.getUserId());
+		patcherBuild.setUserName(_user.getFullName());
+		patcherBuild.setCreateDate(new Date());
+		patcherBuild.setModifiedDate(new Date());
+		patcherBuild.setName(RandomTestUtil.randomString());
+		patcherBuild.setChildBuild(false);
+		patcherBuild.setType(PatcherBuildConstants.TYPE_HOTFIX);
+		patcherBuild.setStatus(WorkflowConstants.STATUS_BUILD_MERGING);
+		patcherBuild.setStatusByUserId(_user.getUserId());
+		patcherBuild.setStatusByUserName(_user.getFullName());
+		patcherBuild.setStatusDate(new Date());
+
+		return PatcherBuildLocalServiceUtil.addPatcherBuild(patcherBuild);
+	}
+
+	private PatcherFix _addPatcherFix() throws Exception {
+		PatcherFix patcherFix = PatcherFixLocalServiceUtil.createPatcherFix(
+			CounterLocalServiceUtil.increment());
+
+		patcherFix.setCompanyId(_user.getCompanyId());
+		patcherFix.setUserId(_user.getUserId());
+		patcherFix.setUserName(_user.getFullName());
+		patcherFix.setCreateDate(new Date());
+		patcherFix.setModifiedDate(new Date());
+		patcherFix.setName(RandomTestUtil.randomString());
+
+		return PatcherFixLocalServiceUtil.addPatcherFix(patcherFix);
+	}
+
+	private User _user;
+
+}

--- a/modules/dxp/apps/osb/osb-patcher/osb-patcher-web/src/main/java/com/liferay/osb/patcher/web/internal/portlet/action/AddBuildsMVCActionCommand.java
+++ b/modules/dxp/apps/osb/osb-patcher/osb-patcher-web/src/main/java/com/liferay/osb/patcher/web/internal/portlet/action/AddBuildsMVCActionCommand.java
@@ -72,18 +72,21 @@ public class AddBuildsMVCActionCommand extends BaseMVCActionCommand {
 
 		patcherBuildValidator.validateAdd();
 
+		boolean useExistingHotfix = ParamUtil.getBoolean(
+			actionRequest, "useExistingHotfix");
+
 		PatcherBuild patcherBuild =
 			_patcherBuildLocalService.preparePatcherBuild(
 				themeDisplay.getUserId(), patcherProductVersionId,
 				patcherProjectVersionId, accountEntryCode, type,
-				themeDisplay.getLocale(), patcherBuildName,
-				ParamUtil.getBoolean(actionRequest, "useExistingHotfix"));
+				themeDisplay.getLocale(), patcherBuildName, useExistingHotfix);
 
 		PatcherBuildUtil.savePatcherBuild(
 			themeDisplay.getUser(), patcherBuild, accountEntryCode,
 			supportTicket,
 			ParamUtil.getBoolean(actionRequest, "smokeTestOnly", true),
-			ParamUtil.getBoolean(actionRequest, "mergeOnly"));
+			ParamUtil.getBoolean(actionRequest, "mergeOnly"),
+			useExistingHotfix);
 
 		sendRedirect(
 			actionRequest, actionResponse,

--- a/modules/dxp/apps/osb/osb-patcher/osb-patcher-web/src/main/java/com/liferay/osb/patcher/web/internal/portlet/action/BuildBuildsMVCActionCommand.java
+++ b/modules/dxp/apps/osb/osb-patcher/osb-patcher-web/src/main/java/com/liferay/osb/patcher/web/internal/portlet/action/BuildBuildsMVCActionCommand.java
@@ -82,7 +82,7 @@ public class BuildBuildsMVCActionCommand extends BaseMVCActionCommand {
 				StringUtil.toUpperCase(patcherAccount.getAccountEntryCode()),
 				patcherBuild.getSupportTicket(),
 				PatcherBuildUtil.isSmokeTestOnly(patcherBuild),
-				PatcherBuildUtil.isMergeOnly(patcherBuild));
+				PatcherBuildUtil.isMergeOnly(patcherBuild), false);
 		}
 		else {
 			JenkinsUtil.sendDistJenkinsRequest(

--- a/modules/dxp/apps/osb/osb-patcher/osb-patcher-web/src/main/java/com/liferay/osb/patcher/web/internal/portlet/action/UpdateBuildsMVCActionCommand.java
+++ b/modules/dxp/apps/osb/osb-patcher/osb-patcher-web/src/main/java/com/liferay/osb/patcher/web/internal/portlet/action/UpdateBuildsMVCActionCommand.java
@@ -93,7 +93,7 @@ public class UpdateBuildsMVCActionCommand extends BaseMVCActionCommand {
 
 		PatcherBuildUtil.savePatcherBuild(
 			themeDisplay.getUser(), patcherBuild, accountEntryCode,
-			supportTicket, smokeTestOnly, mergeOnly);
+			supportTicket, smokeTestOnly, mergeOnly, false);
 	}
 
 	@Reference


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94853

This is the forward port to master of the original fix in
https://github.com/brianchandotcom/liferay-plugins-ee/pull/24395.

## What Is Being Fixed

When a patcher build was created with the "use existing hotfix" option enabled, the build still ran through the full merge-and-rebuild flow even though an equivalent hotfix already existed. The flag only affected how the build was prepared; `savePatcherBuild` had no way to know it should skip the rebuild, so the existing hotfix's artifacts were regenerated unnecessarily.

## How It Is Being Fixed

A `useExistingHotfix` flag is threaded from the action command through `PatcherBuildUtil.savePatcherBuild` down into `updatePatcherBuildFixes`. When the flag is set, `updatePatcherBuildFixes` skips the merge-complete status transition that would otherwise trigger a rebuild, so the build reuses the existing hotfix. `preparePatcherBuild` also copies the source name from the equivalent existing build so the reused build stays consistent with the original. The two `savePatcherBuild` overloads were collapsed into one that carries the flag, and the remaining call sites pass `false` to preserve their current behavior.

## PR Check

**pr-check: PASS** — tested on `646c661d495df313e6366cb98f32016682375c38`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "646c661d495df313e6366cb98f32016682375c38"} -->
