### PR TITLE
LPD-97138 Copy element variations from draft to live on publish

### DIFF
--- a/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/service/LayoutLocalServiceWrapper.java
+++ b/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/service/LayoutLocalServiceWrapper.java
@@ -23,8 +23,10 @@ import com.liferay.layout.model.LayoutClassedModelUsage;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.page.template.model.LayoutPageTemplateStructure;
+import com.liferay.layout.page.template.model.LayoutPageTemplateStructureRelElementVariation;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
 import com.liferay.layout.page.template.service.LayoutPageTemplateStructureLocalService;
+import com.liferay.layout.page.template.service.LayoutPageTemplateStructureRelElementVariationLocalService;
 import com.liferay.layout.seo.model.LayoutSEOEntry;
 import com.liferay.layout.seo.service.LayoutSEOEntryLocalService;
 import com.liferay.layout.service.LayoutClassedModelUsageLocalService;
@@ -79,6 +81,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
 import com.liferay.portlet.exportimport.staging.StagingAdvicesThreadLocal;
 import com.liferay.segments.constants.SegmentsExperienceConstants;
 import com.liferay.segments.model.SegmentsExperience;
@@ -506,6 +509,62 @@ public class LayoutLocalServiceWrapper
 			targetSegmentsExperienceId, user);
 	}
 
+	private void _copyLayoutPageTemplateStructureRelElementVariations(
+			Layout sourceLayout, Layout targetLayout, User user)
+		throws Exception {
+
+		for (LayoutPageTemplateStructureRelElementVariation
+				targetLayoutPageTemplateStructureRelElementVariation :
+					_layoutPageTemplateStructureRelElementVariationLocalService.
+						getLayoutPageTemplateStructureRelElementVariations(
+							targetLayout.getPlid())) {
+
+			_layoutPageTemplateStructureRelElementVariationLocalService.
+				deleteLayoutPageTemplateStructureRelElementVariation(
+					targetLayoutPageTemplateStructureRelElementVariation.
+						getExternalReferenceCode(),
+					targetLayout.getGroupId());
+		}
+
+		for (LayoutPageTemplateStructureRelElementVariation
+				sourceLayoutPageTemplateStructureRelElementVariation :
+					_layoutPageTemplateStructureRelElementVariationLocalService.
+						getLayoutPageTemplateStructureRelElementVariations(
+							sourceLayout.getPlid())) {
+
+			String segmentsExperienceERC = _getTargetSegmentsExperienceERC(
+				sourceLayoutPageTemplateStructureRelElementVariation.
+					getSegmentsExperienceERC(),
+				sourceLayout, targetLayout);
+
+			if (segmentsExperienceERC == null) {
+				continue;
+			}
+
+			List<String> audienceEntryERCs =
+				sourceLayoutPageTemplateStructureRelElementVariation.
+					getAudienceEntryERCs();
+
+			_layoutPageTemplateStructureRelElementVariationLocalService.
+				addOrUpdateLayoutPageTemplateStructureRelElementVariation(
+					PortalUUIDUtil.generate(), user.getUserId(),
+					targetLayout.getGroupId(),
+					audienceEntryERCs.toArray(new String[0]),
+					sourceLayoutPageTemplateStructureRelElementVariation.
+						getHideMap(),
+					sourceLayoutPageTemplateStructureRelElementVariation.
+						getHtmlMap(),
+					sourceLayoutPageTemplateStructureRelElementVariation.
+						getJsMap(),
+					sourceLayoutPageTemplateStructureRelElementVariation.
+						getName(),
+					targetLayout.getPlid(), segmentsExperienceERC,
+					sourceLayoutPageTemplateStructureRelElementVariation.
+						getTargetElement(),
+					ServiceContextThreadLocal.getServiceContext());
+		}
+	}
+
 	private void _copyLayoutSEOEntry(
 			Layout sourceLayout, Layout targetLayout, long userId)
 		throws Exception {
@@ -888,6 +947,32 @@ public class LayoutLocalServiceWrapper
 						targetLayout.getGroupId(), segmentsExperiencesIds,
 						targetLayout.getPlid()),
 				FragmentEntryLink.FRAGMENT_ENTRY_LINK_ID_ACCESSOR));
