### PR TITLE
LPD-97628 Prevent a NullPointerException when there is no HTTP request

### DIFF
--- a/modules/apps/commerce/commerce-order-content-web/build.gradle
+++ b/modules/apps/commerce/commerce-order-content-web/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
 	compileOnly group: "com.liferay", name: "biz.aQute.bnd.annotation", version: "4.2.0.LIFERAY-PATCHED-2"
 	compileOnly group: "com.liferay.jakarta.portlet", name: "com.liferay.jakarta.portlet-api", version: "4.0.0"
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "default"
 	compileOnly group: "jakarta.servlet", name: "jakarta.servlet-api", version: "6.0.0"

--- a/modules/apps/commerce/commerce-order-content-web/src/main/java/com/liferay/commerce/order/content/web/internal/template/CommerceOrderHttpHelperTemplateContextContributor.java
+++ b/modules/apps/commerce/commerce-order-content-web/src/main/java/com/liferay/commerce/order/content/web/internal/template/CommerceOrderHttpHelperTemplateContextContributor.java
@@ -7,6 +7,7 @@ package com.liferay.commerce.order.content.web.internal.template;
 
 import com.liferay.commerce.order.CommerceOrderHttpHelper;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.template.TemplateContextContributor;
 import com.liferay.portal.kernel.util.Portal;
 
@@ -36,7 +37,15 @@ public class CommerceOrderHttpHelperTemplateContextContributor
 		contextObjects.put(
 			"commerceReturnsEnabled",
 			FeatureFlagManagerUtil.isEnabled(
-				_portal.getCompanyId(httpServletRequest), "LPD-10562"));
+				_getCompanyId(httpServletRequest), "LPD-10562"));
+	}
+
+	private long _getCompanyId(HttpServletRequest httpServletRequest) {
+		if (httpServletRequest == null) {
+			return CompanyThreadLocal.getCompanyId();
+		}
+
+		return _portal.getCompanyId(httpServletRequest);
 	}
 
 	@Reference

--- a/modules/apps/commerce/commerce-order-content-web/src/test/java/com/liferay/commerce/order/content/web/internal/template/CommerceOrderHttpHelperTemplateContextContributorTest.java
+++ b/modules/apps/commerce/commerce-order-content-web/src/test/java/com/liferay/commerce/order/content/web/internal/template/CommerceOrderHttpHelperTemplateContextContributorTest.java
@@ -1,0 +1,133 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.commerce.order.content.web.internal.template;
+
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.json.JSONFactoryImpl;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Shuyang Zhou
+ */
+public class CommerceOrderHttpHelperTemplateContextContributorTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@BeforeClass
+	public static void setUpClass() {
+
+		// FeatureFlagManagerUtil serializes the feature flags to JSON when
+		// first loaded, so wire the JSON factory before it is touched.
+
+		JSONFactoryUtil jsonFactoryUtil = new JSONFactoryUtil();
+
+		jsonFactoryUtil.setJSONFactory(new JSONFactoryImpl());
+	}
+
+	@Before
+	public void setUp() {
+		MockitoAnnotations.initMocks(this);
+	}
+
+	@Test
+	public void testPrepareWithHttpServletRequest() {
+		Mockito.when(
+			_portal.getCompanyId(_mockHttpServletRequest)
+		).thenReturn(
+			_COMPANY_ID
+		);
+
+		Map<String, Object> contextObjects = new HashMap<>();
+
+		_commerceOrderHttpHelperTemplateContextContributor.prepare(
+			contextObjects, _mockHttpServletRequest);
+
+		Assert.assertTrue(
+			contextObjects.toString(),
+			contextObjects.containsKey("commerceReturnsEnabled"));
+
+		Mockito.verify(
+			_portal
+		).getCompanyId(
+			_mockHttpServletRequest
+		);
+	}
+
+	@Test
+	public void testPrepareWithoutHttpServletRequest() {
+
+		// A notification such as an object action email prepares the template
+		// outside of an HTTP request, so EmailNotificationType passes a null
+		// request. Portal.getCompanyId(null) throws a NullPointerException
+		// because it dereferences the request, so the company must be resolved
+		// from CompanyThreadLocal instead.
+
+		Mockito.lenient(
+		).when(
+			_portal.getCompanyId((HttpServletRequest)null)
+		).thenThrow(
+			new NullPointerException()
+		);
+
+		Map<String, Object> contextObjects = new HashMap<>();
+
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(_COMPANY_ID)) {
+
+			_commerceOrderHttpHelperTemplateContextContributor.prepare(
+				contextObjects, null);
+		}
+
+		Assert.assertTrue(
+			contextObjects.toString(),
+			contextObjects.containsKey("commerceReturnsEnabled"));
+
+		Mockito.verify(
+			_portal, Mockito.never()
+		).getCompanyId(
+			(HttpServletRequest)null
+		);
+	}
+
+	private static final long _COMPANY_ID = RandomTestUtil.randomLong();
+
+	@InjectMocks
+	private CommerceOrderHttpHelperTemplateContextContributor
+		_commerceOrderHttpHelperTemplateContextContributor;
+
+	private final MockHttpServletRequest _mockHttpServletRequest =
+		new MockHttpServletRequest();
+
+	@Mock
+	private Portal _portal;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97628

## What Is Being Fixed

CommerceOrderHttpHelperTemplateContextContributor resolves the commerceReturnsEnabled feature flag by reading the company ID from the HTTP request via _portal.getCompanyId(httpServletRequest). When a template is prepared without an HTTP request — for example an object action email notification sent from a transaction commit callback — EmailNotificationType passes a null request to every TemplateContextContributor, and PortalInstances.getCompanyId dereferences it, throwing a NullPointerException that aborts the notification.

## How It Is Being Fixed

The contributor now resolves the company ID from CompanyThreadLocal when there is no HTTP request, and keeps the existing request-based lookup when a request is present. The null request has been passed to every TemplateContextContributor since commit 5cfc07ea0a348b (2024); the company ID read that turned it into a NullPointerException was added by commit 7647f2deb99b08553ac91ae7b31d0caee06be98c (LPD-93811). A unit test covers both the request and no-request paths and fails on the unfixed code with the NullPointerException at the feature flag line.

## PR Check

**pr-check: PASS** — tested on `c385d7e7d938426c6f3b7a85ace9aab46a596c26`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "c385d7e7d938426c6f3b7a85ace9aab46a596c26"} -->
