### PR TITLE
LPD-96968 Avoid ERROR log for the missing Configuration_ table

### DIFF
--- a/modules/apps/static/portal-configuration/portal-configuration-persistence-impl/src/main/java/com/liferay/portal/configuration/persistence/internal/ConfigurationPersistenceManager.java
+++ b/modules/apps/static/portal-configuration/portal-configuration-persistence-impl/src/main/java/com/liferay/portal/configuration/persistence/internal/ConfigurationPersistenceManager.java
@@ -23,6 +23,7 @@ import com.liferay.portal.db.partition.util.DBPartitionUtil;
 import com.liferay.portal.events.StartupHelperUtil;
 import com.liferay.portal.file.install.constants.FileInstallConstants;
 import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBInspector;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -211,7 +212,12 @@ public class ConfigurationPersistenceManager
 			}
 		}
 		catch (Exception exception) {
-			_log.error(exception);
+			if (_hasConfigurationTable()) {
+				_log.error(exception);
+			}
+			else if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
 		}
 
 		_createConfigurationTable();
@@ -426,6 +432,21 @@ public class ConfigurationPersistenceManager
 		}
 
 		return 0L;
+	}
+
+	private boolean _hasConfigurationTable() {
+		try (Connection connection = _dataSource.getConnection()) {
+			DBInspector dbInspector = new DBInspector(connection);
+
+			return dbInspector.hasTable("Configuration_");
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+
+			return true;
+		}
 	}
 
 	private boolean _insertConfiguration(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96968

## What Is Being Fixed

Since master ci:test:upgrade build 312, every upgrade smoke test that starts from a pre-7.0 archive (6.1.30, 6.2.10.21, 6.2.5) fails its log assertion on a single ERROR logged during startup, across PostgreSQL, MySQL, MariaDB, and SQL Server (`ERROR [main][ConfigurationPersistenceManager:214] ... relation "configuration_" does not exist`).

On a database restored from a pre-7.0 archive, the `Configuration_` table does not exist yet when `ConfigurationPersistenceManager.start()` runs. Because the database is not new, `start()` calls `_populateDictionaries()`, which selects from the missing table and throws; the exception is expected, so `start()` falls through to `_createConfigurationTable()` and boot continues normally. LPD-92462 raised the log level of that catch from DEBUG to ERROR to surface genuine populate failures that previously could be swallowed silently, which also promoted this expected first-boot exception to ERROR, and the upgrade smoke tests assert that no Liferay ERROR appears in the log.

## How It Is Being Fixed

Check whether the `Configuration_` table exists before choosing the log level. A real populate failure against an existing table still logs at ERROR, preserving the observability LPD-92462 added, while the expected missing-table case drops back to DEBUG. The check runs only inside the catch (the exceptional path), so normal startup pays no extra database read, and it reuses the `DBInspector.hasTable` idiom already used by the sibling `ConfigurationSchemaCreator`. If the check itself cannot run, it defaults to ERROR so nothing is silently swallowed.

## Why Are There No Tests?

The behavior change is a log-level decision on the missing-`Configuration_`-table first-boot path. Reproducing that path in a new automated test means dropping the `Configuration_` table, which is destructive in the shared integration database and would corrupt every subsequent test in the run. The direct coverage is the existing upgrade smoke suite (PortalSmokeUpgrade, PortalSmokeAutoUpgrade, DBStoreUpgrade, VirtualInstancesUpgrade) — the exact tests that regressed on build 312 — which goes green with this fix; the reporter offered to verify a candidate against that suite.

## PR Check

**pr-check: PASS** — tested on `b012ae1897d7a5c4fbad1ade6c771b23b8fc3cf8`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "b012ae1897d7a5c4fbad1ade6c771b23b8fc3cf8"} -->
