### PR TITLE
LPD-93999 Fix missing citation URL in Elasticsearch content retriever

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/langchain4j/rag/content/retriever/ElasticsearchContentRetriever.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/langchain4j/rag/content/retriever/ElasticsearchContentRetriever.java
@@ -57,7 +57,8 @@ public class ElasticsearchContentRetriever extends BaseContentRetriever {
 
 		SearchSearchRequest searchSearchRequest = new SearchSearchRequest();
 
-		searchSearchRequest.setFetchSource(false);
+		searchSearchRequest.setFetchSource(true);
+		searchSearchRequest.setFetchSourceIncludes(new String[] {"url"});
 		searchSearchRequest.setHighlight(
 			_highlightBuilderFactory.builder(
 			).addFieldConfig(

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/test/java/com/liferay/ai/hub/internal/langchain4j/rag/content/retriever/ElasticsearchContentRetrieverTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/test/java/com/liferay/ai/hub/internal/langchain4j/rag/content/retriever/ElasticsearchContentRetrieverTest.java
@@ -16,6 +16,7 @@ import com.liferay.portal.search.hits.SearchHit;
 import com.liferay.portal.search.hits.SearchHits;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
+import dev.langchain4j.data.document.Metadata;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.rag.content.Content;
 import dev.langchain4j.rag.query.Query;
@@ -28,6 +29,7 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 /**
@@ -44,11 +46,6 @@ public class ElasticsearchContentRetrieverTest {
 	public void testSearch() {
 		SearchEngineAdapter searchEngineAdapter = Mockito.mock(
 			SearchEngineAdapter.class);
-
-		SearchSearchResponse searchSearchResponse = Mockito.mock(
-			SearchSearchResponse.class);
-
-		SearchHits searchHits = Mockito.mock(SearchHits.class);
 
 		SearchHit lowScoreSearchHit = Mockito.mock(SearchHit.class);
 
@@ -82,11 +79,24 @@ public class ElasticsearchContentRetrieverTest {
 			0.9F
 		);
 
+		String url = RandomTestUtil.randomString();
+
+		Mockito.when(
+			highScoreSearchHit.getSourcesMap()
+		).thenReturn(
+			Map.of(_URL, url)
+		);
+
+		SearchHits searchHits = Mockito.mock(SearchHits.class);
+
 		Mockito.when(
 			searchHits.getSearchHits()
 		).thenReturn(
 			List.of(lowScoreSearchHit, highScoreSearchHit)
 		);
+
+		SearchSearchResponse searchSearchResponse = Mockito.mock(
+			SearchSearchResponse.class);
 
 		Mockito.when(
 			searchSearchResponse.getSearchHits()
@@ -128,6 +138,27 @@ public class ElasticsearchContentRetrieverTest {
 		TextSegment textSegment = content.textSegment();
 
 		Assert.assertEquals(fragment, textSegment.text());
+
+		Metadata metadata = textSegment.metadata();
+
+		Assert.assertEquals(url, metadata.getString(_URL));
+
+		ArgumentCaptor<SearchSearchRequest> argumentCaptor =
+			ArgumentCaptor.forClass(SearchSearchRequest.class);
+
+		Mockito.verify(
+			searchEngineAdapter
+		).execute(
+			argumentCaptor.capture()
+		);
+
+		SearchSearchRequest searchSearchRequest = argumentCaptor.getValue();
+
+		Assert.assertTrue(searchSearchRequest.getFetchSource());
+		Assert.assertArrayEquals(
+			new String[] {_URL}, searchSearchRequest.getFetchSourceIncludes());
 	}
+
+	private static final String _URL = "url";
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93999

## What Is Being Fixed

The Elasticsearch content retriever disabled source fetching on the search request but still read the "url" field from each hit's source map, so the URL always came back empty. With no real link reaching the model, the chatbot had nothing to cite and would hallucinate plausible but nonexistent documentation URLs.

## How It Is Being Fixed

The search request now enables source fetching and restricts it to the "url" field. That keeps the large text embedding vector out of the response while restoring the citation URL the content injector appends to each text segment.

It rebases on top of LPD-96487 ("Skip low-score chunks"), which already landed on master and touches the same retriever and its test. The unit test is now a single testSearch that covers both behaviors together: a low-score hit is dropped, a high-score hit is kept, its URL reaches the text segment metadata, and the search request is asserted to enable source fetching restricted to "url".

This resends https://github.com/brianchandotcom/liferay-portal/pull/177932 with the source formatting issues from that review addressed. The chained calls on non-builder returns (for example content.textSegment().metadata().getString("url")) are split into named locals, and the whole test was audited line by line rather than fixing a single case.

## PR Check

**pr-check: PASS** - tested on `39f407c4ef1bd14728a3d63bf525ae1f3f75c082`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "39f407c4ef1bd14728a3d63bf525ae1f3f75c082"} -->
