### PR TITLE
LPD-85980 Add upgrade replacement for hasVisibleCustomFields

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -5912,6 +5912,18 @@
 		"issueKey": "LPD-82354"
 	},
 	{
+		"from": "CustomFieldsUtil.hasVisibleCustomFields",
+		"issueKey": "LPD-85980",
+		"newImports": [
+			"com.liferay.expando.util.ExpandoAttributesUtil"
+		],
+		"to": "ExpandoAttributesUtil.hasVisibleAttributes",
+		"validExtensions": [
+			"java",
+			"jsp"
+		]
+	},
+	{
 		"from": "regex:MultiVMPoolUtil\\s*.\\s*getPortalCache\\(\\s*(?<prefixMethodName>[\\s\\S]*?)\\)",
 		"issueKey": "LPS-153962",
 		"newImports": [

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_85980.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_85980.testjava
@@ -1,0 +1,19 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+import com.liferay.expando.util.ExpandoAttributesUtil;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class LPD_85980 {
+
+	public void method(long companyId, Class<?> clazz) {
+		ExpandoAttributesUtil.hasVisibleAttributes(companyId, clazz);
+	}
+
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_85980.testjsp
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_85980.testjsp
@@ -1,0 +1,12 @@
+<%--
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+--%>
+
+<%@ page import="com.liferay.expando.util.ExpandoAttributesUtil" %>
+
+<%
+boolean hasVisibleCustomFields = ExpandoAttributesUtil.hasVisibleAttributes(companyId, clazz);
+%>

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_85980.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_85980.testjava
@@ -1,0 +1,17 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class LPD_85980 {
+
+	public void method(long companyId, Class<?> clazz) {
+		CustomFieldsUtil.hasVisibleCustomFields(companyId, clazz);
+	}
+
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_85980.testjsp
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_85980.testjsp
@@ -1,0 +1,10 @@
+<%--
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+--%>
+
+<%
+boolean hasVisibleCustomFields = CustomFieldsUtil.hasVisibleCustomFields(companyId, clazz);
+%>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-85980

## What Is Being Fixed

`CustomFieldsUtil.hasVisibleCustomFields` was replaced by `ExpandoAttributesUtil.hasVisibleAttributes`, but the source formatter's upgrade catch-all check did not know about the migration, so custom code calling the old API was left untouched during upgrades.

## How It Is Being Fixed

A replacement entry is added to the source formatter's `replacements.json` so the upgrade catch-all check rewrites `CustomFieldsUtil.hasVisibleCustomFields` to `ExpandoAttributesUtil.hasVisibleAttributes` and adds the `com.liferay.expando.util.ExpandoAttributesUtil` import, for both `.java` and `.jsp` files. Before/expected test fixtures for Java and JSP cover the replacement.

## PR Check

**pr-check: PASS** — tested on `0fa728cadbe0c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "0fa728cadbe0c87e759add55bebb0e1e2242c02d"} -->
