### PR TITLE
LPD-96310 Add support for system categories

### DIFF
--- a/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/exportimport/data/handler/AssetCategoryStagedModelDataHandler.java
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/exportimport/data/handler/AssetCategoryStagedModelDataHandler.java
@@ -264,8 +264,8 @@ public class AssetCategoryStagedModelDataHandler
 				portletDataContext.getScopeGroupId(), parentCategoryId,
 				_getCategoryTitleMap(
 					portletDataContext.getScopeGroupId(), category, name),
-				category.getDescriptionMap(), vocabularyId, properties,
-				serviceContext);
+				category.getDescriptionMap(), vocabularyId, category.isSystem(),
+				properties, serviceContext);
 		}
 		else {
 			String name = _getCategoryName(

--- a/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/portlet/action/EditAssetCategoryMVCActionCommand.java
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/portlet/action/EditAssetCategoryMVCActionCommand.java
@@ -92,7 +92,7 @@ public class EditAssetCategoryMVCActionCommand extends BaseMVCActionCommand {
 
 			category = _assetCategoryService.addCategory(
 				externalReferenceCode, groupId, parentCategoryId, titleMap,
-				descriptionMap, vocabularyId, null, serviceContext);
+				descriptionMap, vocabularyId, false, null, serviceContext);
 
 			MultiSessionMessages.add(
 				actionRequest, "categoryAdded",

--- a/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/service/AssetCategoryPropertyAssetCategoryLocalServiceWrapper.java
+++ b/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/service/AssetCategoryPropertyAssetCategoryLocalServiceWrapper.java
@@ -45,7 +45,8 @@ public class AssetCategoryPropertyAssetCategoryLocalServiceWrapper
 			String externalReferenceCode, long userId, long groupId,
 			long parentCategoryId, Map<Locale, String> titleMap,
 			Map<Locale, String> descriptionMap, long vocabularyId,
-			String[] categoryProperties, ServiceContext serviceContext)
+			boolean system, String[] categoryProperties,
+			ServiceContext serviceContext)
 		throws PortalException {
 
 		User user = _userLocalService.getUser(userId);
@@ -70,7 +71,8 @@ public class AssetCategoryPropertyAssetCategoryLocalServiceWrapper
 
 		AssetCategory assetCategory = super.addCategory(
 			externalReferenceCode, userId, groupId, parentCategoryId, titleMap,
-			descriptionMap, vocabularyId, categoryProperties, serviceContext);
+			descriptionMap, vocabularyId, system, categoryProperties,
+			serviceContext);
 
 		if (categoryProperties == null) {
 			return assetCategory;

--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/admin/web/internal/portlet/test/AssetCategoryAdminPortletTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/admin/web/internal/portlet/test/AssetCategoryAdminPortletTest.java
@@ -104,7 +104,8 @@ public class AssetCategoryAdminPortletTest {
 				HashMapBuilder.put(
 					LocaleUtil.US, RandomTestUtil.randomString()
 				).build(),
-				null, assetVocabulary.getVocabularyId(), null, serviceContext);
+				null, assetVocabulary.getVocabularyId(), false, null,
+				serviceContext);
 
 		assetCategories.add(childAssetCategory1);
 
@@ -115,7 +116,8 @@ public class AssetCategoryAdminPortletTest {
 				HashMapBuilder.put(
 					LocaleUtil.US, RandomTestUtil.randomString()
 				).build(),
-				null, assetVocabulary.getVocabularyId(), null, serviceContext);
+				null, assetVocabulary.getVocabularyId(), false, null,
+				serviceContext);
 
 		assetCategories.add(childAssetCategory2);
 

--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/exportimport/data/handler/test/AssetCategoryStagedModelDataHandlerTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/exportimport/data/handler/test/AssetCategoryStagedModelDataHandlerTest.java
@@ -69,7 +69,7 @@ public class AssetCategoryStagedModelDataHandlerTest
 				stagingGroup.getGroupId(),
 				AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID, titleMap,
 				Collections.emptyMap(), stagingVocabulary.getVocabularyId(),
-				null,
+				false, null,
 				ServiceContextTestUtil.getServiceContext(
 					stagingGroup.getGroupId()));
 
@@ -82,7 +82,8 @@ public class AssetCategoryStagedModelDataHandlerTest
 			externalReferenceCode, TestPropsValues.getUserId(),
 			liveGroup.getGroupId(),
 			AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID, titleMap,
-			Collections.emptyMap(), liveVocabulary.getVocabularyId(), null,
+			Collections.emptyMap(), liveVocabulary.getVocabularyId(), false,
+			null,
 			ServiceContextTestUtil.getServiceContext(liveGroup.getGroupId()));
 
 		importStagedModel(stagingCategory);

--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/internal/layout/display/page/test/AssetCategoryLayoutDisplayPageProviderTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/internal/layout/display/page/test/AssetCategoryLayoutDisplayPageProviderTest.java
@@ -77,7 +77,7 @@ public class AssetCategoryLayoutDisplayPageProviderTest {
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), title
 			).build(),
-			new HashMap<>(), assetVocabularyId, null,
+			new HashMap<>(), assetVocabularyId, false, null,
 			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 	}
 
@@ -99,7 +99,7 @@ public class AssetCategoryLayoutDisplayPageProviderTest {
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), StringUtil.randomString()
 			).build(),
-			AssetVocabularyConstants.EMPTY_VOCABULARY_ID, null,
+			AssetVocabularyConstants.EMPTY_VOCABULARY_ID, false, null,
 			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 
 		LayoutDisplayPageObjectProvider layoutDisplayPageObjectProvider =

--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetCategoryLocalServiceTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetCategoryLocalServiceTest.java
@@ -196,7 +196,7 @@ public class AssetCategoryLocalServiceTest {
 			HashMapBuilder.put(
 				locale, StringPool.BLANK
 			).build(),
-			assetVocabulary.getVocabularyId(), null,
+			assetVocabulary.getVocabularyId(), false, null,
 			ServiceContextTestUtil.getServiceContext(
 				_group.getGroupId(), TestPropsValues.getUserId()));
 
@@ -210,7 +210,7 @@ public class AssetCategoryLocalServiceTest {
 			HashMapBuilder.put(
 				locale, StringPool.BLANK
 			).build(),
-			assetVocabulary.getVocabularyId(), null,
+			assetVocabulary.getVocabularyId(), false, null,
 			ServiceContextTestUtil.getServiceContext(
 				_group.getGroupId(), TestPropsValues.getUserId()));
 	}
@@ -234,7 +234,8 @@ public class AssetCategoryLocalServiceTest {
 			AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
 			Collections.singletonMap(LocaleUtil.FRANCE, "Qualification"),
 			Collections.singletonMap(LocaleUtil.FRANCE, "La description"),
-			_assetVocabulary.getVocabularyId(), null, new ServiceContext());
+			_assetVocabulary.getVocabularyId(), false, null,
+			new ServiceContext());
 	}
 
 	@Test
@@ -262,7 +263,8 @@ public class AssetCategoryLocalServiceTest {
 			).put(
 				LocaleUtil.SPAIN, "Descripción"
 			).build(),
-			_assetVocabulary.getVocabularyId(), null, new ServiceContext());
+			_assetVocabulary.getVocabularyId(), false, null,
+			new ServiceContext());
 
 		Assert.assertEquals(
 			"Expected title does not match", expectedAssetCategoryTitle,
@@ -290,7 +292,7 @@ public class AssetCategoryLocalServiceTest {
 			HashMapBuilder.put(
 				locale, StringPool.BLANK
 			).build(),
-			assetVocabulary.getVocabularyId(), null,
+			assetVocabulary.getVocabularyId(), false, null,
 			ServiceContextTestUtil.getServiceContext(
 				_group.getGroupId(), TestPropsValues.getUserId()));
 

--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetCategoryLocalServiceTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetCategoryLocalServiceTest.java
@@ -16,6 +16,7 @@ import com.liferay.asset.kernel.exception.DuplicateCategoryException;
 import com.liferay.asset.kernel.exception.DuplicateCategoryExternalReferenceCodeException;
 import com.liferay.asset.kernel.exception.NoSuchCategoryException;
 import com.liferay.asset.kernel.exception.NoSuchVocabularyException;
+import com.liferay.asset.kernel.exception.SystemCategoryException;
 import com.liferay.asset.kernel.model.AssetCategory;
 import com.liferay.asset.kernel.model.AssetCategoryConstants;
 import com.liferay.asset.kernel.model.AssetVocabulary;
@@ -23,6 +24,7 @@ import com.liferay.asset.kernel.model.AssetVocabularyConstants;
 import com.liferay.asset.kernel.service.AssetCategoryLocalService;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
 import com.liferay.asset.test.util.AssetTestUtil;
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.journal.constants.JournalFolderConstants;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.test.util.JournalTestUtil;
@@ -41,10 +43,12 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ListTypeLocalService;
 import com.liferay.portal.kernel.service.OrganizationLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
+import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.context.ContextUserReplace;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
@@ -61,6 +65,7 @@ import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -517,6 +522,20 @@ public class AssetCategoryLocalServiceTest {
 	}
 
 	@Test
+	public void testDeleteCategories() throws Exception {
+		AssetCategory assetCategory = _addSystemCategory();
+
+		AssertUtils.assertFailure(
+			SystemCategoryException.MustNotDelete.class,
+			StringBundler.concat(
+				"Category ", assetCategory.getCategoryId(),
+				" cannot be deleted"),
+			() -> _assetCategoryLocalService.deleteCategories(
+				new long[] {assetCategory.getCategoryId()}));
+	}
+
+	@FeatureFlag("LPD-86291")
+	@Test
 	public void testDeleteCategory() throws Exception {
 		Map<Locale, String> titleMap = HashMapBuilder.put(
 			LocaleUtil.US, RandomTestUtil.randomString()
@@ -572,6 +591,9 @@ public class AssetCategoryLocalServiceTest {
 		finally {
 			serviceRegistration.unregister();
 		}
+
+		_testDeleteCategorySystem();
+		_testDeleteCategorySystemWhenImporting();
 	}
 
 	@Test
@@ -873,6 +895,31 @@ public class AssetCategoryLocalServiceTest {
 				Assert.assertNotNull(assetCategoryParentCategoryIdException);
 			}
 		}
+	}
+
+	@FeatureFlag("LPD-86291")
+	@Test
+	public void testMoveCategory() throws Exception {
+		AssetCategory assetCategory = _addSystemCategory();
+
+		AssetVocabulary assetVocabulary =
+			_assetVocabularyLocalService.addVocabulary(
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				RandomTestUtil.randomString(),
+				ServiceContextTestUtil.getServiceContext(
+					_group.getGroupId(), TestPropsValues.getUserId()));
+
+		AssertUtils.assertFailure(
+			SystemCategoryException.MustNotModify.class,
+			StringBundler.concat(
+				"Category ", assetCategory.getCategoryId(),
+				" cannot be modified"),
+			() -> _assetCategoryLocalService.moveCategory(
+				assetCategory.getCategoryId(),
+				AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
+				assetVocabulary.getVocabularyId(),
+				ServiceContextTestUtil.getServiceContext(
+					_group.getGroupId(), TestPropsValues.getUserId())));
 	}
 
 	@Test
@@ -1243,6 +1290,16 @@ public class AssetCategoryLocalServiceTest {
 			assetCategory2.getCategoryId());
 	}
 
+	@FeatureFlag("LPD-86291")
+	@Test
+	public void testUpdateCategory() throws Exception {
+		_testUpdateCategorySystemDescription();
+		_testUpdateCategorySystemExternalReferenceCode();
+		_testUpdateCategorySystemRename();
+		_testUpdateCategorySystemWhenImporting();
+		_testUpdateCategorySystemWithNullDescription();
+	}
+
 	@Rule
 	public ExpectedException expectedException = ExpectedException.none();
 
@@ -1269,6 +1326,28 @@ public class AssetCategoryLocalServiceTest {
 			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID, serviceContext);
 	}
 
