### PR TITLE
LPD-60817 Add CPCompareHelper to getCPDefinitionIds upgrade automation

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -5537,6 +5537,7 @@
 	},
 	{
 		"classNames": [
+			"CPCompareHelper",
 			"CPCompareHelperUtil"
 		],
 		"from": "getCPDefinitionIds(long paramName, long paramName, HttpSession paramName)",

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_61133.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_61133.testjava
@@ -5,6 +5,8 @@
 
 package com.liferay.source.formatter.dependencies.upgrade;
 
+import org.osgi.service.component.annotations.Reference;
+
 /**
  * @author Mateus Xavier
  */
@@ -16,6 +18,8 @@ public class LPD_61133 {
 		CPCompareHelperUtil.getCPDefinitionIds(
 			groupId, commerceAccountId, httpSession);
 		CPCompareHelperUtil.getCPDefinitionIds(null, null, null);
+		_cpCompareHelper.getCPDefinitionIds(
+			groupId, commerceAccountId, httpSession);
 	}
 
 	public void method(
@@ -30,5 +34,8 @@ public class LPD_61133 {
 			groupId, commerceAccountId, cpDefinitionId, httpSession);
 		CPCompareHelperUtil.removeCompareProduct(null, null, null, null);
 	}
+
+	@Reference
+	private CPCompareHelper _cpCompareHelper;
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-60817

## What Is Being Fixed

The source formatter's upgrade catch-all check (LPD-61133) rewrites calls to the old `getCPDefinitionIds(long, long, HttpSession)` signature. Its `getCPDefinitionIds` automation only listed `CPCompareHelperUtil`, so calls made through an injected `CPCompareHelper` instance were left unmigrated.

## How It Is Being Fixed

`CPCompareHelper` is added alongside `CPCompareHelperUtil` in the `classNames` list for the `getCPDefinitionIds` replacement in `replacements.json`, so the automation now rewrites instance calls too. The `LPD_61133` test fixture is updated to cover an instance call on an injected `CPCompareHelper` reference.

## PR Check

**pr-check: PASS** — tested on `0a150dd751865a6c4c128b1500d87985e0dc74eb`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "0a150dd751865a6c4c128b1500d87985e0dc74eb"} -->
