### PR TITLE
LPD-97984 Process batch engine units without CompletableFuture

### DIFF
--- a/modules/apps/batch-engine/batch-engine-api/bnd.bnd
+++ b/modules/apps/batch-engine/batch-engine-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Batch Engine API
 Bundle-SymbolicName: com.liferay.batch.engine.api
-Bundle-Version: 37.0.1
+Bundle-Version: 38.0.0
 Export-Package:\
 	com.liferay.batch.engine,\
 	com.liferay.batch.engine.action,\

--- a/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/unit/BatchEngineUnitProcessor.java
+++ b/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/unit/BatchEngineUnitProcessor.java
@@ -6,14 +6,14 @@
 package com.liferay.batch.engine.unit;
 
 import java.util.Collection;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * @author Raymond Augé
  */
 public interface BatchEngineUnitProcessor {
 
-	public CompletableFuture<Void> processBatchEngineUnits(
-		Collection<BatchEngineUnit> batchEngineUnits);
+	public void processBatchEngineUnits(
+			Collection<BatchEngineUnit> batchEngineUnits)
+		throws Exception;
 
 }

--- a/modules/apps/batch-engine/batch-engine-api/src/main/resources/com/liferay/batch/engine/unit/packageinfo
+++ b/modules/apps/batch-engine/batch-engine-api/src/main/resources/com/liferay/batch/engine/unit/packageinfo
@@ -1,1 +1,1 @@
-version 5.0.0
+version 6.0.0

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/bundle/BatchEngineBundleTracker.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/bundle/BatchEngineBundleTracker.java
@@ -11,6 +11,8 @@ import com.liferay.batch.engine.unit.BatchEngineUnitMetaInfo;
 import com.liferay.batch.engine.unit.BatchEngineUnitProcessor;
 import com.liferay.batch.engine.unit.BatchEngineUnitReader;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
 import com.liferay.portal.kernel.upgrade.util.UpgradeProcessUtil;
 
@@ -51,6 +53,9 @@ public class BatchEngineBundleTracker {
 	protected void deactivate() {
 		_bundleTracker.close();
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		BatchEngineBundleTracker.class);
 
 	@Reference
 	private BatchEngineUnitProcessor _batchEngineUnitProcessor;
@@ -112,8 +117,16 @@ public class BatchEngineBundleTracker {
 				}
 			}
 
-			_batchEngineUnitProcessor.processBatchEngineUnits(
-				singleCompanyBatchEngineUnits);
+			try {
+				_batchEngineUnitProcessor.processBatchEngineUnits(
+					singleCompanyBatchEngineUnits);
+			}
+			catch (Exception exception) {
+				_log.error(
+					"Unable to process batch engine units of bundle " +
+						bundle.getSymbolicName(),
+					exception);
+			}
 
 			if (multiCompanyBatchEngineUnits.isEmpty()) {
 				return null;

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/installer/BatchEngineFileInstaller.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/installer/BatchEngineFileInstaller.java
@@ -118,8 +118,16 @@ public class BatchEngineFileInstaller implements FileInstaller {
 			_log.info("Deploying batch engine file " + zipFile.getName());
 		}
 
-		_batchEngineUnitProcessor.processBatchEngineUnits(
-			_getBatchEngineUnitsCollection(zipFile));
+		try {
+			_batchEngineUnitProcessor.processBatchEngineUnits(
+				_getBatchEngineUnitsCollection(zipFile));
+		}
+		catch (Exception exception) {
+			_log.error(
+				"Unable to process batch engine units of file " +
+					zipFile.getName(),
+				exception);
+		}
 	}
 
 	private BatchEngineUnitConfiguration _getBatchEngineUnitConfiguration(

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/instance/lifecycle/MultiCompanyBatchEngineUnitPortalInstanceLifecycleListener.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/instance/lifecycle/MultiCompanyBatchEngineUnitPortalInstanceLifecycleListener.java
@@ -14,8 +14,6 @@ import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 
-import java.util.concurrent.CompletableFuture;
-
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
@@ -35,24 +33,22 @@ public class MultiCompanyBatchEngineUnitPortalInstanceLifecycleListener
 
 		if (db.getDBType() == DBType.HYPERSONIC) {
 			TransactionCallbackUtil.registerCommitCallback(
-				() -> _processBatchEngineUnits(company));
+				() -> {
+					_multiCompanyBatchEngineUnitProcessor.
+						processBatchEngineUnits(company);
+
+					return null;
+				});
 		}
 		else {
-			_processBatchEngineUnits(company);
+			_multiCompanyBatchEngineUnitProcessor.processBatchEngineUnits(
+				company);
 		}
 	}
 
 	@Override
 	public void portalInstanceUnregistered(Company company) {
 		_multiCompanyBatchEngineUnitProcessor.unregister(company);
-	}
-
-	private Void _processBatchEngineUnits(Company company) throws Exception {
-		CompletableFuture<Void> completableFuture =
-			_multiCompanyBatchEngineUnitProcessor.processBatchEngineUnits(
-				company);
-
-		return completableFuture.get();
 	}
 
 	@Reference

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/unit/BatchEngineUnitProcessorImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/unit/BatchEngineUnitProcessorImpl.java
@@ -219,6 +219,8 @@ public class BatchEngineUnitProcessorImpl implements BatchEngineUnitProcessor {
 					ServiceReference<Object> serviceReference) {
 
 					try {
+						_markProcessed(batchEngineUnit);
+
 						Object service = _bundleContext.getService(
 							serviceReference);
 
@@ -487,8 +489,6 @@ public class BatchEngineUnitProcessorImpl implements BatchEngineUnitProcessor {
 		if (_isProcessed(batchEngineUnit)) {
 			return null;
 		}
-
-		_markProcessed(batchEngineUnit);
 
 		BatchEngineUnitConfiguration batchEngineUnitConfiguration = null;
 		byte[] content = null;

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/unit/BatchEngineUnitProcessorImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/unit/BatchEngineUnitProcessorImpl.java
@@ -113,7 +113,23 @@ public class BatchEngineUnitProcessorImpl implements BatchEngineUnitProcessor {
 					batchEngineUnit, nextCompletableFuture);
 
 				if (runnable != null) {
-					completableFuture.thenRun(runnable);
+					completableFuture.whenComplete(
+						(result, throwable) -> {
+							if (throwable != null) {
+								nextCompletableFuture.completeExceptionally(
+									throwable);
+
+								return;
+							}
+
+							try {
+								runnable.run();
+							}
+							catch (Throwable throwable2) {
+								nextCompletableFuture.completeExceptionally(
+									throwable2);
+							}
+						});
 
 					completableFuture = nextCompletableFuture;
 				}
@@ -130,6 +146,13 @@ public class BatchEngineUnitProcessorImpl implements BatchEngineUnitProcessor {
 				if (_log.isWarnEnabled()) {
 					_log.warn(exception);
 				}
+
+				CompletableFuture<Void> nextCompletableFuture =
+					new CompletableFuture<>();
+
+				nextCompletableFuture.completeExceptionally(exception);
+
+				completableFuture = nextCompletableFuture;
 			}
 		}
 
@@ -181,14 +204,11 @@ public class BatchEngineUnitProcessorImpl implements BatchEngineUnitProcessor {
 						_execute(
 							batchEngineUnit, batchEngineUnitConfiguration,
 							content, contentType, service, this);
+
+						completableFuture.complete(null);
 					}
 					catch (Exception exception) {
-						if (_log.isWarnEnabled()) {
-							_log.warn(exception);
-						}
-					}
-					finally {
-						completableFuture.complete(null);
+						completableFuture.completeExceptionally(exception);
 					}
 
 					_bundleContext.ungetService(serviceReference);
@@ -247,6 +267,25 @@ public class BatchEngineUnitProcessorImpl implements BatchEngineUnitProcessor {
 			_batchEngineImportTaskExecutor.execute(
 				batchEngineImportTask, batchEngineTaskItemDelegate,
 				batchEngineUnitConfiguration.isCheckPermissions());
+
+			batchEngineImportTask =
+				_batchEngineImportTaskLocalService.getBatchEngineImportTask(
+					batchEngineImportTask.getBatchEngineImportTaskId());
+
+			BatchEngineTaskExecuteStatus batchEngineTaskExecuteStatus =
+				BatchEngineTaskExecuteStatus.valueOf(
+					batchEngineImportTask.getExecuteStatus());
+
+			if (batchEngineTaskExecuteStatus !=
+					BatchEngineTaskExecuteStatus.COMPLETED) {
+
+				throw new Exception(
+					StringBundler.concat(
+						"Unable to deploy batch engine file ",
+						batchEngineUnit.getFileName(), StringPool.SPACE,
+						batchEngineUnit.getDataFileName(), ": ",
+						batchEngineImportTask.getErrorMessage()));
+			}
 		}
 		finally {
 			BatchEngineUnitThreadLocal.setFileName(StringPool.BLANK);

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/unit/BatchEngineUnitProcessorImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/unit/BatchEngineUnitProcessorImpl.java
@@ -53,6 +53,8 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -100,10 +102,20 @@ public class BatchEngineUnitProcessorImpl implements BatchEngineUnitProcessor {
 								CompletableFuture<Void> localCompletableFuture =
 									new CompletableFuture<>();
 
-								Runnable runnable = _processBatchEngineUnit(
-									batchEngineUnit, localCompletableFuture);
+								if (_isProcessed(batchEngineUnit)) {
+									localCompletableFuture.complete(null);
 
-								runnable.run();
+									return localCompletableFuture;
+								}
+
+								List<BatchEngineUnitData> singletonList =
+									Collections.singletonList(
+										_getBatchEngineUnitData(
+											batchEngineUnit));
+
+								_processBatchEngineUnits(
+									singletonList.iterator(),
+									localCompletableFuture);
 
 								return localCompletableFuture;
 							});
@@ -137,33 +149,8 @@ public class BatchEngineUnitProcessorImpl implements BatchEngineUnitProcessor {
 			return completableFuture;
 		}
 
-		completableFuture.complete(null);
-
-		for (BatchEngineUnitData batchEngineUnitData : batchEngineUnitDatas) {
-			CompletableFuture<Void> nextCompletableFuture =
-				new CompletableFuture<>();
-
-			Runnable runnable = _execute(
-				batchEngineUnitData, nextCompletableFuture);
-
-			completableFuture.whenComplete(
-				(result, throwable) -> {
-					if (throwable != null) {
-						nextCompletableFuture.completeExceptionally(throwable);
-
-						return;
-					}
-
-					try {
-						runnable.run();
-					}
-					catch (Throwable throwable2) {
-						nextCompletableFuture.completeExceptionally(throwable2);
-					}
-				});
-
-			completableFuture = nextCompletableFuture;
-		}
+		_processBatchEngineUnits(
+			batchEngineUnitDatas.iterator(), completableFuture);
 
 		return completableFuture;
 	}
@@ -251,8 +238,9 @@ public class BatchEngineUnitProcessorImpl implements BatchEngineUnitProcessor {
 		}
 	}
 
