### PR TITLE
LPD-92853 Fix the PKCE verifier mismatch I introduced

### DIFF
--- a/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/internal/servlet/test/MCPServerServletTest.java
+++ b/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/internal/servlet/test/MCPServerServletTest.java
@@ -414,12 +414,14 @@ public class MCPServerServletTest {
 		String authorizationURL = HttpComponentsUtil.addParameter(
 			authorizationEndpoint, "client_id", clientId);
 
+		String codeVerifier = RandomTestUtil.randomString(50);
+
 		authorizationURL = HttpComponentsUtil.addParameter(
 			authorizationURL, "code_challenge",
 			StringUtil.removeChar(
 				StringUtil.replace(
 					DigesterUtil.digestBase64(
-						DigesterUtil.SHA_256, RandomTestUtil.randomString()),
+						DigesterUtil.SHA_256, codeVerifier),
 					new char[] {CharPool.PLUS, CharPool.SLASH},
 					new char[] {CharPool.MINUS, CharPool.UNDERLINE}),
 				CharPool.EQUAL));
@@ -497,8 +499,7 @@ public class MCPServerServletTest {
 			StringBundler.concat(
 				"client_id=", URLCodec.encodeURL(clientId), "&code=",
 				URLCodec.encodeURL(code), "&code_verifier=",
-				URLCodec.encodeURL(
-					"mcpServerTestCodeVerifier1234567890123456789012345"),
+				URLCodec.encodeURL(codeVerifier),
 				"&grant_type=authorization_code&redirect_uri=",
 				URLCodec.encodeURL(redirectURI), "&resource=",
 				URLCodec.encodeURL(


### PR DESCRIPTION
While inlining the OAuth flow in LPD-92853 I derived the PKCE `code_challenge` from a fresh random string instead of the `code_verifier` sent to the token endpoint. S256 verification requires `BASE64URL(SHA256(code_verifier))` to equal the challenge, so the exchange failed and `_getAccessToken` never obtained a token, breaking the bearer half of `MCPServerServletTest#testService`.

This uses one random verifier for both the challenge and the token request. Verified locally: `testService` passes (0 failures).