### PR TITLE
LPD-97990 Remove object definition resource actions on partition deletion

### DIFF
--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/security/permission/resource/util/ObjectDefinitionResourcePermissionUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/security/permission/resource/util/ObjectDefinitionResourcePermissionUtil.java
@@ -34,9 +34,12 @@ import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
 import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.permission.ModelPermissions;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.xml.Document;
 import com.liferay.portal.kernel.xml.SAXReaderUtil;
+
+import java.io.Serializable;
 
 import java.util.Collection;
 import java.util.List;
@@ -79,7 +82,7 @@ public class ObjectDefinitionResourcePermissionUtil {
 			}
 
 			_objectDefinitionResourceActionDocumentsMap.put(
-				objectDefinition, document);
+				_getCacheKey(objectDefinition), document);
 		}
 	}
 
@@ -91,7 +94,7 @@ public class ObjectDefinitionResourcePermissionUtil {
 		throws Exception {
 
 		Document document = _objectDefinitionResourceActionDocumentsMap.remove(
-			objectDefinition);
+			_getCacheKey(objectDefinition));
 
 		if (document == null) {
 			document = _readDocument(
@@ -147,6 +150,17 @@ public class ObjectDefinitionResourcePermissionUtil {
 		ResourcePermissionLocalServiceUtil.updateResourcePermissions(
 			companyId, groupId, permissionName, String.valueOf(primKey),
 			modelPermissions);
+	}
+
+	private static Serializable _getCacheKey(
+		ObjectDefinition objectDefinition) {
+
+		if (PropsValues.DATABASE_PARTITION_ENABLED) {
+			return objectDefinition.getObjectDefinitionId() + StringPool.AT +
+				objectDefinition.getCompanyId();
+		}
+
+		return objectDefinition.getObjectDefinitionId();
 	}
 
 	private static String _getObjectActionPermissionKeys(
@@ -306,7 +320,7 @@ public class ObjectDefinitionResourcePermissionUtil {
 				}));
 	}
 
-	private static final Map<ObjectDefinition, Document>
+	private static final Map<Serializable, Document>
 		_objectDefinitionResourceActionDocumentsMap = new ConcurrentHashMap<>();
 
 }

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/instance/lifecycle/CompanyObjectDefinitionPortalInstanceLifecycleListener.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/instance/lifecycle/CompanyObjectDefinitionPortalInstanceLifecycleListener.java
@@ -9,15 +9,20 @@ import com.liferay.asset.list.model.AssetListEntryTable;
 import com.liferay.fragment.model.FragmentCompositionTable;
 import com.liferay.fragment.model.FragmentEntryLinkTable;
 import com.liferay.layout.page.template.model.LayoutPageTemplateStructureRelTable;
+import com.liferay.object.definition.security.permission.resource.util.ObjectDefinitionResourcePermissionUtil;
 import com.liferay.object.definition.util.ObjectDefinitionUtil;
 import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.service.ObjectActionLocalService;
 import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.dao.orm.common.SQLTransformer;
 import com.liferay.portal.instance.lifecycle.BasePortalInstanceLifecycleListener;
 import com.liferay.portal.instance.lifecycle.PortalInstanceLifecycleListener;
 import com.liferay.portal.kernel.dao.jdbc.CurrentConnection;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.ClassNameTable;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.PortletPreferencesTable;
@@ -25,6 +30,7 @@ import com.liferay.portal.kernel.model.PortletTable;
 import com.liferay.portal.kernel.model.ResourceActionTable;
 import com.liferay.portal.kernel.model.ResourcePermissionTable;
 import com.liferay.portal.kernel.model.UserNotificationEventTable;
+import com.liferay.portal.kernel.security.permission.ResourceActions;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.InfrastructureUtil;
 import com.liferay.portal.kernel.util.PropsValues;
@@ -119,6 +125,27 @@ public class CompanyObjectDefinitionPortalInstanceLifecycleListener
 				company.getCompanyId(), WorkflowConstants.STATUS_APPROVED);
 
 		for (ObjectDefinition objectDefinition : objectDefinitions) {
+			if (!objectDefinition.isUnmodifiableSystemObject()) {
+
+				// A partition company is deleted by dropping its schema, so
+				// its object definitions are never individually deleted and
+				// nothing else removes their resource actions. Evict them
+				// from the JVM global maps in ResourceActionsImpl while the
+				// partition is still readable, or the portlet to root model
+				// resource bindings leak and a later company reusing a random
+				// portlet name collides with them. See LPS-135983.
+
+				try {
+					ObjectDefinitionResourcePermissionUtil.
+						removeResourceActions(
+							_objectActionLocalService, objectDefinition,
+							_objectFieldLocalService, _resourceActions);
+				}
+				catch (Exception exception) {
+					_log.error(exception);
+				}
+			}
+
 			_objectDefinitionLocalService.undeployObjectDefinition(
 				objectDefinition);
 		}
@@ -226,6 +253,9 @@ public class CompanyObjectDefinitionPortalInstanceLifecycleListener
 		return sb.toString();
 	}
 
