### PR TITLE
LPD-98131 Annotate transaction boundaries in thread dumps via named helper methods

### DIFF
--- a/portal-impl/src/com/liferay/portal/spring/transaction/DefaultTransactionExecutor.java
+++ b/portal-impl/src/com/liferay/portal/spring/transaction/DefaultTransactionExecutor.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.spring.transaction;
 
 import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.TransactionLifecycleManager;
 
 import org.springframework.transaction.PlatformTransactionManager;
@@ -68,7 +69,22 @@ public class DefaultTransactionExecutor implements TransactionExecutor {
 		T returnValue = null;
 
 		try {
-			returnValue = unsafeSupplier.get();
+			if (transactionAttributeAdapter.getPropagation() ==
+					Propagation.NESTED) {
+
+				if (transactionStatusAdapter.isNewTransaction()) {
+					returnValue = _invokeWithNewTransaction(unsafeSupplier);
+				}
+				else {
+					returnValue = _invokeWithSavepoint(unsafeSupplier);
+				}
+			}
+			else if (transactionStatusAdapter.isNewTransaction()) {
+				returnValue = _invokeWithNewTransaction(unsafeSupplier);
+			}
+			else {
+				returnValue = _invokeWithAmbientTransaction(unsafeSupplier);
+			}
 		}
 		catch (Throwable throwable) {
 			rollback(
@@ -162,6 +178,27 @@ public class DefaultTransactionExecutor implements TransactionExecutor {
 			transactionAttributeAdapter, transactionStatusAdapter);
 
 		return transactionStatusAdapter;
+	}
+
+	private <T> T _invokeWithAmbientTransaction(
+			UnsafeSupplier<T, Throwable> unsafeSupplier)
+		throws Throwable {
+
+		return unsafeSupplier.get();
+	}
+
+	private <T> T _invokeWithNewTransaction(
+			UnsafeSupplier<T, Throwable> unsafeSupplier)
+		throws Throwable {
+
+		return unsafeSupplier.get();
+	}
+
+	private <T> T _invokeWithSavepoint(
+			UnsafeSupplier<T, Throwable> unsafeSupplier)
+		throws Throwable {
+
+		return unsafeSupplier.get();
 	}
 
 	private final PlatformTransactionManager _platformTransactionManager;

--- a/portal-impl/src/com/liferay/portal/spring/transaction/TransactionInterceptor.java
+++ b/portal-impl/src/com/liferay/portal/spring/transaction/TransactionInterceptor.java
@@ -7,6 +7,7 @@ package com.liferay.portal.spring.transaction;
 
 import com.liferay.portal.kernel.aop.AopMethodInvocation;
 import com.liferay.portal.kernel.aop.ChainableMethodAdvice;
+import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.Transactional;
 
 import java.lang.annotation.Annotation;
@@ -65,7 +66,26 @@ public class TransactionInterceptor extends ChainableMethodAdvice {
 		Object returnValue = null;
 
 		try {
-			returnValue = aopMethodInvocation.proceed(arguments);
+			if (transactionAttributeAdapter.getPropagation() ==
+					Propagation.NESTED) {
+
+				if (transactionStatusAdapter.isNewTransaction()) {
+					returnValue = _invokeWithNewTransaction(
+						aopMethodInvocation, arguments);
+				}
+				else {
+					returnValue = _invokeWithSavepoint(
+						aopMethodInvocation, arguments);
+				}
+			}
+			else if (transactionStatusAdapter.isNewTransaction()) {
+				returnValue = _invokeWithNewTransaction(
+					aopMethodInvocation, arguments);
+			}
+			else {
+				returnValue = _invokeWithAmbientTransaction(
+					aopMethodInvocation, arguments);
+			}
 		}
 		catch (Throwable throwable) {
 			_transactionExecutor.rollback(
@@ -77,6 +97,27 @@ public class TransactionInterceptor extends ChainableMethodAdvice {
 			transactionAttributeAdapter, transactionStatusAdapter);
 
 		return returnValue;
+	}
+
+	private Object _invokeWithAmbientTransaction(
+			AopMethodInvocation aopMethodInvocation, Object[] arguments)
+		throws Throwable {
+
+		return aopMethodInvocation.proceed(arguments);
+	}
+
+	private Object _invokeWithNewTransaction(
+			AopMethodInvocation aopMethodInvocation, Object[] arguments)
+		throws Throwable {
+
+		return aopMethodInvocation.proceed(arguments);
+	}
+
+	private Object _invokeWithSavepoint(
+			AopMethodInvocation aopMethodInvocation, Object[] arguments)
+		throws Throwable {
+
+		return aopMethodInvocation.proceed(arguments);
 	}
 
 	private final TransactionExecutor _transactionExecutor;

--- a/portal-impl/test/unit/com/liferay/portal/spring/transaction/DefaultTransactionExecutorTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/spring/transaction/DefaultTransactionExecutorTest.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.spring.transaction;
 
 import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.TransactionLifecycleListener;
 import com.liferay.portal.kernel.transaction.TransactionLifecycleManager;
 import com.liferay.portal.kernel.util.ProxyUtil;
@@ -26,6 +27,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.interceptor.TransactionAttribute;
 
@@ -480,6 +482,12 @@ public class DefaultTransactionExecutorTest {
 							return predicate.test((Throwable)args[0]);
 						}
 
+						if (Objects.equals(
+								method.getName(), "getPropagationBehavior")) {
+
+							return TransactionDefinition.PROPAGATION_REQUIRED;
+						}
+
 						throw new UnsupportedOperationException(
 							method.toString());
 					}
@@ -581,6 +589,11 @@ public class DefaultTransactionExecutorTest {
 
 	private static class TestTransactionAttributeAdapter
 		extends TransactionAttributeAdapter {
+
+		@Override
+		public Propagation getPropagation() {
+			return Propagation.REQUIRED;
+		}
 
 		@Override
 		public boolean rollbackOn(Throwable throwable) {

--- a/portal-impl/test/unit/com/liferay/portal/spring/transaction/ReadOnlyTransactionThreadLocalTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/spring/transaction/ReadOnlyTransactionThreadLocalTest.java
@@ -8,6 +8,7 @@ package com.liferay.portal.spring.transaction;
 import com.liferay.portal.kernel.internal.spring.transaction.ReadOnlyTransactionThreadLocal;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.CodeCoverageAssertor;
+import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.TransactionLifecycleManager;
 import com.liferay.portal.kernel.util.ProxyUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
@@ -210,6 +211,11 @@ public class ReadOnlyTransactionThreadLocalTest {
 
 	private static class TestTransactionAttributeAdapter
 		extends TransactionAttributeAdapter {
+
+		@Override
+		public Propagation getPropagation() {
+			return Propagation.REQUIRED;
+		}
 
 		@Override
 		public boolean isReadOnly() {

--- a/portal-impl/test/unit/com/liferay/portal/spring/transaction/RecordPlatformTransactionManager.java
+++ b/portal-impl/test/unit/com/liferay/portal/spring/transaction/RecordPlatformTransactionManager.java
@@ -10,6 +10,8 @@ import com.liferay.portal.kernel.util.ProxyUtil;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 
+import java.util.Objects;
+
 import org.junit.Assert;
 
 import org.springframework.transaction.PlatformTransactionManager;
@@ -31,6 +33,10 @@ public class RecordPlatformTransactionManager
 				@Override
 				public Object invoke(
 					Object proxy, Method method, Object[] args) {
+
+					if (Objects.equals(method.getName(), "isNewTransaction")) {
+						return true;
+					}
 
 					throw new UnsupportedOperationException(method.toString());
 				}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98131

https://liferay.atlassian.net/browse/LPD-98132

## What Is Being Fixed

In a thread dump, every frame inside a transactional service call bottoms out in the same generic step (`unsafeSupplier.get()` in `DefaultTransactionExecutor`, `aopMethodInvocation.proceed()` in `TransactionInterceptor`). There is no way to tell which transaction boundary a frame is executing under — a new physical transaction, a nested savepoint, or participation in an ambient transaction — without cross-referencing the source and re-deriving the `TransactionAttribute` propagation values.

## How It Is Being Fixed

`DefaultTransactionExecutor.execute` and `TransactionInterceptor.invoke` now route each invocation through a named private helper chosen from the propagation and `TransactionStatus.isNewTransaction()`:

- `_invokeWithNewTransaction` — a new physical transaction was started.
- `_invokeWithSavepoint` — `NESTED` propagation participating via a savepoint.
- `_invokeWithAmbientTransaction` — participating in an existing transaction.

The helpers are functionally identical to the single call they replace, so they are prime JIT inline targets and fold back to the original form after warmup — no functional or performance difference. Their only value is in a thread dump: the method name in each stack frame shows which transaction boundary the frame sits on.

A preceding commit teaches the transaction test scaffolding (`RecordPlatformTransactionManager`, the `TransactionAttribute` proxy, and `TestTransactionAttributeAdapter`) to answer `getPropagationBehavior` and `isNewTransaction`, which the dispatch now reads. That commit is inert on the current code and keeps each commit independently passing.

## PR Check

**pr-check: PASS** — tested on `f10cc6af2c2ad`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "f10cc6af2c2ada7fb757e00af45b200d932eaf42"} -->
