### PR TITLE
LPD-89205 Fix stable build

### DIFF
--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/AGENTS.md
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/AGENTS.md
@@ -174,6 +174,7 @@ Release notes:
 - Keep public API changes intentional and typed; match existing prop/type naming patterns in the package.
 - Never import across package source paths (for example, `../../clay-button/src`). Always import from package entry points (`@clayui/...`).
 - If a cross-package import is needed and the dependency is missing, add that package as an explicit dependency in the consuming package.
+- Re-export a package's public symbols from its entry point (`src/index.tsx`) using the specifier form — `export {Foo, Bar};` — rather than inline `export const`/`function`/`class`. DXP consumes Clay from source, and the DXP export bridge (`modules/frontend-sdk/node-scripts/util/esbuild/util/getExportedSymbols.mjs`) infers a package's exports by AST-parsing the entry module. It only recognizes export specifiers; inline `export const Foo = ...` declarations are silently dropped, so DXP modules that `import {Foo}` fail to build with `No matching export ... for import "Foo"`. Sibling packages such as `clay-drop-down` and `clay-button` follow the specifier form.
 - For CSS/Sass work, follow `clay/clay-css/CONTRIBUTING.md`:
     - hard tabs
     - alphabetical property ordering

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-label/src/index.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-label/src/index.tsx
@@ -29,7 +29,7 @@ export type ContentLabelDisplayType =
 	| 'content-7'
 	| 'content-8';
 
-export const ItemAfter = React.forwardRef<
+const ItemAfter = React.forwardRef<
 	HTMLSpanElement,
 	React.HTMLAttributes<HTMLSpanElement>
 >(({children, className, ...otherProps}, ref) => (
@@ -44,7 +44,7 @@ export const ItemAfter = React.forwardRef<
 
 ItemAfter.displayName = 'ClayLabelItemAfter';
 
-export const ItemBefore = React.forwardRef<
+const ItemBefore = React.forwardRef<
 	HTMLSpanElement,
 	React.HTMLAttributes<HTMLSpanElement>
 >(({children, className, ...otherProps}, ref) => (
@@ -59,7 +59,7 @@ export const ItemBefore = React.forwardRef<
 
 ItemBefore.displayName = 'ClayLabelItemBefore';
 
-export const ItemExpand = React.forwardRef<
+const ItemExpand = React.forwardRef<
 	HTMLAnchorElement | HTMLSpanElement,
 	React.BaseHTMLAttributes<HTMLAnchorElement | HTMLSpanElement>
 >(({children, className, href, ...otherProps}, ref) => {
@@ -245,10 +245,11 @@ const ContentLabelComponent = React.forwardRef<
 
 ContentLabelComponent.displayName = 'ClayContentLabel';
 
-export const ContentLabel = Object.assign(ContentLabelComponent, {
+const ContentLabel = Object.assign(ContentLabelComponent, {
 	ItemAfter,
 	ItemBefore,
 	ItemExpand,
 });
 
+export {ContentLabel, ItemAfter, ItemBefore, ItemExpand};
 export default Label;


### PR DESCRIPTION
This fixes the stable build failure related to the `ContentLabel` import. The [original PR](https://github.com/liferay-page-management/liferay-portal/pull/18611) for LPD-89205 contained two LPD-90973 commits, but these commits were somehow dropped in the [merged PR](https://github.com/brianchandotcom/liferay-portal/pull/177978).

So this fix is a simple cherry-pick of these two commits.