### PR TITLE
LPD-84010 Add source formatter rule to replace getDDMStructures call

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -5920,6 +5920,14 @@
 		"issueKey": "LPD-82354"
 	},
 	{
+		"from": "regex:(?<varName>\\w*?FileEntryType)\\.getDDMStructures\\(\\)",
+		"issueKey": "LPD-84010",
+		"newImports": [
+			"com.liferay.document.library.util.DLFileEntryTypeUtil"
+		],
+		"to": "DLFileEntryTypeUtil.getDDMStructures(${varName})"
+	},
+	{
 		"classNames": [
 			"PhoneLocalService",
 			"PhoneLocalServiceUtil",

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_84010.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_84010.testjava
@@ -5,12 +5,14 @@
 
 package com.liferay.source.formatter.dependencies.upgrade;
 
+import com.liferay.document.library.util.DLFileEntryTypeUtil;
+
 /**
  * @author Mateus Xavier
  */
 public class LPD_84010 {
 
-	public void method(DLFileEntryType dlFileEntryType) {
+	public void method() {
 		DLFileEntryTypeUtil.getDDMStructures(dlFileEntryType);
 	}
 

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_84010.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_84010.testjava
@@ -1,0 +1,17 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+/**
+ * @author Mateus Xavier
+ */
+public class LPD_84010 {
+
+	public void method(DLFileEntryType dlFileEntryType) {
+		DLFileEntryTypeUtil.getDDMStructures(dlFileEntryType);
+	}
+
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_84010.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_84010.testjava
@@ -10,7 +10,7 @@ package com.liferay.source.formatter.dependencies.upgrade;
  */
 public class LPD_84010 {
 
-	public void method(DLFileEntryType dlFileEntryType) {
+	public void method() {
 		dlFileEntryType.getDDMStructures();
 	}
 

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_84010.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_84010.testjava
@@ -1,0 +1,17 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+/**
+ * @author Mateus Xavier
+ */
+public class LPD_84010 {
+
+	public void method(DLFileEntryType dlFileEntryType) {
+		dlFileEntryType.getDDMStructures();
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-84010

## What Is Being Fixed

The `getDDMStructures()` method called directly on a `DLFileEntryType` is
deprecated. Code that invokes it on a file entry type variable should migrate
to `DLFileEntryTypeUtil.getDDMStructures(...)`, but nothing automated that
migration.

## How It Is Being Fixed

A new upgrade replacement rule is added to the source formatter's
`replacements.json`. It matches any `<var>FileEntryType.getDDMStructures()`
call via regex, rewrites it to `DLFileEntryTypeUtil.getDDMStructures(<var>)`,
and adds the `com.liferay.document.library.util.DLFileEntryTypeUtil` import. A
test fixture pair under `upgrade-catch-all-check` covers the transformation.

## PR Check

**pr-check: PASS** — tested on `617eacb373ed6aed1cc82afd9069aed1ae1ede19`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "617eacb373ed6aed1cc82afd9069aed1ae1ede19"} -->
