### PR TITLE
LPD-97683 Require an explicit name on UI configuration @Meta.AD

### DIFF
--- a/modules/util/source-formatter/source-formatter.properties
+++ b/modules/util/source-formatter/source-formatter.properties
@@ -40,6 +40,8 @@
 
     source.check.JavaFeatureFlagManagerUtilCheck.enabled=true
 
+    source.check.JavaMetaAnnotationsCheck.checkMissingName=true
+
     source.check.JavaModuleInheritableVariableAccessModifierCheck.enabled=false
 
     source.check.JavaNewProblemInstantiationParametersCheck.enabled=true

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaMetaAnnotationsCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaMetaAnnotationsCheck.java
@@ -126,7 +126,9 @@ public class JavaMetaAnnotationsCheck extends JavaAnnotationsCheck {
 		String fileName, String absolutePath, String content,
 		String annotation) {
 
-		if (absolutePath.contains("/test/") ||
+		if (absolutePath.contains("/archived/") ||
+			absolutePath.contains("/gradleTest/") ||
+			absolutePath.contains("/test/") ||
 			absolutePath.contains("/testIntegration/") ||
 			annotation.contains("name = ") ||
 			content.contains("generateUI = false") ||

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaMetaAnnotationsCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaMetaAnnotationsCheck.java
@@ -40,6 +40,8 @@ public class JavaMetaAnnotationsCheck extends JavaAnnotationsCheck {
 		}
 
 		_checkDelimiters(fileName, fileContent, annotation);
+		_checkMissingNameAttribute(
+			fileName, absolutePath, fileContent, annotation);
 
 		if (isAttributeValue(_CHECK_CONFIGURATION_NAME_KEY, absolutePath)) {
 			_checkConfigurationNameValue(fileName, fileContent, annotation);
@@ -118,6 +120,26 @@ public class JavaMetaAnnotationsCheck extends JavaAnnotationsCheck {
 			_checkDelimiter(
 				fileName, content, matcher, "name", StringPool.DASH,
 				StringPool.PERIOD);
+		}
+	}
+
+	private void _checkMissingNameAttribute(
+		String fileName, String absolutePath, String content,
+		String annotation) {
+
+		if (!annotation.contains("@Meta.AD") ||
+			!content.contains("@Meta.OCD") ||
+			content.contains("generateUI = false") ||
+			absolutePath.contains("/test/") ||
+			absolutePath.contains("/testIntegration/")) {
+
+			return;
+		}
+
+		if (!annotation.contains("name = ")) {
+			addMessage(
+				fileName, "Missing attribute \"name\" in \"@Meta.AD\"",
+				getLineNumber(content, content.indexOf(annotation)));
 		}
 	}
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaMetaAnnotationsCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaMetaAnnotationsCheck.java
@@ -40,8 +40,7 @@ public class JavaMetaAnnotationsCheck extends JavaAnnotationsCheck {
 		}
 
 		_checkDelimiters(fileName, fileContent, annotation);
-		_checkMissingNameAttribute(
-			fileName, absolutePath, fileContent, annotation);
+		_checkMissingName(fileName, absolutePath, fileContent, annotation);
 
 		if (isAttributeValue(_CHECK_CONFIGURATION_NAME_KEY, absolutePath)) {
 			_checkConfigurationNameValue(fileName, fileContent, annotation);
@@ -123,24 +122,23 @@ public class JavaMetaAnnotationsCheck extends JavaAnnotationsCheck {
 		}
 	}
 
-	private void _checkMissingNameAttribute(
+	private void _checkMissingName(
 		String fileName, String absolutePath, String content,
 		String annotation) {
 
-		if (!annotation.contains("@Meta.AD") ||
-			!content.contains("@Meta.OCD") ||
+		if (absolutePath.contains("/test/") ||
+			absolutePath.contains("/testIntegration/") ||
+			annotation.contains("name = ") ||
 			content.contains("generateUI = false") ||
-			absolutePath.contains("/test/") ||
-			absolutePath.contains("/testIntegration/")) {
+			!annotation.contains("@Meta.AD") ||
+			!content.contains("@Meta.OCD")) {
 
 			return;
 		}
 
-		if (!annotation.contains("name = ")) {
-			addMessage(
-				fileName, "Missing attribute \"name\" in \"@Meta.AD\"",
-				getLineNumber(content, content.indexOf(annotation)));
-		}
+		addMessage(
+			fileName, "Missing attribute \"name\" in \"@Meta.AD\"",
+			getLineNumber(content, content.indexOf(annotation)));
 	}
 
 	private String _fixOCDId(

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaMetaAnnotationsCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaMetaAnnotationsCheck.java
@@ -40,10 +40,13 @@ public class JavaMetaAnnotationsCheck extends JavaAnnotationsCheck {
 		}
 
 		_checkDelimiters(fileName, fileContent, annotation);
-		_checkMissingName(fileName, absolutePath, fileContent, annotation);
 
 		if (isAttributeValue(_CHECK_CONFIGURATION_NAME_KEY, absolutePath)) {
 			_checkConfigurationNameValue(fileName, fileContent, annotation);
+		}
+
+		if (isAttributeValue(_CHECK_MISSING_NAME_KEY, absolutePath)) {
+			_checkMissingName(fileName, absolutePath, fileContent, annotation);
 		}
 
 		annotation = _fixOCDId(
@@ -170,6 +173,8 @@ public class JavaMetaAnnotationsCheck extends JavaAnnotationsCheck {
 
 	private static final String _CHECK_CONFIGURATION_NAME_KEY =
 		"checkConfigurationName";
+
+	private static final String _CHECK_MISSING_NAME_KEY = "checkMissingName";
 
 	private static final Pattern _annotationMetaTypePattern = Pattern.compile(
 		"[\\s\\(](name|description) = \"%");

--- a/modules/util/source-formatter/src/main/resources/documentation/check/java_meta_annotations_check.md
+++ b/modules/util/source-formatter/src/main/resources/documentation/check/java_meta_annotations_check.md
@@ -7,6 +7,10 @@ values of the `id` of the attribute, we use `.` as the delimiter.
 The reason for this is that for `description` and `name` we retrieve translated
 values from `language.properties`.
 
+A `@Meta.AD` in a configuration that generates UI also requires an explicit
+`name`. Without one, bnd derives the name from the method name, which is not a
+language key, so the configuration fails localization at runtime.
+
 ### Example
 
 ```java

--- a/modules/util/source-formatter/src/main/resources/documentation/check/java_meta_annotations_check.md
+++ b/modules/util/source-formatter/src/main/resources/documentation/check/java_meta_annotations_check.md
@@ -20,8 +20,13 @@ language key, so the configuration fails localization at runtime.
     name = "cmis-repository-configuration-name"
 )
 
-@Meta.AD(
-    deflt = "1", description = "delete-depth-description",
-    name = "delete-depth-name", required = false
-)
+public interface ScriptManagementConfiguration {
+
+    @Meta.AD(
+        deflt = "1", description = "delete-depth-description",
+        name = "delete-depth-name", required = false
+    )
+    public int deleteDepth();
+
+}
 ```

--- a/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/JavaSourceProcessorTest.java
+++ b/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/JavaSourceProcessorTest.java
@@ -587,6 +587,13 @@ public class JavaSourceProcessorTest extends BaseSourceProcessorTestCase {
 	}
 
 	@Test
+	public void testMetaAnnotationMissingName() throws Exception {
+		test(
+			"MetaAnnotationMissingName.testjava",
+			"Missing attribute \"name\" in \"@Meta.AD\"", 20);
+	}
+
+	@Test
 	public void testMethodEquals() throws Exception {
 		test(
 			SourceProcessorTestParameters.create(

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/MetaAnnotationMissingName.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/MetaAnnotationMissingName.testjava
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/MetaAnnotationMissingName.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/MetaAnnotationMissingName.testjava
@@ -1,0 +1,26 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies;
+
+import aQute.bnd.annotation.metatype.Meta;
+
+/**
+ * @author Kenji Heigel
+ */
+@Meta.OCD(
+	id = "com.liferay.source.formatter.dependencies.MetaAnnotationMissingName",
+	localization = "content/Language",
+	name = "accessibility-menu-configuration-name"
+)
+public interface MetaAnnotationMissingName {
+
+	@Meta.AD(deflt = "false", required = false)
+	public boolean allowScript();
+
+	@Meta.AD(deflt = "1", name = "delete-depth-name", required = false)
+	public int deleteDepth();
+
+}

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -1246,6 +1246,8 @@
 
     source.check.JavaMetaAnnotationsCheck.checkConfigurationName=true
 
+    source.check.JavaMetaAnnotationsCheck.checkMissingName=true
+
     source.check.JavaModuleClassGetResourceCallCheck.enabled=true
 
     source.check.JavaModuleComponentCheck.allowedClassNames=\


### PR DESCRIPTION
Tested [here](https://github.com/liferay-devtools/liferay-portal/pull/949).

https://liferay.atlassian.net/browse/LPD-97683

## Why this is needed

A configuration that generates UI needs a localized label for every `@Meta.AD` attribute. When the annotation has no explicit `name`, bnd derives the metatype name from the method name, so `allowScriptContentToBeExecutedOrIncluded()` becomes `Allow script content to be executed or included`, which is not a language key. The configuration compiles and passes every local check before it is merged, because nothing verifies that the attribute localization resolves.

The problem only appears later. `ModuleConfigurationLocalizationTest`, an integration test in `portal-smoke-test`, walks every deployed configuration that generates UI and fails with `Missing localization for attributes` when a label does not resolve. On LPD-58498 the migration that made this configuration generate UI (brianchandotcom/liferay-portal#178129) broke the stable upstream master testsuite for roughly ten hours. It took two follow up PRs to resolve, one adding the language keys (brianchandotcom/liferay-portal#178134) and a second adding the missing `name` to the `@Meta.AD` (brianchandotcom/liferay-portal#178137), which is the step this check requires before merge.

## How this catches it

This change extends `JavaMetaAnnotationsCheck` to flag a `@Meta.AD` that has no `name` when the configuration generates UI, meaning the file declares `@Meta.OCD` and does not set `generateUI = false`. Test configurations are skipped. Because Source Formatter runs in `pr-check`, in `formatSource`, and in the CI Source Formatter batch, the missing `name` is now reported on the developer's own change before it is merged. Once the developer adds the `name`, the existing `LanguageKeysCheck` confirms that the value resolves in `Language.properties`. Together the two checks enforce before merge exactly what `ModuleConfigurationLocalizationTest` verifies at runtime.

## Notes for local testing

`JavaSourceProcessorTest` currently fails during setup on master because the `portal-kernel` log wrapper needs `com.liferay.petra.concurrent` and `log4j-core` on the test runtime classpath, and both are declared `compileOnly`. I ran the test with a temporary local `testImplementation` entry for each. The CI unit batch is not affected.

## pr-check

**PASS** — tested on `71e33c8`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Java Unit Tests | PASS |