+	private AssetCategory _addSystemCategory() throws Exception {
+		return _addSystemCategory(
+			_group.getGroupId(), _assetVocabulary.getVocabularyId());
+	}
+
+	private AssetCategory _addSystemCategory(long groupId, long vocabularyId)
+		throws Exception {
+
+		return _assetCategoryLocalService.addCategory(
+			null, TestPropsValues.getUserId(), groupId,
+			AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
+			HashMapBuilder.put(
+				LocaleUtil.getSiteDefault(), RandomTestUtil.randomString()
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.getSiteDefault(), StringPool.BLANK
+			).build(),
+			vocabularyId, true, null,
+			ServiceContextTestUtil.getServiceContext(
+				groupId, TestPropsValues.getUserId()));
+	}
+
 	private void _testAssetCategoryLongTitlesAreTrimmed(
 		AssetCategory assetCategory, String title) {
 
@@ -1279,6 +1358,140 @@ public class AssetCategoryLocalServiceTest {
 		for (Map.Entry<Locale, String> entry : titleMap.entrySet()) {
 			Assert.assertEquals(title, entry.getValue());
 		}
+	}
+
+	private void _testDeleteCategorySystem() throws Exception {
+		AssetCategory assetCategory = _addSystemCategory();
+
+		AssertUtils.assertFailure(
+			SystemCategoryException.MustNotDelete.class,
+			StringBundler.concat(
+				"Category ", assetCategory.getCategoryId(),
+				" cannot be deleted"),
+			() -> _assetCategoryLocalService.deleteCategory(
+				assetCategory.getCategoryId()));
+	}
+
+	private void _testDeleteCategorySystemWhenImporting() throws Exception {
+		AssetCategory assetCategory = _addSystemCategory();
+
+		ExportImportThreadLocal.setPortletImportInProcess(true);
+
+		try {
+			_assetCategoryLocalService.deleteCategory(
+				assetCategory.getCategoryId());
+		}
+		finally {
+			ExportImportThreadLocal.setPortletImportInProcess(false);
+		}
+
+		Assert.assertNull(
+			_assetCategoryLocalService.fetchCategory(
+				assetCategory.getCategoryId()));
+	}
+
+	private void _testUpdateCategorySystemDescription() throws Exception {
+		AssetCategory assetCategory = _addSystemCategory();
+
+		AssertUtils.assertFailure(
+			SystemCategoryException.MustNotModify.class,
+			StringBundler.concat(
+				"Category ", assetCategory.getCategoryId(),
+				" cannot be modified"),
+			() -> _assetCategoryLocalService.updateCategory(
+				assetCategory.getExternalReferenceCode(),
+				TestPropsValues.getUserId(), assetCategory.getCategoryId(),
+				assetCategory.getParentCategoryId(),
+				assetCategory.getTitleMap(),
+				HashMapBuilder.put(
+					LocaleUtil.getSiteDefault(), RandomTestUtil.randomString()
+				).build(),
+				assetCategory.getVocabularyId(), null,
+				ServiceContextTestUtil.getServiceContext(
+					_group.getGroupId(), TestPropsValues.getUserId())));
+	}
+
+	private void _testUpdateCategorySystemExternalReferenceCode()
+		throws Exception {
+
+		AssetCategory assetCategory = _addSystemCategory();
+
+		AssertUtils.assertFailure(
+			SystemCategoryException.MustNotRename.class,
+			StringBundler.concat(
+				"Category ", assetCategory.getCategoryId(),
+				" cannot be renamed"),
+			() -> _assetCategoryLocalService.updateCategory(
+				RandomTestUtil.randomString(), TestPropsValues.getUserId(),
+				assetCategory.getCategoryId(),
+				assetCategory.getParentCategoryId(),
+				assetCategory.getTitleMap(), assetCategory.getDescriptionMap(),
+				assetCategory.getVocabularyId(), null,
+				ServiceContextTestUtil.getServiceContext(
+					_group.getGroupId(), TestPropsValues.getUserId())));
+	}
+
+	private void _testUpdateCategorySystemRename() throws Exception {
+		AssetCategory assetCategory = _addSystemCategory();
+
+		AssertUtils.assertFailure(
+			SystemCategoryException.MustNotRename.class,
+			StringBundler.concat(
+				"Category ", assetCategory.getCategoryId(),
+				" cannot be renamed"),
+			() -> _assetCategoryLocalService.updateCategory(
+				assetCategory.getExternalReferenceCode(),
+				TestPropsValues.getUserId(), assetCategory.getCategoryId(),
+				assetCategory.getParentCategoryId(),
+				HashMapBuilder.put(
+					LocaleUtil.getSiteDefault(), RandomTestUtil.randomString()
+				).build(),
+				assetCategory.getDescriptionMap(),
+				assetCategory.getVocabularyId(), null,
+				ServiceContextTestUtil.getServiceContext(
+					_group.getGroupId(), TestPropsValues.getUserId())));
+	}
+
+	private void _testUpdateCategorySystemWhenImporting() throws Exception {
+		AssetCategory assetCategory = _addSystemCategory();
+
+		String title = RandomTestUtil.randomString();
+
+		ExportImportThreadLocal.setPortletImportInProcess(true);
+
+		try {
+			assetCategory = _assetCategoryLocalService.updateCategory(
+				assetCategory.getExternalReferenceCode(),
+				TestPropsValues.getUserId(), assetCategory.getCategoryId(),
+				assetCategory.getParentCategoryId(),
+				HashMapBuilder.put(
+					LocaleUtil.getSiteDefault(), title
+				).build(),
+				assetCategory.getDescriptionMap(),
+				assetCategory.getVocabularyId(), null,
+				ServiceContextTestUtil.getServiceContext(
+					_group.getGroupId(), TestPropsValues.getUserId()));
+		}
+		finally {
+			ExportImportThreadLocal.setPortletImportInProcess(false);
+		}
+
+		Assert.assertTrue(assetCategory.isSystem());
+		Assert.assertEquals(title, assetCategory.getName());
+	}
+
+	private void _testUpdateCategorySystemWithNullDescription()
+		throws Exception {
+
+		AssetCategory assetCategory = _addSystemCategory();
+
+		_assetCategoryLocalService.updateCategory(
+			assetCategory.getExternalReferenceCode(),
+			TestPropsValues.getUserId(), assetCategory.getCategoryId(),
+			assetCategory.getParentCategoryId(), assetCategory.getTitleMap(),
+			null, assetCategory.getVocabularyId(), null,
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId()));
 	}
 
 	@Inject
@@ -1299,6 +1512,9 @@ public class AssetCategoryLocalServiceTest {
 
 	@DeleteAfterTestRun
 	private Group _group;
+
+	@Inject
+	private GroupLocalService _groupLocalService;
 
 	@Inject
 	private ListTypeLocalService _listTypeLocalService;

--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetCategoryServiceTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetCategoryServiceTest.java
@@ -163,7 +163,8 @@ public class AssetCategoryServiceTest {
 					LocaleUtil.US, RandomTestUtil.randomString()),
 				Collections.singletonMap(
 					LocaleUtil.US, RandomTestUtil.randomString()),
-				_assetVocabulary.getVocabularyId(), null, new ServiceContext());
+				_assetVocabulary.getVocabularyId(), false, null,
+				new ServiceContext());
 
 			assetCategory = _assetCategoryService.getOrAddEmptyCategory(
 				externalReferenceCode, _group.getGroupId());

--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetCategoryServiceTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetCategoryServiceTest.java
@@ -99,6 +99,8 @@ public class AssetCategoryServiceTest {
 		_testAddCategory(
 			String.valueOf(assetCategory.getPrimaryKey()),
 			RoleConstants.SITE_MEMBER);
+
+		_testAddCategorySystem();
 	}
 
 	@Test
@@ -330,6 +332,49 @@ public class AssetCategoryServiceTest {
 				ResourceConstants.SCOPE_INDIVIDUAL, primKey, role.getRoleId());
 
 		Assert.assertTrue(resourcePermission.hasActionId(ActionKeys.VIEW));
+	}
+
+	private void _testAddCategorySystem() throws Exception {
+		PermissionChecker originalPermissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		User user = UserTestUtil.addGroupUser(
+			_group, RoleConstants.SITE_ADMINISTRATOR);
+
+		PermissionThreadLocal.setPermissionChecker(
+			_permissionCheckerFactory.create(user));
+
+		Assert.assertNotNull(
+			_assetCategoryService.addCategory(
+				RandomTestUtil.randomString(), _group.getGroupId(),
+				AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
+				Collections.singletonMap(
+					LocaleUtil.US, RandomTestUtil.randomString()),
+				Collections.singletonMap(
+					LocaleUtil.US, RandomTestUtil.randomString()),
+				_assetVocabulary.getVocabularyId(), false, null,
+				ServiceContextTestUtil.getServiceContext(_group.getGroupId())));
+
+		try {
+			_assetCategoryService.addCategory(
+				RandomTestUtil.randomString(), _group.getGroupId(),
+				AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
+				Collections.singletonMap(
+					LocaleUtil.US, RandomTestUtil.randomString()),
+				Collections.singletonMap(
+					LocaleUtil.US, RandomTestUtil.randomString()),
+				_assetVocabulary.getVocabularyId(), true, null,
+				ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+			Assert.fail();
+		}
+		catch (PrincipalException.MustBeCompanyAdmin principalException) {
+			Assert.assertNotNull(principalException);
+		}
+
+		PermissionThreadLocal.setPermissionChecker(originalPermissionChecker);
+
+		_userLocalService.deleteUser(user);
 	}
 
 	@Inject

--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetVocabularyLocalServiceTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetVocabularyLocalServiceTest.java
@@ -14,12 +14,12 @@ import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.asset.kernel.model.AssetVocabularyConstants;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
 import com.liferay.asset.test.util.AssetTestUtil;
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.lazy.referencing.LazyReferencingThreadLocal;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.ModelHintsUtil;
-import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -76,7 +76,7 @@ public class AssetVocabularyLocalServiceTest {
 	@Test
 	public void testDeleteVocabulary() throws Exception {
 		_testDeleteVocabularySystem();
-		_testDeleteVocabularySystemWhenDeletingGroup();
+		_testDeleteVocabularySystemWhenImporting();
 	}
 
 	@Test
@@ -93,6 +93,8 @@ public class AssetVocabularyLocalServiceTest {
 		_testUpdateVocabularySystemMultiValued();
 		_testUpdateVocabularySystemRename();
 		_testUpdateVocabularySystemVisibilityType();
+		_testUpdateVocabularySystemWhenImporting();
+		_testUpdateVocabularySystemWithNullDescription();
 		_testUpdateVocabularyWithInvalidVisibilityType();
 		_testUpdateVocabularyWithLazyReferencingEnabled();
 	}
@@ -163,14 +165,18 @@ public class AssetVocabularyLocalServiceTest {
 				vocabulary.getVocabularyId()));
 	}
 