+	private static final Log _log = LogFactoryUtil.getLog(
+		CompanyObjectDefinitionPortalInstanceLifecycleListener.class);
+
 	private final Map<String, String> _classNameColumnNamesMap =
 		HashMapBuilder.put(
 			AssetListEntryTable.INSTANCE.getTableName(),
@@ -284,7 +314,13 @@ public class CompanyObjectDefinitionPortalInstanceLifecycleListener
 	private CurrentConnection _currentConnection;
 
 	@Reference
+	private ObjectActionLocalService _objectActionLocalService;
+
+	@Reference
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Reference
+	private ObjectFieldLocalService _objectFieldLocalService;
 
 	@Reference
 	private PLOEntryLocalService _ploEntryLocalService;
@@ -313,5 +349,8 @@ public class CompanyObjectDefinitionPortalInstanceLifecycleListener
 			ResourcePermissionTable.INSTANCE.name.getName() + StringPool.COMMA +
 				ResourcePermissionTable.INSTANCE.primKey.getName()
 		).build();
+
+	@Reference
+	private ResourceActions _resourceActions;
 
 }

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceDBPartitionTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceDBPartitionTest.java
@@ -15,13 +15,17 @@ import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.instance.PortalInstancePool;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
+import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.AssumeTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
@@ -57,6 +61,52 @@ public class ObjectDefinitionLocalServiceDBPartitionTest {
 		DB db = DBManagerUtil.getDB();
 
 		Assume.assumeTrue(db.isSupportsDBPartition());
+	}
+
+	@Test
+	public void testDeleteCompanyRemovesResourceActions() throws Exception {
+		Company company = CompanyTestUtil.addCompany();
+
+		ObjectDefinition objectDefinition = null;
+
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+					company.getCompanyId())) {
+
+			User user = UserTestUtil.getAdminUser(company.getCompanyId());
+
+			objectDefinition = ObjectDefinitionTestUtil.publishObjectDefinition(
+				Collections.singletonList(
+					new TextObjectFieldBuilder(
+					).labelMap(
+						RandomTestUtil.randomLocaleStringMap()
+					).name(
+						"a" + RandomTestUtil.randomString()
+					).build()),
+				ObjectDefinitionConstants.SCOPE_COMPANY, user.getUserId());
+		}
+
+		String portletId = objectDefinition.getPortletId();
+
+		boolean deleted = false;
+
+		try {
+			Assert.assertEquals(
+				objectDefinition.getResourceName(),
+				ResourceActionsUtil.getPortletRootModelResource(portletId));
+
+			_companyLocalService.deleteCompany(company);
+
+			deleted = true;
+
+			Assert.assertNull(
+				ResourceActionsUtil.getPortletRootModelResource(portletId));
+		}
+		finally {
+			if (!deleted) {
+				_companyLocalService.deleteCompany(company);
+			}
+		}
 	}
 
 	@Test
@@ -143,6 +193,9 @@ public class ObjectDefinitionLocalServiceDBPartitionTest {
 					objectDefinition.getClassName()));
 		}
 	}
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
 
 	@DeleteAfterTestRun
 	private ObjectDefinition _objectDefinition;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97990

## What Is Being Fixed

A custom object definition binds its portlet to a root model resource in the JVM global maps of ResourceActionsImpl when it deploys, and ResourceActionsImpl throws a ResourceActionsException when one portlet maps to two different root model resources. That binding is only removed by deleteObjectDefinition. When a database partition company is deleted, the partition schema is dropped wholesale instead of deleting each definition, so deleteObjectDefinition never runs and the binding leaks for every deleted partition company. Because a custom object definition's portlet name embeds a random four character code drawn only against live database rows, a later company can draw a code still bound by a deleted company and fail to deploy with the ResourceActionsException marked "See LPS-135983".

The failure was found by running CompanyLocalServiceDBPartitionTest repeatedly against a single booted portal; leaked bindings accumulate across rounds in the one JVM, so the collision typically fires by round four or five.

## How It Is Being Fixed

The resource action document cache in ObjectDefinitionResourcePermissionUtil was keyed by ObjectDefinition, whose equals compares only the primary key. A partition copy preserves primary keys, so a copied company and its source aliased to one cache entry. The cache is now keyed with the definition's company ID appended only when database partitioning is enabled, the sole mode where primary keys can collide.

CompanyObjectDefinitionPortalInstanceLifecycleListener.portalInstancePreunregistered now removes each definition's resource actions while the partition is still readable, evicting the binding before the schema is dropped. The eviction of the global map runs before any database access and needs no company scope; a definition still shared with a live company is protected by the existing reference count guard in removeModelResources.

A new integration test, ObjectDefinitionLocalServiceDBPartitionTest.testDeleteCompanyRemovesResourceActions, asserts the binding is present while the company is alive and gone after the company is deleted. It fails on the current code and passes with the fix.

## PR Check

**pr-check: PASS** — tested on `e502ae96da81ce5ee121723658032f40bf463083`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Baseline | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |

<!-- pr-check {"result": "success", "sha": "e502ae96da81ce5ee121723658032f40bf463083"} -->