+	}
+
+	private String _getTargetSegmentsExperienceERC(
+		String segmentsExperienceERC, Layout sourceLayout,
+		Layout targetLayout) {
+
+		SegmentsExperience sourceSegmentsExperience =
+			_segmentsExperienceLocalService.
+				fetchSegmentsExperienceByExternalReferenceCode(
+					segmentsExperienceERC, sourceLayout.getGroupId());
+
+		if (sourceSegmentsExperience == null) {
+			return null;
+		}
+
+		SegmentsExperience targetSegmentsExperience =
+			_segmentsExperienceLocalService.fetchSegmentsExperience(
+				targetLayout.getGroupId(),
+				sourceSegmentsExperience.getSegmentsExperienceKey(),
+				targetLayout.getPlid());
+
+		if (targetSegmentsExperience == null) {
+			return null;
+		}
+
+		return targetSegmentsExperience.getExternalReferenceCode();
 	}
 
 	private String _getTypeSettings(Layout sourceLayout, Layout targetLayout) {
@@ -1312,6 +1397,10 @@ public class LayoutLocalServiceWrapper
 		_layoutPageTemplateStructureLocalService;
 
 	@Reference
+	private LayoutPageTemplateStructureRelElementVariationLocalService
+		_layoutPageTemplateStructureRelElementVariationLocalService;
+
+	@Reference
 	private LayoutSEOEntryLocalService _layoutSEOEntryLocalService;
 
 	@Reference
@@ -1375,6 +1464,9 @@ public class LayoutLocalServiceWrapper
 						_sourceSegmentsExperiencesIds, _targetLayout,
 						_targetSegmentsExperiencesIds, _user);
 				}
+
+				_copyLayoutPageTemplateStructureRelElementVariations(
+					_sourceLayout, _targetLayout, _user);
 
 				List<String> portletIds = _getLayoutPortletIds(
 					_sourceLayout, _sourceSegmentsExperiencesIds);

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/service/test/LayoutLocalServiceCopyLayoutContentTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/service/test/LayoutLocalServiceCopyLayoutContentTest.java
@@ -35,9 +35,11 @@ import com.liferay.layout.model.LayoutClassedModelUsage;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.page.template.model.LayoutPageTemplateStructure;
+import com.liferay.layout.page.template.model.LayoutPageTemplateStructureRelElementVariation;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryService;
 import com.liferay.layout.page.template.service.LayoutPageTemplateStructureLocalService;
+import com.liferay.layout.page.template.service.LayoutPageTemplateStructureRelElementVariationLocalService;
 import com.liferay.layout.page.template.service.LayoutPageTemplateStructureRelLocalService;
 import com.liferay.layout.provider.LayoutStructureProvider;
 import com.liferay.layout.seo.model.LayoutSEOEntry;
@@ -1058,6 +1060,91 @@ public class LayoutLocalServiceCopyLayoutContentTest {
 	}
 
 	@Test
