### PR TITLE
LPD-96310 Fix test compilation after category signature change

### DIFF
--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/internal/feature/flag/test/AssetCategoryFriendlyURLFeatureFlagListenerTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/internal/feature/flag/test/AssetCategoryFriendlyURLFeatureFlagListenerTest.java
@@ -143,7 +143,7 @@ public class AssetCategoryFriendlyURLFeatureFlagListenerTest {
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), title
 			).build(),
-			new HashMap<>(), assetVocabularyId, null,
+			new HashMap<>(), assetVocabularyId, false, null,
 			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96310

## What Is Being Fixed

The LPD-96310 system-category work added a boolean parameter to the category creation call, but AssetCategoryFriendlyURLFeatureFlagListenerTest was never updated, so the asset-categories-test module fails to compile in the target repository.

## How It Is Being Fixed

Pass false for the new system-category argument in the test's category setup so the call matches the updated method signature.

## Why Are There No Tests?

This change only updates an existing integration test to match a changed method signature so the module compiles again; it introduces no new behavior to cover.

## PR Check

**pr-check: SKIPPED** — This fixes a compile issue in Brian's remote; reasonable to skip the pr-check.

<!-- pr-check {"reason": "This fixes a compile issue in Brian's remote; reasonable to skip the pr-check.", "result": "skipped", "sha": "9024b11eb33963b181382914dfaa27c2ffce8a56"} -->
