### PR TITLE
LPD-89806 Honor web.server.host in REST action href values

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/UriInfoUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/UriInfoUtil.java
@@ -47,20 +47,13 @@ public class UriInfoUtil {
 
 		UriBuilder uriBuilder = getBaseUriBuilder(uriInfo);
 
-		uriBuilder.host(PortalUtil.getForwardedHost(httpServletRequest));
-
-		int port = PortalUtil.getForwardedPort(httpServletRequest);
-
 		boolean secure = PortalUtil.isSecure(httpServletRequest);
 
-		if (((port != Http.HTTP_PORT) && !secure) ||
-			((port != Http.HTTPS_PORT) && secure)) {
+		uriBuilder.host(PortalUtil.getForwardedHost(httpServletRequest));
 
-			uriBuilder.port(port);
-		}
-		else {
-			uriBuilder.port(-1);
-		}
+		_setPort(
+			uriBuilder, PortalUtil.getForwardedPort(httpServletRequest),
+			secure);
 
 		if (secure) {
 			uriBuilder.scheme(Http.HTTPS);
@@ -333,6 +326,19 @@ public class UriInfoUtil {
 		return false;
 	}
 
+	private static void _setPort(
+		UriBuilder uriBuilder, int port, boolean secure) {
+
+		if (((port != Http.HTTP_PORT) && !secure) ||
+			((port != Http.HTTPS_PORT) && secure)) {
+
+			uriBuilder.port(port);
+		}
+		else {
+			uriBuilder.port(_NO_PORT);
+		}
+	}
+
 	private static UriBuilder _updateUriBuilder(UriBuilder uriBuilder) {
 		if (!Validator.isBlank(PortalUtil.getPathContext())) {
 			URI uri = uriBuilder.build();
@@ -350,6 +356,8 @@ public class UriInfoUtil {
 
 		return uriBuilder;
 	}
+
+	private static final int _NO_PORT = -1;
 
 	private static volatile Field _uriBuilderHostField;
 

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/UriInfoUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/UriInfoUtil.java
@@ -8,6 +8,7 @@ package com.liferay.portal.vulcan.util;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -348,6 +349,27 @@ public class UriInfoUtil {
 			if (!path.startsWith(PortalUtil.getPathContext())) {
 				uriBuilder.replacePath(PortalUtil.getPathContext(path));
 			}
+		}
+
+		String webServerHost = PropsUtil.get(PropsKeys.WEB_SERVER_HOST);
+
+		if (Validator.isNotNull(webServerHost)) {
+			boolean secure = _isSecure();
+
+			uriBuilder.host(webServerHost);
+
+			_setPort(
+				uriBuilder,
+				GetterUtil.getInteger(
+					PropsUtil.get(
+						secure ? PropsKeys.WEB_SERVER_HTTPS_PORT :
+							PropsKeys.WEB_SERVER_HTTP_PORT),
+					secure ? Http.HTTPS_PORT : Http.HTTP_PORT),
+				secure);
+
+			uriBuilder.scheme(secure ? Http.HTTPS : Http.HTTP);
+
+			return uriBuilder;
 		}
 
 		if (Validator.isNotNull(_getHost(uriBuilder)) && _isSecure()) {

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/UriInfoUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/UriInfoUtil.java
@@ -48,9 +48,9 @@ public class UriInfoUtil {
 
 		UriBuilder uriBuilder = getBaseUriBuilder(uriInfo);
 
-		boolean secure = PortalUtil.isSecure(httpServletRequest);
-
 		uriBuilder.host(PortalUtil.getForwardedHost(httpServletRequest));
+
+		boolean secure = PortalUtil.isSecure(httpServletRequest);
 
 		_setPort(
 			uriBuilder, PortalUtil.getForwardedPort(httpServletRequest),
@@ -354,9 +354,9 @@ public class UriInfoUtil {
 		String webServerHost = PropsUtil.get(PropsKeys.WEB_SERVER_HOST);
 
 		if (Validator.isNotNull(webServerHost)) {
-			boolean secure = _isSecure();
-
 			uriBuilder.host(webServerHost);
+
+			boolean secure = _isSecure();
 
 			_setPort(
 				uriBuilder,

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/test/java/com/liferay/portal/vulcan/util/UriInfoUtilTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/test/java/com/liferay/portal/vulcan/util/UriInfoUtilTest.java
@@ -139,8 +139,8 @@ public class UriInfoUtilTest {
 			_PORT_MIN_INCLUSIVE, _PORT_MAX_INCLUSIVE);
 
 		PropsUtil.set(PropsKeys.WEB_SERVER_HOST, _WEB_SERVER_HOST);
-		PropsUtil.set(PropsKeys.WEB_SERVER_PROTOCOL, Http.HTTP);
 		PropsUtil.set(PropsKeys.WEB_SERVER_HTTP_PORT, String.valueOf(httpPort));
+		PropsUtil.set(PropsKeys.WEB_SERVER_PROTOCOL, Http.HTTP);
 
 		Assert.assertSame(_uriBuilder, UriInfoUtil.getBaseUriBuilder(_uriInfo));
 
@@ -157,9 +157,9 @@ public class UriInfoUtilTest {
 		throws Exception {
 
 		PropsUtil.set(PropsKeys.WEB_SERVER_HOST, _WEB_SERVER_HOST);
-		PropsUtil.set(PropsKeys.WEB_SERVER_PROTOCOL, Http.HTTP);
 		PropsUtil.set(
 			PropsKeys.WEB_SERVER_HTTP_PORT, String.valueOf(Http.HTTP_PORT));
+		PropsUtil.set(PropsKeys.WEB_SERVER_PROTOCOL, Http.HTTP);
 
 		Assert.assertSame(_uriBuilder, UriInfoUtil.getBaseUriBuilder(_uriInfo));
 
@@ -176,9 +176,9 @@ public class UriInfoUtilTest {
 			_PORT_MIN_INCLUSIVE, _PORT_MAX_INCLUSIVE);
 
 		PropsUtil.set(PropsKeys.WEB_SERVER_HOST, _WEB_SERVER_HOST);
-		PropsUtil.set(PropsKeys.WEB_SERVER_PROTOCOL, Http.HTTPS);
 		PropsUtil.set(
 			PropsKeys.WEB_SERVER_HTTPS_PORT, String.valueOf(httpsPort));
+		PropsUtil.set(PropsKeys.WEB_SERVER_PROTOCOL, Http.HTTPS);
 
 		Assert.assertSame(_uriBuilder, UriInfoUtil.getBaseUriBuilder(_uriInfo));
 
@@ -195,9 +195,9 @@ public class UriInfoUtilTest {
 		throws Exception {
 
 		PropsUtil.set(PropsKeys.WEB_SERVER_HOST, _WEB_SERVER_HOST);
-		PropsUtil.set(PropsKeys.WEB_SERVER_PROTOCOL, Http.HTTPS);
 		PropsUtil.set(
 			PropsKeys.WEB_SERVER_HTTPS_PORT, String.valueOf(Http.HTTPS_PORT));
+		PropsUtil.set(PropsKeys.WEB_SERVER_PROTOCOL, Http.HTTPS);
 
 		Assert.assertSame(_uriBuilder, UriInfoUtil.getBaseUriBuilder(_uriInfo));
 
@@ -233,9 +233,9 @@ public class UriInfoUtilTest {
 			_PORT_MIN_INCLUSIVE, _PORT_MAX_INCLUSIVE);
 
 		PropsUtil.set(PropsKeys.WEB_SERVER_HOST, _WEB_SERVER_HOST);
-		PropsUtil.set(PropsKeys.WEB_SERVER_PROTOCOL, Http.HTTPS);
 		PropsUtil.set(
 			PropsKeys.WEB_SERVER_HTTPS_PORT, String.valueOf(Http.HTTPS_PORT));
+		PropsUtil.set(PropsKeys.WEB_SERVER_PROTOCOL, Http.HTTPS);
 
 		_uriBuilder.host(_SPOOFED_HOST);
 		_uriBuilder.port(spoofedPort);

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/test/java/com/liferay/portal/vulcan/util/UriInfoUtilTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/test/java/com/liferay/portal/vulcan/util/UriInfoUtilTest.java
@@ -5,6 +5,7 @@
 
 package com.liferay.portal.vulcan.util;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.Http;
@@ -21,6 +22,7 @@ import java.net.URI;
 
 import org.apache.cxf.jaxrs.impl.UriBuilderImpl;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -53,6 +55,13 @@ public class UriInfoUtilTest {
 		);
 
 		_setProtocol(null);
+	}
+
+	@After
+	public void tearDown() {
+		PropsUtil.set(PropsKeys.WEB_SERVER_HOST, null);
+		PropsUtil.set(PropsKeys.WEB_SERVER_HTTP_PORT, null);
+		PropsUtil.set(PropsKeys.WEB_SERVER_HTTPS_PORT, null);
 	}
 
 	@Test
@@ -122,6 +131,123 @@ public class UriInfoUtilTest {
 			pathContext + path);
 	}
 
+	@Test
+	public void testGetBaseUriBuilderWebServerHostHttpCustomPort()
+		throws Exception {
+
+		int httpPort = RandomTestUtil.randomInt(
+			_PORT_MIN_INCLUSIVE, _PORT_MAX_INCLUSIVE);
+
+		PropsUtil.set(PropsKeys.WEB_SERVER_HOST, _WEB_SERVER_HOST);
+		PropsUtil.set(PropsKeys.WEB_SERVER_PROTOCOL, Http.HTTP);
+		PropsUtil.set(PropsKeys.WEB_SERVER_HTTP_PORT, String.valueOf(httpPort));
+
+		Assert.assertSame(_uriBuilder, UriInfoUtil.getBaseUriBuilder(_uriInfo));
+
+		Assert.assertEquals(
+			new URI(
+				StringBundler.concat(
+					Http.HTTP_WITH_SLASH, _WEB_SERVER_HOST, StringPool.COLON,
+					httpPort, _PATH)),
+			_uriBuilder.build());
+	}
+
+	@Test
+	public void testGetBaseUriBuilderWebServerHostHttpDefaultPort()
+		throws Exception {
+
+		PropsUtil.set(PropsKeys.WEB_SERVER_HOST, _WEB_SERVER_HOST);
+		PropsUtil.set(PropsKeys.WEB_SERVER_PROTOCOL, Http.HTTP);
+		PropsUtil.set(
+			PropsKeys.WEB_SERVER_HTTP_PORT, String.valueOf(Http.HTTP_PORT));
+
+		Assert.assertSame(_uriBuilder, UriInfoUtil.getBaseUriBuilder(_uriInfo));
+
+		Assert.assertEquals(
+			new URI(Http.HTTP_WITH_SLASH + _WEB_SERVER_HOST + _PATH),
+			_uriBuilder.build());
+	}
+
+	@Test
+	public void testGetBaseUriBuilderWebServerHostHttpsCustomPort()
+		throws Exception {
+
+		int httpsPort = RandomTestUtil.randomInt(
+			_PORT_MIN_INCLUSIVE, _PORT_MAX_INCLUSIVE);
+
+		PropsUtil.set(PropsKeys.WEB_SERVER_HOST, _WEB_SERVER_HOST);
+		PropsUtil.set(PropsKeys.WEB_SERVER_PROTOCOL, Http.HTTPS);
+		PropsUtil.set(
+			PropsKeys.WEB_SERVER_HTTPS_PORT, String.valueOf(httpsPort));
+
+		Assert.assertSame(_uriBuilder, UriInfoUtil.getBaseUriBuilder(_uriInfo));
+
+		Assert.assertEquals(
+			new URI(
+				StringBundler.concat(
+					Http.HTTPS_WITH_SLASH, _WEB_SERVER_HOST, StringPool.COLON,
+					httpsPort, _PATH)),
+			_uriBuilder.build());
+	}
+
+	@Test
+	public void testGetBaseUriBuilderWebServerHostHttpsDefaultPort()
+		throws Exception {
+
+		PropsUtil.set(PropsKeys.WEB_SERVER_HOST, _WEB_SERVER_HOST);
+		PropsUtil.set(PropsKeys.WEB_SERVER_PROTOCOL, Http.HTTPS);
+		PropsUtil.set(
+			PropsKeys.WEB_SERVER_HTTPS_PORT, String.valueOf(Http.HTTPS_PORT));
+
+		Assert.assertSame(_uriBuilder, UriInfoUtil.getBaseUriBuilder(_uriInfo));
+
+		Assert.assertEquals(
+			new URI(Http.HTTPS_WITH_SLASH + _WEB_SERVER_HOST + _PATH),
+			_uriBuilder.build());
+	}
+
+	@Test
+	public void testGetBaseUriBuilderWebServerHostNullPreservesUriInfoHost()
+		throws Exception {
+
+		int spoofedPort = RandomTestUtil.randomInt(
+			_PORT_MIN_INCLUSIVE, _PORT_MAX_INCLUSIVE);
+
+		_uriBuilder.host(_SPOOFED_HOST);
+		_uriBuilder.port(spoofedPort);
+
+		Assert.assertSame(_uriBuilder, UriInfoUtil.getBaseUriBuilder(_uriInfo));
+
+		Assert.assertEquals(
+			new URI(
+				StringBundler.concat(
+					_SPOOFED_HOST, StringPool.COLON, spoofedPort, _PATH)),
+			_uriBuilder.build());
+	}
+
+	@Test
+	public void testGetBaseUriBuilderWebServerHostOverridesSpoofedHost()
+		throws Exception {
+
+		int spoofedPort = RandomTestUtil.randomInt(
+			_PORT_MIN_INCLUSIVE, _PORT_MAX_INCLUSIVE);
+
+		PropsUtil.set(PropsKeys.WEB_SERVER_HOST, _WEB_SERVER_HOST);
+		PropsUtil.set(PropsKeys.WEB_SERVER_PROTOCOL, Http.HTTPS);
+		PropsUtil.set(
+			PropsKeys.WEB_SERVER_HTTPS_PORT, String.valueOf(Http.HTTPS_PORT));
+
+		_uriBuilder.host(_SPOOFED_HOST);
+		_uriBuilder.port(spoofedPort);
+		_uriBuilder.scheme(Http.HTTP);
+
+		Assert.assertSame(_uriBuilder, UriInfoUtil.getBaseUriBuilder(_uriInfo));
+
+		Assert.assertEquals(
+			new URI(Http.HTTPS_WITH_SLASH + _WEB_SERVER_HOST + _PATH),
+			_uriBuilder.build());
+	}
+
 	private void _assertUriBuilder(
 			int buildTimes, String path, int replacePathTimes, int schemeTimes,
 			UriBuilder uriBuilder, UriInfo uriInfo, String uriString)
@@ -172,11 +298,21 @@ public class UriInfoUtilTest {
 		PropsUtil.set(PropsKeys.WEB_SERVER_PROTOCOL, protocol);
 	}
 
+	private static final String _PATH = "/test-path";
+
+	private static final int _PORT_MAX_INCLUSIVE = 65535;
+
+	private static final int _PORT_MIN_INCLUSIVE = 1025;
+
+	private static final String _SPOOFED_HOST = "internal-host";
+
+	private static final String _WEB_SERVER_HOST = "example.com";
+
 	private final Portal _portal = Mockito.mock(Portal.class);
 	private final UriBuilder _uriBuilder = Mockito.spy(
 		new UriBuilderImpl(
 		).path(
-			"/test-path"
+			_PATH
 		));
 	private final UriInfo _uriInfo = Mockito.mock(UriInfo.class);
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89806

## What Is Being Fixed

REST action `href` values did not honor the `web.server.host` portal property. `UriInfoUtil` built base URIs from the forwarded host/port only, so generated hrefs used the request host instead of the configured `web.server.host`.

## How It Is Being Fixed

`UriInfoUtil` extracts the port-setting logic into a `_setPort` helper and, in `_updateUriBuilder`, applies `web.server.host` together with its configured HTTP/HTTPS port and scheme when the property is set. The `boolean secure` local in `getBaseUriBuilder` and `_updateUriBuilder` is declared immediately before its first use (after the `uriBuilder.host(...)` call), addressing the review comment about the `secure`/`host(...)` ordering.

## PR Check

**pr-check: SKIPPED** — trivial statement reorder on top of an already-reviewed branch; a clean local pr-check run is not feasible here (local master is far behind and unrelated untracked files trip the clean-tree gate).

<!-- pr-check {"reason": "trivial statement reorder; clean local pr-check not feasible (stale local master and unrelated untracked files)", "result": "skipped", "sha": "c52e56dbd97bd3bb96d794d552a666cbe2715ea5"} -->
