### PR TITLE
LPD-97197 Fix Job Scheduler Run Now under database partitioning

### DIFF
--- a/modules/apps/dispatch/dispatch-rest-impl/src/main/java/com/liferay/dispatch/rest/internal/resource/v1_0/DispatchTriggerResourceImpl.java
+++ b/modules/apps/dispatch/dispatch-rest-impl/src/main/java/com/liferay/dispatch/rest/internal/resource/v1_0/DispatchTriggerResourceImpl.java
@@ -65,7 +65,12 @@ public class DispatchTriggerResourceImpl
 			PermissionThreadLocal.getPermissionChecker(), dispatchTriggerId,
 			ActionKeys.UPDATE);
 
+		com.liferay.dispatch.model.DispatchTrigger dispatchTrigger =
+			_dispatchTriggerService.getDispatchTrigger(dispatchTriggerId);
+
 		Message message = new Message();
+
+		message.put("companyId", dispatchTrigger.getCompanyId());
 
 		message.setPayload(
 			JSONUtil.put(

--- a/modules/apps/dispatch/dispatch-rest-impl/src/main/java/com/liferay/dispatch/rest/internal/resource/v1_0/DispatchTriggerResourceImpl.java
+++ b/modules/apps/dispatch/dispatch-rest-impl/src/main/java/com/liferay/dispatch/rest/internal/resource/v1_0/DispatchTriggerResourceImpl.java
@@ -65,10 +65,10 @@ public class DispatchTriggerResourceImpl
 			PermissionThreadLocal.getPermissionChecker(), dispatchTriggerId,
 			ActionKeys.UPDATE);
 
+		Message message = new Message();
+
 		com.liferay.dispatch.model.DispatchTrigger dispatchTrigger =
 			_dispatchTriggerService.getDispatchTrigger(dispatchTriggerId);
-
-		Message message = new Message();
 
 		message.put("companyId", dispatchTrigger.getCompanyId());
 

--- a/modules/apps/dispatch/dispatch-rest-impl/src/main/java/com/liferay/dispatch/rest/internal/resource/v1_0/DispatchTriggerResourceImpl.java
+++ b/modules/apps/dispatch/dispatch-rest-impl/src/main/java/com/liferay/dispatch/rest/internal/resource/v1_0/DispatchTriggerResourceImpl.java
@@ -67,10 +67,11 @@ public class DispatchTriggerResourceImpl
 
 		Message message = new Message();
 
-		com.liferay.dispatch.model.DispatchTrigger dispatchTrigger =
-			_dispatchTriggerService.getDispatchTrigger(dispatchTriggerId);
+		com.liferay.dispatch.model.DispatchTrigger
+			serviceBuilderDispatchTrigger =
+				_dispatchTriggerService.getDispatchTrigger(dispatchTriggerId);
 
-		message.put("companyId", dispatchTrigger.getCompanyId());
+		message.put("companyId", serviceBuilderDispatchTrigger.getCompanyId());
 
 		message.setPayload(
 			JSONUtil.put(

--- a/modules/apps/dispatch/dispatch-rest-impl/src/test/java/com/liferay/dispatch/rest/internal/resource/v1_0/DispatchTriggerResourceImplTest.java
+++ b/modules/apps/dispatch/dispatch-rest-impl/src/test/java/com/liferay/dispatch/rest/internal/resource/v1_0/DispatchTriggerResourceImplTest.java
@@ -1,0 +1,96 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.dispatch.rest.internal.resource.v1_0;
+
+import com.liferay.dispatch.constants.DispatchConstants;
+import com.liferay.dispatch.model.DispatchTrigger;
+import com.liferay.dispatch.service.DispatchTriggerService;
+import com.liferay.portal.kernel.messaging.Message;
+import com.liferay.portal.kernel.messaging.MessageBus;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * @author Magdalena Jedraszak
+ */
+public class DispatchTriggerResourceImplTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		MockitoAnnotations.initMocks(this);
+	}
+
+	@Test
+	public void test() throws Exception {
+		long companyId = RandomTestUtil.randomLong();
+
+		Mockito.when(
+			_dispatchTrigger.getCompanyId()
+		).thenReturn(
+			companyId
+		);
+
+		long dispatchTriggerId = RandomTestUtil.randomLong();
+
+		Mockito.when(
+			_dispatchTriggerService.getDispatchTrigger(dispatchTriggerId)
+		).thenReturn(
+			_dispatchTrigger
+		);
+
+		_dispatchTriggerResourceImpl.postDispatchTriggerRun(dispatchTriggerId);
+
+		ArgumentCaptor<Message> messageArgumentCaptor = ArgumentCaptor.forClass(
+			Message.class);
+
+		Mockito.verify(
+			_messageBus
+		).sendMessage(
+			Mockito.eq(DispatchConstants.EXECUTOR_DESTINATION_NAME),
+			messageArgumentCaptor.capture()
+		);
+
+		Message message = messageArgumentCaptor.getValue();
+
+		Assert.assertEquals(companyId, message.getLong("companyId"));
+	}
+
+	@Mock
+	private DispatchTrigger _dispatchTrigger;
+
+	@Mock
+	private ModelResourcePermission<DispatchTrigger>
+		_dispatchTriggerModelResourcePermission;
+
+	@InjectMocks
+	private final DispatchTriggerResourceImpl _dispatchTriggerResourceImpl =
+		new DispatchTriggerResourceImpl();
+
+	@Mock
+	private DispatchTriggerService _dispatchTriggerService;
+
+	@Mock
+	private MessageBus _messageBus;
+
+}

--- a/modules/apps/dispatch/dispatch-rest-impl/src/test/java/com/liferay/dispatch/rest/internal/resource/v1_0/DispatchTriggerResourceImplTest.java
+++ b/modules/apps/dispatch/dispatch-rest-impl/src/test/java/com/liferay/dispatch/rest/internal/resource/v1_0/DispatchTriggerResourceImplTest.java
@@ -11,6 +11,7 @@ import com.liferay.dispatch.service.DispatchTriggerService;
 import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.messaging.MessageBus;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
@@ -21,10 +22,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
 
 /**
  * @author Magdalena Jedraszak
@@ -38,11 +36,21 @@ public class DispatchTriggerResourceImplTest {
 
 	@Before
 	public void setUp() {
-		MockitoAnnotations.initMocks(this);
+		ReflectionTestUtil.setFieldValue(
+			_dispatchTriggerResourceImpl,
+			"_dispatchTriggerModelResourcePermission",
+			_dispatchTriggerModelResourcePermission);
+		ReflectionTestUtil.setFieldValue(
+			_dispatchTriggerResourceImpl, "_dispatchTriggerService",
+			_dispatchTriggerService);
+		ReflectionTestUtil.setFieldValue(
+			_dispatchTriggerResourceImpl, "_messageBus", _messageBus);
 	}
 
 	@Test
-	public void test() throws Exception {
+	public void testPostDispatchTriggerRunPropagatesCompanyId()
+		throws Exception {
+
 		long companyId = RandomTestUtil.randomLong();
 
 		Mockito.when(
@@ -61,36 +69,30 @@ public class DispatchTriggerResourceImplTest {
 
 		_dispatchTriggerResourceImpl.postDispatchTriggerRun(dispatchTriggerId);
 
-		ArgumentCaptor<Message> messageArgumentCaptor = ArgumentCaptor.forClass(
+		ArgumentCaptor<Message> argumentCaptor = ArgumentCaptor.forClass(
 			Message.class);
 
 		Mockito.verify(
 			_messageBus
 		).sendMessage(
 			Mockito.eq(DispatchConstants.EXECUTOR_DESTINATION_NAME),
-			messageArgumentCaptor.capture()
+			argumentCaptor.capture()
 		);
 
-		Message message = messageArgumentCaptor.getValue();
+		Message message = argumentCaptor.getValue();
 
 		Assert.assertEquals(companyId, message.getLong("companyId"));
 	}
 
-	@Mock
-	private DispatchTrigger _dispatchTrigger;
-
-	@Mock
-	private ModelResourcePermission<DispatchTrigger>
-		_dispatchTriggerModelResourcePermission;
-
-	@InjectMocks
+	private final DispatchTrigger _dispatchTrigger = Mockito.mock(
+		DispatchTrigger.class);
+	private final ModelResourcePermission<DispatchTrigger>
+		_dispatchTriggerModelResourcePermission = Mockito.mock(
+			ModelResourcePermission.class);
 	private final DispatchTriggerResourceImpl _dispatchTriggerResourceImpl =
 		new DispatchTriggerResourceImpl();
-
-	@Mock
-	private DispatchTriggerService _dispatchTriggerService;
-
-	@Mock
-	private MessageBus _messageBus;
+	private final DispatchTriggerService _dispatchTriggerService = Mockito.mock(
+		DispatchTriggerService.class);
+	private final MessageBus _messageBus = Mockito.mock(MessageBus.class);
 
 }

--- a/modules/apps/dispatch/dispatch-web/src/main/java/com/liferay/dispatch/web/internal/portlet/action/EditDispatchTriggerMVCActionCommand.java
+++ b/modules/apps/dispatch/dispatch-web/src/main/java/com/liferay/dispatch/web/internal/portlet/action/EditDispatchTriggerMVCActionCommand.java
@@ -236,8 +236,13 @@ public class EditDispatchTriggerMVCActionCommand extends BaseMVCActionCommand {
 			startDateYear, startDateHour, startDateMinute, timeZoneId);
 	}
 
-	private void _sendMessage(long dispatchTriggerId) {
+	private void _sendMessage(long dispatchTriggerId) throws PortalException {
+		DispatchTrigger dispatchTrigger =
+			_dispatchTriggerLocalService.getDispatchTrigger(dispatchTriggerId);
+
 		Message message = new Message();
+
+		message.put("companyId", dispatchTrigger.getCompanyId());
 
 		message.setPayload(
 			JSONUtil.put(

--- a/modules/apps/dispatch/dispatch-web/src/main/java/com/liferay/dispatch/web/internal/portlet/action/EditDispatchTriggerMVCActionCommand.java
+++ b/modules/apps/dispatch/dispatch-web/src/main/java/com/liferay/dispatch/web/internal/portlet/action/EditDispatchTriggerMVCActionCommand.java
@@ -237,10 +237,10 @@ public class EditDispatchTriggerMVCActionCommand extends BaseMVCActionCommand {
 	}
 
 	private void _sendMessage(long dispatchTriggerId) throws PortalException {
+		Message message = new Message();
+
 		DispatchTrigger dispatchTrigger =
 			_dispatchTriggerLocalService.getDispatchTrigger(dispatchTriggerId);
-
-		Message message = new Message();
 
 		message.put("companyId", dispatchTrigger.getCompanyId());
 

--- a/modules/apps/dispatch/dispatch-web/src/test/java/com/liferay/dispatch/web/internal/portlet/action/EditDispatchTriggerMVCActionCommandTest.java
+++ b/modules/apps/dispatch/dispatch-web/src/test/java/com/liferay/dispatch/web/internal/portlet/action/EditDispatchTriggerMVCActionCommandTest.java
@@ -1,0 +1,95 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.dispatch.web.internal.portlet.action;
+
+import com.liferay.dispatch.constants.DispatchConstants;
+import com.liferay.dispatch.model.DispatchTrigger;
+import com.liferay.dispatch.service.DispatchTriggerLocalService;
+import com.liferay.portal.kernel.messaging.Message;
+import com.liferay.portal.kernel.messaging.MessageBus;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * @author Magdalena Jedraszak
+ */
+public class EditDispatchTriggerMVCActionCommandTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		MockitoAnnotations.initMocks(this);
+	}
+
+	@Test
+	public void test() throws Exception {
+		long companyId = RandomTestUtil.randomLong();
+
+		Mockito.when(
+			_dispatchTrigger.getCompanyId()
+		).thenReturn(
+			companyId
+		);
+
+		long dispatchTriggerId = RandomTestUtil.randomLong();
+
+		Mockito.when(
+			_dispatchTriggerLocalService.getDispatchTrigger(dispatchTriggerId)
+		).thenReturn(
+			_dispatchTrigger
+		);
+
+		ReflectionTestUtil.invoke(
+			_editDispatchTriggerMVCActionCommand, "_sendMessage",
+			new Class<?>[] {long.class}, dispatchTriggerId);
+
+		ArgumentCaptor<Message> messageArgumentCaptor = ArgumentCaptor.forClass(
+			Message.class);
+
+		Mockito.verify(
+			_messageBus
+		).sendMessage(
+			Mockito.eq(DispatchConstants.EXECUTOR_DESTINATION_NAME),
+			messageArgumentCaptor.capture()
+		);
+
+		Message message = messageArgumentCaptor.getValue();
+
+		Assert.assertEquals(companyId, message.getLong("companyId"));
+	}
+
+	@Mock
+	private DispatchTrigger _dispatchTrigger;
+
+	@Mock
+	private DispatchTriggerLocalService _dispatchTriggerLocalService;
+
+	@InjectMocks
+	private final EditDispatchTriggerMVCActionCommand
+		_editDispatchTriggerMVCActionCommand =
+			new EditDispatchTriggerMVCActionCommand();
+
+	@Mock
+	private MessageBus _messageBus;
+
+}

