### PR TITLE
LPD-8037 Warn about removed ContentUtil.get replaced by StringUtil.read

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -254,6 +254,15 @@
 		"to": ""
 	},
 	{
+		"from": "ContentUtil.get(ClassLoader paramName, String paramName)",
+		"hasMessage": true,
+		"issueKey": "LPD-8037",
+		"validExtensions": [
+			"java",
+			"jsp"
+		]
+	},
+	{
 		"classNames": [
 			"LayoutItemSelectorCriterion"
 		],

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_8037.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_8037.testjava
@@ -1,0 +1,18 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class LPD_8037 {
+
+	public void method(ClassLoader classLoader, String location) {
+		ContentUtil.get(classLoader, location);
+		ContentUtil.get(null, null);
+	}
+
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_8037.testjsp
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_8037.testjsp
@@ -1,0 +1,10 @@
+<%--
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+--%>
+
+<%
+String content = ContentUtil.get(classLoader, location);
+%>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-8037

## What Is Being Fixed

`ContentUtil.get(ClassLoader, String)` has been removed, but developers
still calling it get no automated guidance pointing them to the
replacement. Stale usages slip through review and only surface as
compile failures.

## How It Is Being Fixed

A new entry is added to the source formatter's `replacements.json` so
`UpgradeCatchAllCheck` flags any `ContentUtil.get(ClassLoader, String)`
call in `.java` and `.jsp` files and surfaces a message directing the
developer to `StringUtil.read`. Test fixtures (`LPD_8037.testjava` and
`LPD_8037.testjsp`) exercise the new rule.

## PR Check

**pr-check: PASS** — tested on `16242a03e2882cdfd1005fe1c10b64697d160123`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "16242a03e2882cdfd1005fe1c10b64697d160123"} -->
