### PR TITLE
LPD-97572 LPD-97269 Hide the Space tab for legacy assets and the default-selected view

### DIFF
--- a/modules/apps/item-selector/item-selector-taglib/build.gradle
+++ b/modules/apps/item-selector/item-selector-taglib/build.gradle
@@ -15,6 +15,7 @@ dependencies {
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-react")
 	compileOnly project(":apps:item-selector:item-selector-api")
 	compileOnly project(":apps:item-selector:item-selector-criteria-api")
+	compileOnly project(":apps:journal:journal-api")
 	compileOnly project(":apps:site-navigation:site-navigation-taglib")
 	compileOnly project(":apps:site:site-api")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")

--- a/modules/apps/item-selector/item-selector-taglib/src/main/java/com/liferay/item/selector/taglib/internal/display/context/GroupSelectorDisplayContext.java
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/java/com/liferay/item/selector/taglib/internal/display/context/GroupSelectorDisplayContext.java
@@ -7,10 +7,12 @@ package com.liferay.item.selector.taglib.internal.display.context;
 
 import com.liferay.item.selector.ItemSelector;
 import com.liferay.item.selector.ItemSelectorCriterion;
+import com.liferay.item.selector.criteria.info.item.criterion.InfoItemItemSelectorCriterion;
 import com.liferay.item.selector.provider.GroupItemSelectorProvider;
 import com.liferay.item.selector.taglib.internal.servlet.item.selector.ItemSelectorUtil;
 import com.liferay.item.selector.taglib.internal.util.EntryURLUtil;
 import com.liferay.item.selector.taglib.internal.util.GroupItemSelectorProviderRegistryUtil;
+import com.liferay.journal.model.JournalArticle;
 import com.liferay.petra.string.StringPool;
 import com.liferay.petra.string.StringUtil;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
@@ -23,12 +25,14 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.site.search.GroupSearch;
 
 import jakarta.portlet.PortletURL;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -112,7 +116,9 @@ public class GroupSelectorDisplayContext {
 			List<String> parts = StringUtil.split(criterion);
 
 			if (parts.contains("file") || parts.contains("folder") ||
-				parts.contains("image")) {
+				parts.contains("image") ||
+				(parts.contains("infoitem") &&
+				 _isLegacyAssetItemSelectorCriterion())) {
 
 				groupItemSelectorProviderTypes.remove("space-depot");
 
@@ -236,7 +242,50 @@ public class GroupSelectorDisplayContext {
 		_selectedTab = ParamUtil.getString(
 			_liferayPortletRequest, "selectedTab");
 
+		if (Validator.isNull(_selectedTab)) {
+			_selectedTab = GetterUtil.getString(
+				_liferayPortletRequest.getAttribute(
+					"liferay-item-selector:group-selector:selectedTab"));
+		}
+
 		return _selectedTab;
+	}
+
+	private boolean _isLegacyAssetItemSelectorCriterion() {
+		ItemSelector itemSelector = _getItemSelector();
+
+		for (ItemSelectorCriterion itemSelectorCriterion :
+				itemSelector.getItemSelectorCriteria(
+					_liferayPortletRequest.getParameterMap())) {
+
+			if (!(itemSelectorCriterion instanceof
+					InfoItemItemSelectorCriterion)) {
+
+				continue;
+			}
+
+			InfoItemItemSelectorCriterion infoItemItemSelectorCriterion =
+				(InfoItemItemSelectorCriterion)itemSelectorCriterion;
+
+			if (Objects.equals(
+					infoItemItemSelectorCriterion.getItemType(),
+					JournalArticle.class.getName())) {
+
+				return true;
+			}
+		}
+
+		String selectedTab = _getSelectedTab();
+
+		if (Validator.isNotNull(selectedTab) &&
+			!selectedTab.startsWith(
+				_CLASS_NAME_OBJECT_ENTRY_ITEM_SELECTOR_VIEW +
+					StringPool.UNDERLINE)) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	private boolean _isScopeGroupType() {
@@ -249,6 +298,10 @@ public class GroupSelectorDisplayContext {
 
 		return _scopeGroupType;
 	}
+
+	private static final String _CLASS_NAME_OBJECT_ENTRY_ITEM_SELECTOR_VIEW =
+		"com.liferay.object.web.internal.item.selector." +
+			"ObjectEntryItemSelectorView";
 
 	private String _groupType;
 	private final LiferayPortletRequest _liferayPortletRequest;

--- a/modules/apps/item-selector/item-selector-taglib/src/test/java/com/liferay/item/selector/taglib/internal/display/context/GroupSelectorDisplayContextTest.java
+++ b/modules/apps/item-selector/item-selector-taglib/src/test/java/com/liferay/item/selector/taglib/internal/display/context/GroupSelectorDisplayContextTest.java
@@ -5,12 +5,17 @@
 
 package com.liferay.item.selector.taglib.internal.display.context;
 
+import com.liferay.item.selector.ItemSelector;
+import com.liferay.item.selector.criteria.info.item.criterion.InfoItemItemSelectorCriterion;
 import com.liferay.item.selector.provider.GroupItemSelectorProvider;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
+import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.test.portlet.MockLiferayResourceRequest;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import jakarta.portlet.PortletRequest;
@@ -19,6 +24,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -59,17 +65,42 @@ public class GroupSelectorDisplayContextTest {
 			RandomTestUtil.randomLong()
 		);
 
-		_serviceRegistration = bundleContext.registerService(
-			GroupItemSelectorProvider.class,
-			new MockGroupItemSelectorProvider(), null);
+		Mockito.when(
+			PortalUtil.getHttpServletRequest(
+				Mockito.any(LiferayPortletRequest.class))
+		).thenAnswer(
+			invocationOnMock -> {
+				LiferayPortletRequest liferayPortletRequest =
+					invocationOnMock.getArgument(0);
+
+				return liferayPortletRequest.getHttpServletRequest();
+			}
+		);
+
+		_groupItemSelectorProviderServiceRegistration =
+			bundleContext.registerService(
+				GroupItemSelectorProvider.class,
+				new MockGroupItemSelectorProvider("test"), null);
+		_itemSelectorServiceRegistration = bundleContext.registerService(
+			ItemSelector.class, _itemSelector, null);
+		_spaceDepotGroupItemSelectorProviderServiceRegistration =
+			bundleContext.registerService(
+				GroupItemSelectorProvider.class,
+				new MockGroupItemSelectorProvider("space-depot"), null);
 	}
 
 	@AfterClass
 	public static void tearDownClass() {
-		_serviceRegistration.unregister();
-
 		_frameworkUtilMockedStatic.close();
+		_groupItemSelectorProviderServiceRegistration.unregister();
+		_itemSelectorServiceRegistration.unregister();
 		_portalUtilMockedStatic.close();
+		_spaceDepotGroupItemSelectorProviderServiceRegistration.unregister();
+	}
+
+	@After
+	public void tearDown() {
+		Mockito.reset(_itemSelector);
 	}
 
 	@Test
@@ -94,6 +125,163 @@ public class GroupSelectorDisplayContextTest {
 
 	@Test
 	public void testGetGroupTypes() {
+		_testGetGroupTypesWithoutCMSFeatureFlag();
+		_testGetGroupTypesWithDefaultSelectedTabRequestAttribute();
+		_testGetGroupTypesWithFileItemSelectorCriterion();
+		_testGetGroupTypesWithJournalArticleInfoItemItemSelectorCriterion();
+		_testGetGroupTypesWithLegacyItemSelectorViewSelectedTab();
+		_testGetGroupTypesWithObjectEntryItemSelectorViewSelectedTab();
+		_testGetGroupTypesWithoutJournalArticleInfoItemItemSelectorCriterion();
+	}
+
+	private MockedStatic<FeatureFlagManagerUtil> _enableCMSFeatureFlag() {
+		MockedStatic<FeatureFlagManagerUtil>
+			featureFlagManagerUtilMockedStatic = Mockito.mockStatic(
+				FeatureFlagManagerUtil.class);
+
+		featureFlagManagerUtilMockedStatic.when(
+			() -> FeatureFlagManagerUtil.isEnabled(
+				Mockito.anyLong(), Mockito.eq("LPD-17564"))
+		).thenReturn(
+			true
+		);
+
+		return featureFlagManagerUtilMockedStatic;
+	}
+
+	private void _testGetGroupTypesWithDefaultSelectedTabRequestAttribute() {
+		try (MockedStatic<FeatureFlagManagerUtil>
+				featureFlagManagerUtilMockedStatic = _enableCMSFeatureFlag()) {
+
+			Mockito.when(
+				_itemSelector.getItemSelectorCriteria(Mockito.anyMap())
+			).thenReturn(
+				Collections.singletonList(new InfoItemItemSelectorCriterion())
+			);
+
+			MockLiferayResourceRequest mockLiferayResourceRequest =
+				new MockLiferayResourceRequest();
+
+			mockLiferayResourceRequest.addParameter("criteria", "infoitem");
+			mockLiferayResourceRequest.setAttribute(
+				"liferay-item-selector:group-selector:selectedTab",
+				"com.liferay.document.library.item.selector.web.internal." +
+					"info.item.DLInfoItemItemSelectorView_Documents and Media");
+
+			GroupSelectorDisplayContext groupSelectorDisplayContext =
+				new GroupSelectorDisplayContext(mockLiferayResourceRequest);
+
+			Assert.assertEquals(
+				Collections.singleton("test"),
+				groupSelectorDisplayContext.getGroupTypes());
+		}
+	}
+
+	private void _testGetGroupTypesWithFileItemSelectorCriterion() {
+		try (MockedStatic<FeatureFlagManagerUtil>
+				featureFlagManagerUtilMockedStatic = _enableCMSFeatureFlag()) {
+
+			MockLiferayResourceRequest mockLiferayResourceRequest =
+				new MockLiferayResourceRequest();
+
+			mockLiferayResourceRequest.addParameter("criteria", "file");
+
+			GroupSelectorDisplayContext groupSelectorDisplayContext =
+				new GroupSelectorDisplayContext(mockLiferayResourceRequest);
+
+			Assert.assertEquals(
+				Collections.singleton("test"),
+				groupSelectorDisplayContext.getGroupTypes());
+		}
+	}
+
+	private void _testGetGroupTypesWithJournalArticleInfoItemItemSelectorCriterion() {
+		try (MockedStatic<FeatureFlagManagerUtil>
+				featureFlagManagerUtilMockedStatic = _enableCMSFeatureFlag()) {
+
+			InfoItemItemSelectorCriterion infoItemItemSelectorCriterion =
+				new InfoItemItemSelectorCriterion();
+
+			infoItemItemSelectorCriterion.setItemType(
+				"com.liferay.journal.model.JournalArticle");
+
+			Mockito.when(
+				_itemSelector.getItemSelectorCriteria(Mockito.anyMap())
+			).thenReturn(
+				Collections.singletonList(infoItemItemSelectorCriterion)
+			);
+
+			MockLiferayResourceRequest mockLiferayResourceRequest =
+				new MockLiferayResourceRequest();
+
+			mockLiferayResourceRequest.addParameter("criteria", "infoitem");
+
+			GroupSelectorDisplayContext groupSelectorDisplayContext =
+				new GroupSelectorDisplayContext(mockLiferayResourceRequest);
+
+			Assert.assertEquals(
+				Collections.singleton("test"),
+				groupSelectorDisplayContext.getGroupTypes());
+		}
+	}
+
+	private void _testGetGroupTypesWithLegacyItemSelectorViewSelectedTab() {
+		try (MockedStatic<FeatureFlagManagerUtil>
+				featureFlagManagerUtilMockedStatic = _enableCMSFeatureFlag()) {
+
+			Mockito.when(
+				_itemSelector.getItemSelectorCriteria(Mockito.anyMap())
+			).thenReturn(
+				Collections.singletonList(new InfoItemItemSelectorCriterion())
+			);
+
+			MockLiferayResourceRequest mockLiferayResourceRequest =
+				new MockLiferayResourceRequest();
+
+			mockLiferayResourceRequest.addParameter("criteria", "infoitem");
+			mockLiferayResourceRequest.addParameter(
+				"selectedTab",
+				"com.liferay.commerce.order.content.web.internal.item." +
+					"selector.CommerceOrderItemSelectorView_Orders");
+
+			GroupSelectorDisplayContext groupSelectorDisplayContext =
+				new GroupSelectorDisplayContext(mockLiferayResourceRequest);
+
+			Assert.assertEquals(
+				Collections.singleton("test"),
+				groupSelectorDisplayContext.getGroupTypes());
+		}
+	}
+
+	private void _testGetGroupTypesWithObjectEntryItemSelectorViewSelectedTab() {
+		try (MockedStatic<FeatureFlagManagerUtil>
+				featureFlagManagerUtilMockedStatic = _enableCMSFeatureFlag()) {
+
+			Mockito.when(
+				_itemSelector.getItemSelectorCriteria(Mockito.anyMap())
+			).thenReturn(
+				Collections.singletonList(new InfoItemItemSelectorCriterion())
+			);
+
+			MockLiferayResourceRequest mockLiferayResourceRequest =
+				new MockLiferayResourceRequest();
+
+			mockLiferayResourceRequest.addParameter("criteria", "infoitem");
+			mockLiferayResourceRequest.addParameter(
+				"selectedTab",
+				"com.liferay.object.web.internal.item.selector." +
+					"ObjectEntryItemSelectorView_Basic Web Content");
+
+			GroupSelectorDisplayContext groupSelectorDisplayContext =
+				new GroupSelectorDisplayContext(mockLiferayResourceRequest);
+
+			Assert.assertEquals(
+				SetUtil.fromArray("space-depot", "test"),
+				groupSelectorDisplayContext.getGroupTypes());
+		}
+	}
+
+	private void _testGetGroupTypesWithoutCMSFeatureFlag() {
 		GroupSelectorDisplayContext groupSelectorDisplayContext =
 			new GroupSelectorDisplayContext(new MockLiferayResourceRequest());
 
@@ -102,15 +290,49 @@ public class GroupSelectorDisplayContextTest {
 			groupSelectorDisplayContext.getGroupTypes());
 	}
 
+	private void _testGetGroupTypesWithoutJournalArticleInfoItemItemSelectorCriterion() {
+		try (MockedStatic<FeatureFlagManagerUtil>
+				featureFlagManagerUtilMockedStatic = _enableCMSFeatureFlag()) {
+
+			Mockito.when(
+				_itemSelector.getItemSelectorCriteria(Mockito.anyMap())
+			).thenReturn(
+				Collections.singletonList(new InfoItemItemSelectorCriterion())
+			);
+
+			MockLiferayResourceRequest mockLiferayResourceRequest =
+				new MockLiferayResourceRequest();
+
+			mockLiferayResourceRequest.addParameter("criteria", "infoitem");
+
+			GroupSelectorDisplayContext groupSelectorDisplayContext =
+				new GroupSelectorDisplayContext(mockLiferayResourceRequest);
+
+			Assert.assertEquals(
+				SetUtil.fromArray("space-depot", "test"),
+				groupSelectorDisplayContext.getGroupTypes());
+		}
+	}
+
 	private static final MockedStatic<FrameworkUtil>
 		_frameworkUtilMockedStatic = Mockito.mockStatic(FrameworkUtil.class);
+	private static ServiceRegistration<GroupItemSelectorProvider>
+		_groupItemSelectorProviderServiceRegistration;
+	private static final ItemSelector _itemSelector = Mockito.mock(
+		ItemSelector.class);
+	private static ServiceRegistration<ItemSelector>
+		_itemSelectorServiceRegistration;
 	private static final MockedStatic<PortalUtil> _portalUtilMockedStatic =
 		Mockito.mockStatic(PortalUtil.class);
 	private static ServiceRegistration<GroupItemSelectorProvider>
-		_serviceRegistration;
+		_spaceDepotGroupItemSelectorProviderServiceRegistration;
 
 	private static class MockGroupItemSelectorProvider
 		implements GroupItemSelectorProvider {
+
+		public MockGroupItemSelectorProvider(String groupType) {
+			_groupType = groupType;
+		}
 
 		@Override
 		public String getEmptyResultsMessage() {
@@ -133,7 +355,7 @@ public class GroupSelectorDisplayContextTest {
 
 		@Override
 		public String getGroupType() {
-			return "test";
+			return _groupType;
 		}
 
 		@Override
@@ -145,6 +367,8 @@ public class GroupSelectorDisplayContextTest {
 		public String getLabel(Locale locale) {
 			return "label";
 		}
+
+		private final String _groupType;
 
 	}
 

--- a/modules/apps/item-selector/item-selector-web/src/main/java/com/liferay/item/selector/web/internal/portlet/ItemSelectorPortlet.java
+++ b/modules/apps/item-selector/item-selector-web/src/main/java/com/liferay/item/selector/web/internal/portlet/ItemSelectorPortlet.java
@@ -5,6 +5,7 @@
 
 package com.liferay.item.selector.web.internal.portlet;
 
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItem;
 import com.liferay.item.selector.ItemSelector;
 import com.liferay.item.selector.ItemSelectorRendering;
 import com.liferay.item.selector.constants.ItemSelectorPortletKeys;
@@ -12,6 +13,7 @@ import com.liferay.portal.kernel.model.Release;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import jakarta.portlet.Portlet;
@@ -20,6 +22,8 @@ import jakarta.portlet.RenderRequest;
 import jakarta.portlet.RenderResponse;
 
 import java.io.IOException;
+
+import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -69,7 +73,32 @@ public class ItemSelectorPortlet extends MVCPortlet {
 
 		localizedItemSelectorRendering.store(renderRequest);
 
+		_storeSelectedTab(renderRequest, localizedItemSelectorRendering);
+
 		super.render(renderRequest, renderResponse);
+	}
+
+	private void _storeSelectedTab(
+		RenderRequest renderRequest,
+		LocalizedItemSelectorRendering localizedItemSelectorRendering) {
+
+		NavigationItem activeNavigationItem =
+			localizedItemSelectorRendering.getActiveNavigationItem();
+
+		if (activeNavigationItem == null) {
+			return;
+		}
+
+		Map<String, Object> data =
+			(Map<String, Object>)activeNavigationItem.get("data");
+
+		if (data == null) {
+			return;
+		}
+
+		renderRequest.setAttribute(
+			"liferay-item-selector:group-selector:selectedTab",
+			MapUtil.getString(data, "id"));
 	}
 
 	@Reference


### PR DESCRIPTION
Backport of the blocker fixes for [LPD-97572](https://liferay.atlassian.net/browse/LPD-97572) (Space tab present in fragments where it should not appear) and [LPD-97269](https://liferay.atlassian.net/browse/LPD-97269) (Space tab selector visible when mapping content for legacy assets), targeting the 7.4.13.151 release fixes.

The automated cherry-pick hit merge conflicts on the release branch (the surrounding `GroupSelectorDisplayContext` and its test had diverged), so the change was adapted by hand. The resulting diff on the affected files matches master's state:

- `GroupSelectorDisplayContext` hides `space-depot` for legacy asset criteria (`infoitem` mapped to a `JournalArticle` or a non-object-entry selected tab) and resolves the selected tab from the request attribute.
- `ItemSelectorPortlet` stores the active navigation item's tab id as a request attribute.
- Added the `journal-api` compile dependency required by the new import.

Verified locally: `GroupSelectorDisplayContextTest` unit test passes, both modules compile, source formatter clean.

Note: an earlier PR to liferay-release/liferay-portal#1168 was auto-closed by CI ("pulls for reference release-7.4.13.151-fixes should not be sent to repository liferay-portal"); re-sent here against `release-7.4.13.151`.