### PR TITLE
LPD-97240 Fix test compilation after UUID rename

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-image-impl-test/src/testIntegration/java/com/liferay/adaptive/media/image/internal/configuration/test/BaseAMImageConfigurationTestCase.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl-test/src/testIntegration/java/com/liferay/adaptive/media/image/internal/configuration/test/BaseAMImageConfigurationTestCase.java
@@ -124,7 +124,7 @@ public abstract class BaseAMImageConfigurationTestCase {
 		return uuids;
 	}
 
-	private Set<String> _initialAMImageConfigurationEntryUuids;
+	private Set<String> _initialAMImageConfigurationEntryUUIDs;
 
 	@Inject
 	private MessageBus _messageBus;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97240

## What Is Being Fixed

Commit [ba196d7](https://github.com/brianchandotcom/liferay-portal/commit/ba196d7f1e00392dcbc63fda1ec4540f1fe3b0d4) renamed the configuration-entry UUID methods and the field in BaseAMImageConfigurationTestCase to the "UUIDs" acronym capitalization, but left the field declaration as _initialAMImageConfigurationEntryUuids. The mismatch between the declaration and its usages broke compilation of the adaptive-media-image-impl-test integration test module.

## How It Is Being Fixed

Rename the field declaration from _initialAMImageConfigurationEntryUuids to _initialAMImageConfigurationEntryUUIDs so it matches the usages introduced by the rename, restoring compilation.

## Why Are There No Tests?

This change only renames a private field in an existing integration test base class to restore compilation; it adds no product behavior to cover. The fix is verified by the adaptive-media-image-impl-test module compiling successfully.

## PR Check

**pr-check: PASS** — tested on `bc22d7902dfc6630ac718bd848ddb048b904a1eb`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "bc22d7902dfc6630ac718bd848ddb048b904a1eb"} -->
