### PR TITLE
LPD-96562 Disable view connected sites action in the standalone CMS

### DIFF
--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/AssetLibraryResourceImpl.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/AssetLibraryResourceImpl.java
@@ -70,6 +70,8 @@ import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 import org.osgi.service.component.annotations.ServiceScope;
 
 /**
@@ -830,9 +832,12 @@ public class AssetLibraryResourceImpl extends BaseAssetLibraryResourceImpl {
 		new AssetLibraryEntityModel();
 
 	@Reference(
-		target = "(component.name=com.liferay.headless.asset.library.internal.dto.v1_0.converter.AssetLibraryDTOConverter)"
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(dto.class.name=com.liferay.depot.model.DepotEntry)"
 	)
-	private DTOConverter<DepotEntry, AssetLibrary> _assetLibraryDTOConverter;
+	private volatile DTOConverter<DepotEntry, AssetLibrary>
+		_assetLibraryDTOConverter;
 
 	@Reference
 	private CompanyLocalService _companyLocalService;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BreadcrumbDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BreadcrumbDisplayContext.java
@@ -9,6 +9,8 @@ import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.model.DepotEntryPin;
 import com.liferay.depot.service.DepotEntryPinLocalService;
 import com.liferay.exportimport.constants.ExportImportPortletKeys;
+import com.liferay.headless.asset.library.dto.v1_0.AssetLibrary;
+import com.liferay.headless.asset.library.resource.v1_0.AssetLibraryResource;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -41,6 +43,7 @@ import jakarta.portlet.PortletURL;
 
 import jakarta.servlet.http.HttpServletRequest;
 
+import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -50,13 +53,13 @@ import java.util.Map;
 public class BreadcrumbDisplayContext {
 
 	public BreadcrumbDisplayContext(
-		ModelResourcePermission<DepotEntry> depotEntryModelResourcePermission,
+		AssetLibraryResource.Factory assetLibraryResourceFactory,
 		DepotEntryPinLocalService depotEntryPinLocalService, long groupId,
 		GroupLocalService groupLocalService,
 		ModelResourcePermission<Group> groupModelResourcePermission,
 		HttpServletRequest httpServletRequest, String size) {
 
-		_depotEntryModelResourcePermission = depotEntryModelResourcePermission;
+		_assetLibraryResourceFactory = assetLibraryResourceFactory;
 		_depotEntryPinLocalService = depotEntryPinLocalService;
 		_groupId = groupId;
 		_groupLocalService = groupLocalService;
@@ -223,31 +226,38 @@ public class BreadcrumbDisplayContext {
 							).put(
 								"target", "manageMembersModal"
 							));
-						unsafeConsumer.accept(
-							JSONUtil.put(
-								"href", StringPool.BLANK
-							).put(
-								"label",
-								LanguageUtil.get(
-									_httpServletRequest, "view-connected-sites")
-							).put(
-								"manageConnectedSitesData",
-								HashMapBuilder.<String, Object>put(
-									"externalReferenceCode",
-									group.getExternalReferenceCode()
+
+						Map<String, Map<String, String>> actions =
+							_getAssetLibraryActions(group);
+
+						if (actions.containsKey("connect-sites") ||
+							actions.containsKey("view-connected-sites")) {
+
+							unsafeConsumer.accept(
+								JSONUtil.put(
+									"href", StringPool.BLANK
 								).put(
-									"hasConnectSitesPermission",
-									_depotEntryModelResourcePermission.contains(
-										permissionChecker, group.getClassPK(),
-										ActionKeys.UPDATE)
-								).build()
-							).put(
-								"redirect", _themeDisplay.getURLCurrent()
-							).put(
-								"symbolLeft", "globe"
-							).put(
-								"target", "manageConnectedSitesModal"
-							));
+									"label",
+									LanguageUtil.get(
+										_httpServletRequest,
+										"view-connected-sites")
+								).put(
+									"manageConnectedSitesData",
+									HashMapBuilder.<String, Object>put(
+										"externalReferenceCode",
+										group.getExternalReferenceCode()
+									).put(
+										"hasConnectSitesPermission",
+										actions.containsKey("connect-sites")
+									).build()
+								).put(
+									"redirect", _themeDisplay.getURLCurrent()
+								).put(
+									"symbolLeft", "globe"
+								).put(
+									"target", "manageConnectedSitesModal"
+								));
+						}
 					}
 
 					if (permissionChecker.hasPermission(
@@ -393,6 +403,32 @@ public class BreadcrumbDisplayContext {
 		).build();
 	}
 
+	private Map<String, Map<String, String>> _getAssetLibraryActions(
+			Group group)
+		throws Exception {
+
+		AssetLibraryResource assetLibraryResource =
+			_assetLibraryResourceFactory.create(
+			).httpServletRequest(
+				_httpServletRequest
+			).preferredLocale(
+				_themeDisplay.getLocale()
+			).user(
+				_themeDisplay.getUser()
+			).build();
+
+		AssetLibrary assetLibrary = assetLibraryResource.getAssetLibrary(
+			group.getExternalReferenceCode());
+
+		Map<String, Map<String, String>> actions = assetLibrary.getActions();
+
+		if (actions == null) {
+			return Collections.emptyMap();
+		}
+
+		return actions;
+	}
+
 	private String _getControlPanelPortletURL(String portletId)
 		throws Exception {
 
@@ -426,8 +462,7 @@ public class BreadcrumbDisplayContext {
 		return jsonArray;
 	}
 
-	private final ModelResourcePermission<DepotEntry>
-		_depotEntryModelResourcePermission;
+	private final AssetLibraryResource.Factory _assetLibraryResourceFactory;
 	private final DepotEntryPinLocalService _depotEntryPinLocalService;
 	private final long _groupId;
 	private final GroupLocalService _groupLocalService;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BreadcrumbDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BreadcrumbDisplayContext.java
@@ -11,6 +11,7 @@ import com.liferay.depot.service.DepotEntryPinLocalService;
 import com.liferay.exportimport.constants.ExportImportPortletKeys;
 import com.liferay.headless.asset.library.dto.v1_0.AssetLibrary;
 import com.liferay.headless.asset.library.resource.v1_0.AssetLibraryResource;
+import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -83,301 +84,273 @@ public class BreadcrumbDisplayContext {
 		return HashMapBuilder.<String, Object>put(
 			"actionItems",
 			_putAll(
-				unsafeConsumer -> {
-					PermissionChecker permissionChecker =
-						_themeDisplay.getPermissionChecker();
+				unsafeBiConsumer -> {
+					DepotEntryPin depotEntryPin =
+						_depotEntryPinLocalService.fetchGroupDepotEntryPin(
+							_groupId, _themeDisplay.getUserId());
 
-					if (permissionChecker.hasPermission(
-							group, DepotEntry.class.getName(),
-							group.getClassPK(), ActionKeys.UPDATE)) {
+					unsafeBiConsumer.accept(
+						_hasUpdatePermission() && (depotEntryPin == null),
+						JSONUtil.put(
+							"href",
+							StringBundler.concat(
+								"/o/headless-asset-library/v1.0",
+								"/asset-libraries/",
+								group.getExternalReferenceCode(), "/pins")
+						).put(
+							"label",
+							LanguageUtil.get(
+								_httpServletRequest, "pin-to-product-menu")
+						).put(
+							"redirect", _themeDisplay.getURLCurrent()
+						).put(
+							"successMessage",
+							LanguageUtil.get(
+								_httpServletRequest,
+								"the-space-has-been-successfully-pinned-to-" +
+									"the-product-menu")
+						).put(
+							"symbolLeft", "pin"
+						).put(
+							"target", "asyncPut"
+						));
+					unsafeBiConsumer.accept(
+						_hasUpdatePermission() && (depotEntryPin != null),
+						JSONUtil.put(
+							"href",
+							StringBundler.concat(
+								"/o/headless-asset-library/v1.0",
+								"/asset-libraries/",
+								group.getExternalReferenceCode(), "/pins")
+						).put(
+							"label",
+							LanguageUtil.get(
+								_httpServletRequest, "unpin-from-product-menu")
+						).put(
+							"redirect", _themeDisplay.getURLCurrent()
+						).put(
+							"successMessage",
+							LanguageUtil.get(
+								_httpServletRequest,
+								"the-space-has-been-successfully-unpinned-" +
+									"from-the-product-menu")
+						).put(
+							"symbolLeft", "unpin"
+						).put(
+							"target", "asyncDelete"
+						));
 
-						DepotEntryPin depotEntryPin =
-							_depotEntryPinLocalService.fetchGroupDepotEntryPin(
-								_groupId, _themeDisplay.getUserId());
-
-						if (depotEntryPin == null) {
-							unsafeConsumer.accept(
-								JSONUtil.put(
-									"href",
-									StringBundler.concat(
-										"/o/headless-asset-library/v1.0",
-										"/asset-libraries/",
-										group.getExternalReferenceCode(),
-										"/pins")
-								).put(
-									"label",
-									LanguageUtil.get(
-										_httpServletRequest,
-										"pin-to-product-menu")
-								).put(
-									"redirect", _themeDisplay.getURLCurrent()
-								).put(
-									"successMessage",
-									LanguageUtil.get(
-										_httpServletRequest,
-										"the-space-has-been-successfully-" +
-											"pinned-to-the-product-menu")
-								).put(
-									"symbolLeft", "pin"
-								).put(
-									"target", "asyncPut"
-								));
-						}
-						else {
-							unsafeConsumer.accept(
-								JSONUtil.put(
-									"href",
-									StringBundler.concat(
-										"/o/headless-asset-library/v1.0",
-										"/asset-libraries/",
-										group.getExternalReferenceCode(),
-										"/pins")
-								).put(
-									"label",
-									LanguageUtil.get(
-										_httpServletRequest,
-										"unpin-from-product-menu")
-								).put(
-									"redirect", _themeDisplay.getURLCurrent()
-								).put(
-									"successMessage",
-									LanguageUtil.get(
-										_httpServletRequest,
-										"the-space-has-been-successfully-" +
-											"unpinned-from-the-product-menu")
-								).put(
-									"symbolLeft", "unpin"
-								).put(
-									"target", "asyncDelete"
-								));
-						}
-
-						unsafeConsumer.accept(
-							JSONUtil.put(
-								"href",
-								ActionUtil.getSpaceSettingsURL(
-									group.getClassPK(),
-									_themeDisplay.getURLCurrent(),
-									_themeDisplay)
+					unsafeBiConsumer.accept(
+						_hasUpdatePermission(),
+						JSONUtil.put(
+							"href",
+							ActionUtil.getSpaceSettingsURL(
+								group.getClassPK(),
+								_themeDisplay.getURLCurrent(), _themeDisplay)
+						).put(
+							"label",
+							LanguageUtil.get(
+								_httpServletRequest, "space-settings")
+						).put(
+							"symbolLeft", "cog"
+						));
+					unsafeBiConsumer.accept(
+						_hasUpdatePermission(),
+						JSONUtil.put(
+							"href",
+							_getControlPanelPortletURL(
+								ExportImportPortletKeys.EXPORT)
+						).put(
+							"label",
+							LanguageUtil.get(_httpServletRequest, "export")
+						).put(
+							"symbolLeft", "export"
+						));
+					unsafeBiConsumer.accept(
+						_hasUpdatePermission(),
+						JSONUtil.put(
+							"href",
+							_getControlPanelPortletURL(
+								ExportImportPortletKeys.IMPORT)
+						).put(
+							"label",
+							LanguageUtil.get(_httpServletRequest, "import")
+						).put(
+							"symbolLeft", "import"
+						));
+					unsafeBiConsumer.accept(
+						_hasViewPermission(),
+						JSONUtil.put(
+							"href", StringPool.BLANK
+						).put(
+							"label",
+							LanguageUtil.get(
+								_httpServletRequest, "view-members")
+						).put(
+							"manageMembersData",
+							HashMapBuilder.<String, Object>put(
+								"assetLibraryCreatorUserId",
+								_themeDisplay.getUserId()
 							).put(
-								"label",
-								LanguageUtil.get(
-									_httpServletRequest, "space-settings")
+								"externalReferenceCode",
+								group.getExternalReferenceCode()
 							).put(
-								"symbolLeft", "cog"
-							));
-						unsafeConsumer.accept(
-							JSONUtil.put(
-								"href",
-								_getControlPanelPortletURL(
-									ExportImportPortletKeys.EXPORT)
-							).put(
-								"label",
-								LanguageUtil.get(_httpServletRequest, "export")
-							).put(
-								"symbolLeft", "export"
-							));
-						unsafeConsumer.accept(
-							JSONUtil.put(
-								"href",
-								_getControlPanelPortletURL(
-									ExportImportPortletKeys.IMPORT)
-							).put(
-								"label",
-								LanguageUtil.get(_httpServletRequest, "import")
-							).put(
-								"symbolLeft", "import"
-							));
-					}
-
-					if (permissionChecker.hasPermission(
-							group, DepotEntry.class.getName(),
-							group.getClassPK(), ActionKeys.VIEW)) {
-
-						unsafeConsumer.accept(
-							JSONUtil.put(
-								"href", StringPool.BLANK
-							).put(
-								"label",
-								LanguageUtil.get(
-									_httpServletRequest, "view-members")
-							).put(
-								"manageMembersData",
-								HashMapBuilder.<String, Object>put(
-									"assetLibraryCreatorUserId",
-									_themeDisplay.getUserId()
-								).put(
-									"externalReferenceCode",
-									group.getExternalReferenceCode()
-								).put(
-									"hasAssignMembersPermission",
-									_groupModelResourcePermission.contains(
-										permissionChecker, group.getGroupId(),
-										ActionKeys.ASSIGN_MEMBERS)
-								).put(
-									"title",
-									LanguageUtil.get(
-										_httpServletRequest, "all-members")
-								).build()
-							).put(
-								"redirect", _themeDisplay.getURLCurrent()
-							).put(
-								"symbolLeft", "users"
-							).put(
-								"target", "manageMembersModal"
-							));
-
-						Map<String, Map<String, String>> actions =
-							_getAssetLibraryActions(group);
-
-						if (actions.containsKey("connect-sites") ||
-							actions.containsKey("view-connected-sites")) {
-
-							unsafeConsumer.accept(
-								JSONUtil.put(
-									"href", StringPool.BLANK
-								).put(
-									"label",
-									LanguageUtil.get(
-										_httpServletRequest,
-										"view-connected-sites")
-								).put(
-									"manageConnectedSitesData",
-									HashMapBuilder.<String, Object>put(
-										"externalReferenceCode",
-										group.getExternalReferenceCode()
-									).put(
-										"hasConnectSitesPermission",
-										actions.containsKey("connect-sites")
-									).build()
-								).put(
-									"redirect", _themeDisplay.getURLCurrent()
-								).put(
-									"symbolLeft", "globe"
-								).put(
-									"target", "manageConnectedSitesModal"
-								));
-						}
-					}
-
-					if (permissionChecker.hasPermission(
-							group, DepotEntry.class.getName(),
-							group.getClassPK(), ActionKeys.PERMISSIONS)) {
-
-						unsafeConsumer.accept(
-							JSONUtil.put(
-								"href",
-								PermissionsURLTag.doTag(
-									StringPool.BLANK,
-									DepotEntry.class.getName(), group.getName(),
+								"hasAssignMembersPermission",
+								_groupModelResourcePermission.contains(
+									_themeDisplay.getPermissionChecker(),
 									group.getGroupId(),
-									String.valueOf(group.getClassPK()),
-									LiferayWindowState.POP_UP.toString(), null,
-									_httpServletRequest)
+									ActionKeys.ASSIGN_MEMBERS)
 							).put(
-								"label",
+								"title",
 								LanguageUtil.get(
-									_httpServletRequest, "permissions")
-							).put(
-								"symbolLeft", "password-policies"
-							).put(
-								"target", "modal"
-							));
-						unsafeConsumer.accept(
-							JSONUtil.put(
-								"defaultPermissionAdditionalProps",
-								HashMapBuilder.putAll(
-									PermissionUtil.
-										getDefaultPermissionAdditionalProps(
-											_httpServletRequest, _themeDisplay)
-								).put(
-									"classExternalReferenceCode",
-									group.getExternalReferenceCode()
-								).put(
-									"className", DepotEntry.class.getName()
-								).build()
-							).put(
-								"href", StringPool.BLANK
-							).put(
-								"label",
-								LanguageUtil.get(
-									_httpServletRequest, "default-permissions")
-							).put(
-								"symbolLeft", "password-policies"
-							).put(
-								"target", "defaultPermissionsModal"
-							));
-						unsafeConsumer.accept(
-							JSONUtil.put(
-								"defaultPermissionAdditionalProps",
-								HashMapBuilder.putAll(
-									PermissionUtil.
-										getDefaultPermissionAdditionalProps(
-											true, _httpServletRequest,
-											_themeDisplay)
-								).put(
-									"classExternalReferenceCode",
-									group.getExternalReferenceCode()
-								).put(
-									"className", DepotEntry.class.getName()
-								).build()
-							).put(
-								"href", StringPool.BLANK
-							).put(
-								"label",
-								LanguageUtil.get(
-									_httpServletRequest,
-									"edit-and-propagate-default-permissions")
-							).put(
-								"symbolLeft", "password-policies"
-							).put(
-								"target", "defaultPermissionsModal"
-							));
-					}
+									_httpServletRequest, "all-members")
+							).build()
+						).put(
+							"redirect", _themeDisplay.getURLCurrent()
+						).put(
+							"symbolLeft", "users"
+						).put(
+							"target", "manageMembersModal"
+						));
 
-					if (permissionChecker.hasPermission(
-							group, DepotEntry.class.getName(),
-							group.getClassPK(), ActionKeys.DELETE)) {
+					Map<String, Map<String, String>> actions =
+						_getAssetLibraryActions(group);
 
-						unsafeConsumer.accept(
-							JSONUtil.put(
-								"confirmationMessage",
-								LanguageUtil.get(
-									_httpServletRequest,
-									"delete-space-confirmation-body")
+					unsafeBiConsumer.accept(
+						_hasViewPermission() &&
+						(actions.containsKey("connect-sites") ||
+						 actions.containsKey("view-connected-sites")),
+						JSONUtil.put(
+							"href", StringPool.BLANK
+						).put(
+							"label",
+							LanguageUtil.get(
+								_httpServletRequest, "view-connected-sites")
+						).put(
+							"manageConnectedSitesData",
+							HashMapBuilder.<String, Object>put(
+								"externalReferenceCode",
+								group.getExternalReferenceCode()
 							).put(
-								"confirmationTitle",
-								LanguageUtil.format(
-									_httpServletRequest,
-									"delete-space-confirmation-title",
-									group.getDescriptiveName())
+								"hasConnectSitesPermission",
+								actions.containsKey("connect-sites")
+							).build()
+						).put(
+							"redirect", _themeDisplay.getURLCurrent()
+						).put(
+							"symbolLeft", "globe"
+						).put(
+							"target", "manageConnectedSitesModal"
+						));
+
+					unsafeBiConsumer.accept(
+						_hasPermissionsPermission(),
+						JSONUtil.put(
+							"href",
+							PermissionsURLTag.doTag(
+								StringPool.BLANK, DepotEntry.class.getName(),
+								group.getName(), group.getGroupId(),
+								String.valueOf(group.getClassPK()),
+								LiferayWindowState.POP_UP.toString(), null,
+								_httpServletRequest)
+						).put(
+							"label",
+							LanguageUtil.get(_httpServletRequest, "permissions")
+						).put(
+							"symbolLeft", "password-policies"
+						).put(
+							"target", "modal"
+						));
+					unsafeBiConsumer.accept(
+						_hasPermissionsPermission(),
+						JSONUtil.put(
+							"defaultPermissionAdditionalProps",
+							HashMapBuilder.putAll(
+								PermissionUtil.
+									getDefaultPermissionAdditionalProps(
+										_httpServletRequest, _themeDisplay)
 							).put(
-								"href",
-								StringBundler.concat(
-									"/o/headless-asset-library/v1.0",
-									"/asset-libraries/",
-									group.getExternalReferenceCode())
+								"classExternalReferenceCode",
+								group.getExternalReferenceCode()
 							).put(
-								"label",
-								LanguageUtil.get(_httpServletRequest, "delete")
+								"className", DepotEntry.class.getName()
+							).build()
+						).put(
+							"href", StringPool.BLANK
+						).put(
+							"label",
+							LanguageUtil.get(
+								_httpServletRequest, "default-permissions")
+						).put(
+							"symbolLeft", "password-policies"
+						).put(
+							"target", "defaultPermissionsModal"
+						));
+					unsafeBiConsumer.accept(
+						_hasPermissionsPermission(),
+						JSONUtil.put(
+							"defaultPermissionAdditionalProps",
+							HashMapBuilder.putAll(
+								PermissionUtil.
+									getDefaultPermissionAdditionalProps(
+										true, _httpServletRequest,
+										_themeDisplay)
 							).put(
-								"redirect",
-								StringBundler.concat(
-									_themeDisplay.getPathFriendlyURLPublic(),
-									GroupConstants.CMS_FRIENDLY_URL,
-									"/all-spaces")
+								"classExternalReferenceCode",
+								group.getExternalReferenceCode()
 							).put(
-								"successMessage",
-								LanguageUtil.format(
-									_httpServletRequest,
-									"x-was-successfully-deleted",
-									group.getDescriptiveName())
-							).put(
-								"symbolLeft", "trash"
-							).put(
-								"target", "asyncDelete"
-							));
-					}
+								"className", DepotEntry.class.getName()
+							).build()
+						).put(
+							"href", StringPool.BLANK
+						).put(
+							"label",
+							LanguageUtil.get(
+								_httpServletRequest,
+								"edit-and-propagate-default-permissions")
+						).put(
+							"symbolLeft", "password-policies"
+						).put(
+							"target", "defaultPermissionsModal"
+						));
+					unsafeBiConsumer.accept(
+						_hasPermission(ActionKeys.DELETE),
+						JSONUtil.put(
+							"confirmationMessage",
+							LanguageUtil.get(
+								_httpServletRequest,
+								"delete-space-confirmation-body")
+						).put(
+							"confirmationTitle",
+							LanguageUtil.format(
+								_httpServletRequest,
+								"delete-space-confirmation-title",
+								group.getDescriptiveName())
+						).put(
+							"href",
+							StringBundler.concat(
+								"/o/headless-asset-library/v1.0",
+								"/asset-libraries/",
+								group.getExternalReferenceCode())
+						).put(
+							"label",
+							LanguageUtil.get(_httpServletRequest, "delete")
+						).put(
+							"redirect",
+							StringBundler.concat(
+								_themeDisplay.getPathFriendlyURLPublic(),
+								GroupConstants.CMS_FRIENDLY_URL, "/all-spaces")
+						).put(
+							"successMessage",
+							LanguageUtil.format(
+								_httpServletRequest,
+								"x-was-successfully-deleted",
+								group.getDescriptiveName())
+						).put(
+							"symbolLeft", "trash"
+						).put(
+							"target", "asyncDelete"
+						));
 				})
 		).put(
 			"breadcrumbItems",
@@ -406,6 +379,10 @@ public class BreadcrumbDisplayContext {
 	private Map<String, Map<String, String>> _getAssetLibraryActions(
 			Group group)
 		throws Exception {
+
+		if (!_hasViewPermission()) {
+			return Collections.emptyMap();
+		}
 
 		AssetLibraryResource assetLibraryResource =
 			_assetLibraryResourceFactory.create(
@@ -443,17 +420,61 @@ public class BreadcrumbDisplayContext {
 	}
 
 	private Group _getGroup() throws Exception {
-		return _groupLocalService.getGroup(_groupId);
+		if (_group == null) {
+			_group = _groupLocalService.getGroup(_groupId);
+		}
+
+		return _group;
+	}
+
+	private boolean _hasPermission(String actionId) throws Exception {
+		PermissionChecker permissionChecker =
+			_themeDisplay.getPermissionChecker();
+
+		Group group = _getGroup();
+
+		return permissionChecker.hasPermission(
+			group, DepotEntry.class.getName(), group.getClassPK(), actionId);
+	}
+
+	private boolean _hasPermissionsPermission() throws Exception {
+		if (_hasPermissionsPermission == null) {
+			_hasPermissionsPermission = _hasPermission(ActionKeys.PERMISSIONS);
+		}
+
+		return _hasPermissionsPermission;
+	}
+
+	private boolean _hasUpdatePermission() throws Exception {
+		if (_hasUpdatePermission == null) {
+			_hasUpdatePermission = _hasPermission(ActionKeys.UPDATE);
+		}
+
+		return _hasUpdatePermission;
+	}
+
+	private boolean _hasViewPermission() throws Exception {
+		if (_hasViewPermission == null) {
+			_hasViewPermission = _hasPermission(ActionKeys.VIEW);
+		}
+
+		return _hasViewPermission;
 	}
 
 	private JSONArray _putAll(
-			UnsafeConsumer<UnsafeConsumer<JSONObject, Exception>, Exception>
-				unsafeConsumer)
+			UnsafeConsumer
+				<UnsafeBiConsumer<Boolean, JSONObject, Exception>, Exception>
+					unsafeConsumer)
 		throws Exception {
 
 		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
 
-		unsafeConsumer.accept(jsonArray::put);
+		unsafeConsumer.accept(
+			(boolean1, jsonObject) -> {
+				if (boolean1) {
+					jsonArray.put(jsonObject);
+				}
+			});
 
 		if (jsonArray.length() == 0) {
 			return null;
@@ -464,9 +485,13 @@ public class BreadcrumbDisplayContext {
 
 	private final AssetLibraryResource.Factory _assetLibraryResourceFactory;
 	private final DepotEntryPinLocalService _depotEntryPinLocalService;
+	private Group _group;
 	private final long _groupId;
 	private final GroupLocalService _groupLocalService;
 	private final ModelResourcePermission<Group> _groupModelResourcePermission;
+	private Boolean _hasPermissionsPermission;
+	private Boolean _hasUpdatePermission;
+	private Boolean _hasViewPermission;
 	private final HttpServletRequest _httpServletRequest;
 	private final String _size;
 	private final ThemeDisplay _themeDisplay;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/BreadcrumbComponentSectionFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/BreadcrumbComponentSectionFragmentRenderer.java
@@ -5,10 +5,10 @@
 
 package com.liferay.site.cms.site.initializer.internal.fragment.renderer;
 
-import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryPinLocalService;
 import com.liferay.fragment.renderer.FragmentRenderer;
 import com.liferay.fragment.renderer.FragmentRendererContext;
+import com.liferay.headless.asset.library.resource.v1_0.AssetLibraryResource;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
@@ -53,7 +53,7 @@ public class BreadcrumbComponentSectionFragmentRenderer
 
 		BreadcrumbDisplayContext breadcrumbDisplayContext =
 			new BreadcrumbDisplayContext(
-				_depotEntryModelResourcePermission, _depotEntryPinLocalService,
+				_assetLibraryResourceFactory, _depotEntryPinLocalService,
 				InfoItemUtil.getGroupId(httpServletRequest), _groupLocalService,
 				_groupModelResourcePermission, httpServletRequest,
 				CMSSpaceConstants.SPACE_STICKER_MD);
@@ -61,9 +61,8 @@ public class BreadcrumbComponentSectionFragmentRenderer
 		return breadcrumbDisplayContext.getProps();
 	}
 
-	@Reference(target = "(model.class.name=com.liferay.depot.model.DepotEntry)")
-	private ModelResourcePermission<DepotEntry>
-		_depotEntryModelResourcePermission;
+	@Reference
+	private AssetLibraryResource.Factory _assetLibraryResourceFactory;
 
 	@Reference
 	private DepotEntryPinLocalService _depotEntryPinLocalService;

--- a/modules/apps/site/site-cms-standalone-site-initializer/build.gradle
+++ b/modules/apps/site/site-cms-standalone-site-initializer/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+	compileOnly group: "com.liferay", name: "jakarta.ws.rs", version: "3.1.0.LIFERAY-PATCHED-1"
 	compileOnly group: "com.liferay.jakarta.portlet", name: "com.liferay.jakarta.portlet-api", version: "4.0.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "default"
@@ -25,6 +26,8 @@ dependencies {
 	compileOnly project(":apps:export-import:export-import-api")
 	compileOnly project(":apps:fragment:fragment-api")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-react")
+	compileOnly project(":apps:headless:headless-asset-library:headless-asset-library-api")
+	compileOnly project(":apps:info:info-api")
 	compileOnly project(":apps:journal:journal-api")
 	compileOnly project(":apps:knowledge-base:knowledge-base-api")
 	compileOnly project(":apps:layout:layout-admin-api")
@@ -35,6 +38,7 @@ dependencies {
 	compileOnly project(":apps:message-boards:message-boards-api")
 	compileOnly project(":apps:notification:notification-api")
 	compileOnly project(":apps:on-demand-admin:on-demand-admin-api")
+	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")
 	compileOnly project(":apps:portal-workflow:portal-workflow-api")
 	compileOnly project(":apps:portal:portal-instance-lifecycle-api")
 	compileOnly project(":apps:push-notifications:push-notifications-api")

--- a/modules/apps/site/site-cms-standalone-site-initializer/src/main/java/com/liferay/site/cms/standalone/site/initializer/internal/dto/v1_0/converter/CMSAssetLibraryDTOConverter.java
+++ b/modules/apps/site/site-cms-standalone-site-initializer/src/main/java/com/liferay/site/cms/standalone/site/initializer/internal/dto/v1_0/converter/CMSAssetLibraryDTOConverter.java
@@ -1,0 +1,81 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.standalone.site.initializer.internal.dto.v1_0.converter;
+
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.headless.asset.library.dto.v1_0.AssetLibrary;
+import com.liferay.portal.vulcan.dto.converter.DTOConverter;
+import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
+
+import jakarta.ws.rs.core.UriInfo;
+
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Adolfo Pérez
+ */
+@Component(
+	property = {
+		"dto.class.name=com.liferay.depot.model.DepotEntry",
+		"service.ranking:Integer=100"
+	},
+	service = DTOConverter.class
+)
+public class CMSAssetLibraryDTOConverter
+	implements DTOConverter<DepotEntry, AssetLibrary> {
+
+	@Override
+	public String getContentType() {
+		return _dtoConverter.getContentType();
+	}
+
+	@Override
+	public String getJaxRsLink(long classPK, UriInfo uriInfo) {
+		return _dtoConverter.getJaxRsLink(classPK, uriInfo);
+	}
+
+	@Override
+	public AssetLibrary toDTO(DTOConverterContext dtoConverterContext)
+		throws Exception {
+
+		_removeConnectedSitesActions(dtoConverterContext);
+
+		return _dtoConverter.toDTO(dtoConverterContext);
+	}
+
+	@Override
+	public AssetLibrary toDTO(
+			DTOConverterContext dtoConverterContext, DepotEntry depotEntry)
+		throws Exception {
+
+		_removeConnectedSitesActions(dtoConverterContext);
+
+		return _dtoConverter.toDTO(dtoConverterContext, depotEntry);
+	}
+
+	private void _removeConnectedSitesActions(
+		DTOConverterContext dtoConverterContext) {
+
+		Map<String, Map<String, String>> actions =
+			dtoConverterContext.getActions();
+
+		if (actions == null) {
+			return;
+		}
+
+		actions.remove("connect-sites");
+		actions.remove("view-connected-sites");
+	}
+
+	@Reference(
+		target = "(component.name=com.liferay.headless.asset.library.internal.dto.v1_0.converter.AssetLibraryDTOConverter)"
+	)
+	private DTOConverter<DepotEntry, AssetLibrary> _dtoConverter;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96562

## What Is Being Fixed

In the standalone CMS, the space breadcrumb dropdown exposed connected-sites actions (such as "view connected sites") regardless of whether they applied, because their visibility was not driven by the headless asset library actions.

## How It Is Being Fixed

The breadcrumb display context now derives each dropdown action's enabled/disabled state from the headless AssetLibrary actions and the user's DepotEntry permissions, and a dedicated CMS asset library DTO converter surfaces the actions the standalone CMS needs. As part of unnesting the action-building logic, the permission checks were extracted into memoized helpers and the asset library actions lookup is skipped when the user lacks view permission.

## Why Are There No Tests?

This change only applies to the standalone CMS build, and there is currently no way to run tests exclusively for that build, so the change cannot be covered by an automated test.

## PR Check

**pr-check: PASS** — tested on `74065b0c3ee10de20fe636c4869d7bb1ec59ac06`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | PASS |

Integration Test Compile: the changed modules have no own `testIntegration`; `headless-asset-library-test` compiles clean. `site-cms-site-initializer-test` has a pre-existing compile break in `ViewCategoriesDisplayContextTest` (a drifted `AssetCategoryLocalService.addCategory` signature, unrelated to and untouched by this PR).

<!-- pr-check {"result": "success", "sha": "74065b0c3ee10de20fe636c4869d7bb1ec59ac06"} -->
