### PR TITLE
LPD-87449 Fix SF bug in GradleStylingCheck

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/GradleStylingCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/GradleStylingCheck.java
@@ -304,7 +304,7 @@ public class GradleStylingCheck extends BaseFileCheck {
 	private static final Pattern _mapKeyPattern = Pattern.compile(
 		"(\".+?\") *: *(\".+?\")");
 	private static final Pattern _multiLineStringsPattern = Pattern.compile(
-		"(\"\"\"|''')\\\\\n.*?\\1", Pattern.DOTALL);
+		"(\"\"\"|''').*?\\1", Pattern.DOTALL);
 	private static final Pattern _stylingPattern1 = Pattern.compile(
 		"(\\A|\n)(\\w+)\\.(\\w+ = \\w+)(\n|\\Z)");
 	private static final Pattern _stylingPattern2 = Pattern.compile(


### PR DESCRIPTION
LPD-87449 Allow any content between the triple quotes, not just content starting with a newline

Tested [here](https://github.com/ling-alan-huang/liferay-portal/pull/4305).