### PR TITLE
LPD-35156 Add upgrade check for BaseJSPDynamicInclude servlet context

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -3719,6 +3719,20 @@
 	},
 	{
 		"classNames": [
+			"BaseJSPDynamicInclude"
+		],
+		"classStructurePattern": true,
+		"issueKey": "LPD-35156",
+		"newImports": [
+			"jakarta.servlet.ServletContext"
+		],
+		"newMethods": [
+			"@Override\n\tprotected ServletContext getServletContext() {\n\t\treturn _servletContext;\n\t}"
+		],
+		"newReference": "ServletContext _servletContext"
+	},
+	{
+		"classNames": [
 			"ListTypeLocalService"
 		],
 		"from": "addListType(String paramName, String paramName)",

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_35156.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_35156.testjava
@@ -1,0 +1,25 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+import jakarta.servlet.ServletContext;
+
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class LPD_35156 extends BaseJSPDynamicInclude {
+
+	@Override
+	protected ServletContext getServletContext() {
+		return _servletContext;
+	}
+
+	@Reference
+	private ServletContext _servletContext;
+
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_35156.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_35156.testjava
@@ -1,0 +1,12 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class LPD_35156 extends BaseJSPDynamicInclude {
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-35156

## What Is Being Fixed

`BaseJSPDynamicInclude` now expects its subclasses to expose a
`getServletContext()` method backed by a `_servletContext` reference field.
Subclasses that predate this requirement lack both, and there was no automated
upgrade to bring them into line.

## How It Is Being Fixed

Adds an upgrade catch-all check entry to the source formatter's
`replacements.json`. For any class matching `BaseJSPDynamicInclude`, the check
injects the `jakarta.servlet.ServletContext` import, an `@Override`
`getServletContext()` method returning `_servletContext`, and a
`ServletContext _servletContext` reference field. Two test fixtures — a bare
subclass input and the transformed expected output — cover the rule.

## PR Check

**pr-check: PASS** — tested on `d29fd7faccf570495ba290ceb5709e05ea3a745c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "d29fd7faccf570495ba290ceb5709e05ea3a745c"} -->
