### PR TITLE
LPD-94314 Page builder agent shows up in the list of agents to add to the chatbot

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/agent_definition_form/services/AgentDefinitionService.ts
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/agent_definition_form/services/AgentDefinitionService.ts
@@ -46,7 +46,7 @@ async function getAgentDefinition(externalReferenceCode: string) {
 }
 
 async function getAgentDefinitions() {
-	const response = await fetch(AGENT_DEFINITION_BASE_URI, {
+	const response = await fetch('/o/ai-hub/v1.0/agent-definitions', {
 		method: 'GET',
 	});
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94314

## What Is Being Fixed

The agent definition form loaded the agent list from the unversioned object endpoint, which returned the Page Builder agent. As a result, the Page Builder agent showed up in the list of agents that can be added to a chatbot, where it does not belong.

## How It Is Being Fixed

`getAgentDefinitions` now calls the versioned REST Builder endpoint `/o/ai-hub/v1.0/agent-definitions` instead of the base object URI. That endpoint applies the server-side filtering that excludes the Page Builder agent, so it no longer appears in the chatbot's agent list.

## Why Are There No Tests?

This is a one-line correction to the REST endpoint the service calls; a dedicated unit test adds no meaningful coverage for a constant-path change.

Supersedes liferay-ai-hub#525.

## PR Check

**pr-check: PASS** — tested on `a6ceb5c5dfc0344f0cfcf19c3de586de4f5019e5`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "a6ceb5c5dfc0344f0cfcf19c3de586de4f5019e5"} -->
