### PR TITLE
LRCI-6550 Fix .lfrbuild-ci deploy for deep and scoped module [STABLE FIX]

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -438,7 +438,10 @@ testray.build.type=EE Development (@{to.branch.name})</echo>
 								<filtermapper>
 									<replacestring from="/" to=":" />
 								</filtermapper>
-								<globmapper from="*" to=":*:deploy" />
+								<globmapper
+									from="*"
+									to=":*:deploy"
+								/>
 							</chainedmapper>
 						</pathconvert>
 

--- a/build.xml
+++ b/build.xml
@@ -428,10 +428,18 @@ testray.build.type=EE Development (@{to.branch.name})</echo>
 									to="*/.lfrbuild-ci"
 								/>
 							</present>
+
+							<exclude name="**/node_modules/**" />
 						</dirset>
 
 						<pathconvert pathsep=" " property="ci.build.module.deploy.tasks" refid="lfrbuild-ci.dirs">
-							<regexpmapper from=".*modules/([^/]+)/([^/]+)$" to=":\1:\2:deploy" />
+							<chainedmapper>
+								<regexpmapper from=".*/modules/(.+)$" to="\1" />
+								<filtermapper>
+									<replacestring from="/" to=":" />
+								</filtermapper>
+								<globmapper from="*" to=":*:deploy" />
+							</chainedmapper>
 						</pathconvert>
 
 						<gradle-execute dir="${project.dir}/modules" task="${ci.build.module.deploy.tasks}">


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-6550

What Is Being Fixed
The .lfrbuild-ci deploy step in build.xml crashes app-server-bundle-builder with "Cannot locate tasks that match ':https://github.com/liferay:seo-studio-web:deploy' as project 'https://github.com/liferay' not found in root project 'modules'".

The step globs modules/ for .lfrbuild-ci markers and converts each directory to a Gradle deploy task. Two defects combine: the dirset follows the yarn workspace symlinks under modules/node_modules/@liferay/..., and the regexpmapper only captures two path segments. For the scoped, deeply nested seo-studio-web module, the greedy match on the node_modules symlink produces the invalid :@liferay:seo-studio-web:deploy, while the real 4-level path dxp/apps/seo-studio/seo-studio-web is silently dropped. The mechanism has only ever worked for two-level test/* and util/* modules (salesforce-connector has the same latent drop).

How It Is Being Fixed
The dirset now excludes **/node_modules/**, so yarn workspace symlinks can no longer be picked up. The path conversion is replaced with a chained mapper that strips everything through /modules/, turns the remaining separators into colons, and wraps the result as a deploy task. This resolves modules at any depth to their true Gradle path (:dxp:apps:seo-studio:seo-studio-web:deploy) while leaving the existing two-level modules unchanged.

Why Are There No Tests?
The change is to an Ant target in build.xml that runs only in CI; it has no local test surface and is validated by running app-server-bundle-builder.

hi @brianchandotcom , this should fix the app-server-bundle-builder failure in stable.