### PR TITLE
LRCI-7759 Add ability to generate build properties for local usage

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/EnvironmentBuildProperties.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/EnvironmentBuildProperties.java
@@ -65,6 +65,8 @@ public class EnvironmentBuildProperties extends Properties {
 
 			load(new StringReader(contents));
 
+			_loadLocalProperties(urlString, checkCache);
+
 			return;
 		}
 		catch (IOException ioException) {
@@ -99,6 +101,8 @@ public class EnvironmentBuildProperties extends Properties {
 		}
 		catch (IOException ioException) {
 		}
+
+		_loadLocalProperties(urlString, checkCache);
 	}
 
 	public EnvironmentBuildProperties(File file) throws IOException {
@@ -179,6 +183,31 @@ public class EnvironmentBuildProperties extends Properties {
 		sb.append(_simpleDateFormat.format(new Date()));
 
 		return sb.toString();
+	}
+
+	private void _loadLocalProperties(String urlString, boolean checkCache) {
+		if (!JenkinsResultsParserUtil.isNullOrEmpty(
+				System.getenv("JENKINS_URL"))) {
+
+			return;
+		}
+
+		Matcher matcher = _propertiesURLPattern.matcher(urlString);
+
+		if (!matcher.matches()) {
+			return;
+		}
+
+		try {
+			String content = _toString(
+				JenkinsResultsParserUtil.combine(
+					matcher.group(1), "-local", matcher.group(2)),
+				checkCache);
+
+			load(new StringReader(content));
+		}
+		catch (IOException ioException) {
+		}
 	}
 
 	private String _toString(String url, boolean checkCache)


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7759

## What Is Being Fixed

`EnvironmentBuildProperties` loads build properties from a remote URL, which works on Jenkins but offers no way to override those values when running the results parser locally. Local runs were stuck with the published properties, with no hook to layer in tweaked values for local experimentation.

## How It Is Being Fixed

After the properties URL is loaded in each constructor path, a new `_loadLocalProperties` helper layers a `-local` variant of the same URL on top of the already-loaded properties. It is a no-op when `JENKINS_URL` is set, so CI behavior is unchanged, and it only acts when the URL matches the expected properties pattern. Loading the `-local` content over the existing properties lets a local file override individual keys while leaving the rest intact, and a missing `-local` file is silently ignored.

## Why Are There No Tests?

`EnvironmentBuildProperties` is jenkins-results-parser CI infrastructure, validated through the CI pipeline itself. The new local-properties branch only activates off-Jenkins and has no unit harness, so it is covered by the existing CI exercise rather than a new unit test.

## PR Check

**pr-check: PASS** — tested on `13aae36e7797cc0ea9486871e7cfc0108cd0d411`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "13aae36e7797cc0ea9486871e7cfc0108cd0d411"} -->
