### PR TITLE
LPD-96312 Restore Group Pages import handler for existing site LARs

### DIFF
--- a/modules/apps/export-import/export-import-api/bnd.bnd
+++ b/modules/apps/export-import/export-import-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Export Import API
 Bundle-SymbolicName: com.liferay.exportimport.api
-Bundle-Version: 17.2.1
+Bundle-Version: 17.3.0
 Export-Package:\
 	com.liferay.exportimport.attachment,\
 	com.liferay.exportimport.configuration,\

--- a/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/vulcan/batch/engine/ExportImportVulcanBatchEngineTaskItemDelegate.java
+++ b/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/vulcan/batch/engine/ExportImportVulcanBatchEngineTaskItemDelegate.java
@@ -11,6 +11,7 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 
 import java.io.Serializable;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -29,6 +30,10 @@ public interface ExportImportVulcanBatchEngineTaskItemDelegate<T>
 
 		public default Function<T, Boolean> getApplicableModelFunction() {
 			return null;
+		}
+
+		public default List<String> getCompatibilityPortletIds() {
+			return Collections.emptyList();
 		}
 
 		public default String getDescription(Locale locale) {

--- a/modules/apps/export-import/export-import-api/src/main/resources/com/liferay/exportimport/vulcan/batch/engine/packageinfo
+++ b/modules/apps/export-import/export-import-api/src/main/resources/com/liferay/exportimport/vulcan/batch/engine/packageinfo
@@ -1,1 +1,1 @@
-version 8.2.0
+version 8.3.0

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/data/handler/BatchEnginePortletDataHandlerRegistrar.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/data/handler/BatchEnginePortletDataHandlerRegistrar.java
@@ -27,6 +27,7 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.staging.StagingGroupHelper;
 
 import java.util.Dictionary;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -185,6 +186,24 @@ public class BatchEnginePortletDataHandlerRegistrar {
 			BatchEnginePortletDataHandler finalBatchEnginePortletDataHandler =
 				batchEnginePortletDataHandler;
 
+			List<String> compatibilityPortletIds =
+				exportImportDescriptor.getCompatibilityPortletIds();
+
+			for (String compatibilityPortletId : compatibilityPortletIds) {
+				_portletIdServiceRegistrations.computeIfAbsent(
+					compatibilityPortletId,
+					key -> _bundleContext.registerService(
+						PortletDataHandler.class,
+						finalBatchEnginePortletDataHandler,
+						_setEnabledCompanyId(
+							companyId,
+							HashMapDictionaryBuilder.<String, Object>put(
+								"jakarta.portlet.name", key
+							).put(
+								"service.ranking", Integer.MAX_VALUE
+							).build())));
+			}
+
 			return _portletIdServiceRegistrations.computeIfAbsent(
 				portletId,
 				key -> _bundleContext.registerService(
@@ -235,6 +254,9 @@ public class BatchEnginePortletDataHandlerRegistrar {
 				return;
 			}
 
+			List<String> compatibilityPortletIds =
+				exportImportDescriptor.getCompatibilityPortletIds();
+
 			exportImportDescriptor =
 				batchEnginePortletDataHandler.
 					unregisterExportImportVulcanBatchEngineTaskItemDelegate(
@@ -255,6 +277,17 @@ public class BatchEnginePortletDataHandlerRegistrar {
 					companyId, portletId);
 
 				_portletIdServiceRegistrations.remove(portletId);
+
+				for (String compatibilityPortletId : compatibilityPortletIds) {
+					ServiceRegistration<PortletDataHandler>
+						compatibilityServiceRegistration =
+							_portletIdServiceRegistrations.remove(
+								compatibilityPortletId);
+
+					if (compatibilityServiceRegistration != null) {
+						compatibilityServiceRegistration.unregister();
+					}
+				}
 			}
 		}
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/DisplayPageTemplateFolderResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/DisplayPageTemplateFolderResourceImpl.java
@@ -13,6 +13,7 @@ import com.liferay.headless.admin.site.internal.resource.v1_0.util.DisplayPageTe
 import com.liferay.headless.admin.site.internal.util.EnabledUtil;
 import com.liferay.headless.admin.site.resource.v1_0.DisplayPageTemplateFolderResource;
 import com.liferay.headless.common.spi.util.GroupUtil;
+import com.liferay.layout.admin.constants.LayoutAdminPortletKeys;
 import com.liferay.layout.page.template.admin.constants.LayoutPageTemplateAdminPortletKeys;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateCollectionTypeConstants;
 import com.liferay.layout.page.template.model.LayoutPageTemplateCollection;
@@ -34,6 +35,7 @@ import io.swagger.v3.oas.annotations.tags.Tags;
 import jakarta.ws.rs.core.MultivaluedMap;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
 
@@ -89,6 +91,12 @@ public class DisplayPageTemplateFolderResourceImpl
 				return layoutPageTemplateCollection ->
 					layoutPageTemplateCollection.getType() ==
 						LayoutPageTemplateCollectionTypeConstants.DISPLAY_PAGE;
+			}
+
+			@Override
+			public List<String> getCompatibilityPortletIds() {
+				return Collections.singletonList(
+					LayoutAdminPortletKeys.GROUP_PAGES);
 			}
 
 			@Override

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/DisplayPageTemplateResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/DisplayPageTemplateResourceImpl.java
@@ -135,6 +135,12 @@ public class DisplayPageTemplateResourceImpl
 			}
 
 			@Override
+			public List<String> getCompatibilityPortletIds() {
+				return Collections.singletonList(
+					LayoutAdminPortletKeys.GROUP_PAGES);
+			}
+
+			@Override
 			public String getKey() {
 				return LayoutPageTemplateEntry.class.getName() + "-" +
 					LayoutPageTemplateEntryTypeConstants.DISPLAY_PAGE;

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/MasterPageResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/MasterPageResourceImpl.java
@@ -111,6 +111,12 @@ public class MasterPageResourceImpl
 			}
 
 			@Override
+			public List<String> getCompatibilityPortletIds() {
+				return Collections.singletonList(
+					LayoutAdminPortletKeys.GROUP_PAGES);
+			}
+
+			@Override
 			public String getKey() {
 				return LayoutPageTemplateEntry.class.getName() + "-" +
 					LayoutPageTemplateEntryTypeConstants.MASTER_LAYOUT;

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageTemplateResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageTemplateResourceImpl.java
@@ -136,6 +136,12 @@ public class PageTemplateResourceImpl
 			}
 
 			@Override
+			public List<String> getCompatibilityPortletIds() {
+				return Collections.singletonList(
+					LayoutAdminPortletKeys.GROUP_PAGES);
+			}
+
+			@Override
 			public String getKey() {
 				return LayoutPageTemplateEntry.class.getName() + "-" +
 					LayoutPageTemplateEntryTypeConstants.BASIC;

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageTemplateSetResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageTemplateSetResourceImpl.java
@@ -14,6 +14,7 @@ import com.liferay.headless.admin.site.internal.resource.v1_0.util.PageTemplateS
 import com.liferay.headless.admin.site.internal.util.EnabledUtil;
 import com.liferay.headless.admin.site.resource.v1_0.PageTemplateSetResource;
 import com.liferay.headless.common.spi.util.GroupUtil;
+import com.liferay.layout.admin.constants.LayoutAdminPortletKeys;
 import com.liferay.layout.page.template.admin.constants.LayoutPageTemplateAdminPortletKeys;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateCollectionTypeConstants;
 import com.liferay.layout.page.template.model.LayoutPageTemplateCollection;
@@ -36,6 +37,7 @@ import io.swagger.v3.oas.annotations.tags.Tags;
 import jakarta.ws.rs.core.MultivaluedMap;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.function.Function;
 
 import org.osgi.service.component.annotations.Component;
@@ -88,6 +90,12 @@ public class PageTemplateSetResourceImpl
 				return layoutPageTemplateCollection ->
 					layoutPageTemplateCollection.getType() ==
 						LayoutPageTemplateCollectionTypeConstants.BASIC;
+			}
+
+			@Override
+			public List<String> getCompatibilityPortletIds() {
+				return Collections.singletonList(
+					LayoutAdminPortletKeys.GROUP_PAGES);
 			}
 
 			@Override


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96312

## What Is Being Fixed

The Poshi test `LocalFile.ImportProcess#LARFileRemovedAfterImportProcess` fails with `ElementNotInteractableException` because importing an existing site LAR is rejected. Commit `83bcf33` ("LPD-95672 Group page template export/import under Page Templates") moved the page-template, master-page, and display-page-template export delegates from the Group Pages portlet (`GROUP_PAGES`) to the Page Templates portlet (`LAYOUT_PAGE_TEMPLATES`). Because `BatchEnginePortletDataHandlerRegistrar` registers one `BatchEnginePortletDataHandler` (schema 4.0.0) per portlet ID, the Group Pages portlet lost its 4.0.0 handler. Existing site LARs whose Group Pages data was exported at schema 4.0.0 are now rejected by import validation ("Application's schema version 4.0.0 in the LAR is not valid for the deployed application Group Pages with schema version 1.0.0"), which keeps the import wizard's Continue button hidden. LPD-95671/LPD-95672 intended only a cosmetic re-grouping and document no change to LAR importability, so this is a regression.

## How It Is Being Fixed

A `getCompatibilityPortletIds()` default method (returning an empty list) is added to `ExportImportVulcanBatchEngineTaskItemDelegate.ExportImportDescriptor`. The page-template, master-page, and display-page-template delegates return `GROUP_PAGES` from it, and `BatchEnginePortletDataHandlerRegistrar` registers the same 4.0.0 handler under each compatibility portlet ID, unregistering it on removal. New exports stay grouped under the Page Templates portlet — preserving LPD-95672's intent — while existing Group Pages LARs validate and import again. The export-import-api package and bundle versions are bumped to reflect the added API method.

## Why Are There No Tests?

This is a regression fix for the existing Poshi test `LocalFile.ImportProcess#LARFileRemovedAfterImportProcess` (and the broader export/import site-LAR Poshi coverage) that commit 83bcf33 broke. That existing test, which now passes locally, is the coverage.

## PR Check

Targeted run of the validations triggered by this diff (the full suite's rebase and clean-tree gate were constrained by unrelated pre-existing untracked files in the working tree).

**pr-check: PASS** — tested on `3543beaca9ffbc0fb9374e5fd0e68577f7616185`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Baseline | PASS |

<!-- pr-check {"result": "success", "sha": "3543beaca9ffbc0fb9374e5fd0e68577f7616185"} -->
