### PR TITLE
LPD-95101 Assign Personas and Funnel Stages to an Asset

### DIFF
--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/ItemSelector.tsx
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/ItemSelector.tsx
@@ -155,6 +155,12 @@ export interface IBaseItemSelectorProps<T> {
 	items?: T[];
 
 	/**
+	 * Optional predicate used to filter the fetched items before they are
+	 * rendered in the dropdown. Items for which it returns `false` are hidden.
+	 */
+	itemsFilter?: (item: T) => boolean;
+
+	/**
 	 * A string key used to locate the id, label, or value within each item.
 	 * Can be used as a period separated path (e.g.: 'embedded.id').
 	 */
@@ -225,6 +231,7 @@ function ItemSelector<T extends Record<string, any>>({
 	onItemsChange,
 	multiSelect = false,
 	items: externalItems,
+	itemsFilter,
 	defaultValue,
 	defaultItems,
 	displaySelectedItems = true,
@@ -321,6 +328,14 @@ function ItemSelector<T extends Record<string, any>>({
 			) ?? []
 		);
 	}, [items, locator.value]);
+
+	const filteredSourceItems = useMemo(
+		() =>
+			itemsFilter && sourceItems
+				? sourceItems.filter(itemsFilter)
+				: sourceItems,
+		[itemsFilter, sourceItems]
+	);
 
 	const memoizedChildren = useCallback(
 		(item: T) => {
@@ -420,7 +435,7 @@ function ItemSelector<T extends Record<string, any>>({
 				onChange={setValue}
 				onItemsChange={setItems}
 				onLoadMore={async () => loadMore()}
-				sourceItems={sourceItems}
+				sourceItems={filteredSourceItems}
 				value={value}
 			>
 				{children}
@@ -438,7 +453,7 @@ function ItemSelector<T extends Record<string, any>>({
 						path: locator.label,
 					});
 				}}
-				items={sourceItems}
+				items={filteredSourceItems}
 				loadingState={networkStatus}
 				menuTrigger="focus"
 				messages={{

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/test/ItemSelector.test.tsx
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/test/ItemSelector.test.tsx
@@ -243,4 +243,35 @@ describe('ItemSelector component', () => {
 			listItemSelected.querySelector('.lexicon-icon-check-small')
 		).toBeDefined();
 	});
+
+	it('hides items rejected by itemsFilter from the dropdown', async () => {
+		const {findByRole, queryByRole} = render(
+			<ItemSelector<TestItem>
+				apiURL={`${location.origin}/o/headless-delivery/v1.0/test-api-url`}
+				itemsFilter={(item) => item.id !== 1}
+			>
+				{(item) => (
+					<ItemSelector.Item key={item.id} textValue={item.name}>
+						{item.name}
+					</ItemSelector.Item>
+				)}
+			</ItemSelector>
+		);
+
+		const input = await findByRole('combobox');
+
+		await userEvent.click(input);
+
+		const menu = await findByRole('listbox');
+
+		expect(menu).toBeVisible();
+
+		expect(
+			await findByRole('option', {name: mockSecondItemName})
+		).toBeTruthy();
+
+		expect(
+			queryByRole('option', {name: mockFirstItemName})
+		).not.toBeInTheDocument();
+	});
 });

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/VocabularyMultiSelect.spec.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/VocabularyMultiSelect.spec.tsx
@@ -27,37 +27,6 @@ const mockCategories = [
 ];
 
 describe('VocabularyMultiSelect', () => {
-	it('renders initial selected categories as chips', () => {
-		const {getByText} = render(
-			<VocabularyMultiSelect
-				disabled={false}
-				label="Personas"
-				onChange={jest.fn()}
-				placeholder="Add Personas"
-				value={mockCategories}
-				vocabularyERC="L_CMP_PERSONAS"
-			/>
-		);
-
-		expect(getByText('Decision Maker')).toBeInTheDocument();
-		expect(getByText('Champion')).toBeInTheDocument();
-	});
-
-	it('renders the label', () => {
-		const {getByText} = render(
-			<VocabularyMultiSelect
-				disabled={false}
-				label="Personas"
-				onChange={jest.fn()}
-				placeholder="Add Personas"
-				value={[]}
-				vocabularyERC="L_CMP_PERSONAS"
-			/>
-		);
-
-		expect(getByText('Personas')).toBeInTheDocument();
-	});
-
 	it('calls onChange with remaining items when a chip is removed', () => {
 		const onChange = jest.fn();
 
@@ -92,5 +61,36 @@ describe('VocabularyMultiSelect', () => {
 		getAllByLabelText('remove').forEach((button) => {
 			expect(button).toBeDisabled();
 		});
+	});
+
+	it('renders initial selected categories as chips', () => {
+		const {getByText} = render(
+			<VocabularyMultiSelect
+				disabled={false}
+				label="Personas"
+				onChange={jest.fn()}
+				placeholder="Add Personas"
+				value={mockCategories}
+				vocabularyERC="L_CMP_PERSONAS"
+			/>
+		);
+
+		expect(getByText('Decision Maker')).toBeInTheDocument();
+		expect(getByText('Champion')).toBeInTheDocument();
+	});
+
+	it('renders the label', () => {
+		const {getByText} = render(
+			<VocabularyMultiSelect
+				disabled={false}
+				label="Personas"
+				onChange={jest.fn()}
+				placeholder="Add Personas"
+				value={[]}
+				vocabularyERC="L_CMP_PERSONAS"
+			/>
+		);
+
+		expect(getByText('Personas')).toBeInTheDocument();
 	});
 });

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/services/VocabularyService.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/services/VocabularyService.ts
@@ -58,6 +58,66 @@ async function getRequiredVocabularies({
 	});
 }
 
+async function getVocabularyIdsByExternalReferenceCode({
+	assetLibraryId,
+	externalReferenceCodes,
+	siteGroupId,
+}: {
+	assetLibraryId: number | string;
+	externalReferenceCodes: string[];
+	siteGroupId: number | string;
+}) {
+	const vocabularyIds: {[externalReferenceCode: string]: number} = {};
+
+	await Promise.all(
+		externalReferenceCodes.map(async (externalReferenceCode) => {
+			const {data} = await ApiHelper.get<{id?: number}>(
+				`/o/headless-admin-taxonomy/v1.0/sites/${siteGroupId}/taxonomy-vocabularies/by-external-reference-code/${externalReferenceCode}`
+			);
+
+			if (data?.id) {
+				vocabularyIds[externalReferenceCode] = data.id;
+			}
+		})
+	);
+
+	const missingExternalReferenceCodes = externalReferenceCodes.filter(
+		(externalReferenceCode) => !(externalReferenceCode in vocabularyIds)
+	);
+
+	if (missingExternalReferenceCodes.length) {
+		const scope =
+			Number(assetLibraryId) > 0
+				? `asset-libraries/${assetLibraryId}`
+				: `sites/${siteGroupId}`;
+
+		const {data} = await ApiHelper.get<{
+			items?: Array<{
+				parentTaxonomyVocabulary?: {
+					externalReferenceCode?: string;
+					id?: number;
+				};
+			}>;
+		}>(
+			`/o/headless-admin-taxonomy/v1.0/${scope}/taxonomy-categories?filter=assetTypes in ('0')&pageSize=100`
+		);
+
+		(data?.items || []).forEach(({parentTaxonomyVocabulary}) => {
+			const {externalReferenceCode, id} = parentTaxonomyVocabulary || {};
+
+			if (
+				id &&
+				externalReferenceCode &&
+				missingExternalReferenceCodes.includes(externalReferenceCode)
+			) {
+				vocabularyIds[externalReferenceCode] = id;
+			}
+		});
+	}
+
+	return vocabularyIds;
+}
+
 async function updateVocabulary(vocabulary: IVocabulary) {
 	return await ApiHelper.put<IVocabulary>(
 		`/o/headless-admin-taxonomy/v1.0/taxonomy-vocabularies/${vocabulary.id}`,
@@ -85,5 +145,6 @@ export default {
 	getCommonCategories,
 	getRequiredVocabularies,
 	getVocabularies,
+	getVocabularyIdsByExternalReferenceCode,
 	updateVocabulary,
 };

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/AssetCategories.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/AssetCategories.tsx
@@ -19,6 +19,17 @@ import {CategorizationInputSize} from './AssetCategorization';
 
 import type {EntryCategorizationDTO} from '../services/ObjectEntryService';
 
+/**
+ * Renders an asset's categories in one of two modes:
+ *
+ * - Generic mode (no vocabularyId): shows categories from every vocabulary,
+ *   grouped under vocabulary-name headers. Pass systemVocabularyIds to hide
+ *   the vocabularies that have their own dedicated panel (Personas, Funnel
+ *   Stage) so they are not shown twice.
+ *
+ * - Scoped mode (vocabularyId set): shows the categories of that single
+ *   vocabulary only, with no header, and ignores systemVocabularyIds.
+ */
 const AssetCategories = ({
 	cmsGroupId,
 	collapsable = true,
@@ -26,7 +37,11 @@ const AssetCategories = ({
 	hasUpdatePermission,
 	inputSize,
 	objectEntry,
+	placeholder,
+	systemVocabularyIds,
+	title,
 	updateObjectEntry,
+	vocabularyId,
 }: {
 	cmsGroupId: number | string;
 	collapsable?: boolean;
@@ -34,13 +49,21 @@ const AssetCategories = ({
 	hasUpdatePermission?: boolean;
 	inputSize?: CategorizationInputSize;
 	objectEntry: IAssetObjectEntry | EntryCategorizationDTO;
+	placeholder?: string;
+	systemVocabularyIds?: number[];
+	title?: string;
 	updateObjectEntry: (object: EntryCategorizationDTO) => void | Promise<void>;
+	vocabularyId?: number;
 }) => {
 	const [value, setValue] = useState('');
 
 	const feedbackId = useId();
 
 	const apiURL = useMemo(() => {
+		if (vocabularyId) {
+			return `${Liferay.ThemeDisplay.getPortalURL()}/o/headless-admin-taxonomy/v1.0/taxonomy-vocabularies/${vocabularyId}/taxonomy-categories`;
+		}
+
 		const {
 			scopeId,
 			systemProperties: {objectDefinitionBrief: {classNameId = -1} = {}},
@@ -67,7 +90,29 @@ const AssetCategories = ({
 		const filterString = `?filter=${filterStrings.join(' and ')}`;
 
 		return `${Liferay.ThemeDisplay.getPortalURL()}/o/headless-admin-taxonomy/v1.0/${endpoint}/taxonomy-categories${filterString}`;
-	}, [cmsGroupId, objectEntry]);
+	}, [cmsGroupId, objectEntry, vocabularyId]);
+
+	const isVisibleVocabulary = useCallback(
+		(currentVocabularyId: number) => {
+			if (vocabularyId) {
+				return currentVocabularyId === vocabularyId;
+			}
+
+			return !systemVocabularyIds?.includes(currentVocabularyId);
+		},
+		[systemVocabularyIds, vocabularyId]
+	);
+
+	// Hide categories from the system vocabularies (Personas, Funnel Stage)
+	// in the generic dropdown, since they have their own dedicated panels.
+
+	const filterDropdownItem = useCallback(
+		(item: any) =>
+			!systemVocabularyIds?.includes(
+				Number(item?.parentTaxonomyVocabulary?.id)
+			),
+		[systemVocabularyIds]
+	);
 
 	const groupedTaxonomies: IGroupedTaxonomies = useMemo(
 		() =>
@@ -130,11 +175,6 @@ const AssetCategories = ({
 		[groupedTaxonomies.taxonomyCategoryIds, updateObjectEntry]
 	);
 
-	const selectedCategories = useMemo(
-		() => Object.values(groupedTaxonomies.taxonomyVocabularies).flat(),
-		[groupedTaxonomies.taxonomyVocabularies]
-	);
-
 	const removeCategory = useCallback(
 		async (category: ITaxonomyCategoryFacade) => {
 			const {taxonomyCategoryIds} = groupedTaxonomies;
@@ -163,13 +203,23 @@ const AssetCategories = ({
 		[groupedTaxonomies, updateObjectEntry]
 	);
 
+	const selectedCategories = useMemo(
+		() =>
+			Object.entries(groupedTaxonomies.taxonomyVocabularies)
+				.filter(([currentVocabularyId]) =>
+					isVisibleVocabulary(Number(currentVocabularyId))
+				)
+				.flatMap(([, vocabularyCategories]) => vocabularyCategories),
+		[groupedTaxonomies.taxonomyVocabularies, isVisibleVocabulary]
+	);
+
 	return (
 		<ClayPanel
 			collapsable={collapsable}
 			defaultExpanded={true}
 			displayTitle={
 				<ClayPanel.Title className="panel-title text-secondary">
-					{Liferay.Language.get('categories')}
+					{title ?? Liferay.Language.get('categories')}
 				</ClayPanel.Title>
 			}
 			displayType="unstyled"
@@ -187,6 +237,9 @@ const AssetCategories = ({
 						disabled={!hasUpdatePermission}
 						estimateSize={49}
 						items={selectedCategories}
+						itemsFilter={
+							vocabularyId ? undefined : filterDropdownItem
+						}
 						locator={{
 							id: 'id',
 							label: 'name',
@@ -204,7 +257,9 @@ const AssetCategories = ({
 								setTimeout(() => setValue(''));
 							}
 						}}
-						placeholder={Liferay.Language.get('add-category')}
+						placeholder={
+							placeholder ?? Liferay.Language.get('add-category')
+						}
 						refetchOnActive
 						sizing={inputSize}
 						value={value}
@@ -239,16 +294,29 @@ const AssetCategories = ({
 
 				{groupedTaxonomies.taxonomyVocabularies &&
 					Object.entries(groupedTaxonomies?.taxonomyVocabularies).map(
-						([, vocabularyCategories], index) => {
+						(
+							[currentVocabularyId, vocabularyCategories],
+							index
+						) => {
+							if (
+								!isVisibleVocabulary(
+									Number(currentVocabularyId)
+								)
+							) {
+								return null;
+							}
+
 							const vocabularyName =
 								vocabularyCategories[0].parentTaxonomyVocabulary
 									.name;
 
 							return vocabularyCategories.length ? (
 								<div className="pt-3" key={index}>
-									<p className="font-weight-semi-bold vocabulary-name">
-										{vocabularyName}
-									</p>
+									{!vocabularyId && (
+										<p className="font-weight-semi-bold vocabulary-name">
+											{vocabularyName}
+										</p>
+									)}
 
 									{vocabularyCategories.map(
 										(category: ITaxonomyCategoryFacade) => (

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/AssetCategorization.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/AssetCategorization.tsx
@@ -12,8 +12,7 @@ import {
 	ITaxonomyCategoryBrief,
 } from '../../../common/types/AssetType';
 import ObjectEntryService from '../services/ObjectEntryService';
-import AssetCategories from './AssetCategories';
-import AssetTags from './AssetTags';
+import AssetCategorizationSections from './AssetCategorizationSections';
 
 type Categorization = Pick<
 	IAssetObjectEntry,
@@ -150,26 +149,15 @@ export default function AssetCategorization({
 	}
 
 	return (
-		<>
-			<AssetCategories
-				cmsGroupId={cmsGroupId}
-				errorMessage={categoriesErrorMessage}
-				hasUpdatePermission={hasUpdatePermission}
-				inputSize={inputSize}
-				objectEntry={objectEntry}
-				updateObjectEntry={updateObjectEntry}
-			/>
-
-			<AssetTags
-				assetLibraryId={assetLibraryId}
-				cmsGroupId={cmsGroupId}
-				hasUpdatePermission={hasUpdatePermission}
-				inputSize={inputSize}
-				key={objectEntry.keywords?.join(',') || 'tags'}
-				objectEntry={objectEntry}
-				updateObjectEntry={updateObjectEntry}
-			/>
-		</>
+		<AssetCategorizationSections
+			assetLibraryId={assetLibraryId}
+			cmsGroupId={cmsGroupId}
+			errorMessage={categoriesErrorMessage}
+			hasUpdatePermission={hasUpdatePermission}
+			inputSize={inputSize}
+			objectEntry={objectEntry}
+			updateObjectEntry={updateObjectEntry}
+		/>
 	);
 }
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/AssetCategorizationSections.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/components/AssetCategorizationSections.tsx
@@ -1,0 +1,125 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import React, {useEffect, useMemo, useState} from 'react';
+
+import VocabularyService from '../../../common/services/VocabularyService';
+import {IAssetObjectEntry} from '../../../common/types/AssetType';
+import AssetCategories from './AssetCategories';
+import {CategorizationInputSize} from './AssetCategorization';
+import AssetTags from './AssetTags';
+
+import type {EntryCategorizationDTO} from '../services/ObjectEntryService';
+
+const FUNNEL_STAGE_VOCABULARY_ERC = 'L_CMP_FUNNEL_STAGE';
+const PERSONAS_VOCABULARY_ERC = 'L_CMP_PERSONAS';
+
+export default function AssetCategorizationSections({
+	assetLibraryId,
+	cmsGroupId,
+	errorMessage,
+	hasUpdatePermission,
+	inputSize,
+	objectEntry,
+	updateObjectEntry,
+}: {
+	assetLibraryId: number | string;
+	cmsGroupId: number | string;
+	errorMessage?: string;
+	hasUpdatePermission: boolean;
+	inputSize?: CategorizationInputSize;
+	objectEntry: IAssetObjectEntry | EntryCategorizationDTO;
+	updateObjectEntry: (object: EntryCategorizationDTO) => void | Promise<void>;
+}) {
+	const [funnelStageVocabularyId, setFunnelStageVocabularyId] = useState<
+		number | null
+	>(null);
+	const [personaVocabularyId, setPersonaVocabularyId] = useState<
+		number | null
+	>(null);
+
+	const systemVocabularyIds = useMemo(
+		() =>
+			[personaVocabularyId, funnelStageVocabularyId].filter(
+				(id): id is number => id !== null
+			),
+		[funnelStageVocabularyId, personaVocabularyId]
+	);
+
+	useEffect(() => {
+		const loadVocabularyIds = async () => {
+			const vocabularyIds =
+				await VocabularyService.getVocabularyIdsByExternalReferenceCode(
+					{
+						assetLibraryId,
+						externalReferenceCodes: [
+							PERSONAS_VOCABULARY_ERC,
+							FUNNEL_STAGE_VOCABULARY_ERC,
+						],
+						siteGroupId: Liferay.ThemeDisplay.getSiteGroupId(),
+					}
+				);
+
+			setPersonaVocabularyId(
+				vocabularyIds[PERSONAS_VOCABULARY_ERC] ?? null
+			);
+			setFunnelStageVocabularyId(
+				vocabularyIds[FUNNEL_STAGE_VOCABULARY_ERC] ?? null
+			);
+		};
+
+		loadVocabularyIds();
+	}, [assetLibraryId]);
+
+	return (
+		<>
+			<AssetCategories
+				cmsGroupId={cmsGroupId}
+				errorMessage={errorMessage}
+				hasUpdatePermission={hasUpdatePermission}
+				inputSize={inputSize}
+				objectEntry={objectEntry}
+				systemVocabularyIds={systemVocabularyIds}
+				updateObjectEntry={updateObjectEntry}
+			/>
+
+			<AssetTags
+				assetLibraryId={assetLibraryId}
+				cmsGroupId={cmsGroupId}
+				hasUpdatePermission={hasUpdatePermission}
+				inputSize={inputSize}
+				key={objectEntry.keywords?.join(',') || 'tags'}
+				objectEntry={objectEntry}
+				updateObjectEntry={updateObjectEntry}
+			/>
+
+			{personaVocabularyId !== null && (
+				<AssetCategories
+					cmsGroupId={cmsGroupId}
+					hasUpdatePermission={hasUpdatePermission}
+					inputSize={inputSize}
+					objectEntry={objectEntry}
+					placeholder={Liferay.Language.get('add-personas')}
+					title={Liferay.Language.get('personas')}
+					updateObjectEntry={updateObjectEntry}
+					vocabularyId={personaVocabularyId}
+				/>
+			)}
+
+			{funnelStageVocabularyId !== null && (
+				<AssetCategories
+					cmsGroupId={cmsGroupId}
+					hasUpdatePermission={hasUpdatePermission}
+					inputSize={inputSize}
+					objectEntry={objectEntry}
+					placeholder={Liferay.Language.get('add-stages')}
+					title={Liferay.Language.get('funnel-stages')}
+					updateObjectEntry={updateObjectEntry}
+					vocabularyId={funnelStageVocabularyId}
+				/>
+			)}
+		</>
+	);
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/tab_content/CategorizationTabContent.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/info_panel/tab_content/CategorizationTabContent.tsx
@@ -13,8 +13,7 @@ import React, {
 
 import {IAssetObjectEntry} from '../../../common/types/AssetType';
 import {displayErrorToast} from '../../../common/utils/toastUtil';
-import AssetCategories from '../components/AssetCategories';
-import AssetTags from '../components/AssetTags';
+import AssetCategorizationSections from '../components/AssetCategorizationSections';
 import {AssetTypeInfoPanelContext} from '../context';
 import ObjectEntryService from '../services/ObjectEntryService';
 
@@ -105,22 +104,13 @@ const CategorizationTabContent = () => {
 	}
 
 	return !currentAsset ? null : (
-		<>
-			<AssetCategories
-				cmsGroupId={cmsGroupId}
-				hasUpdatePermission={hasUpdatePermission}
-				objectEntry={currentAsset}
-				updateObjectEntry={updateObjectEntry}
-			/>
-
-			<AssetTags
-				assetLibraryId={assetLibrary.groupId}
-				cmsGroupId={cmsGroupId}
-				hasUpdatePermission={hasUpdatePermission}
-				objectEntry={currentAsset}
-				updateObjectEntry={updateObjectEntry}
-			/>
-		</>
+		<AssetCategorizationSections
+			assetLibraryId={assetLibrary.groupId}
+			cmsGroupId={cmsGroupId}
+			hasUpdatePermission={hasUpdatePermission}
+			objectEntry={currentAsset}
+			updateObjectEntry={updateObjectEntry}
+		/>
 	);
 };
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/cell_renderers/SimpleActionLinkRenderer.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/cell_renderers/SimpleActionLinkRenderer.tsx
@@ -38,7 +38,7 @@ export default function SimpleActionLinkRenderer({
 	itemData: any;
 	onViewClick?: (itemData: any) => void;
 	options: {actionId: string};
-	systemIconLabel: string;
+	systemIconLabel?: string;
 	trailingIcon?: React.ReactNode;
 	value: string;
 }) {
@@ -104,7 +104,7 @@ export default function SimpleActionLinkRenderer({
 		</ClaySticker>
 	);
 
-	const systemIcon = itemData.system && (
+	const systemIcon = itemData.system && systemIconLabel && (
 		<ClayIcon
 			aria-label={systemIconLabel}
 			className="c-ml-2 lfr-portal-tooltip text-secondary"

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/info_panel/components/AssetCategories.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/info_panel/components/AssetCategories.test.tsx
@@ -9,8 +9,29 @@ import React from 'react';
 
 import AssetCategories from '../../../../../src/main/resources/META-INF/resources/js/main_view/info_panel/components/AssetCategories';
 
-function MockItemSelector({apiURL}: {apiURL?: string}) {
-	return <div data-api-url={apiURL} data-testid="item-selector" />;
+function MockItemSelector({
+	apiURL,
+	itemsFilter,
+	placeholder,
+}: {
+	apiURL?: string;
+	itemsFilter?: (item: any) => boolean;
+	placeholder?: string;
+}) {
+	const filteredVocabularyIds = itemsFilter
+		? [10, 20]
+				.filter((id) => !itemsFilter({parentTaxonomyVocabulary: {id}}))
+				.join(',')
+		: '';
+
+	return (
+		<div
+			data-api-url={apiURL}
+			data-filtered-vocabulary-ids={filteredVocabularyIds}
+			data-placeholder={placeholder}
+			data-testid="item-selector"
+		/>
+	);
 }
 
 function MockItemSelectorItem({children}: {children: React.ReactNode}) {
@@ -53,14 +74,22 @@ function renderComponent({
 	classNameId = 1,
 	cmsGroupId = 456,
 	collapsable,
+	placeholder,
 	scopeId = 123,
+	systemVocabularyIds,
 	taxonomyCategoryBriefs = [],
+	title,
+	vocabularyId,
 }: {
 	classNameId?: number;
 	cmsGroupId?: number;
 	collapsable?: boolean;
+	placeholder?: string;
 	scopeId?: number;
+	systemVocabularyIds?: number[];
 	taxonomyCategoryBriefs?: ReturnType<typeof buildCategoryBrief>[];
+	title?: string;
+	vocabularyId?: number;
 } = {}) {
 	return render(
 		<AssetCategories
@@ -76,7 +105,11 @@ function renderComponent({
 					taxonomyCategoryBriefs,
 				} as any
 			}
+			placeholder={placeholder}
+			systemVocabularyIds={systemVocabularyIds}
+			title={title}
 			updateObjectEntry={jest.fn()}
+			vocabularyId={vocabularyId}
 		/>
 	);
 }
@@ -95,6 +128,92 @@ describe('AssetCategories', () => {
 
 	afterEach(() => {
 		jest.resetAllMocks();
+	});
+
+	it('builds the categories apiURL against the asset library when the scope is positive', () => {
+		renderComponent({classNameId: 1, scopeId: 123});
+
+		const apiURL = screen
+			.getByTestId('item-selector')
+			.getAttribute('data-api-url');
+
+		expect(apiURL).toContain(
+			'/o/headless-admin-taxonomy/v1.0/asset-libraries/123/taxonomy-categories'
+		);
+		expect(apiURL).toContain("assetTypes in ('0', '1')");
+		expect(apiURL).not.toContain('assetLibraries in');
+	});
+
+	it('builds the categories apiURL against the site with an asset library filter when the scope is negative', () => {
+		renderComponent({classNameId: 1, cmsGroupId: 456, scopeId: -1});
+
+		const apiURL = screen
+			.getByTestId('item-selector')
+			.getAttribute('data-api-url');
+
+		expect(apiURL).toContain(
+			'/o/headless-admin-taxonomy/v1.0/sites/456/taxonomy-categories'
+		);
+		expect(apiURL).toContain("assetLibraries in ('-1')");
+	});
+
+	it('builds the vocabulary-scoped apiURL and uses the custom placeholder when scoped to a vocabulary', () => {
+		renderComponent({placeholder: 'add-personas', vocabularyId: 10});
+
+		const itemSelector = screen.getByTestId('item-selector');
+
+		expect(itemSelector.getAttribute('data-api-url')).toContain(
+			'/o/headless-admin-taxonomy/v1.0/taxonomy-vocabularies/10/taxonomy-categories'
+		);
+		expect(itemSelector.getAttribute('data-placeholder')).toBe(
+			'add-personas'
+		);
+	});
+
+	it('does not filter the dropdown when scoped to a vocabulary', () => {
+		renderComponent({vocabularyId: 10});
+
+		expect(
+			screen
+				.getByTestId('item-selector')
+				.getAttribute('data-filtered-vocabulary-ids')
+		).toBe('');
+	});
+
+	it('filters system vocabulary categories out of the generic dropdown', () => {
+		renderComponent({scopeId: 123, systemVocabularyIds: [10]});
+
+		expect(
+			screen
+				.getByTestId('item-selector')
+				.getAttribute('data-filtered-vocabulary-ids')
+		).toBe('10');
+	});
+
+	it('hides categories from system vocabularies', () => {
+		renderComponent({
+			systemVocabularyIds: [10],
+			taxonomyCategoryBriefs: [
+				buildCategoryBrief({
+					id: 1,
+					name: 'category-1',
+					taxonomyVocabularyId: 10,
+					vocabularyName: 'vocabulary-a',
+				}),
+				buildCategoryBrief({
+					id: 3,
+					name: 'category-3',
+					taxonomyVocabularyId: 20,
+					vocabularyName: 'vocabulary-b',
+				}),
+			],
+		});
+
+		expect(screen.queryByText('vocabulary-a')).not.toBeInTheDocument();
+		expect(screen.queryByText('category-1')).not.toBeInTheDocument();
+
+		expect(screen.getByText('vocabulary-b')).toBeInTheDocument();
+		expect(screen.getByText('category-3')).toBeInTheDocument();
 	});
 
 	it('renders categories grouped under their vocabulary names', () => {
@@ -143,6 +262,34 @@ describe('AssetCategories', () => {
 		).toBeInTheDocument();
 	});
 
+	it('renders only the scoped vocabulary categories with a custom title and no vocabulary header', () => {
+		renderComponent({
+			taxonomyCategoryBriefs: [
+				buildCategoryBrief({
+					id: 1,
+					name: 'persona-1',
+					taxonomyVocabularyId: 10,
+					vocabularyName: 'Personas',
+				}),
+				buildCategoryBrief({
+					id: 3,
+					name: 'stage-1',
+					taxonomyVocabularyId: 20,
+					vocabularyName: 'Funnel Stage',
+				}),
+			],
+			title: 'personas',
+			vocabularyId: 10,
+		});
+
+		expect(screen.getByText('personas')).toBeInTheDocument();
+		expect(screen.getByText('persona-1')).toBeInTheDocument();
+
+		expect(screen.queryByText('stage-1')).not.toBeInTheDocument();
+
+		expect(screen.queryByText('Personas')).not.toBeInTheDocument();
+	});
+
 	it('renders the panel as collapsable by default', () => {
 		renderComponent();
 
@@ -159,32 +306,5 @@ describe('AssetCategories', () => {
 		).not.toBeInTheDocument();
 
 		expect(screen.getByText('categories')).toBeInTheDocument();
-	});
-
-	it('builds the categories apiURL against the asset library when the scope is positive', () => {
-		renderComponent({classNameId: 1, scopeId: 123});
-
-		const apiURL = screen
-			.getByTestId('item-selector')
-			.getAttribute('data-api-url');
-
-		expect(apiURL).toContain(
-			'/o/headless-admin-taxonomy/v1.0/asset-libraries/123/taxonomy-categories'
-		);
-		expect(apiURL).toContain("assetTypes in ('0', '1')");
-		expect(apiURL).not.toContain('assetLibraries in');
-	});
-
-	it('builds the categories apiURL against the site with an asset library filter when the scope is negative', () => {
-		renderComponent({classNameId: 1, cmsGroupId: 456, scopeId: -1});
-
-		const apiURL = screen
-			.getByTestId('item-selector')
-			.getAttribute('data-api-url');
-
-		expect(apiURL).toContain(
-			'/o/headless-admin-taxonomy/v1.0/sites/456/taxonomy-categories'
-		);
-		expect(apiURL).toContain("assetLibraries in ('-1')");
 	});
 });

--- a/modules/test/playwright/tests/site-cmp-site-initializer/main/categorization.spec.ts
+++ b/modules/test/playwright/tests/site-cmp-site-initializer/main/categorization.spec.ts
@@ -27,34 +27,6 @@ test(
 	'Can create, read, update, and delete personas and funnel stages from a project',
 	{tag: ['@LPD-93348']},
 	async ({apiHelpers, editProjectPage, page, projectPage, projectsPage}) => {
-		const cmsSite = await apiHelpers.headlessAdminSite.getSite('L_CMS');
-
-		const personasVocabulary =
-			await apiHelpers.headlessAdminTaxonomy.postSiteTaxonomyVocabulary({
-				externalReferenceCode: 'L_CMP_PERSONAS',
-				name: 'Personas',
-				siteId: cmsSite.id,
-			});
-
-		for (const name of ['Decision Maker', 'Champion']) {
-			await apiHelpers.headlessAdminTaxonomy.postTaxonomyVocabularyTaxonomyCategory(
-				{name, vocabularyId: personasVocabulary.id}
-			);
-		}
-
-		const funnelStagesVocabulary =
-			await apiHelpers.headlessAdminTaxonomy.postSiteTaxonomyVocabulary({
-				externalReferenceCode: 'L_CMP_FUNNEL_STAGE',
-				name: 'Funnel Stages',
-				siteId: cmsSite.id,
-			});
-
-		for (const name of ['Awareness', 'Consideration']) {
-			await apiHelpers.headlessAdminTaxonomy.postTaxonomyVocabularyTaxonomyCategory(
-				{name, vocabularyId: funnelStagesVocabulary.id}
-			);
-		}
-
 		const projectTitle = getRandomString();
 
 		const project = await apiHelpers.objectEntry.postObjectEntry(

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/info-panel/categorization.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/info-panel/categorization.spec.ts
@@ -138,6 +138,49 @@ test(
 				await expect(categoryLabel).toBeAttached();
 			});
 
+			let personaLabel;
+			let personaName;
+
+			await test.step('Add a new persona to the content', async () => {
+				const personasAutocomplete =
+					page.getByPlaceholder('Add personas');
+
+				personaName = 'Decision Maker';
+
+				await personasAutocomplete.fill(personaName);
+
+				const option = page.getByRole('option', {name: personaName});
+
+				await option.waitFor();
+				await option.click();
+
+				personaLabel = page.locator('.label-item', {
+					hasText: personaName,
+				});
+
+				await expect(personaLabel).toBeAttached();
+			});
+
+			let stageLabel;
+			let stageName;
+
+			await test.step('Add a new funnel stage to the content', async () => {
+				const stagesAutocomplete = page.getByPlaceholder('Add stages');
+
+				stageName = 'Awareness';
+
+				await stagesAutocomplete.fill(stageName);
+
+				const option = page.getByRole('option', {name: stageName});
+
+				await option.waitFor();
+				await option.click();
+
+				stageLabel = page.locator('.label-item', {hasText: stageName});
+
+				await expect(stageLabel).toBeAttached();
+			});
+
 			await test.step('Create an user and add to the Space', async () => {
 				user = await apiHelpers.headlessAdminUser.postUserAccount();
 
@@ -176,11 +219,19 @@ test(
 			await test.step('Check that space member can see tags and vocabulary but cannot edit them', async () => {
 				await expect(tagLabel).toBeAttached();
 				await expect(categoryLabel).toBeAttached();
+				await expect(personaLabel).toBeAttached();
+				await expect(stageLabel).toBeAttached();
 				await expect(
 					page.getByLabel(tagName).getByLabel('Close')
 				).toBeDisabled();
 				await expect(
 					page.getByLabel(categoryName).getByLabel('Close')
+				).toBeDisabled();
+				await expect(
+					page.getByLabel(personaName).getByLabel('Close')
+				).toBeDisabled();
+				await expect(
+					page.getByLabel(stageName).getByLabel('Close')
 				).toBeDisabled();
 			});
 		}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95101

### What Is Being Fixed
Content assets (documents, web content, blogs, external videos in a CMS depot) had no way to be classified with the organization's Personas and Funnel Stage vocabularies. These two global system vocabularies (L_CMP_PERSONAS, L_CMP_FUNNEL_STAGE) were only surfaced on the project side; an asset's Categorization could not assign them, and the generic categories dropdown exposed them inconsistently.

### How It Is Being Fixed
A shared AssetCategorizationSections component now renders an asset's categorization across both surfaces — the content editor side panel and the asset-list info-panel Categorization tab — so they behave identically. It resolves the Personas and Funnel Stage vocabularies by external reference code (with a category-derivation fallback for empty vocabularies) and renders a dedicated, selection-only panel for each, alongside the generic categories and tags.

The generic categories panel must not duplicate those system vocabularies. Rather than filtering them server-side (the taxonomy endpoint has no vocabulary filter, and a broad asset-library filter wrongly excluded global vocabularies), an opt-in itemsFilter prop was added to the shared ItemSelector to hide rejected items from the dropdown; AssetCategories uses it to drop only the system vocabularies, and only in generic mode. Categories remain selection-only, per the requirement to support existing terms only.

resent from here: https://github.com/brianchandotcom/liferay-portal/pull/177849

there were some duplicated commits already on master that didn't get rebased