### PR TITLE
LPD-93589 Description of the avatar field not showing correct info

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer-test/src/testIntegration/java/com/liferay/ai/hub/site/initializer/internal/test/AIHubSiteInitializerTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer-test/src/testIntegration/java/com/liferay/ai/hub/site/initializer/internal/test/AIHubSiteInitializerTest.java
@@ -203,6 +203,9 @@ public class AIHubSiteInitializerTest {
 			"L_AI_HUB_INSTRUCTION_DEFINITION", "L_AI_HUB_PROHIBITED_PRACTICES");
 		_assertObjectFieldDefaultValue(
 			"L_AI_HUB_GUARDRAIL", "location", "europe-west1");
+		_assertObjectFieldSettingValue(
+			"L_AI_HUB_CHATBOT", "avatar",
+			ObjectFieldSettingConstants.NAME_MAX_FILE_SIZE, "512000");
 		_assertObjectFieldsExist(
 			"L_AI_HUB_AGENT_DEFINITION", "active", "description",
 			"inputVariables", "outputVariable",
@@ -503,6 +506,27 @@ public class AIHubSiteInitializerTest {
 			_objectFieldSettingLocalService.fetchObjectFieldSetting(
 				objectField.getObjectFieldId(),
 				ObjectFieldSettingConstants.NAME_DEFAULT_VALUE);
+
+		Assert.assertEquals(value, objectFieldSetting.getValue());
+	}
+
+	private void _assertObjectFieldSettingValue(
+			String objectDefinitionExternalReferenceCode,
+			String objectFieldName, String objectFieldSettingName, String value)
+		throws Exception {
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.
+				fetchObjectDefinitionByExternalReferenceCode(
+					objectDefinitionExternalReferenceCode,
+					TestPropsValues.getCompanyId());
+
+		ObjectField objectField = _objectFieldLocalService.fetchObjectField(
+			objectDefinition.getObjectDefinitionId(), objectFieldName);
+
+		ObjectFieldSetting objectFieldSetting =
+			_objectFieldSettingLocalService.fetchObjectFieldSetting(
+				objectField.getObjectFieldId(), objectFieldSettingName);
 
 		Assert.assertEquals(value, objectFieldSetting.getValue());
 	}

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/object-definitions/chatbot-object-definition.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/object-definitions/chatbot-object-definition.json
@@ -45,7 +45,7 @@
 				},
 				{
 					"name": "maximumFileSize",
-					"value": 0
+					"value": 512000
 				},
 				{
 					"name": "fileSource",

--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/java/com/liferay/ai/hub/web/internal/display/context/EditChatbotDisplayContext.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/java/com/liferay/ai/hub/web/internal/display/context/EditChatbotDisplayContext.java
@@ -9,14 +9,16 @@ import com.liferay.account.model.AccountEntry;
 import com.liferay.ai.hub.util.AccountEntryUtil;
 import com.liferay.ai.hub.web.internal.util.DisplayContextUtil;
 import com.liferay.object.constants.ObjectFieldSettingConstants;
-import com.liferay.object.field.attachment.AttachmentManager;
 import com.liferay.object.field.setting.util.ObjectFieldSettingUtil;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectField;
+import com.liferay.object.model.ObjectFieldSetting;
 import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
 import com.liferay.object.service.ObjectFieldLocalServiceUtil;
+import com.liferay.object.service.ObjectFieldSettingLocalService;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -32,12 +34,12 @@ import java.util.Map;
 public class EditChatbotDisplayContext {
 
 	public EditChatbotDisplayContext(
-		AttachmentManager attachmentManager,
-		HttpServletRequest httpServletRequest, Language language) {
+		HttpServletRequest httpServletRequest, Language language,
+		ObjectFieldSettingLocalService objectFieldSettingLocalService) {
 
-		_attachmentManager = attachmentManager;
 		_httpServletRequest = httpServletRequest;
 		_language = language;
+		_objectFieldSettingLocalService = objectFieldSettingLocalService;
 
 		_themeDisplay = (ThemeDisplay)httpServletRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
@@ -54,8 +56,12 @@ public class EditChatbotDisplayContext {
 				ObjectFieldSettingConstants.NAME_ACCEPTED_FILE_EXTENSIONS,
 				objectField);
 
-			maximumFileSize = _attachmentManager.getMaximumFileSize(
-				objectField.getObjectFieldId(), _themeDisplay.isSignedIn());
+			ObjectFieldSetting objectFieldSetting =
+				_objectFieldSettingLocalService.fetchObjectFieldSetting(
+					objectField.getObjectFieldId(),
+					ObjectFieldSettingConstants.NAME_MAX_FILE_SIZE);
+
+			maximumFileSize = GetterUtil.getLong(objectFieldSetting.getValue());
 		}
 
 		return HashMapBuilder.<String, Object>put(
@@ -129,9 +135,10 @@ public class EditChatbotDisplayContext {
 			objectDefinition.getObjectDefinitionId(), "avatar");
 	}
 
-	private final AttachmentManager _attachmentManager;
 	private final HttpServletRequest _httpServletRequest;
 	private final Language _language;
+	private final ObjectFieldSettingLocalService
+		_objectFieldSettingLocalService;
 	private final ThemeDisplay _themeDisplay;
 
 }

--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/java/com/liferay/ai/hub/web/internal/fragment/renderer/EditChatbotFragmentRenderer.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/java/com/liferay/ai/hub/web/internal/fragment/renderer/EditChatbotFragmentRenderer.java
@@ -7,7 +7,7 @@ package com.liferay.ai.hub.web.internal.fragment.renderer;
 
 import com.liferay.ai.hub.web.internal.display.context.EditChatbotDisplayContext;
 import com.liferay.fragment.renderer.FragmentRenderer;
-import com.liferay.object.field.attachment.AttachmentManager;
+import com.liferay.object.service.ObjectFieldSettingLocalService;
 import com.liferay.portal.kernel.language.Language;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -32,7 +32,7 @@ public class EditChatbotFragmentRenderer
 		HttpServletRequest httpServletRequest) {
 
 		return new EditChatbotDisplayContext(
-			_attachmentManager, httpServletRequest, _language);
+			httpServletRequest, _language, _objectFieldSettingLocalService);
 	}
 
 	@Override
