### PR TITLE
LPD-92853 Derive the PKCE code challenge from the sent code verifier

### DIFF
--- a/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/internal/servlet/test/MCPServerServletTest.java
+++ b/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/internal/servlet/test/MCPServerServletTest.java
@@ -411,6 +411,8 @@ public class MCPServerServletTest {
 			authorizationServerMetadataJSONObject.getString(
 				"authorization_endpoint");
 
+		String codeVerifier = RandomTestUtil.randomString(50);
+
 		String authorizationURL = HttpComponentsUtil.addParameter(
 			authorizationEndpoint, "client_id", clientId);
 
@@ -419,7 +421,7 @@ public class MCPServerServletTest {
 			StringUtil.removeChar(
 				StringUtil.replace(
 					DigesterUtil.digestBase64(
-						DigesterUtil.SHA_256, RandomTestUtil.randomString()),
+						DigesterUtil.SHA_256, codeVerifier),
 					new char[] {CharPool.PLUS, CharPool.SLASH},
 					new char[] {CharPool.MINUS, CharPool.UNDERLINE}),
 				CharPool.EQUAL));
@@ -497,8 +499,7 @@ public class MCPServerServletTest {
 			StringBundler.concat(
 				"client_id=", URLCodec.encodeURL(clientId), "&code=",
 				URLCodec.encodeURL(code), "&code_verifier=",
-				URLCodec.encodeURL(
-					"mcpServerTestCodeVerifier1234567890123456789012345"),
+				URLCodec.encodeURL(codeVerifier),
 				"&grant_type=authorization_code&redirect_uri=",
 				URLCodec.encodeURL(redirectURI), "&resource=",
 				URLCodec.encodeURL(


### PR DESCRIPTION
The MCP server servlet test walked the authorization code flow with a `code_challenge` computed from a throwaway `RandomTestUtil.randomString()` while presenting a fixed literal as the `code_verifier` at the token endpoint. Because S256 verification requires `BASE64URL(SHA256(code_verifier))` to equal the challenge, the exchange failed and `_getAccessToken` never obtained a token, so the bearer half of `testService` could not authenticate.

This feeds a single random verifier into both the challenge and the token request so the two agree. Verified locally: `MCPServerServletTest#testService` now passes (0 failures).