### PR TITLE
LPD-81227 Auto-migrate getSupportedActions for BasePortletProvider

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -5880,6 +5880,19 @@
 	},
 	{
 		"classNames": [
+			"BasePortletProvider"
+		],
+		"classStructurePattern": true,
+		"issueKey": "LPD-81227",
+		"newImports": [
+			"com.liferay.portal.kernel.portlet.PortletProvider"
+		],
+		"newMethods": [
+			"@Override\n\tpublic Action[] getSupportedActions() {\n\t\treturn PortletProvider.Action.values();\n\t}"
+		]
+	},
+	{
+		"classNames": [
 			"AssetEntryLocalService",
 			"AssetEntryLocalServiceUtil"
 		],

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_81227.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_81227.testjava
@@ -1,0 +1,21 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+import com.liferay.portal.kernel.portlet.PortletProvider;
+
+/**
+ * @author Regisson Aguiar
+ */
+@Component(service = PortletProvider.class)
+public class LPD_81227 extends BasePortletProvider {
+
+	@Override
+	public Action[] getSupportedActions() {
+		return PortletProvider.Action.values();
+	}
+
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_81227.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_81227.testjava
@@ -1,0 +1,13 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+/**
+ * @author Regisson Aguiar
+ */
+@Component(service = PortletProvider.class)
+public class LPD_81227 extends BasePortletProvider {
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-81227

## What Is Being Fixed

PortletProvider implementations that extend BasePortletProvider need to declare the getSupportedActions method, but adding it by hand to every implementation is tedious and easy to miss.

## How It Is Being Fixed

A source-formatter upgrade rule was added to the catch-all upgrade check through replacements.json. It matches classes that extend BasePortletProvider and injects an overriding getSupportedActions method returning PortletProvider.Action.values(), along with the required PortletProvider import, so the formatter performs the migration automatically. A fixture under the upgrade-catch-all-check test resources covers the transformation.

## PR Check

**pr-check: PASS** — tested on `95fad794f1d8b4ec31597e37c4078bcc419c16e7`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "95fad794f1d8b4ec31597e37c4078bcc419c16e7"} -->
