### PR TITLE
LPD-97628 Prevent a NullPointerException when there is no HTTP request

### DIFF
--- a/modules/apps/commerce/commerce-order-content-web/src/main/java/com/liferay/commerce/order/content/web/internal/template/CommerceOrderHttpHelperTemplateContextContributor.java
+++ b/modules/apps/commerce/commerce-order-content-web/src/main/java/com/liferay/commerce/order/content/web/internal/template/CommerceOrderHttpHelperTemplateContextContributor.java
@@ -7,6 +7,7 @@ package com.liferay.commerce.order.content.web.internal.template;
 
 import com.liferay.commerce.order.CommerceOrderHttpHelper;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.template.TemplateContextContributor;
 import com.liferay.portal.kernel.util.Portal;
 
@@ -36,7 +37,15 @@ public class CommerceOrderHttpHelperTemplateContextContributor
 		contextObjects.put(
 			"commerceReturnsEnabled",
 			FeatureFlagManagerUtil.isEnabled(
-				_portal.getCompanyId(httpServletRequest), "LPD-10562"));
+				_getCompanyId(httpServletRequest), "LPD-10562"));
+	}
+
+	private long _getCompanyId(HttpServletRequest httpServletRequest) {
+		if (httpServletRequest == null) {
+			return CompanyThreadLocal.getCompanyId();
+		}
+
+		return _portal.getCompanyId(httpServletRequest);
 	}
 
 	@Reference


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97628

## What Is Being Fixed

CommerceOrderHttpHelperTemplateContextContributor resolves the commerceReturnsEnabled feature flag by reading the company ID from the HTTP request via _portal.getCompanyId(httpServletRequest). When a template is prepared without an HTTP request — for example an object action email notification sent from a transaction commit callback — EmailNotificationType passes a null request to every TemplateContextContributor, and PortalInstances.getCompanyId dereferences it, throwing a NullPointerException that aborts the notification.

## How It Is Being Fixed

The contributor now resolves the company ID from CompanyThreadLocal when there is no HTTP request, and keeps the existing request-based lookup when a request is present. The null request has been passed to every TemplateContextContributor since commit 5cfc07ea0a348b (2024); the company ID read that turned it into a NullPointerException was added by commit 7647f2deb99b08553ac91ae7b31d0caee06be98c (LPD-93811).

## Why Are There No Tests?

The behavior is already covered by the existing integration test com.liferay.headless.cmp.resource.v1_0.test.TaskStatisticsResourceTest, whose setUp performs a partial object entry update that fires an object action email notification (EmailNotificationType.sendNotification -> _formatBody, the prepare(template, null) call). That is where this NullPointerException surfaced on CI.

## PR Check

**pr-check: SKIPPED** — Author requested send without re-running pr-check; the identical fix content passed a full pr-check on prior head c385d7e (Source Format, Per-Module Compile, Integration Test Compile, Structural Smoke, Java Unit Tests all PASS), and this commit only removes that unit test and its build.gradle test dependency.

<!-- pr-check {"reason": "Author requested send without re-running pr-check; identical fix content passed full pr-check on prior head c385d7e; this commit only removes the unit test and its build.gradle dependency.", "result": "skipped", "sha": "6a86d2d715633e44a05a43f93bef258e65022b65"} -->
