### PR TITLE
LPD-97199 Overwrite stale negative entries when caching query results

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/service/persistence/impl/BasePersistenceImpl.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/persistence/impl/BasePersistenceImpl.java
@@ -185,15 +185,14 @@ public class BasePersistenceImpl
 
 		if (getCTPersistenceHelper() == null) {
 			for (T model : models) {
-				@SuppressWarnings("unchecked")
-				T cachedModel = (T)entityCache.getResult(
+				Serializable serializable = entityCache.getResult(
 					_modelImplClass, model.getPrimaryKeyObj());
 
-				if (cachedModel == null) {
-					cacheResult(model);
+				if (_modelImplClass.isInstance(serializable)) {
+					model.copyCacheFields(_modelImplClass.cast(serializable));
 				}
 				else {
-					model.copyCacheFields(cachedModel);
+					cacheResult(model);
 				}
 			}
 
@@ -207,15 +206,14 @@ public class BasePersistenceImpl
 					CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
 						ctModel.getCtCollectionId())) {
 
-				@SuppressWarnings("unchecked")
-				T cachedModel = (T)entityCache.getResult(
+				Serializable serializable = entityCache.getResult(
 					_modelImplClass, model.getPrimaryKeyObj());
 
-				if (cachedModel == null) {
-					cacheResult(model);
+				if (_modelImplClass.isInstance(serializable)) {
+					model.copyCacheFields(_modelImplClass.cast(serializable));
 				}
 				else {
-					model.copyCacheFields(cachedModel);
+					cacheResult(model);
 				}
 			}
 		}


### PR DESCRIPTION
### Problem

`cacheResult(List)` merges cache-only fields from the currently cached entry into each model it is handed, but it decided whether to merge by testing the cached slot for `null` alone. The negative `nullModel` sentinel that `fetchByPrimaryKey` caches for a database miss is not `null`, so it took the merge branch, where `copyCacheFields` cast it to the entity type and threw `ClassCastException`. The failure is self-sustaining: the exception aborts before the finder cache is populated, so every repeat of the query re-runs the merge against the same stale sentinel — a query that has just returned the entity keeps failing until the cache is cleared.

### Fix

Merge only when the cached slot actually holds an instance of the entity model (`_modelImplClass.isInstance(...)`), so the negative sentinel — and any other non-entity — routes to caching the fresh result instead. Since the query has just proven the entity exists, caching over a stale negative heals the slot.

### Results Summary

**pr-check: PASS** — tested on `0a6081b6bc8b7b0ef03de8c32362c1a54eaa2c09`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Full Portal Build | PASS |
| Java Unit Tests | PASS |