+	public void testCopyLayoutPageTemplateStructureRelElementVariations()
+		throws Exception {
+
+		Layout targetLayout = LayoutTestUtil.addTypeContentLayout(_group);
+
+		Layout sourceLayout = targetLayout.fetchDraftLayout();
+
+		LayoutPageTemplateStructure layoutPageTemplateStructure =
+			_layoutPageTemplateStructureLocalService.
+				fetchLayoutPageTemplateStructure(
+					_group.getGroupId(), sourceLayout.getPlid());
+
+		SegmentsExperience sourceSegmentsExperience =
+			SegmentsTestUtil.addSegmentsExperience(
+				_group.getGroupId(), sourceLayout.getPlid());
+
+		_layoutPageTemplateStructureRelLocalService.
+			addLayoutPageTemplateStructureRel(
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				layoutPageTemplateStructure.getLayoutPageTemplateStructureId(),
+				sourceSegmentsExperience.getSegmentsExperienceId(),
+				layoutPageTemplateStructure.getDefaultSegmentsExperienceData(),
+				ServiceContextTestUtil.getServiceContext(
+					_group.getGroupId(), TestPropsValues.getUserId()));
+
+		LayoutPageTemplateStructureRelElementVariation
+			sourceLayoutPageTemplateStructureRelElementVariation =
+				_addLayoutPageTemplateStructureRelElementVariation(
+					sourceLayout,
+					sourceSegmentsExperience.getExternalReferenceCode());
+
+		_layoutLocalService.copyLayoutContent(sourceLayout, targetLayout);
+
+		List<LayoutPageTemplateStructureRelElementVariation>
+			targetLayoutPageTemplateStructureRelElementVariations =
+				_layoutPageTemplateStructureRelElementVariationLocalService.
+					getLayoutPageTemplateStructureRelElementVariations(
+						targetLayout.getPlid());
+
+		Assert.assertEquals(
+			targetLayoutPageTemplateStructureRelElementVariations.toString(), 1,
+			targetLayoutPageTemplateStructureRelElementVariations.size());
+
+		LayoutPageTemplateStructureRelElementVariation
+			targetLayoutPageTemplateStructureRelElementVariation =
+				targetLayoutPageTemplateStructureRelElementVariations.get(0);
+
+		Assert.assertEquals(
+			sourceLayoutPageTemplateStructureRelElementVariation.
+				getAudienceEntryERCs(),
+			targetLayoutPageTemplateStructureRelElementVariation.
+				getAudienceEntryERCs());
+		Assert.assertNotEquals(
+			sourceLayoutPageTemplateStructureRelElementVariation.
+				getExternalReferenceCode(),
+			targetLayoutPageTemplateStructureRelElementVariation.
+				getExternalReferenceCode());
+		Assert.assertEquals(
+			sourceLayoutPageTemplateStructureRelElementVariation.getName(),
+			targetLayoutPageTemplateStructureRelElementVariation.getName());
+
+		SegmentsExperience targetSegmentsExperience =
+			_segmentsExperienceLocalService.fetchSegmentsExperience(
+				targetLayout.getGroupId(),
+				sourceSegmentsExperience.getSegmentsExperienceKey(),
+				targetLayout.getPlid());
+
+		Assert.assertNotNull(targetSegmentsExperience);
+		Assert.assertEquals(
+			targetSegmentsExperience.getExternalReferenceCode(),
+			targetLayoutPageTemplateStructureRelElementVariation.
+				getSegmentsExperienceERC());
+
+		Assert.assertNotEquals(
+			sourceSegmentsExperience.getExternalReferenceCode(),
+			targetLayoutPageTemplateStructureRelElementVariation.
+				getSegmentsExperienceERC());
+		Assert.assertEquals(
+			sourceLayoutPageTemplateStructureRelElementVariation.
+				getTargetElement(),
+			targetLayoutPageTemplateStructureRelElementVariation.
+				getTargetElement());
+	}
+
+	@Test
 	public void testCopyLayoutPortletPreferences() throws Exception {
 		String portletId = LayoutPortletKeys.LAYOUT_TEST_PORTLET;
 
@@ -1553,6 +1640,25 @@ public class LayoutLocalServiceCopyLayoutContentTest {
 		return _layoutLocalService.getLayout(layout.getPlid());
 	}
 
+	private LayoutPageTemplateStructureRelElementVariation
+			_addLayoutPageTemplateStructureRelElementVariation(
+				Layout layout, String segmentsExperienceERC)
+		throws Exception {
+
+		return _layoutPageTemplateStructureRelElementVariationLocalService.
+			addOrUpdateLayoutPageTemplateStructureRelElementVariation(
+				RandomTestUtil.randomString(), TestPropsValues.getUserId(),
+				layout.getGroupId(),
+				new String[] {RandomTestUtil.randomString()},
+				Collections.<Locale, String>emptyMap(),
+				Collections.<Locale, String>emptyMap(),
+				Collections.<Locale, String>emptyMap(),
+				RandomTestUtil.randomString(), layout.getPlid(),
+				segmentsExperienceERC, RandomTestUtil.randomString(),
+				ServiceContextTestUtil.getServiceContext(
+					layout.getGroupId(), TestPropsValues.getUserId()));
+	}
+
 	private void _addPortletPreferenceValue(
 			String name, Layout layout, String portletId, String value)
 		throws Exception {
@@ -1849,6 +1955,10 @@ public class LayoutLocalServiceCopyLayoutContentTest {
 	@Inject
 	private LayoutPageTemplateStructureLocalService
 		_layoutPageTemplateStructureLocalService;
+
+	@Inject
+	private LayoutPageTemplateStructureRelElementVariationLocalService
+		_layoutPageTemplateStructureRelElementVariationLocalService;
 
 	@Inject
 	private LayoutPageTemplateStructureRelLocalService


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97138

## What Is Being Fixed

When a page is published (draft copied to live), element variations defined on the draft layout were not carried over to the live layout. The published page therefore lost its element-level variations.

## How It Is Being Fixed

Adds an element-variation reconciliation step to the layout content copy. It first clears any existing element variations on the target layout, then re-creates each one from the source layout. Each variation's segments experience is remapped from the source group to the equivalent experience in the target group by matching the segments experience key; variations whose experience has no counterpart in the target are skipped rather than copied with a dangling reference.

## PR Check

**pr-check: PASS** — tested on 

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {result: success, sha: 7d8179b2944da224f6a063674f7fa7a69d11764e} -->