### PR TITLE
LPD-96287 Localize element variation fields with a language picker

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/build.gradle
+++ b/modules/apps/layout/layout-content-page-editor-web/build.gradle
@@ -53,6 +53,7 @@ dependencies {
 	compileOnly project(":apps:marketplace:marketplace-api")
 	compileOnly project(":apps:mentions:mentions-api")
 	compileOnly project(":apps:portal-configuration:portal-configuration-module-configuration-api")
+	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")
 	compileOnly project(":apps:portal:portal-aop-api")
 	compileOnly project(":apps:portlet-display-template:portlet-display-template-api")
 	compileOnly project(":apps:product-navigation:product-navigation-control-menu-api")

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/EditElementVariationsDisplayContext.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/EditElementVariationsDisplayContext.java
@@ -11,6 +11,7 @@ import com.liferay.layout.page.template.service.LayoutPageTemplateStructureRelEl
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Layout;
@@ -18,14 +19,16 @@ import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Constants;
-import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.JavaConstants;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 import com.liferay.segments.service.SegmentsExperienceService;
 
 import jakarta.portlet.PortletResponse;
@@ -35,7 +38,6 @@ import jakarta.servlet.http.HttpServletRequest;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -73,6 +75,9 @@ public class EditElementVariationsDisplayContext {
 		).put(
 			"audiences", _getAudiencesEntries()
 		).put(
+			"defaultLanguageId",
+			LocaleUtil.toLanguageId(_themeDisplay.getSiteDefaultLocale())
+		).put(
 			"deleteElementVariationURL",
 			_getActionURL(
 				"/layout_content_page_editor" +
@@ -84,7 +89,7 @@ public class EditElementVariationsDisplayContext {
 		).put(
 			"experiences", _getSegmentsExperiences()
 		).put(
-			"languageId", _themeDisplay.getLanguageId()
+			"locales", _getLocales()
 		).put(
 			"plid", _getPlid()
 		).put(
@@ -144,8 +149,6 @@ public class EditElementVariationsDisplayContext {
 		_getLayoutPageTemplateStructureRelElementVariations() {
 
 		try {
-			Locale locale = _themeDisplay.getLocale();
-
 			return TransformUtil.transform(
 				_layoutPageTemplateStructureRelElementVariationService.
 					getLayoutPageTemplateStructureRelElementVariations(
@@ -161,17 +164,19 @@ public class EditElementVariationsDisplayContext {
 							getExternalReferenceCode()
 					).put(
 						"hide",
-						GetterUtil.getBoolean(
+						LocalizedMapUtil.getLanguageIdMap(
 							layoutPageTemplateStructureRelElementVariation.
-								getHide(locale))
+								getHideMap())
 					).put(
 						"html",
-						layoutPageTemplateStructureRelElementVariation.getHtml(
-							locale)
+						LocalizedMapUtil.getLanguageIdMap(
+							layoutPageTemplateStructureRelElementVariation.
+								getHtmlMap())
 					).put(
 						"js",
-						layoutPageTemplateStructureRelElementVariation.getJs(
-							locale)
+						LocalizedMapUtil.getLanguageIdMap(
+							layoutPageTemplateStructureRelElementVariation.
+								getJsMap())
 					).put(
 						"name",
 						layoutPageTemplateStructureRelElementVariation.getName()
@@ -190,6 +195,24 @@ public class EditElementVariationsDisplayContext {
 
 			return Collections.emptyList();
 		}
+	}
+
+	private List<Map<String, Object>> _getLocales() {
+		return TransformUtil.transform(
+			LanguageUtil.getAvailableLocales(_themeDisplay.getSiteGroupId()),
+			locale -> {
+				String w3cLanguageId = LocaleUtil.toW3cLanguageId(locale);
+
+				return HashMapBuilder.<String, Object>put(
+					"id", LocaleUtil.toLanguageId(locale)
+				).put(
+					"label", w3cLanguageId
+				).put(
+					"name", locale.getDisplayName()
+				).put(
+					"symbol", StringUtil.toLowerCase(w3cLanguageId)
+				).build();
+			});
 	}
 
 	private long _getPlid() {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationForm.tsx
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationForm.tsx
@@ -4,6 +4,7 @@
  */
 
 import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
+import {LanguagePicker} from '@clayui/core';
 import ClayForm, {ClayInput, ClayToggle} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import ClayMultiSelect from '@clayui/multi-select';
@@ -19,18 +20,26 @@ type ElementVariationFormData = Pick<
 
 interface Props {
 	audiences: Array<{label: string; value: string}>;
+	defaultLanguageId: string;
 	elementVariation: ElementVariationFormData;
+	languageId: string;
+	locales: Array<{id: string; label: string; symbol: string}>;
 	onCancel: () => void;
 	onChange: (properties: Partial<ElementVariationFormData>) => void;
+	onLanguageIdChange: (languageId: string) => void;
 	onReloadPreview: () => void;
 	onSave: () => void;
 }
 
 export default function ElementVariationForm({
 	audiences,
+	defaultLanguageId,
 	elementVariation,
+	languageId,
+	locales,
 	onCancel,
 	onChange,
+	onLanguageIdChange,
 	onReloadPreview,
 	onSave,
 }: Props) {
@@ -56,6 +65,31 @@ export default function ElementVariationForm({
 				<span className="font-weight-bold">
 					{Liferay.Language.get('element-variation')}
 				</span>
+
+				<div className="ml-auto">
+					<LanguagePicker
+						defaultLocaleId={defaultLanguageId}
+						hideTriggerText
+						locales={locales}
+						messages={{
+							default: Liferay.Language.get('default'),
+							option: Liferay.Language.get('x-language-x'),
+							translated: Liferay.Language.get('translated'),
+							translating:
+								Liferay.Language.get('translating-x-x'),
+							trigger: Liferay.Language.get(
+								'select-a-language.-current-language-x'
+							),
+							untranslated:
+								Liferay.Language.get('not-translated'),
+						}}
+						onSelectedLocaleChange={(id) =>
+							onLanguageIdChange(String(id))
+						}
+						selectedLocaleId={languageId}
+						small
+					/>
+				</div>
 			</div>
 
 			<div className="flex-grow-1 overflow-auto p-3">
@@ -150,8 +184,15 @@ export default function ElementVariationForm({
 						label={Liferay.Language.get(
 							'hide-element-for-this-audience'
 						)}
-						onToggle={(hide) => onChange({hide})}
-						toggled={elementVariation.hide}
+						onToggle={(hide) =>
+							onChange({
+								hide: {
+									...elementVariation.hide,
+									[languageId]: hide,
+								},
+							})
+						}
+						toggled={Boolean(elementVariation.hide[languageId])}
 					/>
 				</ClayForm.Group>
 
@@ -162,9 +203,17 @@ export default function ElementVariationForm({
 
 					<ClayInput
 						component="textarea"
-						defaultValue={elementVariation.html}
+						defaultValue={elementVariation.html[languageId] ?? ''}
 						id={htmlId}
-						onBlur={(event) => onChange({html: event.target.value})}
+						key={languageId}
+						onBlur={(event) =>
+							onChange({
+								html: {
+									...elementVariation.html,
+									[languageId]: event.target.value,
+								},
+							})
+						}
 					/>
 				</ClayForm.Group>
 
@@ -181,9 +230,17 @@ export default function ElementVariationForm({
 
 					<ClayInput
 						component="textarea"
-						defaultValue={elementVariation.js}
+						defaultValue={elementVariation.js[languageId] ?? ''}
 						id={jsId}
-						onBlur={(event) => onChange({js: event.target.value})}
+						key={languageId}
+						onBlur={(event) =>
+							onChange({
+								js: {
+									...elementVariation.js,
+									[languageId]: event.target.value,
+								},
+							})
+						}
 					/>
 
 					<ClayButton

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationService.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationService.ts
@@ -9,7 +9,6 @@ import {ElementVariation} from './elementVariationsReducer';
 interface AddElementVariationParameters {
 	addElementVariationURL: string;
 	elementVariation: ElementVariation;
-	languageId: string;
 	plid: number;
 }
 
@@ -23,7 +22,6 @@ export default {
 	addElementVariation({
 		addElementVariationURL,
 		elementVariation,
-		languageId,
 		plid,
 	}: AddElementVariationParameters) {
 		return serviceFetch<void>(addElementVariationURL, {
@@ -32,9 +30,9 @@ export default {
 					audienceEntryERC: elementVariation.audienceEntryERC,
 					externalReferenceCode:
 						elementVariation.externalReferenceCode,
-					hideMap: {[languageId]: String(elementVariation.hide)},
-					htmlMap: {[languageId]: elementVariation.html},
-					jsMap: {[languageId]: elementVariation.js},
+					hideMap: elementVariation.hide,
+					htmlMap: elementVariation.html,
+					jsMap: elementVariation.js,
 					name: elementVariation.name,
 					segmentsExperienceERC:
 						elementVariation.segmentsExperienceERC,

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariations.tsx
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariations.tsx
@@ -29,6 +29,7 @@ import './ElementVariations.scss';
 interface Props {
 	addElementVariationURL: string;
 	audiences: Array<{label: string; value: string}>;
+	defaultLanguageId: string;
 	deleteElementVariationURL: string;
 	elementVariations: Array<Omit<ElementVariation, 'key'>>;
 	experiences: Array<{
@@ -36,7 +37,7 @@ interface Props {
 		segmentsExperienceERC: string;
 		segmentsExperienceId: number;
 	}>;
-	languageId: string;
+	locales: Array<{id: string; label: string; symbol: string}>;
 	plid: number;
 	portletNamespace: string;
 	previewURL: string;
@@ -52,10 +53,11 @@ export default function (props: Props) {
 function ElementVariations({
 	addElementVariationURL,
 	audiences = [],
+	defaultLanguageId,
 	deleteElementVariationURL,
 	elementVariations: initialElementVariations = [],
 	experiences = [],
-	languageId,
+	locales,
 	plid,
 	previewURL,
 	selectedSegmentsExperienceId,
@@ -74,6 +76,8 @@ function ElementVariations({
 			''
 		);
 	});
+
+	const [languageId, setLanguageId] = useState(defaultLanguageId);
 
 	const [{draftElementVariation, elementVariations}, dispatch] = useReducer(
 		reducer,
@@ -96,8 +100,11 @@ function ElementVariations({
 					{draftElementVariation ? (
 						<ElementVariationForm
 							audiences={audiences}
+							defaultLanguageId={defaultLanguageId}
 							elementVariation={draftElementVariation}
 							key={draftElementVariation.key}
+							languageId={languageId}
+							locales={locales}
 							onCancel={() =>
 								dispatch({
 									type: 'CANCEL_ELEMENT_VARIATION_DRAFT',
@@ -109,6 +116,7 @@ function ElementVariations({
 									type: 'UPDATE_ELEMENT_VARIATION_DRAFT',
 								})
 							}
+							onLanguageIdChange={setLanguageId}
 							onReloadPreview={() =>
 								elementVariationsPreviewRef.current?.reload()
 							}
@@ -116,7 +124,6 @@ function ElementVariations({
 								ElementVariationService.addElementVariation({
 									addElementVariationURL,
 									elementVariation: draftElementVariation,
-									languageId,
 									plid,
 								}).then(() =>
 									dispatch({
@@ -228,7 +235,9 @@ function ElementVariations({
 				</div>
 
 				<ElementVariationsPreview
+					defaultLanguageId={defaultLanguageId}
 					draftElementVariation={draftElementVariation}
+					languageId={languageId}
 					previewURL={previewURL}
 					ref={elementVariationsPreviewRef}
 				/>

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariations.tsx
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariations.tsx
@@ -18,7 +18,7 @@ import ElementVariationsPreview, {
 	ElementVariationsPreviewRef,
 } from './ElementVariationsPreview';
 import {
-	ElementVariation,
+	LoadedElementVariation,
 	createElementVariation,
 	createInitialState,
 	reducer,
@@ -31,7 +31,7 @@ interface Props {
 	audiences: Array<{label: string; value: string}>;
 	defaultLanguageId: string;
 	deleteElementVariationURL: string;
-	elementVariations: Array<Omit<ElementVariation, 'key'>>;
+	elementVariations: Array<LoadedElementVariation>;
 	experiences: Array<{
 		label: string;
 		segmentsExperienceERC: string;

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariations.tsx
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariations.tsx
@@ -77,13 +77,15 @@ function ElementVariations({
 		);
 	});
 
-	const [languageId, setLanguageId] = useState(defaultLanguageId);
-
-	const [{draftElementVariation, elementVariations}, dispatch] = useReducer(
-		reducer,
-		initialElementVariations,
-		createInitialState
-	);
+	const [{draftElementVariation, elementVariations, languageId}, dispatch] =
+		useReducer(
+			reducer,
+			{
+				defaultLanguageId,
+				elementVariations: initialElementVariations,
+			},
+			createInitialState
+		);
 
 	const experienceElementVariations = elementVariations.filter(
 		(elementVariation) =>
@@ -116,7 +118,12 @@ function ElementVariations({
 									type: 'UPDATE_ELEMENT_VARIATION_DRAFT',
 								})
 							}
-							onLanguageIdChange={setLanguageId}
+							onLanguageIdChange={(languageId) =>
+								dispatch({
+									languageId,
+									type: 'SET_LANGUAGE_ID',
+								})
+							}
 							onReloadPreview={() =>
 								elementVariationsPreviewRef.current?.reload()
 							}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationsPreview.tsx
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationsPreview.tsx
@@ -21,13 +21,20 @@ export interface ElementVariationsPreviewRef {
 }
 
 interface Props {
+	defaultLanguageId: string;
 	draftElementVariation: ElementVariation | null;
+	languageId: string;
 	previewURL: string;
 }
 
 const ElementVariationsPreview = forwardRef<ElementVariationsPreviewRef, Props>(
 	function ElementVariationsPreview(
-		{draftElementVariation, previewURL},
+		{
+			defaultLanguageId,
+			draftElementVariation,
+			languageId,
+			previewURL: initialPreviewURL,
+		},
 		ref
 	) {
 		const iframeRef = useRef<HTMLIFrameElement>(null);
@@ -38,6 +45,9 @@ const ElementVariationsPreview = forwardRef<ElementVariationsPreviewRef, Props>(
 		} | null>(null);
 
 		const [previewReady, setPreviewReady] = useState(false);
+		const [previewURL, setPreviewURL] = useState(
+			() => `${initialPreviewURL}&languageId=${languageId}`
+		);
 
 		useImperativeHandle(
 			ref,
@@ -86,28 +96,35 @@ const ElementVariationsPreview = forwardRef<ElementVariationsPreviewRef, Props>(
 				return;
 			}
 
+			const hideValue = Boolean(
+				hide[languageId] ?? hide[defaultLanguageId]
+			);
+			const htmlValue = html[languageId] ?? html[defaultLanguageId] ?? '';
+			const jsValue = js[languageId] ?? js[defaultLanguageId] ?? '';
+
 			let originalHTML: string | null = null;
 			let styleElement: HTMLStyleElement | null = null;
 
-			if (html) {
+			if (htmlValue) {
 				originalHTML = element.innerHTML;
 
-				element.innerHTML = html;
+				element.innerHTML = htmlValue;
 			}
 
-			if (js) {
+			if (jsValue) {
 				const scriptElement = iframeDocument.createElement('script');
 
-				scriptElement.textContent = getElementVariationScript(
-					draftElementVariation
-				);
+				scriptElement.textContent = getElementVariationScript({
+					js: jsValue,
+					targetElement,
+				});
 
 				iframeDocument.body.appendChild(scriptElement);
 
 				iframeDocument.body.removeChild(scriptElement);
 			}
 
-			if (hide) {
+			if (hideValue) {
 				styleElement = iframeDocument.createElement('style');
 
 				styleElement.textContent = `${targetElement} { display: none !important; }`;
@@ -120,11 +137,17 @@ const ElementVariationsPreview = forwardRef<ElementVariationsPreviewRef, Props>(
 				originalHTML,
 				styleElement,
 			};
-		}, [draftElementVariation]);
+		}, [defaultLanguageId, draftElementVariation, languageId]);
 
 		useEffect(() => {
 			applyDraftElementVariation();
 		}, [applyDraftElementVariation]);
+
+		useEffect(() => {
+			setPreviewReady(false);
+
+			setPreviewURL(`${initialPreviewURL}&languageId=${languageId}`);
+		}, [initialPreviewURL, languageId]);
 
 		return (
 			<div className="d-flex flex-column flex-grow-1 position-relative">

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/elementVariationsReducer.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/elementVariationsReducer.ts
@@ -8,9 +8,9 @@ import {v4 as uuidv4} from 'uuid';
 export interface ElementVariation {
 	audienceEntryERC: string;
 	externalReferenceCode: string;
-	hide: boolean;
-	html: string;
-	js: string;
+	hide: Record<string, boolean>;
+	html: Record<string, string>;
+	js: Record<string, string>;
 	key: string;
 	name: string;
 	segmentsExperienceERC: string;
@@ -41,9 +41,9 @@ export function createElementVariation(
 	return {
 		audienceEntryERC: '',
 		externalReferenceCode: uuidv4(),
-		hide: false,
-		html: '',
-		js: '',
+		hide: {},
+		html: {},
+		js: {},
 		key: uuidv4(),
 		name: '',
 		segmentsExperienceERC,

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/elementVariationsReducer.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/elementVariationsReducer.ts
@@ -18,8 +18,10 @@ export interface ElementVariation {
 }
 
 export interface State {
+	defaultLanguageId: string;
 	draftElementVariation: ElementVariation | null;
 	elementVariations: ElementVariation[];
+	languageId: string;
 }
 
 type Action =
@@ -29,6 +31,7 @@ type Action =
 	  }
 	| {key: string; type: 'DELETE_ELEMENT_VARIATION'}
 	| {key: string; type: 'EDIT_ELEMENT_VARIATION'}
+	| {languageId: string; type: 'SET_LANGUAGE_ID'}
 	| {
 			properties: Partial<ElementVariation>;
 			type: 'UPDATE_ELEMENT_VARIATION_DRAFT';
@@ -51,22 +54,32 @@ export function createElementVariation(
 	};
 }
 
-export function createInitialState(
-	elementVariations: Omit<ElementVariation, 'key'>[]
-): State {
+export function createInitialState({
+	defaultLanguageId,
+	elementVariations,
+}: {
+	defaultLanguageId: string;
+	elementVariations: Omit<ElementVariation, 'key'>[];
+}): State {
 	return {
+		defaultLanguageId,
 		draftElementVariation: null,
 		elementVariations: elementVariations.map((elementVariation) => ({
 			...elementVariation,
 			key: uuidv4(),
 		})),
+		languageId: defaultLanguageId,
 	};
 }
 
 export function reducer(state: State, action: Action): State {
 	switch (action.type) {
 		case 'CANCEL_ELEMENT_VARIATION_DRAFT':
-			return {...state, draftElementVariation: null};
+			return {
+				...state,
+				draftElementVariation: null,
+				languageId: state.defaultLanguageId,
+			};
 
 		case 'DELETE_ELEMENT_VARIATION':
 			return {
@@ -101,6 +114,7 @@ export function reducer(state: State, action: Action): State {
 			);
 
 			return {
+				...state,
 				draftElementVariation: null,
 				elementVariations: existing
 					? elementVariations.map((elementVariation) =>
@@ -109,6 +123,7 @@ export function reducer(state: State, action: Action): State {
 								: elementVariation
 						)
 					: [...elementVariations, draftElementVariation],
+				languageId: state.defaultLanguageId,
 			};
 		}
 
@@ -117,6 +132,9 @@ export function reducer(state: State, action: Action): State {
 				...state,
 				draftElementVariation: action.draftElementVariation,
 			};
+
+		case 'SET_LANGUAGE_ID':
+			return {...state, languageId: action.languageId};
 
 		case 'UPDATE_ELEMENT_VARIATION_DRAFT':
 			return {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/elementVariationsReducer.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/elementVariationsReducer.ts
@@ -54,18 +54,30 @@ export function createElementVariation(
 	};
 }
 
+export type LoadedElementVariation = Omit<ElementVariation, 'hide' | 'key'> & {
+	hide: Record<string, string>;
+};
+
 export function createInitialState({
 	defaultLanguageId,
 	elementVariations,
 }: {
 	defaultLanguageId: string;
-	elementVariations: Omit<ElementVariation, 'key'>[];
+	elementVariations: LoadedElementVariation[];
 }): State {
 	return {
 		defaultLanguageId,
 		draftElementVariation: null,
 		elementVariations: elementVariations.map((elementVariation) => ({
 			...elementVariation,
+			hide: Object.fromEntries(
+				Object.entries(elementVariation.hide).map(
+					([languageId, value]): [string, boolean] => [
+						languageId,
+						value === 'true',
+					]
+				)
+			),
 			key: uuidv4(),
 		})),
 		languageId: defaultLanguageId,

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/getElementVariationScript.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/getElementVariationScript.ts
@@ -3,12 +3,13 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {ElementVariation} from './elementVariationsReducer';
-
 export default function getElementVariationScript({
 	js,
 	targetElement,
-}: ElementVariation): string {
+}: {
+	js: string;
+	targetElement: string;
+}): string {
 	return `
 (function () {
 	const element = document.querySelector(${JSON.stringify(targetElement)});

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/plugins/element_variations/elementVariationsReducer.test.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/plugins/element_variations/elementVariationsReducer.test.ts
@@ -5,6 +5,7 @@
 
 import {
 	ElementVariation,
+	State,
 	createElementVariation,
 	createInitialState,
 	reducer,
@@ -27,6 +28,16 @@ function buildElementVariation(
 	};
 }
 
+function buildState(properties: Partial<State> = {}): State {
+	return {
+		defaultLanguageId: 'en_US',
+		draftElementVariation: null,
+		elementVariations: [],
+		languageId: 'en_US',
+		...properties,
+	};
+}
+
 describe('elementVariationsReducer', () => {
 	describe('createElementVariation', () => {
 		it('creates an empty variation for the given experience with a unique key', () => {
@@ -44,27 +55,37 @@ describe('elementVariationsReducer', () => {
 	});
 
 	describe('createInitialState', () => {
-		it('starts with no draft and no variations when none are loaded', () => {
-			expect(createInitialState([])).toEqual({
+		it('starts on the default language with no draft and no variations when none are loaded', () => {
+			expect(
+				createInitialState({
+					defaultLanguageId: 'en_US',
+					elementVariations: [],
+				})
+			).toEqual({
+				defaultLanguageId: 'en_US',
 				draftElementVariation: null,
 				elementVariations: [],
+				languageId: 'en_US',
 			});
 		});
 
 		it('assigns a key to each loaded variation', () => {
 			const {draftElementVariation, elementVariations} =
-				createInitialState([
-					{
-						audienceEntryERC: '',
-						externalReferenceCode: 'erc-1',
-						hide: {},
-						html: {},
-						js: {},
-						name: 'Variation 1',
-						segmentsExperienceERC: 'experience-1',
-						targetElement: '#main',
-					},
-				]);
+				createInitialState({
+					defaultLanguageId: 'en_US',
+					elementVariations: [
+						{
+							audienceEntryERC: '',
+							externalReferenceCode: 'erc-1',
+							hide: {},
+							html: {},
+							js: {},
+							name: 'Variation 1',
+							segmentsExperienceERC: 'experience-1',
+							targetElement: '#main',
+						},
+					],
+				});
 
 			expect(draftElementVariation).toBeNull();
 			expect(elementVariations).toHaveLength(1);
@@ -77,20 +98,17 @@ describe('elementVariationsReducer', () => {
 		it('sets the draft on CREATE_ELEMENT_VARIATION_DRAFT', () => {
 			const draftElementVariation = buildElementVariation();
 
-			const state = reducer(
-				{draftElementVariation: null, elementVariations: []},
-				{draftElementVariation, type: 'CREATE_ELEMENT_VARIATION_DRAFT'}
-			);
+			const state = reducer(buildState(), {
+				draftElementVariation,
+				type: 'CREATE_ELEMENT_VARIATION_DRAFT',
+			});
 
 			expect(state.draftElementVariation).toBe(draftElementVariation);
 		});
 
 		it('merges properties into the draft on UPDATE_ELEMENT_VARIATION_DRAFT', () => {
 			const state = reducer(
-				{
-					draftElementVariation: buildElementVariation(),
-					elementVariations: [],
-				},
+				buildState({draftElementVariation: buildElementVariation()}),
 				{
 					properties: {hide: {en_US: true}, name: 'Renamed'},
 					type: 'UPDATE_ELEMENT_VARIATION_DRAFT',
@@ -101,13 +119,21 @@ describe('elementVariationsReducer', () => {
 			expect(state.draftElementVariation?.hide).toEqual({en_US: true});
 		});
 
+		it('sets the language on SET_LANGUAGE_ID', () => {
+			const state = reducer(buildState(), {
+				languageId: 'es_ES',
+				type: 'SET_LANGUAGE_ID',
+			});
+
+			expect(state.languageId).toBe('es_ES');
+		});
+
 		it('appends a new draft and clears it on SAVE_ELEMENT_VARIATION_DRAFT', () => {
 			const draftElementVariation = buildElementVariation({key: 'new'});
 
-			const state = reducer(
-				{draftElementVariation, elementVariations: []},
-				{type: 'SAVE_ELEMENT_VARIATION_DRAFT'}
-			);
+			const state = reducer(buildState({draftElementVariation}), {
+				type: 'SAVE_ELEMENT_VARIATION_DRAFT',
+			});
 
 			expect(state.draftElementVariation).toBeNull();
 			expect(state.elementVariations).toEqual([draftElementVariation]);
@@ -120,13 +146,13 @@ describe('elementVariationsReducer', () => {
 			});
 
 			const state = reducer(
-				{
+				buildState({
 					draftElementVariation: {
 						...existingElementVariation,
 						name: 'New',
 					},
 					elementVariations: [existingElementVariation],
-				},
+				}),
 				{type: 'SAVE_ELEMENT_VARIATION_DRAFT'}
 			);
 
@@ -134,14 +160,23 @@ describe('elementVariationsReducer', () => {
 			expect(state.elementVariations[0].name).toBe('New');
 		});
 
+		it('resets the language to the default on SAVE_ELEMENT_VARIATION_DRAFT', () => {
+			const state = reducer(
+				buildState({
+					draftElementVariation: buildElementVariation({key: 'new'}),
+					languageId: 'es_ES',
+				}),
+				{type: 'SAVE_ELEMENT_VARIATION_DRAFT'}
+			);
+
+			expect(state.languageId).toBe('en_US');
+		});
+
 		it('loads a variation into the draft on EDIT_ELEMENT_VARIATION', () => {
 			const elementVariation = buildElementVariation({key: 'key-1'});
 
 			const state = reducer(
-				{
-					draftElementVariation: null,
-					elementVariations: [elementVariation],
-				},
+				buildState({elementVariations: [elementVariation]}),
 				{key: 'key-1', type: 'EDIT_ELEMENT_VARIATION'}
 			);
 
@@ -152,26 +187,24 @@ describe('elementVariationsReducer', () => {
 			const elementVariation = buildElementVariation({key: 'key-1'});
 
 			const state = reducer(
-				{
-					draftElementVariation: null,
-					elementVariations: [elementVariation],
-				},
+				buildState({elementVariations: [elementVariation]}),
 				{key: 'key-1', type: 'DELETE_ELEMENT_VARIATION'}
 			);
 
 			expect(state.elementVariations).toEqual([]);
 		});
 
-		it('clears the draft on CANCEL_ELEMENT_VARIATION_DRAFT', () => {
+		it('clears the draft and resets the language on CANCEL_ELEMENT_VARIATION_DRAFT', () => {
 			const state = reducer(
-				{
+				buildState({
 					draftElementVariation: buildElementVariation(),
-					elementVariations: [],
-				},
+					languageId: 'es_ES',
+				}),
 				{type: 'CANCEL_ELEMENT_VARIATION_DRAFT'}
 			);
 
 			expect(state.draftElementVariation).toBeNull();
+			expect(state.languageId).toBe('en_US');
 		});
 	});
 });

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/plugins/element_variations/elementVariationsReducer.test.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/plugins/element_variations/elementVariationsReducer.test.ts
@@ -16,9 +16,9 @@ function buildElementVariation(
 	return {
 		audienceEntryERC: '',
 		externalReferenceCode: '',
-		hide: false,
-		html: '',
-		js: '',
+		hide: {},
+		html: {},
+		js: {},
 		key: 'key-1',
 		name: '',
 		segmentsExperienceERC: 'experience-1',
@@ -34,7 +34,7 @@ describe('elementVariationsReducer', () => {
 
 			expect(elementVariation.segmentsExperienceERC).toBe('experience-1');
 			expect(elementVariation.name).toBe('');
-			expect(elementVariation.hide).toBe(false);
+			expect(elementVariation.hide).toEqual({});
 			expect(elementVariation.key).toBeTruthy();
 
 			expect(createElementVariation('experience-1').key).not.toBe(
@@ -57,9 +57,9 @@ describe('elementVariationsReducer', () => {
 					{
 						audienceEntryERC: '',
 						externalReferenceCode: 'erc-1',
-						hide: false,
-						html: '',
-						js: '',
+						hide: {},
+						html: {},
+						js: {},
 						name: 'Variation 1',
 						segmentsExperienceERC: 'experience-1',
 						targetElement: '#main',
@@ -92,13 +92,13 @@ describe('elementVariationsReducer', () => {
 					elementVariations: [],
 				},
 				{
-					properties: {hide: true, name: 'Renamed'},
+					properties: {hide: {en_US: true}, name: 'Renamed'},
 					type: 'UPDATE_ELEMENT_VARIATION_DRAFT',
 				}
 			);
 
 			expect(state.draftElementVariation?.name).toBe('Renamed');
-			expect(state.draftElementVariation?.hide).toBe(true);
+			expect(state.draftElementVariation?.hide).toEqual({en_US: true});
 		});
 
 		it('appends a new draft and clears it on SAVE_ELEMENT_VARIATION_DRAFT', () => {

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/plugins/element_variations/elementVariationsReducer.test.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/plugins/element_variations/elementVariationsReducer.test.ts
@@ -69,7 +69,7 @@ describe('elementVariationsReducer', () => {
 			});
 		});
 
-		it('assigns a key to each loaded variation', () => {
+		it('assigns a key and parses the hide map to each loaded variation', () => {
 			const {draftElementVariation, elementVariations} =
 				createInitialState({
 					defaultLanguageId: 'en_US',
@@ -77,7 +77,7 @@ describe('elementVariationsReducer', () => {
 						{
 							audienceEntryERC: '',
 							externalReferenceCode: 'erc-1',
-							hide: {},
+							hide: {en_US: 'true'},
 							html: {},
 							js: {},
 							name: 'Variation 1',
@@ -91,6 +91,7 @@ describe('elementVariationsReducer', () => {
 			expect(elementVariations).toHaveLength(1);
 			expect(elementVariations[0].name).toBe('Variation 1');
 			expect(elementVariations[0].key).toBeTruthy();
+			expect(elementVariations[0].hide).toEqual({en_US: true});
 		});
 	});
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96287

## What Is Being Fixed

Element variations could only be authored in a single language. A variation's hide, HTML, and JavaScript fields each stored one value, so a variation behaved the same regardless of the visitor's locale — even though the underlying columns are localized.

## How It Is Being Fixed

The element variation form gains a language picker, and the hide, HTML, and JavaScript fields are edited and stored per locale. Across the reducer, form, and save request these fields are languageId-keyed maps; the display context returns them as locale maps along with the site default language and the available locales that populate the picker. The hide field travels as a languageId-keyed string map like the others and is parsed to a boolean once on ingestion in createInitialState, so the components keep working with booleans. The preview follows the picker: the iframe loads the page in the selected locale (via the languageId parameter on the preview URL) and reapplies the variation, falling back to the default locale when a field has no value for that language. The selected language lives in the editor reducer state and resets to the default when a variation is saved or the form is closed.

## PR Check

**pr-check: PASS** — tested on `3b22ed16f79b1dc69871b63d3c087909d3df9da4`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Structural Smoke | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "3b22ed16f79b1dc69871b63d3c087909d3df9da4"} -->