@@ -41,9 +41,9 @@ public class EditChatbotFragmentRenderer
 	}
 
 	@Reference
-	private AttachmentManager _attachmentManager;
+	private Language _language;
 
 	@Reference
-	private Language _language;
+	private ObjectFieldSettingLocalService _objectFieldSettingLocalService;
 
 }

--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/test/java/com/liferay/ai/hub/web/internal/display/context/EditChatbotDisplayContextTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/test/java/com/liferay/ai/hub/web/internal/display/context/EditChatbotDisplayContextTest.java
@@ -7,12 +7,14 @@ package com.liferay.ai.hub.web.internal.display.context;
 
 import com.liferay.ai.hub.util.AccountEntryUtil;
 import com.liferay.ai.hub.web.internal.test.util.DisplayContextTestUtil;
-import com.liferay.object.field.attachment.AttachmentManager;
 import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
 import com.liferay.object.service.ObjectEntryServiceUtil;
+import com.liferay.object.service.ObjectFieldSettingLocalService;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -40,6 +42,8 @@ public class EditChatbotDisplayContextTest {
 
 	@Before
 	public void setUp() throws Exception {
+		_setUpPortalUtil();
+
 		HttpServletRequest httpServletRequest =
 			DisplayContextTestUtil.setUpHttpServletRequest();
 
@@ -48,14 +52,20 @@ public class EditChatbotDisplayContextTest {
 			httpServletRequest);
 
 		_editChatbotDisplayContext = new EditChatbotDisplayContext(
-			Mockito.mock(AttachmentManager.class), httpServletRequest,
-			Mockito.mock(Language.class));
+			httpServletRequest, Mockito.mock(Language.class),
+			Mockito.mock(ObjectFieldSettingLocalService.class));
 	}
 
 	@Test
 	public void testGetReactData() throws Exception {
 		_testGetReactData(true, false);
 		_testGetReactData(false, true);
+	}
+
+	private void _setUpPortalUtil() {
+		PortalUtil portalUtil = new PortalUtil();
+
+		portalUtil.setPortal(_portal);
 	}
 
 	private void _testGetReactData(
@@ -89,5 +99,6 @@ public class EditChatbotDisplayContextTest {
 	}
 
 	private EditChatbotDisplayContext _editChatbotDisplayContext;
+	private final Portal _portal = Mockito.mock(Portal.class);
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93589

## What Is Being Fixed

The chatbot avatar upload field showed an incorrect maximum file size in its helper text. The avatar object field's maximumFileSize setting was 0, and EditChatbotDisplayContext derived the displayed size from AttachmentManager.getMaximumFileSize(...), which returns a general/default limit rather than the value configured on the field. As a result, the "upload no larger than X" description did not reflect the field's actual limit.

## How It Is Being Fixed

The avatar field's maximumFileSize setting in the chatbot object definition is set to 500KB (512000). EditChatbotDisplayContext now reads that setting directly through ObjectFieldSettingLocalService, so the description reflects the configured limit. Since the display context no longer needs AttachmentManager, that dependency was removed from the display context, its fragment renderer, and the unit test. Coverage was added: an integration test asserts the object field setting value on the deployed definition, and a display-context unit test verifies the computed React data.

## PR Check

**pr-check: PASS** — tested on `072d6a8fffbe0c00b9b3711b8e0a84408a62f5f0`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "072d6a8fffbe0c00b9b3711b8e0a84408a62f5f0"} -->
