### PR TITLE
LPD-85864 Add externalReferenceCode parameter to updatePhone method

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -5912,6 +5912,17 @@
 		"issueKey": "LPD-82354"
 	},
 	{
+		"classNames": [
+			"PhoneLocalService",
+			"PhoneLocalServiceUtil",
+			"PhoneService",
+			"PhoneServiceUtil"
+		],
+		"from": "updatePhone(long paramName, String paramName, String paramName, long paramName, boolean paramName)",
+		"issueKey": "LPD-85864",
+		"to": "updatePhone(null, param#0#, param#1#, param#2#, param#3#, param#4#)"
+	},
+	{
 		"from": "CustomFieldsUtil.hasVisibleCustomFields",
 		"issueKey": "LPD-85980",
 		"newImports": [

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_85864.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_85864.testjava
@@ -1,0 +1,33 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class LPD_85864 {
+
+	public void method(
+		long phoneId, String number, String extension, long typeId,
+		boolean primary) {
+
+		PhoneLocalServiceUtil.updatePhone(
+			123, number, extension, typeId, primary);
+		PhoneLocalServiceUtil.updatePhone(null, phoneId, number, extension, typeId, primary);
+		PhoneServiceUtil.updatePhone(null, phoneId, number, extension, typeId, primary);
+		_phoneLocalService.updatePhone(null, phoneId, number, extension, typeId, primary);
+		_phoneService.updatePhone(null, phoneId, number, extension, typeId, primary);
+	}
+
+	@Reference
+	private PhoneLocalService _phoneLocalService;
+
+	@Reference
+	private PhoneService _phoneService;
+
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_85864.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_85864.testjava
@@ -1,0 +1,36 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class LPD_85864 {
+
+	public void method(
+		long phoneId, String number, String extension, long typeId,
+		boolean primary) {
+
+		PhoneLocalServiceUtil.updatePhone(
+			123, number, extension, typeId, primary);
+		PhoneLocalServiceUtil.updatePhone(
+			phoneId, number, extension, typeId, primary);
+		PhoneServiceUtil.updatePhone(
+			phoneId, number, extension, typeId, primary);
+		_phoneLocalService.updatePhone(
+			phoneId, number, extension, typeId, primary);
+		_phoneService.updatePhone(phoneId, number, extension, typeId, primary);
+	}
+
+	@Reference
+	private PhoneLocalService _phoneLocalService;
+
+	@Reference
+	private PhoneService _phoneService;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-85864

## What Is Being Fixed

The `updatePhone` method gained a new `externalReferenceCode` first parameter, changing its signature. Existing callers of the old `updatePhone(long, String, String, long, boolean)` signature would break, and nothing guided them to the new form.

## How It Is Being Fixed

A source formatter upgrade rule is added to `replacements.json` covering `PhoneLocalService`, `PhoneLocalServiceUtil`, `PhoneService`, and `PhoneServiceUtil`. It rewrites calls to the old `updatePhone` signature to the new one, inserting `null` for the new `externalReferenceCode` argument. Input and expected `.testjava` fixtures verify the rewrite across static-util and injected-reference call sites.

## PR Check

**pr-check: PASS** — tested on `af692b88d5302c9f8752a7e30735fe12cf71e43d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "af692b88d5302c9f8752a7e30735fe12cf71e43d"} -->