-	private Runnable _execute(
+	private void _execute(
 		BatchEngineUnitData batchEngineUnitData,
+		Iterator<BatchEngineUnitData> iterator,
 		CompletableFuture<Void> completableFuture) {
 
 		BatchEngineUnit batchEngineUnit = batchEngineUnitData._batchEngineUnit;
@@ -283,6 +271,8 @@ public class BatchEngineUnitProcessorImpl implements BatchEngineUnitProcessor {
 					Future<ServiceReference<Object>> future,
 					ServiceReference<Object> serviceReference) {
 
+					boolean imported = false;
+
 					try {
 						_markProcessed(batchEngineUnit);
 
@@ -303,7 +293,7 @@ public class BatchEngineUnitProcessorImpl implements BatchEngineUnitProcessor {
 							batchEngineUnitData._content,
 							batchEngineUnitData._contentType, service);
 
-						completableFuture.complete(null);
+						imported = true;
 					}
 					catch (Throwable throwable) {
 						completableFuture.completeExceptionally(throwable);
@@ -326,11 +316,15 @@ public class BatchEngineUnitProcessorImpl implements BatchEngineUnitProcessor {
 							_log.warn(exception);
 						}
 					}
+
+					if (imported) {
+						_processBatchEngineUnits(iterator, completableFuture);
+					}
 				}
 
 			});
 
-		return serviceTracker::open;
+		serviceTracker.open();
 	}
 
 	private long _getAdminUserId(long companyId) throws PortalException {
@@ -532,17 +526,30 @@ public class BatchEngineUnitProcessorImpl implements BatchEngineUnitProcessor {
 		}
 	}
 
