### PR TITLE
LPD-88080 Clean up company transaction callbacks and iteration

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-web/src/main/java/com/liferay/adaptive/media/web/internal/processor/AMAsyncProcessorImpl.java
+++ b/modules/apps/adaptive-media/adaptive-media-web/src/main/java/com/liferay/adaptive/media/web/internal/processor/AMAsyncProcessorImpl.java
@@ -14,7 +14,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.messaging.MessageBus;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.Collections;
@@ -80,7 +80,7 @@ public final class AMAsyncProcessorImpl<M, T>
 			message.put("modelId", modelId);
 		}
 
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				_messageBus.sendMessage(
 					AMDestinationNames.ADAPTIVE_MEDIA_PROCESSOR, message);
@@ -118,7 +118,7 @@ public final class AMAsyncProcessorImpl<M, T>
 			message.put("modelId", modelId);
 		}
 
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				_messageBus.sendMessage(
 					AMDestinationNames.ADAPTIVE_MEDIA_PROCESSOR, message);

--- a/modules/apps/application-list/application-list-my-account-permissions/src/main/java/com/liferay/application/list/my/account/permissions/internal/model/listener/CompanyModelListener.java
+++ b/modules/apps/application-list/application-list-my-account-permissions/src/main/java/com/liferay/application/list/my/account/permissions/internal/model/listener/CompanyModelListener.java
@@ -32,7 +32,7 @@ import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.PrefsProps;
 
