### PR TITLE
LPD-31312 Warn about removed RecurrenceSerializer.toCronText method

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -3522,6 +3522,14 @@
 	},
 	{
 		"classNames": [
+			"RecurrenceSerializer"
+		],
+		"from": "toCronText(Recurrence paramName)",
+		"hasMessage": true,
+		"issueKey": "LPD-31312"
+	},
+	{
+		"classNames": [
 			"CustomFacetPortletPreferences"
 		],
 		"from": "getFederatedSearchKeyOptional",

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_31312.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_31312.testjava
@@ -1,0 +1,21 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+import com.liferay.calendar.recurrence.Recurrence;
+import com.liferay.calendar.recurrence.RecurrenceSerializer;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class LPD_31312 {
+
+	public void method(Recurrence recurrence) {
+		RecurrenceSerializer.toCronText(recurrence);
+		RecurrenceSerializer.toCronText(null);
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-31312

## What Is Being Fixed

The `RecurrenceSerializer#toCronText` method was removed, but nothing flagged existing or new callers of it. Code still invoking `RecurrenceSerializer.toCronText(...)` had no guidance pointing at the removal.

## How It Is Being Fixed

A new entry is added to the source formatter's upgrade catch-all check (`replacements.json`) matching calls to `toCronText(Recurrence paramName)` on `RecurrenceSerializer`, so the formatter surfaces the removal to developers. A `.testjava` fixture exercising both `toCronText(recurrence)` and `toCronText(null)` is added to cover the new check.

## PR Check

**pr-check: PASS** — tested on `5fe27e8b7ba34100c2247dddfa88e4023402cf70`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "5fe27e8b7ba34100c2247dddfa88e4023402cf70"} -->