-	private Runnable _processBatchEngineUnit(
-			BatchEngineUnit batchEngineUnit,
-			CompletableFuture<Void> completableFuture)
-		throws Exception {
+	private void _processBatchEngineUnits(
+		Iterator<BatchEngineUnitData> iterator,
+		CompletableFuture<Void> completableFuture) {
 
-		if (_isProcessed(batchEngineUnit)) {
-			return null;
+		// Exactly one thread advances the iterator at any time: the caller
+		// until the current unit's tracker is opened, then only the unit's
+		// single listener firing, which imports the unit and reenters this
+		// method. The handoff is serialized by the unit's
+		// DefaultNoticeableFuture: its set-once semantics pick exactly one
+		// continuation and its listener registration publishes the iterator
+		// state to the continuing thread.
+
+		if (!iterator.hasNext()) {
+			completableFuture.complete(null);
+
+			return;
 		}
 
-		return _execute(
-			_getBatchEngineUnitData(batchEngineUnit), completableFuture);
+		try {
+			_execute(iterator.next(), iterator, completableFuture);
+		}
+		catch (Throwable throwable) {
+			completableFuture.completeExceptionally(throwable);
+		}
 	}
 
 	private BatchEngineUnitConfiguration _updateBatchEngineUnitConfiguration(

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/unit/BatchEngineUnitProcessorImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/unit/BatchEngineUnitProcessorImpl.java
@@ -53,12 +53,12 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
@@ -79,11 +79,14 @@ import org.osgi.util.tracker.ServiceTracker;
 public class BatchEngineUnitProcessorImpl implements BatchEngineUnitProcessor {
 
 	@Override
-	public CompletableFuture<Void> processBatchEngineUnits(
-		Collection<BatchEngineUnit> batchEngineUnits) {
+	public void processBatchEngineUnits(
+			Collection<BatchEngineUnit> batchEngineUnits)
+		throws Exception {
 
 		List<BatchEngineUnitData> batchEngineUnitDatas = new ArrayList<>();
 		Exception exception1 = null;
+		Map<Map.Entry<Long, String>, List<BatchEngineUnit>>
+			featureFlagBatchEngineUnitsMap = new LinkedHashMap<>();
 
 		for (BatchEngineUnit batchEngineUnit : batchEngineUnits) {
 			try {
@@ -94,31 +97,14 @@ public class BatchEngineUnitProcessorImpl implements BatchEngineUnitProcessor {
 					batchEngineUnitMetaInfo.getFeatureFlagKey();
 
 				if (_isFeatureFlagDisabled(featureFlagKey)) {
-					_featureFlagBatchEngineUnitProcessor.
-						registerBatchEngineUnit(
-							batchEngineUnitMetaInfo.getCompanyId(),
-							featureFlagKey,
-							() -> {
-								CompletableFuture<Void> localCompletableFuture =
-									new CompletableFuture<>();
+					List<BatchEngineUnit> featureFlagBatchEngineUnits =
+						featureFlagBatchEngineUnitsMap.computeIfAbsent(
+							Map.entry(
+								batchEngineUnitMetaInfo.getCompanyId(),
+								featureFlagKey),
+							key -> new ArrayList<>());
 
-								if (_isProcessed(batchEngineUnit)) {
-									localCompletableFuture.complete(null);
-
-									return localCompletableFuture;
-								}
-
-								List<BatchEngineUnitData> singletonList =
-									Collections.singletonList(
-										_getBatchEngineUnitData(
-											batchEngineUnit));
-
-								_processBatchEngineUnits(
-									singletonList.iterator(),
-									localCompletableFuture);
-
-								return localCompletableFuture;
-							});
+					featureFlagBatchEngineUnits.add(batchEngineUnit);
 
 					continue;
 				}
@@ -141,18 +127,32 @@ public class BatchEngineUnitProcessorImpl implements BatchEngineUnitProcessor {
 			}
 		}
 
-		CompletableFuture<Void> completableFuture = new CompletableFuture<>();
+		for (Map.Entry<Map.Entry<Long, String>, List<BatchEngineUnit>> entry :
+				featureFlagBatchEngineUnitsMap.entrySet()) {
 
-		if (exception1 != null) {
-			completableFuture.completeExceptionally(exception1);
+			Map.Entry<Long, String> key = entry.getKey();
 
-			return completableFuture;
+			long companyId = key.getKey();
+			String featureFlagKey = key.getValue();
+
+			_featureFlagBatchEngineUnitProcessor.registerBatchEngineUnits(
+				companyId, featureFlagKey,
+				() -> _processFeatureFlagBatchEngineUnits(
+					entry.getValue(), companyId, featureFlagKey));
 		}
 
-		_processBatchEngineUnits(
-			batchEngineUnitDatas.iterator(), completableFuture);
+		if (exception1 != null) {
+			throw exception1;
+		}
 
-		return completableFuture;
+		DefaultNoticeableFuture<Void> defaultNoticeableFuture =
+			new DefaultNoticeableFuture<>();
+
+		_processBatchEngineUnits(
+			batchEngineUnitDatas.iterator(), defaultNoticeableFuture);
+
+		_processDefaultNoticeableFuture(
+			defaultNoticeableFuture, "Unable to process batch engine units");
 	}
 
 	@Activate
@@ -241,12 +241,13 @@ public class BatchEngineUnitProcessorImpl implements BatchEngineUnitProcessor {
 	private void _execute(
 		BatchEngineUnitData batchEngineUnitData,
 		Iterator<BatchEngineUnitData> iterator,
-		CompletableFuture<Void> completableFuture) {
+		DefaultNoticeableFuture<Void> defaultNoticeableFuture) {
 
 		BatchEngineUnit batchEngineUnit = batchEngineUnitData._batchEngineUnit;
 
 		DefaultNoticeableFuture<ServiceReference<Object>>
-			defaultNoticeableFuture = new DefaultNoticeableFuture<>();
+			serviceReferenceDefaultNoticeableFuture =
+				new DefaultNoticeableFuture<>();
 
 		ServiceTracker<Object, Object> serviceTracker =
 			new ServiceTracker<Object, Object>(
@@ -256,14 +257,15 @@ public class BatchEngineUnitProcessorImpl implements BatchEngineUnitProcessor {
 				public Object addingService(
 					ServiceReference<Object> serviceReference) {
 
-					defaultNoticeableFuture.set(serviceReference);
+					serviceReferenceDefaultNoticeableFuture.set(
+						serviceReference);
 
 					return null;
 				}
 
 			};
 
-		defaultNoticeableFuture.addFutureListener(
+		serviceReferenceDefaultNoticeableFuture.addFutureListener(
 			new BaseFutureListener<>() {
 
 				@Override
@@ -296,7 +298,7 @@ public class BatchEngineUnitProcessorImpl implements BatchEngineUnitProcessor {
 						imported = true;
 					}
 					catch (Throwable throwable) {
-						completableFuture.completeExceptionally(throwable);
+						defaultNoticeableFuture.setException(throwable);
 					}
 
 					try {
@@ -318,13 +320,24 @@ public class BatchEngineUnitProcessorImpl implements BatchEngineUnitProcessor {
 					}
 
 					if (imported) {
-						_processBatchEngineUnits(iterator, completableFuture);
+						_processBatchEngineUnits(
+							iterator, defaultNoticeableFuture);
 					}
 				}
 
 			});
 
 		serviceTracker.open();
+
+		if (!serviceReferenceDefaultNoticeableFuture.isDone() &&
+			_log.isInfoEnabled()) {
+
+			_log.info(
+				StringBundler.concat(
+					"Waiting for a service matching ",
+					batchEngineUnitData._filter, " to process ",
+					batchEngineUnit.getDataFileName()));
+		}
 	}
 
 	private long _getAdminUserId(long companyId) throws PortalException {
@@ -528,7 +541,7 @@ public class BatchEngineUnitProcessorImpl implements BatchEngineUnitProcessor {
 
 	private void _processBatchEngineUnits(
 		Iterator<BatchEngineUnitData> iterator,
-		CompletableFuture<Void> completableFuture) {
+		DefaultNoticeableFuture<Void> defaultNoticeableFuture) {
 
 		// Exactly one thread advances the iterator at any time: the caller
 		// until the current unit's tracker is opened, then only the unit's
@@ -539,17 +552,87 @@ public class BatchEngineUnitProcessorImpl implements BatchEngineUnitProcessor {
 		// state to the continuing thread.
 
 		if (!iterator.hasNext()) {
-			completableFuture.complete(null);
+			defaultNoticeableFuture.set(null);
 
 			return;
 		}
 
 		try {
-			_execute(iterator.next(), iterator, completableFuture);
+			_execute(iterator.next(), iterator, defaultNoticeableFuture);
 		}
 		catch (Throwable throwable) {
-			completableFuture.completeExceptionally(throwable);
+			defaultNoticeableFuture.setException(throwable);
 		}
+	}
+
+	private void _processDefaultNoticeableFuture(
+			DefaultNoticeableFuture<Void> defaultNoticeableFuture,
+			String message)
+		throws Exception {
+
+		if (defaultNoticeableFuture.isDone()) {
+			try {
+				defaultNoticeableFuture.get();
+			}
+			catch (ExecutionException executionException) {
+				Throwable throwable = executionException.getCause();
+
+				if (throwable instanceof Exception exception) {
+					throw exception;
+				}
+
+				throw executionException;
+			}
+			catch (InterruptedException interruptedException) {
+				Thread currentThread = Thread.currentThread();
+
+				currentThread.interrupt();
+
+				throw interruptedException;
+			}
+
+			return;
+		}
+
+		defaultNoticeableFuture.addFutureListener(
+			new BaseFutureListener<>() {
+
+				@Override
+				public void completeWithException(
+					Future<Void> future, Throwable throwable) {
+
+					_log.error(message, throwable);
+				}
+
+			});
+	}
+
+	private void _processFeatureFlagBatchEngineUnits(
+			List<BatchEngineUnit> batchEngineUnits, long companyId,
+			String featureFlagKey)
+		throws Exception {
+
+		List<BatchEngineUnitData> batchEngineUnitDatas = new ArrayList<>();
+
+		for (BatchEngineUnit batchEngineUnit : batchEngineUnits) {
+			if (_isProcessed(batchEngineUnit)) {
+				continue;
+			}
+
+			batchEngineUnitDatas.add(_getBatchEngineUnitData(batchEngineUnit));
+		}
+
+		DefaultNoticeableFuture<Void> defaultNoticeableFuture =
+			new DefaultNoticeableFuture<>();
+
+		_processBatchEngineUnits(
+			batchEngineUnitDatas.iterator(), defaultNoticeableFuture);
+
+		_processDefaultNoticeableFuture(
+			defaultNoticeableFuture,
+			StringBundler.concat(
+				"Unable to process batch engine units deferred for feature ",
+				"flag ", featureFlagKey, " in company ", companyId));
 	}
 
 	private BatchEngineUnitConfiguration _updateBatchEngineUnitConfiguration(

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/unit/BatchEngineUnitProcessorImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/unit/BatchEngineUnitProcessorImpl.java
@@ -50,8 +50,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
@@ -61,6 +63,7 @@ import java.util.zip.ZipOutputStream;
 
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
+import org.osgi.framework.Filter;
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -77,9 +80,8 @@ public class BatchEngineUnitProcessorImpl implements BatchEngineUnitProcessor {
 	public CompletableFuture<Void> processBatchEngineUnits(
 		Collection<BatchEngineUnit> batchEngineUnits) {
 
-		CompletableFuture<Void> completableFuture = new CompletableFuture<>();
-
-		completableFuture.complete(null);
+		List<BatchEngineUnitData> batchEngineUnitDatas = new ArrayList<>();
+		Exception exception1 = null;
 
 		for (BatchEngineUnit batchEngineUnit : batchEngineUnits) {
 			try {
@@ -109,54 +111,58 @@ public class BatchEngineUnitProcessorImpl implements BatchEngineUnitProcessor {
 					continue;
 				}
 
-				CompletableFuture<Void> nextCompletableFuture =
-					new CompletableFuture<>();
-
-				Runnable runnable = _processBatchEngineUnit(
-					batchEngineUnit, nextCompletableFuture);
-
-				if (runnable != null) {
-					completableFuture.whenComplete(
-						(result, throwable) -> {
-							if (throwable != null) {
-								nextCompletableFuture.completeExceptionally(
-									throwable);
-
-								return;
-							}
-
-							try {
-								runnable.run();
-							}
-							catch (Throwable throwable2) {
-								nextCompletableFuture.completeExceptionally(
-									throwable2);
-							}
-						});
-
-					completableFuture = nextCompletableFuture;
+				if ((exception1 != null) || _isProcessed(batchEngineUnit)) {
+					continue;
 				}
 
-				if (_log.isInfoEnabled()) {
-					_log.info(
-						StringBundler.concat(
-							"Successfully enqueued batch file ",
-							batchEngineUnit.getFileName(), " ",
-							batchEngineUnit.getDataFileName()));
-				}
+				batchEngineUnitDatas.add(
+					_getBatchEngineUnitData(batchEngineUnit));
 			}
-			catch (Exception exception) {
+			catch (Exception exception2) {
 				if (_log.isWarnEnabled()) {
-					_log.warn(exception);
+					_log.warn(exception2);
 				}
 
-				CompletableFuture<Void> nextCompletableFuture =
-					new CompletableFuture<>();
-
-				nextCompletableFuture.completeExceptionally(exception);
-
-				completableFuture = nextCompletableFuture;
+				if (exception1 == null) {
+					exception1 = exception2;
+				}
 			}
+		}
+
+		CompletableFuture<Void> completableFuture = new CompletableFuture<>();
+
+		if (exception1 != null) {
+			completableFuture.completeExceptionally(exception1);
+
+			return completableFuture;
+		}
+
+		completableFuture.complete(null);
+
+		for (BatchEngineUnitData batchEngineUnitData : batchEngineUnitDatas) {
+			CompletableFuture<Void> nextCompletableFuture =
+				new CompletableFuture<>();
+
+			Runnable runnable = _execute(
+				batchEngineUnitData, nextCompletableFuture);
+
+			completableFuture.whenComplete(
+				(result, throwable) -> {
+					if (throwable != null) {
+						nextCompletableFuture.completeExceptionally(throwable);
+
+						return;
+					}
+
+					try {
+						runnable.run();
+					}
+					catch (Throwable throwable2) {
+						nextCompletableFuture.completeExceptionally(throwable2);
+					}
+				});
+
+			completableFuture = nextCompletableFuture;
 		}
 
 		return completableFuture;
@@ -165,105 +171,6 @@ public class BatchEngineUnitProcessorImpl implements BatchEngineUnitProcessor {
 	@Activate
 	protected void activate(BundleContext bundleContext) {
 		_bundleContext = bundleContext;
-	}
-
-	private Runnable _execute(
-			BatchEngineUnit batchEngineUnit,
-			BatchEngineUnitConfiguration batchEngineUnitConfiguration,
-			byte[] content, String contentType,
-			CompletableFuture<Void> completableFuture)
-		throws Exception {
-
-		DefaultNoticeableFuture<ServiceReference<Object>>
-			defaultNoticeableFuture = new DefaultNoticeableFuture<>();
-
-		ServiceTracker<Object, Object> serviceTracker =
-			new ServiceTracker<Object, Object>(
-				_bundleContext,
-				_bundleContext.createFilter(
-					StringBundler.concat(
-						"(|(&(batch.engine.entity.class.name=",
-						batchEngineUnitConfiguration.getClassName(), ")",
-						"(!(batch.engine.task.item.delegate.name=*)))",
-						"(&(batch.engine.entity.class.name=",
-						_getObjectEntryClassName(batchEngineUnitConfiguration),
-						")(batch.engine.task.item.delegate=true)",
-						"(batch.engine.task.item.delegate.name=",
-						batchEngineUnitConfiguration.getTaskItemDelegateName(),
-						")(companyId=",
-						batchEngineUnitConfiguration.getCompanyId(),
-						"))(&(batch.engine.entity.class.name=",
-						batchEngineUnitConfiguration.getClassName(),
-						")(batch.engine.task.item.delegate.name=",
-						batchEngineUnitConfiguration.getTaskItemDelegateName(),
-						")))")),
-				null) {
-
-				@Override
-				public Object addingService(
-					ServiceReference<Object> serviceReference) {
-
-					defaultNoticeableFuture.set(serviceReference);
-
-					return null;
-				}
-
-			};
-
-		defaultNoticeableFuture.addFutureListener(
-			new BaseFutureListener<>() {
-
-				@Override
-				public void completeWithResult(
-					Future<ServiceReference<Object>> future,
-					ServiceReference<Object> serviceReference) {
-
-					try {
-						_markProcessed(batchEngineUnit);
-
-						Object service = _bundleContext.getService(
-							serviceReference);
-
-						if (service == null) {
-							throw new IllegalStateException(
-								StringBundler.concat(
-									"Unable to get service ", serviceReference,
-									" to process ",
-									batchEngineUnit.getDataFileName()));
-						}
-
-						_execute(
-							batchEngineUnit, batchEngineUnitConfiguration,
-							content, contentType, service);
-
-						completableFuture.complete(null);
-					}
-					catch (Throwable throwable) {
-						completableFuture.completeExceptionally(throwable);
-					}
-
-					try {
-						_bundleContext.ungetService(serviceReference);
-					}
-					catch (Exception exception) {
-						if (_log.isWarnEnabled()) {
-							_log.warn(exception);
-						}
-					}
-
-					try {
-						serviceTracker.close();
-					}
-					catch (Exception exception) {
-						if (_log.isWarnEnabled()) {
-							_log.warn(exception);
-						}
-					}
-				}
-
-			});
-
-		return serviceTracker::open;
 	}
 
 	private void _execute(
@@ -344,6 +251,88 @@ public class BatchEngineUnitProcessorImpl implements BatchEngineUnitProcessor {
 		}
 	}
 
+	private Runnable _execute(
+		BatchEngineUnitData batchEngineUnitData,
+		CompletableFuture<Void> completableFuture) {
+
+		BatchEngineUnit batchEngineUnit = batchEngineUnitData._batchEngineUnit;
+
+		DefaultNoticeableFuture<ServiceReference<Object>>
+			defaultNoticeableFuture = new DefaultNoticeableFuture<>();
+
+		ServiceTracker<Object, Object> serviceTracker =
+			new ServiceTracker<Object, Object>(
+				_bundleContext, batchEngineUnitData._filter, null) {
+
+				@Override
+				public Object addingService(
+					ServiceReference<Object> serviceReference) {
+
+					defaultNoticeableFuture.set(serviceReference);
+
+					return null;
+				}
+
+			};
+
+		defaultNoticeableFuture.addFutureListener(
+			new BaseFutureListener<>() {
+
+				@Override
+				public void completeWithResult(
+					Future<ServiceReference<Object>> future,
+					ServiceReference<Object> serviceReference) {
+
+					try {
+						_markProcessed(batchEngineUnit);
+
+						Object service = _bundleContext.getService(
+							serviceReference);
+
+						if (service == null) {
+							throw new IllegalStateException(
+								StringBundler.concat(
+									"Unable to get service ", serviceReference,
+									" to process ",
+									batchEngineUnit.getDataFileName()));
+						}
+
+						_execute(
+							batchEngineUnit,
+							batchEngineUnitData._batchEngineUnitConfiguration,
+							batchEngineUnitData._content,
+							batchEngineUnitData._contentType, service);
+
+						completableFuture.complete(null);
+					}
+					catch (Throwable throwable) {
+						completableFuture.completeExceptionally(throwable);
+					}
+
+					try {
+						_bundleContext.ungetService(serviceReference);
+					}
+					catch (Exception exception) {
+						if (_log.isWarnEnabled()) {
+							_log.warn(exception);
+						}
+					}
+
+					try {
+						serviceTracker.close();
+					}
+					catch (Exception exception) {
+						if (_log.isWarnEnabled()) {
+							_log.warn(exception);
+						}
+					}
+				}
+
+			});
+
+		return serviceTracker::open;
+	}
+
 	private long _getAdminUserId(long companyId) throws PortalException {
 		try (SafeCloseable safeCloseable =
 				CompanyThreadLocal.setCompanyIdWithSafeCloseable(companyId)) {
@@ -366,6 +355,68 @@ public class BatchEngineUnitProcessorImpl implements BatchEngineUnitProcessor {
 					"No active user exists in company ", companyId,
 					" with role ", role.getName()));
 		}
+	}
+
+	private BatchEngineUnitData _getBatchEngineUnitData(
+			BatchEngineUnit batchEngineUnit)
+		throws Exception {
+
+		BatchEngineUnitConfiguration batchEngineUnitConfiguration = null;
+		byte[] content = null;
+		String contentType = null;
+
+		if (batchEngineUnit.isValid()) {
+			batchEngineUnitConfiguration =
+				batchEngineUnit.getBatchEngineUnitConfiguration();
+
+			UnsyncByteArrayOutputStream compressedUnsyncByteArrayOutputStream =
+				new UnsyncByteArrayOutputStream();
+
+			try (InputStream inputStream = batchEngineUnit.getDataInputStream();
+				ZipOutputStream zipOutputStream = new ZipOutputStream(
+					compressedUnsyncByteArrayOutputStream)) {
+
+				zipOutputStream.putNextEntry(
+					new ZipEntry(batchEngineUnit.getDataFileName()));
+
+				StreamUtil.transfer(inputStream, zipOutputStream, false);
+			}
+
+			content = compressedUnsyncByteArrayOutputStream.toByteArray();
+
+			contentType = _file.getExtension(batchEngineUnit.getDataFileName());
+		}
+
+		if ((batchEngineUnitConfiguration == null) || (content == null) ||
+			Validator.isNull(contentType)) {
+
+			throw new IllegalStateException(
+				StringBundler.concat(
+					"Invalid batch engine file ", batchEngineUnit.getFileName(),
+					" ", batchEngineUnit.getDataFileName()));
+		}
+
+		batchEngineUnitConfiguration = _updateBatchEngineUnitConfiguration(
+			batchEngineUnitConfiguration);
+
+		return new BatchEngineUnitData(
+			batchEngineUnit, batchEngineUnitConfiguration, content, contentType,
+			_bundleContext.createFilter(
+				StringBundler.concat(
+					"(|(&(batch.engine.entity.class.name=",
+					batchEngineUnitConfiguration.getClassName(), ")",
+					"(!(batch.engine.task.item.delegate.name=*)))",
+					"(&(batch.engine.entity.class.name=",
+					_getObjectEntryClassName(batchEngineUnitConfiguration),
+					")(batch.engine.task.item.delegate=true)",
+					"(batch.engine.task.item.delegate.name=",
+					batchEngineUnitConfiguration.getTaskItemDelegateName(),
+					")(companyId=", batchEngineUnitConfiguration.getCompanyId(),
+					"))(&(batch.engine.entity.class.name=",
+					batchEngineUnitConfiguration.getClassName(),
+					")(batch.engine.task.item.delegate.name=",
+					batchEngineUnitConfiguration.getTaskItemDelegateName(),
+					")))")));
 	}
 
 	private Bundle _getBundle(BatchEngineUnit batchEngineUnit) {
@@ -490,45 +541,8 @@ public class BatchEngineUnitProcessorImpl implements BatchEngineUnitProcessor {
 			return null;
 		}
 
-		BatchEngineUnitConfiguration batchEngineUnitConfiguration = null;
-		byte[] content = null;
-		String contentType = null;
-
-		if (batchEngineUnit.isValid()) {
-			batchEngineUnitConfiguration =
-				batchEngineUnit.getBatchEngineUnitConfiguration();
-
-			UnsyncByteArrayOutputStream compressedUnsyncByteArrayOutputStream =
-				new UnsyncByteArrayOutputStream();
-
-			try (InputStream inputStream = batchEngineUnit.getDataInputStream();
-				ZipOutputStream zipOutputStream = new ZipOutputStream(
-					compressedUnsyncByteArrayOutputStream)) {
-
-				zipOutputStream.putNextEntry(
-					new ZipEntry(batchEngineUnit.getDataFileName()));
-
-				StreamUtil.transfer(inputStream, zipOutputStream, false);
-			}
-
-			content = compressedUnsyncByteArrayOutputStream.toByteArray();
-
-			contentType = _file.getExtension(batchEngineUnit.getDataFileName());
-		}
-
-		if ((batchEngineUnitConfiguration == null) || (content == null) ||
-			Validator.isNull(contentType)) {
-
-			throw new IllegalStateException(
-				StringBundler.concat(
-					"Invalid batch engine file ", batchEngineUnit.getFileName(),
-					" ", batchEngineUnit.getDataFileName()));
-		}
-
 		return _execute(
-			batchEngineUnit,
-			_updateBatchEngineUnitConfiguration(batchEngineUnitConfiguration),
-			content, contentType, completableFuture);
+			_getBatchEngineUnitData(batchEngineUnit), completableFuture);
 	}
 
 	private BatchEngineUnitConfiguration _updateBatchEngineUnitConfiguration(
@@ -607,5 +621,28 @@ public class BatchEngineUnitProcessorImpl implements BatchEngineUnitProcessor {
 
 	@Reference
 	private UserLocalService _userLocalService;
+
+	private static class BatchEngineUnitData {
+
+		private BatchEngineUnitData(
+			BatchEngineUnit batchEngineUnit,
+			BatchEngineUnitConfiguration batchEngineUnitConfiguration,
+			byte[] content, String contentType, Filter filter) {
+
+			_batchEngineUnit = batchEngineUnit;
+			_batchEngineUnitConfiguration = batchEngineUnitConfiguration;
+			_content = content;
+			_contentType = contentType;
+			_filter = filter;
+		}
+
+		private final BatchEngineUnit _batchEngineUnit;
+		private final BatchEngineUnitConfiguration
+			_batchEngineUnitConfiguration;
+		private final byte[] _content;
+		private final String _contentType;
+		private final Filter _filter;
+
+	}
 
 }

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/unit/BatchEngineUnitProcessorImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/unit/BatchEngineUnitProcessorImpl.java
@@ -353,6 +353,23 @@ public class BatchEngineUnitProcessorImpl implements BatchEngineUnitProcessor {
 		return className;
 	}
 
+	private java.io.File _getProcessedFile(
+			BatchEngineUnit batchEngineUnit, Bundle bundle)
+		throws IOException {
+
+		BatchEngineUnitConfiguration batchEngineUnitConfiguration =
+			batchEngineUnit.getBatchEngineUnitConfiguration();
+
+		String dataFileName = batchEngineUnit.getDataFileName();
+
+		return bundle.getDataFile(
+			com.liferay.petra.string.StringUtil.merge(
+				Arrays.asList(
+					dataFileName.replaceAll("\\W+", "."),
+					batchEngineUnitConfiguration.getCompanyId(), "processed"),
+				"."));
+	}
+
 	private boolean _isFeatureFlagDisabled(String featureFlagKey) {
 		if (Validator.isNotNull(featureFlagKey) &&
 			!FeatureFlagManagerUtil.isEnabled(featureFlagKey)) {
@@ -371,37 +388,20 @@ public class BatchEngineUnitProcessorImpl implements BatchEngineUnitProcessor {
 		}
 
 		try {
-			BatchEngineUnitConfiguration batchEngineUnitConfiguration =
-				batchEngineUnit.getBatchEngineUnitConfiguration();
-
-			String dataFileName = batchEngineUnit.getDataFileName();
-
-			java.io.File processedFile = bundle.getDataFile(
-				com.liferay.petra.string.StringUtil.merge(
-					Arrays.asList(
-						dataFileName.replaceAll("\\W+", "."),
-						batchEngineUnitConfiguration.getCompanyId(),
-						"processed"),
-					"."));
+			java.io.File processedFile = _getProcessedFile(
+				batchEngineUnit, bundle);
 
 			if (processedFile == null) {
 				return false;
 			}
 
-			String lastModifiedString = String.valueOf(
-				bundle.getLastModified());
-
 			if (processedFile.exists() &&
-				Objects.equals(_file.read(processedFile), lastModifiedString)) {
+				Objects.equals(
+					_file.read(processedFile),
+					String.valueOf(bundle.getLastModified()))) {
 
 				return true;
 			}
-
-			if (!processedFile.exists()) {
-				processedFile.createNewFile();
-			}
-
-			_file.write(processedFile, lastModifiedString, true);
 
 			return false;
 		}
@@ -412,6 +412,33 @@ public class BatchEngineUnitProcessorImpl implements BatchEngineUnitProcessor {
 		return false;
 	}
 
+	private void _markProcessed(BatchEngineUnit batchEngineUnit) {
+		Bundle bundle = _getBundle(batchEngineUnit);
+
+		if (bundle == null) {
+			return;
+		}
+
+		try {
+			java.io.File processedFile = _getProcessedFile(
+				batchEngineUnit, bundle);
+
+			if (processedFile == null) {
+				return;
+			}
+
+			if (!processedFile.exists()) {
+				processedFile.createNewFile();
+			}
+
+			_file.write(
+				processedFile, String.valueOf(bundle.getLastModified()), true);
+		}
+		catch (IOException ioException) {
+			ReflectionUtil.throwException(ioException);
+		}
+	}
+
 	private Runnable _processBatchEngineUnit(
 			BatchEngineUnit batchEngineUnit,
 			CompletableFuture<Void> completableFuture)
@@ -420,6 +447,8 @@ public class BatchEngineUnitProcessorImpl implements BatchEngineUnitProcessor {
 		if (_isProcessed(batchEngineUnit)) {
 			return null;
 		}
+
+		_markProcessed(batchEngineUnit);
 
 		BatchEngineUnitConfiguration batchEngineUnitConfiguration = null;
 		byte[] content = null;

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/unit/BatchEngineUnitProcessorImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/unit/BatchEngineUnitProcessorImpl.java
@@ -19,6 +19,8 @@ import com.liferay.batch.engine.unit.BatchEngineUnitMetaInfo;
 import com.liferay.batch.engine.unit.BatchEngineUnitProcessor;
 import com.liferay.batch.engine.unit.BatchEngineUnitThreadLocal;
 import com.liferay.batch.engine.unit.BundleBatchEngineUnit;
+import com.liferay.petra.concurrent.BaseFutureListener;
+import com.liferay.petra.concurrent.DefaultNoticeableFuture;
 import com.liferay.petra.io.StreamUtil;
 import com.liferay.petra.io.unsync.UnsyncByteArrayOutputStream;
 import com.liferay.petra.lang.SafeCloseable;
@@ -53,6 +55,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -171,6 +174,9 @@ public class BatchEngineUnitProcessorImpl implements BatchEngineUnitProcessor {
 			CompletableFuture<Void> completableFuture)
 		throws Exception {
 
+		DefaultNoticeableFuture<ServiceReference<Object>>
+			defaultNoticeableFuture = new DefaultNoticeableFuture<>();
+
 		ServiceTracker<Object, Object> serviceTracker =
 			new ServiceTracker<Object, Object>(
 				_bundleContext,
@@ -197,26 +203,63 @@ public class BatchEngineUnitProcessorImpl implements BatchEngineUnitProcessor {
 				public Object addingService(
 					ServiceReference<Object> serviceReference) {
 
-					Object service = _bundleContext.getService(
-						serviceReference);
-
-					try {
-						_execute(
-							batchEngineUnit, batchEngineUnitConfiguration,
-							content, contentType, service, this);
-
-						completableFuture.complete(null);
-					}
-					catch (Exception exception) {
-						completableFuture.completeExceptionally(exception);
-					}
-
-					_bundleContext.ungetService(serviceReference);
+					defaultNoticeableFuture.set(serviceReference);
 
 					return null;
 				}
 
 			};
+
+		defaultNoticeableFuture.addFutureListener(
+			new BaseFutureListener<>() {
+
+				@Override
+				public void completeWithResult(
+					Future<ServiceReference<Object>> future,
+					ServiceReference<Object> serviceReference) {
+
+					try {
+						Object service = _bundleContext.getService(
+							serviceReference);
+
+						if (service == null) {
+							throw new IllegalStateException(
+								StringBundler.concat(
+									"Unable to get service ", serviceReference,
+									" to process ",
+									batchEngineUnit.getDataFileName()));
+						}
+
+						_execute(
+							batchEngineUnit, batchEngineUnitConfiguration,
+							content, contentType, service);
+
+						completableFuture.complete(null);
+					}
+					catch (Throwable throwable) {
+						completableFuture.completeExceptionally(throwable);
+					}
+
+					try {
+						_bundleContext.ungetService(serviceReference);
+					}
+					catch (Exception exception) {
+						if (_log.isWarnEnabled()) {
+							_log.warn(exception);
+						}
+					}
+
+					try {
+						serviceTracker.close();
+					}
+					catch (Exception exception) {
+						if (_log.isWarnEnabled()) {
+							_log.warn(exception);
+						}
+					}
+				}
+
+			});
 
 		return serviceTracker::open;
 	}
@@ -224,8 +267,7 @@ public class BatchEngineUnitProcessorImpl implements BatchEngineUnitProcessor {
 	private void _execute(
 			BatchEngineUnit batchEngineUnit,
 			BatchEngineUnitConfiguration batchEngineUnitConfiguration,
-			byte[] content, String contentType, Object service,
-			ServiceTracker<Object, Object> serviceTracker)
+			byte[] content, String contentType, Object service)
 		throws Exception {
 
 		int importStrategy =
@@ -298,8 +340,6 @@ public class BatchEngineUnitProcessorImpl implements BatchEngineUnitProcessor {
 					batchEngineUnit.getFileName(), " ",
 					batchEngineUnit.getDataFileName()));
 		}
-
-		serviceTracker.close();
 	}
 
 	private long _getAdminUserId(long companyId) throws PortalException {

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/unit/FeatureFlagBatchEngineUnitProcessor.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/unit/FeatureFlagBatchEngineUnitProcessor.java
@@ -88,45 +88,41 @@ public class FeatureFlagBatchEngineUnitProcessor {
 				return;
 			}
 
-			Tuple tuple = _getTuple(companyId, featureFlagKey);
+			List<UnsafeSupplier<CompletableFuture<Void>, Exception>>
+				unsafeSuppliers = _unsafeSuppliers.remove(
+					_getTuple(companyId, featureFlagKey));
 
-			if (!_unsafeSuppliers.containsKey(tuple)) {
+			if (unsafeSuppliers == null) {
 				return;
 			}
 
-			synchronized (_unsafeSuppliers) {
-				List<UnsafeSupplier<CompletableFuture<Void>, Exception>>
-					unsafeSuppliers = _unsafeSuppliers.remove(tuple);
+			ExecutorService executorService =
+				_portalExecutorManager.getPortalExecutor(
+					FeatureFlagListenerImpl.class.getName());
 
-				ExecutorService executorService =
-					_portalExecutorManager.getPortalExecutor(
-						FeatureFlagListenerImpl.class.getName());
+			executorService.submit(
+				() -> {
+					for (UnsafeSupplier<CompletableFuture<Void>, Exception>
+							unsafeSupplier : unsafeSuppliers) {
 
-				executorService.submit(
-					() -> {
-						for (UnsafeSupplier<CompletableFuture<Void>, Exception>
-								unsafeSupplier : unsafeSuppliers) {
+						try {
+							CompletableFuture<Void> completableFuture =
+								unsafeSupplier.get();
 
-							try {
-								CompletableFuture<Void> completableFuture =
-									unsafeSupplier.get();
-
-								completableFuture.get();
-							}
-							catch (Exception exception) {
-								_log.error(
-									StringBundler.concat(
-										"Unable to process batch engine units ",
-										"deferred for feature flag ",
-										featureFlagKey, " in company ",
-										companyId),
-									exception);
-
-								return;
-							}
+							completableFuture.get();
 						}
-					});
-			}
+						catch (Exception exception) {
+							_log.error(
+								StringBundler.concat(
+									"Unable to process batch engine units ",
+									"deferred for feature flag ",
+									featureFlagKey, " in company ", companyId),
+								exception);
+
+							return;
+						}
+					}
+				});
 		}
 
 	}

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/unit/FeatureFlagBatchEngineUnitProcessor.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/unit/FeatureFlagBatchEngineUnitProcessor.java
@@ -6,18 +6,16 @@
 package com.liferay.batch.engine.internal.unit;
 
 import com.liferay.petra.executor.PortalExecutorManager;
-import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.function.UnsafeRunnable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagListener;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.MapUtil;
-import com.liferay.portal.kernel.util.Tuple;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 
@@ -34,20 +32,20 @@ import org.osgi.service.component.annotations.Reference;
 @Component(service = FeatureFlagBatchEngineUnitProcessor.class)
 public class FeatureFlagBatchEngineUnitProcessor {
 
-	public void registerBatchEngineUnit(
+	public void registerBatchEngineUnits(
 		long companyId, String featureFlagKey,
-		UnsafeSupplier<CompletableFuture<Void>, Exception> unsafeSupplier) {
+		UnsafeRunnable<Exception> unsafeRunnable) {
 
-		_unsafeSuppliers.compute(
-			_getTuple(companyId, featureFlagKey),
-			(key, unsafeSuppliers) -> {
-				if (unsafeSuppliers == null) {
-					unsafeSuppliers = new ArrayList<>();
+		_unsafeRunnables.compute(
+			Map.entry(companyId, featureFlagKey),
+			(key, unsafeRunnables) -> {
+				if (unsafeRunnables == null) {
+					unsafeRunnables = new ArrayList<>();
 				}
 
-				unsafeSuppliers.add(unsafeSupplier);
+				unsafeRunnables.add(unsafeRunnable);
 
-				return unsafeSuppliers;
+				return unsafeRunnables;
 			});
 	}
 
@@ -63,10 +61,6 @@ public class FeatureFlagBatchEngineUnitProcessor {
 		_serviceRegistration.unregister();
 	}
 
-	private Tuple _getTuple(long companyId, String featureFlagKey) {
-		return new Tuple(companyId, featureFlagKey);
-	}
-
 	private static final Log _log = LogFactoryUtil.getLog(
 		FeatureFlagBatchEngineUnitProcessor.class);
 
@@ -74,9 +68,8 @@ public class FeatureFlagBatchEngineUnitProcessor {
 	private PortalExecutorManager _portalExecutorManager;
 
 	private ServiceRegistration<FeatureFlagListener> _serviceRegistration;
-	private final Map
-		<Tuple, List<UnsafeSupplier<CompletableFuture<Void>, Exception>>>
-			_unsafeSuppliers = new ConcurrentHashMap<>();
+	private final Map<Map.Entry<Long, String>, List<UnsafeRunnable<Exception>>>
+		_unsafeRunnables = new ConcurrentHashMap<>();
 
 	private class FeatureFlagListenerImpl implements FeatureFlagListener {
 
@@ -88,11 +81,10 @@ public class FeatureFlagBatchEngineUnitProcessor {
 				return;
 			}
 
-			List<UnsafeSupplier<CompletableFuture<Void>, Exception>>
-				unsafeSuppliers = _unsafeSuppliers.remove(
-					_getTuple(companyId, featureFlagKey));
+			List<UnsafeRunnable<Exception>> unsafeRunnables =
+				_unsafeRunnables.remove(Map.entry(companyId, featureFlagKey));
 
-			if (unsafeSuppliers == null) {
+			if (unsafeRunnables == null) {
 				return;
 			}
 
@@ -102,22 +94,19 @@ public class FeatureFlagBatchEngineUnitProcessor {
 
 			executorService.submit(
 				() -> {
-					for (UnsafeSupplier<CompletableFuture<Void>, Exception>
-							unsafeSupplier : unsafeSuppliers) {
+					for (UnsafeRunnable<Exception> unsafeRunnable :
+							unsafeRunnables) {
 
 						try {
-							CompletableFuture<Void> completableFuture =
-								unsafeSupplier.get();
-
-							completableFuture.get();
+							unsafeRunnable.run();
 						}
-						catch (Exception exception) {
+						catch (Throwable throwable) {
 							_log.error(
 								StringBundler.concat(
 									"Unable to process batch engine units ",
 									"deferred for feature flag ",
 									featureFlagKey, " in company ", companyId),
-								exception);
+								throwable);
 
 							return;
 						}

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/unit/FeatureFlagBatchEngineUnitProcessor.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/unit/FeatureFlagBatchEngineUnitProcessor.java
@@ -7,7 +7,10 @@ package com.liferay.batch.engine.internal.unit;
 
 import com.liferay.petra.executor.PortalExecutorManager;
 import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagListener;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Tuple;
 
@@ -64,6 +67,9 @@ public class FeatureFlagBatchEngineUnitProcessor {
 		return new Tuple(companyId, featureFlagKey);
 	}
 
+	private static final Log _log = LogFactoryUtil.getLog(
+		FeatureFlagBatchEngineUnitProcessor.class);
+
 	@Reference
 	private PortalExecutorManager _portalExecutorManager;
 
@@ -108,7 +114,15 @@ public class FeatureFlagBatchEngineUnitProcessor {
 								completableFuture.get();
 							}
 							catch (Exception exception) {
-								throw new RuntimeException(exception);
+								_log.error(
+									StringBundler.concat(
+										"Unable to process batch engine units ",
+										"deferred for feature flag ",
+										featureFlagKey, " in company ",
+										companyId),
+									exception);
+
+								return;
 							}
 						}
 					});

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/unit/MultiCompanyBatchEngineUnitProcessor.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/unit/MultiCompanyBatchEngineUnitProcessor.java
@@ -13,12 +13,11 @@ import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 
 import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.osgi.framework.Bundle;
 import org.osgi.service.component.annotations.Component;
@@ -72,13 +71,11 @@ public class MultiCompanyBatchEngineUnitProcessor {
 		Bundle bundle, Company company) {
 
 		Set<Long> companyIds = _bundleProcessedCompanies.computeIfAbsent(
-			bundle, key -> new HashSet<>());
+			bundle, key -> ConcurrentHashMap.newKeySet());
 
-		if (companyIds.contains(company.getCompanyId())) {
+		if (!companyIds.add(company.getCompanyId())) {
 			return CompletableFuture.completedFuture(null);
 		}
-
-		companyIds.add(company.getCompanyId());
 
 		return _batchEngineUnitProcessor.processBatchEngineUnits(
 			TransformUtil.transform(
@@ -91,9 +88,9 @@ public class MultiCompanyBatchEngineUnitProcessor {
 	private BatchEngineUnitProcessor _batchEngineUnitProcessor;
 
 	private final Map<Bundle, List<BatchEngineUnit>> _bundleBatchEngineUnits =
-		new HashMap<>();
+		new ConcurrentHashMap<>();
 	private final Map<Bundle, Set<Long>> _bundleProcessedCompanies =
-		new HashMap<>();
+		new ConcurrentHashMap<>();
 
 	@Reference
 	private CompanyLocalService _companyLocalService;

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/unit/MultiCompanyBatchEngineUnitProcessor.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/unit/MultiCompanyBatchEngineUnitProcessor.java
@@ -9,14 +9,15 @@ import com.liferay.batch.engine.internal.bundle.CompanyBatchEngineUnitWrapper;
 import com.liferay.batch.engine.unit.BatchEngineUnit;
 import com.liferay.batch.engine.unit.BatchEngineUnitProcessor;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.osgi.framework.Bundle;
@@ -30,15 +31,27 @@ import org.osgi.service.component.annotations.Reference;
 @Component(service = MultiCompanyBatchEngineUnitProcessor.class)
 public class MultiCompanyBatchEngineUnitProcessor {
 
-	public CompletableFuture<Void> processBatchEngineUnits(Company company) {
-		List<CompletableFuture<Void>> completableFutures = new ArrayList<>();
+	public void processBatchEngineUnits(Company company) throws Exception {
+		Exception exception1 = null;
 
 		for (Bundle bundle : _bundleBatchEngineUnits.keySet()) {
-			completableFutures.add(_processBatchEngineUnits(bundle, company));
+			try {
+				_processBatchEngineUnits(bundle, company);
+			}
+			catch (Exception exception2) {
+				if (exception1 == null) {
+					exception1 = new Exception(
+						"Unable to process batch engine units for company " +
+							company.getCompanyId());
+				}
+
+				exception1.addSuppressed(exception2);
+			}
 		}
 
-		return CompletableFuture.allOf(
-			completableFutures.toArray(new CompletableFuture[0]));
+		if (exception1 != null) {
+			throw exception1;
+		}
 	}
 
 	public void registerBatchEngineUnits(
@@ -47,7 +60,19 @@ public class MultiCompanyBatchEngineUnitProcessor {
 		_bundleBatchEngineUnits.put(bundle, batchEngineUnits);
 
 		_companyLocalService.forEachCompany(
-			company -> _processBatchEngineUnits(bundle, company));
+			company -> {
+				try {
+					_processBatchEngineUnits(bundle, company);
+				}
+				catch (Exception exception) {
+					_log.error(
+						StringBundler.concat(
+							"Unable to process batch engine units of bundle ",
+							bundle.getSymbolicName(), " for company ",
+							company.getCompanyId()),
+						exception);
+				}
+			});
 	}
 
 	public void unregister(Bundle bundle) {
@@ -67,22 +92,25 @@ public class MultiCompanyBatchEngineUnitProcessor {
 		_bundleProcessedCompanies.clear();
 	}
 
-	private CompletableFuture<Void> _processBatchEngineUnits(
-		Bundle bundle, Company company) {
+	private void _processBatchEngineUnits(Bundle bundle, Company company)
+		throws Exception {
 
 		Set<Long> companyIds = _bundleProcessedCompanies.computeIfAbsent(
 			bundle, key -> ConcurrentHashMap.newKeySet());
 
 		if (!companyIds.add(company.getCompanyId())) {
-			return CompletableFuture.completedFuture(null);
+			return;
 		}
 
-		return _batchEngineUnitProcessor.processBatchEngineUnits(
+		_batchEngineUnitProcessor.processBatchEngineUnits(
 			TransformUtil.transform(
 				_bundleBatchEngineUnits.get(bundle),
 				batchEngineUnit -> new CompanyBatchEngineUnitWrapper(
 					batchEngineUnit, company)));
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		MultiCompanyBatchEngineUnitProcessor.class);
 
 	@Reference
 	private BatchEngineUnitProcessor _batchEngineUnitProcessor;

--- a/modules/apps/batch-engine/batch-engine-service/src/main/resources/META-INF/module-log4j.xml
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/resources/META-INF/module-log4j.xml
@@ -4,5 +4,6 @@
 	<Loggers>
 		<Logger level="WARN" name="com.liferay.batch.engine" />
 		<Logger level="INFO" name="com.liferay.batch.engine.internal.BatchEngineImportTaskExecutorImpl" />
+		<Logger level="INFO" name="com.liferay.batch.engine.internal.unit.BatchEngineUnitProcessorImpl" />
 	</Loggers>
 </Configuration>

--- a/modules/apps/batch-engine/batch-engine-test-util/src/main/java/com/liferay/batch/engine/test/util/BatchEngineTestUtil.java
+++ b/modules/apps/batch-engine/batch-engine-test-util/src/main/java/com/liferay/batch/engine/test/util/BatchEngineTestUtil.java
@@ -12,7 +12,6 @@ import com.liferay.portal.kernel.module.service.Snapshot;
 import java.io.File;
 
 import java.util.Objects;
-import java.util.concurrent.CompletableFuture;
 
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
@@ -44,11 +43,13 @@ public class BatchEngineTestUtil {
 				_deleteFile(bundle, fileName);
 			}
 
-			CompletableFuture<Void> completableFuture =
+			try {
 				batchEngineUnitProcessor.processBatchEngineUnits(
 					batchEngineUnitReader.getBatchEngineUnits(bundle));
-
-			completableFuture.join();
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
 		}
 	}
 

--- a/modules/apps/batch-engine/batch-engine-test/build.gradle
+++ b/modules/apps/batch-engine/batch-engine-test/build.gradle
@@ -19,6 +19,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:headless:headless-admin-user:headless-admin-user-client")
 	testIntegrationImplementation project(":apps:journal:journal-api")
 	testIntegrationImplementation project(":apps:layout:layout-test-util")
+	testIntegrationImplementation project(":apps:list-type:list-type-api")
 	testIntegrationImplementation project(":apps:object:object-api")
 	testIntegrationImplementation project(":apps:object:object-test-util")
 	testIntegrationImplementation project(":apps:portal-odata:portal-odata-api")

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BatchEngineBundleTrackerTest.java
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BatchEngineBundleTrackerTest.java
@@ -7,8 +7,10 @@ package com.liferay.batch.engine.internal.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.batch.engine.BatchEngineImportTaskExecutor;
+import com.liferay.batch.engine.BatchEngineTaskExecuteStatus;
 import com.liferay.batch.engine.BatchEngineTaskItemDelegate;
 import com.liferay.batch.engine.model.BatchEngineImportTask;
+import com.liferay.batch.engine.service.BatchEngineImportTaskLocalService;
 import com.liferay.batch.engine.unit.BatchEngineUnitConfiguration;
 import com.liferay.batch.engine.unit.BatchEngineUnitMetaInfo;
 import com.liferay.batch.engine.unit.BatchEngineUnitReader;
@@ -222,6 +224,16 @@ public class BatchEngineBundleTrackerTest {
 			"batch10", "/batch10/data.batch-engine-data.json");
 	}
 
+	private void _completeBatchEngineImportTask(
+		BatchEngineImportTask batchEngineImportTask) {
+
+		batchEngineImportTask.setExecuteStatus(
+			BatchEngineTaskExecuteStatus.COMPLETED.toString());
+
+		_batchEngineImportTaskLocalService.updateBatchEngineImportTask(
+			batchEngineImportTask);
+	}
+
 	private String _getDataFileName(
 		BatchEngineImportTask batchEngineImportTask) {
 
@@ -275,6 +287,8 @@ public class BatchEngineBundleTrackerTest {
 						if (dataFileName != null) {
 							processedDataFileNames.add(dataFileName);
 						}
+
+						_completeBatchEngineImportTask(batchEngineImportTask);
 					}
 
 					@Override
@@ -294,6 +308,8 @@ public class BatchEngineBundleTrackerTest {
 						if (dataFileName != null) {
 							processedDataFileNames.add(dataFileName);
 						}
+
+						_completeBatchEngineImportTask(batchEngineImportTask);
 					}
 
 				},
@@ -367,6 +383,10 @@ public class BatchEngineBundleTrackerTest {
 
 	@Inject
 	private BatchEngineImportTaskExecutor _batchEngineImportTaskExecutor;
+
+	@Inject
+	private BatchEngineImportTaskLocalService
+		_batchEngineImportTaskLocalService;
 
 	@Inject
 	private BatchEngineUnitReader _batchEngineUnitReader;

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/unit/test/BatchEngineUnitProcessorTest.java
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/unit/test/BatchEngineUnitProcessorTest.java
@@ -1,0 +1,229 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.batch.engine.internal.unit.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.batch.engine.unit.BatchEngineUnitProcessor;
+import com.liferay.batch.engine.unit.BatchEngineUnitReader;
+import com.liferay.list.type.model.ListTypeDefinition;
+import com.liferay.list.type.service.ListTypeDefinitionLocalService;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ZipFileTestUtil;
+import com.liferay.portal.kernel.zip.ZipWriterFactory;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
+import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.io.InputStream;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+
+/**
+ * @author Shuyang Zhou
+ */
+@RunWith(Arquillian.class)
+public class BatchEngineUnitProcessorTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() {
+		_bundle = FrameworkUtil.getBundle(BatchEngineUnitProcessorTest.class);
+
+		_bundleContext = _bundle.getBundleContext();
+	}
+
+	@Test
+	public void testProcessBatchEngineUnitsAbortsRemainingUnitsAfterImportFailure()
+		throws Exception {
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				_CLASS_NAME_BATCH_ENGINE_IMPORT_TASK_EXECUTOR_IMPL,
+				LoggerTestUtil.ERROR)) {
+
+			CompletableFuture<Void> completableFuture =
+				_processBatchEngineUnits("abort");
+
+			Assert.assertTrue(completableFuture.isCompletedExceptionally());
+
+			try {
+				completableFuture.join();
+
+				Assert.fail();
+			}
+			catch (CompletionException completionException) {
+				Throwable throwable = completionException.getCause();
+
+				String message = throwable.getMessage();
+
+				Assert.assertTrue(
+					message,
+					message.contains("Unable to deploy batch engine file"));
+				Assert.assertTrue(
+					message,
+					message.contains(
+						"01-invalid-list-type-definition.batch-engine-data." +
+							"json"));
+			}
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertEquals(logEntries.toString(), 2, logEntries.size());
+
+			LogEntry logEntry1 = logEntries.get(0);
+
+			Assert.assertEquals(LoggerTestUtil.ERROR, logEntry1.getPriority());
+
+			String logEntryMessage1 = logEntry1.getMessage();
+
+			Assert.assertTrue(
+				logEntryMessage1, logEntryMessage1.contains("Name is null"));
+
+			LogEntry logEntry2 = logEntries.get(1);
+
+			Assert.assertEquals(LoggerTestUtil.ERROR, logEntry2.getPriority());
+
+			String logEntryMessage2 = logEntry2.getMessage();
+
+			Assert.assertTrue(
+				logEntryMessage2,
+				logEntryMessage2.startsWith(
+					"Unable to update batch engine import task"));
+		}
+
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+					PortalInstancePool.getDefaultCompanyId())) {
+
+			Assert.assertNull(
+				_listTypeDefinitionLocalService.
+					fetchListTypeDefinitionByExternalReferenceCode(
+						"TEST_ABORT_INVALID",
+						PortalInstancePool.getDefaultCompanyId()));
+			Assert.assertNull(
+				_listTypeDefinitionLocalService.
+					fetchListTypeDefinitionByExternalReferenceCode(
+						"TEST_ABORT_VALID",
+						PortalInstancePool.getDefaultCompanyId()));
+		}
+	}
+
+	@Test
+	public void testProcessBatchEngineUnitsProcessesAllValidUnits()
+		throws Exception {
+
+		CompletableFuture<Void> completableFuture = _processBatchEngineUnits(
+			"control");
+
+		completableFuture.join();
+
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+					PortalInstancePool.getDefaultCompanyId())) {
+
+			ListTypeDefinition listTypeDefinition1 = null;
+			ListTypeDefinition listTypeDefinition2 = null;
+
+			try {
+				listTypeDefinition1 =
+					_listTypeDefinitionLocalService.
+						fetchListTypeDefinitionByExternalReferenceCode(
+							"TEST_CONTROL_VALID_1",
+							PortalInstancePool.getDefaultCompanyId());
+
+				Assert.assertNotNull(listTypeDefinition1);
+
+				listTypeDefinition2 =
+					_listTypeDefinitionLocalService.
+						fetchListTypeDefinitionByExternalReferenceCode(
+							"TEST_CONTROL_VALID_2",
+							PortalInstancePool.getDefaultCompanyId());
+
+				Assert.assertNotNull(listTypeDefinition2);
+			}
+			finally {
+				if (listTypeDefinition1 != null) {
+					_listTypeDefinitionLocalService.deleteListTypeDefinition(
+						listTypeDefinition1);
+				}
+
+				if (listTypeDefinition2 != null) {
+					_listTypeDefinitionLocalService.deleteListTypeDefinition(
+						listTypeDefinition2);
+				}
+			}
+		}
+	}
+
+	private CompletableFuture<Void> _processBatchEngineUnits(String dirName)
+		throws Exception {
+
+		Bundle bundle = _bundleContext.installBundle(
+			RandomTestUtil.randomString(), _toInputStream(dirName));
+
+		try {
+			return _batchEngineUnitProcessor.processBatchEngineUnits(
+				_batchEngineUnitReader.getBatchEngineUnits(bundle));
+		}
+		finally {
+			bundle.uninstall();
+		}
+	}
+
+	private InputStream _toInputStream(String dirName) throws Exception {
+		String basePath = StringBundler.concat(
+			"com/liferay/batch/engine/internal/unit/test/dependencies/",
+			dirName, StringPool.SLASH);
+
+		return ZipFileTestUtil.toInputStream(
+			basePath, _bundle, _zipWriterFactory.getZipWriter());
+	}
+
+	private static final String
+		_CLASS_NAME_BATCH_ENGINE_IMPORT_TASK_EXECUTOR_IMPL =
+			"com.liferay.batch.engine.internal." +
+				"BatchEngineImportTaskExecutorImpl";
+
+	@Inject
+	private BatchEngineUnitProcessor _batchEngineUnitProcessor;
+
+	@Inject
+	private BatchEngineUnitReader _batchEngineUnitReader;
+
+	private Bundle _bundle;
+	private BundleContext _bundleContext;
+
+	@Inject
+	private ListTypeDefinitionLocalService _listTypeDefinitionLocalService;
+
+	@Inject
+	private ZipWriterFactory _zipWriterFactory;
+
+}

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/unit/test/BatchEngineUnitProcessorTest.java
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/unit/test/BatchEngineUnitProcessorTest.java
@@ -28,8 +28,6 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import java.io.InputStream;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -68,20 +66,13 @@ public class BatchEngineUnitProcessorTest {
 				_CLASS_NAME_BATCH_ENGINE_IMPORT_TASK_EXECUTOR_IMPL,
 				LoggerTestUtil.ERROR)) {
 
-			CompletableFuture<Void> completableFuture =
-				_processBatchEngineUnits("abort");
-
-			Assert.assertTrue(completableFuture.isCompletedExceptionally());
-
 			try {
-				completableFuture.join();
+				_processBatchEngineUnits("abort");
 
 				Assert.fail();
 			}
-			catch (CompletionException completionException) {
-				Throwable throwable = completionException.getCause();
-
-				String message = throwable.getMessage();
+			catch (Exception exception) {
+				String message = exception.getMessage();
 
 				Assert.assertTrue(
 					message,
@@ -139,10 +130,7 @@ public class BatchEngineUnitProcessorTest {
 	public void testProcessBatchEngineUnitsProcessesAllValidUnits()
 		throws Exception {
 
-		CompletableFuture<Void> completableFuture = _processBatchEngineUnits(
-			"control");
-
-		completableFuture.join();
+		_processBatchEngineUnits("control");
 
 		try (SafeCloseable safeCloseable =
 				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
@@ -182,14 +170,12 @@ public class BatchEngineUnitProcessorTest {
 		}
 	}
 
-	private CompletableFuture<Void> _processBatchEngineUnits(String dirName)
-		throws Exception {
-
+	private void _processBatchEngineUnits(String dirName) throws Exception {
 		Bundle bundle = _bundleContext.installBundle(
 			RandomTestUtil.randomString(), _toInputStream(dirName));
 
 		try {
-			return _batchEngineUnitProcessor.processBatchEngineUnits(
+			_batchEngineUnitProcessor.processBatchEngineUnits(
 				_batchEngineUnitReader.getBatchEngineUnits(bundle));
 		}
 		finally {

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/resources/com/liferay/batch/engine/internal/unit/test/dependencies/abort/META-INF/MANIFEST.MF
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/resources/com/liferay/batch/engine/internal/unit/test/dependencies/abort/META-INF/MANIFEST.MF
@@ -1,0 +1,5 @@
+Manifest-Version: 2
+Bundle-ManifestVersion: 2
+Bundle-SymbolicName: com.liferay.batch.engine.unit.processor.test.abort
+Bundle-Version: 1.0.0
+Liferay-Client-Extension-Batch: batch

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/resources/com/liferay/batch/engine/internal/unit/test/dependencies/abort/batch/01-invalid-list-type-definition.batch-engine-data.json
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/resources/com/liferay/batch/engine/internal/unit/test/dependencies/abort/batch/01-invalid-list-type-definition.batch-engine-data.json
@@ -1,0 +1,17 @@
+{
+	"configuration": {
+		"className": "com.liferay.headless.admin.list.type.dto.v1_0.ListTypeDefinition",
+		"parameters": {
+			"containsHeaders": "true",
+			"createStrategy": "UPSERT",
+			"importStrategy": "ON_ERROR_FAIL",
+			"updateStrategy": "UPDATE"
+		},
+		"taskItemDelegateName": "DEFAULT"
+	},
+	"items": [
+		{
+			"externalReferenceCode": "TEST_ABORT_INVALID"
+		}
+	]
+}

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/resources/com/liferay/batch/engine/internal/unit/test/dependencies/abort/batch/02-valid-list-type-definition.batch-engine-data.json
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/resources/com/liferay/batch/engine/internal/unit/test/dependencies/abort/batch/02-valid-list-type-definition.batch-engine-data.json
@@ -1,0 +1,18 @@
+{
+	"configuration": {
+		"className": "com.liferay.headless.admin.list.type.dto.v1_0.ListTypeDefinition",
+		"parameters": {
+			"containsHeaders": "true",
+			"createStrategy": "UPSERT",
+			"importStrategy": "ON_ERROR_FAIL",
+			"updateStrategy": "UPDATE"
+		},
+		"taskItemDelegateName": "DEFAULT"
+	},
+	"items": [
+		{
+			"externalReferenceCode": "TEST_ABORT_VALID",
+			"name": "Test Abort Valid"
+		}
+	]
+}

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/resources/com/liferay/batch/engine/internal/unit/test/dependencies/control/META-INF/MANIFEST.MF
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/resources/com/liferay/batch/engine/internal/unit/test/dependencies/control/META-INF/MANIFEST.MF
@@ -1,0 +1,5 @@
+Manifest-Version: 2
+Bundle-ManifestVersion: 2
+Bundle-SymbolicName: com.liferay.batch.engine.unit.processor.test.control
+Bundle-Version: 1.0.0
+Liferay-Client-Extension-Batch: batch

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/resources/com/liferay/batch/engine/internal/unit/test/dependencies/control/batch/01-valid-list-type-definition.batch-engine-data.json
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/resources/com/liferay/batch/engine/internal/unit/test/dependencies/control/batch/01-valid-list-type-definition.batch-engine-data.json
@@ -1,0 +1,18 @@
+{
+	"configuration": {
+		"className": "com.liferay.headless.admin.list.type.dto.v1_0.ListTypeDefinition",
+		"parameters": {
+			"containsHeaders": "true",
+			"createStrategy": "UPSERT",
+			"importStrategy": "ON_ERROR_FAIL",
+			"updateStrategy": "UPDATE"
+		},
+		"taskItemDelegateName": "DEFAULT"
+	},
+	"items": [
+		{
+			"externalReferenceCode": "TEST_CONTROL_VALID_1",
+			"name": "Test Control Valid 1"
+		}
+	]
+}

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/resources/com/liferay/batch/engine/internal/unit/test/dependencies/control/batch/02-valid-list-type-definition.batch-engine-data.json
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/resources/com/liferay/batch/engine/internal/unit/test/dependencies/control/batch/02-valid-list-type-definition.batch-engine-data.json
@@ -1,0 +1,18 @@
+{
+	"configuration": {
+		"className": "com.liferay.headless.admin.list.type.dto.v1_0.ListTypeDefinition",
+		"parameters": {
+			"containsHeaders": "true",
+			"createStrategy": "UPSERT",
+			"importStrategy": "ON_ERROR_FAIL",
+			"updateStrategy": "UPDATE"
+		},
+		"taskItemDelegateName": "DEFAULT"
+	},
+	"items": [
+		{
+			"externalReferenceCode": "TEST_CONTROL_VALID_2",
+			"name": "Test Control Valid 2"
+		}
+	]
+}

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/internal/upgrade/v0_2_0/test/ListTypeDefinitionsUpgradeProcessTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/internal/upgrade/v0_2_0/test/ListTypeDefinitionsUpgradeProcessTest.java
@@ -42,7 +42,6 @@ import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.CompletableFuture;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -153,7 +152,7 @@ public class ListTypeDefinitionsUpgradeProcessTest {
 		}
 	}
 
-	private void _deployLatestVersion() {
+	private void _deployLatestVersion() throws Exception {
 		Bundle testBundle = FrameworkUtil.getBundle(BaseTestCase.class);
 
 		BundleContext bundleContext = testBundle.getBundleContext();
@@ -166,11 +165,8 @@ public class ListTypeDefinitionsUpgradeProcessTest {
 				_deleteFile(bundle, "00.list.type.definition");
 				_deleteFile(bundle, "01.object.definition");
 
-				CompletableFuture<Void> completableFuture =
-					_batchEngineUnitProcessor.processBatchEngineUnits(
-						_batchEngineUnitReader.getBatchEngineUnits(bundle));
-
-				completableFuture.join();
+				_batchEngineUnitProcessor.processBatchEngineUnits(
+					_batchEngineUnitReader.getBatchEngineUnits(bundle));
 			}
 		}
 	}
@@ -252,11 +248,8 @@ public class ListTypeDefinitionsUpgradeProcessTest {
 			new FileInputStream(zipWriter.getFile()));
 
 		try {
-			CompletableFuture<Void> completableFuture =
-				_batchEngineUnitProcessor.processBatchEngineUnits(
-					_batchEngineUnitReader.getBatchEngineUnits(testBundle));
-
-			completableFuture.join();
+			_batchEngineUnitProcessor.processBatchEngineUnits(
+				_batchEngineUnitReader.getBatchEngineUnits(testBundle));
 		}
 		finally {
 			testBundle.uninstall();

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/test/BaseTestCase.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/test/BaseTestCase.java
@@ -18,7 +18,6 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import java.io.File;
 
 import java.util.Objects;
-import java.util.concurrent.CompletableFuture;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -58,11 +57,8 @@ public abstract class BaseTestCase {
 				_deleteFile(bundle, "00.list.type.definition");
 				_deleteFile(bundle, "01.object.definition");
 
-				CompletableFuture<Void> completableFuture =
-					_batchEngineUnitProcessor.processBatchEngineUnits(
-						_batchEngineUnitReader.getBatchEngineUnits(bundle));
-
-				completableFuture.join();
+				_batchEngineUnitProcessor.processBatchEngineUnits(
+					_batchEngineUnitReader.getBatchEngineUnits(bundle));
 			}
 		}
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97984

## What Is Being Fixed

Batch engine unit processing returned a CompletableFuture that callers resolved with a blocking get()/join(). When a unit's import failed — for example the intermittent LPS-135983 ResourceActionsException during ObjectDefinition deploy — and a dependent unit waited for a delegate service that then never registered, the aggregate future never completed and the blocking get() parked the company registration thread forever. On a portal instance this surfaced as company registration hanging indefinitely with no error reported.

## How It Is Being Fixed

processBatchEngineUnits now returns void and throws instead of returning a CompletableFuture. A failure known when the method returns is thrown to the caller. A unit still waiting for its delegate service is reported at INFO level naming the service filter and the data file, the method returns, and the service's registration thread later resumes the sequential walk, logging an error if that resumed import fails. A batch whose delegate never registers leaves that INFO entry as its trace instead of parking the consuming thread. Company registration fails fast, aggregating each bundle's failure as suppressed exceptions where the previous allOf future surfaced a single arbitrary one; deploy-time paths log and continue. Feature-flag-deferred units are processed as one sequential group per company and feature flag pair so ordering and stop-on-failure are preserved.

This change makes the failure visible and non-hanging; it does not fix the underlying LPS-135983 race, which is tracked separately. Coverage: a new integration test, BatchEngineUnitProcessorTest, guards the abort behavior — a failing unit aborts the remaining units and reports without hanging — plus an all-valid-units control. The original hang was reproduced by running CompanyLocalServiceDBPartitionTest repeatedly against a single booted portal (multiple rounds against one boot) and confirmed to now report and continue.

## PR Check

**pr-check: PASS** — tested on `8f64d37db0234fb9db6439b80bda555cfc9c05ee`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "8f64d37db0234fb9db6439b80bda555cfc9c05ee"} -->
