### PR TITLE
LPD-97338 Load element variations only in view mode

### DIFF
--- a/modules/apps/frontend-js/frontend-js-audiences-web/src/main/java/com/liferay/frontend/js/audiences/web/internal/servlet/taglib/FrontendJSAudiencesWebTopHeadDynamicInclude.java
+++ b/modules/apps/frontend-js/frontend-js-audiences-web/src/main/java/com/liferay/frontend/js/audiences/web/internal/servlet/taglib/FrontendJSAudiencesWebTopHeadDynamicInclude.java
@@ -17,6 +17,8 @@ import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.module.configuration.ConfigurationException;
 import com.liferay.portal.kernel.servlet.taglib.DynamicInclude;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.Constants;
+import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.url.builder.AbsolutePortalURLBuilder;
@@ -28,6 +30,7 @@ import jakarta.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -48,6 +51,13 @@ public class FrontendJSAudiencesWebTopHeadDynamicInclude
 		long companyId = _portal.getCompanyId(httpServletRequest);
 
 		if (!FeatureFlagManagerUtil.isEnabled(companyId, "LPD-83647")) {
+			return;
+		}
+
+		String layoutMode = ParamUtil.getString(
+			httpServletRequest, "p_l_mode", Constants.VIEW);
+
+		if  (!Objects.equals(layoutMode, Constants.VIEW)) {
 			return;
 		}
 

--- a/modules/apps/frontend-js/frontend-js-audiences-web/src/main/java/com/liferay/frontend/js/audiences/web/internal/servlet/taglib/FrontendJSAudiencesWebTopHeadDynamicInclude.java
+++ b/modules/apps/frontend-js/frontend-js-audiences-web/src/main/java/com/liferay/frontend/js/audiences/web/internal/servlet/taglib/FrontendJSAudiencesWebTopHeadDynamicInclude.java
@@ -30,6 +30,7 @@ import jakarta.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+
 import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
@@ -57,7 +58,7 @@ public class FrontendJSAudiencesWebTopHeadDynamicInclude
 		String layoutMode = ParamUtil.getString(
 			httpServletRequest, "p_l_mode", Constants.VIEW);
 
-		if  (!Objects.equals(layoutMode, Constants.VIEW)) {
+		if (!Objects.equals(layoutMode, Constants.VIEW)) {
 			return;
 		}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97338

## What Is Being Fixed

The audiences JavaScript that powers element variations was loaded in every layout mode, including edit and preview. It should only load when the page is being viewed.

## How It Is Being Fixed

Guards FrontendJSAudiencesWebTopHeadDynamicInclude so it returns early unless the current layout mode (p_l_mode) is view. In any other mode the script is no longer written to the page head.

## Why Are There No Tests?

Tests for this change will be added in LPD-96221.

## PR Check

**pr-check: PASS** — tested on 

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |

<!-- pr-check {result: success, sha: b601869e7c38717eac2de839ec64bc25aedb42d0} -->