### PR TITLE
LPD-97691 Prevent a subprocess hang when it floods stderr

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -6233,6 +6233,12 @@ public class JenkinsResultsParserUtil {
 
 					processBuilder.directory(baseDir);
 
+					// Merge the error stream into the output stream so the
+					// single reader below drains both. An unread error stream
+					// blocks the process once its buffer fills.
+
+					processBuilder.redirectErrorStream(true);
+
 					Process process = processBuilder.start();
 
 					try (CountingInputStream countingInputStream =

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -82,6 +82,7 @@ import java.util.Properties;
 import java.util.Random;
 import java.util.Set;
 import java.util.Stack;
+import java.util.StringTokenizer;
 import java.util.TimeZone;
 import java.util.TreeSet;
 import java.util.concurrent.Callable;
@@ -6205,24 +6206,34 @@ public class JenkinsResultsParserUtil {
 
 					sb.append(command);
 
-					Runtime runtime = Runtime.getRuntime();
+					String bashCommand = sb.toString();
 
-					String[] environmentParameters =
-						new String[environments.size()];
-
-					int i = 0;
-
-					for (Map.Entry<String, String> environment :
-							environments.entrySet()) {
-
-						environmentParameters[i] = combine(
-							environment.getKey(), "=", environment.getValue());
-
-						i++;
+					if (bashCommand.isEmpty()) {
+						throw new IllegalArgumentException("Empty command");
 					}
 
-					Process process = runtime.exec(
-						sb.toString(), environmentParameters, baseDir);
+					StringTokenizer stringTokenizer = new StringTokenizer(
+						bashCommand);
+
+					String[] commands =
+						new String[stringTokenizer.countTokens()];
+
+					for (int i = 0; stringTokenizer.hasMoreTokens(); i++) {
+						commands[i] = stringTokenizer.nextToken();
+					}
+
+					ProcessBuilder processBuilder = new ProcessBuilder(
+						commands);
+
+					Map<String, String> processEnvironment =
+						processBuilder.environment();
+
+					processEnvironment.clear();
+					processEnvironment.putAll(environments);
+
+					processBuilder.directory(baseDir);
+
+					Process process = processBuilder.start();
 
 					try (CountingInputStream countingInputStream =
 							new CountingInputStream(process.getInputStream());


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97691

## What Is Being Fixed

JenkinsResultsParserUtil._executeCommandService launches subprocesses (for example the CI app server) with Runtime.exec and reads only the process output stream, never the error stream, and Runtime.exec does not merge the two. A subprocess that writes more than the OS pipe buffer (~64KB) to stderr blocks forever on the write because nothing ever drains it, which stalls the output-stream reader and hangs the run indefinitely with nothing echoed to the console. This surfaced as ClusterGeneralTest.testShutdownAndStartupNodes intermittently timing out after two hours on CI; thread dumps (attached to LPD-97691) show the controller blocked writing relayed subprocess output to its own stderr, and the JVM deadlock detector reports nothing because every hop is a thread blocked in a native write() waiting on a peer process.

## How It Is Being Fixed

The first commit inlines the internals of Runtime.exec(String, String[], File) and the Runtime.exec(String[], String[], File) it delegates to as an equivalent ProcessBuilder, with no functional change. The second commit adds redirectErrorStream(true), which folds the error stream into the output stream that the existing reader already drains, so the subprocess can no longer block on stderr and its error output finally reaches the console. The only behavioral change is redirectErrorStream(true).

## Why Are There No Tests?

The fix is a single behavioral flag on a subprocess launch. Reproducing the failure in a unit test would require spawning a real subprocess that floods stderr and relying on OS pipe-buffer backpressure to deadlock, which is impractical and inherently flaky. The surrounding method is exercised by the existing JenkinsResultsParserUtilTest, which passes, and the regression is verified on CI: a loaded relevant run that previously hung now completes and surfaces the subprocess error output in the Jenkins console.

## PR Check

**pr-check: PASS** — tested on `05acf59d5f7bc1480964ea0c7667170ad3b96d23`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "05acf59d5f7bc1480964ea0c7667170ad3b96d23"} -->