-	private void _testDeleteVocabularySystemWhenDeletingGroup()
-		throws Exception {
+	private void _testDeleteVocabularySystemWhenImporting() throws Exception {
+		AssetVocabulary vocabulary = _addSystemVocabulary();
 
-		Group group = GroupTestUtil.addGroup();
+		ExportImportThreadLocal.setPortletImportInProcess(true);
 
-		AssetVocabulary vocabulary = _addSystemVocabulary(group.getGroupId());
-
-		_groupLocalService.deleteGroup(group);
+		try {
+			_assetVocabularyLocalService.deleteVocabulary(
+				vocabulary.getVocabularyId());
+		}
+		finally {
+			ExportImportThreadLocal.setPortletImportInProcess(false);
+		}
 
 		Assert.assertNull(
 			_assetVocabularyLocalService.fetchAssetVocabulary(
@@ -300,6 +306,42 @@ public class AssetVocabularyLocalServiceTest {
 				AssetVocabularyConstants.VISIBILITY_TYPE_INTERNAL));
 	}
 
+	private void _testUpdateVocabularySystemWhenImporting() throws Exception {
+		AssetVocabulary vocabulary = _addSystemVocabulary();
+
+		ExportImportThreadLocal.setPortletImportInProcess(true);
+
+		try {
+			vocabulary = _assetVocabularyLocalService.updateVocabulary(
+				vocabulary.getExternalReferenceCode(),
+				vocabulary.getVocabularyId(),
+				HashMapBuilder.put(
+					LocaleUtil.getSiteDefault(), RandomTestUtil.randomString()
+				).build(),
+				vocabulary.getDescriptionMap(), vocabulary.getSettings(),
+				AssetVocabularyConstants.VISIBILITY_TYPE_INTERNAL);
+		}
+		finally {
+			ExportImportThreadLocal.setPortletImportInProcess(false);
+		}
+
+		Assert.assertTrue(vocabulary.isSystem());
+		Assert.assertEquals(
+			AssetVocabularyConstants.VISIBILITY_TYPE_INTERNAL,
+			vocabulary.getVisibilityType());
+	}
+
+	private void _testUpdateVocabularySystemWithNullDescription()
+		throws Exception {
+
+		AssetVocabulary vocabulary = _addSystemVocabulary();
+
+		_assetVocabularyLocalService.updateVocabulary(
+			vocabulary.getExternalReferenceCode(), vocabulary.getVocabularyId(),
+			vocabulary.getTitleMap(), null, vocabulary.getSettings(),
+			vocabulary.getVisibilityType());
+	}
+
 	private void _testUpdateVocabularyWithInvalidVisibilityType()
 		throws Exception {
 
@@ -362,8 +404,5 @@ public class AssetVocabularyLocalServiceTest {
 
 	@DeleteAfterTestRun
 	private Group _group;
-
-	@Inject
-	private GroupLocalService _groupLocalService;
 
 }

--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetVocabularyServiceTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetVocabularyServiceTest.java
@@ -67,6 +67,7 @@ import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portlet.asset.util.AssetVocabularySettingsHelper;
 import com.liferay.site.cms.site.initializer.test.util.CMSTestUtil;
 
 import java.util.List;
@@ -129,6 +130,8 @@ public class AssetVocabularyServiceTest {
 		_testAddVocabulary(
 			String.valueOf(vocabulary.getPrimaryKey()),
 			RoleConstants.SITE_MEMBER);
+
+		_testAddVocabularySystem();
 	}
 
 	@Test
@@ -684,6 +687,44 @@ public class AssetVocabularyServiceTest {
 	}
 
 	@Test
+	public void testUpdateVocabulary() throws Exception {
+		AssetVocabularySettingsHelper assetVocabularySettingsHelper =
+			new AssetVocabularySettingsHelper();
+
+		assetVocabularySettingsHelper.setSystem(true);
+
+		User user = UserTestUtil.addGroupUser(
+			_group, RoleConstants.SITE_ADMINISTRATOR);
+
+		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
+				user, PermissionCheckerFactoryUtil.create(user))) {
+
+			AssetVocabulary vocabulary = _assetVocabularyService.addVocabulary(
+				_group.getGroupId(), RandomTestUtil.randomString(),
+				HashMapBuilder.put(
+					LocaleUtil.getSiteDefault(), RandomTestUtil.randomString()
+				).build(),
+				null, null, AssetVocabularyConstants.VISIBILITY_TYPE_PUBLIC,
+				ServiceContextTestUtil.getServiceContext(
+					_group.getGroupId(), user.getUserId()));
+
+			try {
+				_assetVocabularyService.updateVocabulary(
+					vocabulary.getExternalReferenceCode(),
+					vocabulary.getVocabularyId(), vocabulary.getTitleMap(),
+					vocabulary.getDescriptionMap(),
+					assetVocabularySettingsHelper.toString(),
+					vocabulary.getVisibilityType());
+
+				Assert.fail();
+			}
+			catch (PrincipalException.MustBeCompanyAdmin principalException) {
+				Assert.assertNotNull(principalException);
+			}
+		}
+	}
+
+	@Test
 	public void testUpdateVocabularyLongTitlesAreTrimmed() throws Exception {
 		String name = RandomTestUtil.randomString();
 
@@ -750,6 +791,49 @@ public class AssetVocabularyServiceTest {
 				ResourceConstants.SCOPE_INDIVIDUAL, primKey, role.getRoleId());
 
 		Assert.assertTrue(resourcePermission.hasActionId(ActionKeys.VIEW));
+	}
+
+	private void _testAddVocabularySystem() throws Exception {
+		AssetVocabularySettingsHelper assetVocabularySettingsHelper =
+			new AssetVocabularySettingsHelper();
+
+		assetVocabularySettingsHelper.setSystem(true);
+
+		User user = UserTestUtil.addGroupUser(
+			_group, RoleConstants.SITE_ADMINISTRATOR);
+
+		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
+				user, PermissionCheckerFactoryUtil.create(user))) {
+
+			Assert.assertNotNull(
+				_assetVocabularyService.addVocabulary(
+					_group.getGroupId(), RandomTestUtil.randomString(),
+					HashMapBuilder.put(
+						LocaleUtil.getSiteDefault(),
+						RandomTestUtil.randomString()
+					).build(),
+					null, null, AssetVocabularyConstants.VISIBILITY_TYPE_PUBLIC,
+					ServiceContextTestUtil.getServiceContext(
+						_group.getGroupId(), user.getUserId())));
+
+			try {
+				_assetVocabularyService.addVocabulary(
+					_group.getGroupId(), RandomTestUtil.randomString(),
+					HashMapBuilder.put(
+						LocaleUtil.getSiteDefault(),
+						RandomTestUtil.randomString()
+					).build(),
+					null, assetVocabularySettingsHelper.toString(),
+					AssetVocabularyConstants.VISIBILITY_TYPE_PUBLIC,
+					ServiceContextTestUtil.getServiceContext(
+						_group.getGroupId(), user.getUserId()));
+
+				Assert.fail();
+			}
+			catch (PrincipalException.MustBeCompanyAdmin principalException) {
+				Assert.assertNotNull(principalException);
+			}
+		}
 	}
 
 	@Inject

--- a/modules/apps/asset/asset-category-property-test/src/testIntegration/java/com/liferay/asset/category/property/internal/upgrade/v2_4_0/test/AssetCategoryPropertyExternalReferenceCodeUpgradeProcessTest.java
+++ b/modules/apps/asset/asset-category-property-test/src/testIntegration/java/com/liferay/asset/category/property/internal/upgrade/v2_4_0/test/AssetCategoryPropertyExternalReferenceCodeUpgradeProcessTest.java
@@ -45,7 +45,7 @@ public class AssetCategoryPropertyExternalReferenceCodeUpgradeProcessTest
 		AssetCategory assetCategory = _assetCategoryLocalService.addCategory(
 			RandomTestUtil.randomString(), group.getCreatorUserId(),
 			group.getGroupId(), 0, RandomTestUtil.randomLocaleStringMap(), null,
-			assetVocabulary.getVocabularyId(), null,
+			assetVocabulary.getVocabularyId(), false, null,
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
 
 		return new ExternalReferenceCodeModel[] {

--- a/modules/apps/asset/asset-entry-query-processor-custom-user-attributes-test/src/testIntegration/java/com/liferay/asset/entry/query/processor/custom/user/attributes/internal/test/CustomUserAttributesAssetEntryQueryProcessorTest.java
+++ b/modules/apps/asset/asset-entry-query-processor-custom-user-attributes-test/src/testIntegration/java/com/liferay/asset/entry/query/processor/custom/user/attributes/internal/test/CustomUserAttributesAssetEntryQueryProcessorTest.java
@@ -201,7 +201,7 @@ public class CustomUserAttributesAssetEntryQueryProcessorTest {
 		return _assetCategoryLocalService.addCategory(
 			null, TestPropsValues.getUserId(), _companyGroup.getGroupId(),
 			AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID, titleMap,
-			Collections.emptyMap(), vocabularyId, null, _serviceContext);
+			Collections.emptyMap(), vocabularyId, false, null, _serviceContext);
 	}
 
 	private AssetCategory _addCategory(String name, long vocabularyId)

--- a/modules/apps/asset/asset-entry-rel-test/src/testIntegration/java/com/liferay/asset/entry/rel/test/AssetEntryAssetCategoryRelAssetEntryLocalServiceTest.java
+++ b/modules/apps/asset/asset-entry-rel-test/src/testIntegration/java/com/liferay/asset/entry/rel/test/AssetEntryAssetCategoryRelAssetEntryLocalServiceTest.java
@@ -154,7 +154,7 @@ public class AssetEntryAssetCategoryRelAssetEntryLocalServiceTest {
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			_assetVocabulary.getVocabularyId(), null, serviceContext);
+			_assetVocabulary.getVocabularyId(), false, null, serviceContext);
 
 		_assetCategories.add(assetCategory);
 

--- a/modules/apps/asset/asset-test-util/src/main/java/com/liferay/asset/test/util/AssetTestUtil.java
+++ b/modules/apps/asset/asset-test-util/src/main/java/com/liferay/asset/test/util/AssetTestUtil.java
@@ -93,7 +93,7 @@ public class AssetTestUtil {
 
 		return AssetCategoryLocalServiceUtil.addCategory(
 			null, TestPropsValues.getUserId(), groupId, parentCategoryId,
-			titleMap, descriptionMap, vocabularyId, categoryProperties,
+			titleMap, descriptionMap, vocabularyId, false, categoryProperties,
 			serviceContext);
 	}
 
@@ -118,7 +118,7 @@ public class AssetTestUtil {
 		return AssetCategoryLocalServiceUtil.addCategory(
 			externalReferenceCode, TestPropsValues.getUserId(), groupId,
 			AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID, titleMap,
-			descriptionMap, vocabularyId, null, serviceContext);
+			descriptionMap, vocabularyId, false, null, serviceContext);
 	}
 
 	public static AssetTag addTag(long groupId) throws Exception {

--- a/modules/apps/asset/asset-test/src/testIntegration/java/com/liferay/asset/info/item/provider/test/AssetEntryInfoItemFieldSetProviderTest.java
+++ b/modules/apps/asset/asset-test/src/testIntegration/java/com/liferay/asset/info/item/provider/test/AssetEntryInfoItemFieldSetProviderTest.java
@@ -418,7 +418,7 @@ public class AssetEntryInfoItemFieldSetProviderTest {
 			HashMapBuilder.put(
 				LocaleUtil.US, RandomTestUtil.randomString()
 			).build(),
-			null, assetVocabulary.getVocabularyId(), null,
+			null, assetVocabulary.getVocabularyId(), false, null,
 			new ServiceContext());
 	}
 

--- a/modules/apps/blogs/blogs-web-test/src/testIntegration/java/com/liferay/blogs/web/internal/display/context/test/BlogsEditEntryDisplayContextTest.java
+++ b/modules/apps/blogs/blogs-web-test/src/testIntegration/java/com/liferay/blogs/web/internal/display/context/test/BlogsEditEntryDisplayContextTest.java
@@ -376,7 +376,7 @@ public class BlogsEditEntryDisplayContextTest {
 					HashMapBuilder.put(
 						LocaleUtil.US, "cat" + i
 					).build(),
-					null, _assetVocabulary.getVocabularyId(), null,
+					null, _assetVocabulary.getVocabularyId(), false, null,
 					new ServiceContext());
 
 			_assetCategoryIds = ArrayUtil.append(

--- a/modules/apps/blogs/blogs-web-test/src/testIntegration/java/com/liferay/blogs/web/internal/display/context/test/BlogsViewEntriesDisplayContextTest.java
+++ b/modules/apps/blogs/blogs-web-test/src/testIntegration/java/com/liferay/blogs/web/internal/display/context/test/BlogsViewEntriesDisplayContextTest.java
@@ -207,7 +207,7 @@ public class BlogsViewEntriesDisplayContextTest {
 			HashMapBuilder.put(
 				LocaleUtil.US, RandomTestUtil.randomString()
 			).build(),
-			null, assetVocabulary.getVocabularyId(), null,
+			null, assetVocabulary.getVocabularyId(), false, null,
 			new ServiceContext());
 	}
 

