### PR TITLE
LPD-97692 Launch cluster test nodes with the harness JDK

### DIFF
--- a/portal-test/src/com/liferay/portal/test/cluster/tomcat/TomcatNode.java
+++ b/portal-test/src/com/liferay/portal/test/cluster/tomcat/TomcatNode.java
@@ -198,6 +198,8 @@ public class TomcatNode {
 
 		builder.setBootstrapClassPath(_buildBoostrapClassPath());
 		builder.setEnvironment(System.getenv());
+		builder.setJavaExecutable(
+			System.getProperty("java.home") + "/bin/java");
 		builder.setReactClassLoader(PortalClassLoaderUtil.getClassLoader());
 		builder.setRuntimeClassPath(runtimeClassPath);
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97692

## What Is Being Fixed

TomcatNode.start launches each forked cluster node subprocess via ProcessConfig, which defaults its java executable to the bare command "java", and TomcatNode never overrode it. Each node therefore ran whichever java came first on the controller's PATH rather than the JDK the test harness itself runs on. On CI this silently launched the cluster test nodes on a different JDK than the harness (observed while investigating LPD-97691: node thread dumps reported java.base@17.0.19 while the controller reported java.base@21.0.11).

## How It Is Being Fixed

Set the process java executable to ${java.home}/bin/java in TomcatNode.start so each forked node inherits the same JDK as the harness that launches it.

## Why Are There No Tests?

The change is a single subprocess launch-configuration line. Verifying it would require inspecting the JDK of a forked node process, which is environment-dependent and not a meaningful unit test. Compilation is covered by the portal-test build, and the effect (nodes running the harness JDK) is observable on CI.

## PR Check

**pr-check: PASS** — tested on `9cbeddafe9170c273cedc262b8dd2c871aeaab0a`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build (portal-test compile) | PASS |

<!-- pr-check {"result": "success", "sha": "9cbeddafe9170c273cedc262b8dd2c871aeaab0a"} -->
