### PR TITLE
LPD-96227 Assert the live asset library reference survives publish for the Media Gallery

### DIFF
--- a/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/exportimport/portlet/preferences/processor/test/IGExportImportPortletPreferencesProcessorTest.java
+++ b/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/exportimport/portlet/preferences/processor/test/IGExportImportPortletPreferencesProcessorTest.java
@@ -317,16 +317,11 @@ public class IGExportImportPortletPreferencesProcessorTest {
 
 		GroupTestUtil.enableLocalStaging(depotLiveGroup);
 
-		Group depotStagingGroup = depotLiveGroup.getStagingGroup();
-
-		FileEntry stagingFileEntry = _dlAppLocalService.getFileEntry(
-			depotStagingGroup.getGroupId(),
-			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-			liveFileEntry.getTitle());
+		Map<String, String> livePortletPreferencesValues =
+			_getPortletPreferencesValues(liveFileEntry);
 
 		_testExportImportFolderInAssetLibraryWithStagingInProcess(
-			_getPortletPreferencesValues(liveFileEntry),
-			_getPortletPreferencesValues(stagingFileEntry));
+			livePortletPreferencesValues, livePortletPreferencesValues);
 	}
 
 	@Test
@@ -376,15 +371,11 @@ public class IGExportImportPortletPreferencesProcessorTest {
 
 		GroupTestUtil.enableLocalStaging(depotLiveGroup);
 
-		Group depotStagingGroup = depotLiveGroup.getStagingGroup();
-
-		Folder stagingFolder = _dlAppLocalService.getFolder(
-			depotStagingGroup.getGroupId(),
-			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, liveFolder.getName());
+		Map<String, String> livePortletPreferencesValues =
+			_getPortletPreferencesValues(liveFolder);
 
 		_testExportImportFolderInAssetLibraryWithStagingInProcess(
-			_getPortletPreferencesValues(liveFolder),
-			_getPortletPreferencesValues(stagingFolder));
+			livePortletPreferencesValues, livePortletPreferencesValues);
 	}
 
 	@Test


### PR DESCRIPTION
The LPD-96227 fix changed `DLExportImportPortletPreferencesProcessor` so the live asset library reference is preserved on staging publish, but `IGExportImportPortletPreferencesProcessorTest` was overlooked. `IGDisplayExportImportPortletPreferencesProcessor` delegates to the DL processor, so the Media Gallery export/import behavior changed too, and the `...FromLive` cases still asserted the old live→staging flip. This aligns them with `DLExportImportPortletPreferencesProcessorTest`.

Surfaced by the release backport CI (liferay/liferay-portal-ee#39158, liferay/liferay-portal-ee#39159).