--- a/modules/apps/blogs/blogs-web-test/src/testIntegration/java/com/liferay/blogs/web/internal/display/context/test/BlogsViewEntryContentDisplayContextTest.java
+++ b/modules/apps/blogs/blogs-web-test/src/testIntegration/java/com/liferay/blogs/web/internal/display/context/test/BlogsViewEntryContentDisplayContextTest.java
@@ -264,7 +264,7 @@ public class BlogsViewEntryContentDisplayContextTest {
 			HashMapBuilder.put(
 				LocaleUtil.US, "cat1"
 			).build(),
-			null, assetVocabulary.getVocabularyId(), null,
+			null, assetVocabulary.getVocabularyId(), false, null,
 			new ServiceContext());
 
 		serviceContext.setAssetCategoryIds(

--- a/modules/apps/commerce/commerce-initializer-util/src/main/java/com/liferay/commerce/initializer/util/AssetCategoriesImporter.java
+++ b/modules/apps/commerce/commerce-initializer-util/src/main/java/com/liferay/commerce/initializer/util/AssetCategoriesImporter.java
@@ -208,7 +208,7 @@ public class AssetCategoriesImporter {
 				null, serviceContext.getUserId(),
 				serviceContext.getScopeGroupId(),
 				AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID, titleMap,
-				null, assetVocabularyId, new String[0], serviceContext);
+				null, assetVocabularyId, false, new String[0], serviceContext);
 		}
 
 		// Commerce product friendly URL entry

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/product/internal/site/provider/test/CommerceSitemapURLProviderTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/product/internal/site/provider/test/CommerceSitemapURLProviderTest.java
@@ -177,7 +177,8 @@ public class CommerceSitemapURLProviderTest {
 		AssetCategory assetCategory = _assetCategoryLocalService.addCategory(
 			null, _serviceContext.getUserId(), assetVocabulary.getGroupId(),
 			AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID, titleMap, null,
-			assetVocabulary.getVocabularyId(), new String[0], _serviceContext);
+			assetVocabulary.getVocabularyId(), false, new String[0],
+			_serviceContext);
 
 		FriendlyURLEntry friendlyURLEntry =
 			_friendlyURLEntryLocalService.addFriendlyURLEntry(

--- a/modules/apps/external-reference/external-reference-service/src/main/java/com/liferay/external/reference/service/impl/ERAssetCategoryLocalServiceImpl.java
+++ b/modules/apps/external-reference/external-reference-service/src/main/java/com/liferay/external/reference/service/impl/ERAssetCategoryLocalServiceImpl.java
@@ -48,7 +48,7 @@ public class ERAssetCategoryLocalServiceImpl
 		if (assetCategory == null) {
 			assetCategory = _assetCategoryLocalService.addCategory(
 				null, userId, groupId, parentCategoryId, titleMap,
-				descriptionMap, vocabularyId, categoryProperties,
+				descriptionMap, vocabularyId, false, categoryProperties,
 				serviceContext);
 
 			assetCategory.setExternalReferenceCode(externalReferenceCode);

--- a/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/service/test/FriendlyURLEntryLocalServiceTest.java
+++ b/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/service/test/FriendlyURLEntryLocalServiceTest.java
@@ -861,7 +861,7 @@ public class FriendlyURLEntryLocalServiceTest {
 			).put(
 				new Locale("es", "ES"), "cat1-es"
 			).build(),
-			new HashMap<>(), assetVocabulary.getVocabularyId(), null,
+			new HashMap<>(), assetVocabulary.getVocabularyId(), false, null,
 			serviceContext);
 		AssetCategory assetCategory2 = _assetCategoryLocalService.addCategory(
 			null, TestPropsValues.getUserId(), _group.getGroupId(), 0,
@@ -870,7 +870,7 @@ public class FriendlyURLEntryLocalServiceTest {
 			).put(
 				new Locale("es", "ES"), "cat2-es"
 			).build(),
-			new HashMap<>(), assetVocabulary.getVocabularyId(), null,
+			new HashMap<>(), assetVocabulary.getVocabularyId(), false, null,
 			serviceContext);
 
 		serviceContext.setAttribute(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/util/AssetTestUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/util/AssetTestUtil.java
@@ -154,7 +154,8 @@ public class AssetTestUtil {
 					assetVocabulary.getGroupId(), 0,
 					RandomTestUtil.randomLocaleStringMap(),
 					RandomTestUtil.randomLocaleStringMap(),
-					assetVocabulary.getVocabularyId(), null, serviceContext));
+					assetVocabulary.getVocabularyId(), false, null,
+					serviceContext));
 		}
 
 		return assetCategories;

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyCategoryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyCategoryResourceImpl.java
@@ -719,7 +719,7 @@ public class TaxonomyCategoryResourceImpl
 		return _toTaxonomyCategory(
 			_assetCategoryService.addCategory(
 				externalReferenceCode, groupId, parentTaxonomyCategoryId,
-				titleMap, descriptionMap, taxonomyVocabularyId,
+				titleMap, descriptionMap, taxonomyVocabularyId, false,
 				_toStringArray(
 					taxonomyCategory.getTaxonomyCategoryProperties()),
 				_getServiceContext(groupId, taxonomyCategory)));

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyCategoryResourceTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyCategoryResourceTest.java
@@ -883,7 +883,7 @@ public class TaxonomyCategoryResourceTest
 			null, TestPropsValues.getUserId(), testGroup.getGroupId(),
 			parentAssetCategory.getCategoryId(),
 			RandomTestUtil.randomLocaleStringMap(), null,
-			assetVocabulary.getVocabularyId(), null, serviceContext);
+			assetVocabulary.getVocabularyId(), false, null, serviceContext);
 
 		assetCategory.setCreateDate(date);
 		assetCategory.setModifiedDate(date);

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BlogPostingResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BlogPostingResourceTest.java
@@ -192,7 +192,7 @@ public class BlogPostingResourceTest extends BaseBlogPostingResourceTestCase {
 		return _assetCategoryLocalService.addCategory(
 			RandomTestUtil.randomString(), group.getCreatorUserId(),
 			group.getGroupId(), 0, RandomTestUtil.randomLocaleStringMap(), null,
-			assetVocabulary.getVocabularyId(), null,
+			assetVocabulary.getVocabularyId(), false, null,
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/SitePageResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/SitePageResourceTest.java
@@ -2215,7 +2215,7 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 			RandomTestUtil.randomString(), irrelevantGroup.getCreatorUserId(),
 			irrelevantGroup.getGroupId(), 0,
 			RandomTestUtil.randomLocaleStringMap(), null,
-			assetVocabulary.getVocabularyId(), null,
+			assetVocabulary.getVocabularyId(), false, null,
 			ServiceContextTestUtil.getServiceContext(
 				irrelevantGroup.getGroupId()));
 
@@ -2343,7 +2343,7 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		AssetCategory assetCategory = _assetCategoryLocalService.addCategory(
 			RandomTestUtil.randomString(), testGroup.getCreatorUserId(),
 			testGroup.getGroupId(), 0, RandomTestUtil.randomLocaleStringMap(),
-			null, assetVocabulary.getVocabularyId(), null,
+			null, assetVocabulary.getVocabularyId(), false, null,
 			ServiceContextTestUtil.getServiceContext(testGroup.getGroupId()));
 
 		TaxonomyCategoryBrief[] expectedTaxonomyCategoryBriefs = {
@@ -2397,7 +2397,7 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		AssetCategory assetCategory = _assetCategoryLocalService.addCategory(
 			RandomTestUtil.randomString(), testGroup.getCreatorUserId(),
 			testGroup.getGroupId(), 0, RandomTestUtil.randomLocaleStringMap(),
-			null, assetVocabulary.getVocabularyId(), null,
+			null, assetVocabulary.getVocabularyId(), false, null,
 			ServiceContextTestUtil.getServiceContext(testGroup.getGroupId()));
 
 		TaxonomyCategoryBrief[] expectedTaxonomyCategoryBriefs = {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/WikiPageResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/WikiPageResourceTest.java
@@ -341,7 +341,7 @@ public class WikiPageResourceTest extends BaseWikiPageResourceTestCase {
 		AssetCategory assetCategory = _assetCategoryLocalService.addCategory(
 			RandomTestUtil.randomString(), testGroup.getCreatorUserId(),
 			testGroup.getGroupId(), 0, RandomTestUtil.randomLocaleStringMap(),
-			null, assetVocabulary.getVocabularyId(), null,
+			null, assetVocabulary.getVocabularyId(), false, null,
 			ServiceContextTestUtil.getServiceContext(testGroup.getGroupId()));
 
 		TaxonomyCategoryBrief[] expectedTaxonomyCategoryBriefs = {

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/exportimport/data/handler/test/JournalExportImportTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/exportimport/data/handler/test/JournalExportImportTest.java
@@ -442,7 +442,8 @@ public class JournalExportImportTest extends BasePortletExportImportTestCase {
 				HashMapBuilder.put(
 					LocaleUtil.getDefault(), RandomTestUtil.randomString()
 				).build(),
-				null, assetVocabulary.getVocabularyId(), null, serviceContext);
+				null, assetVocabulary.getVocabularyId(), false, null,
+				serviceContext);
 
 		serviceContext.setAssetCategoryIds(
 			new long[] {parentAssetCategory.getCategoryId()});

--- a/modules/apps/site-navigation/site-navigation-menu-item-asset-vocabulary-test/src/testIntegration/java/com/liferay/site/navigation/menu/item/asset/vocabulary/test/AssetVocabularySiteNavigationMenuItemTypeTest.java
+++ b/modules/apps/site-navigation/site-navigation-menu-item-asset-vocabulary-test/src/testIntegration/java/com/liferay/site/navigation/menu/item/asset/vocabulary/test/AssetVocabularySiteNavigationMenuItemTypeTest.java
@@ -361,7 +361,8 @@ public class AssetVocabularySiteNavigationMenuItemTypeTest {
 				null, TestPropsValues.getUserId(), _group.getGroupId(), 0,
 				RandomTestUtil.randomLocaleStringMap(),
 				RandomTestUtil.randomLocaleStringMap(),
-				_assetVocabulary.getVocabularyId(), null, serviceContext);
+				_assetVocabulary.getVocabularyId(), false, null,
+				serviceContext);
 
 		Assert.assertEquals(
 			2,
@@ -934,7 +935,7 @@ public class AssetVocabularySiteNavigationMenuItemTypeTest {
 			null, TestPropsValues.getUserId(), _group.getGroupId(),
 			parentAssetCategoryId, RandomTestUtil.randomLocaleStringMap(),
 			RandomTestUtil.randomLocaleStringMap(),
-			_assetVocabulary.getVocabularyId(), null, _serviceContext);
+			_assetVocabulary.getVocabularyId(), false, null, _serviceContext);
 	}
 
 	private SiteNavigationMenuItem _addSiteNavigationMenuItem(

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewCategoriesDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewCategoriesDisplayContextTest.java
@@ -86,7 +86,7 @@ public class ViewCategoriesDisplayContextTest
 			).put(
 				LocaleUtil.FRANCE, RandomTestUtil.randomString()
 			).build(),
-			Collections.emptyMap(), _assetVocabulary.getVocabularyId(),
+			Collections.emptyMap(), _assetVocabulary.getVocabularyId(), false,
 			new String[0],
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
 	}

--- a/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/service/test/GroupLocalServiceTest.java
+++ b/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/service/test/GroupLocalServiceTest.java
@@ -6,6 +6,12 @@
 package com.liferay.site.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.kernel.model.AssetCategory;
+import com.liferay.asset.kernel.model.AssetCategoryConstants;
+import com.liferay.asset.kernel.model.AssetVocabulary;
+import com.liferay.asset.kernel.model.AssetVocabularyConstants;
+import com.liferay.asset.kernel.service.AssetCategoryLocalService;
+import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -37,6 +43,7 @@ import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portlet.asset.util.AssetVocabularySettingsHelper;
 
 import java.util.List;
 
@@ -189,6 +196,52 @@ public class GroupLocalServiceTest {
 		finally {
 			_companyLocalService.deleteCompany(company);
 		}
+	}
+
+	@FeatureFlag("LPD-86291")
+	@Test
+	public void testDeleteGroup() throws Exception {
+		Group group = GroupTestUtil.addGroup();
+
+		AssetVocabularySettingsHelper assetVocabularySettingsHelper =
+			new AssetVocabularySettingsHelper();
+
+		assetVocabularySettingsHelper.setMultiValued(true);
+		assetVocabularySettingsHelper.setSystem(true);
+
+		AssetVocabulary assetVocabulary =
+			_assetVocabularyLocalService.addVocabulary(
+				null, TestPropsValues.getUserId(), group.getGroupId(),
+				RandomTestUtil.randomString(), null,
+				HashMapBuilder.put(
+					LocaleUtil.getSiteDefault(), RandomTestUtil.randomString()
+				).build(),
+				null, assetVocabularySettingsHelper.toString(),
+				AssetVocabularyConstants.VISIBILITY_TYPE_PUBLIC,
+				ServiceContextTestUtil.getServiceContext(
+					group.getGroupId(), TestPropsValues.getUserId()));
+
+		AssetCategory assetCategory = _assetCategoryLocalService.addCategory(
+			null, TestPropsValues.getUserId(), group.getGroupId(),
+			AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
+			HashMapBuilder.put(
+				LocaleUtil.getSiteDefault(), RandomTestUtil.randomString()
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.getSiteDefault(), StringPool.BLANK
+			).build(),
+			assetVocabulary.getVocabularyId(), true, null,
+			ServiceContextTestUtil.getServiceContext(
+				group.getGroupId(), TestPropsValues.getUserId()));
+
+		_groupLocalService.deleteGroup(group);
+
+		Assert.assertNull(
+			_assetVocabularyLocalService.fetchAssetVocabulary(
+				assetVocabulary.getVocabularyId()));
+		Assert.assertNull(
+			_assetCategoryLocalService.fetchAssetCategory(
+				assetCategory.getCategoryId()));
 	}
 
 	@FeatureFlag("LPD-82960")
@@ -344,6 +397,12 @@ public class GroupLocalServiceTest {
 		"/api", "/c", "/combo", "/documents", "/group", "/html", "/image",
 		"/layouttpl", "/o", "/web", "/webdav"
 	};
+
+	@Inject
+	private AssetCategoryLocalService _assetCategoryLocalService;
+
+	@Inject
+	private AssetVocabularyLocalService _assetVocabularyLocalService;
 
 	@Inject
 	private ClassNameLocalService _classNameLocalService;

--- a/modules/apps/staging/staging-test/src/testIntegration/java/com/liferay/staging/test/StagingImplTest.java
+++ b/modules/apps/staging/staging-test/src/testIntegration/java/com/liferay/staging/test/StagingImplTest.java
@@ -584,8 +584,8 @@ public class StagingImplTest {
 
 		return AssetCategoryLocalServiceUtil.addCategory(
 			null, TestPropsValues.getUserId(), groupId, 0, titleMap,
-			descriptionMap, assetVocabulary.getVocabularyId(), new String[0],
-			serviceContext);
+			descriptionMap, assetVocabulary.getVocabularyId(), false,
+			new String[0], serviceContext);
 	}
 
 	protected void doTestInitialPublication() throws Exception {

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/asset/service/persistence/test/AssetCategoryPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/asset/service/persistence/test/AssetCategoryPersistenceTest.java
@@ -148,6 +148,8 @@ public class AssetCategoryPersistenceTest {
 
 		newAssetCategory.setVocabularyId(RandomTestUtil.nextLong());
 
+		newAssetCategory.setSystem(RandomTestUtil.randomBoolean());
+
 		newAssetCategory.setLastPublishDate(RandomTestUtil.nextDate());
 
 		newAssetCategory.setStatus(RandomTestUtil.nextInt());
@@ -205,6 +207,8 @@ public class AssetCategoryPersistenceTest {
 		Assert.assertEquals(
 			existingAssetCategory.getVocabularyId(),
 			newAssetCategory.getVocabularyId());
+		Assert.assertEquals(
+			existingAssetCategory.isSystem(), newAssetCategory.isSystem());
 		Assert.assertEquals(
 			Time.getShortTimestamp(existingAssetCategory.getLastPublishDate()),
 			Time.getShortTimestamp(newAssetCategory.getLastPublishDate()));
@@ -439,7 +443,7 @@ public class AssetCategoryPersistenceTest {
 			"groupId", true, "companyId", true, "userId", true, "userName",
 			true, "createDate", true, "modifiedDate", true, "parentCategoryId",
 			true, "treePath", true, "name", true, "vocabularyId", true,
-			"lastPublishDate", true, "status", true);
+			"system", true, "lastPublishDate", true, "status", true);
 	}
 
 	@Test
@@ -780,6 +784,8 @@ public class AssetCategoryPersistenceTest {
 
 		assetCategory.setVocabularyId(RandomTestUtil.nextLong());
 
+		assetCategory.setSystem(RandomTestUtil.randomBoolean());
+
 		assetCategory.setLastPublishDate(RandomTestUtil.nextDate());
 
 		assetCategory.setStatus(RandomTestUtil.nextInt());
@@ -795,4 +801,4 @@ public class AssetCategoryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1772366963
+// LIFERAY-SERVICE-BUILDER-HASH:563891789

--- a/portal-impl/bnd.bnd
+++ b/portal-impl/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 129.0.1
+Bundle-Version: 129.1.0
 CPE-Name: ${cpe.name}
 Export-Package:\
 	com.liferay.portal.bean,\

--- a/portal-impl/src/META-INF/portal-hbm.xml
+++ b/portal-impl/src/META-INF/portal-hbm.xml
@@ -1294,6 +1294,7 @@
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="title" type="com.liferay.portal.dao.orm.hibernate.StringClobType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="description" type="com.liferay.portal.dao.orm.hibernate.StringClobType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="vocabularyId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" column="system_" name="system" type="com.liferay.portal.dao.orm.hibernate.BooleanType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="lastPublishDate" type="timestamp" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="status" type="com.liferay.portal.dao.orm.hibernate.IntegerType" />
 	</class>

--- a/portal-impl/src/META-INF/portal-model-hints.xml
+++ b/portal-impl/src/META-INF/portal-model-hints.xml
@@ -108,6 +108,7 @@
 			<hint name="display-width">350</hint>
 		</field>
 		<field name="vocabularyId" type="long" />
+		<field name="system" type="boolean" />
 		<field name="lastPublishDate" type="Date" />
 		<field name="status" type="int" />
 	</model>

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
@@ -783,6 +783,11 @@ public class PortalUpgradeProcessRegistryImpl
 				"AssetVocabularyGroupRel", "depotEntryType INTEGER"),
 			UpgradeProcessFactory.runSQL(
 				"update AssetVocabularyGroupRel set depotEntryType = 1"));