@@ -58,7 +58,7 @@ public class CompanyModelListener extends BaseModelListener<Company> {
 
 	@Override
 	public void onAfterCreate(Company company) {
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				PanelCategoryHelper panelCategoryHelper =
 					new PanelCategoryHelper(_panelAppRegistry);

--- a/modules/apps/application-list/application-list-user-personal-site-permissions/src/main/java/com/liferay/application/list/user/personal/site/permissions/internal/model/listener/CompanyModelListener.java
+++ b/modules/apps/application-list/application-list-user-personal-site-permissions/src/main/java/com/liferay/application/list/user/personal/site/permissions/internal/model/listener/CompanyModelListener.java
@@ -29,7 +29,7 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.List;
@@ -51,7 +51,7 @@ public class CompanyModelListener extends BaseModelListener<Company> {
 
 	@Override
 	public void onAfterCreate(Company company) {
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				PanelCategoryHelper panelCategoryHelper =
 					new PanelCategoryHelper(_panelAppRegistry);

--- a/modules/apps/asset/asset-auto-tagger-service/src/main/java/com/liferay/asset/auto/tagger/internal/model/listener/AssetEntryModelListener.java
+++ b/modules/apps/asset/asset-auto-tagger-service/src/main/java/com/liferay/asset/auto/tagger/internal/model/listener/AssetEntryModelListener.java
@@ -26,7 +26,7 @@ import com.liferay.portal.kernel.model.ModelListener;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.GroupThreadLocal;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -79,7 +79,7 @@ public class AssetEntryModelListener extends BaseModelListener<AssetEntry> {
 		if (updateAutoTags ||
 			(assetEntryFromDatabase.getPublishDate() == null)) {
 
-			TransactionCommitCallbackUtil.registerCallback(
+			TransactionCallbackUtil.registerCommitCallback(
 				(Callable<Void>)() -> {
 					if (!updateAutoTags &&
 						((assetEntry.getPublishDate() == null) ||

--- a/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/service/AssetEntryAssetCategoryRelAssetCategoryLocalServiceWrapper.java
+++ b/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/service/AssetEntryAssetCategoryRelAssetCategoryLocalServiceWrapper.java
@@ -23,7 +23,7 @@ import com.liferay.portal.kernel.model.ModelHintsUtil;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceWrapper;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 
 import java.util.Collections;
@@ -168,7 +168,7 @@ public class AssetEntryAssetCategoryRelAssetCategoryLocalServiceWrapper
 	}
 
 	private void _reindexAssetCategoryAssetEntries(long assetCategoryId) {
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				Message message = new Message();
 

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/service/impl/AssetListEntryAssetEntryRelLocalServiceImpl.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/service/impl/AssetListEntryAssetEntryRelLocalServiceImpl.java
@@ -16,7 +16,7 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 
 import java.util.Date;
@@ -288,7 +288,7 @@ public class AssetListEntryAssetEntryRelLocalServiceImpl
 		long swapAssetListEntryAssetEntryRelId =
 			swapAssetListEntryAssetEntryRel.getAssetListEntryAssetEntryRelId();
 
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				AssetListEntryAssetEntryRel
 					callbackAssetListEntryAssetEntryRel =

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/instance/lifecycle/MultiCompanyBatchEngineUnitPortalInstanceLifecycleListener.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/instance/lifecycle/MultiCompanyBatchEngineUnitPortalInstanceLifecycleListener.java
@@ -12,7 +12,7 @@ import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.model.Company;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -34,7 +34,7 @@ public class MultiCompanyBatchEngineUnitPortalInstanceLifecycleListener
 		DB db = DBManagerUtil.getDB();
 
 		if (db.getDBType() == DBType.HYPERSONIC) {
-			TransactionCommitCallbackUtil.registerCallback(
+			TransactionCallbackUtil.registerCommitCallback(
 				() -> _processBatchEngineUnits(company));
 		}
 		else {

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/messaging/CTMessageEventListener.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/messaging/CTMessageEventListener.java
@@ -11,7 +11,7 @@ import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.messaging.MessageBus;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 
 import java.util.List;
 
@@ -26,7 +26,7 @@ public class CTMessageEventListener implements CTEventListener {
 
 	@Override
 	public void onAfterPublish(long ctCollectionId) {
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				List<Message> messages = _ctMessageLocalService.getMessages(
 					ctCollectionId);

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/model/listener/CTEntryModelListener.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/model/listener/CTEntryModelListener.java
@@ -13,7 +13,7 @@ import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.messaging.MessageBus;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.ModelListener;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 
 import org.osgi.service.component.annotations.Component;
@@ -63,7 +63,7 @@ public class CTEntryModelListener extends BaseModelListener<CTEntry> {
 	}
 
 	private void _reindexCTEntry(CTEntry ctEntry, String type) {
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				Message message = new Message();
 
@@ -84,7 +84,7 @@ public class CTEntryModelListener extends BaseModelListener<CTEntry> {
 	}
 
 	private void _updateCTScore(CTEntry ctEntry, boolean increment) {
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				Message message = new Message();
 

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/search/CTSearchEventListener.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/search/CTSearchEventListener.java
@@ -24,7 +24,7 @@ import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistry;
 import com.liferay.portal.kernel.search.SearchException;
 import com.liferay.portal.kernel.service.change.tracking.CTService;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.search.model.uid.UIDFactory;
 
@@ -53,7 +53,7 @@ public class CTSearchEventListener implements CTEventListener {
 	public void onAfterCopy(
 		long sourceCTCollectionId, long targetCTCollectionId) {
 
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				try (SafeCloseable safeCloseable =
 						CTCollectionThreadLocal.
@@ -81,7 +81,7 @@ public class CTSearchEventListener implements CTEventListener {
 			return;
 		}
 
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				try (SafeCloseable safeCloseable =
 						CTCollectionThreadLocal.

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/impl/CTCollectionLocalServiceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/impl/CTCollectionLocalServiceImpl.java
@@ -96,7 +96,7 @@ import com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalService;
 import com.liferay.portal.kernel.service.change.tracking.CTService;
 import com.liferay.portal.kernel.service.persistence.BasePersistence;
 import com.liferay.portal.kernel.service.persistence.change.tracking.CTPersistence;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
@@ -1431,7 +1431,7 @@ public class CTCollectionLocalServiceImpl
 		Indexer<?> indexer = _indexerRegistry.getIndexer(modelClass);
 
 		if (indexer != null) {
-			TransactionCommitCallbackUtil.registerCallback(
+			TransactionCallbackUtil.registerCommitCallback(
 				() -> {
 					List<String> uids = new ArrayList<>(ctEntries.size());
 
@@ -1657,7 +1657,7 @@ public class CTCollectionLocalServiceImpl
 			ctService.getModelClass());
 
 		if (indexer != null) {
-			TransactionCommitCallbackUtil.registerCallback(
+			TransactionCallbackUtil.registerCommitCallback(
 				() -> {
 					List<String> uids = new ArrayList<>(ctEntries.size());
 

--- a/modules/apps/commerce/commerce-currency-service/src/main/java/com/liferay/commerce/currency/internal/model/listener/util/ImportDefaultValuesUtil.java
+++ b/modules/apps/commerce/commerce-currency-service/src/main/java/com/liferay/commerce/currency/internal/model/listener/util/ImportDefaultValuesUtil.java
@@ -9,7 +9,7 @@ import com.liferay.commerce.currency.service.CommerceCurrencyLocalService;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.ServiceContext;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.util.LocaleThreadLocal;
 import com.liferay.portal.kernel.util.LocaleUtil;
 
@@ -24,7 +24,7 @@ public class ImportDefaultValuesUtil {
 		CommerceCurrencyLocalService commerceCurrencyLocalService,
 		Company company) {
 
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				Locale defaultLocale = LocaleThreadLocal.getDefaultLocale();
 				Locale siteDefaultLocale =

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPDefinitionLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPDefinitionLocalServiceImpl.java
@@ -134,7 +134,7 @@ import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalService;
 import com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalService;
 import com.liferay.portal.kernel.settings.CompanyServiceSettingsLocator;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.ContentTypes;
@@ -2605,7 +2605,7 @@ public class CPDefinitionLocalServiceImpl
 						cProduct.getCProductId(),
 						cpDefinition.getCPDefinitionId());
 
-					TransactionCommitCallbackUtil.registerCallback(
+					TransactionCallbackUtil.registerCommitCallback(
 						() -> {
 							cpDefinitionLocalService.maintainVersionThreshold(
 								cProduct.getCompanyId(),

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPSpecificationOptionLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPSpecificationOptionLocalServiceImpl.java
@@ -43,7 +43,7 @@ import com.liferay.portal.kernel.service.ResourceLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.util.FriendlyURLNormalizer;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -391,7 +391,7 @@ public class CPSpecificationOptionLocalServiceImpl
 	private void _reindexCPDefinitions1(
 		long companyId, long cpSpecificationOptionId) {
 
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				_reindexCPDefinitions2(companyId, cpSpecificationOptionId);
 

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/object/action/executor/SplitCommerceOrderByCatalogObjectActionExecutorImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/object/action/executor/SplitCommerceOrderByCatalogObjectActionExecutorImpl.java
@@ -24,7 +24,7 @@ import com.liferay.object.action.executor.ObjectActionExecutor;
 import com.liferay.object.scope.ObjectDefinitionScoped;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONObject;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
@@ -57,7 +57,7 @@ public class SplitCommerceOrderByCatalogObjectActionExecutorImpl
 			JSONObject payloadJSONObject, long userId)
 		throws Exception {
 
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				long commerceOrderId = payloadJSONObject.getLong("classPK");
 

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/order/engine/CommerceOrderEngineImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/order/engine/CommerceOrderEngineImpl.java
@@ -68,7 +68,7 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.settings.GroupServiceSettingsLocator;
 import com.liferay.portal.kernel.transaction.Propagation;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.transaction.TransactionConfig;
 import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
 import com.liferay.portal.kernel.util.BigDecimalUtil;
@@ -409,7 +409,7 @@ public class CommerceOrderEngineImpl implements CommerceOrderEngine {
 			commerceOrder.getCommerceCurrencyCode(), commerceOrderId,
 			commerceOrder.getCompanyId());
 
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				_bookQuantities(commerceOrderId);
 
@@ -558,7 +558,7 @@ public class CommerceOrderEngineImpl implements CommerceOrderEngine {
 		CommerceOrder originalCommerceOrder =
 			commerceOrder.cloneWithOriginalValues();
 
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				if ((orderStatus ==
 						CommerceOrderConstants.ORDER_STATUS_PENDING) &&

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderLocalServiceImpl.java
@@ -126,7 +126,7 @@ import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalService;
 import com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalService;
 import com.liferay.portal.kernel.settings.GroupServiceSettingsLocator;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -2709,7 +2709,7 @@ public class CommerceOrderLocalServiceImpl
 		CommerceOrder commerceOrder, CommerceOrder originalCommerceOrder,
 		int previousPaymentStatus) {
 
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				Message message = new Message();
 

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceShipmentLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceShipmentLocalServiceImpl.java
@@ -58,7 +58,7 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.transaction.Propagation;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.transaction.Transactional;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -689,7 +689,7 @@ public class CommerceShipmentLocalServiceImpl
 	protected void sendShipmentStatusMessage(
 		CommerceShipment commerceShipment) {
 
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				Message message = new Message();
 

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceSubscriptionEntryLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceSubscriptionEntryLocalServiceImpl.java
@@ -39,7 +39,7 @@ import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.SearchException;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.service.UserLocalService;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
@@ -790,7 +790,7 @@ public class CommerceSubscriptionEntryLocalServiceImpl
 	private void _sendSubscriptionStatusMessage(
 		long commerceSubscriptionEntryId, int subscriptionStatus) {
 
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				Message message = new Message();
 

--- a/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceDBPartitionTest.java
+++ b/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceDBPartitionTest.java
@@ -31,6 +31,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.model.ClassName;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.model.Repository;
 import com.liferay.portal.kernel.model.ResourceAction;
 import com.liferay.portal.kernel.model.User;
@@ -88,6 +89,7 @@ import java.sql.Types;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -751,6 +753,10 @@ public class CompanyLocalServiceDBPartitionTest
 		companyLocalService.deleteCompany(_company1);
 
 		Assert.assertFalse(
+			PortalInstances.isCompanyInDeletionProcess(
+				_company1.getCompanyId()));
+
+		Assert.assertFalse(
 			ArrayUtil.contains(
 				CompanyLocalServiceTestUtil.getCompanyIdsBySQL(),
 				_company1.getCompanyId()));
@@ -807,6 +813,53 @@ public class CompanyLocalServiceDBPartitionTest
 					CompanyLocalServiceTestUtil.getCompanyIdsBySQL(),
 					_company1.getCompanyId()));
 		}
+	}
+
+	@Test
+	public void testForEachCompanyIdSkipsGoneOrInDeletionCompanies()
+		throws Exception {
+
+		_company1 = CompanyTestUtil.addCompany();
+
+		long companyId = _company1.getCompanyId();
+
+		List<Long> companyIds = new ArrayList<>();
+
+		// A company in the deletion process is skipped
+
+		try (SafeCloseable safeCloseable =
+				PortalInstances.setCompanyInDeletionProcessWithSafeCloseable(
+					companyId)) {
+
+			companyLocalService.forEachCompanyId(
+				companyIds::add, new long[] {companyId});
+		}
+
+		Assert.assertEquals(companyIds.toString(), 0, companyIds.size());
+
+		// A company that no longer exists is skipped
+
+		companyLocalService.forEachCompanyId(
+			companyIds::add, new long[] {RandomTestUtil.nextLong()});
+
+		Assert.assertEquals(companyIds.toString(), 0, companyIds.size());
+
+		// The system scope is passed through
+
+		companyLocalService.forEachCompanyId(
+			companyIds::add, new long[] {CompanyConstants.SYSTEM});
+
+		Assert.assertEquals(
+			Collections.singletonList(CompanyConstants.SYSTEM), companyIds);
+
+		companyIds.clear();
+
+		// A live company is iterated
+
+		companyLocalService.forEachCompanyId(
+			companyIds::add, new long[] {companyId});
+
+		Assert.assertEquals(Collections.singletonList(companyId), companyIds);
 	}
 
 	private void _addCopyDBPartitionCompanyCache(long companyId) {

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/model/listener/GroupModelListener.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/model/listener/GroupModelListener.java
@@ -19,7 +19,7 @@ import com.liferay.portal.kernel.model.ModelListener;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 
 import java.util.List;
@@ -38,7 +38,7 @@ public class GroupModelListener extends BaseModelListener<Group> {
 		if ((group != null) && group.isDepot() &&
 			_isStaging(ServiceContextThreadLocal.getServiceContext())) {
 
-			TransactionCommitCallbackUtil.registerCallback(
+			TransactionCallbackUtil.registerCommitCallback(
 				() -> {
 					_copyLiveDepotEntryGroupRelsToStaging(group);
 
@@ -50,7 +50,7 @@ public class GroupModelListener extends BaseModelListener<Group> {
 	@Override
 	public void onAfterRemove(Group group) throws ModelListenerException {
 		if ((group != null) && group.isDepot()) {
-			TransactionCommitCallbackUtil.registerCallback(
+			TransactionCallbackUtil.registerCommitCallback(
 				() -> {
 					DepotEntry depotEntry =
 						_depotEntryLocalService.fetchGroupDepotEntry(

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/repository/capabilities/LiferayProcessorCapability.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/repository/capabilities/LiferayProcessorCapability.java
@@ -19,7 +19,7 @@ import com.liferay.portal.kernel.repository.model.FileEntryWrapper;
 import com.liferay.portal.kernel.repository.model.FileVersion;
 import com.liferay.portal.kernel.repository.model.FileVersionWrapper;
 import com.liferay.portal.kernel.repository.registry.RepositoryEventRegistry;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.repository.liferayrepository.LiferayProcessorLocalRepositoryWrapper;
 import com.liferay.portal.repository.liferayrepository.LiferayProcessorRepositoryWrapper;
@@ -100,7 +100,7 @@ public class LiferayProcessorCapability
 	private void _registerDLProcessorCallback(
 		FileEntry fileEntry, FileVersion fileVersion) {
 
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				DLProcessorHelperUtil.trigger(
 					fileEntry, _wrap(fileVersion), true);

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/repository/capabilities/LiferayVersioningCapability.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/repository/capabilities/LiferayVersioningCapability.java
@@ -16,7 +16,7 @@ import com.liferay.portal.kernel.repository.capabilities.Capability;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.FileVersion;
 import com.liferay.portal.kernel.service.ServiceContext;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.repository.capabilities.util.DLAppServiceAdapter;
 import com.liferay.portal.repository.util.LocalRepositoryWrapper;
 import com.liferay.portal.repository.util.RepositoryWrapper;
@@ -194,7 +194,7 @@ public class LiferayVersioningCapability
 			return fileEntry;
 		}
 
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			(Callable<Void>)() -> {
 				for (FileVersion fileVersion :
 						_versionPurger.getToPurgeFileVersions(fileEntry)) {

--- a/modules/apps/document-library/document-library-sync-service/src/main/java/com/liferay/document/library/sync/internal/model/listener/CompanyModelListener.java
+++ b/modules/apps/document-library/document-library-sync-service/src/main/java/com/liferay/document/library/sync/internal/model/listener/CompanyModelListener.java
@@ -14,7 +14,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.ModelListener;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -27,7 +27,7 @@ public class CompanyModelListener extends BaseModelListener<Company> {
 
 	@Override
 	public void onAfterRemove(Company company) throws ModelListenerException {
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				_deleteDLSyncEvent(company);
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/model/listener/DDMFormInstanceModelListener.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/model/listener/DDMFormInstanceModelListener.java
@@ -15,7 +15,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.ModelListener;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -57,7 +57,7 @@ public class DDMFormInstanceModelListener
 					getFormInstanceReportByFormInstanceId(
 						ddmFormInstance.getFormInstanceId());
 
-			TransactionCommitCallbackUtil.registerCallback(
+			TransactionCallbackUtil.registerCommitCallback(
 				() -> {
 					_ddmFormInstanceReportPortalExecutor.execute(
 						() ->

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/model/listener/DDMFormInstanceRecordVersionModelListener.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/model/listener/DDMFormInstanceRecordVersionModelListener.java
@@ -17,7 +17,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.ModelListener;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
 import org.osgi.service.component.annotations.Component;
@@ -108,7 +108,7 @@ public class DDMFormInstanceRecordVersionModelListener
 				getFormInstanceReportByFormInstanceId(
 					ddmFormInstanceRecordVersion.getFormInstanceId());
 
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				ddmFormInstanceReportLocalService.
 					processFormInstanceReportEvent(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMStructureLocalServiceImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMStructureLocalServiceImpl.java
@@ -92,7 +92,7 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.permission.ModelPermissions;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.transaction.Transactional;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -2022,7 +2022,7 @@ public class DDMStructureLocalServiceImpl
 			return;
 		}
 
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				Message message = new Message();
 
@@ -2065,7 +2065,7 @@ public class DDMStructureLocalServiceImpl
 	}
 
 	private void _syncStructureTemplatesFields(DDMStructure structure) {
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				DDMFormTemplateSynchonizer ddmFormTemplateSynchonizer =
 					new DDMFormTemplateSynchonizer(

--- a/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/model/listener/CompanyModelListener.java
+++ b/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/model/listener/CompanyModelListener.java
@@ -19,7 +19,7 @@ import com.liferay.portal.kernel.model.ModelListener;
 import com.liferay.portal.kernel.portlet.PortalPreferences;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.PortalPreferencesLocalService;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portlet.PortalPreferencesWrapper;
@@ -39,7 +39,7 @@ public class CompanyModelListener extends BaseModelListener<Company> {
 
 	@Override
 	public void onAfterCreate(Company company) throws ModelListenerException {
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				_processDeprecationFeatureFlags(company.getCompanyId());
 

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/instance/lifecycle/APIApplicationPublisherPortalInstanceLifecycleListener.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/instance/lifecycle/APIApplicationPublisherPortalInstanceLifecycleListener.java
@@ -19,7 +19,7 @@ import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -43,7 +43,7 @@ public class APIApplicationPublisherPortalInstanceLifecycleListener
 			return;
 		}
 
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				PermissionThreadLocal.setPermissionChecker(
 					_permissionCheckerFactory.create(

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/model/listener/APIApplicationPublisherObjectEntryModelListener.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/model/listener/APIApplicationPublisherObjectEntryModelListener.java
@@ -15,7 +15,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.ModelListener;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 
@@ -206,7 +206,7 @@ public class APIApplicationPublisherObjectEntryModelListener
 
 		_pendingAPIApplications.add(apiApplicationId);
 
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				if (!_pendingAPIApplications.remove(apiApplicationId)) {
 					return null;

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/change/tracking/spi/listener/JournalArticleCTSearchEventListener.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/change/tracking/spi/listener/JournalArticleCTSearchEventListener.java
@@ -16,7 +16,7 @@ import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.search.Indexer;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.util.Portal;
 
 import java.util.List;
@@ -41,7 +41,7 @@ public class JournalArticleCTSearchEventListener implements CTEventListener {
 			return;
 		}
 
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				List<JournalArticle> journalArticles = null;
 

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -168,7 +168,7 @@ import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.systemevent.SystemEventHierarchyEntryThreadLocal;
 import com.liferay.portal.kernel.templateparser.TransformerListener;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.util.CalendarFactoryUtil;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.ContentTypes;
@@ -6006,7 +6006,7 @@ public class JournalArticleLocalServiceImpl
 		finally {
 			FileEntry finalTempFileEntry = tempFileEntry;
 
-			TransactionCommitCallbackUtil.registerCallback(
+			TransactionCallbackUtil.registerCommitCallback(
 				() -> {
 					if (finalTempFileEntry != null) {
 						FileEntry persistedFileEntry =

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
@@ -108,7 +108,7 @@ import com.liferay.portal.kernel.settings.GroupServiceSettingsLocator;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.systemevent.SystemEventHierarchyEntryThreadLocal;
 import com.liferay.portal.kernel.transaction.Propagation;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.transaction.Transactional;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Constants;
@@ -2636,7 +2636,7 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 	}
 
 	private void _indexKBArticle(KBArticle kbArticle) {
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				Indexer<KBArticle> indexer = _indexerRegistry.getIndexer(
 					KBArticle.class);

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/model/listener/LayoutModelListener.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/model/listener/LayoutModelListener.java
@@ -29,7 +29,7 @@ import com.liferay.portal.kernel.search.SearchException;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.UnicodeProperties;
@@ -307,7 +307,7 @@ public class LayoutModelListener extends BaseModelListener<Layout> {
 			_getLayoutPageTemplateEntry(layout);
 
 		if (layoutPageTemplateEntry != null) {
-			TransactionCommitCallbackUtil.registerCallback(
+			TransactionCallbackUtil.registerCommitCallback(
 				() -> _copyStructure(layoutPageTemplateEntry, layout));
 		}
 	}

--- a/modules/apps/mail/mail-messaging-impl/src/main/java/com/liferay/mail/messaging/internal/MailServiceImpl.java
+++ b/modules/apps/mail/mail-messaging-impl/src/main/java/com/liferay/mail/messaging/internal/MailServiceImpl.java
@@ -28,7 +28,7 @@ import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.module.configuration.ConfigurationException;
 import com.liferay.portal.kernel.module.framework.service.IdentifiableOSGiService;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PropertiesUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
@@ -374,7 +374,7 @@ public class MailServiceImpl
 
 	@Override
 	public void sendEmail(MailMessage mailMessage) {
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				if (_log.isDebugEnabled()) {
 					_log.debug("sendEmail");

--- a/modules/apps/microblogs/microblogs-service/src/main/java/com/liferay/microblogs/service/impl/MicroblogsEntryLocalServiceImpl.java
+++ b/modules/apps/microblogs/microblogs-service/src/main/java/com/liferay/microblogs/service/impl/MicroblogsEntryLocalServiceImpl.java
@@ -40,7 +40,7 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.UserNotificationEventLocalService;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.social.kernel.service.SocialActivityLocalService;
@@ -565,7 +565,7 @@ public class MicroblogsEntryLocalServiceImpl
 
 		};
 
-		TransactionCommitCallbackUtil.registerCallback(callable);
+		TransactionCallbackUtil.registerCommitCallback(callable);
 	}
 
 	private void _subscribeUsers(

--- a/modules/apps/notification/notification-service/src/main/java/com/liferay/notification/internal/type/EmailNotificationType.java
+++ b/modules/apps/notification/notification-service/src/main/java/com/liferay/notification/internal/type/EmailNotificationType.java
@@ -78,7 +78,7 @@ import com.liferay.portal.kernel.template.TemplateContextContributor;
 import com.liferay.portal.kernel.template.TemplateManagerUtil;
 import com.liferay.portal.kernel.templateparser.TemplateNode;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.KeyValuePair;
@@ -391,7 +391,7 @@ public class EmailNotificationType extends BaseNotificationType {
 	public void sendNotification(
 		NotificationQueueEntry notificationQueueEntry) {
 
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				try {
 					Map<String, Object> notificationRecipientSettingsMap =

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/action/executor/BaseObjectActionExecutor.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/action/executor/BaseObjectActionExecutor.java
@@ -6,7 +6,7 @@
 package com.liferay.object.action.executor;
 
 import com.liferay.portal.kernel.json.JSONObject;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 
 /**
@@ -21,7 +21,7 @@ public abstract class BaseObjectActionExecutor implements ObjectActionExecutor {
 			JSONObject payloadJSONObject, long userId)
 		throws Exception {
 
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				doExecute(
 					companyId, objectActionId, parametersUnicodeProperties,

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/model/listener/AccountEntryOrganizationRelModelListener.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/model/listener/AccountEntryOrganizationRelModelListener.java
@@ -24,7 +24,7 @@ import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.ModelListener;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.search.indexer.IndexerDocumentBuilder;
 
 import org.osgi.framework.BundleContext;
@@ -46,7 +46,7 @@ public class AccountEntryOrganizationRelModelListener
 			AccountEntryOrganizationRel accountEntryOrganizationRel)
 		throws ModelListenerException {
 
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				_reindex(accountEntryOrganizationRel);
 
@@ -59,7 +59,7 @@ public class AccountEntryOrganizationRelModelListener
 			AccountEntryOrganizationRel accountEntryOrganizationRel)
 		throws ModelListenerException {
 
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				_reindex(accountEntryOrganizationRel);
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/system/model/listener/SystemObjectDefinitionManagerModelListener.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/system/model/listener/SystemObjectDefinitionManagerModelListener.java
@@ -31,7 +31,7 @@ import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.service.UserLocalService;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
@@ -101,7 +101,7 @@ public class SystemObjectDefinitionManagerModelListener<T extends BaseModel<T>>
 				clearObjectEntryIdsMap);
 		}
 
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				ObjectActionThreadLocal.setSkipObjectActionExecution(false);
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -173,7 +173,7 @@ import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalService;
 import com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalService;
 import com.liferay.portal.kernel.service.persistence.ResourcePermissionPersistence;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.FriendlyURLNormalizer;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -2638,7 +2638,7 @@ public class ObjectDefinitionLocalServiceImpl
 		MethodKey methodKey, ObjectDefinition objectDefinition) {
 
 		if (ClusterExecutorUtil.isEnabled()) {
-			TransactionCommitCallbackUtil.registerCallback(
+			TransactionCallbackUtil.registerCommitCallback(
 				() -> {
 					ClusterRequest clusterRequest =
 						ClusterRequest.createMulticastRequest(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -233,7 +233,7 @@ import com.liferay.portal.kernel.service.UserNotificationEventLocalService;
 import com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalService;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.transaction.Propagation;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.transaction.Transactional;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Base64;
@@ -377,7 +377,7 @@ public class ObjectEntryLocalServiceImpl
 
 		serviceContext.setStrictAdd(true);
 
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				serviceContext.setStrictAdd(false);
 
@@ -3387,7 +3387,7 @@ public class ObjectEntryLocalServiceImpl
 			lastObjectEntry.getReviewDate(),
 			lastObjectEntry.getObjectEntryId());
 
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				_companyIdReviewCheckpoint.put(companyId, nextReviewCheckpoint);
 

--- a/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/service/impl/BackgroundTaskLocalServiceImpl.java
+++ b/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/service/impl/BackgroundTaskLocalServiceImpl.java
@@ -35,7 +35,7 @@ import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.OrderByComparator;
@@ -86,7 +86,7 @@ public class BackgroundTaskLocalServiceImpl
 
 		long backgroundTaskId = backgroundTask.getBackgroundTaskId();
 
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				backgroundTaskLocalService.triggerBackgroundTask(
 					backgroundTaskId);
@@ -225,7 +225,7 @@ public class BackgroundTaskLocalServiceImpl
 			}
 		}
 
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				Message message = new Message();
 
@@ -768,7 +768,7 @@ public class BackgroundTaskLocalServiceImpl
 
 		backgroundTask = backgroundTaskPersistence.update(backgroundTask);
 
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				backgroundTaskLocalService.triggerBackgroundTask(
 					backgroundTaskId);

--- a/modules/apps/portal-language/portal-language-override-service/src/main/java/com/liferay/portal/language/override/internal/PLOEntryModelListener.java
+++ b/modules/apps/portal-language/portal-language-override-service/src/main/java/com/liferay/portal/language/override/internal/PLOEntryModelListener.java
@@ -10,7 +10,7 @@ import com.liferay.portal.kernel.cluster.ClusterInvokeThreadLocal;
 import com.liferay.portal.kernel.cluster.ClusterRequest;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.ModelListener;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.util.MethodHandler;
 import com.liferay.portal.kernel.util.MethodKey;
 import com.liferay.portal.language.override.model.PLOEntry;
@@ -38,7 +38,7 @@ public class PLOEntryModelListener extends BaseModelListener<PLOEntry> {
 
 		clusterRequest.setFireAndForget(true);
 
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> clusterExecutor.execute(clusterRequest));
 	}
 

--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/index/CompanyIndexHelper.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/index/CompanyIndexHelper.java
@@ -397,54 +397,52 @@ public class CompanyIndexHelper {
 		ElasticsearchIndicesClient elasticsearchIndicesClient =
 			elasticsearchClient.indices();
 
-		_companyLocalService.forEachCompanyId(
-			companyId -> {
-				String indexName = getIndexName(companyId);
+		for (long companyId :
+				IndexFactoryCompanyIdRegistryUtil.getCompanyIds()) {
 
-				SettingsHelperImpl settingsHelperImpl =
-					new SettingsHelperImpl();
+			String indexName = getIndexName(companyId);
 
-				companyIndexConfigurationContributor.contributeSettings(
-					companyId, settingsHelperImpl);
+			SettingsHelperImpl settingsHelperImpl = new SettingsHelperImpl();
 
-				JSONObject settingsJSONObject =
-					settingsHelperImpl.getSettingsJSONObject();
+			companyIndexConfigurationContributor.contributeSettings(
+				companyId, settingsHelperImpl);
 
-				if (SetUtil.isNotEmpty(settingsJSONObject.keySet())) {
-					try {
-						elasticsearchIndicesClient.close(
-							CloseIndexRequest.of(
-								closeIndexRequest -> closeIndexRequest.index(
-									indexName)));
+			JSONObject settingsJSONObject =
+				settingsHelperImpl.getSettingsJSONObject();
 
-						elasticsearchIndicesClient.putSettings(
-							_buildPutIndicesSettingsRequest(
-								indexName, settingsJSONObject.toString()));
+			if (SetUtil.isNotEmpty(settingsJSONObject.keySet())) {
+				try {
+					elasticsearchIndicesClient.close(
+						CloseIndexRequest.of(
+							closeIndexRequest -> closeIndexRequest.index(
+								indexName)));
 
-						elasticsearchIndicesClient.open(
-							OpenRequest.of(
-								openRequest -> openRequest.index(indexName)));
-					}
-					catch (Exception exception) {
-						_log.error(
-							StringBundler.concat(
-								"Unable to put settings for index ", indexName,
-								" with contributor ",
-								companyIndexConfigurationContributor),
-							exception);
-					}
+					elasticsearchIndicesClient.putSettings(
+						_buildPutIndicesSettingsRequest(
+							indexName, settingsJSONObject.toString()));
+
+					elasticsearchIndicesClient.open(
+						OpenRequest.of(
+							openRequest -> openRequest.index(indexName)));
 				}
+				catch (Exception exception) {
+					_log.error(
+						StringBundler.concat(
+							"Unable to put settings for index ", indexName,
+							" with contributor ",
+							companyIndexConfigurationContributor),
+						exception);
+				}
+			}
 
-				companyIndexConfigurationContributor.contributeMappings(
-					companyId,
-					new MappingsHelperImpl(
-						elasticsearchIndicesClient, indexName, _jsonFactory,
-						_elasticsearchConnectionManager.getJsonpMapper(null),
-						_elasticsearchConfigurationWrapper.
-							overrideTypeMappings(),
-						_searchEngineInformation));
-			},
-			IndexFactoryCompanyIdRegistryUtil.getCompanyIds());
+			companyIndexConfigurationContributor.contributeMappings(
+				companyId,
+				new MappingsHelperImpl(
+					elasticsearchIndicesClient, indexName, _jsonFactory,
+					_elasticsearchConnectionManager.getJsonpMapper(null),
+					_elasticsearchConfigurationWrapper.overrideTypeMappings(),
+					_searchEngineInformation));
+		}
 	}
 
 	private void _putAdditionalMappings(MappingsHelperImpl mappingsHelperImpl) {

--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/index/IndexFactory.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/index/IndexFactory.java
@@ -125,9 +125,11 @@ public class IndexFactory
 	}
 
 	private synchronized void _initializeCompanyIndexes() {
-		_companyLocalService.forEachCompanyId(
-			companyId -> _initializeIndex(companyId),
-			IndexFactoryCompanyIdRegistryUtil.getCompanyIds());
+		for (long companyId :
+				IndexFactoryCompanyIdRegistryUtil.getCompanyIds()) {
+
+			_initializeIndex(companyId);
+		}
 	}
 
 	private void _initializeIndex(long companyId) {

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/OpenSearchSearchEngine.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/OpenSearchSearchEngine.java
@@ -337,9 +337,9 @@ public class OpenSearchSearchEngine
 			setAutoCreateIndex(false);
 
 			if (StartupHelperUtil.isDBNew()) {
-				_companyLocalService.forEachCompanyId(
-					companyId -> removeCompany(companyId),
-					_getIndexedCompanyIds());
+				for (long companyId : _getIndexedCompanyIds()) {
+					removeCompany(companyId);
+				}
 			}
 
 			_putTimestampPipeline();

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/index/CompanyIndexHelper.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/index/CompanyIndexHelper.java
@@ -397,52 +397,51 @@ public class CompanyIndexHelper {
 		OpenSearchIndicesClient openSearchIndicesClient =
 			openSearchClient.indices();
 
-		_companyLocalService.forEachCompanyId(
-			companyId -> {
-				String indexName = getIndexName(companyId);
+		for (long companyId :
+				IndexFactoryCompanyIdRegistryUtil.getCompanyIds()) {
 
-				SettingsHelperImpl settingsHelperImpl =
-					new SettingsHelperImpl();
+			String indexName = getIndexName(companyId);
 
-				companyIndexConfigurationContributor.contributeSettings(
-					companyId, settingsHelperImpl);
+			SettingsHelperImpl settingsHelperImpl = new SettingsHelperImpl();
 
-				JSONObject settingsJSONObject =
-					settingsHelperImpl.getSettingsJSONObject();
+			companyIndexConfigurationContributor.contributeSettings(
+				companyId, settingsHelperImpl);
 
-				if (SetUtil.isNotEmpty(settingsJSONObject.keySet())) {
-					try {
-						openSearchIndicesClient.close(
-							CloseIndexRequest.of(
-								closeIndexRequest -> closeIndexRequest.index(
-									indexName)));
+			JSONObject settingsJSONObject =
+				settingsHelperImpl.getSettingsJSONObject();
 
-						openSearchIndicesClient.putSettings(
-							_buildPutIndicesSettingsRequest(
-								indexName, settingsJSONObject.toString()));
+			if (SetUtil.isNotEmpty(settingsJSONObject.keySet())) {
+				try {
+					openSearchIndicesClient.close(
+						CloseIndexRequest.of(
+							closeIndexRequest -> closeIndexRequest.index(
+								indexName)));
 
-						openSearchIndicesClient.open(
-							OpenRequest.of(
-								openRequest -> openRequest.index(indexName)));
-					}
-					catch (Exception exception) {
-						_log.error(
-							StringBundler.concat(
-								"Unable to put settings for index ", indexName,
-								" with contributor ",
-								companyIndexConfigurationContributor),
-							exception);
-					}
+					openSearchIndicesClient.putSettings(
+						_buildPutIndicesSettingsRequest(
+							indexName, settingsJSONObject.toString()));
+
+					openSearchIndicesClient.open(
+						OpenRequest.of(
+							openRequest -> openRequest.index(indexName)));
 				}
+				catch (Exception exception) {
+					_log.error(
+						StringBundler.concat(
+							"Unable to put settings for index ", indexName,
+							" with contributor ",
+							companyIndexConfigurationContributor),
+						exception);
+				}
+			}
 
-				companyIndexConfigurationContributor.contributeMappings(
-					companyId,
-					new MappingsHelperImpl(
-						indexName, _jsonFactory, openSearchIndicesClient,
-						_openSearchConfigurationWrapper.overrideTypeMappings(),
-						_searchEngineInformation));
-			},
-			IndexFactoryCompanyIdRegistryUtil.getCompanyIds());
+			companyIndexConfigurationContributor.contributeMappings(
+				companyId,
+				new MappingsHelperImpl(
+					indexName, _jsonFactory, openSearchIndicesClient,
+					_openSearchConfigurationWrapper.overrideTypeMappings(),
+					_searchEngineInformation));
+		}
 	}
 
 	private void _putAdditionalMappings(MappingsHelperImpl mappingsHelperImpl) {

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/index/IndexFactory.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/index/IndexFactory.java
@@ -122,9 +122,11 @@ public class IndexFactory
 	}
 
 	private synchronized void _initializeCompanyIndexes() {
-		_companyLocalService.forEachCompanyId(
-			companyId -> _initializeIndex(companyId),
-			IndexFactoryCompanyIdRegistryUtil.getCompanyIds());
+		for (long companyId :
+				IndexFactoryCompanyIdRegistryUtil.getCompanyIds()) {
+
+			_initializeIndex(companyId);
+		}
 	}
 
 	private void _initializeIndex(long companyId) {

--- a/modules/apps/portal-search-opensearch2/source-formatter-suppressions.xml
+++ b/modules/apps/portal-search-opensearch2/source-formatter-suppressions.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+
+<suppressions>
+	<checkstyle>
+		<suppress checks="CompanyIterationCheck" files=".*" />
+	</checkstyle>
+</suppressions>

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/internal/AuditEventManagerImpl.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/internal/AuditEventManagerImpl.java
@@ -7,15 +7,12 @@ package com.liferay.portal.security.audit.storage.internal;
 
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.audit.AuditMessage;
-import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.service.CompanyLocalService;
-import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.security.audit.AuditEvent;
 import com.liferay.portal.security.audit.AuditEventManager;
 import com.liferay.portal.security.audit.storage.service.AuditEventLocalService;
-import com.liferay.portal.util.PortalInstances;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -53,14 +50,6 @@ public class AuditEventManagerImpl implements AuditEventManager {
 
 			for (Map.Entry<Long, List<AuditMessage>> entry :
 					auditMessagesMap.entrySet()) {
-
-				if (PortalInstances.isCompanyInDeletionProcess(
-						entry.getKey()) ||
-					!ArrayUtil.contains(
-						PortalInstancePool.getCompanyIds(), entry.getKey())) {
-
-					continue;
-				}
 
 				_companyLocalService.forEachCompanyId(
 					companyId -> _auditEventLocalService.addAuditEvents(

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/internal/model/listener/CompanyModelListener.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/internal/model/listener/CompanyModelListener.java
@@ -12,7 +12,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.ModelListener;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.security.audit.storage.model.AuditEvent;
 import com.liferay.portal.security.audit.storage.service.AuditEventLocalService;
 
@@ -27,7 +27,7 @@ public class CompanyModelListener extends BaseModelListener<Company> {
 
 	@Override
 	public void onAfterRemove(Company company) throws ModelListenerException {
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				_deleteAuditEvents(company);
 

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/model/listener/BaseLDAPExportModelListener.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/model/listener/BaseLDAPExportModelListener.java
@@ -13,7 +13,7 @@ import com.liferay.portal.kernel.security.auth.PasswordModificationThreadLocal;
 import com.liferay.portal.kernel.security.ldap.LDAPSettings;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.security.exportimport.UserExporter;
 import com.liferay.portal.security.ldap.internal.UserImportTransactionThreadLocal;
 
@@ -85,7 +85,7 @@ public abstract class BaseLDAPExportModelListener<T extends BaseModel<T>>
 			callable.call();
 		}
 		else {
-			TransactionCommitCallbackUtil.registerCallback(callable);
+			TransactionCallbackUtil.registerCommitCallback(callable);
 		}
 	}
 

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/model/listener/ContactModelListener.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/model/listener/ContactModelListener.java
@@ -12,7 +12,7 @@ import com.liferay.portal.kernel.model.Contact;
 import com.liferay.portal.kernel.model.ModelListener;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.UserLocalService;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.security.exportimport.UserExporter;
 import com.liferay.portal.security.ldap.internal.UserImportTransactionThreadLocal;
 
@@ -68,7 +68,7 @@ public class ContactModelListener extends BaseLDAPExportModelListener<Contact> {
 			return;
 		}
 
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			CallableUtil.getCallable(
 				expandoBridgeAttributes -> {
 					try {

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/model/listener/UserGroupModelListener.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/model/listener/UserGroupModelListener.java
@@ -14,7 +14,7 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.UserGroup;
 import com.liferay.portal.kernel.service.UserGroupLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.security.exportimport.UserExporter;
 import com.liferay.portal.security.exportimport.UserOperation;
 import com.liferay.portal.security.ldap.internal.UserImportTransactionThreadLocal;
@@ -77,7 +77,7 @@ public class UserGroupModelListener extends BaseModelListener<UserGroup> {
 			return;
 		}
 
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			CallableUtil.getCallable(
 				expandoBridgeAttributes -> {
 					if ((_userLocalService.fetchUser(userId) == null) ||

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/DefaultWorkflowEngineImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/DefaultWorkflowEngineImpl.java
@@ -23,7 +23,7 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.transaction.Isolation;
 import com.liferay.portal.kernel.transaction.Propagation;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.transaction.Transactional;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
@@ -232,7 +232,7 @@ public class DefaultWorkflowEngineImpl
 					updateKaleoTimerInstanceToken(kaleoTimerInstanceToken);
 			}
 
-			TransactionCommitCallbackUtil.registerCallback(
+			TransactionCallbackUtil.registerCommitCallback(
 				() -> {
 					_kaleoSignaler.signalExecute(
 						kaleoInstanceToken.getCurrentKaleoNode(),
@@ -601,7 +601,7 @@ public class DefaultWorkflowEngineImpl
 			ExecutionContext executionContext = new ExecutionContext(
 				kaleoInstanceToken, workflowContext, serviceContext);
 
-			TransactionCommitCallbackUtil.registerCallback(
+			TransactionCallbackUtil.registerCommitCallback(
 				() -> {
 					try {
 						_kaleoSignaler.signalExit(

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/WorkflowTaskManagerImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/WorkflowTaskManagerImpl.java
@@ -33,7 +33,7 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserGroupGroupRoleLocalService;
 import com.liferay.portal.kernel.service.UserGroupRoleLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.comparator.UserScreenNameComparator;
@@ -230,7 +230,7 @@ public class WorkflowTaskManagerImpl implements WorkflowTaskManager {
 				kaleoInstanceToken, kaleoTaskInstanceToken, workflowContext,
 				serviceContext);
 
-			TransactionCommitCallbackUtil.registerCallback(
+			TransactionCallbackUtil.registerCommitCallback(
 				() -> {
 					try {
 						_kaleoSignaler.signalExit(

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/model/listener/KaleoDefinitionModelListener.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/model/listener/KaleoDefinitionModelListener.java
@@ -12,7 +12,7 @@ import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.ModelListener;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.workflow.kaleo.definition.constants.WorkflowDefinitionDestinationNames;
 import com.liferay.portal.workflow.kaleo.model.KaleoDefinition;
 
@@ -59,7 +59,7 @@ public class KaleoDefinitionModelListener
 			return;
 		}
 
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				try {
 					Message message = new Message();

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/impl/KaleoInstanceServiceImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/impl/KaleoInstanceServiceImpl.java
@@ -14,7 +14,7 @@ import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.resource.PortletResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
@@ -129,7 +129,7 @@ public class KaleoInstanceServiceImpl extends KaleoInstanceServiceBaseImpl {
 		ExecutionContext executionContext = new ExecutionContext(
 			rootKaleoInstanceToken, workflowContext, serviceContext);
 
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				try {
 					_kaleoSignaler.signalEntry(

--- a/modules/apps/portal/portal-async-advice/src/main/java/com/liferay/portal/async/advice/internal/AsyncAdvice.java
+++ b/modules/apps/portal/portal-async-advice/src/main/java/com/liferay/portal/async/advice/internal/AsyncAdvice.java
@@ -15,7 +15,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.messaging.MessageBus;
 import com.liferay.portal.kernel.messaging.async.Async;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
@@ -122,7 +122,7 @@ public class AsyncAdvice extends ChainableMethodAdvice {
 
 		String destinationName = aopMethodInvocation.getAdviceMethodContext();
 
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				Message message = new Message();
 

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionUtilTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionUtilTest.java
@@ -104,8 +104,8 @@ public class DBPartitionUtilTest extends BaseDBPartitionTestCase {
 	public void testAccessCompanyByCompanyThreadLocal() throws Exception {
 		for (long companyId : COMPANY_IDS) {
 			try (SafeCloseable safeCloseable =
-					CompanyThreadLocal.
-						setInitializingCompanyIdWithSafeCloseable(companyId);
+					CompanyThreadLocal.setRawCompanyIdWithSafeCloseable(
+						companyId);
 
 				Connection connection = DataAccess.getConnection();
 

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/release/ReleasePublisher.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/release/ReleasePublisher.java
@@ -13,7 +13,7 @@ import com.liferay.portal.kernel.model.Release;
 import com.liferay.portal.kernel.model.ReleaseConstants;
 import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
 import com.liferay.portal.kernel.service.ReleaseLocalService;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.upgrade.internal.model.listener.ReleaseModelListener;
 
@@ -99,7 +99,7 @@ public class ReleasePublisher {
 	}
 
 	public void unpublish(Release release) {
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				ServiceRegistration<Release> serviceRegistration =
 					_serviceConfiguratorRegistrations.remove(

--- a/modules/apps/portlet-preferences/portlet-preferences-test/src/testIntegration/java/com/liferay/portlet/preferences/test/PortalPreferencesLocalServiceTest.java
+++ b/modules/apps/portlet-preferences/portlet-preferences-test/src/testIntegration/java/com/liferay/portlet/preferences/test/PortalPreferencesLocalServiceTest.java
@@ -17,7 +17,7 @@ import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.PortalPreferenceValueLocalService;
 import com.liferay.portal.kernel.service.PortalPreferencesLocalService;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.PrefsProps;
 import com.liferay.portal.test.rule.Inject;
@@ -115,7 +115,7 @@ public class PortalPreferencesLocalServiceTest {
 							PortalPreferenceValue portalPreferenceValue)
 						throws ModelListenerException {
 
-						TransactionCommitCallbackUtil.registerCallback(
+						TransactionCallbackUtil.registerCommitCallback(
 							() -> {
 								countDownLatch3.countDown();
 

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/odata/entity/BaseExpandoEntityModel.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/odata/entity/BaseExpandoEntityModel.java
@@ -21,7 +21,7 @@ import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.ModelListener;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.odata.entity.BooleanEntityField;
@@ -219,7 +219,7 @@ public abstract class BaseExpandoEntityModel implements EntityModel {
 	}
 
 	private void _refresh() {
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				Class<?> clazz = getClass();
 

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/impl/SegmentsEntryLocalServiceImpl.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/impl/SegmentsEntryLocalServiceImpl.java
@@ -36,7 +36,7 @@ import com.liferay.portal.kernel.service.ResourceLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.GroupThreadLocal;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -600,7 +600,7 @@ public class SegmentsEntryLocalServiceImpl
 	}
 
 	private void _reindexSegmentsEntryRels2(SegmentsEntry segmentsEntry) {
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				Message message = new Message();
 

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/impl/SegmentsExperimentLocalServiceImpl.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/impl/SegmentsExperimentLocalServiceImpl.java
@@ -31,7 +31,7 @@ import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.UserNotificationEventLocalService;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.util.BigDecimalUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.UnicodeProperties;
@@ -466,7 +466,7 @@ public class SegmentsExperimentLocalServiceImpl
 		long variantSegmentsExperienceId =
 			variantSegmentsExperience.getSegmentsExperienceId();
 
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				SegmentsExperience callbackVariantSegmentsExperience =
 					_segmentsExperienceLocalService.getSegmentsExperience(

--- a/modules/apps/site/site-dsr-site-initializer/src/main/java/com/liferay/site/dsr/site/initializer/internal/model/listener/ObjectEntryModelListener.java
+++ b/modules/apps/site/site-dsr-site-initializer/src/main/java/com/liferay/site/dsr/site/initializer/internal/model/listener/ObjectEntryModelListener.java
@@ -59,7 +59,7 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.service.UserGroupRoleLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -456,7 +456,7 @@ public class ObjectEntryModelListener extends BaseModelListener<ObjectEntry> {
 
 			long[] fileEntryIds = DSRRoomThreadLocal.getFileEntryIds();
 
-			TransactionCommitCallbackUtil.registerCallback(
+			TransactionCallbackUtil.registerCommitCallback(
 				() -> {
 					if (sourceObjectEntryId != 0) {
 						_duplicateGroup(

--- a/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/model/listener/BaseSitemapModelListener.java
+++ b/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/model/listener/BaseSitemapModelListener.java
@@ -8,7 +8,7 @@ package com.liferay.site.internal.model.listener;
 import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.GroupedModel;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.site.manager.SitemapManager;
 
 import org.osgi.service.component.annotations.Reference;
@@ -42,7 +42,7 @@ public abstract class BaseSitemapModelListener<T extends BaseModel<T>>
 	private void _scheduleRegenerateSitemap(T model) {
 		GroupedModel groupedModel = (GroupedModel)model;
 
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				sitemapManager.scheduleRegenerateSitemap(
 					getAssetTypeKey(), groupedModel.getCompanyId(),

--- a/modules/apps/subscription/subscription-service/src/main/java/com/liferay/subscription/internal/model/listener/SubscriptionPortletPreferencesModelListener.java
+++ b/modules/apps/subscription/subscription-service/src/main/java/com/liferay/subscription/internal/model/listener/SubscriptionPortletPreferencesModelListener.java
@@ -12,7 +12,7 @@ import com.liferay.portal.kernel.model.ModelListener;
 import com.liferay.portal.kernel.model.PortletPreferences;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.util.CopyLayoutThreadLocal;
 import com.liferay.subscription.service.SubscriptionLocalService;
 
@@ -46,7 +46,7 @@ public class SubscriptionPortletPreferencesModelListener
 				return;
 			}
 
-			TransactionCommitCallbackUtil.registerCallback(
+			TransactionCallbackUtil.registerCommitCallback(
 				() -> {
 					PortletPreferences remainingPortletPreferences =
 						_portletPreferencesLocalService.fetchPortletPreferences(

--- a/modules/dxp/apps/antivirus/antivirus-async-store/src/main/java/com/liferay/antivirus/async/store/internal/AntivirusAsyncDLStore.java
+++ b/modules/dxp/apps/antivirus/antivirus-async-store/src/main/java/com/liferay/antivirus/async/store/internal/AntivirusAsyncDLStore.java
@@ -24,7 +24,7 @@ import com.liferay.portal.kernel.messaging.MessageBus;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -393,7 +393,7 @@ public class AntivirusAsyncDLStore implements DLStore {
 
 		_antivirusAsyncEventListenerManager.onPrepare(message);
 
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				_messageBus.sendMessage(
 					AntivirusAsyncDestinationNames.ANTIVIRUS, message);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-metrics-integration/src/main/java/com/liferay/portal/workflow/kaleo/metrics/integration/internal/model/listener/KaleoTaskInstanceTokenModelListener.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-metrics-integration/src/main/java/com/liferay/portal/workflow/kaleo/metrics/integration/internal/model/listener/KaleoTaskInstanceTokenModelListener.java
@@ -7,7 +7,7 @@ package com.liferay.portal.workflow.kaleo.metrics.integration.internal.model.lis
 
 import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.model.ModelListener;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.workflow.kaleo.metrics.integration.internal.helper.IndexerHelper;
 import com.liferay.portal.workflow.kaleo.model.KaleoDefinitionVersion;
 import com.liferay.portal.workflow.kaleo.model.KaleoTaskAssignmentInstance;
@@ -39,7 +39,7 @@ public class KaleoTaskInstanceTokenModelListener
 	public void onAfterCreate(KaleoTaskInstanceToken kaleoTaskInstanceToken)
 		throws ModelListenerException {
 
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				KaleoDefinitionVersion kaleoDefinitionVersion =
 					getKaleoDefinitionVersion(
@@ -64,7 +64,7 @@ public class KaleoTaskInstanceTokenModelListener
 			KaleoTaskInstanceToken kaleoTaskInstanceToken)
 		throws ModelListenerException {
 
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				List<KaleoTaskAssignmentInstance> kaleoTaskAssignmentInstances =
 					_kaleoTaskAssignmentInstanceLocalService.

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/model/listener/UserModelListener.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/model/listener/UserModelListener.java
@@ -10,7 +10,7 @@ import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.ModelListener;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.UserLocalService;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.search.capabilities.SearchCapabilities;
 import com.liferay.portal.search.engine.adapter.SearchEngineAdapter;
@@ -47,7 +47,7 @@ public class UserModelListener extends BaseModelListener<User> {
 
 		User currentUser = _userLocalService.fetchUserById(user.getUserId());
 
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				if (Objects.equals(
 						currentUser.getFullName(), user.getFullName())) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/creation/helper/WorkflowMetricsIndexCreator.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/creation/helper/WorkflowMetricsIndexCreator.java
@@ -12,7 +12,7 @@ import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.service.ServiceContext;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.search.capabilities.SearchCapabilities;
 import com.liferay.portal.search.engine.adapter.SearchEngineAdapter;
@@ -54,7 +54,7 @@ public class WorkflowMetricsIndexCreator {
 			return;
 		}
 
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				CountSearchRequest countSearchRequest =
 					new CountSearchRequest();

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/model/listener/CompanyModelListener.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/model/listener/CompanyModelListener.java
@@ -11,7 +11,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.ModelListener;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.search.experiences.internal.util.SXPElementUtil;
 import com.liferay.search.experiences.service.SXPBlueprintLocalService;
 import com.liferay.search.experiences.service.SXPElementLocalService;
@@ -27,7 +27,7 @@ public class CompanyModelListener extends BaseModelListener<Company> {
 
 	@Override
 	public void onAfterCreate(Company company) {
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				try {
 					SXPElementUtil.addSXPElements(

--- a/portal-impl/src/META-INF/base-spring.xml
+++ b/portal-impl/src/META-INF/base-spring.xml
@@ -17,7 +17,7 @@
 				<util:constant static-field="com.liferay.portal.kernel.cache.transactional.TransactionalPortalCacheUtil.TRANSACTION_LIFECYCLE_LISTENER" />
 				<util:constant static-field="com.liferay.portal.kernel.internal.spring.transaction.ReadOnlyTransactionThreadLocal.TRANSACTION_LIFECYCLE_LISTENER" />
 				<util:constant static-field="com.liferay.portal.kernel.transaction.TransactionLifecycleNotifier.TRANSACTION_LIFECYCLE_LISTENER" />
-				<util:constant static-field="com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil.TRANSACTION_LIFECYCLE_LISTENER" />
+				<util:constant static-field="com.liferay.portal.kernel.transaction.TransactionCallbackUtil.TRANSACTION_LIFECYCLE_LISTENER" />
 			</list>
 		</property>
 	</bean>

--- a/portal-impl/src/com/liferay/portal/increment/BufferedIncrementAdvice.java
+++ b/portal-impl/src/com/liferay/portal/increment/BufferedIncrementAdvice.java
@@ -17,7 +17,7 @@ import com.liferay.portal.kernel.increment.Increment;
 import com.liferay.portal.kernel.increment.IncrementFactory;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 
 import java.io.Serializable;
@@ -86,7 +86,7 @@ public class BufferedIncrementAdvice extends ChainableMethodAdvice {
 				new BufferedIncreasableEntry(
 					aopMethodInvocation, arguments, batchKey, increment);
 
-			TransactionCommitCallbackUtil.registerCallback(
+			TransactionCallbackUtil.registerCommitCallback(
 				() -> {
 					bufferedIncrementProcessor.process(
 						bufferedIncreasableEntry);

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -240,99 +240,104 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 
 		boolean newDBPartitionAdded = DBPartitionUtil.addDBPartition(companyId);
 
+		Callable<Company> callable = () -> {
+			company.setWebId(webId);
+			company.setMx(mx);
+			company.setMaxUsers(maxUsers);
+			company.setActive(active);
+
+			String name = webId;
+
+			if (webId.equals(PropsValues.COMPANY_DEFAULT_WEB_ID)) {
+				name = PropsValues.COMPANY_DEFAULT_NAME;
+			}
+
+			company.setName(name);
+
+			Company updatedCompany = companyPersistence.update(company);
+
+			User guestUser = _addGuestUser(updatedCompany);
+
+			// Virtual host
+
+			updateVirtualHostname(
+				updatedCompany.getCompanyId(), lowerCaseVirtualHostname);
+
+			if (newDBPartitionAdded) {
+				_dlFileEntryTypeLocalService.
+					createBasicDocumentDLFileEntryType();
+			}
+
+			// Company info
+
+			try {
+				updatedCompany.setKey(
+					EncryptorUtil.serializeKey(EncryptorUtil.generateKey()));
+			}
+			catch (EncryptorException encryptorException) {
+				throw new SystemException(encryptorException);
+			}
+
+			_companyInfoPersistence.update(updatedCompany.getCompanyInfo());
+
+			// Demo settings
+
+			if (webId.equals("liferay.net")) {
+				_addDemoSettings(updatedCompany);
+			}
+
+			updatedCompany = checkCompany(updatedCompany, true);
+
+			if (addDefaultAdminUser) {
+				_userLocalService.addDefaultAdminUser(
+					updatedCompany.getCompanyId(),
+					GetterUtil.getString(
+						defaultAdminPassword,
+						PropsValues.DEFAULT_ADMIN_PASSWORD),
+					GetterUtil.getString(
+						defaultAdminScreenName,
+						PropsValues.DEFAULT_ADMIN_SCREEN_NAME),
+					GetterUtil.getString(
+						defaultAdminEmailAddress,
+						PropsValues.DEFAULT_ADMIN_EMAIL_ADDRESS_PREFIX + "@" +
+							mx),
+					guestUser.getLocale(),
+					GetterUtil.getString(
+						defaultAdminFirstName,
+						PropsValues.DEFAULT_ADMIN_FIRST_NAME),
+					GetterUtil.getString(
+						defaultAdminMiddleName,
+						PropsValues.DEFAULT_ADMIN_MIDDLE_NAME),
+					GetterUtil.getString(
+						defaultAdminLastName,
+						PropsValues.DEFAULT_ADMIN_LAST_NAME));
+			}
+
+			// Guest user must have the Guest role
+
+			Role guestRole = _roleLocalService.getRole(
+				updatedCompany.getCompanyId(), RoleConstants.GUEST);
+
+			_roleLocalService.setUserRoles(
+				guestUser.getUserId(), new long[] {guestRole.getRoleId()});
+
+			return updatedCompany;
+		};
+
 		SafeCloseable safeCloseable =
 			CompanyThreadLocal.setRawCompanyIdWithSafeCloseable(
 				company.getCompanyId());
 
 		try {
-			Company addedCompany = _transactionAwareInvoke(
-				() -> {
-					company.setWebId(webId);
-					company.setMx(mx);
-					company.setMaxUsers(maxUsers);
-					company.setActive(active);
+			Company addedCompany = null;
 
-					String name = webId;
-
-					if (webId.equals(PropsValues.COMPANY_DEFAULT_WEB_ID)) {
-						name = PropsValues.COMPANY_DEFAULT_NAME;
-					}
-
-					company.setName(name);
-
-					Company updatedCompany = companyPersistence.update(company);
-
-					User guestUser = _addGuestUser(updatedCompany);
-
-					// Virtual host
-
-					updateVirtualHostname(
-						updatedCompany.getCompanyId(),
-						lowerCaseVirtualHostname);
-
-					if (newDBPartitionAdded) {
-						_dlFileEntryTypeLocalService.
-							createBasicDocumentDLFileEntryType();
-					}
-
-					// Company info
-
-					try {
-						updatedCompany.setKey(
-							EncryptorUtil.serializeKey(
-								EncryptorUtil.generateKey()));
-					}
-					catch (EncryptorException encryptorException) {
-						throw new SystemException(encryptorException);
-					}
-
-					_companyInfoPersistence.update(
-						updatedCompany.getCompanyInfo());
-
-					// Demo settings
-
-					if (webId.equals("liferay.net")) {
-						_addDemoSettings(updatedCompany);
-					}
-
-					updatedCompany = checkCompany(updatedCompany, true);
-
-					if (addDefaultAdminUser) {
-						_userLocalService.addDefaultAdminUser(
-							updatedCompany.getCompanyId(),
-							GetterUtil.getString(
-								defaultAdminPassword,
-								PropsValues.DEFAULT_ADMIN_PASSWORD),
-							GetterUtil.getString(
-								defaultAdminScreenName,
-								PropsValues.DEFAULT_ADMIN_SCREEN_NAME),
-							GetterUtil.getString(
-								defaultAdminEmailAddress,
-								PropsValues.DEFAULT_ADMIN_EMAIL_ADDRESS_PREFIX +
-									"@" + mx),
-							guestUser.getLocale(),
-							GetterUtil.getString(
-								defaultAdminFirstName,
-								PropsValues.DEFAULT_ADMIN_FIRST_NAME),
-							GetterUtil.getString(
-								defaultAdminMiddleName,
-								PropsValues.DEFAULT_ADMIN_MIDDLE_NAME),
-							GetterUtil.getString(
-								defaultAdminLastName,
-								PropsValues.DEFAULT_ADMIN_LAST_NAME));
-					}
-
-					// Guest user must have the Guest role
-
-					Role guestRole = _roleLocalService.getRole(
-						updatedCompany.getCompanyId(), RoleConstants.GUEST);
-
-					_roleLocalService.setUserRoles(
-						guestUser.getUserId(),
-						new long[] {guestRole.getRoleId()});
-
-					return updatedCompany;
-				});
+			if (PropsValues.DATABASE_PARTITION_ENABLED) {
+				addedCompany = TransactionInvokerUtil.invoke(
+					_transactionConfig, callable);
+			}
+			else {
+				addedCompany = callable.call();
+			}
 
 			TransactionCommitCallbackUtil.registerCallback(
 				() -> {
@@ -348,12 +353,19 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 				if (newDBPartitionAdded) {
 					long addedCompanyId = companyId;
 
-					_transactionAwareInvoke(
-						() -> {
-							DBPartitionUtil.removeDBPartition(addedCompanyId);
+					try {
+						TransactionInvokerUtil.invoke(
+							_transactionConfig,
+							() -> {
+								DBPartitionUtil.removeDBPartition(
+									addedCompanyId);
 
-							return null;
-						});
+								return null;
+							});
+					}
+					catch (Throwable throwable2) {
+						throw new PortalException(throwable2);
+					}
 				}
 			}
 			finally {
@@ -401,7 +413,8 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 			companyPersistence.clearCache();
 			_virtualHostPersistence.clearCache();
 
-			Company importedCompany = _transactionAwareInvoke(
+			Company importedCompany = TransactionInvokerUtil.invoke(
+				_transactionConfig,
 				() -> {
 					Company company = companyPersistence.findByPrimaryKey(
 						companyId);
@@ -455,14 +468,20 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 						setCompanyInDeletionProcessWithSafeCloseable(
 							companyId)) {
 
-				_transactionAwareInvoke(
-					() -> {
-						exportCompany(companyId);
+				try {
+					TransactionInvokerUtil.invoke(
+						_transactionConfig,
+						() -> {
+							exportCompany(companyId);
 
-						DBPartitionUtil.removeDBPartition(companyId);
+							DBPartitionUtil.removeDBPartition(companyId);
 
-						return null;
-					});
+							return null;
+						});
+				}
+				catch (Throwable throwable2) {
+					throw new PortalException(throwable2);
+				}
 			}
 			finally {
 				safeCloseable1.close();
@@ -671,7 +690,8 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 		long companyId = toCompanyId;
 
 		try {
-			Company copiedCompany = _transactionAwareInvoke(
+			Company copiedCompany = TransactionInvokerUtil.invoke(
+				_transactionConfig,
 				() -> {
 					Company company = fromCompany.cloneWithOriginalValues();
 
@@ -699,12 +719,18 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 						setCompanyInDeletionProcessWithSafeCloseable(
 							companyId)) {
 
-				_transactionAwareInvoke(
-					() -> {
-						DBPartitionUtil.removeDBPartition(companyId);
+				try {
+					TransactionInvokerUtil.invoke(
+						_transactionConfig,
+						() -> {
+							DBPartitionUtil.removeDBPartition(companyId);
 
-						return null;
-					});
+							return null;
+						});
+				}
+				catch (Throwable throwable2) {
+					throw new PortalException(throwable2);
+				}
 			}
 			finally {
 				safeCloseable1.close();
@@ -2499,22 +2525,6 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 		clusterRequest.setFireAndForget(true);
 
 		ClusterExecutorUtil.execute(clusterRequest);
-	}
-
-	private Company _transactionAwareInvoke(Callable<Company> callable)
-		throws PortalException {
-
-		try {
-			if (PropsValues.DATABASE_PARTITION_ENABLED) {
-				return TransactionInvokerUtil.invoke(
-					_transactionConfig, callable);
-			}
-
-			return callable.call();
-		}
-		catch (Throwable throwable) {
-			throw new PortalException(throwable);
-		}
 	}
 
 	private void _updateGroupLanguageIds(

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -661,20 +661,32 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 					companyId);
 		}
 
-		try (SafeCloseable safeCloseable1 =
-				CompanyThreadLocal.setCompanyIdWithSafeCloseable(companyId);
-			SafeCloseable safeCloseable2 =
-				PortalInstances.setCompanyInDeletionProcessWithSafeCloseable(
-					companyId)) {
+		SafeCloseable safeCloseable1 =
+			PortalInstances.setCompanyInDeletionProcessWithSafeCloseable(
+				companyId);
 
-			return doDeleteCompany(companyId);
+		try (SafeCloseable safeCloseable2 =
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(companyId)) {
+
+			Company company = doDeleteCompany(companyId);
+
+			TransactionCallbackUtil.registerCompletionCallback(
+				() -> {
+					safeCloseable1.close();
+
+					return null;
+				});
+
+			return company;
 		}
-		catch (PortalException portalException) {
+		catch (Throwable throwable) {
+			safeCloseable1.close();
+
 			if (_log.isDebugEnabled()) {
-				_log.debug(portalException);
+				_log.debug(throwable);
 			}
 
-			throw portalException;
+			throw throwable;
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -2458,8 +2458,10 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 				EntityCacheUtil.removeResult(
 					company.getClass(), company.getPrimaryKeyObj());
 
-				EntityCacheUtil.removeResult(
-					virtualHost.getClass(), virtualHost.getPrimaryKeyObj());
+				if (virtualHost != null) {
+					EntityCacheUtil.removeResult(
+						virtualHost.getClass(), virtualHost.getPrimaryKeyObj());
+				}
 
 				return null;
 			});

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -1642,6 +1642,8 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 		preunregisterCompany(company);
 
 		if (PropsValues.DATABASE_PARTITION_ENABLED) {
+			_clearCacheCallback(companyId, true);
+
 			TransactionCommitCallbackUtil.registerCallback(
 				() -> {
 					_clearCache(companyId);
@@ -1665,8 +1667,6 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 
 					return null;
 				});
-
-			_clearCacheCallback(companyId, true);
 
 			DBPartitionUtil.removeDBPartition(companyId);
 

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -240,7 +240,7 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 		boolean newDBPartitionAdded = DBPartitionUtil.addDBPartition(companyId);
 
 		SafeCloseable safeCloseable =
-			CompanyThreadLocal.setInitializingCompanyIdWithSafeCloseable(
+			CompanyThreadLocal.setRawCompanyIdWithSafeCloseable(
 				company.getCompanyId());
 
 		try {

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -2243,13 +2243,19 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 				PortalInstances.initCompany(company);
 			});
 
-		companyLocalService.forEachCompanyId(
-			companyId -> {
-				PortalInstances.removeCompany(companyId);
+		for (long companyId : companyIds) {
+			PortalInstances.removeCompany(companyId);
+
+			try (SafeCloseable safeCloseable1 =
+					CompanyThreadLocal.setRawCompanyIdWithSafeCloseable(
+						companyId);
+				SafeCloseable safeCloseable2 =
+					CTCollectionThreadLocal.
+						setProductionModeWithSafeCloseable()) {
 
 				CacheRegistryUtil.clear();
-			},
-			ArrayUtil.toLongArray(companyIds));
+			}
+		}
 	}
 
 	private Company _addDBPartitionCompany(Company company)

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -444,13 +444,8 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 					return _addDBPartitionCompany(company);
 				});
 
-			TransactionCommitCallbackUtil.registerCallback(
-				() -> {
-					safeCloseable1.close();
-					safeCloseable2.close();
-
-					return null;
-				});
+			safeCloseable1.close();
+			safeCloseable2.close();
 
 			return importedCompany;
 		}
@@ -693,13 +688,8 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 					return _addDBPartitionCompany(company);
 				});
 
-			TransactionCommitCallbackUtil.registerCallback(
-				() -> {
-					safeCloseable1.close();
-					safeCloseable2.close();
-
-					return null;
-				});
+			safeCloseable1.close();
+			safeCloseable2.close();
 
 			return copiedCompany;
 		}

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -106,7 +106,7 @@ import com.liferay.portal.kernel.service.persistence.PortletPersistence;
 import com.liferay.portal.kernel.service.persistence.UserPersistence;
 import com.liferay.portal.kernel.service.persistence.VirtualHostPersistence;
 import com.liferay.portal.kernel.transaction.Propagation;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.transaction.TransactionConfig;
 import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
 import com.liferay.portal.kernel.transaction.Transactional;
@@ -481,7 +481,7 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 
 			Company finalCompany = company;
 
-			TransactionCommitCallbackUtil.registerCallback(
+			TransactionCallbackUtil.registerCommitCallback(
 				() -> {
 					registerCompany(finalCompany);
 
@@ -1564,34 +1564,45 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 			VirtualHost virtualHost = _virtualHostPersistence.fetchByHostname(
 				company.getVirtualHostname());
 
-			TransactionCommitCallbackUtil.registerCallback(
+			TransactionCallbackUtil.registerCommitCallback(
 				() -> {
-					EntityCacheUtil.removeResult(
-						company.getClass(), company.getPrimaryKeyObj());
 
-					if (virtualHost != null) {
+					// The target company's partition is already dropped, so
+					// this cleanup runs under the system company instead of a
+					// scope that resolves to it.
+
+					try (SafeCloseable safeCloseable =
+							CompanyThreadLocal.setRawCompanyIdWithSafeCloseable(
+								CompanyConstants.SYSTEM)) {
+
 						EntityCacheUtil.removeResult(
-							virtualHost.getClass(),
-							virtualHost.getPrimaryKeyObj());
+							company.getClass(), company.getPrimaryKeyObj());
+
+						if (virtualHost != null) {
+							EntityCacheUtil.removeResult(
+								virtualHost.getClass(),
+								virtualHost.getPrimaryKeyObj());
+						}
+
+						PortalCacheHelperUtil.removePortalCaches(
+							PortalCacheManagerNames.MULTI_VM, companyId);
+
+						Store store = _storeSnapshot.get();
+
+						store.deleteDirectory(companyId);
+
+						PortalInstances.removeCompany(company.getCompanyId());
+
+						unregisterCompany(company);
+
+						_synchronizePortalInstances();
 					}
 
-					PortalCacheHelperUtil.removePortalCaches(
-						PortalCacheManagerNames.MULTI_VM, companyId);
+					// Back under the deleted company's scope, clear its
+					// sharded caches, which resolve per company from the
+					// scope, in production mode.
 
-					Store store = _storeSnapshot.get();
-
-					store.deleteDirectory(companyId);
-
-					PortalInstances.removeCompany(company.getCompanyId());
-
-					unregisterCompany(company);
-
-					_synchronizePortalInstances();
-
-					try (SafeCloseable safeCloseable1 =
-							CompanyThreadLocal.setRawCompanyIdWithSafeCloseable(
-								companyId);
-						SafeCloseable safeCloseable2 =
+					try (SafeCloseable safeCloseable =
 							CTCollectionThreadLocal.
 								setProductionModeWithSafeCloseable()) {
 
@@ -2380,7 +2391,7 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 
 		// Portal instance
 
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				PortalInstances.removeCompany(company.getCompanyId());
 

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -1533,7 +1533,7 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 		}
 
 		companyPersistence.clearCache(SetUtil.fromArray(companyId));
-		_clearCacheCallback(companyId, false);
+		_clearCacheCallback(companyId);
 	}
 
 	/**
@@ -1587,7 +1587,7 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 			throw new SystemException(exception);
 		}
 
-		_clearCacheCallback(companyId, false);
+		_clearCacheCallback(companyId);
 	}
 
 	protected Company checkLogo(long companyId) throws PortalException {
@@ -1642,11 +1642,22 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 		preunregisterCompany(company);
 
 		if (PropsValues.DATABASE_PARTITION_ENABLED) {
-			_clearCacheCallback(companyId, true);
+			VirtualHost virtualHost = _virtualHostPersistence.fetchByHostname(
+				company.getVirtualHostname());
 
 			TransactionCommitCallbackUtil.registerCallback(
 				() -> {
-					_clearCache(companyId);
+					EntityCacheUtil.removeResult(
+						company.getClass(), company.getPrimaryKeyObj());
+
+					if (virtualHost != null) {
+						EntityCacheUtil.removeResult(
+							virtualHost.getClass(),
+							virtualHost.getPrimaryKeyObj());
+					}
+
+					PortalCacheHelperUtil.removePortalCaches(
+						PortalCacheManagerNames.MULTI_VM, companyId);
 
 					Store store = _storeSnapshot.get();
 
@@ -2432,22 +2443,7 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 		return guestUser;
 	}
 
-	private void _clearCache(long companyId) {
-		Company company = companyPersistence.fetchByPrimaryKey(companyId);
-
-		if (company != null) {
-			companyPersistence.clearCache(company);
-
-			VirtualHost virtualHost = _virtualHostPersistence.fetchByHostname(
-				company.getVirtualHostname());
-
-			_virtualHostPersistence.clearCache(virtualHost);
-		}
-	}
-
-	private void _clearCacheCallback(
-		long companyId, boolean removePortalCache) {
-
+	private void _clearCacheCallback(long companyId) {
 		Company company = companyPersistence.fetchByPrimaryKey(companyId);
 
 		if (company == null) {
@@ -2464,11 +2460,6 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 
 				EntityCacheUtil.removeResult(
 					virtualHost.getClass(), virtualHost.getPrimaryKeyObj());
-
-				if (removePortalCache) {
-					PortalCacheHelperUtil.removePortalCaches(
-						PortalCacheManagerNames.MULTI_VM, companyId);
-				}
 
 				return null;
 			});

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -1531,9 +1531,6 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 		catch (Exception exception) {
 			throw new SystemException(exception);
 		}
-
-		companyPersistence.clearCache(SetUtil.fromArray(companyId));
-		_clearCacheCallback(companyId);
 	}
 
 	/**
@@ -1586,8 +1583,6 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 		catch (IOException | PortletException exception) {
 			throw new SystemException(exception);
 		}
-
-		_clearCacheCallback(companyId);
 	}
 
 	protected Company checkLogo(long companyId) throws PortalException {
@@ -2441,30 +2436,6 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 		_contactPersistence.update(guestContact);
 
 		return guestUser;
-	}
-
-	private void _clearCacheCallback(long companyId) {
-		Company company = companyPersistence.fetchByPrimaryKey(companyId);
-
-		if (company == null) {
-			return;
-		}
-
-		VirtualHost virtualHost = _virtualHostPersistence.fetchByHostname(
-			company.getVirtualHostname());
-
-		TransactionCommitCallbackUtil.registerCallback(
-			() -> {
-				EntityCacheUtil.removeResult(
-					company.getClass(), company.getPrimaryKeyObj());
-
-				if (virtualHost != null) {
-					EntityCacheUtil.removeResult(
-						virtualHost.getClass(), virtualHost.getPrimaryKeyObj());
-				}
-
-				return null;
-			});
 	}
 
 	private void _deletePortalInstance(Company company) throws PortalException {

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -379,85 +379,71 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 				"Company ID " + companyId + " is the default company ID");
 		}
 
-		SafeCloseable safeCloseable1 =
-			PortalInstances.setImportInProcessCompanyIdWithSafeCloseable(
-				companyId);
+		try (SafeCloseable safeCloseable1 =
+				PortalInstances.setImportInProcessCompanyIdWithSafeCloseable(
+					companyId)) {
 
-		try {
 			DBPartitionUtil.importDBPartition(companyId);
-		}
-		catch (Throwable throwable) {
-			safeCloseable1.close();
 
-			throw throwable;
-		}
+			try (SafeCloseable safeCloseable2 =
+					CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+						companyId)) {
 
-		SafeCloseable safeCloseable2 =
-			CompanyThreadLocal.setCompanyIdWithSafeCloseable(companyId);
+				companyPersistence.clearCache();
+				_virtualHostPersistence.clearCache();
 
-		try {
-			companyPersistence.clearCache();
-			_virtualHostPersistence.clearCache();
+				Company dbPartitionCompany = TransactionInvokerUtil.invoke(
+					_transactionConfig,
+					() -> {
+						Company company = companyPersistence.findByPrimaryKey(
+							companyId);
 
-			Company importedCompany = TransactionInvokerUtil.invoke(
-				_transactionConfig,
-				() -> {
-					Company company = companyPersistence.findByPrimaryKey(
-						companyId);
+						if (Validator.isNotNull(name) &&
+							!StringUtil.equals(company.getName(), name)) {
 
-					if (Validator.isNotNull(name) &&
-						!StringUtil.equals(company.getName(), name)) {
+							validateName(companyId, name);
 
-						validateName(companyId, name);
+							company.setName(name);
 
-						company.setName(name);
+							company = companyPersistence.update(company);
+						}
 
-						company = companyPersistence.update(company);
-					}
+						String lowerCaseVirtualHostname =
+							StringUtil.toLowerCase(
+								StringUtil.trim(virtualHostname));
 
-					String lowerCaseVirtualHostname = StringUtil.toLowerCase(
-						StringUtil.trim(virtualHostname));
+						if (Validator.isNotNull(lowerCaseVirtualHostname) &&
+							!StringUtil.equals(
+								company.getVirtualHostname(),
+								lowerCaseVirtualHostname)) {
 
-					if (Validator.isNotNull(lowerCaseVirtualHostname) &&
-						!StringUtil.equals(
-							company.getVirtualHostname(),
-							lowerCaseVirtualHostname)) {
+							validateVirtualHost(
+								company.getWebId(), lowerCaseVirtualHostname);
 
-						validateVirtualHost(
-							company.getWebId(), lowerCaseVirtualHostname);
+							company = updateVirtualHostname(
+								companyId, lowerCaseVirtualHostname);
+						}
 
-						company = updateVirtualHostname(
-							companyId, lowerCaseVirtualHostname);
-					}
+						if (Validator.isNotNull(webId) &&
+							!StringUtil.equals(company.getWebId(), webId)) {
 
-					if (Validator.isNotNull(webId) &&
-						!StringUtil.equals(company.getWebId(), webId)) {
+							validateWebId(webId);
 
-						validateWebId(webId);
+							company.setWebId(webId);
 
-						company.setWebId(webId);
+							company = companyPersistence.update(company);
+						}
 
-						company = companyPersistence.update(company);
-					}
+						return _addDBPartitionCompany(company);
+					});
 
-					return _addDBPartitionCompany(company);
-				});
-
-			safeCloseable1.close();
-			safeCloseable2.close();
-
-			return importedCompany;
-		}
-		catch (Throwable throwable) {
-			try {
+				return _registerDBPartitionCompany(dbPartitionCompany);
+			}
+			catch (Throwable throwable) {
 				_removeDBPartition(companyId, true);
-			}
-			finally {
-				safeCloseable1.close();
-				safeCloseable2.close();
-			}
 
-			throw new PortalException(throwable);
+				throw new PortalException(throwable);
+			}
 		}
 	}
 
@@ -640,58 +626,43 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 
 		validateWebId(webId);
 
-		SafeCloseable safeCloseable1 =
-			PortalInstances.setCopyInProcessCompanyIdWithSafeCloseable(
-				fromCompanyId);
+		try (SafeCloseable safeCloseable1 =
+				PortalInstances.setCopyInProcessCompanyIdWithSafeCloseable(
+					fromCompanyId)) {
 
-		try {
 			DBPartitionUtil.copyDBPartition(fromCompanyId, toCompanyId);
-		}
-		catch (Throwable throwable) {
-			safeCloseable1.close();
 
-			throw throwable;
-		}
+			long companyId = toCompanyId;
 
-		SafeCloseable safeCloseable2 =
-			CompanyThreadLocal.setCompanyIdWithSafeCloseable(toCompanyId);
+			try (SafeCloseable safeCloseable2 =
+					CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+						toCompanyId)) {
 
-		long companyId = toCompanyId;
+				Company dbPartitionCompany = TransactionInvokerUtil.invoke(
+					_transactionConfig,
+					() -> {
+						Company company = fromCompany.cloneWithOriginalValues();
 
-		try {
-			Company copiedCompany = TransactionInvokerUtil.invoke(
-				_transactionConfig,
-				() -> {
-					Company company = fromCompany.cloneWithOriginalValues();
+						company.setCompanyId(companyId);
+						company.setWebId(webId);
+						company.setName(name);
+						company.setNew(true);
 
-					company.setCompanyId(companyId);
-					company.setWebId(webId);
-					company.setName(name);
-					company.setNew(true);
+						company = companyPersistence.update(company);
 
-					company = companyPersistence.update(company);
+						company = updateVirtualHostname(
+							company.getCompanyId(), lowerCaseVirtualHostname);
 
-					company = updateVirtualHostname(
-						company.getCompanyId(), lowerCaseVirtualHostname);
+						return _addDBPartitionCompany(company);
+					});
 
-					return _addDBPartitionCompany(company);
-				});
-
-			safeCloseable1.close();
-			safeCloseable2.close();
-
-			return copiedCompany;
-		}
-		catch (Throwable throwable) {
-			try {
+				return _registerDBPartitionCompany(dbPartitionCompany);
+			}
+			catch (Throwable throwable) {
 				_removeDBPartition(companyId, false);
-			}
-			finally {
-				safeCloseable1.close();
-				safeCloseable2.close();
-			}
 
-			throw new PortalException(throwable);
+				throw new PortalException(throwable);
+			}
 		}
 	}
 
@@ -2292,20 +2263,6 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 
 		_portletLocalService.checkPortlets(company.getCompanyId());
 
-		TransactionCommitCallbackUtil.registerCallback(
-			() -> {
-				Company dbPartitionCompany =
-					companyPersistence.findByPrimaryKey(company.getCompanyId());
-
-				registerCompany(dbPartitionCompany);
-
-				PortalInstances.initCompany(dbPartitionCompany, true);
-
-				_synchronizePortalInstances();
-
-				return null;
-			});
-
 		return company;
 	}
 
@@ -2470,6 +2427,27 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 		}
 
 		return nextLong;
+	}
+
+	private Company _registerDBPartitionCompany(Company company) {
+		registerCompany(company);
+
+		try {
+			PortalInstances.initCompany(company, true);
+
+			_synchronizePortalInstances();
+		}
+		catch (RuntimeException runtimeException) {
+
+			// registerCompany already ran, so undo it rather than leave
+			// listeners bound to a company that never finished initializing
+
+			unregisterCompany(company);
+
+			throw runtimeException;
+		}
+
+		return company;
 	}
 
 	private void _removeDBPartition(long companyId, boolean export)

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -244,7 +244,7 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 				company.getCompanyId());
 
 		try {
-			return _transactionAwareInvoke(
+			Company addedCompany = _transactionAwareInvoke(
 				() -> {
 					company.setWebId(webId);
 					company.setMx(mx);
@@ -332,6 +332,15 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 
 					return updatedCompany;
 				});
+
+			TransactionCommitCallbackUtil.registerCallback(
+				() -> {
+					safeCloseable.close();
+
+					return null;
+				});
+
+			return addedCompany;
 		}
 		catch (Throwable throwable) {
 			try {
@@ -351,14 +360,6 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 			}
 
 			throw new PortalException(throwable);
-		}
-		finally {
-			TransactionCommitCallbackUtil.registerCallback(
-				() -> {
-					safeCloseable.close();
-
-					return null;
-				});
 		}
 	}
 
@@ -395,11 +396,11 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 		SafeCloseable safeCloseable2 =
 			CompanyThreadLocal.setCompanyIdWithSafeCloseable(companyId);
 
-		companyPersistence.clearCache();
-		_virtualHostPersistence.clearCache();
-
 		try {
-			return _transactionAwareInvoke(
+			companyPersistence.clearCache();
+			_virtualHostPersistence.clearCache();
+
+			Company importedCompany = _transactionAwareInvoke(
 				() -> {
 					Company company = companyPersistence.findByPrimaryKey(
 						companyId);
@@ -441,6 +442,16 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 
 					return _addDBPartitionCompany(company);
 				});
+
+			TransactionCommitCallbackUtil.registerCallback(
+				() -> {
+					safeCloseable1.close();
+					safeCloseable2.close();
+
+					return null;
+				});
+
+			return importedCompany;
 		}
 		catch (Throwable throwable) {
 			try (SafeCloseable safeCloseable3 =
@@ -463,15 +474,6 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 			}
 
 			throw new PortalException(throwable);
-		}
-		finally {
-			TransactionCommitCallbackUtil.registerCallback(
-				() -> {
-					safeCloseable1.close();
-					safeCloseable2.close();
-
-					return null;
-				});
 		}
 	}
 
@@ -673,7 +675,7 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 		long companyId = toCompanyId;
 
 		try {
-			return _transactionAwareInvoke(
+			Company copiedCompany = _transactionAwareInvoke(
 				() -> {
 					Company company = fromCompany.cloneWithOriginalValues();
 
@@ -689,6 +691,16 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 
 					return _addDBPartitionCompany(company);
 				});
+
+			TransactionCommitCallbackUtil.registerCallback(
+				() -> {
+					safeCloseable1.close();
+					safeCloseable2.close();
+
+					return null;
+				});
+
+			return copiedCompany;
 		}
 		catch (Throwable throwable) {
 			try (SafeCloseable safeCloseable3 =
@@ -709,15 +721,6 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 			}
 
 			throw new PortalException(throwable);
-		}
-		finally {
-			TransactionCommitCallbackUtil.registerCallback(
-				() -> {
-					safeCloseable1.close();
-					safeCloseable2.close();
-
-					return null;
-				});
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -324,38 +324,20 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 			return updatedCompany;
 		};
 
-		SafeCloseable safeCloseable =
-			CompanyThreadLocal.setRawCompanyIdWithSafeCloseable(
-				company.getCompanyId());
-
-		try {
-			Company addedCompany = null;
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setRawCompanyIdWithSafeCloseable(
+					companyId)) {
 
 			if (PropsValues.DATABASE_PARTITION_ENABLED) {
-				addedCompany = TransactionInvokerUtil.invoke(
+				return TransactionInvokerUtil.invoke(
 					_transactionConfig, callable);
 			}
-			else {
-				addedCompany = callable.call();
-			}
 
-			TransactionCommitCallbackUtil.registerCallback(
-				() -> {
-					safeCloseable.close();
-
-					return null;
-				});
-
-			return addedCompany;
+			return callable.call();
 		}
 		catch (Throwable throwable) {
-			try {
-				if (newDBPartitionAdded) {
-					_removeDBPartition(companyId, false);
-				}
-			}
-			finally {
-				safeCloseable.close();
+			if (newDBPartitionAdded) {
+				_removeDBPartition(companyId, false);
 			}
 
 			throw new PortalException(throwable);

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -872,7 +872,42 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 					CompanyThreadLocal.getCompanyId(), " is locked"));
 		}
 
+		Set<Long> persistedCompanyIds = new HashSet<>();
+
+		// getCompanyIds() returns the live instance IDs from the pool, or reads
+		// them by ID from the database when the pool is disabled, so the
+		// existence check never loads the full Company model
+
+		for (long companyId : PortalInstancePool.getCompanyIds()) {
+			persistedCompanyIds.add(companyId);
+		}
+
+		// The system scope is not a company: it cannot be deleted and has no
+		// Company row, so neither liveness check applies to it
+
+		persistedCompanyIds.add(CompanyConstants.SYSTEM);
+
 		for (long companyId : companyIds) {
+			if (PortalInstances.isCompanyInDeletionProcess(companyId)) {
+				if (_log.isWarnEnabled()) {
+					_log.warn(
+						"Skipping company " + companyId +
+							" because it is in the deletion process");
+				}
+
+				continue;
+			}
+
+			if (!persistedCompanyIds.contains(companyId)) {
+				if (_log.isWarnEnabled()) {
+					_log.warn(
+						"Skipping company " + companyId +
+							" because it no longer exists");
+				}
+
+				continue;
+			}
+
 			try (SafeCloseable safeCloseable =
 					CompanyThreadLocal.setCompanyIdWithSafeCloseable(
 						companyId)) {

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.cache.CacheRegistryUtil;
 import com.liferay.portal.kernel.cache.PortalCacheHelperUtil;
 import com.liferay.portal.kernel.cache.PortalCacheManagerNames;
+import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.cluster.ClusterExecutorUtil;
 import com.liferay.portal.kernel.cluster.ClusterRequest;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
@@ -1664,9 +1665,12 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 
 					_synchronizePortalInstances();
 
-					try (SafeCloseable safeCloseable =
-							CompanyThreadLocal.setCompanyIdWithSafeCloseable(
-								companyId)) {
+					try (SafeCloseable safeCloseable1 =
+							CompanyThreadLocal.setRawCompanyIdWithSafeCloseable(
+								companyId);
+						SafeCloseable safeCloseable2 =
+							CTCollectionThreadLocal.
+								setProductionModeWithSafeCloseable()) {
 
 						CacheRegistryUtil.clear();
 					}

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -351,21 +351,7 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 		catch (Throwable throwable) {
 			try {
 				if (newDBPartitionAdded) {
-					long addedCompanyId = companyId;
-
-					try {
-						TransactionInvokerUtil.invoke(
-							_transactionConfig,
-							() -> {
-								DBPartitionUtil.removeDBPartition(
-									addedCompanyId);
-
-								return null;
-							});
-					}
-					catch (Throwable throwable2) {
-						throw new PortalException(throwable2);
-					}
+					_removeDBPartition(companyId, false);
 				}
 			}
 			finally {
@@ -463,25 +449,8 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 			return importedCompany;
 		}
 		catch (Throwable throwable) {
-			try (SafeCloseable safeCloseable3 =
-					PortalInstances.
-						setCompanyInDeletionProcessWithSafeCloseable(
-							companyId)) {
-
-				try {
-					TransactionInvokerUtil.invoke(
-						_transactionConfig,
-						() -> {
-							exportCompany(companyId);
-
-							DBPartitionUtil.removeDBPartition(companyId);
-
-							return null;
-						});
-				}
-				catch (Throwable throwable2) {
-					throw new PortalException(throwable2);
-				}
+			try {
+				_removeDBPartition(companyId, true);
 			}
 			finally {
 				safeCloseable1.close();
@@ -714,23 +683,8 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 			return copiedCompany;
 		}
 		catch (Throwable throwable) {
-			try (SafeCloseable safeCloseable3 =
-					PortalInstances.
-						setCompanyInDeletionProcessWithSafeCloseable(
-							companyId)) {
-
-				try {
-					TransactionInvokerUtil.invoke(
-						_transactionConfig,
-						() -> {
-							DBPartitionUtil.removeDBPartition(companyId);
-
-							return null;
-						});
-				}
-				catch (Throwable throwable2) {
-					throw new PortalException(throwable2);
-				}
+			try {
+				_removeDBPartition(companyId, false);
 			}
 			finally {
 				safeCloseable1.close();
@@ -2516,6 +2470,30 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 		}
 
 		return nextLong;
+	}
+
+	private void _removeDBPartition(long companyId, boolean export)
+		throws PortalException {
+
+		try (SafeCloseable safeCloseable =
+				PortalInstances.setCompanyInDeletionProcessWithSafeCloseable(
+					companyId)) {
+
+			TransactionInvokerUtil.invoke(
+				_transactionConfig,
+				() -> {
+					if (export) {
+						exportCompany(companyId);
+					}
+
+					DBPartitionUtil.removeDBPartition(companyId);
+
+					return null;
+				});
+		}
+		catch (Throwable throwable) {
+			throw new PortalException(throwable);
+		}
 	}
 
 	private void _synchronizePortalInstances() {

--- a/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
@@ -135,7 +135,7 @@ import com.liferay.portal.kernel.service.persistence.RolePersistence;
 import com.liferay.portal.kernel.service.persistence.UserGroupPersistence;
 import com.liferay.portal.kernel.service.persistence.UserPersistence;
 import com.liferay.portal.kernel.transaction.Propagation;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.transaction.Transactional;
 import com.liferay.portal.kernel.tree.TreeModelTasksAdapter;
 import com.liferay.portal.kernel.tree.TreePathUtil;
@@ -1212,7 +1212,7 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 				long[] userIds = getUserPrimaryKeys(group.getGroupId());
 
 				if (ArrayUtil.isNotEmpty(userIds)) {
-					TransactionCommitCallbackUtil.registerCallback(
+					TransactionCallbackUtil.registerCommitCallback(
 						() -> {
 							reindex(companyId, userIds);
 
@@ -3973,7 +3973,7 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 
 			long companyId = group.getCompanyId();
 
-			TransactionCommitCallbackUtil.registerCallback(
+			TransactionCallbackUtil.registerCommitCallback(
 				() -> {
 					reindex(companyId, getUserPrimaryKeys(groupId));
 
@@ -4918,7 +4918,7 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 		if (ArrayUtil.isNotEmpty(userIds)) {
 			long companyId = organization.getCompanyId();
 
-			TransactionCommitCallbackUtil.registerCallback(
+			TransactionCallbackUtil.registerCommitCallback(
 				() -> {
 					reindex(companyId, userIds);
 
@@ -4938,7 +4938,7 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 		if (ArrayUtil.isNotEmpty(userIds)) {
 			long companyId = userGroup.getCompanyId();
 
-			TransactionCommitCallbackUtil.registerCallback(
+			TransactionCallbackUtil.registerCommitCallback(
 				() -> {
 					reindex(companyId, userIds);
 					reindexUserGroup(userGroupId);
@@ -5468,7 +5468,7 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 			return;
 		}
 
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				ClusterRequest clusterRequest =
 					ClusterRequest.createMulticastRequest(

--- a/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
@@ -1595,10 +1595,16 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 	public Group fetchUserPersonalSiteGroup(long companyId)
 		throws PortalException {
 
+		User user = _userLocalService.fetchGuestUser(companyId);
+
+		if (user == null) {
+			return null;
+		}
+
 		return groupPersistence.fetchByC_C_C(
 			companyId,
 			_classNameLocalService.getClassNameId(UserPersonalSite.class),
-			_userLocalService.getGuestUserId(companyId));
+			user.getUserId());
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutSetLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutSetLocalServiceImpl.java
@@ -32,7 +32,7 @@ import com.liferay.portal.kernel.service.persistence.GroupPersistence;
 import com.liferay.portal.kernel.service.persistence.LayoutPersistence;
 import com.liferay.portal.kernel.service.persistence.LayoutSetBranchPersistence;
 import com.liferay.portal.kernel.service.persistence.VirtualHostPersistence;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ColorSchemeFactoryUtil;
 import com.liferay.portal.kernel.util.FileUtil;
@@ -582,7 +582,7 @@ public class LayoutSetLocalServiceImpl extends LayoutSetLocalServiceBaseImpl {
 
 			layoutSetPersistence.clearCache(layoutSet);
 
-			TransactionCommitCallbackUtil.registerCallback(
+			TransactionCallbackUtil.registerCommitCallback(
 				() -> {
 					EntityCacheUtil.removeResult(
 						LayoutSetImpl.class, layoutSet.getLayoutSetId());

--- a/portal-impl/src/com/liferay/portal/service/impl/OrganizationLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/OrganizationLocalServiceImpl.java
@@ -72,7 +72,7 @@ import com.liferay.portal.kernel.service.persistence.RegionPersistence;
 import com.liferay.portal.kernel.service.persistence.UserFinder;
 import com.liferay.portal.kernel.service.persistence.UserPersistence;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.tree.TreeModelTasksAdapter;
 import com.liferay.portal.kernel.tree.TreePathUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -2602,7 +2602,7 @@ public class OrganizationLocalServiceImpl
 		if (ArrayUtil.isNotEmpty(userIds)) {
 			long companyId = organization.getCompanyId();
 
-			TransactionCommitCallbackUtil.registerCallback(
+			TransactionCallbackUtil.registerCommitCallback(
 				() -> {
 					reindex(companyId, userIds);
 

--- a/portal-impl/src/com/liferay/portal/service/impl/UserGroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserGroupLocalServiceImpl.java
@@ -59,7 +59,7 @@ import com.liferay.portal.kernel.service.persistence.TeamPersistence;
 import com.liferay.portal.kernel.service.persistence.UserFinder;
 import com.liferay.portal.kernel.service.persistence.UserPersistence;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
@@ -1403,7 +1403,7 @@ public class UserGroupLocalServiceImpl extends UserGroupLocalServiceBaseImpl {
 		}
 
 		for (Map.Entry<Long, List<UserGroup>> entry : map.entrySet()) {
-			TransactionCommitCallbackUtil.registerCallback(
+			TransactionCallbackUtil.registerCommitCallback(
 				() -> {
 					Set<Long> userIdsSet = new LinkedHashSet<>();
 
@@ -1440,7 +1440,7 @@ public class UserGroupLocalServiceImpl extends UserGroupLocalServiceBaseImpl {
 		long companyId = userGroup.getCompanyId();
 		long userGroupId = userGroup.getUserGroupId();
 
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				long[] userIds = getUserPrimaryKeys(userGroupId);
 

--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -60,7 +60,6 @@ import com.liferay.portal.kernel.exception.UserReminderQueryException;
 import com.liferay.portal.kernel.exception.UserScreenNameException;
 import com.liferay.portal.kernel.exception.UserSmsException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
-import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -200,7 +199,6 @@ import com.liferay.portal.security.pwd.PwdAuthenticator;
 import com.liferay.portal.security.pwd.PwdToolkitUtil;
 import com.liferay.portal.security.pwd.RegExpToolkit;
 import com.liferay.portal.service.base.UserLocalServiceBaseImpl;
-import com.liferay.portal.util.PortalInstances;
 import com.liferay.portlet.usersadmin.util.UsersAdminUtil;
 import com.liferay.ratings.kernel.service.RatingsStatsLocalService;
 import com.liferay.social.kernel.model.SocialRelation;
@@ -7566,15 +7564,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 
 				_companyLocalService.forEachCompanyId(
 					companyId -> {
-						if (PortalInstances.
-								isCurrentCompanyInDeletionProcess() ||
-							!ArrayUtil.contains(
-								PortalInstancePool.getCompanyIds(),
-								companyId)) {
-
-							return;
-						}
-
 						Session session = null;
 
 						try {

--- a/portal-impl/src/com/liferay/portal/service/impl/UserNotificationEventLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserNotificationEventLocalServiceImpl.java
@@ -25,7 +25,7 @@ import com.liferay.portal.kernel.search.Indexable;
 import com.liferay.portal.kernel.search.IndexableType;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.persistence.UserPersistence;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.base.UserNotificationEventLocalServiceBaseImpl;
 
@@ -663,7 +663,7 @@ public class UserNotificationEventLocalServiceImpl
 	}
 
 	protected void sendPushNotification(NotificationEvent notificationEvent) {
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				Message message = new Message();
 

--- a/portal-impl/src/com/liferay/portal/service/impl/VirtualHostLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/VirtualHostLocalServiceImpl.java
@@ -22,7 +22,7 @@ import com.liferay.portal.kernel.model.VirtualHost;
 import com.liferay.portal.kernel.service.persistence.CompanyPersistence;
 import com.liferay.portal.kernel.service.persistence.GroupPersistence;
 import com.liferay.portal.kernel.service.persistence.LayoutSetPersistence;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PropsUtil;
@@ -257,7 +257,7 @@ public class VirtualHostLocalServiceImpl
 		Company company = _companyPersistence.fetchByPrimaryKey(companyId);
 
 		if (company != null) {
-			TransactionCommitCallbackUtil.registerCallback(
+			TransactionCallbackUtil.registerCommitCallback(
 				() -> {
 					EntityCacheUtil.removeResult(
 						company.getClass(), company.getPrimaryKeyObj());
@@ -283,7 +283,7 @@ public class VirtualHostLocalServiceImpl
 		if (layoutSet != null) {
 			_layoutSetPersistence.clearCache(layoutSet);
 
-			TransactionCommitCallbackUtil.registerCallback(
+			TransactionCallbackUtil.registerCommitCallback(
 				() -> {
 					EntityCacheUtil.removeResult(
 						LayoutSetImpl.class, layoutSetId);

--- a/portal-impl/src/com/liferay/portal/util/PortalInstances.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalInstances.java
@@ -6,9 +6,13 @@
 package com.liferay.portal.util;
 
 import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.lang.HashUtil;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.events.EventsProcessorUtil;
+import com.liferay.portal.kernel.cluster.ClusterExecutorUtil;
+import com.liferay.portal.kernel.cluster.ClusterNode;
+import com.liferay.portal.kernel.cluster.ClusterRequest;
 import com.liferay.portal.kernel.cookies.CookiesManagerUtil;
 import com.liferay.portal.kernel.cookies.constants.CookiesConstants;
 import com.liferay.portal.kernel.exception.NoSuchVirtualHostException;
@@ -31,6 +35,8 @@ import com.liferay.portal.kernel.service.LayoutSetLocalServiceUtil;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.service.VirtualHostLocalServiceUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.MethodHandler;
+import com.liferay.portal.kernel.util.MethodKey;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
@@ -44,11 +50,11 @@ import jakarta.servlet.http.HttpServletRequest;
 
 import java.sql.SQLException;
 
-import java.util.List;
+import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * @author Brian Wing Shun Chan
@@ -373,7 +379,51 @@ public class PortalInstances {
 	}
 
 	public static boolean isCompanyInDeletionProcess(long companyId) {
-		return _companyIdsInDeletionProcess.contains(companyId);
+		CompanyDeletionProcess companyDeletionProcess =
+			_companyIdsInDeletionProcess.get(companyId);
+
+		if (companyDeletionProcess == null) {
+			return false;
+		}
+
+		if (ClusterExecutorUtil.isEnabled() &&
+			(companyDeletionProcess._clusterNodeId != null) &&
+			!ClusterExecutorUtil.isClusterNodeAlive(
+				companyDeletionProcess._clusterNodeId)) {
+
+			if (_companyIdsInDeletionProcess.remove(
+					companyId, companyDeletionProcess) &&
+				_log.isWarnEnabled()) {
+
+				_log.warn(
+					StringBundler.concat(
+						"Removing company ", companyId,
+						" from the deletion process because cluster node \"",
+						companyDeletionProcess._clusterNodeId,
+						"\" left the cluster"));
+			}
+
+			return false;
+		}
+
+		long elapsedTime =
+			System.currentTimeMillis() - companyDeletionProcess._timestamp;
+
+		if (elapsedTime <= PropsValues.COMPANY_DELETE_IN_PROCESS_MAX_TIME) {
+			return true;
+		}
+
+		if (_companyIdsInDeletionProcess.remove(
+				companyId, companyDeletionProcess) &&
+			_log.isWarnEnabled()) {
+
+			_log.warn(
+				StringBundler.concat(
+					"Removing company ", companyId,
+					" from the deletion process after ", elapsedTime, " ms"));
+		}
+
+		return false;
 	}
 
 	public static boolean isCompanyInImportProcess() {
@@ -385,8 +435,7 @@ public class PortalInstances {
 	}
 
 	public static boolean isCurrentCompanyInDeletionProcess() {
-		return _companyIdsInDeletionProcess.contains(
-			CompanyThreadLocal.getCompanyId());
+		return isCompanyInDeletionProcess(CompanyThreadLocal.getCompanyId());
 	}
 
 	public static boolean isVirtualHostsIgnoreHost(String host) {
@@ -416,14 +465,33 @@ public class PortalInstances {
 	public static SafeCloseable setCompanyInDeletionProcessWithSafeCloseable(
 		long companyId) {
 
-		if (_companyIdsInDeletionProcess.contains(companyId)) {
+		if (isCompanyInDeletionProcess(companyId)) {
 			throw new UnsupportedOperationException(
 				companyId + " is already in deletion");
 		}
 
-		_companyIdsInDeletionProcess.add(companyId);
+		CompanyDeletionProcess companyDeletionProcess =
+			new CompanyDeletionProcess(
+				_getLocalClusterNodeId(), System.currentTimeMillis());
 
-		return () -> _companyIdsInDeletionProcess.remove(companyId);
+		_companyIdsInDeletionProcess.put(companyId, companyDeletionProcess);
+
+		_notifyCluster(
+			new MethodHandler(
+				_addCompanyIdInDeletionProcessMethodKey, companyId,
+				companyDeletionProcess._clusterNodeId,
+				companyDeletionProcess._timestamp));
+
+		return () -> {
+			_companyIdsInDeletionProcess.remove(
+				companyId, companyDeletionProcess);
+
+			_notifyCluster(
+				new MethodHandler(
+					_removeCompanyIdInDeletionProcessMethodKey, companyId,
+					companyDeletionProcess._clusterNodeId,
+					companyDeletionProcess._timestamp));
+		};
 	}
 
 	public static SafeCloseable setCopyInProcessCompanyIdWithSafeCloseable(
@@ -450,6 +518,13 @@ public class PortalInstances {
 		_importInProcessCompanyId = companyId;
 
 		return () -> _importInProcessCompanyId = null;
+	}
+
+	private static void _addCompanyIdInDeletionProcess(
+		long companyId, String clusterNodeId, long timestamp) {
+
+		_companyIdsInDeletionProcess.put(
+			companyId, new CompanyDeletionProcess(clusterNodeId, timestamp));
 	}
 
 	private static long _getCompanyIdByHost(
@@ -508,6 +583,16 @@ public class PortalInstances {
 		return companyId;
 	}
 
+	private static String _getLocalClusterNodeId() {
+		ClusterNode clusterNode = ClusterExecutorUtil.getLocalClusterNode();
+
+		if (clusterNode == null) {
+			return null;
+		}
+
+		return clusterNode.getClusterNodeId();
+	}
+
 	private static boolean _isCompanyVirtualHostname(
 			long companyId, String serverName)
 		throws PortalException {
@@ -521,6 +606,22 @@ public class PortalInstances {
 		}
 
 		return Objects.equals(virtualHostname, serverName);
+	}
+
+	private static void _notifyCluster(MethodHandler methodHandler) {
+		ClusterRequest clusterRequest = ClusterRequest.createMulticastRequest(
+			methodHandler, true);
+
+		clusterRequest.setFireAndForget(true);
+
+		ClusterExecutorUtil.execute(clusterRequest);
+	}
+
+	private static void _removeCompanyIdInDeletionProcess(
+		long companyId, String clusterNodeId, long timestamp) {
+
+		_companyIdsInDeletionProcess.remove(
+			companyId, new CompanyDeletionProcess(clusterNodeId, timestamp));
 	}
 
 	private static void _setAttributes(
@@ -565,12 +666,20 @@ public class PortalInstances {
 	private static final Log _log = LogFactoryUtil.getLog(
 		PortalInstances.class);
 
+	private static final MethodKey _addCompanyIdInDeletionProcessMethodKey =
+		new MethodKey(
+			PortalInstances.class, "_addCompanyIdInDeletionProcess", long.class,
+			String.class, long.class);
 	private static final Set<String> _autoLoginIgnoreHosts;
 	private static final Set<String> _autoLoginIgnorePaths;
-	private static final List<Long> _companyIdsInDeletionProcess =
-		new CopyOnWriteArrayList<>();
+	private static final Map<Long, CompanyDeletionProcess>
+		_companyIdsInDeletionProcess = new ConcurrentHashMap<>();
 	private static Long _copyInProcessCompanyId;
 	private static Long _importInProcessCompanyId;
+	private static final MethodKey _removeCompanyIdInDeletionProcessMethodKey =
+		new MethodKey(
+			PortalInstances.class, "_removeCompanyIdInDeletionProcess",
+			long.class, String.class, long.class);
 	private static final Set<String> _virtualHostsIgnoreHosts;
 	private static final Set<String> _virtualHostsIgnorePaths;
 
@@ -583,6 +692,47 @@ public class PortalInstances {
 			PropsUtil.getArray(PropsKeys.VIRTUAL_HOSTS_IGNORE_HOSTS));
 		_virtualHostsIgnorePaths = SetUtil.fromArray(
 			PropsUtil.getArray(PropsKeys.VIRTUAL_HOSTS_IGNORE_PATHS));
+	}
+
+	private static class CompanyDeletionProcess {
+
+		@Override
+		public boolean equals(Object object) {
+			if (this == object) {
+				return true;
+			}
+
+			if (!(object instanceof
+					CompanyDeletionProcess companyDeletionProcess)) {
+
+				return false;
+			}
+
+			if (Objects.equals(
+					_clusterNodeId, companyDeletionProcess._clusterNodeId) &&
+				(_timestamp == companyDeletionProcess._timestamp)) {
+
+				return true;
+			}
+
+			return false;
+		}
+
+		@Override
+		public int hashCode() {
+			int hash = HashUtil.hash(0, _clusterNodeId);
+
+			return HashUtil.hash(hash, _timestamp);
+		}
+
+		private CompanyDeletionProcess(String clusterNodeId, long timestamp) {
+			_clusterNodeId = clusterNodeId;
+			_timestamp = timestamp;
+		}
+
+		private final String _clusterNodeId;
+		private final long _timestamp;
+
 	}
 
 }

--- a/portal-impl/src/com/liferay/portal/util/PrefsPropsImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PrefsPropsImpl.java
@@ -21,7 +21,7 @@ import com.liferay.portal.kernel.model.PortalPreferences;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.service.PortalPreferenceValueLocalService;
 import com.liferay.portal.kernel.service.PortalPreferencesLocalService;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.MethodHandler;
 import com.liferay.portal.kernel.util.MethodKey;
@@ -666,7 +666,7 @@ public class PrefsPropsImpl implements PrefsProps {
 
 					_skipCache.set(true);
 
-					TransactionCommitCallbackUtil.registerCallback(
+					TransactionCallbackUtil.registerCommitCallback(
 						() -> {
 							_removePortletPreference(
 								portalPreferenceValue.getCompanyId());

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppServiceImpl.java
@@ -69,7 +69,7 @@ import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.persistence.RepositoryPersistence;
 import com.liferay.portal.kernel.transaction.Propagation;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.transaction.Transactional;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
@@ -3475,7 +3475,7 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 			sourceFolder.getRepositoryId(), sourceFolder.getFolderId(),
 			targetFolder.getRepositoryId(), targetFolder.getFolderId());
 
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				for (FileEntry fileEntry : fileEntries) {
 					DLProcessorHelperUtil.trigger(fileEntry, null);

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -128,7 +128,7 @@ import com.liferay.portal.kernel.service.persistence.UserPersistence;
 import com.liferay.portal.kernel.service.persistence.WebDAVPropsPersistence;
 import com.liferay.portal.kernel.settings.LocalizedValuesMap;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.transaction.Transactional;
 import com.liferay.portal.kernel.trash.helper.TrashHelper;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -3736,7 +3736,7 @@ public class DLFileEntryLocalServiceImpl
 	private void _registerPWCDeletionCallback(
 		DLFileEntry dlFileEntry, String storeFileName) {
 
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				_deleteFile(
 					dlFileEntry.getCompanyId(),

--- a/portal-impl/src/com/liferay/portlet/social/service/impl/SocialActivityLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/social/service/impl/SocialActivityLocalServiceImpl.java
@@ -26,7 +26,7 @@ import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.persistence.UserPersistence;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portlet.asset.util.DeletedAssetEntryThreadLocal;
@@ -201,7 +201,7 @@ public class SocialActivityLocalServiceImpl
 
 		};
 
-		TransactionCommitCallbackUtil.registerCallback(callable);
+		TransactionCallbackUtil.registerCommitCallback(callable);
 	}
 
 	/**

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -1920,6 +1920,16 @@
     #company.default.virtual.host.sync.on.startup=false
 
     #
+    # Set the maximum amount of time in milliseconds that a company can remain
+    # marked as being in the deletion process. An entry that outlives this limit
+    # is considered stranded (e.g. the deleting transaction failed at commit
+    # time and never cleared it) and is removed the next time it is checked.
+    #
+    # Env: LIFERAY_COMPANY_PERIOD_DELETE_PERIOD_IN_PERIOD_PROCESS_PERIOD_MAX_PERIOD_TIME
+    #
+    company.delete.in.process.max.time=7200000
+
+    #
     # Set this to the appropriate encryption algorithm to be used for company
     # level encryption algorithms (except password encryption which is defined
     # via the property "passwords.encryption.algorithm").

--- a/portal-impl/test/unit/com/liferay/portal/util/PortalInstancesTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/util/PortalInstancesTest.java
@@ -1,0 +1,395 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.util;
+
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.cluster.ClusterEventListener;
+import com.liferay.portal.kernel.cluster.ClusterExecutor;
+import com.liferay.portal.kernel.cluster.ClusterNode;
+import com.liferay.portal.kernel.cluster.ClusterRequest;
+import com.liferay.portal.kernel.cluster.FutureClusterResponses;
+import com.liferay.portal.kernel.module.util.SystemBundleUtil;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.MethodHandler;
+import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
+import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+
+/**
+ * @author Shuyang Zhou
+ */
+public class PortalInstancesTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@BeforeClass
+	public static void setUpClass() {
+		BundleContext bundleContext = SystemBundleUtil.getBundleContext();
+
+		_serviceRegistration = bundleContext.registerService(
+			ClusterExecutor.class,
+			new ClusterExecutor() {
+
+				@Override
+				public FutureClusterResponses execute(
+					ClusterRequest clusterRequest) {
+
+					_clusterRequests.add(clusterRequest);
+
+					return null;
+				}
+
+				@Override
+				public InetAddress getBindInetAddress() {
+					return null;
+				}
+
+				@Override
+				public NetworkInterface getBindNetworkInterface() {
+					return null;
+				}
+
+				@Override
+				public List<ClusterEventListener> getClusterEventListeners() {
+					return Collections.emptyList();
+				}
+
+				@Override
+				public List<ClusterNode> getClusterNodes() {
+					return Collections.emptyList();
+				}
+
+				@Override
+				public ClusterNode getLocalClusterNode() {
+					return _localClusterNode;
+				}
+
+				@Override
+				public boolean isClusterNodeAlive(String clusterNodeId) {
+					if (!_clusterEnabled) {
+						Assert.fail(
+							"Cluster node aliveness was checked while " +
+								"clustering is disabled");
+					}
+
+					return _aliveClusterNodeIds.contains(clusterNodeId);
+				}
+
+				@Override
+				public boolean isEnabled() {
+					return _clusterEnabled;
+				}
+
+			},
+			null);
+	}
+
+	@AfterClass
+	public static void tearDownClass() {
+		_serviceRegistration.unregister();
+	}
+
+	@Before
+	public void setUp() {
+		_aliveClusterNodeIds.clear();
+		_clusterEnabled = false;
+		_clusterRequests.clear();
+		_localClusterNode = null;
+	}
+
+	@After
+	public void tearDown() {
+		Map<Long, ?> companyIdsInDeletionProcess =
+			_getCompanyIdsInDeletionProcess();
+
+		companyIdsInDeletionProcess.clear();
+	}
+
+	@Test
+	public void testIsCompanyInDeletionProcessWhenClusteringIsDisabled() {
+		long companyId = RandomTestUtil.randomLong();
+
+		_addCompanyIdInDeletionProcess(
+			companyId, "goneClusterNode", System.currentTimeMillis());
+
+		Assert.assertTrue(
+			PortalInstances.isCompanyInDeletionProcess(companyId));
+	}
+
+	@Test
+	public void testIsCompanyInDeletionProcessWhenEntryIsExpired() {
+		long companyId = RandomTestUtil.randomLong();
+
+		_addCompanyIdInDeletionProcess(
+			companyId, null,
+			System.currentTimeMillis() -
+				PropsValues.COMPANY_DELETE_IN_PROCESS_MAX_TIME - 1000);
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				PortalInstances.class.getName(), LoggerTestUtil.WARN)) {
+
+			Assert.assertFalse(
+				PortalInstances.isCompanyInDeletionProcess(companyId));
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
+
+			LogEntry logEntry = logEntries.get(0);
+
+			String message = logEntry.getMessage();
+
+			Assert.assertTrue(
+				message,
+				message.startsWith(
+					"Removing company " + companyId +
+						" from the deletion process after "));
+		}
+
+		Map<Long, ?> companyIdsInDeletionProcess =
+			_getCompanyIdsInDeletionProcess();
+
+		Assert.assertFalse(
+			companyIdsInDeletionProcess.toString(),
+			companyIdsInDeletionProcess.containsKey(companyId));
+	}
+
+	@Test
+	public void testIsCompanyInDeletionProcessWhenOriginClusterNodeIsAlive() {
+		_clusterEnabled = true;
+
+		_aliveClusterNodeIds.add("aliveClusterNode");
+
+		long companyId = RandomTestUtil.randomLong();
+
+		_addCompanyIdInDeletionProcess(
+			companyId, "aliveClusterNode", System.currentTimeMillis());
+
+		Assert.assertTrue(
+			PortalInstances.isCompanyInDeletionProcess(companyId));
+	}
+
+	@Test
+	public void testIsCompanyInDeletionProcessWhenOriginClusterNodeIsGone() {
+		_clusterEnabled = true;
+
+		long companyId = RandomTestUtil.randomLong();
+
+		_addCompanyIdInDeletionProcess(
+			companyId, "goneClusterNode", System.currentTimeMillis());
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				PortalInstances.class.getName(), LoggerTestUtil.WARN)) {
+
+			Assert.assertFalse(
+				PortalInstances.isCompanyInDeletionProcess(companyId));
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
+
+			LogEntry logEntry = logEntries.get(0);
+
+			Assert.assertEquals(
+				StringBundler.concat(
+					"Removing company ", companyId,
+					" from the deletion process because cluster node ",
+					"\"goneClusterNode\" left the cluster"),
+				logEntry.getMessage());
+		}
+
+		Map<Long, ?> companyIdsInDeletionProcess =
+			_getCompanyIdsInDeletionProcess();
+
+		Assert.assertFalse(
+			companyIdsInDeletionProcess.toString(),
+			companyIdsInDeletionProcess.containsKey(companyId));
+	}
+
+	@Test
+	public void testRemoteReleaseRequiresMatchingEntry() {
+		long companyId = RandomTestUtil.randomLong();
+		long timestamp = System.currentTimeMillis();
+
+		_addCompanyIdInDeletionProcess(
+			companyId, "aliveClusterNode", timestamp);
+
+		_removeCompanyIdInDeletionProcess(
+			companyId, "aliveClusterNode", timestamp + 1);
+
+		Assert.assertTrue(
+			PortalInstances.isCompanyInDeletionProcess(companyId));
+
+		_removeCompanyIdInDeletionProcess(
+			companyId, "otherClusterNode", timestamp);
+
+		Assert.assertTrue(
+			PortalInstances.isCompanyInDeletionProcess(companyId));
+
+		_removeCompanyIdInDeletionProcess(
+			companyId, "aliveClusterNode", timestamp);
+
+		Assert.assertFalse(
+			PortalInstances.isCompanyInDeletionProcess(companyId));
+	}
+
+	@Test
+	public void testSetCompanyInDeletionProcessWithSafeCloseable() {
+		long companyId = RandomTestUtil.randomLong();
+
+		Assert.assertFalse(
+			PortalInstances.isCompanyInDeletionProcess(companyId));
+
+		SafeCloseable safeCloseable =
+			PortalInstances.setCompanyInDeletionProcessWithSafeCloseable(
+				companyId);
+
+		Assert.assertTrue(
+			PortalInstances.isCompanyInDeletionProcess(companyId));
+
+		safeCloseable.close();
+
+		Assert.assertFalse(
+			PortalInstances.isCompanyInDeletionProcess(companyId));
+	}
+
+	@Test
+	public void testSetCompanyInDeletionProcessWithSafeCloseableMulticasts()
+		throws Exception {
+
+		_clusterEnabled = true;
+
+		_aliveClusterNodeIds.add("localClusterNode");
+
+		_localClusterNode = new ClusterNode(
+			"localClusterNode", InetAddress.getLoopbackAddress());
+
+		long companyId = RandomTestUtil.randomLong();
+
+		SafeCloseable safeCloseable =
+			PortalInstances.setCompanyInDeletionProcessWithSafeCloseable(
+				companyId);
+
+		Assert.assertEquals(
+			_clusterRequests.toString(), 1, _clusterRequests.size());
+
+		safeCloseable.close();
+
+		Assert.assertEquals(
+			_clusterRequests.toString(), 2, _clusterRequests.size());
+
+		Assert.assertFalse(
+			PortalInstances.isCompanyInDeletionProcess(companyId));
+
+		ClusterRequest addClusterRequest = _clusterRequests.get(0);
+
+		Assert.assertTrue(addClusterRequest.isFireAndForget());
+
+		MethodHandler addMethodHandler =
+			(MethodHandler)addClusterRequest.getPayload();
+
+		addMethodHandler.invoke();
+
+		Assert.assertTrue(
+			PortalInstances.isCompanyInDeletionProcess(companyId));
+
+		ClusterRequest removeClusterRequest = _clusterRequests.get(1);
+
+		Assert.assertTrue(removeClusterRequest.isFireAndForget());
+
+		MethodHandler removeMethodHandler =
+			(MethodHandler)removeClusterRequest.getPayload();
+
+		removeMethodHandler.invoke();
+
+		Assert.assertFalse(
+			PortalInstances.isCompanyInDeletionProcess(companyId));
+	}
+
+	@Test
+	public void testSetCompanyInDeletionProcessWithSafeCloseableWhenAlreadyInDeletion() {
+		long companyId = RandomTestUtil.randomLong();
+
+		try (SafeCloseable safeCloseable =
+				PortalInstances.setCompanyInDeletionProcessWithSafeCloseable(
+					companyId)) {
+
+			try {
+				PortalInstances.setCompanyInDeletionProcessWithSafeCloseable(
+					companyId);
+
+				Assert.fail();
+			}
+			catch (UnsupportedOperationException
+						unsupportedOperationException) {
+
+				Assert.assertEquals(
+					companyId + " is already in deletion",
+					unsupportedOperationException.getMessage());
+			}
+		}
+	}
+
+	private void _addCompanyIdInDeletionProcess(
+		long companyId, String clusterNodeId, long timestamp) {
+
+		ReflectionTestUtil.invoke(
+			PortalInstances.class, "_addCompanyIdInDeletionProcess",
+			new Class<?>[] {long.class, String.class, long.class}, companyId,
+			clusterNodeId, timestamp);
+	}
+
+	private Map<Long, ?> _getCompanyIdsInDeletionProcess() {
+		return ReflectionTestUtil.getFieldValue(
+			PortalInstances.class, "_companyIdsInDeletionProcess");
+	}
+
+	private void _removeCompanyIdInDeletionProcess(
+		long companyId, String clusterNodeId, long timestamp) {
+
+		ReflectionTestUtil.invoke(
+			PortalInstances.class, "_removeCompanyIdInDeletionProcess",
+			new Class<?>[] {long.class, String.class, long.class}, companyId,
+			clusterNodeId, timestamp);
+	}
+
+	private static final Set<String> _aliveClusterNodeIds = new HashSet<>();
+	private static boolean _clusterEnabled;
+	private static final List<ClusterRequest> _clusterRequests =
+		new ArrayList<>();
+	private static ClusterNode _localClusterNode;
+	private static ServiceRegistration<ClusterExecutor> _serviceRegistration;
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/instance/PortalInstancePool.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/instance/PortalInstancePool.java
@@ -5,11 +5,14 @@
 
 package com.liferay.portal.kernel.instance;
 
-import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.dao.jdbc.CurrentConnection;
+import com.liferay.portal.kernel.dao.jdbc.CurrentConnectionUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.InfrastructureUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
 
@@ -23,6 +26,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+
+import javax.sql.DataSource;
 
 /**
  * @author Tina Tian
@@ -161,10 +166,10 @@ public class PortalInstancePool {
 		_portalInstances.remove(companyId);
 	}
 
-	private static long _getCompanyIdBySQL(String webId) throws SQLException {
-		try (Connection connection = DataAccess.getConnection();
+	private static long _getCompanyIdBySQL(Connection connection, String webId)
+		throws SQLException {
 
-			PreparedStatement preparedStatement = connection.prepareStatement(
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
 				"select companyId from Company where webId = ?")) {
 
 			preparedStatement.setString(1, webId);
@@ -179,10 +184,12 @@ public class PortalInstancePool {
 		throw new IllegalArgumentException("Invalid web ID" + webId);
 	}
 
+	private static long _getCompanyIdBySQL(String webId) throws SQLException {
+		return _read(connection -> _getCompanyIdBySQL(connection, webId));
+	}
+
 	private static long[] _getCompanyIdsBySQL() throws SQLException {
-		try (Connection connection = DataAccess.getConnection()) {
-			return _getCompanyIdsBySQL(connection);
-		}
+		return _read(connection -> _getCompanyIdsBySQL(connection));
 	}
 
 	private static long[] _getCompanyIdsBySQL(Connection connection)
@@ -214,9 +221,7 @@ public class PortalInstancePool {
 	}
 
 	private static long _getDefaultCompanyIdBySQL() throws SQLException {
-		try (Connection connection = DataAccess.getConnection()) {
-			return _getDefaultCompanyIdBySQL(connection);
-		}
+		return _read(connection -> _getDefaultCompanyIdBySQL(connection));
 	}
 
 	private static long _getDefaultCompanyIdBySQL(Connection connection)
@@ -238,10 +243,10 @@ public class PortalInstancePool {
 		return 0;
 	}
 
-	private static String _getWebIdBySQL(long companyId) throws SQLException {
-		try (Connection connection = DataAccess.getConnection();
+	private static String _getWebIdBySQL(Connection connection, long companyId)
+		throws SQLException {
 
-			PreparedStatement preparedStatement = connection.prepareStatement(
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
 				"select webId from Company where companyId = ?")) {
 
 			preparedStatement.setLong(1, companyId);
@@ -256,12 +261,20 @@ public class PortalInstancePool {
 		throw new IllegalArgumentException("Invalid company ID" + companyId);
 	}
 
+	private static String _getWebIdBySQL(long companyId) throws SQLException {
+		return _read(connection -> _getWebIdBySQL(connection, companyId));
+	}
+
 	private static String[] _getWebIdsBySQL() throws SQLException {
+		return _read(connection -> _getWebIdsBySQL(connection));
+	}
+
+	private static String[] _getWebIdsBySQL(Connection connection)
+		throws SQLException {
+
 		List<String> webIds = new ArrayList<>();
 
-		try (Connection connection = DataAccess.getConnection();
-
-			PreparedStatement preparedStatement = connection.prepareStatement(
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
 				"select webId from Company");
 
 			ResultSet resultSet = preparedStatement.executeQuery()) {
@@ -274,6 +287,35 @@ public class PortalInstancePool {
 		}
 
 		return webIds.toArray(new String[0]);
+	}
+
+	private static <T> T _read(
+			UnsafeFunction<Connection, T, SQLException> unsafeFunction)
+		throws SQLException {
+
+		DataSource dataSource = InfrastructureUtil.getDataSource();
+
+		// Reuse the current transaction's connection when one is bound, so a
+		// read issued mid-transaction sees that transaction's own uncommitted
+		// writes instead of opening a second connection that blocks on them on
+		// a database without snapshot reads. Fall back to a fresh connection,
+		// which must be closed, when there is no bound connection, which also
+		// covers reads that run before the current connection helper is wired
+
+		CurrentConnection currentConnection =
+			CurrentConnectionUtil.getCurrentConnection();
+
+		if (currentConnection != null) {
+			Connection connection = currentConnection.getConnection(dataSource);
+
+			if (connection != null) {
+				return unsafeFunction.apply(connection);
+			}
+		}
+
+		try (Connection connection = dataSource.getConnection()) {
+			return unsafeFunction.apply(connection);
+		}
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/portal-kernel/src/com/liferay/portal/kernel/security/auth/CompanyThreadLocal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/auth/CompanyThreadLocal.java
@@ -245,14 +245,15 @@ public class CompanyThreadLocal {
 		};
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 *             #setRawCompanyIdWithSafeCloseable(long)}
+	 */
+	@Deprecated
 	public static SafeCloseable setInitializingCompanyIdWithSafeCloseable(
 		long companyId) {
 
-		if (companyId > 0) {
-			return _companyId.setWithSafeCloseable(companyId);
-		}
-
-		return _companyId.setWithSafeCloseable(CompanyConstants.SYSTEM);
+		return setRawCompanyIdWithSafeCloseable(companyId);
 	}
 
 	public static SafeCloseable setInitializingPortalInstanceWithSafeCloseable(
@@ -260,6 +261,16 @@ public class CompanyThreadLocal {
 
 		return _initializingPortalInstance.setWithSafeCloseable(
 			initializingPortalInstance);
+	}
+
+	public static SafeCloseable setRawCompanyIdWithSafeCloseable(
+		long companyId) {
+
+		if (companyId > 0) {
+			return _companyId.setWithSafeCloseable(companyId);
+		}
+
+		return _companyId.setWithSafeCloseable(CompanyConstants.SYSTEM);
 	}
 
 	public static SafeCloseable setUpgradingPortalInstanceWithSafeCloseable(

--- a/portal-kernel/src/com/liferay/portal/kernel/security/auth/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/auth/packageinfo
@@ -1,1 +1,1 @@
-version 10.0.0
+version 10.1.0

--- a/portal-kernel/src/com/liferay/portal/kernel/transaction/TransactionCallbackUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/transaction/TransactionCallbackUtil.java
@@ -1,0 +1,344 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.transaction;
+
+import com.liferay.petra.lang.CentralizedThreadLocal;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.spring.orm.LastSessionRecorderHelperUtil;
+import com.liferay.portal.kernel.util.PropsValues;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Callable;
+
+/**
+ * Registers callbacks against the current transaction's lifecycle. Commit
+ * callbacks run after the transaction commits, rollback callbacks run after it
+ * rolls back, and completion callbacks run after either outcome, ordered after
+ * the outcome specific callbacks. The listener recognizes savepoint backed
+ * nested propagation scopes and keeps their callbacks in savepoint frames: a
+ * scope that commits promotes its callbacks to the enclosing scope, while a
+ * scope that rolls back runs its rollback and completion callbacks and
+ * discards its commit callbacks.
+ *
+ * @author Shuyang Zhou
+ */
+public class TransactionCallbackUtil {
+
+	public static final TransactionLifecycleListener
+		TRANSACTION_LIFECYCLE_LISTENER = new TransactionLifecycleListener() {
+
+			@Override
+			public void committed(
+				TransactionAttribute transactionAttribute,
+				TransactionStatus transactionStatus) {
+
+				if (transactionAttribute.getPropagation() ==
+						Propagation.NESTED) {
+
+					if (transactionStatus.isNewTransaction()) {
+						_committed();
+					}
+					else {
+						_savepointReleased();
+					}
+				}
+				else if (transactionStatus.isNewTransaction()) {
+					_committed();
+				}
+			}
+
+			@Override
+			public void created(
+				TransactionAttribute transactionAttribute,
+				TransactionStatus transactionStatus) {
+
+				if (transactionAttribute.getPropagation() ==
+						Propagation.NESTED) {
+
+					if (transactionStatus.isNewTransaction()) {
+						_created();
+					}
+					else {
+						_savepointCreated();
+					}
+				}
+				else if (transactionStatus.isNewTransaction()) {
+					_created();
+				}
+			}
+
+			@Override
+			public void rollbacked(
+				TransactionAttribute transactionAttribute,
+				TransactionStatus transactionStatus, Throwable throwable) {
+
+				if (transactionAttribute.getPropagation() ==
+						Propagation.NESTED) {
+
+					if (transactionStatus.isNewTransaction()) {
+						_rollbacked();
+					}
+					else {
+						_savepointRollbacked();
+					}
+				}
+				else if (transactionStatus.isNewTransaction()) {
+					_rollbacked();
+				}
+			}
+
+		};
+
+	public static void registerCommitCallback(Callable<?> callable) {
+		Callbacks callbacks = _getCallbacks();
+
+		if (callbacks == null) {
+			_call(callable);
+
+			return;
+		}
+
+		callbacks._commitCallables.add(_wrapCallable(callable));
+	}
+
+	public static void registerCompletionCallback(Callable<?> callable) {
+		Callbacks callbacks = _getCallbacks();
+
+		if (callbacks == null) {
+			_call(callable);
+
+			return;
+		}
+
+		callbacks._completionCallables.add(_wrapCallable(callable));
+	}
+
+	public static void registerRollbackCallback(Callable<?> callable) {
+		Callbacks callbacks = _getCallbacks();
+
+		if (callbacks == null) {
+
+			// Without a transaction nothing can roll back
+
+			return;
+		}
+
+		callbacks._rollbackCallables.add(_wrapCallable(callable));
+	}
+
+	private static void _call(Callable<?> callable) {
+		try {
+			callable.call();
+		}
+		catch (Exception exception) {
+			throw new RuntimeException(exception);
+		}
+	}
+
+	private static void _committed() {
+		List<Callbacks> callbacksList = _popCallbacksList();
+
+		if (callbacksList == _emptyCallbacksList) {
+			return;
+		}
+
+		Callbacks callbacks = callbacksList.get(0);
+
+		for (int i = 1; i < callbacksList.size(); i++) {
+			callbacks._merge(callbacksList.get(i));
+		}
+
+		_invoke(callbacks._commitCallables);
+		_invoke(callbacks._completionCallables);
+	}
+
+	private static void _created() {
+		List<List<Callbacks>> callbacksLists = _callbacksLists.get();
+
+		callbacksLists.add(_emptyCallbacksList);
+	}
+
+	private static Callbacks _getCallbacks() {
+		List<Callbacks> callbacksList = _getWritableCallbacksList();
+
+		if (callbacksList == null) {
+			return null;
+		}
+
+		return callbacksList.get(callbacksList.size() - 1);
+	}
+
+	private static List<Callbacks> _getWritableCallbacksList() {
+		List<List<Callbacks>> callbacksLists = _callbacksLists.get();
+
+		if (callbacksLists.isEmpty()) {
+			return null;
+		}
+
+		int index = callbacksLists.size() - 1;
+
+		List<Callbacks> callbacksList = callbacksLists.get(index);
+
+		if (callbacksList == _emptyCallbacksList) {
+			callbacksList = new ArrayList<>();
+
+			callbacksList.add(new Callbacks());
+
+			callbacksLists.set(index, callbacksList);
+		}
+
+		return callbacksList;
+	}
+
+	private static void _invoke(List<Callable<?>> callables) {
+		for (Callable<?> callable : callables) {
+			try {
+				callable.call();
+			}
+			catch (Exception exception) {
+				_log.error("Unable to execute transaction callback", exception);
+			}
+		}
+	}
+
+	private static List<Callbacks> _popCallbacksList() {
+		List<List<Callbacks>> callbacksLists = _callbacksLists.get();
+
+		return callbacksLists.remove(callbacksLists.size() - 1);
+	}
+
+	private static void _rollbacked() {
+		List<Callbacks> callbacksList = _popCallbacksList();
+
+		if (callbacksList == _emptyCallbacksList) {
+			return;
+		}
+
+		for (int i = callbacksList.size() - 1; i >= 0; i--) {
+			Callbacks callbacks = callbacksList.get(i);
+
+			_invoke(callbacks._rollbackCallables);
+			_invoke(callbacks._completionCallables);
+		}
+	}
+
+	private static void _savepointCreated() {
+		List<Callbacks> callbacksList = _getWritableCallbacksList();
+
+		if (callbacksList == null) {
+			return;
+		}
+
+		callbacksList.add(new Callbacks());
+	}
+
+	private static void _savepointReleased() {
+		List<Callbacks> callbacksList = _getWritableCallbacksList();
+
+		if ((callbacksList == null) || (callbacksList.size() < 2)) {
+			return;
+		}
+
+		Callbacks callbacks = callbacksList.remove(callbacksList.size() - 1);
+
+		Callbacks parentCallbacks = callbacksList.get(callbacksList.size() - 1);
+
+		parentCallbacks._merge(callbacks);
+	}
+
+	private static void _savepointRollbacked() {
+		List<Callbacks> callbacksList = _getWritableCallbacksList();
+
+		if ((callbacksList == null) || (callbacksList.size() < 2)) {
+			return;
+		}
+
+		Callbacks callbacks = callbacksList.remove(callbacksList.size() - 1);
+
+		_invoke(callbacks._rollbackCallables);
+		_invoke(callbacks._completionCallables);
+	}
+
+	private static Callable<?> _wrapCallable(Callable<?> callable) {
+		long companyId = CompanyThreadLocal.getCompanyId();
+
+		return () -> {
+			if (companyId == CompanyThreadLocal.getCompanyId()) {
+				return callable.call();
+			}
+
+			// A callback runs under the company scope it was registered in.
+			// Company scoped entities stamp the live company thread local
+			// into new rows, so a callback running under whatever scope is
+			// current when the transaction completes would mislabel the data
+			// it creates.
+
+			if (PropsValues.DATABASE_PARTITION_ENABLED) {
+
+				// Statement routing reads the live company thread local, so
+				// session state left pending under the current scope must
+				// flush before the switch, and state created under the
+				// captured scope must flush before the restore, or it would
+				// execute against the wrong company's partition
+
+				LastSessionRecorderHelperUtil.syncLastSessionState(false);
+
+				try (SafeCloseable safeCloseable =
+						CompanyThreadLocal.setRawCompanyIdWithSafeCloseable(
+							companyId)) {
+
+					try {
+						return callable.call();
+					}
+					finally {
+						LastSessionRecorderHelperUtil.syncLastSessionState(
+							false);
+					}
+				}
+			}
+
+			// Without partitions every statement runs against the same
+			// schema, so only the company id itself needs to be restored
+
+			try (SafeCloseable safeCloseable =
+					CompanyThreadLocal.setRawCompanyIdWithSafeCloseable(
+						companyId)) {
+
+				return callable.call();
+			}
+		};
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		TransactionCallbackUtil.class);
+
+	private static final ThreadLocal<List<List<Callbacks>>> _callbacksLists =
+		new CentralizedThreadLocal<>(
+			TransactionCallbackUtil.class + "._callbacksLists", ArrayList::new);
+	private static final List<Callbacks> _emptyCallbacksList =
+		Collections.emptyList();
+
+	private static class Callbacks {
+
+		private void _merge(Callbacks callbacks) {
+			_commitCallables.addAll(callbacks._commitCallables);
+			_completionCallables.addAll(callbacks._completionCallables);
+			_rollbackCallables.addAll(callbacks._rollbackCallables);
+		}
+
+		private final List<Callable<?>> _commitCallables = new ArrayList<>();
+		private final List<Callable<?>> _completionCallables =
+			new ArrayList<>();
+		private final List<Callable<?>> _rollbackCallables = new ArrayList<>();
+
+	}
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/transaction/TransactionCommitCallbackUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/transaction/TransactionCommitCallbackUtil.java
@@ -5,108 +5,22 @@
 
 package com.liferay.portal.kernel.transaction;
 
-import com.liferay.petra.lang.CentralizedThreadLocal;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 import java.util.concurrent.Callable;
 
 /**
- * @author Shuyang Zhou
+ * @author     Shuyang Zhou
+ * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+ *             TransactionCallbackUtil}
  */
+@Deprecated
 public class TransactionCommitCallbackUtil {
 
 	public static final TransactionLifecycleListener
-		TRANSACTION_LIFECYCLE_LISTENER = new NewTransactionLifecycleListener() {
-
-			@Override
-			protected void doCommitted(
-				TransactionAttribute transactionAttribute,
-				TransactionStatus transactionStatus) {
-
-				List<Callable<?>> callables = popCallbackList();
-
-				for (Callable<?> callable : callables) {
-					try {
-						callable.call();
-					}
-					catch (Exception exception) {
-						_log.error(
-							"Unable to execute transaction commit callback",
-							exception);
-					}
-				}
-			}
-
-			@Override
-			protected void doCreated(
-				TransactionAttribute transactionAttribute,
-				TransactionStatus transactionStatus) {
-
-				pushCallbackList();
-			}
-
-			@Override
-			protected void doRollbacked(
-				TransactionAttribute transactionAttribute,
-				TransactionStatus transactionStatus, Throwable throwable) {
-
-				popCallbackList();
-			}
-
-		};
+		TRANSACTION_LIFECYCLE_LISTENER =
+			TransactionCallbackUtil.TRANSACTION_LIFECYCLE_LISTENER;
 
 	public static void registerCallback(Callable<?> callable) {
-		List<List<Callable<?>>> callbackListList = _callbackListList.get();
-
-		if (callbackListList.isEmpty()) {
-
-			// Not within a transaction boundary, should only happen during an
-			// upgrade and verify process. See DBUpgrader#_disableTransactions.
-
-			try {
-				callable.call();
-			}
-			catch (Exception exception) {
-				throw new RuntimeException(exception);
-			}
-		}
-		else {
-			int index = callbackListList.size() - 1;
-
-			List<Callable<?>> callableList = callbackListList.get(index);
-
-			if (callableList == Collections.<Callable<?>>emptyList()) {
-				callableList = new ArrayList<>();
-
-				callbackListList.set(index, callableList);
-			}
-
-			callableList.add(callable);
-		}
+		TransactionCallbackUtil.registerCommitCallback(callable);
 	}
-
-	protected static List<Callable<?>> popCallbackList() {
-		List<List<Callable<?>>> callbackListList = _callbackListList.get();
-
-		return callbackListList.remove(callbackListList.size() - 1);
-	}
-
-	protected static void pushCallbackList() {
-		List<List<Callable<?>>> callbackListList = _callbackListList.get();
-
-		callbackListList.add(Collections.<Callable<?>>emptyList());
-	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		TransactionCommitCallbackUtil.class);
-
-	private static final ThreadLocal<List<List<Callable<?>>>>
-		_callbackListList = new CentralizedThreadLocal<>(
-			TransactionCommitCallbackUtil.class + "._callbackListList",
-			ArrayList::new);
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/transaction/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/transaction/packageinfo
@@ -1,1 +1,1 @@
-version 9.0.0
+version 10.0.0

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -483,6 +483,9 @@ public interface PropsKeys {
 	public static final String COMPANY_DEFAULT_WEB_ID =
 		"company.default.web.id";
 
+	public static final String COMPANY_DELETE_IN_PROCESS_MAX_TIME =
+		"company.delete.in.process.max.time";
+
 	public static final String COMPANY_ENCRYPTION_ALGORITHM =
 		"company.encryption.algorithm";
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsValues.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsValues.java
@@ -381,6 +381,10 @@ public class PropsValues {
 	public static String COMPANY_DEFAULT_WEB_ID = PropsUtil.get(
 		PropsKeys.COMPANY_DEFAULT_WEB_ID);
 
+	public static final long COMPANY_DELETE_IN_PROCESS_MAX_TIME =
+		GetterUtil.getLong(
+			PropsUtil.get(PropsKeys.COMPANY_DELETE_IN_PROCESS_MAX_TIME));
+
 	public static final boolean COMPANY_LOGIN_PREPOPULATE_DOMAIN =
 		GetterUtil.getBoolean(
 			PropsUtil.get(PropsKeys.COMPANY_LOGIN_PREPOPULATE_DOMAIN));

--- a/portal-kernel/src/com/liferay/portal/kernel/util/SubscriptionSender.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/SubscriptionSender.java
@@ -50,7 +50,7 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.SubscriptionLocalServiceUtil;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.service.UserNotificationEventLocalServiceUtil;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
 
 import jakarta.mail.internet.InternetAddress;
@@ -233,7 +233,7 @@ public class SubscriptionSender implements Serializable {
 	}
 
 	public void flushNotificationsAsync() {
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				Thread currentThread = Thread.currentThread();
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
@@ -1,1 +1,1 @@
-version 98.2.0
+version 98.3.0

--- a/portal-kernel/src/com/liferay/portal/kernel/workflow/WorkflowHandlerRegistryUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/workflow/WorkflowHandlerRegistryUtil.java
@@ -17,7 +17,7 @@ import com.liferay.portal.kernel.model.WorkflowInstanceLink;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalServiceUtil;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -150,7 +150,7 @@ public class WorkflowHandlerRegistryUtil {
 		if (workflowDefinitionLink != null) {
 			Map<String, Serializable> tempWorkflowContext = workflowContext;
 
-			TransactionCommitCallbackUtil.registerCallback(
+			TransactionCallbackUtil.registerCommitCallback(
 				() -> {
 					if (!_hasWorkflowInstanceInProgress(
 							companyId, groupId, className, classPK)) {

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/transaction/TransactionCallbackUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/transaction/TransactionCallbackUtilTest.java
@@ -1,0 +1,481 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.transaction;
+
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
+import com.liferay.portal.test.log.LoggerTestUtil;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Shuyang Zhou
+ */
+public class TransactionCallbackUtilTest {
+
+	@Test
+	public void testCommitted() {
+		_fireCreated(Propagation.REQUIRED, true);
+
+		TransactionCallbackUtil.registerCommitCallback(
+			() -> _records.add("commit1"));
+		TransactionCallbackUtil.registerCommitCallback(
+			() -> _records.add("commit2"));
+		TransactionCallbackUtil.registerCompletionCallback(
+			() -> _records.add("completion"));
+		TransactionCallbackUtil.registerRollbackCallback(
+			() -> _records.add("rollback"));
+
+		Assert.assertTrue(_records.toString(), _records.isEmpty());
+
+		_fireCommitted(Propagation.REQUIRED, true);
+
+		Assert.assertEquals(
+			Arrays.asList("commit1", "commit2", "completion"), _records);
+	}
+
+	@Test
+	public void testCommittedWhenCallableThrows() {
+		_fireCreated(Propagation.REQUIRED, true);
+
+		Exception exception = new Exception();
+
+		TransactionCallbackUtil.registerCommitCallback(
+			() -> {
+				throw exception;
+			});
+
+		TransactionCallbackUtil.registerCommitCallback(
+			() -> _records.add("commit"));
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				TransactionCallbackUtil.class.getName(),
+				LoggerTestUtil.ERROR)) {
+
+			_fireCommitted(Propagation.REQUIRED, true);
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
+
+			LogEntry logEntry = logEntries.get(0);
+
+			Assert.assertEquals(
+				"Unable to execute transaction callback",
+				logEntry.getMessage());
+			Assert.assertSame(exception, logEntry.getThrowable());
+		}
+
+		Assert.assertEquals(Collections.singletonList("commit"), _records);
+	}
+
+	@Test
+	public void testCommittedWithJoiningTransactionEvents() {
+		_fireCreated(Propagation.REQUIRED, true);
+
+		TransactionCallbackUtil.registerCommitCallback(
+			() -> _records.add("outerCommit"));
+
+		_fireCreated(Propagation.REQUIRED, false);
+
+		TransactionCallbackUtil.registerCommitCallback(
+			() -> _records.add("joinedCommit"));
+
+		_fireCommitted(Propagation.REQUIRED, false);
+		_fireRollbacked(Propagation.REQUIRED, false);
+
+		Assert.assertTrue(_records.toString(), _records.isEmpty());
+
+		_fireCommitted(Propagation.REQUIRED, true);
+
+		Assert.assertEquals(
+			Arrays.asList("outerCommit", "joinedCommit"), _records);
+	}
+
+	@Test
+	public void testNestedNewTransaction() {
+		_fireCreated(Propagation.NESTED, true);
+
+		TransactionCallbackUtil.registerCommitCallback(
+			() -> _records.add("commit"));
+		TransactionCallbackUtil.registerCompletionCallback(
+			() -> _records.add("completion"));
+
+		_fireCommitted(Propagation.NESTED, true);
+
+		Assert.assertEquals(Arrays.asList("commit", "completion"), _records);
+
+		_records.clear();
+
+		_fireCreated(Propagation.NESTED, true);
+
+		TransactionCallbackUtil.registerRollbackCallback(
+			() -> _records.add("rollback"));
+
+		_fireRollbacked(Propagation.NESTED, true);
+
+		Assert.assertEquals(Collections.singletonList("rollback"), _records);
+	}
+
+	@Test
+	public void testRollbacked() {
+		_fireCreated(Propagation.REQUIRED, true);
+
+		TransactionCallbackUtil.registerCommitCallback(
+			() -> _records.add("commit"));
+		TransactionCallbackUtil.registerCompletionCallback(
+			() -> _records.add("completion"));
+		TransactionCallbackUtil.registerRollbackCallback(
+			() -> _records.add("rollback1"));
+		TransactionCallbackUtil.registerRollbackCallback(
+			() -> _records.add("rollback2"));
+
+		Assert.assertTrue(_records.toString(), _records.isEmpty());
+
+		_fireRollbacked(Propagation.REQUIRED, true);
+
+		Assert.assertEquals(
+			Arrays.asList("rollback1", "rollback2", "completion"), _records);
+	}
+
+	@Test
+	public void testRollbackedWhenCallableThrows() {
+		_fireCreated(Propagation.REQUIRED, true);
+
+		Exception exception1 = new Exception();
+		Exception exception2 = new Exception();
+
+		TransactionCallbackUtil.registerRollbackCallback(
+			() -> {
+				throw exception1;
+			});
+		TransactionCallbackUtil.registerRollbackCallback(
+			() -> _records.add("rollback"));
+		TransactionCallbackUtil.registerCompletionCallback(
+			() -> {
+				throw exception2;
+			});
+		TransactionCallbackUtil.registerCompletionCallback(
+			() -> _records.add("completion"));
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				TransactionCallbackUtil.class.getName(),
+				LoggerTestUtil.ERROR)) {
+
+			_fireRollbacked(Propagation.REQUIRED, true);
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertEquals(logEntries.toString(), 2, logEntries.size());
+
+			LogEntry logEntry1 = logEntries.get(0);
+
+			Assert.assertEquals(
+				"Unable to execute transaction callback",
+				logEntry1.getMessage());
+			Assert.assertSame(exception1, logEntry1.getThrowable());
+
+			LogEntry logEntry2 = logEntries.get(1);
+
+			Assert.assertEquals(
+				"Unable to execute transaction callback",
+				logEntry2.getMessage());
+			Assert.assertSame(exception2, logEntry2.getThrowable());
+		}
+
+		Assert.assertEquals(Arrays.asList("rollback", "completion"), _records);
+	}
+
+	@Test
+	public void testRollbackedWithOpenSavepointScopes() {
+		_fireCreated(Propagation.REQUIRED, true);
+
+		TransactionCallbackUtil.registerCompletionCallback(
+			() -> _records.add("outerCompletion"));
+		TransactionCallbackUtil.registerRollbackCallback(
+			() -> _records.add("outerRollback"));
+
+		_fireCreated(Propagation.NESTED, false);
+
+		TransactionCallbackUtil.registerCompletionCallback(
+			() -> _records.add("savepointCompletion"));
+		TransactionCallbackUtil.registerRollbackCallback(
+			() -> _records.add("savepointRollback"));
+
+		_fireRollbacked(Propagation.REQUIRED, true);
+
+		Assert.assertEquals(
+			Arrays.asList(
+				"savepointRollback", "savepointCompletion", "outerRollback",
+				"outerCompletion"),
+			_records);
+	}
+
+	@Test
+	public void testSavepointScopeCommitted() {
+		_fireCreated(Propagation.REQUIRED, true);
+
+		TransactionCallbackUtil.registerCommitCallback(
+			() -> _records.add("outerCommit"));
+		TransactionCallbackUtil.registerCompletionCallback(
+			() -> _records.add("outerCompletion"));
+
+		_fireCreated(Propagation.NESTED, false);
+
+		TransactionCallbackUtil.registerCommitCallback(
+			() -> _records.add("savepointCommit"));
+		TransactionCallbackUtil.registerCompletionCallback(
+			() -> _records.add("savepointCompletion"));
+		TransactionCallbackUtil.registerRollbackCallback(
+			() -> _records.add("savepointRollback"));
+
+		_fireCommitted(Propagation.NESTED, false);
+
+		Assert.assertTrue(_records.toString(), _records.isEmpty());
+
+		_fireCommitted(Propagation.REQUIRED, true);
+
+		Assert.assertEquals(
+			Arrays.asList(
+				"outerCommit", "savepointCommit", "outerCompletion",
+				"savepointCompletion"),
+			_records);
+	}
+
+	@Test
+	public void testSavepointScopeCommittedThenRollbacked() {
+		_fireCreated(Propagation.REQUIRED, true);
+
+		TransactionCallbackUtil.registerCompletionCallback(
+			() -> _records.add("outerCompletion"));
+		TransactionCallbackUtil.registerRollbackCallback(
+			() -> _records.add("outerRollback"));
+
+		_fireCreated(Propagation.NESTED, false);
+
+		TransactionCallbackUtil.registerCommitCallback(
+			() -> _records.add("savepointCommit"));
+		TransactionCallbackUtil.registerCompletionCallback(
+			() -> _records.add("savepointCompletion"));
+		TransactionCallbackUtil.registerRollbackCallback(
+			() -> _records.add("savepointRollback"));
+
+		_fireCommitted(Propagation.NESTED, false);
+
+		Assert.assertTrue(_records.toString(), _records.isEmpty());
+
+		_fireRollbacked(Propagation.REQUIRED, true);
+
+		Assert.assertEquals(
+			Arrays.asList(
+				"outerRollback", "savepointRollback", "outerCompletion",
+				"savepointCompletion"),
+			_records);
+	}
+
+	@Test
+	public void testSavepointScopeRollbacked() {
+		_fireCreated(Propagation.REQUIRED, true);
+
+		TransactionCallbackUtil.registerCommitCallback(
+			() -> _records.add("outerCommit"));
+		TransactionCallbackUtil.registerCompletionCallback(
+			() -> _records.add("outerCompletion"));
+
+		_fireCreated(Propagation.NESTED, false);
+
+		TransactionCallbackUtil.registerCommitCallback(
+			() -> _records.add("savepointCommit"));
+		TransactionCallbackUtil.registerCompletionCallback(
+			() -> _records.add("savepointCompletion"));
+		TransactionCallbackUtil.registerRollbackCallback(
+			() -> _records.add("savepointRollback"));
+
+		_fireRollbacked(Propagation.NESTED, false);
+
+		Assert.assertEquals(
+			Arrays.asList("savepointRollback", "savepointCompletion"),
+			_records);
+
+		_fireCommitted(Propagation.REQUIRED, true);
+
+		Assert.assertEquals(
+			Arrays.asList(
+				"savepointRollback", "savepointCompletion", "outerCommit",
+				"outerCompletion"),
+			_records);
+	}
+
+	@Test
+	public void testSavepointScopesNested() {
+		_fireCreated(Propagation.REQUIRED, true);
+
+		TransactionCallbackUtil.registerCommitCallback(
+			() -> _records.add("outerCommit"));
+
+		_fireCreated(Propagation.NESTED, false);
+
+		TransactionCallbackUtil.registerCompletionCallback(
+			() -> _records.add("savepoint1Completion"));
+		TransactionCallbackUtil.registerRollbackCallback(
+			() -> _records.add("savepoint1Rollback"));
+
+		_fireCreated(Propagation.NESTED, false);
+
+		TransactionCallbackUtil.registerCommitCallback(
+			() -> _records.add("savepoint2Commit"));
+		TransactionCallbackUtil.registerCompletionCallback(
+			() -> _records.add("savepoint2Completion"));
+		TransactionCallbackUtil.registerRollbackCallback(
+			() -> _records.add("savepoint2Rollback"));
+
+		_fireCommitted(Propagation.NESTED, false);
+
+		Assert.assertTrue(_records.toString(), _records.isEmpty());
+
+		_fireRollbacked(Propagation.NESTED, false);
+
+		Assert.assertEquals(
+			Arrays.asList(
+				"savepoint1Rollback", "savepoint2Rollback",
+				"savepoint1Completion", "savepoint2Completion"),
+			_records);
+
+		_fireCommitted(Propagation.REQUIRED, true);
+
+		Assert.assertEquals(
+			Arrays.asList(
+				"savepoint1Rollback", "savepoint2Rollback",
+				"savepoint1Completion", "savepoint2Completion", "outerCommit"),
+			_records);
+	}
+
+	@Test
+	public void testWithoutCallbacks() {
+		_fireCreated(Propagation.REQUIRED, true);
+		_fireCommitted(Propagation.REQUIRED, true);
+
+		_fireCreated(Propagation.REQUIRED, true);
+		_fireRollbacked(Propagation.REQUIRED, true);
+
+		Assert.assertTrue(_records.toString(), _records.isEmpty());
+	}
+
+	@Test
+	public void testWithoutTransaction() {
+		TransactionCallbackUtil.registerCommitCallback(
+			() -> _records.add("commit"));
+
+		Assert.assertEquals(Collections.singletonList("commit"), _records);
+
+		TransactionCallbackUtil.registerCompletionCallback(
+			() -> _records.add("completion"));
+
+		Assert.assertEquals(Arrays.asList("commit", "completion"), _records);
+
+		TransactionCallbackUtil.registerRollbackCallback(
+			() -> _records.add("rollback"));
+
+		Assert.assertEquals(Arrays.asList("commit", "completion"), _records);
+	}
+
+	@Test
+	public void testWithoutTransactionWhenCallableThrows() {
+		Exception exception = new Exception();
+
+		try {
+			TransactionCallbackUtil.registerCommitCallback(
+				() -> {
+					throw exception;
+				});
+
+			Assert.fail();
+		}
+		catch (RuntimeException runtimeException) {
+			Assert.assertSame(exception, runtimeException.getCause());
+		}
+
+		try {
+			TransactionCallbackUtil.registerCompletionCallback(
+				() -> {
+					throw exception;
+				});
+
+			Assert.fail();
+		}
+		catch (RuntimeException runtimeException) {
+			Assert.assertSame(exception, runtimeException.getCause());
+		}
+	}
+
+	private TransactionAttribute _createTransactionAttribute(
+		Propagation propagation) {
+
+		TransactionAttribute.Builder builder =
+			new TransactionAttribute.Builder();
+
+		builder.setPropagation(propagation);
+
+		return builder.build();
+	}
+
+	private TransactionStatus _createTransactionStatus(boolean newTransaction) {
+		return new TransactionStatus() {
+
+			@Override
+			public boolean isCompleted() {
+				return false;
+			}
+
+			@Override
+			public boolean isNewTransaction() {
+				return newTransaction;
+			}
+
+			@Override
+			public boolean isRollbackOnly() {
+				return false;
+			}
+
+			@Override
+			public void suppressLifecycleListenerThrowable(
+				Throwable throwable) {
+			}
+
+		};
+	}
+
+	private void _fireCommitted(
+		Propagation propagation, boolean newTransaction) {
+
+		TransactionCallbackUtil.TRANSACTION_LIFECYCLE_LISTENER.committed(
+			_createTransactionAttribute(propagation),
+			_createTransactionStatus(newTransaction));
+	}
+
+	private void _fireCreated(Propagation propagation, boolean newTransaction) {
+		TransactionCallbackUtil.TRANSACTION_LIFECYCLE_LISTENER.created(
+			_createTransactionAttribute(propagation),
+			_createTransactionStatus(newTransaction));
+	}
+
+	private void _fireRollbacked(
+		Propagation propagation, boolean newTransaction) {
+
+		TransactionCallbackUtil.TRANSACTION_LIFECYCLE_LISTENER.rollbacked(
+			_createTransactionAttribute(propagation),
+			_createTransactionStatus(newTransaction), null);
+	}
+
+	private final List<String> _records = new ArrayList<>();
+
+}


### PR DESCRIPTION
Cleanup of `CompanyLocalServiceImpl` transaction-callback and company-iteration handling for LPD-88080, hardened against the database-partition and Hypersonic edge cases surfaced along the way.

## What

- Introduces `TransactionCallbackUtil` — a savepoint-aware replacement for `TransactionCommitCallbackUtil` that fires commit/rollback/completion callbacks correctly across `NESTED` savepoints and re-applies each callback's registration-time company scope so deferred, company-scoped work runs under the right instance. `TransactionCommitCallbackUtil` is kept as a deprecated delegating shim.
- Holds the per-company deletion-process flag (cluster-replicated, TTL'd, origin-node-liveness-aware) until cleanup completes, and guards `forEachCompanyId` so it skips companies that are gone or mid-deletion.
- Search index initializers (ES8/OS2) iterate their registered company IDs directly instead of through `forEachCompanyId`, so leftover-index cleanup still covers gone companies.
- `PortalInstancePool` reads on the current transaction's connection when one is bound, so a cache-off read issued mid-transaction cannot self-deadlock on databases without snapshot reads (Hypersonic).
- `GroupLocalServiceImpl.fetchUserPersonalSiteGroup` honors its fetch contract — returns null when the guest user is missing rather than throwing.

## pr-check

Ran locally against `brianchandotcom/master`. Integration/Playwright/Poshi are out of scope for pr-check.

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Service Builder / REST Builder | PASS (no descriptor changes) |
| Baseline (semver) | PASS (`security/auth` 10.1.0, `transaction` 10.0.0 breaking, `util` 98.3.0) |
| Full Portal Build (`ant all`) | PASS |
| Java Unit Tests | PASS (TransactionCallbackUtilTest 14/14, PortalInstancesTest 8/8) |
