### PR TITLE
LPD-89205 Fix stable build failure from dropped clay-label commits

### DIFF
--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/AGENTS.md
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/AGENTS.md
@@ -174,6 +174,7 @@ Release notes:
 - Keep public API changes intentional and typed; match existing prop/type naming patterns in the package.
 - Never import across package source paths (for example, `../../clay-button/src`). Always import from package entry points (`@clayui/...`).
 - If a cross-package import is needed and the dependency is missing, add that package as an explicit dependency in the consuming package.
+- Re-export a package's public symbols from its entry point (`src/index.tsx`) using the specifier form — `export {Foo, Bar};` — rather than inline `export const`/`function`/`class`. DXP consumes Clay from source, and the DXP export bridge (`modules/frontend-sdk/node-scripts/util/esbuild/util/getExportedSymbols.mjs`) infers a package's exports by AST-parsing the entry module. It only recognizes export specifiers; inline `export const Foo = ...` declarations are silently dropped, so DXP modules that `import {Foo}` fail to build with `No matching export ... for import "Foo"`. Sibling packages such as `clay-drop-down` and `clay-button` follow the specifier form.
 - For CSS/Sass work, follow `clay/clay-css/CONTRIBUTING.md`:
     - hard tabs
     - alphabetical property ordering

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-label/src/index.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-label/src/index.tsx
@@ -29,7 +29,7 @@ export type ContentLabelDisplayType =
 	| 'content-7'
 	| 'content-8';
 
-export const ItemAfter = React.forwardRef<
+const ItemAfter = React.forwardRef<
 	HTMLSpanElement,
 	React.HTMLAttributes<HTMLSpanElement>
 >(({children, className, ...otherProps}, ref) => (
@@ -44,7 +44,7 @@ export const ItemAfter = React.forwardRef<
 
 ItemAfter.displayName = 'ClayLabelItemAfter';
 
-export const ItemBefore = React.forwardRef<
+const ItemBefore = React.forwardRef<
 	HTMLSpanElement,
 	React.HTMLAttributes<HTMLSpanElement>
 >(({children, className, ...otherProps}, ref) => (
@@ -59,7 +59,7 @@ export const ItemBefore = React.forwardRef<
 
 ItemBefore.displayName = 'ClayLabelItemBefore';
 
-export const ItemExpand = React.forwardRef<
+const ItemExpand = React.forwardRef<
 	HTMLAnchorElement | HTMLSpanElement,
 	React.BaseHTMLAttributes<HTMLAnchorElement | HTMLSpanElement>
 >(({children, className, href, ...otherProps}, ref) => {
@@ -245,10 +245,11 @@ const ContentLabelComponent = React.forwardRef<
 
 ContentLabelComponent.displayName = 'ClayContentLabel';
 
-export const ContentLabel = Object.assign(ContentLabelComponent, {
+const ContentLabel = Object.assign(ContentLabelComponent, {
 	ItemAfter,
 	ItemBefore,
 	ItemExpand,
 });
 
+export {ContentLabel, ItemAfter, ItemBefore, ItemExpand};
 export default Label;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89205

## What Is Being Fixed

Building `layout-content-page-editor-web`'s `StyleBooksList.js` fails with `No matching export in "build/node-scripts/import/@clayui$label.js" for import "ContentLabel"`. The DXP frontend export bridge infers a package's exported symbols by parsing its entry module's AST, but it only recognizes the `export {Foo}` specifier form, not inline `export const`/`function`/`class` declarations. `@clayui/label`'s `src/index.tsx` declared `ContentLabel`, `ItemAfter`, `ItemBefore`, and `ItemExpand` inline with `export const`, so the bridge silently dropped them and only exposed the default `Label` export, breaking any consumer importing a named export from `@clayui/label`.

This fix already existed: [PR #18672](https://github.com/liferay-page-management/liferay-portal/pull/18672) for LPD-90973 fixed it upstream, but the two commits landing that fix were dropped when merged into this fork, leaving the break in place.

## How It Is Being Fixed

Cherry-picks the two missing commits verbatim:

- `45bb93f` switches `ContentLabel`, `ItemAfter`, `ItemBefore`, and `ItemExpand` from inline `export const` declarations to plain `const` plus a trailing `export {...}` specifier statement — the form the export bridge already parses correctly, matching sibling packages like `clay-drop-down` and `clay-button`.
- `5540b88` documents this specifier-form requirement in `clay/AGENTS.md` so the constraint doesn't regress silently again.

No other behavior changes.

## Why Are There No Tests?

These are cherry-picks of already-reviewed commits from LPD-90973 restoring code that was dropped during a prior merge; no new behavior is introduced, so no new test coverage is needed.

## PR Check

**pr-check: PASS** — tested on `5540b88aef4ee5e7fee3b1aaa6b8e405be132967`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "5540b88aef4ee5e7fee3b1aaa6b8e405be132967"} -->