+
+		upgradeVersionTreeMap.put(
+			new Version(38, 7, 0),
+			UpgradeProcessFactory.addColumns(
+				"AssetCategory", "system_ BOOLEAN"));
 	}
 
 }

--- a/portal-impl/src/com/liferay/portlet/asset/model/impl/AssetCategoryCacheModel.java
+++ b/portal-impl/src/com/liferay/portlet/asset/model/impl/AssetCategoryCacheModel.java
@@ -68,7 +68,7 @@ public class AssetCategoryCacheModel
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(39);
+		StringBundler sb = new StringBundler(41);
 
 		sb.append("{mvccVersion=");
 		sb.append(mvccVersion);
@@ -104,6 +104,8 @@ public class AssetCategoryCacheModel
 		sb.append(description);
 		sb.append(", vocabularyId=");
 		sb.append(vocabularyId);
+		sb.append(", system=");
+		sb.append(system);
 		sb.append(", lastPublishDate=");
 		sb.append(lastPublishDate);
 		sb.append(", status=");
@@ -191,6 +193,7 @@ public class AssetCategoryCacheModel
 		}
 
 		assetCategoryImpl.setVocabularyId(vocabularyId);
+		assetCategoryImpl.setSystem(system);
 
 		if (lastPublishDate == Long.MIN_VALUE) {
 			assetCategoryImpl.setLastPublishDate(null);
@@ -234,6 +237,8 @@ public class AssetCategoryCacheModel
 		description = (String)objectInput.readObject();
 
 		vocabularyId = objectInput.readLong();
+
+		system = objectInput.readBoolean();
 		lastPublishDate = objectInput.readLong();
 
 		status = objectInput.readInt();
@@ -308,6 +313,8 @@ public class AssetCategoryCacheModel
 		}
 
 		objectOutput.writeLong(vocabularyId);
+
+		objectOutput.writeBoolean(system);
 		objectOutput.writeLong(lastPublishDate);
 
 		objectOutput.writeInt(status);
@@ -330,8 +337,9 @@ public class AssetCategoryCacheModel
 	public String title;
 	public String description;
 	public long vocabularyId;
+	public boolean system;
 	public long lastPublishDate;
 	public int status;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1753721811
+// LIFERAY-SERVICE-BUILDER-HASH:299791781

--- a/portal-impl/src/com/liferay/portlet/asset/model/impl/AssetCategoryModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/model/impl/AssetCategoryModelImpl.java
@@ -79,8 +79,8 @@ public class AssetCategoryModelImpl
 		{"modifiedDate", Types.TIMESTAMP}, {"parentCategoryId", Types.BIGINT},
 		{"treePath", Types.VARCHAR}, {"name", Types.VARCHAR},
 		{"title", Types.CLOB}, {"description", Types.CLOB},
-		{"vocabularyId", Types.BIGINT}, {"lastPublishDate", Types.TIMESTAMP},
-		{"status", Types.INTEGER}
+		{"vocabularyId", Types.BIGINT}, {"system_", Types.BOOLEAN},
+		{"lastPublishDate", Types.TIMESTAMP}, {"status", Types.INTEGER}
 	};
 
 	public static final Map<String, Integer> TABLE_COLUMNS_MAP =
@@ -104,12 +104,13 @@ public class AssetCategoryModelImpl
 		TABLE_COLUMNS_MAP.put("title", Types.CLOB);
 		TABLE_COLUMNS_MAP.put("description", Types.CLOB);
 		TABLE_COLUMNS_MAP.put("vocabularyId", Types.BIGINT);
+		TABLE_COLUMNS_MAP.put("system_", Types.BOOLEAN);
 		TABLE_COLUMNS_MAP.put("lastPublishDate", Types.TIMESTAMP);
 		TABLE_COLUMNS_MAP.put("status", Types.INTEGER);
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table AssetCategory (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,categoryId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,parentCategoryId LONG,treePath STRING null,name VARCHAR(255) null,title TEXT null,description TEXT null,vocabularyId LONG,lastPublishDate DATE null,status INTEGER,primary key (categoryId, ctCollectionId))";
+		"create table AssetCategory (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,categoryId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,parentCategoryId LONG,treePath STRING null,name VARCHAR(255) null,title TEXT null,description TEXT null,vocabularyId LONG,system_ BOOLEAN,lastPublishDate DATE null,status INTEGER,primary key (categoryId, ctCollectionId))";
 
 	public static final String TABLE_SQL_DROP = "drop table AssetCategory";
 
@@ -328,6 +329,7 @@ public class AssetCategoryModelImpl
 				"description", AssetCategory::getDescription);
 			attributeGetterFunctions.put(
 				"vocabularyId", AssetCategory::getVocabularyId);
+			attributeGetterFunctions.put("system", AssetCategory::getSystem);
 			attributeGetterFunctions.put(
 				"lastPublishDate", AssetCategory::getLastPublishDate);
 			attributeGetterFunctions.put("status", AssetCategory::getStatus);
@@ -405,6 +407,9 @@ public class AssetCategoryModelImpl
 				"vocabularyId",
 				(BiConsumer<AssetCategory, Long>)
 					AssetCategory::setVocabularyId);
+			attributeSetterBiConsumers.put(
+				"system",
+				(BiConsumer<AssetCategory, Boolean>)AssetCategory::setSystem);
 			attributeSetterBiConsumers.put(
 				"lastPublishDate",
 				(BiConsumer<AssetCategory, Date>)
@@ -989,6 +994,27 @@ public class AssetCategoryModelImpl
 
 	@JSON
 	@Override
+	public boolean getSystem() {
+		return _system;
+	}
+
+	@JSON
+	@Override
+	public boolean isSystem() {
+		return _system;
+	}
+
+	@Override
+	public void setSystem(boolean system) {
+		if (_columnOriginalValues == Collections.EMPTY_MAP) {
+			_setColumnOriginalValues();
+		}
+
+		_system = system;
+	}
+
+	@JSON
+	@Override
 	public Date getLastPublishDate() {
 		return _lastPublishDate;
 	}
@@ -1184,6 +1210,7 @@ public class AssetCategoryModelImpl
 		assetCategoryImpl.setTitle(getTitle());
 		assetCategoryImpl.setDescription(getDescription());
 		assetCategoryImpl.setVocabularyId(getVocabularyId());
+		assetCategoryImpl.setSystem(isSystem());
 		assetCategoryImpl.setLastPublishDate(getLastPublishDate());
 		assetCategoryImpl.setStatus(getStatus());
 
@@ -1228,6 +1255,8 @@ public class AssetCategoryModelImpl
 			this.<String>getColumnOriginalValue("description"));
 		assetCategoryImpl.setVocabularyId(
 			this.<Long>getColumnOriginalValue("vocabularyId"));
