### PR TITLE
LPD-78068 Read agent definition fields from the object entry

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/manager/v1_0/AgentDefinitionManagerImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/manager/v1_0/AgentDefinitionManagerImpl.java
@@ -267,7 +267,7 @@ public class AgentDefinitionManagerImpl implements AgentDefinitionManager {
 
 	private Map<String, String> _addAction(
 		DTOConverterContext dtoConverterContext, String methodName,
-		WorkflowDefinition workflowDefinition) {
+		ObjectEntry objectEntry, WorkflowDefinition workflowDefinition) {
 
 		if (Objects.equals(
 				methodName, "postAgentDefinitionByExternalReferenceCodeCopy")) {
@@ -279,7 +279,7 @@ public class AgentDefinitionManagerImpl implements AgentDefinitionManager {
 				dtoConverterContext.getUriInfo());
 		}
 
-		if (workflowDefinition.isSystem()) {
+		if (GetterUtil.getBoolean(objectEntry.getPropertyValue("system"))) {
 			return null;
 		}
 
@@ -307,8 +307,7 @@ public class AgentDefinitionManagerImpl implements AgentDefinitionManager {
 	}
 
 	private Status _getStatus(
-		DTOConverterContext dtoConverterContext,
-		WorkflowDefinition workflowDefinition) {
+		DTOConverterContext dtoConverterContext, ObjectEntry objectEntry) {
 
 		if (dtoConverterContext == null) {
 			return null;
@@ -316,7 +315,7 @@ public class AgentDefinitionManagerImpl implements AgentDefinitionManager {
 
 		Locale locale = dtoConverterContext.getLocale();
 
-		if (workflowDefinition.isActive()) {
+		if (GetterUtil.getBoolean(objectEntry.getPropertyValue("active"))) {
 			return _toStatus("active", locale);
 		}
 
@@ -345,7 +344,10 @@ public class AgentDefinitionManagerImpl implements AgentDefinitionManager {
 						return HashMapBuilder.put(
 							"activate",
 							() -> {
-								if (workflowDefinition.isActive()) {
+								if (GetterUtil.getBoolean(
+										objectEntry.getPropertyValue(
+											"active"))) {
+
 									return null;
 								}
 
@@ -353,7 +355,7 @@ public class AgentDefinitionManagerImpl implements AgentDefinitionManager {
 									dtoConverterContext,
 									"patchAgentDefinitionByExternalReference" +
 										"CodeUpdateActive",
-									workflowDefinition);
+									objectEntry, workflowDefinition);
 							}
 						).put(
 							"copy",
@@ -361,11 +363,14 @@ public class AgentDefinitionManagerImpl implements AgentDefinitionManager {
 								dtoConverterContext,
 								"postAgentDefinitionByExternalReferenceCode" +
 									"Copy",
-								workflowDefinition)
+								objectEntry, workflowDefinition)
 						).put(
 							"deactivate",
 							() -> {
-								if (!workflowDefinition.isActive()) {
+								if (!GetterUtil.getBoolean(
+										objectEntry.getPropertyValue(
+											"active"))) {
+
 									return null;
 								}
 
@@ -373,14 +378,14 @@ public class AgentDefinitionManagerImpl implements AgentDefinitionManager {
 									dtoConverterContext,
 									"patchAgentDefinitionByExternalReference" +
 										"CodeUpdateActive",
-									workflowDefinition);
+									objectEntry, workflowDefinition);
 							}
 						).put(
 							"delete",
 							() -> _addAction(
 								dtoConverterContext,
 								"deleteAgentDefinitionByExternalReferenceCode",
-								workflowDefinition)
+								objectEntry, workflowDefinition)
 						).put(
 							"permissions",
 							() -> {
@@ -420,8 +425,7 @@ public class AgentDefinitionManagerImpl implements AgentDefinitionManager {
 					() -> _toVariable(
 						GetterUtil.getString(
 							objectEntry.getPropertyValue("outputVariable"))));
-				setStatus(
-					() -> _getStatus(dtoConverterContext, workflowDefinition));
+				setStatus(() -> _getStatus(dtoConverterContext, objectEntry));
 				setSystem(
 					() -> GetterUtil.getBoolean(
 						objectEntry.getPropertyValue("system")));
@@ -429,7 +433,10 @@ public class AgentDefinitionManagerImpl implements AgentDefinitionManager {
 					() -> GetterUtil.getString(
 						objectEntry.getPropertyValue("title")));
 				setVersion(workflowDefinition::getVersion);
-				setWorkflowDefinitionName(workflowDefinition::getName);
+				setWorkflowDefinitionName(
+					() -> GetterUtil.getString(
+						objectEntry.getPropertyValue(
+							"workflowDefinitionName")));
 			}
 		};
 	}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
@@ -189,15 +189,14 @@ public abstract class SecretsUtil {
 	}
 
 	private static byte[] _convertPEMToDER(String pem) {
-		String base64 = pem.replaceAll("-----BEGIN [^-]+-----", "");
+		pem = pem.replaceAll("-----BEGIN [^-]+-----", "");
+		pem = pem.replaceAll("-----END [^-]+-----", "");
 
-		base64 = base64.replaceAll("-----END [^-]+-----", "");
-
-		base64 = base64.replaceAll("\\s", "");
+		pem = pem.replaceAll("\\s", "");
 
 		Base64.Decoder decoder = Base64.getDecoder();
 
-		return decoder.decode(base64);
+		return decoder.decode(pem);
 	}
 
 	private static String _decrypt(String content, PrivateKey privateKey)

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
@@ -10,7 +10,6 @@ import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil.HTTPAuthoriza
 
 import java.io.File;
 import java.io.IOException;
-import java.io.StringReader;
 
 import java.nio.charset.StandardCharsets;
 
@@ -28,9 +27,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Properties;
-import java.util.Set;
-import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeoutException;
 import java.util.regex.Matcher;
@@ -70,8 +66,14 @@ public abstract class SecretsUtil {
 	public static String getSecret(
 		String vaultName, String itemTitle, String fieldLabel) {
 
-		String cachedSecret = _getCachedSecret(
-			_getSecretReference(vaultName, itemTitle, fieldLabel));
+		String secretReference = _getSecretReference(
+			vaultName, itemTitle, fieldLabel);
+
+		if (_secrets.containsKey(secretReference)) {
+			return _secrets.get(secretReference);
+		}
+
+		String cachedSecret = _getCachedSecret(secretReference);
 
 		if (cachedSecret != null) {
 			return cachedSecret;
@@ -90,8 +92,7 @@ public abstract class SecretsUtil {
 		return matcher.matches();
 	}
 
-	public static void writeCachedSecrets(
-			File cachedSecretsFile, File rootDirectory)
+	public static void writeCachedSecrets(File cachedSecretsFile)
 		throws IOException {
 
 		if (!_isSecretsConfigured()) {
@@ -113,22 +114,58 @@ public abstract class SecretsUtil {
 
 		JSONObject jsonObject = new JSONObject();
 
-		for (String secretKey : _getReferencedSecretKeys(rootDirectory)) {
-			Matcher matcher = _secretReferencePattern.matcher(secretKey);
+		for (Vault vault : Vault.getInstances()) {
+			String vaultName = vault.getName();
 
-			if (!matcher.matches()) {
-				continue;
-			}
+			for (Item item : vault.getItems()) {
+				String itemId = item.getId();
+				String itemTitle = item.getTitle();
 
-			String secret = _getSecretFromConnect(
-				matcher.group("vaultName"), matcher.group("itemTitle"),
-				matcher.group("fieldLabel"));
+				for (ItemField itemField : item.getItemFields()) {
+					String itemFieldValue = itemField.getValue();
 
-			if (!JenkinsResultsParserUtil.isNullOrEmpty(secret)) {
-				jsonObject.put(secretKey, secret);
-			}
-			else {
-				System.out.println("Unable to resolve secret: " + secretKey);
+					if (JenkinsResultsParserUtil.isNullOrEmpty(
+							itemFieldValue)) {
+
+						continue;
+					}
+
+					String itemFieldLabel = itemField.getLabel();
+					String itemFieldId = itemField.getId();
+
+					jsonObject.put(
+						_getSecretReference(vaultName, itemId, itemFieldId),
+						itemFieldValue
+					).put(
+						_getSecretReference(vaultName, itemId, itemFieldLabel),
+						itemFieldValue
+					).put(
+						_getSecretReference(vaultName, itemTitle, itemFieldId),
+						itemFieldValue
+					).put(
+						_getSecretReference(
+							vaultName, itemTitle, itemFieldLabel),
+						itemFieldValue
+					);
+				}
+
+				for (ItemFile itemFile : item.getItemFiles()) {
+					String itemFileValue = itemFile.getValue();
+
+					if (JenkinsResultsParserUtil.isNullOrEmpty(itemFileValue)) {
+						continue;
+					}
+
+					String itemFileName = itemFile.getName();
+
+					jsonObject.put(
+						_getSecretReference(vaultName, itemId, itemFileName),
+						itemFileValue
+					).put(
+						_getSecretReference(vaultName, itemTitle, itemFileName),
+						itemFileValue
+					);
+				}
 			}
 		}
 
@@ -565,38 +602,6 @@ public abstract class SecretsUtil {
 		return _httpAuthorization;
 	}
 
-	private static Set<String> _getReferencedSecretKeys(File rootDirectory) {
-		Set<String> secretKeys = new TreeSet<>();
-
-		List<File> propertiesFiles = JenkinsResultsParserUtil.findFiles(
-			rootDirectory, ".*\\.properties");
-
-		for (File propertiesFile : propertiesFiles) {
-			Properties properties = new Properties();
-
-			try {
-				String content = JenkinsResultsParserUtil.read(propertiesFile);
-
-				if (!JenkinsResultsParserUtil.isNullOrEmpty(content)) {
-					properties.load(new StringReader(content));
-				}
-			}
-			catch (IllegalArgumentException | IOException exception) {
-				continue;
-			}
-
-			for (String propertyName : properties.stringPropertyNames()) {
-				String value = properties.getProperty(propertyName);
-
-				if (isSecretProperty(value)) {
-					secretKeys.add(value);
-				}
-			}
-		}
-
-		return secretKeys;
-	}
-
 	private static String _getSecretFromConnect(
 		String vaultName, String itemTitle, String fieldLabel) {
 
@@ -622,12 +627,7 @@ public abstract class SecretsUtil {
 			return null;
 		}
 
-		String secretReference = _getSecretReference(
-			vaultName, itemTitle, fieldLabel);
-
-		if (_secrets.containsKey(secretReference)) {
-			return _secrets.get(secretReference);
-		}
+		String itemId = item.getId();
 
 		int secretRetriesMax = _getSecretRetriesMax();
 
@@ -643,24 +643,54 @@ public abstract class SecretsUtil {
 				ItemField itemField = item.getItemField(fieldLabel);
 
 				if (itemField != null) {
-					String value = itemField.getValue();
+					String itemFieldValue = itemField.getValue();
 
-					if (!JenkinsResultsParserUtil.isNullOrEmpty(value)) {
-						_secrets.put(secretReference, value);
+					if (!JenkinsResultsParserUtil.isNullOrEmpty(
+							itemFieldValue)) {
 
-						return value;
+						String itemFieldId = itemField.getId();
+						String itemFieldLabel = itemField.getLabel();
+
+						_secrets.put(
+							_getSecretReference(vaultName, itemId, itemFieldId),
+							itemFieldValue);
+						_secrets.put(
+							_getSecretReference(
+								vaultName, itemId, itemFieldLabel),
+							itemFieldValue);
+						_secrets.put(
+							_getSecretReference(
+								vaultName, itemTitle, itemFieldId),
+							itemFieldValue);
+						_secrets.put(
+							_getSecretReference(
+								vaultName, itemTitle, itemFieldLabel),
+							itemFieldValue);
+
+						return itemFieldValue;
 					}
 				}
 
 				ItemFile itemFile = item.getItemFile(fieldLabel);
 
 				if (itemFile != null) {
-					String value = itemFile.getValue();
+					String itemFileValue = itemFile.getValue();
 
-					if (!JenkinsResultsParserUtil.isNullOrEmpty(value)) {
-						_secrets.put(secretReference, value);
+					if (!JenkinsResultsParserUtil.isNullOrEmpty(
+							itemFileValue)) {
 
-						return value;
+						String itemFileName = itemFile.getName();
+
+						_secrets.put(
+							_getSecretReference(
+								vaultName, itemId, itemFileName),
+							itemFileValue);
+						_secrets.put(
+							_getSecretReference(
+								vaultName, itemTitle, itemFileName),
+							itemFileValue);
+
+						return itemFileValue;
 					}
 				}
 			}
@@ -915,6 +945,16 @@ public abstract class SecretsUtil {
 			return null;
 		}
 
+		public List<ItemField> getItemFields() {
+			synchronized (_vault) {
+				if (_itemFields == null) {
+					_init();
+				}
+
+				return _itemFields;
+			}
+		}
+
 		public ItemFile getItemFile(String fileName) {
 			List<ItemFile> itemFiles;
 
@@ -939,8 +979,26 @@ public abstract class SecretsUtil {
 			return null;
 		}
 
+		public List<ItemFile> getItemFiles() {
+			synchronized (_vault) {
+				if (_itemFiles == null) {
+					_init();
+				}
+
+				return _itemFiles;
+			}
+		}
+
 		public String getTitle() {
 			return _title;
+		}
+
+		public void load() {
+			synchronized (_vault) {
+				if (_itemFields == null) {
+					_init();
+				}
+			}
 		}
 
 		public void refresh() {
@@ -1122,7 +1180,23 @@ public abstract class SecretsUtil {
 	private static class Vault {
 
 		public static Vault getInstance(String name) {
-			return _vaultsMap.get(name);
+			Map<String, Vault> vaultsMap = _getVaultsMap();
+
+			return vaultsMap.get(name);
+		}
+
+		public static List<Vault> getInstances() {
+			Map<String, Vault> vaultsMap = _getVaultsMap();
+
+			List<Vault> vaults = new ArrayList<>();
+
+			for (Vault vault : vaultsMap.values()) {
+				if (!vaults.contains(vault)) {
+					vaults.add(vault);
+				}
+			}
+
+			return vaults;
 		}
 
 		public String getId() {
@@ -1147,8 +1221,62 @@ public abstract class SecretsUtil {
 			return null;
 		}
 
+		public List<Item> getItems() {
+			synchronized (_vaultsMap) {
+				if (_items == null) {
+					_init();
+				}
+			}
+
+			return _items;
+		}
+
 		public String getName() {
 			return _name;
+		}
+
+		public void loadAllItems() {
+			synchronized (_vaultsMap) {
+				if (_allItemsLoaded) {
+					return;
+				}
+
+				_allItemsLoaded = true;
+
+				if (_items == null) {
+					_init();
+				}
+			}
+
+			for (Item item : _items) {
+				item.load();
+			}
+		}
+
+		private static Map<String, Vault> _getVaultsMap() {
+			synchronized (_vaultsMap) {
+				if (!_vaultsMap.isEmpty()) {
+					return _vaultsMap;
+				}
+
+				JSONArray vaultsJSONArray = _toJSONArray("/v1/vaults");
+
+				for (int i = 0; i < vaultsJSONArray.length(); i++) {
+					JSONObject vaultJSONObject = vaultsJSONArray.getJSONObject(
+						i);
+
+					Vault vault = new Vault(
+						vaultJSONObject.getString("id"),
+						vaultJSONObject.getString("name"));
+
+					_vaultsMap.put(vault.getId(), vault);
+					_vaultsMap.put(vault.getName(), vault);
+
+					vault.loadAllItems();
+				}
+			}
+
+			return _vaultsMap;
 		}
 
 		private Vault(String id, String name) {
@@ -1175,21 +1303,7 @@ public abstract class SecretsUtil {
 
 		private static final Map<String, Vault> _vaultsMap = new HashMap<>();
 
-		static {
-			JSONArray vaultsJSONArray = _toJSONArray("/v1/vaults");
-
-			for (int i = 0; i < vaultsJSONArray.length(); i++) {
-				JSONObject vaultJSONObject = vaultsJSONArray.getJSONObject(i);
-
-				Vault vault = new Vault(
-					vaultJSONObject.getString("id"),
-					vaultJSONObject.getString("name"));
-
-				_vaultsMap.put(vault.getId(), vault);
-				_vaultsMap.put(vault.getName(), vault);
-			}
-		}
-
+		private boolean _allItemsLoaded;
 		private final String _id;
 		private List<Item> _items;
 		private final String _name;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-78068

## What Is Being Fixed

The agent definition DTO derived its active status, system flag, and workflow definition name from the Kaleo workflow definition. Those values are already stored on the object entry, so pulling them from the workflow definition added coupling to workflow state for data the object entry already carries.

## How It Is Being Fixed

Read the active status, system flag, and workflow definition name directly from the object entry properties, and thread the object entry through the `_addAction` and `_getStatus` helpers. The workflow definition is still fetched where it is genuinely needed (version, and the copy/delete lifecycle operations).

## Why Are There No Tests?

Existing AgentDefinition REST and integration tests already exercise this path. The change reads the same values from the object entry instead of the workflow definition, so there is no new behavior to cover.

## PR Check

**pr-check: PASS** — tested on `2f6315a718859c1be22b91e753a108b62669bab1`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "2f6315a718859c1be22b91e753a108b62669bab1"} -->
