### PR TITLE
LPD-28363 Remove redundant company send password check

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -3096,6 +3096,16 @@
 		]
 	},
 	{
+		"from": "regex:!company\\.isSendPassword\\(\\) && (?<condition>!company\\.isSendPasswordResetLink\\(\\))",
+		"issueKey": "LPD-28363",
+		"to": "${condition}"
+	},
+	{
+		"from": "regex:PropsKeys\\.COMPANY_SECURITY_SEND_PASSWORD,\\s+(?<suffix>PropsKeys\\.COMPANY_SECURITY_SEND_PASSWORD_RESET_LINK)",
+		"issueKey": "LPD-28363",
+		"to": "${suffix}"
+	},
+	{
 		"classNames": [
 			"StrutsAction"
 		],

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_28363.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_28363.testjava
@@ -1,0 +1,22 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class LPD_28363 {
+
+	public void method(Company company) {
+		if (!company.isSendPasswordResetLink()) {
+			doSomething();
+		}
+
+		addProps(
+			PropsKeys.COMPANY_SECURITY_SEND_PASSWORD_RESET_LINK);
+	}
+
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_28363.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_28363.testjava
@@ -1,0 +1,23 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class LPD_28363 {
+
+	public void method(Company company) {
+		if (!company.isSendPassword() && !company.isSendPasswordResetLink()) {
+			doSomething();
+		}
+
+		addProps(
+			PropsKeys.COMPANY_SECURITY_SEND_PASSWORD,
+			PropsKeys.COMPANY_SECURITY_SEND_PASSWORD_RESET_LINK);
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-28363

## What Is Being Fixed

Classes that implement `ForgotPasswordMVCActionCommand` guard the forgot-password flow with `!company.isSendPassword() && !company.isSendPasswordResetLink()` and register both `PropsKeys.COMPANY_SECURITY_SEND_PASSWORD` and `PropsKeys.COMPANY_SECURITY_SEND_PASSWORD_RESET_LINK`. The `sendPassword` half of these checks is redundant for the forgot-password path, which is governed solely by the send-password-reset-link setting.

## How It Is Being Fixed

Rather than editing each call site by hand, two `upgrade-catch-all-check` replacement rules are added to the source formatter under LPD-28363. The first collapses `!company.isSendPassword() && !company.isSendPasswordResetLink()` down to `!company.isSendPasswordResetLink()`; the second drops the `PropsKeys.COMPANY_SECURITY_SEND_PASSWORD` argument. The formatter then applies these transformations across the codebase, and input/expected fixtures verify both rules.

## PR Check

**pr-check: PASS** — tested on `e352d4d107ab9ce760690852286e02ec49dcdc11`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "e352d4d107ab9ce760690852286e02ec49dcdc11"} -->