--- a/modules/apps/dispatch/dispatch-web/src/test/java/com/liferay/dispatch/web/internal/portlet/action/EditDispatchTriggerMVCActionCommandTest.java
+++ b/modules/apps/dispatch/dispatch-web/src/test/java/com/liferay/dispatch/web/internal/portlet/action/EditDispatchTriggerMVCActionCommandTest.java
@@ -21,10 +21,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
 
 /**
  * @author Magdalena Jedraszak
@@ -38,11 +35,15 @@ public class EditDispatchTriggerMVCActionCommandTest {
 
 	@Before
 	public void setUp() {
-		MockitoAnnotations.initMocks(this);
+		ReflectionTestUtil.setFieldValue(
+			_editDispatchTriggerMVCActionCommand,
+			"_dispatchTriggerLocalService", _dispatchTriggerLocalService);
+		ReflectionTestUtil.setFieldValue(
+			_editDispatchTriggerMVCActionCommand, "_messageBus", _messageBus);
 	}
 
 	@Test
-	public void test() throws Exception {
+	public void testSendMessagePropagatesCompanyId() throws Exception {
 		long companyId = RandomTestUtil.randomLong();
 
 		Mockito.when(
@@ -63,33 +64,28 @@ public class EditDispatchTriggerMVCActionCommandTest {
 			_editDispatchTriggerMVCActionCommand, "_sendMessage",
 			new Class<?>[] {long.class}, dispatchTriggerId);
 
-		ArgumentCaptor<Message> messageArgumentCaptor = ArgumentCaptor.forClass(
+		ArgumentCaptor<Message> argumentCaptor = ArgumentCaptor.forClass(
 			Message.class);
 
 		Mockito.verify(
 			_messageBus
 		).sendMessage(
 			Mockito.eq(DispatchConstants.EXECUTOR_DESTINATION_NAME),
-			messageArgumentCaptor.capture()
+			argumentCaptor.capture()
 		);
 
-		Message message = messageArgumentCaptor.getValue();
+		Message message = argumentCaptor.getValue();
 
 		Assert.assertEquals(companyId, message.getLong("companyId"));
 	}
 
-	@Mock
-	private DispatchTrigger _dispatchTrigger;
-
-	@Mock
-	private DispatchTriggerLocalService _dispatchTriggerLocalService;
-
-	@InjectMocks
+	private final DispatchTrigger _dispatchTrigger = Mockito.mock(
+		DispatchTrigger.class);
+	private final DispatchTriggerLocalService _dispatchTriggerLocalService =
+		Mockito.mock(DispatchTriggerLocalService.class);
 	private final EditDispatchTriggerMVCActionCommand
 		_editDispatchTriggerMVCActionCommand =
 			new EditDispatchTriggerMVCActionCommand();
-
-	@Mock
-	private MessageBus _messageBus;
+	private final MessageBus _messageBus = Mockito.mock(MessageBus.class);
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97197

Continuation of #178225 addressing review feedback.

## What Is Being Fixed

Running a Job Scheduler trigger via "Run Now" dispatched a message without the company ID, which breaks execution under database partitioning since the executing thread has no ambient company context.

## How It Is Being Fixed

`companyId` is now propagated on the message payload from both entry points that trigger a run: the REST resource (`DispatchTriggerResourceImpl`) and the portlet action (`EditDispatchTriggerMVCActionCommand`). Both fetch the `DispatchTrigger` once and reuse it for the company ID and the message payload. Per feedback on #178225, the REST resource's fetched entity is named `serviceBuilderDispatchTrigger` to distinguish it from the REST DTO of the same simple name, matching the naming convention used elsewhere in `*ResourceImpl` classes that straddle a DTO and a Service Builder model sharing a name.

## PR Check

**pr-check: PASS** — tested on `7c4b46acd13a7917de06cd82f80c95627e8a7e45`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "7c4b46acd13a7917de06cd82f80c95627e8a7e45"} -->
