### PR TITLE
LPD-94024 Add the Generate Content agent for the AI Assistant

### DIFF
--- a/modules/apps/ai-hub-cell/ai-hub-cell-impl/src/main/java/com/liferay/ai/hub/cell/internal/configuration/persistence/listener/AIHubCellConfigurationModelListener.java
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-impl/src/main/java/com/liferay/ai/hub/cell/internal/configuration/persistence/listener/AIHubCellConfigurationModelListener.java
@@ -87,7 +87,9 @@ public class AIHubCellConfigurationModelListener
 				OAuth2SecureRandomGenerator.generateClientSecret(), null, null,
 				company.getPortalURL(0), 0, null, "AI Hub Cell", null,
 				Arrays.asList(), false,
-				Arrays.asList("Liferay.Portal.Search.REST.everything.read"),
+				Arrays.asList(
+					"Liferay.Headless.Batch.Engine.everything",
+					"Liferay.Portal.Search.REST.everything.read"),
 				false, new ServiceContext());
 		}
 		catch (PortalException portalException) {

--- a/modules/apps/portal-workflow/portal-workflow-api/src/main/java/com/liferay/portal/workflow/constants/WorkflowDefinitionConstants.java
+++ b/modules/apps/portal-workflow/portal-workflow-api/src/main/java/com/liferay/portal/workflow/constants/WorkflowDefinitionConstants.java
@@ -17,6 +17,9 @@ public class WorkflowDefinitionConstants {
 		EXTERNAL_REFERENCE_CODE_FIX_SPELLING_AND_GRAMMAR =
 			"L_FIX_SPELLING_AND_GRAMMAR";
 
+	public static final String EXTERNAL_REFERENCE_CODE_GENERATE_CONTENT =
+		"L_GENERATE_CONTENT";
+
 	public static final String EXTERNAL_REFERENCE_CODE_GENERATE_IMAGE =
 		"L_GENERATE_IMAGE";
 
@@ -48,6 +51,8 @@ public class WorkflowDefinitionConstants {
 	public static final String NAME_FIX_SPELLING_AND_GRAMMAR =
 		"Fix Spelling and Grammar";
 
+	public static final String NAME_GENERATE_CONTENT = "Generate Content";
+
 	public static final String NAME_GENERATE_IMAGE = "Generate Image";
 
 	public static final String NAME_IMPROVE_WRITING = "Improve Writing";
@@ -73,7 +78,8 @@ public class WorkflowDefinitionConstants {
 	public static final String SCOPE_ALL = "all";
 
 	public static final String[] SYSTEM_WORKFLOW_DEFINITION_NAMES = {
-		NAME_CHANGE_TONE, NAME_FIX_SPELLING_AND_GRAMMAR, NAME_GENERATE_IMAGE,
+		NAME_CHANGE_TONE, NAME_FIX_SPELLING_AND_GRAMMAR, NAME_GENERATE_CONTENT,
+		NAME_GENERATE_IMAGE, NAME_CHANGE_TONE, NAME_FIX_SPELLING_AND_GRAMMAR,
 		NAME_IMPROVE_WRITING, NAME_LIFERAY_SEARCH, NAME_MAKE_LONGER,
 		NAME_MAKE_SHORTER, NAME_PAGE_BUILDER, NAME_SEO_STUDIO_TITLE_GENERATOR
 	};

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/struts/EditContentItemStrutsAction.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/struts/EditContentItemStrutsAction.java
@@ -11,14 +11,17 @@ import com.liferay.fragment.service.FragmentEntryLinkService;
 import com.liferay.info.item.InfoItemServiceRegistry;
 import com.liferay.info.search.InfoSearchClassMapperRegistry;
 import com.liferay.layout.manager.FormManager;
+import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryService;
 import com.liferay.portal.kernel.struts.StrutsAction;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.site.cms.site.initializer.internal.util.ActionUtil;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -43,8 +46,7 @@ public class EditContentItemStrutsAction implements StrutsAction {
 			HttpServletResponse httpServletResponse)
 		throws Exception {
 
-		ObjectEntry objectEntry = _objectEntryService.getObjectEntry(
-			ParamUtil.getLong(httpServletRequest, "objectEntryId"));
+		ObjectEntry objectEntry = _getObjectEntry(httpServletRequest);
 
 		String editURL = ActionUtil.getEditURL(
 			_formManager, _fragmentEntryLinkListenerRegistry,
@@ -79,6 +81,32 @@ public class EditContentItemStrutsAction implements StrutsAction {
 		httpServletResponse.sendRedirect(editURL);
 
 		return null;
+	}
+
+	private ObjectEntry _getObjectEntry(HttpServletRequest httpServletRequest)
+		throws Exception {
+
+		long objectEntryId = ParamUtil.getLong(
+			httpServletRequest, "objectEntryId");
+
+		if (objectEntryId > 0) {
+			return _objectEntryService.getObjectEntry(objectEntryId);
+		}
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.getObjectDefinition(
+				themeDisplay.getCompanyId(),
+				ParamUtil.getString(
+					httpServletRequest, "objectDefinitionName"));
+
+		return _objectEntryService.getObjectEntry(
+			ParamUtil.getString(httpServletRequest, "externalReferenceCode"),
+			ParamUtil.getLong(httpServletRequest, "groupId"),
+			objectDefinition.getObjectDefinitionId());
 	}
 
 	@Reference

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/langchain4j/agentic/internal/InternalAgentImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/langchain4j/agentic/internal/InternalAgentImpl.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.ProxyUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.kernel.workflow.WorkflowDefinition;
 import com.liferay.portal.kernel.workflow.WorkflowInstance;
@@ -142,6 +143,20 @@ public class InternalAgentImpl implements InternalAgent, InvocationHandler {
 
 				workflowContext.put(
 					name, MapUtil.getString(inputObjects, name));
+			}
+
+			Map<String, ?> input = _agentContext.getInput();
+
+			if (input != null) {
+				for (String key : input.keySet()) {
+					if (StringUtil.equals(key, "message") ||
+						workflowContext.containsKey(key)) {
+
+						continue;
+					}
+
+					workflowContext.put(key, MapUtil.getString(input, key));
+				}
 			}
 
 			Message message = new Message();

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/HTTPRequestNodeExecutor.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/HTTPRequestNodeExecutor.java
@@ -6,6 +6,7 @@
 package com.liferay.ai.hub.internal.workflow.kaleo.runtime.node;
 
 import com.liferay.ai.hub.internal.workflow.kaleo.runtime.node.util.KaleoNodeSettingUtil;
+import com.liferay.ai.hub.internal.workflow.kaleo.runtime.node.util.OAuth2ApplicationHomePageURLResolverUtil;
 import com.liferay.ai.hub.internal.workflow.kaleo.runtime.node.util.VariablesUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.encryptor.EncryptorUtil;
@@ -16,6 +17,7 @@ import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.workflow.kaleo.definition.NodeType;
 import com.liferay.portal.workflow.kaleo.model.KaleoInstanceToken;
@@ -65,6 +67,11 @@ public class HTTPRequestNodeExecutor extends BaseNodeExecutor {
 
 		Map<String, Serializable> workflowContext =
 			executionContext.getWorkflowContext();
+
+		workflowContext.put(
+			"aiHubCellLiferayDXPURL",
+			OAuth2ApplicationHomePageURLResolverUtil.resolve(
+				MapUtil.getLong(workflowContext, "oAuth2ApplicationId")));
 
 		try {
 			KaleoInstanceToken kaleoInstanceToken =

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/ServiceNodeExecutor.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/ServiceNodeExecutor.java
@@ -6,10 +6,9 @@
 package com.liferay.ai.hub.internal.workflow.kaleo.runtime.node;
 
 import com.liferay.ai.hub.internal.workflow.kaleo.runtime.node.util.KaleoNodeSettingUtil;
+import com.liferay.ai.hub.internal.workflow.kaleo.runtime.node.util.OAuth2ApplicationHomePageURLResolverUtil;
 import com.liferay.ai.hub.internal.workflow.kaleo.runtime.node.util.VariablesUtil;
 import com.liferay.ai.hub.workflow.node.ServiceNodeDelegate;
-import com.liferay.oauth2.provider.model.OAuth2Application;
-import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
 import com.liferay.petra.string.StringBundler;
@@ -18,9 +17,7 @@ import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.InetAddressUtil;
-import com.liferay.portal.kernel.util.PortalRunMode;
+import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.workflow.kaleo.definition.NodeType;
 import com.liferay.portal.workflow.kaleo.model.KaleoInstanceToken;
@@ -33,10 +30,6 @@ import com.liferay.portal.workflow.kaleo.runtime.node.NodeExecutor;
 
 import java.io.Serializable;
 
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.net.UnknownHostException;
-
 import java.util.List;
 import java.util.Map;
 
@@ -44,7 +37,6 @@ import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
-import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Iliyan Peychev
@@ -110,7 +102,8 @@ public class ServiceNodeExecutor extends BaseNodeExecutor {
 
 		workflowContext.put(
 			"aiHubCellLiferayDXPURL",
-			_getAIHubCellLiferayDXPURL(workflowContext));
+			OAuth2ApplicationHomePageURLResolverUtil.resolve(
+				MapUtil.getLong(workflowContext, "oAuth2ApplicationId")));
 
 		KaleoInstanceToken kaleoInstanceToken =
 			executionContext.getKaleoInstanceToken();
@@ -169,42 +162,8 @@ public class ServiceNodeExecutor extends BaseNodeExecutor {
 					executionContext.getServiceContext())));
 	}
 
-	private String _getAIHubCellLiferayDXPURL(
-			Map<String, Serializable> workflowContext)
-		throws PortalException {
-
-		OAuth2Application oAuth2Application =
-			_oAuth2ApplicationLocalService.getOAuth2Application(
-				GetterUtil.getLong(workflowContext.get("oAuth2ApplicationId")));
-
-		String homePageURL = oAuth2Application.getHomePageURL();
-
-		try {
-			URL url = new URL(homePageURL);
-
-			if (!PortalRunMode.isTestMode() &&
-				InetAddressUtil.isLocalInetAddress(
-					InetAddressUtil.getInetAddressByName(url.getHost()))) {
-
-				throw new PortalException(
-					"The AI Hub Cell Liferay DXP URL must not be local: " +
-						homePageURL);
-			}
-		}
-		catch (MalformedURLException | UnknownHostException exception) {
-			throw new PortalException(
-				"The AI Hub Cell Liferay DXP URL is invalid: " + homePageURL,
-				exception);
-		}
-
-		return homePageURL;
-	}
-
 	private static final Log _log = LogFactoryUtil.getLog(
 		ServiceNodeExecutor.class);
-
-	@Reference
-	private OAuth2ApplicationLocalService _oAuth2ApplicationLocalService;
 
 	private ServiceTrackerMap<String, ServiceNodeDelegate> _serviceTrackerMap;
 

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/ServiceNodeExecutor.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/ServiceNodeExecutor.java
@@ -135,13 +135,6 @@ public class ServiceNodeExecutor extends BaseNodeExecutor {
 
 			throw new PortalException(exception);
 		}
-	}
-
-	@Override
-	protected void doExit(
-			KaleoNode currentKaleoNode, ExecutionContext executionContext,
-			List<PathElement> remainingPathElements)
-		throws PortalException {
 
 		KaleoTransition kaleoTransition = null;
 
@@ -160,6 +153,12 @@ public class ServiceNodeExecutor extends BaseNodeExecutor {
 					executionContext.getKaleoInstanceToken(),
 					executionContext.getWorkflowContext(),
 					executionContext.getServiceContext())));
+	}
+
+	@Override
+	protected void doExit(
+		KaleoNode currentKaleoNode, ExecutionContext executionContext,
+		List<PathElement> remainingPathElements) {
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/util/OAuth2ApplicationHomePageURLResolverUtil.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/util/OAuth2ApplicationHomePageURLResolverUtil.java
@@ -1,0 +1,54 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.internal.workflow.kaleo.runtime.node.util;
+
+import com.liferay.oauth2.provider.model.OAuth2Application;
+import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalServiceUtil;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.util.InetAddressUtil;
+import com.liferay.portal.kernel.util.PortalRunMode;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.UnknownHostException;
+
+/**
+ * @author Pedro Leite
+ */
+public class OAuth2ApplicationHomePageURLResolverUtil {
+
+	public static String resolve(long oAuth2ApplicationId)
+		throws PortalException {
+
+		OAuth2Application oAuth2Application =
+			OAuth2ApplicationLocalServiceUtil.getOAuth2Application(
+				oAuth2ApplicationId);
+
+		String homePageURL = oAuth2Application.getHomePageURL();
+
+		try {
+			URL url = new URL(homePageURL);
+
+			if (!PortalRunMode.isTestMode() &&
+				InetAddressUtil.isLocalInetAddress(
+					InetAddressUtil.getInetAddressByName(url.getHost()))) {
+
+				throw new PortalException(
+					"The OAuth2 application home page URL must not be local: " +
+						homePageURL);
+			}
+		}
+		catch (MalformedURLException | UnknownHostException exception) {
+			throw new PortalException(
+				"The OAuth2 application home page URL is invalid: " +
+					homePageURL,
+				exception);
+		}
+
+		return homePageURL;
+	}
+
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/node/delegate/ComposeContentEntriesOutputServiceNodeDelegate.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/node/delegate/ComposeContentEntriesOutputServiceNodeDelegate.java
@@ -1,0 +1,114 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.internal.workflow.node.delegate;
+
+import com.liferay.ai.hub.workflow.node.ServiceNodeDelegate;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.URLCodec;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.io.Serializable;
+
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Pedro Leite
+ */
+@Component(service = ServiceNodeDelegate.class)
+public class ComposeContentEntriesOutputServiceNodeDelegate
+	implements ServiceNodeDelegate {
+
+	@Override
+	public String execute(
+			Map<String, String> inputVariables,
+			Map<String, Serializable> workflowContext)
+		throws Exception {
+
+		String contentEntriesPayload = inputVariables.get(
+			"contentEntriesPayload");
+
+		if (Validator.isNull(contentEntriesPayload)) {
+			String output =
+				"I could not generate any content. Please try again.";
+
+			workflowContext.put("output", output);
+
+			return output;
+		}
+
+		JSONArray jsonArray = _jsonFactory.createJSONArray(
+			contentEntriesPayload);
+
+		if (jsonArray.length() == 0) {
+			String output = _getOutput(inputVariables);
+
+			workflowContext.put("output", output);
+
+			return output;
+		}
+
+		String output = StringUtil.merge(
+			JSONUtil.toList(
+				jsonArray,
+				jsonObject -> {
+					JSONObject propertiesJSONObject = jsonObject.getJSONObject(
+						"properties");
+
+					return StringBundler.concat(
+						"- [", propertiesJSONObject.getString("title"), "](",
+						MapUtil.getString(
+							workflowContext, "aiHubCellLiferayDXPURL"),
+						"/c/cms/edit_content_item?externalReferenceCode=",
+						URLCodec.encodeURL(
+							jsonObject.getString("externalReferenceCode")),
+						"&groupId=",
+						URLCodec.encodeURL(inputVariables.get("spaceId")),
+						"&objectDefinitionName=",
+						URLCodec.encodeURL(
+							inputVariables.get("objectDefinitionName")),
+						")");
+				}),
+			"\n");
+
+		workflowContext.put("output", output);
+
+		return output;
+	}
+
+	@Override
+	public String getKey() {
+		return "javaDelegate#composeContentEntriesOutput";
+	}
+
+	private String _getOutput(Map<String, String> inputVariables) {
+		if (Validator.isNull(inputVariables.get("objectDefinitionName")) ||
+			Validator.isNull(inputVariables.get("spaceId"))) {
+
+			return StringBundler.concat(
+				"I can only generate content when a destination space and a ",
+				"content type are selected. Please open the AI Assistant from ",
+				"a content section.");
+		}
+
+		return StringBundler.concat(
+			"I can only generate ", inputVariables.get("objectDefinitionName"),
+			" content here. To generate a different content type, open the AI ",
+			"Assistant from that content type's section.");
+	}
+
+	@Reference
+	private JSONFactory _jsonFactory;
+
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/resource/v1_0/MessageResourceImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/resource/v1_0/MessageResourceImpl.java
@@ -15,10 +15,9 @@ import com.liferay.ai.hub.util.AccountEntryUtil;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.ServiceContextFactory;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
 import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
-
-import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -63,7 +62,11 @@ public class MessageResourceImpl extends BaseMessageResourceImpl {
 			).groupId(
 				AccountEntryUtil.getUserAccountEntryGroupId(user.getUserId())
 			).input(
-				Map.of("message", message.getText())
+				HashMapBuilder.<String, Object>putAll(
+					message.getContext()
+				).put(
+					"message", message.getText()
+				).build()
 			).instructionDefinitionScope(
 				message.getInstructionDefinitionScopeAsString()
 			).oAuth2ApplicationId(

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/AgentDefinitionResourceTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/AgentDefinitionResourceTest.java
@@ -647,7 +647,7 @@ public class AgentDefinitionResourceTest
 	private void _testGetAgentDefinitionsPage() throws Exception {
 		Page<AgentDefinition> page =
 			agentDefinitionResource.getAgentDefinitionsPage(
-				null, null, Pagination.of(1, 10), null);
+				null, null, Pagination.of(1, 20), null);
 
 		assertEquals(
 			_systemAgentDefinitions, (List<AgentDefinition>)page.getItems());
@@ -659,7 +659,7 @@ public class AgentDefinitionResourceTest
 
 		Page<AgentDefinition> page =
 			agentDefinitionResource.getAgentDefinitionsPage(
-				null, "(active eq false)", Pagination.of(1, 10), null);
+				null, "(active eq false)", Pagination.of(1, 20), null);
 
 		assertEquals(
 			ListUtil.filter(
@@ -670,7 +670,7 @@ public class AgentDefinitionResourceTest
 		// Active as true
 
 		page = agentDefinitionResource.getAgentDefinitionsPage(
-			null, "(active eq true)", Pagination.of(1, 10), null);
+			null, "(active eq true)", Pagination.of(1, 20), null);
 
 		assertEquals(
 			ListUtil.filter(
@@ -680,7 +680,7 @@ public class AgentDefinitionResourceTest
 		// Date created
 
 		page = agentDefinitionResource.getAgentDefinitionsPage(
-			null, "dateCreated gt 2000-01-01T00:00:00Z", Pagination.of(1, 10),
+			null, "dateCreated gt 2000-01-01T00:00:00Z", Pagination.of(1, 20),
 			null);
 
 		assertEquals(
@@ -689,7 +689,7 @@ public class AgentDefinitionResourceTest
 		// Date modified
 
 		page = agentDefinitionResource.getAgentDefinitionsPage(
-			null, "dateModified gt 2000-01-01T00:00:00Z", Pagination.of(1, 10),
+			null, "dateModified gt 2000-01-01T00:00:00Z", Pagination.of(1, 20),
 			null);
 
 		assertEquals(
@@ -794,7 +794,7 @@ public class AgentDefinitionResourceTest
 
 		Page<AgentDefinition> page =
 			agentDefinitionResource.getAgentDefinitionsPage(
-				null, null, Pagination.of(1, 10), null);
+				null, null, Pagination.of(1, 20), null);
 
 		for (AgentDefinition agentDefinition : page.getItems()) {
 			Map<String, Map<String, String>> actions =
@@ -810,7 +810,7 @@ public class AgentDefinitionResourceTest
 			new String[] {ActionKeys.PERMISSIONS, ActionKeys.VIEW});
 
 		page = agentDefinitionResource.getAgentDefinitionsPage(
-			null, null, Pagination.of(1, 10), null);
+			null, null, Pagination.of(1, 20), null);
 
 		for (AgentDefinition agentDefinition : page.getItems()) {
 			Map<String, Map<String, String>> actions =
@@ -836,11 +836,11 @@ public class AgentDefinitionResourceTest
 
 		Page<AgentDefinition> ascPage =
 			agentDefinitionResource.getAgentDefinitionsPage(
-				null, null, Pagination.of(1, 10), sortField + ":asc");
+				null, null, Pagination.of(1, 20), sortField + ":asc");
 
 		Page<AgentDefinition> descPage =
 			agentDefinitionResource.getAgentDefinitionsPage(
-				null, null, Pagination.of(1, 10), sortField + ":desc");
+				null, null, Pagination.of(1, 20), sortField + ":desc");
 
 		List<AgentDefinition> agentDefinitions = ListUtil.fromCollection(
 			descPage.getItems());
@@ -964,6 +964,37 @@ public class AgentDefinitionResourceTest
 					workflowDefinitionName =
 						WorkflowDefinitionConstants.
 							NAME_FIX_SPELLING_AND_GRAMMAR;
+				}
+			},
+			new AgentDefinition() {
+				{
+					active = true;
+					externalReferenceCode =
+						WorkflowDefinitionConstants.
+							EXTERNAL_REFERENCE_CODE_GENERATE_CONTENT;
+					inputVariables = new Variable[] {
+						new Variable() {
+							{
+								name = "brief";
+								type = "string";
+							}
+						},
+						new Variable() {
+							{
+								name = "count";
+								type = "string";
+							}
+						}
+					};
+					outputVariable = new Variable() {
+						{
+							name = "output";
+							type = "string";
+						}
+					};
+					version = 1;
+					workflowDefinitionName =
+						WorkflowDefinitionConstants.NAME_GENERATE_CONTENT;
 				}
 			},
 			new AgentDefinition() {

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/AgentInstanceResourceTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/AgentInstanceResourceTest.java
@@ -320,6 +320,7 @@ public class AgentInstanceResourceTest
 			_testPostAgentInstanceWithTypeAIDecisionNodeWorkflowDefinition();
 			_testPostAgentInstanceWithTypeAutoCategorize();
 			_testPostAgentInstanceWithTypeFixSpellingAndGrammarWithInstruction();
+			_testPostAgentInstanceWithTypeGenerateContent();
 			_testPostAgentInstanceWithTypeGenerateTags();
 			_testPostAgentInstanceWithTypeHTTPRequestNodeWithLLMNodeWorkflowDefinition();
 			_testPostAgentInstanceWithTypeLLMNodeWithRAGWorkflowDefinition();
@@ -817,6 +818,42 @@ public class AgentInstanceResourceTest
 			});
 
 		SseUtil.closeAll();
+	}
+
+	private void _testPostAgentInstanceWithTypeGenerateContent()
+		throws Exception {
+
+		String data = _postAndAwaitAgentInstance(
+			"L_GENERATE_CONTENT",
+			JSONUtil.put(
+				"brief", "Liferay DXP"
+			).put(
+				"count", "1"
+			).put(
+				"objectDefinitionName", _objectDefinition.getName()
+			).put(
+				"objectFields",
+				JSONUtil.putAll(
+					JSONUtil.put(
+						"businessType", "LongText"
+					).put(
+						"name", "description"
+					).put(
+						"readOnly", "false"
+					),
+					JSONUtil.put(
+						"businessType", "Text"
+					).put(
+						"name", "name"
+					).put(
+						"readOnly", "false"
+					)
+				).toString()
+			).put(
+				"spaceId", String.valueOf(TestPropsValues.getGroupId())
+			));
+
+		_assertContains(data, "AI-generated", "L_CONTENTS", "Liferay");
 	}
 
 	private void _testPostAgentInstanceWithTypeGenerateTags() throws Exception {

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer-test/src/testIntegration/java/com/liferay/ai/hub/site/initializer/internal/test/AIHubSiteInitializerTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer-test/src/testIntegration/java/com/liferay/ai/hub/site/initializer/internal/test/AIHubSiteInitializerTest.java
@@ -295,6 +295,11 @@ public class AIHubSiteInitializerTest {
 			WorkflowDefinitionConstants.NAME_FIX_SPELLING_AND_GRAMMAR);
 		_assertWorkflowDefinitionExists(
 			_ACCOUNT_EXTERNAL_REFERENCE_CODE_AI_HUB,
+			WorkflowDefinitionConstants.
+				EXTERNAL_REFERENCE_CODE_GENERATE_CONTENT,
+			WorkflowDefinitionConstants.NAME_GENERATE_CONTENT);
+		_assertWorkflowDefinitionExists(
+			_ACCOUNT_EXTERNAL_REFERENCE_CODE_AI_HUB,
 			WorkflowDefinitionConstants.EXTERNAL_REFERENCE_CODE_GENERATE_IMAGE,
 			WorkflowDefinitionConstants.NAME_GENERATE_IMAGE);
 		_assertWorkflowDefinitionExists(

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/object-entries/agent-definition-object-entries.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/object-entries/agent-definition-object-entries.json
@@ -54,6 +54,19 @@
 		},
 		{
 			"active": true,
+			"description": "This agent generates one or more CMS content entries (assets backed by a Content Structure) as drafts from a brief, decomposing it into distinct angles. Use it whenever the user asks to generate, write, draft, or create CMS content, blog posts, or web content. From the user request, extract brief (the topic or description) and count. Always pass count as an integer number of entries: use the quantity the user asks for, and default to 1 whenever no quantity is given, treating singular phrasing or an article such as \"a\", \"an\", or \"one\" as 1. Every other input is resolved automatically by the application, so always proceed and never ask the user for, infer, or wait on the content type, structure, fields, or destination space.",
+			"externalReferenceCode": "L_GENERATE_CONTENT",
+			"inputVariables": "brief,count",
+			"outputVariable": "output",
+			"r_accountToAIHubAgentDefinitions_accountEntryERC": "L_AI_HUB",
+			"system": true,
+			"title_i18n": {
+				"en_US": "Generate Content"
+			},
+			"workflowDefinitionName": "Generate Content"
+		},
+		{
+			"active": true,
 			"description": "This agent analyzes content and proposes tags, prioritizing reuse of existing tags and proposing new tags only when needed.",
 			"externalReferenceCode": "L_GENERATE_TAGS",
 			"inputVariables": "content,count,existingTags",

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/workflow-definitions/generate-content-workflow-definition/workflow-definition.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/workflow-definitions/generate-content-workflow-definition/workflow-definition.json
@@ -1,0 +1,11 @@
+{
+	"active": true,
+	"externalReferenceCode": "L_GENERATE_CONTENT",
+	"groupExternalReferenceCode": "[$ACCOUNT_ENTRY_GROUP_ERC:L_AI_HUB$]",
+	"name": "Generate Content",
+	"scope": "ai",
+	"title": "Generate Content",
+	"title_i18n": {
+		"en_US": "Generate Content"
+	}
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/workflow-definitions/generate-content-workflow-definition/workflow-definition.xml
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/workflow-definitions/generate-content-workflow-definition/workflow-definition.xml
@@ -1,0 +1,330 @@
+<?xml version="1.0"?>
+
+<workflow-definition
+	xmlns="urn:liferay.com:liferay-workflow_7.4.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="urn:liferay.com:liferay-workflow_7.4.0 http://www.liferay.com/dtd/liferay-workflow-definition_7_4_0.xsd"
+>
+	<name>Generate Content</name>
+	<version>1</version>
+	<llm>
+		<name>contentEntriesGenerator</name>
+		<metadata>
+			<![CDATA[
+				{
+					"xy": [
+						276,
+						242
+					]
+				}
+			]]>
+		</metadata>
+		<labels>
+			<label language-id="en_US">
+				Content Entries Generator
+			</label>
+		</labels>
+		<input-variables>
+			<![CDATA[
+				[
+					{
+						"name": "brief",
+						"type": "string"
+					},
+					{
+						"name": "count",
+						"type": "string"
+					},
+					{
+						"name": "objectDefinitionName",
+						"type": "string"
+					},
+					{
+						"name": "objectFields",
+						"type": "string"
+					},
+					{
+						"name": "spaceId",
+						"type": "string"
+					}
+				]
+			]]>
+		</input-variables>
+		<output-variables>
+			<![CDATA[
+				[
+					{
+						"name": "contentEntriesPayload",
+						"type": "string"
+					}
+				]
+			]]>
+		</output-variables>
+		<prompt>
+			<![CDATA[# Role
+
+You are a content generation assistant. You generate one or more Liferay CMS
+content entries (object entries that follow a predefined Content Structure) from
+a brief. You decompose the brief into the requested number of DISTINCT angles
+and produce one object entry payload per angle.
+
+# Inputs
+
+- brief: the free-text description of the content to generate.
+- count: the number of entries to generate.
+- objectDefinitionName: the target Content Structure. Provided by the
+application.
+- objectFields: a JSON array string describing the target structure's fields.
+- spaceId: the destination space id. Provided by the application.
+
+# Target structure
+
+The object type is {{objectDefinitionName}}. Its fields are described by
+this JSON, taken from the structure definition:
+
+{{objectFields}}
+
+Fill ONLY the fields where `readOnly` is "false" AND `businessType` is one of
+`Text`, `LongText`, or `RichText` — except `externalReferenceCode`. Key each
+value by the exact field `name` under `properties`. `RichText` values are rich
+HTML bodies. Never fill any other field.
+
+# Required target
+
+The target structure ({{objectDefinitionName}}) and the destination space id
+({{spaceId}}) are both provided by the application. If EITHER is empty or
+missing, generate nothing: output an empty JSON array `[]` and nothing else. The
+application then tells the user to start from a space with a selected content
+type.
+
+# Structure lock
+
+You can ONLY generate content for the selected structure
+{{objectDefinitionName}}. The destination structure is fixed by the
+application and cannot be changed from the conversation. If the brief clearly
+asks for a different content type or structure than {{objectDefinitionName}},
+generate nothing: output an empty JSON array `[]` and nothing else. The
+application then tells the user that only {{objectDefinitionName}} can be
+generated here.
+
+Output an empty JSON array `[]` ONLY to refuse — a missing target or a structure
+mismatch. In every other case you MUST produce at least one entry (default to 1
+when count is empty) — never return an empty array for a vague, short, or empty
+brief.
+
+# Hard rules
+
+- Produce exactly {{count}} entries (default 1 when count is empty). Each entry
+must have a DISTINCT angle and title — never duplicate titles across the batch.
+- Fill every eligible field of the {{objectDefinitionName}} structure under
+`properties`, keyed by the exact field `name`. Never invent field names.
+- Give each entry a deterministic `externalReferenceCode` (a slug of its title)
+so re-running the same brief updates the existing draft instead of duplicating.
+- Always include the `AI-generated` keyword and set
+`objectEntryFolderExternalReferenceCode` to `L_CONTENTS`.
+- Set `scopeKey` on every entry to the provided space id ({{spaceId}}).
+- `status.code` is `2` (draft).
+
+# Output policy
+
+- Output a SINGLE raw JSON array of object entry payloads and nothing else.
+- DO NOT wrap the JSON in markdown fences (no ```json, no ```).
+- DO NOT add prose, commentary, or trailing text.
+- Each element has the shape:
+
+{
+	"externalReferenceCode": "<unique-slug>",
+	"keywords": [
+		"AI-generated"
+	],
+	"objectEntryFolderExternalReferenceCode": "L_CONTENTS",
+	"properties": {
+		"<fieldName>": "<value>"
+	},
+	"scopeKey": "<spaceId>",
+	"status": {
+		"code": 2
+	}
+}]]>
+		</prompt>
+		<tools>
+			<![CDATA[[]]]>
+		</tools>
+		<transitions>
+			<transition>
+				<labels>
+					<label language-id="en_US">
+						Post Content Entries
+					</label>
+				</labels>
+				<name>postContentEntries</name>
+				<target>postContentEntries</target>
+				<default>true</default>
+			</transition>
+		</transitions>
+		<user-message>
+			<![CDATA[Brief: {{brief}}
+
+Number of entries requested: {{count}}
+
+Space id: {{spaceId}}]]>
+		</user-message>
+	</llm>
+	<http-request>
+		<name>postContentEntries</name>
+		<labels>
+			<label language-id="en_US">
+				Post Content Entries
+			</label>
+		</labels>
+		<http-method>POST</http-method>
+		<input-variables>
+			<![CDATA[
+				[
+					{
+						"name": "aiHubCellLiferayDXPURL",
+						"type": "string"
+					},
+					{
+						"name": "contentEntriesPayload",
+						"type": "string"
+					},
+					{
+						"name": "objectDefinitionName",
+						"type": "string"
+					},
+					{
+						"name": "spaceId",
+						"type": "string"
+					}
+				]
+			]]>
+		</input-variables>
+		<output-variables>
+			<![CDATA[
+				[
+					{
+						"name": "response",
+						"type": "string"
+					}
+				]
+			]]>
+		</output-variables>
+		<request-body>
+			<![CDATA[{{contentEntriesPayload}}]]>
+		</request-body>
+		<timeout>10000</timeout>
+		<transitions>
+			<transition>
+				<labels>
+					<label language-id="en_US">
+						Compose Content Entries Output
+					</label>
+				</labels>
+				<name>composeContentEntriesOutput</name>
+				<target>composeContentEntriesOutput</target>
+				<default>true</default>
+			</transition>
+		</transitions>
+		<url>{{aiHubCellLiferayDXPURL}}/o/headless-batch-engine/v1.0/import-task/com.liferay.object.rest.dto.v1_0.ObjectEntry?createStrategy=UPSERT&amp;importStrategy=ON_ERROR_CONTINUE&amp;scopeKey={{spaceId}}&amp;taskItemDelegateName={{objectDefinitionName}}</url>
+	</http-request>
+	<service>
+		<name>composeContentEntriesOutput</name>
+		<input-variables>
+			<![CDATA[
+				[
+					{
+						"name": "contentEntriesPayload",
+						"type": "string"
+					},
+					{
+						"name": "objectDefinitionName",
+						"type": "string"
+					},
+					{
+						"name": "spaceId",
+						"type": "string"
+					}
+				]
+			]]>
+		</input-variables>
+		<java-delegate>javaDelegate#composeContentEntriesOutput</java-delegate>
+		<labels>
+			<label language-id="en_US">
+				Compose Content Entries Output
+			</label>
+		</labels>
+		<output-variables>
+			<![CDATA[
+				[
+					{
+						"name": "output",
+						"type": "string"
+					}
+				]
+			]]>
+		</output-variables>
+		<transitions>
+			<transition>
+				<labels>
+					<label language-id="en_US">
+						End
+					</label>
+				</labels>
+				<name>end</name>
+				<target>end</target>
+				<default>true</default>
+			</transition>
+		</transitions>
+	</service>
+	<state>
+		<name>start</name>
+		<metadata>
+			<![CDATA[
+				{
+					"xy": [
+						273,
+						25
+					]
+				}
+			]]>
+		</metadata>
+		<initial>true</initial>
+		<labels>
+			<label language-id="en_US">
+				Start
+			</label>
+		</labels>
+		<transitions>
+			<transition>
+				<labels>
+					<label language-id="en_US">
+						Content Entries Generator
+					</label>
+				</labels>
+				<name>contentEntriesGenerator</name>
+				<target>contentEntriesGenerator</target>
+				<default>true</default>
+			</transition>
+		</transitions>
+	</state>
+	<state>
+		<name>end</name>
+		<metadata>
+			<![CDATA[
+				{
+					"terminal": true,
+					"xy": [
+						277,
+						459
+					]
+				}
+			]]>
+		</metadata>
+		<labels>
+			<label language-id="en_US">
+				End
+			</label>
+		</labels>
+	</state>
+</workflow-definition>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94024

**What is being fixed:** The AI Assistant could not generate CMS content entries from a text conversation. There was also a latent workflow bug: the synchronous HTTP request and service Kaleo node executors added their transition in doExit instead of doExecute, so any workflow containing one of those nodes stalled after it — invisible until now because every shipped agent workflow was start → llm → end.

**How it is being fixed:** Adds a new L_GENERATE_CONTENT AI Hub agent whose Kaleo workflow generates one or more CMS content entries from a brief (llm node), imports them as drafts through the Batch Engine over HTTP (http request node), and composes the chat output with edit links (service node backed by ComposeContentEntriesOutputServiceNodeDelegate). Fixes the node executor stall by moving the transition into doExecute. Forwards the chat message context (object definition, space, object fields) into the workflow so the generation target is pinned by the application rather than inferred by the planner. Resolves content edit links by external reference code, since the draft id is unknown when the links are composed. Grants the batch engine scopes to the AI Hub Cell app, adds the workflow definition constants for the agent, and adds integration test coverage.


**pr-check: PASS** — tested on `e7a17701887c38f8abc6a90ce78fb9ee7f68e81c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "e7a17701887c38f8abc6a90ce78fb9ee7f68e81c"} -->


Resent after https://github.com/brianchandotcom/liferay-portal/pull/178414#issuecomment-4927788067