+		assetCategoryImpl.setSystem(
+			this.<Boolean>getColumnOriginalValue("system_"));
 		assetCategoryImpl.setLastPublishDate(
 			this.<Date>getColumnOriginalValue("lastPublishDate"));
 		assetCategoryImpl.setStatus(
@@ -1402,6 +1431,8 @@ public class AssetCategoryModelImpl
 
 		assetCategoryCacheModel.vocabularyId = getVocabularyId();
 
+		assetCategoryCacheModel.system = isSystem();
+
 		Date lastPublishDate = getLastPublishDate();
 
 		if (lastPublishDate != null) {
@@ -1494,6 +1525,7 @@ public class AssetCategoryModelImpl
 	private String _description;
 	private String _descriptionCurrentLanguageId;
 	private long _vocabularyId;
+	private boolean _system;
 	private Date _lastPublishDate;
 	private int _status;
 
@@ -1545,6 +1577,7 @@ public class AssetCategoryModelImpl
 		_columnOriginalValues.put("title", _title);
 		_columnOriginalValues.put("description", _description);
 		_columnOriginalValues.put("vocabularyId", _vocabularyId);
+		_columnOriginalValues.put("system_", _system);
 		_columnOriginalValues.put("lastPublishDate", _lastPublishDate);
 		_columnOriginalValues.put("status", _status);
 	}
@@ -1555,6 +1588,7 @@ public class AssetCategoryModelImpl
 		Map<String, String> attributeNames = new HashMap<>();
 
 		attributeNames.put("uuid_", "uuid");
+		attributeNames.put("system_", "system");
 
 		_attributeNames = Collections.unmodifiableMap(attributeNames);
 	}
@@ -1604,9 +1638,11 @@ public class AssetCategoryModelImpl
 
 		columnBitmasks.put("vocabularyId", 65536L);
 
-		columnBitmasks.put("lastPublishDate", 131072L);
+		columnBitmasks.put("system_", 131072L);
 
-		columnBitmasks.put("status", 262144L);
+		columnBitmasks.put("lastPublishDate", 262144L);
+
+		columnBitmasks.put("status", 524288L);
 
 		_columnBitmasks = Collections.unmodifiableMap(columnBitmasks);
 	}
@@ -1615,4 +1651,4 @@ public class AssetCategoryModelImpl
 	private AssetCategory _escapedModel;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1836741370
+// LIFERAY-SERVICE-BUILDER-HASH:1057895887

--- a/portal-impl/src/com/liferay/portlet/asset/model/impl/packageinfo
+++ b/portal-impl/src/com/liferay/portlet/asset/model/impl/packageinfo
@@ -1,1 +1,1 @@
-version 7.7.0
+version 7.8.0

--- a/portal-impl/src/com/liferay/portlet/asset/service.xml
+++ b/portal-impl/src/com/liferay/portlet/asset/service.xml
@@ -29,6 +29,7 @@
 		<column localized="true" name="title" type="String" />
 		<column localized="true" name="description" type="String" />
 		<column name="vocabularyId" type="long" />
+		<column name="system" type="boolean" />
 		<column name="lastPublishDate" type="Date" />
 		<column name="status" type="int" />
 
@@ -384,6 +385,7 @@
 		<exception>DuplicateVocabulary</exception>
 		<exception>DuplicateVocabularyExternalReferenceCode</exception>
 		<exception>InvalidAssetCategory</exception>
+		<exception>SystemCategory</exception>
 		<exception>SystemVocabulary</exception>
 		<exception>VocabularyExternalReferenceCode</exception>
 		<exception>VocabularyName</exception>

--- a/portal-impl/src/com/liferay/portlet/asset/service/http/AssetCategoryServiceHttp.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/http/AssetCategoryServiceHttp.java
@@ -133,7 +133,7 @@ public class AssetCategoryServiceHttp {
 			long groupId, long parentCategoryId,
 			java.util.Map<java.util.Locale, String> titleMap,
 			java.util.Map<java.util.Locale, String> descriptionMap,
-			long vocabularyId, String[] categoryProperties,
+			long vocabularyId, boolean system, String[] categoryProperties,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
@@ -144,8 +144,8 @@ public class AssetCategoryServiceHttp {
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, externalReferenceCode, groupId, parentCategoryId,
-				titleMap, descriptionMap, vocabularyId, categoryProperties,
-				serviceContext);
+				titleMap, descriptionMap, vocabularyId, system,
+				categoryProperties, serviceContext);
 
 			Object returnObj = null;
 
@@ -1747,7 +1747,7 @@ public class AssetCategoryServiceHttp {
 	};
 	private static final Class<?>[] _addCategoryParameterTypes2 = new Class[] {
 		String.class, long.class, long.class, java.util.Map.class,
-		java.util.Map.class, long.class, String[].class,
+		java.util.Map.class, long.class, boolean.class, String[].class,
 		com.liferay.portal.kernel.service.ServiceContext.class
 	};
 	private static final Class<?>[] _deleteCategoriesParameterTypes3 =
@@ -1896,4 +1896,4 @@ public class AssetCategoryServiceHttp {
 		};
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-146585217
+// LIFERAY-SERVICE-BUILDER-HASH:1262342086

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetCategoryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetCategoryLocalServiceImpl.java
@@ -13,6 +13,7 @@ import com.liferay.asset.kernel.exception.DuplicateCategoryExternalReferenceCode
 import com.liferay.asset.kernel.exception.InvalidAssetCategoryException;
 import com.liferay.asset.kernel.exception.NoSuchCategoryException;
 import com.liferay.asset.kernel.exception.NoSuchVocabularyException;
+import com.liferay.asset.kernel.exception.SystemCategoryException;
 import com.liferay.asset.kernel.model.AssetCategory;
 import com.liferay.asset.kernel.model.AssetCategoryConstants;
 import com.liferay.asset.kernel.model.AssetVocabulary;
@@ -25,6 +26,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.cache.thread.local.ThreadLocalCachable;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.model.ModelHintsUtil;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.SystemEventConstants;
@@ -52,6 +54,7 @@ import com.liferay.portal.kernel.service.permission.ModelPermissions;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.GroupThreadLocal;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -70,6 +73,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Provides the local service for accessing, adding, deleting, merging, moving,
@@ -109,7 +113,8 @@ public class AssetCategoryLocalServiceImpl
 			String externalReferenceCode, long userId, long groupId,
 			long parentCategoryId, Map<Locale, String> titleMap,
 			Map<Locale, String> descriptionMap, long vocabularyId,
-			String[] categoryProperties, ServiceContext serviceContext)
+			boolean system, String[] categoryProperties,
+			ServiceContext serviceContext)
 		throws PortalException {
 
 		// Category
@@ -165,6 +170,7 @@ public class AssetCategoryLocalServiceImpl
 		category.setTitleMap(trimmedTitleMap);
 		category.setDescriptionMap(descriptionMap);
 		category.setVocabularyId(vocabularyId);
+		category.setSystem(system);
 
 		if (EmptyModelManagerUtil.isEmptyModel()) {
 			category.setStatus(WorkflowConstants.STATUS_EMPTY);
@@ -252,6 +258,14 @@ public class AssetCategoryLocalServiceImpl
 	public AssetCategory deleteCategory(
 			AssetCategory category, boolean skipRebuildTree)
 		throws PortalException {
+
+		if (FeatureFlagManagerUtil.isEnabled(
+				category.getCompanyId(), "LPD-86291") &&
+			!GroupThreadLocal.isDeleteInProcess() && category.isSystem()) {
+
+			throw new SystemCategoryException.MustNotDelete(
+				category.getCategoryId());
+		}
 
 		// Categories
 
@@ -652,6 +666,11 @@ public class AssetCategoryLocalServiceImpl
 		AssetCategory category = assetCategoryPersistence.findByPrimaryKey(
 			categoryId);
 
+		_checkSystemCategory(
+			category.getExternalReferenceCode(), category.getTitleMap(),
+			category.getDescriptionMap(), parentCategoryId, vocabularyId,
+			category);
+
 		return _moveCategory(category, parentCategoryId, vocabularyId);
 	}
 
@@ -727,14 +746,18 @@ public class AssetCategoryLocalServiceImpl
 		AssetCategory category = assetCategoryPersistence.findByPrimaryKey(
 			categoryId);
 
+		Map<Locale, String> trimmedTitleMap = _getTrimmedTitleMap(titleMap);
+
+		_checkSystemCategory(
+			externalReferenceCode, trimmedTitleMap, descriptionMap,
+			parentCategoryId, vocabularyId, category);
+
 		if (Validator.isNotNull(externalReferenceCode)) {
 			_validateExternalReferenceCode(
 				externalReferenceCode, category.getGroupId(), categoryId);
 
 			category.setExternalReferenceCode(externalReferenceCode);
 		}
-
-		Map<Locale, String> trimmedTitleMap = _getTrimmedTitleMap(titleMap);
 
 		Locale defaultLocale = PortalUtil.getSiteDefaultLocale(
 			category.getGroupId());
@@ -874,6 +897,37 @@ public class AssetCategoryLocalServiceImpl
 						"Category ", parentCategoryId,
 						" does not exist in group ", groupId));
 			}
+		}
+	}
+
+	private void _checkSystemCategory(
+			String externalReferenceCode, Map<Locale, String> trimmedTitleMap,
+			Map<Locale, String> descriptionMap, long parentCategoryId,
+			long vocabularyId, AssetCategory category)
+		throws PortalException {
+
+		if (!FeatureFlagManagerUtil.isEnabled(
+				category.getCompanyId(), "LPD-86291") ||
+			!category.isSystem()) {
+
+			return;
+		}
+
+		if ((Validator.isNotNull(externalReferenceCode) &&
+			 !externalReferenceCode.equals(
+				 category.getExternalReferenceCode())) ||
+			!trimmedTitleMap.equals(category.getTitleMap())) {
+
+			throw new SystemCategoryException.MustNotRename(
+				category.getCategoryId());
+		}
+
+		if (!Objects.equals(descriptionMap, category.getDescriptionMap()) ||
+			(parentCategoryId != category.getParentCategoryId()) ||
+			(vocabularyId != category.getVocabularyId())) {
+
+			throw new SystemCategoryException.MustNotModify(
+				category.getCategoryId());
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetCategoryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetCategoryLocalServiceImpl.java
@@ -106,7 +106,7 @@ public class AssetCategoryLocalServiceImpl
 			HashMapBuilder.put(
 				locale, StringPool.BLANK
 			).build(),
-			vocabularyId, null, serviceContext);
+			vocabularyId, false, null, serviceContext);
 	}
 
 	@Indexable(type = IndexableType.REINDEX)
@@ -464,7 +464,7 @@ public class AssetCategoryLocalServiceImpl
 				AssetCategoryConstants.EMPTY_PARENT_CATEGORY_ID,
 				Collections.singletonMap(
 					LocaleUtil.getSiteDefault(), externalReferenceCode),
-				null, AssetVocabularyConstants.EMPTY_VOCABULARY_ID,
+				null, AssetVocabularyConstants.EMPTY_VOCABULARY_ID, false,
 				new String[0], new ServiceContext()),
 			externalReferenceCode,
 			this::fetchAssetCategoryByExternalReferenceCode,

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetCategoryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetCategoryLocalServiceImpl.java
@@ -21,6 +21,7 @@ import com.liferay.asset.kernel.model.AssetVocabularyConstants;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
 import com.liferay.asset.kernel.service.persistence.AssetVocabularyPersistence;
 import com.liferay.exportimport.kernel.empty.model.EmptyModelManagerUtil;
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.bean.BeanReference;
@@ -262,7 +263,9 @@ public class AssetCategoryLocalServiceImpl
 
 		if (FeatureFlagManagerUtil.isEnabled(
 				category.getCompanyId(), "LPD-86291") &&
-			!GroupThreadLocal.isDeleteInProcess() && category.isSystem()) {
+			category.isSystem() &&
+			!ExportImportThreadLocal.isImportInProcess() &&
+			!GroupThreadLocal.isDeleteInProcess()) {
 
 			throw new SystemCategoryException.MustNotDelete(
 				category.getCategoryId());
@@ -909,7 +912,8 @@ public class AssetCategoryLocalServiceImpl
 
 		if (!FeatureFlagManagerUtil.isEnabled(
 				category.getCompanyId(), "LPD-86291") ||
-			!category.isSystem()) {
+			!category.isSystem() ||
+			ExportImportThreadLocal.isImportInProcess()) {
 
 			return;
 		}

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetCategoryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetCategoryLocalServiceImpl.java
@@ -58,6 +58,7 @@ import com.liferay.portal.kernel.util.GroupThreadLocal;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -922,13 +923,23 @@ public class AssetCategoryLocalServiceImpl
 				category.getCategoryId());
 		}
 
