### PR TITLE
LPD-88080 Skip the CORS company loop when no instance mapper exists

### DIFF
--- a/modules/apps/portal-remote/portal-remote-cors-impl/src/main/java/com/liferay/portal/remote/cors/internal/configuration/admin/service/PortalCORSManagedServiceFactory.java
+++ b/modules/apps/portal-remote/portal-remote-cors-impl/src/main/java/com/liferay/portal/remote/cors/internal/configuration/admin/service/PortalCORSManagedServiceFactory.java
@@ -18,7 +18,9 @@ import com.liferay.portal.remote.cors.internal.util.PortalCORSRegistryUtil;
 
 import java.util.Dictionary;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Set;
 
 import org.osgi.framework.Constants;
 import org.osgi.service.cm.ConfigurationException;
@@ -144,14 +146,17 @@ public class PortalCORSManagedServiceFactory implements ManagedServiceFactory {
 				URLPatternMapperFactory.create(corsSupports));
 		}
 
+		Set<Long> companyIds = new LinkedHashSet<>(
+			PortalCORSRegistryUtil.getKeySetUrlPatternMappers());
+
+		companyIds.remove(CompanyConstants.SYSTEM);
+
+		if (companyIds.isEmpty()) {
+			return;
+		}
+
 		_companyLocalService.forEachCompanyId(
-			companyId -> {
-				if (companyId != CompanyConstants.SYSTEM) {
-					_rebuild(companyId);
-				}
-			},
-			ArrayUtil.toLongArray(
-				PortalCORSRegistryUtil.getKeySetUrlPatternMappers()));
+			this::_rebuild, ArrayUtil.toLongArray(companyIds));
 	}
 
 	private void _rebuild(long companyId) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88080

## What Is Being Fixed

Follow-up to LPD-88080. PortalCORSManagedServiceFactory._rebuild() calls forEachCompanyId over the registered instance URLPatternMapper keys. Configuration Admin's update thread pulls configuration early during startup, before PortalInstancePool is cached, so forEachCompanyId reads the company IDs directly from the database — two extra queries — even when there is no company-scoped mapper to rebuild.

## How It Is Being Fixed

Copy the mapper key set, drop CompanyConstants.SYSTEM (already rebuilt just above), and return early when no company-scoped mapper remains, skipping the forEachCompanyId call and its startup database reads. Behavior is unchanged for every non-empty case; the consumer simplifies to a this::_rebuild method reference.

## Why Are There No Tests?

Behavior-preserving startup performance optimization (it only avoids two database queries when the company-scoped CORS mapper set is empty). There is no new observable behavior to assert, and the forEachCompanyId semantics it relies on are covered by LPD-88080.

## PR Check

**pr-check: PASS** — tested on `7e900498c4ca382d1382e5a033dc36fc2b4190da`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "7e900498c4ca382d1382e5a033dc36fc2b4190da"} -->
