### PR TITLE
LPD-94849 Method getUserAccountEntry only supports users with exactly two accounts

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-api/src/main/java/com/liferay/ai/hub/util/AccountEntryUtil.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-api/src/main/java/com/liferay/ai/hub/util/AccountEntryUtil.java
@@ -25,21 +25,42 @@ public class AccountEntryUtil {
 			AccountEntryUserRelLocalServiceUtil.
 				getAccountEntryUserRelsByAccountUserId(userId);
 
-		if (accountEntryUserRels.size() != 2) {
+		if ((accountEntryUserRels.size() != 2) &&
+			(accountEntryUserRels.size() != 3)) {
+
 			return null;
 		}
+
+		AccountEntry customerAccountEntry = null;
+		boolean hasAIHubAccountEntry = false;
+		boolean hasSEOStudioAccountEntry = false;
 
 		for (AccountEntryUserRel accountEntryUserRel : accountEntryUserRels) {
 			AccountEntry accountEntry = accountEntryUserRel.getAccountEntry();
 
-			if (!Objects.equals(
-					accountEntry.getExternalReferenceCode(), "L_AI_HUB")) {
+			String externalReferenceCode =
+				accountEntry.getExternalReferenceCode();
 
-				return accountEntry;
+			if (Objects.equals(externalReferenceCode, "L_AI_HUB")) {
+				hasAIHubAccountEntry = true;
+			}
+			else if (Objects.equals(externalReferenceCode, "L_SEO_STUDIO")) {
+				hasSEOStudioAccountEntry = true;
+			}
+			else {
+				customerAccountEntry = accountEntry;
 			}
 		}
 
-		return null;
+		if (((accountEntryUserRels.size() == 2) &&
+			 (!hasAIHubAccountEntry || hasSEOStudioAccountEntry)) ||
+			((accountEntryUserRels.size() == 3) &&
+			 (!hasAIHubAccountEntry || !hasSEOStudioAccountEntry))) {
+
+			return null;
+		}
+
+		return customerAccountEntry;
 	}
 
 	public static long getUserAccountEntryGroupId(long userId)

--- a/modules/dxp/apps/ai-hub/ai-hub-api/src/test/java/com/liferay/ai/hub/util/AccountEntryUtilTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-api/src/test/java/com/liferay/ai/hub/util/AccountEntryUtilTest.java
@@ -1,0 +1,183 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.util;
+
+import com.liferay.account.model.AccountEntry;
+import com.liferay.account.model.AccountEntryUserRel;
+import com.liferay.account.service.AccountEntryUserRelLocalServiceUtil;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author Joao Victor
+ */
+public class AccountEntryUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testGetUserAccountEntry() throws Exception {
+		AccountEntryUserRel accountEntryUserRel = _mockAccountEntryUserRel(
+			RandomTestUtil.randomString());
+
+		try (MockedStatic<AccountEntryUserRelLocalServiceUtil> mockedStatic =
+				Mockito.mockStatic(AccountEntryUserRelLocalServiceUtil.class)) {
+
+			_mockGetAccountEntryUserRels(
+				mockedStatic,
+				List.of(
+					_mockAccountEntryUserRel("L_AI_HUB"), accountEntryUserRel));
+
+			Assert.assertSame(
+				accountEntryUserRel.getAccountEntry(),
+				AccountEntryUtil.getUserAccountEntry(_USER_ID));
+		}
+	}
+
+	@Test
+	public void testGetUserAccountEntryWithFourAccountEntryUserRels()
+		throws Exception {
+
+		try (MockedStatic<AccountEntryUserRelLocalServiceUtil> mockedStatic =
+				Mockito.mockStatic(AccountEntryUserRelLocalServiceUtil.class)) {
+
+			_mockGetAccountEntryUserRels(
+				mockedStatic,
+				List.of(
+					_mockAccountEntryUserRel("L_AI_HUB"),
+					_mockAccountEntryUserRel("L_SEO_STUDIO"),
+					_mockAccountEntryUserRel(RandomTestUtil.randomString()),
+					_mockAccountEntryUserRel(RandomTestUtil.randomString())));
+
+			Assert.assertNull(AccountEntryUtil.getUserAccountEntry(_USER_ID));
+		}
+	}
+
+	@Test
+	public void testGetUserAccountEntryWithOneAccountEntryUserRel()
+		throws Exception {
+
+		try (MockedStatic<AccountEntryUserRelLocalServiceUtil> mockedStatic =
+				Mockito.mockStatic(AccountEntryUserRelLocalServiceUtil.class)) {
+
+			_mockGetAccountEntryUserRels(
+				mockedStatic, List.of(_mockAccountEntryUserRel("L_AI_HUB")));
+
+			Assert.assertNull(AccountEntryUtil.getUserAccountEntry(_USER_ID));
+		}
+	}
+
+	@Test
+	public void testGetUserAccountEntryWithoutAIHubAccountEntry()
+		throws Exception {
+
+		try (MockedStatic<AccountEntryUserRelLocalServiceUtil> mockedStatic =
+				Mockito.mockStatic(AccountEntryUserRelLocalServiceUtil.class)) {
+
+			_mockGetAccountEntryUserRels(
+				mockedStatic,
+				List.of(
+					_mockAccountEntryUserRel(RandomTestUtil.randomString()),
+					_mockAccountEntryUserRel("L_SEO_STUDIO")));
+
+			Assert.assertNull(AccountEntryUtil.getUserAccountEntry(_USER_ID));
+		}
+	}
+
+	@Test
+	public void testGetUserAccountEntryWithoutSEOStudioAccountEntry()
+		throws Exception {
+
+		try (MockedStatic<AccountEntryUserRelLocalServiceUtil> mockedStatic =
+				Mockito.mockStatic(AccountEntryUserRelLocalServiceUtil.class)) {
+
+			_mockGetAccountEntryUserRels(
+				mockedStatic,
+				List.of(
+					_mockAccountEntryUserRel("L_AI_HUB"),
+					_mockAccountEntryUserRel(RandomTestUtil.randomString()),
+					_mockAccountEntryUserRel(RandomTestUtil.randomString())));
+
+			Assert.assertNull(AccountEntryUtil.getUserAccountEntry(_USER_ID));
+		}
+	}
+
+	@Test
+	public void testGetUserAccountEntryWithSEOStudioAccountEntry()
+		throws Exception {
+
+		AccountEntryUserRel accountEntryUserRel = _mockAccountEntryUserRel(
+			RandomTestUtil.randomString());
+
+		try (MockedStatic<AccountEntryUserRelLocalServiceUtil> mockedStatic =
+				Mockito.mockStatic(AccountEntryUserRelLocalServiceUtil.class)) {
+
+			_mockGetAccountEntryUserRels(
+				mockedStatic,
+				List.of(
+					_mockAccountEntryUserRel("L_AI_HUB"), accountEntryUserRel,
+					_mockAccountEntryUserRel("L_SEO_STUDIO")));
+
+			Assert.assertSame(
+				accountEntryUserRel.getAccountEntry(),
+				AccountEntryUtil.getUserAccountEntry(_USER_ID));
+		}
+	}
+
+	private AccountEntryUserRel _mockAccountEntryUserRel(
+			String externalReferenceCode)
+		throws PortalException {
+
+		AccountEntry accountEntry = Mockito.mock(AccountEntry.class);
+
+		Mockito.when(
+			accountEntry.getExternalReferenceCode()
+		).thenReturn(
+			externalReferenceCode
+		);
+
+		AccountEntryUserRel accountEntryUserRel = Mockito.mock(
+			AccountEntryUserRel.class);
+
+		Mockito.when(
+			accountEntryUserRel.getAccountEntry()
+		).thenReturn(
+			accountEntry
+		);
+
+		return accountEntryUserRel;
+	}
+
+	private void _mockGetAccountEntryUserRels(
+		MockedStatic<AccountEntryUserRelLocalServiceUtil> mockedStatic,
+		List<AccountEntryUserRel> accountEntryUserRels) {
+
+		mockedStatic.when(
+			() ->
+				AccountEntryUserRelLocalServiceUtil.
+					getAccountEntryUserRelsByAccountUserId(_USER_ID)
+		).thenReturn(
+			accountEntryUserRels
+		);
+	}
+
+	private static final long _USER_ID = 1;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94849

## What Is Being Fixed

AccountEntryUtil.getUserAccountEntry only handled users belonging to exactly two account entries (the AI Hub account plus their customer account). A user who is also a member of the SEO Studio account — three account entries — was not supported, so the helper failed to resolve the customer account for those users.

## How It Is Being Fixed

getUserAccountEntry now accepts two or three account-entry memberships. It always requires the L_AI_HUB account; when a third membership is present it must be the L_SEO_STUDIO account, and the remaining membership is returned as the customer account. Any other shape — too few or too many memberships, a missing L_AI_HUB account, an unexpected SEO Studio membership in the two-account case, or a missing one in the three-account case — yields null. AccountEntryUtilTest covers each membership case.

## PR Check

**pr-check: PASS** — tested on `c679d5fec6ef9697a85bd9e96b96a18f31b5cfbe`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Baseline | PASS |
| Cross-Module Compile | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "c679d5fec6ef9697a85bd9e96b96a18f31b5cfbe"} -->
