### PR TITLE
LPD-97873 Improve element variation code editing and localization

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/CodeEditorField.tsx
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/CodeEditorField.tsx
@@ -5,6 +5,7 @@
 
 import {ClayButtonWithIcon} from '@clayui/button';
 import ClayForm, {ClayInput} from '@clayui/form';
+import classNames from 'classnames';
 import {useId} from 'frontend-js-components-web';
 import {sub} from 'frontend-js-web';
 import React, {useState} from 'react';
@@ -75,9 +76,22 @@ export default function CodeEditorField({
 				value={value}
 			/>
 
-			{defaultLanguageValue ? (
-				<p className="element-variations__default-language-value font-italic mt-1 pl-2 text-3 text-break text-secondary">
-					{defaultLanguageValue}
+			{defaultLanguageValue !== undefined ? (
+				<p
+					className={classNames(
+						'element-variations__default-language-value mt-2 pl-2 text-3 text-break',
+						{
+							'element-variations__default-language-value--empty':
+								!defaultLanguageValue,
+							'font-italic': defaultLanguageValue,
+							'text-secondary': Boolean(defaultLanguageValue),
+						}
+					)}
+				>
+					{defaultLanguageValue ||
+						Liferay.Language.get(
+							'there-is-no-default-value-to-localize'
+						)}
 				</p>
 			) : null}
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/CodeEditorField.tsx
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/CodeEditorField.tsx
@@ -1,0 +1,87 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {ClayButtonWithIcon} from '@clayui/button';
+import ClayForm, {ClayInput} from '@clayui/form';
+import {useId} from 'frontend-js-components-web';
+import {sub} from 'frontend-js-web';
+import React, {useState} from 'react';
+
+import openCodeEditorModal from './openCodeEditorModal';
+
+interface Props {
+	defaultLanguageValue?: string;
+	description?: string;
+	footer?: React.ReactNode;
+	initialValue: string;
+	label: string;
+	mode: 'text/html' | 'text/javascript';
+	onChange: (value: string) => void;
+}
+
+export default function CodeEditorField({
+	defaultLanguageValue,
+	description,
+	footer,
+	initialValue,
+	label,
+	mode,
+	onChange,
+}: Props) {
+	const fieldId = useId();
+
+	const [value, setValue] = useState(initialValue);
+
+	return (
+		<ClayForm.Group small>
+			<div className="align-items-center d-flex justify-content-between">
+				<label className="mb-0" htmlFor={fieldId}>
+					{label}
+				</label>
+
+				<ClayButtonWithIcon
+					aria-label={sub(Liferay.Language.get('edit-x'), label)}
+					borderless
+					displayType="secondary"
+					onClick={() =>
+						openCodeEditorModal({
+							initialValue: value,
+							mode,
+							onSave: (newValue) => {
+								setValue(newValue);
+
+								onChange(newValue);
+							},
+							title: label,
+						})
+					}
+					size="xs"
+					symbol="expand"
+					title={sub(Liferay.Language.get('edit-x'), label)}
+				/>
+			</div>
+
+			{description ? (
+				<p className="mb-1 text-2 text-secondary">{description}</p>
+			) : null}
+
+			<ClayInput
+				component="textarea"
+				id={fieldId}
+				onBlur={() => onChange(value)}
+				onChange={(event) => setValue(event.target.value)}
+				value={value}
+			/>
+
+			{defaultLanguageValue ? (
+				<p className="element-variations__default-language-value font-italic mt-1 pl-2 text-3 text-break text-secondary">
+					{defaultLanguageValue}
+				</p>
+			) : null}
+
+			{footer}
+		</ClayForm.Group>
+	);
+}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationForm.tsx
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationForm.tsx
@@ -285,7 +285,7 @@ export default function ElementVariationForm({
 										translating
 											? elementVariation.html[
 													defaultLanguageId
-												]
+												] ?? ''
 											: undefined
 									}
 									initialValue={
@@ -309,7 +309,7 @@ export default function ElementVariationForm({
 										translating
 											? elementVariation.js[
 													defaultLanguageId
-												]
+												] ?? ''
 											: undefined
 									}
 									description={Liferay.Language.get(

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationForm.tsx
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationForm.tsx
@@ -11,6 +11,7 @@ import ClayMultiSelect from '@clayui/multi-select';
 import {useId} from 'frontend-js-components-web';
 import React from 'react';
 
+import CodeEditorField from './CodeEditorField';
 import {Action, ElementVariation} from './elementVariationsReducer';
 import {EditableElementOption} from './getEditableElementOptions';
 
@@ -49,8 +50,6 @@ export default function ElementVariationForm({
 	onSave,
 }: Props) {
 	const audienceId = useId();
-	const htmlId = useId();
-	const jsId = useId();
 	const nameId = useId();
 	const targetElementId = useId();
 
@@ -287,97 +286,71 @@ export default function ElementVariationForm({
 
 						{elementVariation.hide[languageId] ? null : (
 							<>
-								<ClayForm.Group small>
-									<label htmlFor={htmlId}>
-										{Liferay.Language.get('html')}
-									</label>
-
-									<ClayInput
-										component="textarea"
-										defaultValue={
-											elementVariation.html[languageId] ??
-											''
-										}
-										id={htmlId}
-										key={languageId}
-										onBlur={(event) =>
-											onChange({
-												html: {
-													...elementVariation.html,
-													[languageId]:
-														event.target.value,
-												},
-											})
-										}
-									/>
-
-									{translating &&
-									elementVariation.html[defaultLanguageId] ? (
-										<p className="element-variations__default-language-value font-italic mt-1 pl-2 text-3 text-break text-secondary">
-											{
-												elementVariation.html[
+								<CodeEditorField
+									defaultLanguageValue={
+										translating
+											? elementVariation.html[
 													defaultLanguageId
 												]
-											}
-										</p>
-									) : null}
-								</ClayForm.Group>
+											: undefined
+									}
+									initialValue={
+										elementVariation.html[languageId] ?? ''
+									}
+									key={`html-${languageId}`}
+									label={Liferay.Language.get('html')}
+									mode="text/html"
+									onChange={(value) =>
+										onChange({
+											html: {
+												...elementVariation.html,
+												[languageId]: value,
+											},
+										})
+									}
+								/>
 
-								<ClayForm.Group small>
-									<label htmlFor={jsId}>
-										{Liferay.Language.get('javascript')}
-									</label>
-
-									<p className="mb-1 text-2 text-secondary">
-										{Liferay.Language.get(
-											'changes-persist-in-the-preview.-reload-to-update'
-										)}
-									</p>
-
-									<ClayInput
-										component="textarea"
-										defaultValue={
-											elementVariation.js[languageId] ??
-											''
-										}
-										id={jsId}
-										key={languageId}
-										onBlur={(event) =>
-											onChange({
-												js: {
-													...elementVariation.js,
-													[languageId]:
-														event.target.value,
-												},
-											})
-										}
-									/>
-
-									{translating &&
-									elementVariation.js[defaultLanguageId] ? (
-										<p className="element-variations__default-language-value font-italic mt-1 pl-2 text-3 text-break text-secondary">
-											{
-												elementVariation.js[
+								<CodeEditorField
+									defaultLanguageValue={
+										translating
+											? elementVariation.js[
 													defaultLanguageId
 												]
-											}
-										</p>
-									) : null}
+											: undefined
+									}
+									description={Liferay.Language.get(
+										'changes-persist-in-the-preview.-reload-to-update'
+									)}
+									footer={
+										<ClayButton
+											className="mt-2"
+											displayType="secondary"
+											onClick={onReloadPreview}
+											size="sm"
+										>
+											<ClayIcon
+												className="mr-2"
+												symbol="reload"
+											/>
 
-									<ClayButton
-										className="mt-2"
-										displayType="secondary"
-										onClick={onReloadPreview}
-										size="sm"
-									>
-										<ClayIcon
-											className="mr-2"
-											symbol="reload"
-										/>
-
-										{Liferay.Language.get('reload')}
-									</ClayButton>
-								</ClayForm.Group>
+											{Liferay.Language.get('reload')}
+										</ClayButton>
+									}
+									initialValue={
+										elementVariation.js[languageId] ?? ''
+									}
+									key={`js-${languageId}`}
+									label={Liferay.Language.get('javascript')}
+									mode="text/javascript"
+									onChange={(value) =>
+										onChange({
+											js: {
+												...elementVariation.js,
+												[languageId]: value,
+											},
+										})
+									}
+								/>
 							</>
 						)}
 					</>

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationForm.tsx
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationForm.tsx
@@ -69,7 +69,7 @@ export default function ElementVariationForm({
 	const translating = languageId !== defaultLanguageId;
 
 	const notLocalizableHint = translating ? (
-		<span className="element-variations__not-localizable-label font-weight-lighter">
+		<span className="element-variations__not-localizable-label font-weight-lighter ml-1">
 			({Liferay.Language.get('not-localizable')})
 		</span>
 	) : null;
@@ -251,40 +251,34 @@ export default function ElementVariationForm({
 							/>
 						</ClayForm.Group>
 
-						<ClayForm.Group className="my-4">
+						<ClayForm.Group className="align-items-center d-flex my-4">
 							<ClayToggle
+								disabled={translating}
 								label={Liferay.Language.get(
 									'hide-page-element'
 								)}
 								onToggle={(hide) => {
 									const properties: Partial<ElementVariationFormData> =
-										{
-											hide: {
-												...elementVariation.hide,
-												[languageId]: hide,
-											},
-										};
+										{hide};
 
 									if (hide) {
-										properties.html = {
-											...elementVariation.html,
-											[languageId]: '',
-										};
-										properties.js = {
-											...elementVariation.js,
-											[languageId]: '',
-										};
+										properties.html = {};
+										properties.js = {};
 									}
 
 									onChange(properties);
 								}}
-								toggled={Boolean(
-									elementVariation.hide[languageId]
-								)}
+								toggled={elementVariation.hide}
 							/>
+
+							{translating ? (
+								<span className="element-variations__not-localizable-label font-weight-lighter mb-1 ml-2 text-2">
+									({Liferay.Language.get('not-localizable')})
+								</span>
+							) : null}
 						</ClayForm.Group>
 
-						{elementVariation.hide[languageId] ? null : (
+						{elementVariation.hide ? null : (
 							<>
 								<CodeEditorField
 									defaultLanguageValue={

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationService.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationService.ts
@@ -8,6 +8,7 @@ import {ElementVariation} from './elementVariationsReducer';
 
 interface AddElementVariationParameters {
 	addElementVariationURL: string;
+	defaultLanguageId: string;
 	elementVariation: ElementVariation;
 	plid: number;
 }
@@ -21,6 +22,7 @@ interface DeleteElementVariationParameters {
 export default {
 	addElementVariation({
 		addElementVariationURL,
+		defaultLanguageId,
 		elementVariation,
 		plid,
 	}: AddElementVariationParameters) {
@@ -30,7 +32,7 @@ export default {
 					audienceEntryERCs: elementVariation.audienceEntryERCs,
 					externalReferenceCode:
 						elementVariation.externalReferenceCode,
-					hideMap: elementVariation.hide,
+					hideMap: {[defaultLanguageId]: elementVariation.hide},
 					htmlMap: elementVariation.html,
 					jsMap: elementVariation.js,
 					name: elementVariation.name,

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariations.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariations.scss
@@ -13,6 +13,11 @@
 		border-radius: 2px;
 	}
 
+	&__default-language-value--empty {
+		border-color: $primary-d2;
+		color: $primary-d2;
+	}
+
 	&__not-localizable-label {
 		color: $secondary-l0;
 	}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariations.tsx
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariations.tsx
@@ -133,6 +133,7 @@ function ElementVariations({
 							onSave={() =>
 								ElementVariationService.addElementVariation({
 									addElementVariationURL,
+									defaultLanguageId,
 									elementVariation: draftElementVariation,
 									plid,
 								}).then(() =>

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationsList.tsx
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationsList.tsx
@@ -11,7 +11,7 @@ import {ElementVariation} from './elementVariationsReducer';
 import {EditableElementOption} from './getEditableElementOptions';
 
 function hasValueInAnyLanguage(
-	localizedValue: Record<string, boolean | string>
+	localizedValue: Record<string, string>
 ): boolean {
 	return Object.values(localizedValue).some(Boolean);
 }
@@ -114,9 +114,7 @@ export default function ElementVariationsList({
 														</ClayLabel>
 													) : null}
 
-													{hasValueInAnyLanguage(
-														elementVariation.hide
-													) ? (
+													{elementVariation.hide ? (
 														<ClayLabel
 															displayType="success"
 															inverse

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationsPreview.tsx
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationsPreview.tsx
@@ -105,9 +105,6 @@ const ElementVariationsPreview = forwardRef<ElementVariationsPreviewRef, Props>(
 				return;
 			}
 
-			const hideValue = Boolean(
-				hide[languageId] ?? hide[defaultLanguageId]
-			);
 			const htmlValue = html[languageId] ?? html[defaultLanguageId] ?? '';
 			const jsValue = js[languageId] ?? js[defaultLanguageId] ?? '';
 
@@ -133,7 +130,7 @@ const ElementVariationsPreview = forwardRef<ElementVariationsPreviewRef, Props>(
 				iframeDocument.body.removeChild(scriptElement);
 			}
 
-			if (hideValue) {
+			if (hide) {
 				styleElement = iframeDocument.createElement('style');
 
 				styleElement.textContent = `${targetElement} { display: none !important; }`;

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/elementVariationsReducer.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/elementVariationsReducer.ts
@@ -10,7 +10,7 @@ import {EditableElementOption} from './getEditableElementOptions';
 export interface ElementVariation {
 	audienceEntryERCs: string[];
 	externalReferenceCode: string;
-	hide: Record<string, boolean>;
+	hide: boolean;
 	html: Record<string, string>;
 	js: Record<string, string>;
 	key: string;
@@ -58,7 +58,7 @@ export function createElementVariation(
 	return {
 		audienceEntryERCs: [],
 		externalReferenceCode: uuidv4(),
-		hide: {},
+		hide: false,
 		html: {},
 		js: {},
 		key: uuidv4(),
@@ -98,14 +98,7 @@ export function createInitialState({
 		editableElementOptions: [],
 		elementVariations: elementVariations.map((elementVariation) => ({
 			...elementVariation,
-			hide: Object.fromEntries(
-				Object.entries(elementVariation.hide).map(
-					([languageId, value]): [string, boolean] => [
-						languageId,
-						value === 'true',
-					]
-				)
-			),
+			hide: elementVariation.hide[defaultLanguageId] === 'true',
 			key: uuidv4(),
 		})),
 		experienceKey:

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/openCodeEditorModal.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/openCodeEditorModal.scss
@@ -1,0 +1,8 @@
+@import 'functions/_global-functions';
+@import 'variables/_globals';
+
+.element-variations__code-editor-modal {
+	.lfr-objects__code-editor-source.form-control {
+		height: 100%;
+	}
+}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/openCodeEditorModal.tsx
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/openCodeEditorModal.tsx
@@ -1,0 +1,94 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayButton from '@clayui/button';
+import ClayModal from '@clayui/modal';
+import {CodeEditor} from '@liferay/object-js-components-web';
+import {openModal} from 'frontend-js-components-web';
+import React, {useState} from 'react';
+
+import './openCodeEditorModal.scss';
+
+interface Props {
+	initialValue: string;
+	mode: 'text/html' | 'text/javascript';
+	onSave: (value: string) => void;
+	title: string;
+}
+
+export default function openCodeEditorModal({
+	initialValue,
+	mode,
+	onSave,
+	title,
+}: Props) {
+	openModal({
+		className: 'element-variations__code-editor-modal',
+		containerProps: {},
+		contentComponent: ({closeModal}: {closeModal: () => void}) => (
+			<CodeEditorModalContent
+				closeModal={closeModal}
+				initialValue={initialValue}
+				mode={mode}
+				onSave={onSave}
+				title={title}
+			/>
+		),
+		size: 'full-screen',
+	});
+}
+
+function CodeEditorModalContent({
+	closeModal,
+	initialValue,
+	mode,
+	onSave,
+	title,
+}: Props & {closeModal: () => void}) {
+	const [content, setContent] = useState(initialValue);
+
+	return (
+		<>
+			<ClayModal.Header
+				closeButtonAriaLabel={Liferay.Language.get('close')}
+			>
+				{title}
+			</ClayModal.Header>
+
+			<ClayModal.Body className="d-flex flex-column">
+				<CodeEditor
+					className="flex-grow-1"
+					mode={mode}
+					onChange={(value) => setContent(value ?? '')}
+					value={initialValue}
+				/>
+			</ClayModal.Body>
+
+			<ClayModal.Footer
+				last={
+					<ClayButton.Group spaced>
+						<ClayButton
+							displayType="secondary"
+							onClick={closeModal}
+						>
+							{Liferay.Language.get('cancel')}
+						</ClayButton>
+
+						<ClayButton
+							displayType="primary"
+							onClick={() => {
+								onSave(content);
+
+								closeModal();
+							}}
+						>
+							{Liferay.Language.get('save')}
+						</ClayButton>
+					</ClayButton.Group>
+				}
+			/>
+		</>
+	);
+}

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/plugins/element_variations/ElementVariationForm.test.tsx
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/plugins/element_variations/ElementVariationForm.test.tsx
@@ -19,7 +19,7 @@ type ElementVariationProp = React.ComponentProps<
 
 const BASE_ELEMENT_VARIATION: ElementVariationProp = {
 	audienceEntryERCs: [],
-	hide: {},
+	hide: false,
 	html: {},
 	js: {},
 	name: 'My Variation',
@@ -98,7 +98,7 @@ describe('ElementVariationForm', () => {
 	});
 
 	it('keeps the toggle but hides the html and js fields while the element is hidden', () => {
-		renderForm({hide: {en_US: true}, targetElement: '.title'});
+		renderForm({hide: true, targetElement: '.title'});
 
 		expect(screen.getByLabelText('hide-page-element')).toBeChecked();
 		expect(screen.queryByLabelText('html')).not.toBeInTheDocument();
@@ -115,15 +115,15 @@ describe('ElementVariationForm', () => {
 		await userEvent.click(screen.getByLabelText('hide-page-element'));
 
 		expect(onChange).toHaveBeenCalledWith({
-			hide: {en_US: true},
-			html: {en_US: ''},
-			js: {en_US: ''},
+			hide: true,
+			html: {},
+			js: {},
 		});
 	});
 
 	it('preserves the html and js values when the element is shown again', async () => {
 		const {onChange} = renderForm({
-			hide: {en_US: true},
+			hide: true,
 			html: {en_US: '<p>Hello</p>'},
 			js: {en_US: 'console.log("hi");'},
 			targetElement: '.title',
@@ -131,16 +131,17 @@ describe('ElementVariationForm', () => {
 
 		await userEvent.click(screen.getByLabelText('hide-page-element'));
 
-		expect(onChange).toHaveBeenCalledWith({hide: {en_US: false}});
+		expect(onChange).toHaveBeenCalledWith({hide: false});
 	});
 
 	it('marks the not-localizable fields as read-only when translating', () => {
 		renderForm({targetElement: '.title'}, TRANSLATING_PROPS);
 
-		expect(screen.getAllByText('(not-localizable)')).toHaveLength(3);
+		expect(screen.getAllByText('(not-localizable)')).toHaveLength(4);
 		expect(screen.getByDisplayValue('My Variation')).toHaveAttribute(
 			'readonly'
 		);
+		expect(screen.getByLabelText('hide-page-element')).toBeDisabled();
 	});
 
 	it('does not mark fields as not-localizable on the default language', () => {
@@ -161,6 +162,14 @@ describe('ElementVariationForm', () => {
 
 		expect(screen.getByText('default html content')).toBeInTheDocument();
 		expect(screen.getByText('default js content')).toBeInTheDocument();
+	});
+
+	it('shows a fallback message when translating a field with no default language value', () => {
+		renderForm({targetElement: '.title'}, TRANSLATING_PROPS);
+
+		expect(
+			screen.getAllByText('there-is-no-default-value-to-localize')
+		).toHaveLength(2);
 	});
 
 	it('has no accessibility violations', async () => {

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/plugins/element_variations/elementVariationsReducer.test.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/plugins/element_variations/elementVariationsReducer.test.ts
@@ -17,7 +17,7 @@ function buildElementVariation(
 	return {
 		audienceEntryERCs: [],
 		externalReferenceCode: '',
-		hide: {},
+		hide: false,
 		html: {},
 		js: {},
 		key: 'key-1',
@@ -48,7 +48,7 @@ describe('elementVariationsReducer', () => {
 
 			expect(elementVariation.segmentsExperienceERC).toBe('experience-1');
 			expect(elementVariation.name).toBe('');
-			expect(elementVariation.hide).toEqual({});
+			expect(elementVariation.hide).toBe(false);
 			expect(elementVariation.key).toBeTruthy();
 
 			expect(createElementVariation('experience-1').key).not.toBe(
@@ -77,7 +77,7 @@ describe('elementVariationsReducer', () => {
 			});
 		});
 
-		it('assigns a key and parses the hide map to each loaded variation', () => {
+		it('assigns a key and derives the hide flag from the default language entry of the hide map', () => {
 			const {draftElementVariation, elementVariations} =
 				createInitialState({
 					defaultLanguageId: 'en_US',
@@ -101,7 +101,7 @@ describe('elementVariationsReducer', () => {
 			expect(elementVariations).toHaveLength(1);
 			expect(elementVariations[0].name).toBe('Variation 1');
 			expect(elementVariations[0].key).toBeTruthy();
-			expect(elementVariations[0].hide).toEqual({en_US: true});
+			expect(elementVariations[0].hide).toBe(true);
 		});
 	});
 
@@ -121,13 +121,13 @@ describe('elementVariationsReducer', () => {
 			const state = reducer(
 				buildState({draftElementVariation: buildElementVariation()}),
 				{
-					properties: {hide: {en_US: true}, name: 'Renamed'},
+					properties: {hide: true, name: 'Renamed'},
 					type: 'UPDATE_ELEMENT_VARIATION_DRAFT',
 				}
 			);
 
 			expect(state.draftElementVariation?.name).toBe('Renamed');
-			expect(state.draftElementVariation?.hide).toEqual({en_US: true});
+			expect(state.draftElementVariation?.hide).toBe(true);
 		});
 
 		it('sets the language on SET_LANGUAGE_ID', () => {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97873

## What Is Being Fixed

Editing an element variation's HTML and JavaScript happens in small sidebar textareas that are impractical for real code. The hide flag is stored and edited per language, even though hiding a page element is not a translatable decision, so translators could change it accidentally and per-language values drifted apart. On top of that, when translating a field whose default language has no value, the form showed nothing where the default value hint normally appears.

## How It Is Being Fixed

The HTML and JavaScript fields move into a shared CodeEditorField component with an expand action that opens a full screen CodeMirror modal through openModal, replacing the previous inline textareas. The hide flag becomes a plain boolean in the frontend model: it is derived from the default language entry when loading and wrapped back into a single entry localized map when saving, so the backend contract stays unchanged, and the toggle is disabled and marked as not localizable while translating. Finally, when translating a field with no default language value, the subtext now falls back to a "There is no default value to localize." message styled with the primary color so the missing default stands out.

## PR Check

**pr-check: PASS** — tested on `dbba1b511ba52e67312d273de9a5b9cb9eced7a0`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "dbba1b511ba52e67312d273de9a5b9cb9eced7a0"} -->
