### PR TITLE
LPD-58498 Follow up PR - Fix stable build failure from missing language keys

### DIFF
--- a/modules/apps/portal-security/portal-security-script-management-api/src/main/java/com/liferay/portal/security/script/management/configuration/ScriptManagementConfiguration.java
+++ b/modules/apps/portal-security/portal-security-script-management-api/src/main/java/com/liferay/portal/security/script/management/configuration/ScriptManagementConfiguration.java
@@ -23,7 +23,11 @@ import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClass
 )
 public interface ScriptManagementConfiguration {
 
-	@Meta.AD(deflt = "false", required = false)
+	@Meta.AD(
+		deflt = "false",
+		name = "allow-script-content-to-be-executed-or-included",
+		required = false
+	)
 	public boolean allowScriptContentToBeExecutedOrIncluded();
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-58498

Follow-up to #178134.

## What Is Being Fixed

`ModuleConfigurationLocalizationTest` still fails on master for `ScriptManagementConfiguration`, even after #178134 added the `allow-script-content-to-be-executed-or-included` language key.

The reason: the `allowScriptContentToBeExecutedOrIncluded` `@Meta.AD` has no explicit `name`, so bnd generates the attribute name as the de-camelCased literal `Allow script content to be executed or included`. The test resolves the label with `getString(resourceBundle, attributeDefinition.getName())`, so it looks up that literal string as a key, which does not exist, and reports the attribute as missing localization. The language key added in #178134 is never consulted because nothing points the attribute at it.

## How It Is Being Fixed

Adds `name = "allow-script-content-to-be-executed-or-included"` to the `@Meta.AD`, so the generated attribute name is the language key added in #178134. This matches the portal-wide convention: every UI-generating `@Meta.AD` sets an explicit `name` that resolves to a key in the global `Language.properties`.

## Why Are There No Tests?

`ModuleConfigurationLocalizationTest` is the existing test that covers this. It was verified locally against a running bundle with this change deployed:

```
com.liferay.portal.smoke.test.ModuleConfigurationLocalizationTest > testConfigurationLocalization PASSED
BUILD SUCCESSFUL
```

## PR Check

**pr-check: SKIPPED.** This restores a failing stable-build test in Brian's remote. The change adds one annotation attribute pointing at an already-merged language key, so it is reasonable to skip the pr-check.

<!-- pr-check {"reason": "Restores a failing stable-build test; one annotation attribute pointing at an already-merged language key, reasonable to skip the pr-check.", "result": "skipped", "sha": "71a4b4102d0efc50b4862b130babbe30ff9c4979"} -->