-		if (!Objects.equals(descriptionMap, category.getDescriptionMap()) ||
+		if (!_equals(descriptionMap, category.getDescriptionMap()) ||
 			(parentCategoryId != category.getParentCategoryId()) ||
 			(vocabularyId != category.getVocabularyId())) {
 
 			throw new SystemCategoryException.MustNotModify(
 				category.getCategoryId());
 		}
+	}
+
+	private boolean _equals(
+		Map<Locale, String> map1, Map<Locale, String> map2) {
+
+		if (MapUtil.isEmpty(map1) && MapUtil.isEmpty(map2)) {
+			return true;
+		}
+
+		return Objects.equals(map1, map2);
 	}
 
 	private Map<Locale, String> _getTrimmedTitleMap(

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetCategoryServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetCategoryServiceImpl.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.search.BaseModelSearchResult;
 import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -89,9 +90,15 @@ public class AssetCategoryServiceImpl extends AssetCategoryServiceBaseImpl {
 			ServiceContext serviceContext)
 		throws PortalException {
 
+		PermissionChecker permissionChecker = getPermissionChecker();
+
 		AssetCategoryPermission.check(
-			getPermissionChecker(), groupId, parentCategoryId,
+			permissionChecker, groupId, parentCategoryId,
 			ActionKeys.ADD_CATEGORY);
+
+		if (system && !permissionChecker.isCompanyAdmin()) {
+			throw new PrincipalException.MustBeCompanyAdmin(getUserId());
+		}
 
 		return assetCategoryLocalService.addCategory(
 			externalReferenceCode, getUserId(), groupId, parentCategoryId,

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetCategoryServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetCategoryServiceImpl.java
@@ -64,7 +64,8 @@ public class AssetCategoryServiceImpl extends AssetCategoryServiceBaseImpl {
 
 		return assetCategoryLocalService.addCategory(
 			null, getUserId(), groupId, parentCategoryId, titleMap,
-			descriptionMap, vocabularyId, categoryProperties, serviceContext);
+			descriptionMap, vocabularyId, false, categoryProperties,
+			serviceContext);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetCategoryServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetCategoryServiceImpl.java
@@ -85,7 +85,7 @@ public class AssetCategoryServiceImpl extends AssetCategoryServiceBaseImpl {
 	public AssetCategory addCategory(
 			String externalReferenceCode, long groupId, long parentCategoryId,
 			Map<Locale, String> titleMap, Map<Locale, String> descriptionMap,
-			long vocabularyId, String[] categoryProperties,
+			long vocabularyId, boolean system, String[] categoryProperties,
 			ServiceContext serviceContext)
 		throws PortalException {
 
@@ -95,7 +95,7 @@ public class AssetCategoryServiceImpl extends AssetCategoryServiceBaseImpl {
 
 		return assetCategoryLocalService.addCategory(
 			externalReferenceCode, getUserId(), groupId, parentCategoryId,
-			titleMap, descriptionMap, vocabularyId, categoryProperties,
+			titleMap, descriptionMap, vocabularyId, system, categoryProperties,
 			serviceContext);
 	}
 

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyLocalServiceImpl.java
@@ -16,6 +16,7 @@ import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.asset.kernel.model.AssetVocabularyConstants;
 import com.liferay.asset.kernel.service.AssetCategoryLocalService;
 import com.liferay.exportimport.kernel.empty.model.EmptyModelManagerUtil;
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -292,6 +293,7 @@ public class AssetVocabularyLocalServiceImpl
 
 		if (FeatureFlagManagerUtil.isEnabled(
 				vocabulary.getCompanyId(), "LPD-86291") &&
+			!ExportImportThreadLocal.isImportInProcess() &&
 			!GroupThreadLocal.isDeleteInProcess() && vocabulary.isSystem()) {
 
 			throw new SystemVocabularyException.MustNotDelete(
@@ -815,6 +817,7 @@ public class AssetVocabularyLocalServiceImpl
 
 		if (!FeatureFlagManagerUtil.isEnabled(
 				vocabulary.getCompanyId(), "LPD-86291") ||
+			ExportImportThreadLocal.isImportInProcess() ||
 			!vocabulary.isSystem()) {
 
 			return;

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyLocalServiceImpl.java
@@ -53,6 +53,7 @@ import com.liferay.portal.kernel.util.GroupThreadLocal;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -683,6 +684,16 @@ public class AssetVocabularyLocalServiceImpl
 		}
 	}
 
+	private boolean _equals(
+		Map<Locale, String> map1, Map<Locale, String> map2) {
+
+		if (MapUtil.isEmpty(map1) && MapUtil.isEmpty(map2)) {
+			return true;
+		}
+
+		return Objects.equals(map1, map2);
+	}
+
 	private String _generateVocabularyName(long groupId, String name) {
 		String vocabularyName = _getVocabularyName(name);
 
@@ -818,7 +829,7 @@ public class AssetVocabularyLocalServiceImpl
 				vocabulary.getVocabularyId());
 		}
 
-		if (!Objects.equals(descriptionMap, vocabulary.getDescriptionMap()) ||
+		if (!_equals(descriptionMap, vocabulary.getDescriptionMap()) ||
 			(visibilityType != vocabulary.getVisibilityType()) ||
 			!_isValidSystemVocabularySettings(
 				vocabulary.getSettings(), settings)) {

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyServiceImpl.java
@@ -14,7 +14,9 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.search.BaseModelSearchResult;
 import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -23,6 +25,7 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portlet.asset.service.base.AssetVocabularyServiceBaseImpl;
 import com.liferay.portlet.asset.service.permission.AssetCategoriesPermission;
 import com.liferay.portlet.asset.service.permission.AssetVocabularyPermission;
+import com.liferay.portlet.asset.util.AssetVocabularySettingsHelper;
 import com.liferay.util.dao.orm.CustomSQLUtil;
 
 import java.util.ArrayList;
@@ -51,6 +54,8 @@ public class AssetVocabularyServiceImpl extends AssetVocabularyServiceBaseImpl {
 		AssetCategoriesPermission.check(
 			getPermissionChecker(), groupId, ActionKeys.ADD_VOCABULARY);
 
+		_checkSystemVocabulary(settings);
+
 		return assetVocabularyLocalService.addVocabulary(
 			getUserId(), groupId, title, titleMap, descriptionMap, settings,
 			visibilityType, serviceContext);
@@ -65,6 +70,8 @@ public class AssetVocabularyServiceImpl extends AssetVocabularyServiceBaseImpl {
 
 		AssetCategoriesPermission.check(
 			getPermissionChecker(), groupId, ActionKeys.ADD_VOCABULARY);
+
+		_checkSystemVocabulary(settings);
 
 		return assetVocabularyLocalService.addVocabulary(
 			getUserId(), groupId, title, titleMap, descriptionMap, settings,
@@ -93,6 +100,8 @@ public class AssetVocabularyServiceImpl extends AssetVocabularyServiceBaseImpl {
 		AssetCategoriesPermission.check(
 			getPermissionChecker(), groupId, ActionKeys.ADD_VOCABULARY);
 
+		_checkSystemVocabulary(settings);
+
 		return assetVocabularyLocalService.addVocabulary(
 			getUserId(), groupId, name, title, titleMap, descriptionMap,
 			settings, serviceContext);
@@ -108,6 +117,8 @@ public class AssetVocabularyServiceImpl extends AssetVocabularyServiceBaseImpl {
 
 		AssetCategoriesPermission.check(
 			getPermissionChecker(), groupId, ActionKeys.ADD_VOCABULARY);
+
+		_checkSystemVocabulary(settings);
 
 		return assetVocabularyLocalService.addVocabulary(
 			externalReferenceCode, getUserId(), groupId, name, title, titleMap,
@@ -492,6 +503,8 @@ public class AssetVocabularyServiceImpl extends AssetVocabularyServiceBaseImpl {
 		AssetVocabularyPermission.check(
 			getPermissionChecker(), vocabularyId, ActionKeys.UPDATE);
 
+		_checkSystemVocabulary(settings);
+
 		return assetVocabularyLocalService.updateVocabulary(
 			externalReferenceCode, vocabularyId, titleMap, descriptionMap,
 			settings);
@@ -506,6 +519,8 @@ public class AssetVocabularyServiceImpl extends AssetVocabularyServiceBaseImpl {
 
 		AssetVocabularyPermission.check(
 			getPermissionChecker(), vocabularyId, ActionKeys.UPDATE);
+
+		_checkSystemVocabulary(settings);
 
 		return assetVocabularyLocalService.updateVocabulary(
 			externalReferenceCode, vocabularyId, titleMap, descriptionMap,
@@ -522,9 +537,26 @@ public class AssetVocabularyServiceImpl extends AssetVocabularyServiceBaseImpl {
 		AssetVocabularyPermission.check(
 			getPermissionChecker(), vocabularyId, ActionKeys.UPDATE);
 
+		_checkSystemVocabulary(settings);
+
 		return assetVocabularyLocalService.updateVocabulary(
 			externalReferenceCode, vocabularyId, title, titleMap,
 			descriptionMap, settings, visibilityType, serviceContext);
+	}
+
+	private void _checkSystemVocabulary(String settings)
+		throws PortalException {
+
+		AssetVocabularySettingsHelper assetVocabularySettingsHelper =
+			new AssetVocabularySettingsHelper(settings);
+
+		PermissionChecker permissionChecker = getPermissionChecker();
+
+		if (assetVocabularySettingsHelper.isSystem() &&
+			!permissionChecker.isCompanyAdmin()) {
+
+			throw new PrincipalException.MustBeCompanyAdmin(getUserId());
+		}
 	}
 
 	@BeanReference(type = ClassNameLocalService.class)

--- a/portal-impl/src/com/liferay/portlet/asset/service/persistence/impl/AssetCategoryPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/persistence/impl/AssetCategoryPersistenceImpl.java
@@ -2299,6 +2299,7 @@ public class AssetCategoryPersistenceImpl
 		Map<String, String> dbColumnNames = new HashMap<String, String>();
 
 		dbColumnNames.put("uuid", "uuid_");
+		dbColumnNames.put("system", "system_");
 
 		setDBColumnNames(dbColumnNames);
 
@@ -2639,6 +2640,7 @@ public class AssetCategoryPersistenceImpl
 		ctMergeColumnNames.add("title");
 		ctMergeColumnNames.add("description");
 		ctMergeColumnNames.add("vocabularyId");
+		ctMergeColumnNames.add("system_");
 		ctMergeColumnNames.add("lastPublishDate");
 		ctMergeColumnNames.add("status");
 
@@ -3138,7 +3140,7 @@ public class AssetCategoryPersistenceImpl
 		"SELECT COUNT(assetCategory) FROM AssetCategory assetCategory WHERE ";
 
 	private static final Set<String> _badColumnNames = SetUtil.fromArray(
-		new String[] {"uuid"});
+		new String[] {"uuid", "system"});
 
 	@Override
 	protected FinderCache getFinderCache() {
@@ -3146,4 +3148,4 @@ public class AssetCategoryPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:31394165
+// LIFERAY-SERVICE-BUILDER-HASH:-992189092

--- a/portal-kernel/src/com/liferay/asset/kernel/exception/SystemCategoryException.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/exception/SystemCategoryException.java
@@ -1,0 +1,55 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.asset.kernel.exception;
+
+import com.liferay.portal.kernel.exception.PortalException;
+
+/**
+ * @author Adolfo Pérez
+ */
+public class SystemCategoryException extends PortalException {
+
+	public static class MustNotDelete extends SystemCategoryException {
+
+		public MustNotDelete(long categoryId) {
+			super(String.format("Category %s cannot be deleted", categoryId));
+
+			this.categoryId = categoryId;
+		}
+
+		public long categoryId;
+
+	}
+
+	public static class MustNotModify extends SystemCategoryException {
+
+		public MustNotModify(long categoryId) {
+			super(String.format("Category %s cannot be modified", categoryId));
+
+			this.categoryId = categoryId;
+		}
+
+		public long categoryId;
+
+	}
+
+	public static class MustNotRename extends SystemCategoryException {
+
+		public MustNotRename(long categoryId) {
+			super(String.format("Category %s cannot be renamed", categoryId));
+
+			this.categoryId = categoryId;
+		}
+
+		public long categoryId;
+
+	}
+
+	private SystemCategoryException(String msg) {
+		super(msg);
+	}
+
+}

--- a/portal-kernel/src/com/liferay/asset/kernel/exception/packageinfo
+++ b/portal-kernel/src/com/liferay/asset/kernel/exception/packageinfo
@@ -1,1 +1,1 @@
-version 4.6.0
+version 4.7.0

--- a/portal-kernel/src/com/liferay/asset/kernel/model/AssetCategoryModel.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/model/AssetCategoryModel.java
@@ -512,6 +512,27 @@ public interface AssetCategoryModel
 	public void setVocabularyId(long vocabularyId);
 
 	/**
+	 * Returns the system of this asset category.
+	 *
+	 * @return the system of this asset category
+	 */
+	public boolean getSystem();
+
+	/**
+	 * Returns <code>true</code> if this asset category is system.
+	 *
+	 * @return <code>true</code> if this asset category is system; <code>false</code> otherwise
+	 */
+	public boolean isSystem();
+
+	/**
+	 * Sets whether this asset category is system.
+	 *
+	 * @param system the system of this asset category
+	 */
+	public void setSystem(boolean system);
+
+	/**
 	 * Returns the last publish date of this asset category.
 	 *
 	 * @return the last publish date of this asset category
@@ -562,4 +583,4 @@ public interface AssetCategoryModel
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:653123457
+// LIFERAY-SERVICE-BUILDER-HASH:-158957911

--- a/portal-kernel/src/com/liferay/asset/kernel/model/AssetCategoryTable.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/model/AssetCategoryTable.java
@@ -61,6 +61,8 @@ public class AssetCategoryTable extends BaseTable<AssetCategoryTable> {
 		"description", Clob.class, Types.CLOB, Column.FLAG_DEFAULT);
 	public final Column<AssetCategoryTable, Long> vocabularyId = createColumn(
 		"vocabularyId", Long.class, Types.BIGINT, Column.FLAG_DEFAULT);
+	public final Column<AssetCategoryTable, Boolean> system = createColumn(
+		"system_", Boolean.class, Types.BOOLEAN, Column.FLAG_DEFAULT);
 	public final Column<AssetCategoryTable, Date> lastPublishDate =
 		createColumn(
 			"lastPublishDate", Date.class, Types.TIMESTAMP,
@@ -73,4 +75,4 @@ public class AssetCategoryTable extends BaseTable<AssetCategoryTable> {
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-226998557
+// LIFERAY-SERVICE-BUILDER-HASH:1574476507

--- a/portal-kernel/src/com/liferay/asset/kernel/model/AssetCategoryWrapper.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/model/AssetCategoryWrapper.java
@@ -53,6 +53,7 @@ public class AssetCategoryWrapper
 		attributes.put("title", getTitle());
 		attributes.put("description", getDescription());
 		attributes.put("vocabularyId", getVocabularyId());
+		attributes.put("system", isSystem());
 		attributes.put("lastPublishDate", getLastPublishDate());
 		attributes.put("status", getStatus());
 
@@ -162,6 +163,12 @@ public class AssetCategoryWrapper
 
 		if (vocabularyId != null) {
 			setVocabularyId(vocabularyId);
+		}
+
+		Boolean system = (Boolean)attributes.get("system");
+
+		if (system != null) {
+			setSystem(system);
 		}
 
 		Date lastPublishDate = (Date)attributes.get("lastPublishDate");
@@ -432,6 +439,16 @@ public class AssetCategoryWrapper
 	}
 
 	/**
+	 * Returns the system of this asset category.
+	 *
+	 * @return the system of this asset category
+	 */
+	@Override
+	public boolean getSystem() {
+		return model.getSystem();
+	}
+
+	/**
 	 * Returns the title of this asset category.
 	 *
 	 * @return the title of this asset category
@@ -570,6 +587,16 @@ public class AssetCategoryWrapper
 	@Override
 	public boolean isRootCategory() {
 		return model.isRootCategory();
+	}
+
+	/**
+	 * Returns <code>true</code> if this asset category is system.
+	 *
+	 * @return <code>true</code> if this asset category is system; <code>false</code> otherwise
+	 */
+	@Override
+	public boolean isSystem() {
+		return model.isSystem();
 	}
 
 	@Override
@@ -790,6 +817,16 @@ public class AssetCategoryWrapper
 	}
 
 	/**
+	 * Sets whether this asset category is system.
+	 *
+	 * @param system the system of this asset category
+	 */
+	@Override
+	public void setSystem(boolean system) {
+		model.setSystem(system);
+	}
+
+	/**
 	 * Sets the title of this asset category.
 	 *
 	 * @param title the title of this asset category
@@ -948,4 +985,4 @@ public class AssetCategoryWrapper
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-39771690
+// LIFERAY-SERVICE-BUILDER-HASH:1786975427

--- a/portal-kernel/src/com/liferay/asset/kernel/model/packageinfo
+++ b/portal-kernel/src/com/liferay/asset/kernel/model/packageinfo
@@ -1,1 +1,1 @@
-version 14.4.0
+version 14.5.0

--- a/portal-kernel/src/com/liferay/asset/kernel/service/AssetCategoryLocalService.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/AssetCategoryLocalService.java
@@ -98,7 +98,8 @@ public interface AssetCategoryLocalService
 			String externalReferenceCode, long userId, long groupId,
 			long parentCategoryId, Map<Locale, String> titleMap,
 			Map<Locale, String> descriptionMap, long vocabularyId,
-			String[] categoryProperties, ServiceContext serviceContext)
+			boolean system, String[] categoryProperties,
+			ServiceContext serviceContext)
 		throws PortalException;
 
 	public void addCategoryResources(
@@ -556,4 +557,4 @@ public interface AssetCategoryLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-416155490
+// LIFERAY-SERVICE-BUILDER-HASH:-1228879460

--- a/portal-kernel/src/com/liferay/asset/kernel/service/AssetCategoryLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/AssetCategoryLocalServiceUtil.java
@@ -64,13 +64,14 @@ public class AssetCategoryLocalServiceUtil {
 			String externalReferenceCode, long userId, long groupId,
 			long parentCategoryId, Map<java.util.Locale, String> titleMap,
 			Map<java.util.Locale, String> descriptionMap, long vocabularyId,
-			String[] categoryProperties,
+			boolean system, String[] categoryProperties,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
 		return getService().addCategory(
 			externalReferenceCode, userId, groupId, parentCategoryId, titleMap,
-			descriptionMap, vocabularyId, categoryProperties, serviceContext);
+			descriptionMap, vocabularyId, system, categoryProperties,
+			serviceContext);
 	}
 
 	public static void addCategoryResources(
@@ -712,4 +713,4 @@ public class AssetCategoryLocalServiceUtil {
 	private static volatile AssetCategoryLocalService _service;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1797070939
+// LIFERAY-SERVICE-BUILDER-HASH:-583019191

--- a/portal-kernel/src/com/liferay/asset/kernel/service/AssetCategoryLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/AssetCategoryLocalServiceWrapper.java
@@ -63,13 +63,14 @@ public class AssetCategoryLocalServiceWrapper
 			long parentCategoryId,
 			java.util.Map<java.util.Locale, String> titleMap,
 			java.util.Map<java.util.Locale, String> descriptionMap,
-			long vocabularyId, String[] categoryProperties,
+			long vocabularyId, boolean system, String[] categoryProperties,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _assetCategoryLocalService.addCategory(
 			externalReferenceCode, userId, groupId, parentCategoryId, titleMap,
-			descriptionMap, vocabularyId, categoryProperties, serviceContext);
+			descriptionMap, vocabularyId, system, categoryProperties,
+			serviceContext);
 	}
 
 	@Override
@@ -842,4 +843,4 @@ public class AssetCategoryLocalServiceWrapper
 	private AssetCategoryLocalService _assetCategoryLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1671983655
+// LIFERAY-SERVICE-BUILDER-HASH:605567399

--- a/portal-kernel/src/com/liferay/asset/kernel/service/AssetCategoryService.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/AssetCategoryService.java
@@ -65,7 +65,7 @@ public interface AssetCategoryService extends BaseService {
 	public AssetCategory addCategory(
 			String externalReferenceCode, long groupId, long parentCategoryId,
 			Map<Locale, String> titleMap, Map<Locale, String> descriptionMap,
-			long vocabularyId, String[] categoryProperties,
+			long vocabularyId, boolean system, String[] categoryProperties,
 			ServiceContext serviceContext)
 		throws PortalException;
 
@@ -294,4 +294,4 @@ public interface AssetCategoryService extends BaseService {
 		throws PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-629663018
+// LIFERAY-SERVICE-BUILDER-HASH:-1974174816

--- a/portal-kernel/src/com/liferay/asset/kernel/service/AssetCategoryServiceUtil.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/AssetCategoryServiceUtil.java
@@ -57,13 +57,14 @@ public class AssetCategoryServiceUtil {
 			String externalReferenceCode, long groupId, long parentCategoryId,
 			Map<java.util.Locale, String> titleMap,
 			Map<java.util.Locale, String> descriptionMap, long vocabularyId,
-			String[] categoryProperties,
+			boolean system, String[] categoryProperties,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
 		return getService().addCategory(
 			externalReferenceCode, groupId, parentCategoryId, titleMap,
-			descriptionMap, vocabularyId, categoryProperties, serviceContext);
+			descriptionMap, vocabularyId, system, categoryProperties,
+			serviceContext);
 	}
 
 	public static void deleteCategories(long[] categoryIds)
@@ -430,4 +431,4 @@ public class AssetCategoryServiceUtil {
 	private static volatile AssetCategoryService _service;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1607392872
+// LIFERAY-SERVICE-BUILDER-HASH:-1564060164

--- a/portal-kernel/src/com/liferay/asset/kernel/service/AssetCategoryServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/AssetCategoryServiceWrapper.java
@@ -57,13 +57,14 @@ public class AssetCategoryServiceWrapper
 			String externalReferenceCode, long groupId, long parentCategoryId,
 			java.util.Map<java.util.Locale, String> titleMap,
 			java.util.Map<java.util.Locale, String> descriptionMap,
-			long vocabularyId, String[] categoryProperties,
+			long vocabularyId, boolean system, String[] categoryProperties,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _assetCategoryService.addCategory(
 			externalReferenceCode, groupId, parentCategoryId, titleMap,
-			descriptionMap, vocabularyId, categoryProperties, serviceContext);
+			descriptionMap, vocabularyId, system, categoryProperties,
+			serviceContext);
 	}
 
 	@Override
@@ -487,4 +488,4 @@ public class AssetCategoryServiceWrapper
 	private AssetCategoryService _assetCategoryService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1230983580
+// LIFERAY-SERVICE-BUILDER-HASH:-176315480

--- a/portal-kernel/src/com/liferay/asset/kernel/service/packageinfo
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/packageinfo
@@ -1,1 +1,1 @@
-version 18.1.0
+version 19.0.0

--- a/sql/portal-tables.sql
+++ b/sql/portal-tables.sql
@@ -98,6 +98,7 @@ create table AssetCategory (
 	title TEXT null,
 	description TEXT null,
 	vocabularyId LONG,
+	system_ BOOLEAN,
 	lastPublishDate DATE null,
 	status INTEGER,
 	primary key (categoryId, ctCollectionId)


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96310

## What Is Being Fixed

Asset vocabularies already support a "system" flag that marks them as platform-managed: protected entries that regular users cannot rename, modify, or delete. Asset categories had no equivalent, so a category that should be owned by the platform could be renamed, edited, or deleted by any user with category permissions, with no way to mark a category as system-owned or enforce those restrictions.

## How It Is Being Fixed

A `system` column is added to the AssetCategory entity and threaded through the local and remote services. A new SystemCategoryException, with MustNotDelete, MustNotModify, and MustNotRename nested types, is thrown when a regular user attempts to delete, modify, or rename a system category, mirroring the existing system-vocabulary behavior. Export/import is exempt from these restrictions so system entries can still be created and updated during a portlet import. Category attribute comparisons now treat a null map and an empty map as equivalent, so a no-op update is not misread as a modification. References across the affected modules are updated, and integration tests cover the new restrictions in AssetCategoryLocalServiceTest, AssetCategoryServiceTest, AssetVocabularyLocalServiceTest, and AssetVocabularyServiceTest, along with GroupLocalServiceTest verifying that system categories and vocabularies are cascade-deleted with their group.

## PR Check

**pr-check: PASS** — tested on `ec07f2a6b72aca92c49da0b0556d4e0e0e9fa4a0`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Full Portal Build | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |

<!-- pr-check {"result": "success", "sha": "ec07f2a6b72aca92c49da0b0556d4e0e0e9fa4a0"} -->
