### PR TITLE
LPD-98144 Support disabling element variations

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/DeleteLayoutPageTemplateStructureRelElementVariationMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/DeleteLayoutPageTemplateStructureRelElementVariationMVCActionCommandTest.java
@@ -61,10 +61,10 @@ public class
 				externalReferenceCode, TestPropsValues.getUserId(),
 				group.getGroupId(),
 				new String[] {RandomTestUtil.randomString()},
-				Collections.emptyMap(), Collections.emptyMap(),
+				RandomTestUtil.randomString(), Collections.emptyMap(),
 				Collections.emptyMap(), RandomTestUtil.randomString(),
 				layout.getPlid(), RandomTestUtil.randomString(),
-				RandomTestUtil.randomString(),
+				RandomTestUtil.randomString(), RandomTestUtil.randomBoolean(),
 				ServiceContextTestUtil.getServiceContext(
 					group, TestPropsValues.getUserId()));
 

--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/SaveLayoutPageTemplateStructureRelElementVariationMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/SaveLayoutPageTemplateStructureRelElementVariationMVCActionCommandTest.java
@@ -75,8 +75,7 @@ public class
 				).put(
 					"externalReferenceCode", externalReferenceCode
 				).put(
-					"hideMap",
-					JSONUtil.put("en_US", RandomTestUtil.randomString())
+					"hide", "true"
 				).put(
 					"htmlMap",
 					JSONUtil.put("en_US", RandomTestUtil.randomString())
@@ -111,10 +110,14 @@ public class
 			externalReferenceCode,
 			Arrays.asList(audienceEntryERC1, audienceEntryERC2));
 
+		Assert.assertTrue(
+			layoutPageTemplateStructureRelElementVariation.isActive());
 		Assert.assertEquals(
 			externalReferenceCode,
 			layoutPageTemplateStructureRelElementVariation.
 				getExternalReferenceCode());
+		Assert.assertEquals(
+			"true", layoutPageTemplateStructureRelElementVariation.getHide());
 		Assert.assertEquals(
 			name, layoutPageTemplateStructureRelElementVariation.getName());
 		Assert.assertEquals(
@@ -128,13 +131,14 @@ public class
 		_mvcActionCommand.processAction(
 			_getMockLiferayPortletActionRequest(
 				JSONUtil.put(
+					"active", false
+				).put(
 					"audienceEntryERCs",
 					JSONUtil.putAll(updatedAudienceEntryERC)
 				).put(
 					"externalReferenceCode", externalReferenceCode
 				).put(
-					"hideMap",
-					JSONUtil.put("en_US", RandomTestUtil.randomString())
+					"hide", "false"
 				).put(
 					"htmlMap",
 					JSONUtil.put("en_US", RandomTestUtil.randomString())
@@ -167,6 +171,8 @@ public class
 			externalReferenceCode,
 			Collections.singletonList(updatedAudienceEntryERC));
 
+		Assert.assertFalse(
+			layoutPageTemplateStructureRelElementVariation.isActive());
 		Assert.assertEquals(
 			updatedName,
 			layoutPageTemplateStructureRelElementVariation.getName());

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/EditElementVariationsDisplayContext.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/EditElementVariationsDisplayContext.java
@@ -196,6 +196,10 @@ public class EditElementVariationsDisplayContext {
 						_getPlid()),
 				layoutPageTemplateStructureRelElementVariation ->
 					HashMapBuilder.<String, Object>put(
+						"active",
+						layoutPageTemplateStructureRelElementVariation.
+							isActive()
+					).put(
 						"audienceEntryERCs",
 						layoutPageTemplateStructureRelElementVariation.
 							getAudienceEntryERCs()
@@ -205,9 +209,7 @@ public class EditElementVariationsDisplayContext {
 							getExternalReferenceCode()
 					).put(
 						"hide",
-						LocalizedMapUtil.getLanguageIdMap(
-							layoutPageTemplateStructureRelElementVariation.
-								getHideMap())
+						layoutPageTemplateStructureRelElementVariation.getHide()
 					).put(
 						"html",
 						LocalizedMapUtil.getLanguageIdMap(

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/frontend/js/audiences/ElementVariationsProviderImpl.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/frontend/js/audiences/ElementVariationsProviderImpl.java
@@ -110,7 +110,6 @@ public class ElementVariationsProviderImpl
 
 		for (String xml :
 				new String[] {
-					layoutPageTemplateStructureRelElementVariation.getHide(),
 					layoutPageTemplateStructureRelElementVariation.getHtml(),
 					layoutPageTemplateStructureRelElementVariation.getJs()
 				}) {
@@ -148,9 +147,7 @@ public class ElementVariationsProviderImpl
 				_getDefaultLanguageId(
 					layoutPageTemplateStructureRelElementVariation)
 			).put(
-				"hide",
-				_getLocalizedValuesJSONObject(
-					layoutPageTemplateStructureRelElementVariation.getHideMap())
+				"hide", layoutPageTemplateStructureRelElementVariation.getHide()
 			).put(
 				"html",
 				_getLocalizedValuesJSONObject(
@@ -172,7 +169,7 @@ public class ElementVariationsProviderImpl
 		List<String> elementVariationsJS = TransformUtil.transform(
 			_layoutPageTemplateStructureRelElementVariationLocalService.
 				getLayoutPageTemplateStructureRelElementVariations(
-					plid, segmentsExperienceERC),
+					plid, segmentsExperienceERC, true),
 			layoutPageTemplateStructureRelElementVariation ->
 				_getElementVariationJS(
 					layoutPageTemplateStructureRelElementVariation,

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/SaveLayoutPageTemplateStructureRelElementVariationMVCActionCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/SaveLayoutPageTemplateStructureRelElementVariationMVCActionCommand.java
@@ -57,13 +57,14 @@ public class SaveLayoutPageTemplateStructureRelElementVariationMVCActionCommand
 				themeDisplay.getScopeGroupId(),
 				JSONUtil.toStringArray(
 					jsonObject.getJSONArray("audienceEntryERCs")),
-				_toLocalizedMap(jsonObject.getJSONObject("hideMap")),
+				jsonObject.getString("hide"),
 				_toLocalizedMap(jsonObject.getJSONObject("htmlMap")),
 				_toLocalizedMap(jsonObject.getJSONObject("jsMap")),
 				jsonObject.getString("name"),
 				ParamUtil.getLong(actionRequest, "plid"),
 				jsonObject.getString("segmentsExperienceERC"),
 				jsonObject.getString("targetElement"),
+				jsonObject.getBoolean("active", true),
 				ServiceContextFactory.getInstance(actionRequest));
 
 		return _jsonFactory.createJSONObject();

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationForm.tsx
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationForm.tsx
@@ -5,7 +5,7 @@
 
 import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
 import {LanguagePicker, Option, Picker} from '@clayui/core';
-import ClayForm, {ClayInput, ClayToggle} from '@clayui/form';
+import ClayForm, {ClayCheckbox, ClayInput, ClayToggle} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import ClayMultiSelect from '@clayui/multi-select';
 import {useId} from 'frontend-js-components-web';
@@ -17,7 +17,13 @@ import {EditableElementOption} from './getEditableElementOptions';
 
 type ElementVariationFormData = Pick<
 	ElementVariation,
-	'audienceEntryERCs' | 'hide' | 'html' | 'js' | 'name' | 'targetElement'
+	| 'active'
+	| 'audienceEntryERCs'
+	| 'hide'
+	| 'html'
+	| 'js'
+	| 'name'
+	| 'targetElement'
 >;
 
 interface Props {
@@ -347,6 +353,19 @@ export default function ElementVariationForm({
 								/>
 							</>
 						)}
+
+						<ClayForm.Group className="my-4" small>
+							<ClayCheckbox
+								checked={!elementVariation.active}
+								disabled={translating}
+								label={Liferay.Language.get(
+									'disable-element-variation'
+								)}
+								onChange={(event) =>
+									onChange({active: !event.target.checked})
+								}
+							/>
+						</ClayForm.Group>
 					</>
 				) : null}
 			</div>

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationService.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationService.ts
@@ -8,7 +8,6 @@ import {ElementVariation} from './elementVariationsReducer';
 
 interface AddElementVariationParameters {
 	addElementVariationURL: string;
-	defaultLanguageId: string;
 	elementVariation: ElementVariation;
 	plid: number;
 }
@@ -22,17 +21,17 @@ interface DeleteElementVariationParameters {
 export default {
 	addElementVariation({
 		addElementVariationURL,
-		defaultLanguageId,
 		elementVariation,
 		plid,
 	}: AddElementVariationParameters) {
 		return serviceFetch<void>(addElementVariationURL, {
 			body: {
 				elementVariation: JSON.stringify({
+					active: elementVariation.active,
 					audienceEntryERCs: elementVariation.audienceEntryERCs,
 					externalReferenceCode:
 						elementVariation.externalReferenceCode,
-					hideMap: {[defaultLanguageId]: elementVariation.hide},
+					hide: String(elementVariation.hide),
 					htmlMap: elementVariation.html,
 					jsMap: elementVariation.js,
 					name: elementVariation.name,

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariations.tsx
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariations.tsx
@@ -133,7 +133,6 @@ function ElementVariations({
 							onSave={() =>
 								ElementVariationService.addElementVariation({
 									addElementVariationURL,
-									defaultLanguageId,
 									elementVariation: draftElementVariation,
 									plid,
 								}).then(() =>

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/elementVariationsReducer.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/elementVariationsReducer.ts
@@ -8,6 +8,7 @@ import {v4 as uuidv4} from 'uuid';
 import {EditableElementOption} from './getEditableElementOptions';
 
 export interface ElementVariation {
+	active: boolean;
 	audienceEntryERCs: string[];
 	externalReferenceCode: string;
 	hide: boolean;
@@ -56,6 +57,7 @@ export function createElementVariation(
 	segmentsExperienceERC: string
 ): ElementVariation {
 	return {
+		active: true,
 		audienceEntryERCs: [],
 		externalReferenceCode: uuidv4(),
 		hide: false,
@@ -69,7 +71,7 @@ export function createElementVariation(
 }
 
 export type LoadedElementVariation = Omit<ElementVariation, 'hide' | 'key'> & {
-	hide: Record<string, string>;
+	hide: string;
 };
 
 export function createInitialState({
@@ -98,7 +100,7 @@ export function createInitialState({
 		editableElementOptions: [],
 		elementVariations: elementVariations.map((elementVariation) => ({
 			...elementVariation,
-			hide: elementVariation.hide[defaultLanguageId] === 'true',
+			hide: elementVariation.hide === 'true',
 			key: uuidv4(),
 		})),
 		experienceKey:

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/com/liferay/layout/content/page/editor/web/internal/frontend/js/audiences/util/dependencies/element_variations.js.tpl
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/com/liferay/layout/content/page/editor/web/internal/frontend/js/audiences/util/dependencies/element_variations.js.tpl
@@ -24,12 +24,7 @@ function applyElementVariation(elementVariation) {
 			return;
 		}
 
-		if (
-			getLocalizedValue(
-				elementVariation.hide,
-				elementVariation.defaultLanguageId
-			) === 'true'
-		) {
+		if (elementVariation.hide === 'true') {
 			element.style.display = 'none';
 		}
 

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/plugins/element_variations/ElementVariationForm.test.tsx
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/plugins/element_variations/ElementVariationForm.test.tsx
@@ -18,6 +18,7 @@ type ElementVariationProp = React.ComponentProps<
 >['elementVariation'];
 
 const BASE_ELEMENT_VARIATION: ElementVariationProp = {
+	active: true,
 	audienceEntryERCs: [],
 	hide: false,
 	html: {},
@@ -132,6 +133,34 @@ describe('ElementVariationForm', () => {
 		await userEvent.click(screen.getByLabelText('hide-page-element'));
 
 		expect(onChange).toHaveBeenCalledWith({hide: false});
+	});
+
+	it('disables the variation when the disable checkbox is checked', async () => {
+		const {onChange} = renderForm({targetElement: '.title'});
+
+		const disableCheckbox = screen.getByLabelText(
+			'disable-element-variation'
+		);
+
+		expect(disableCheckbox).not.toBeChecked();
+
+		await userEvent.click(disableCheckbox);
+
+		expect(onChange).toHaveBeenCalledWith({active: false});
+	});
+
+	it('enables the variation when the disable checkbox is unchecked', async () => {
+		const {onChange} = renderForm({active: false, targetElement: '.title'});
+
+		const disableCheckbox = screen.getByLabelText(
+			'disable-element-variation'
+		);
+
+		expect(disableCheckbox).toBeChecked();
+
+		await userEvent.click(disableCheckbox);
+
+		expect(onChange).toHaveBeenCalledWith({active: true});
 	});
 
 	it('marks the not-localizable fields as read-only when translating', () => {

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/plugins/element_variations/elementVariationsReducer.test.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/plugins/element_variations/elementVariationsReducer.test.ts
@@ -15,6 +15,7 @@ function buildElementVariation(
 	properties: Partial<ElementVariation> = {}
 ): ElementVariation {
 	return {
+		active: true,
 		audienceEntryERCs: [],
 		externalReferenceCode: '',
 		hide: false,
@@ -47,6 +48,7 @@ describe('elementVariationsReducer', () => {
 			const elementVariation = createElementVariation('experience-1');
 
 			expect(elementVariation.segmentsExperienceERC).toBe('experience-1');
+			expect(elementVariation.active).toBe(true);
 			expect(elementVariation.name).toBe('');
 			expect(elementVariation.hide).toBe(false);
 			expect(elementVariation.key).toBeTruthy();
@@ -77,15 +79,16 @@ describe('elementVariationsReducer', () => {
 			});
 		});
 
-		it('assigns a key and derives the hide flag from the default language entry of the hide map', () => {
+		it('assigns a key and derives the hide flag from the hide value', () => {
 			const {draftElementVariation, elementVariations} =
 				createInitialState({
 					defaultLanguageId: 'en_US',
 					elementVariations: [
 						{
+							active: true,
 							audienceEntryERCs: [],
 							externalReferenceCode: 'erc-1',
-							hide: {en_US: 'true'},
+							hide: 'true',
 							html: {},
 							js: {},
 							name: 'Variation 1',

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/model/LayoutPageTemplateStructureRelElementVariationModel.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/model/LayoutPageTemplateStructureRelElementVariationModel.java
@@ -261,58 +261,8 @@ public interface LayoutPageTemplateStructureRelElementVariationModel
 	 *
 	 * @return the hide of this layout page template structure rel element variation
 	 */
+	@AutoEscape
 	public String getHide();
-
-	/**
-	 * Returns the localized hide of this layout page template structure rel element variation in the language. Uses the default language if no localization exists for the requested language.
-	 *
-	 * @param locale the locale of the language
-	 * @return the localized hide of this layout page template structure rel element variation
-	 */
-	@AutoEscape
-	public String getHide(Locale locale);
-
-	/**
-	 * Returns the localized hide of this layout page template structure rel element variation in the language, optionally using the default language if no localization exists for the requested language.
-	 *
-	 * @param locale the local of the language
-	 * @param useDefault whether to use the default language if no localization exists for the requested language
-	 * @return the localized hide of this layout page template structure rel element variation. If <code>useDefault</code> is <code>false</code> and no localization exists for the requested language, an empty string will be returned.
-	 */
-	@AutoEscape
-	public String getHide(Locale locale, boolean useDefault);
-
-	/**
-	 * Returns the localized hide of this layout page template structure rel element variation in the language. Uses the default language if no localization exists for the requested language.
-	 *
-	 * @param languageId the ID of the language
-	 * @return the localized hide of this layout page template structure rel element variation
-	 */
-	@AutoEscape
-	public String getHide(String languageId);
-
-	/**
-	 * Returns the localized hide of this layout page template structure rel element variation in the language, optionally using the default language if no localization exists for the requested language.
-	 *
-	 * @param languageId the ID of the language
-	 * @param useDefault whether to use the default language if no localization exists for the requested language
-	 * @return the localized hide of this layout page template structure rel element variation
-	 */
-	@AutoEscape
-	public String getHide(String languageId, boolean useDefault);
-
-	@AutoEscape
-	public String getHideCurrentLanguageId();
-
-	@AutoEscape
-	public String getHideCurrentValue();
-
-	/**
-	 * Returns a map of the locales and localized hides of this layout page template structure rel element variation.
-	 *
-	 * @return the locales and localized hides of this layout page template structure rel element variation
-	 */
-	public Map<Locale, String> getHideMap();
 
 	/**
 	 * Sets the hide of this layout page template structure rel element variation.
@@ -320,40 +270,6 @@ public interface LayoutPageTemplateStructureRelElementVariationModel
 	 * @param hide the hide of this layout page template structure rel element variation
 	 */
 	public void setHide(String hide);
-
-	/**
-	 * Sets the localized hide of this layout page template structure rel element variation in the language.
-	 *
-	 * @param hide the localized hide of this layout page template structure rel element variation
-	 * @param locale the locale of the language
-	 */
-	public void setHide(String hide, Locale locale);
-
-	/**
-	 * Sets the localized hide of this layout page template structure rel element variation in the language, and sets the default locale.
-	 *
-	 * @param hide the localized hide of this layout page template structure rel element variation
-	 * @param locale the locale of the language
-	 * @param defaultLocale the default locale
-	 */
-	public void setHide(String hide, Locale locale, Locale defaultLocale);
-
-	public void setHideCurrentLanguageId(String languageId);
-
-	/**
-	 * Sets the localized hides of this layout page template structure rel element variation from the map of locales and localized hides.
-	 *
-	 * @param hideMap the locales and localized hides of this layout page template structure rel element variation
-	 */
-	public void setHideMap(Map<Locale, String> hideMap);
-
-	/**
-	 * Sets the localized hides of this layout page template structure rel element variation from the map of locales and localized hides, and sets the default locale.
-	 *
-	 * @param hideMap the locales and localized hides of this layout page template structure rel element variation
-	 * @param defaultLocale the default locale
-	 */
-	public void setHideMap(Map<Locale, String> hideMap, Locale defaultLocale);
 
 	/**
 	 * Returns the html of this layout page template structure rel element variation.
@@ -612,6 +528,27 @@ public interface LayoutPageTemplateStructureRelElementVariationModel
 	 */
 	public void setTargetElement(String targetElement);
 
+	/**
+	 * Returns the active of this layout page template structure rel element variation.
+	 *
+	 * @return the active of this layout page template structure rel element variation
+	 */
+	public boolean getActive();
+
+	/**
+	 * Returns <code>true</code> if this layout page template structure rel element variation is active.
+	 *
+	 * @return <code>true</code> if this layout page template structure rel element variation is active; <code>false</code> otherwise
+	 */
+	public boolean isActive();
+
+	/**
+	 * Sets whether this layout page template structure rel element variation is active.
+	 *
+	 * @param active the active of this layout page template structure rel element variation
+	 */
+	public void setActive(boolean active);
+
 	@Override
 	public String[] getAvailableLanguageIds();
 
@@ -634,4 +571,4 @@ public interface LayoutPageTemplateStructureRelElementVariationModel
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1774816791
+// LIFERAY-SERVICE-BUILDER-HASH:1923096027

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/model/LayoutPageTemplateStructureRelElementVariationTable.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/model/LayoutPageTemplateStructureRelElementVariationTable.java
@@ -8,6 +8,7 @@ package com.liferay.layout.page.template.model;
 import com.liferay.petra.sql.dsl.Column;
 import com.liferay.petra.sql.dsl.base.BaseTable;
 
+import java.sql.Clob;
 import java.sql.Types;
 
 import java.util.Date;
@@ -74,9 +75,8 @@ public class LayoutPageTemplateStructureRelElementVariationTable
 				"modifiedDate", Date.class, Types.TIMESTAMP,
 				Column.FLAG_DEFAULT);
 	public final Column
-		<LayoutPageTemplateStructureRelElementVariationTable, String> hide =
-			createColumn(
-				"hide", String.class, Types.VARCHAR, Column.FLAG_DEFAULT);
+		<LayoutPageTemplateStructureRelElementVariationTable, Clob> hide =
+			createColumn("hide", Clob.class, Types.CLOB, Column.FLAG_DEFAULT);
 	public final Column
 		<LayoutPageTemplateStructureRelElementVariationTable, String> html =
 			createColumn(
@@ -102,6 +102,10 @@ public class LayoutPageTemplateStructureRelElementVariationTable
 			targetElement = createColumn(
 				"targetElement", String.class, Types.VARCHAR,
 				Column.FLAG_DEFAULT);
+	public final Column
+		<LayoutPageTemplateStructureRelElementVariationTable, Boolean> active =
+			createColumn(
+				"active_", Boolean.class, Types.BOOLEAN, Column.FLAG_DEFAULT);
 
 	private LayoutPageTemplateStructureRelElementVariationTable() {
 		super(
@@ -110,4 +114,4 @@ public class LayoutPageTemplateStructureRelElementVariationTable
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:647063486
+// LIFERAY-SERVICE-BUILDER-HASH:-1371568153

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/model/LayoutPageTemplateStructureRelElementVariationWrapper.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/model/LayoutPageTemplateStructureRelElementVariationWrapper.java
@@ -60,6 +60,7 @@ public class LayoutPageTemplateStructureRelElementVariationWrapper
 		attributes.put("plid", getPlid());
 		attributes.put("segmentsExperienceERC", getSegmentsExperienceERC());
 		attributes.put("targetElement", getTargetElement());
+		attributes.put("active", isActive());
 
 		return attributes;
 	}
@@ -178,6 +179,12 @@ public class LayoutPageTemplateStructureRelElementVariationWrapper
 		if (targetElement != null) {
 			setTargetElement(targetElement);
 		}
+
+		Boolean active = (Boolean)attributes.get("active");
+
+		if (active != null) {
+			setActive(active);
+		}
 	}
 
 	@Override
@@ -185,6 +192,16 @@ public class LayoutPageTemplateStructureRelElementVariationWrapper
 		cloneWithOriginalValues() {
 
 		return wrap(model.cloneWithOriginalValues());
+	}
+
+	/**
+	 * Returns the active of this layout page template structure rel element variation.
+	 *
+	 * @return the active of this layout page template structure rel element variation
+	 */
+	@Override
+	public boolean getActive() {
+		return model.getActive();
 	}
 
 	@Override
@@ -260,72 +277,6 @@ public class LayoutPageTemplateStructureRelElementVariationWrapper
 	@Override
 	public String getHide() {
 		return model.getHide();
-	}
-
-	/**
-	 * Returns the localized hide of this layout page template structure rel element variation in the language. Uses the default language if no localization exists for the requested language.
-	 *
-	 * @param locale the locale of the language
-	 * @return the localized hide of this layout page template structure rel element variation
-	 */
-	@Override
-	public String getHide(java.util.Locale locale) {
-		return model.getHide(locale);
-	}
-
-	/**
-	 * Returns the localized hide of this layout page template structure rel element variation in the language, optionally using the default language if no localization exists for the requested language.
-	 *
-	 * @param locale the local of the language
-	 * @param useDefault whether to use the default language if no localization exists for the requested language
-	 * @return the localized hide of this layout page template structure rel element variation. If <code>useDefault</code> is <code>false</code> and no localization exists for the requested language, an empty string will be returned.
-	 */
-	@Override
-	public String getHide(java.util.Locale locale, boolean useDefault) {
-		return model.getHide(locale, useDefault);
-	}
-
-	/**
-	 * Returns the localized hide of this layout page template structure rel element variation in the language. Uses the default language if no localization exists for the requested language.
-	 *
-	 * @param languageId the ID of the language
-	 * @return the localized hide of this layout page template structure rel element variation
-	 */
-	@Override
-	public String getHide(String languageId) {
-		return model.getHide(languageId);
-	}
-
-	/**
-	 * Returns the localized hide of this layout page template structure rel element variation in the language, optionally using the default language if no localization exists for the requested language.
-	 *
-	 * @param languageId the ID of the language
-	 * @param useDefault whether to use the default language if no localization exists for the requested language
-	 * @return the localized hide of this layout page template structure rel element variation
-	 */
-	@Override
-	public String getHide(String languageId, boolean useDefault) {
-		return model.getHide(languageId, useDefault);
-	}
-
-	@Override
-	public String getHideCurrentLanguageId() {
-		return model.getHideCurrentLanguageId();
-	}
-
-	@Override
-	public String getHideCurrentValue() {
-		return model.getHideCurrentValue();
-	}
-
-	/**
-	 * Returns a map of the locales and localized hides of this layout page template structure rel element variation.
-	 *
-	 * @return the locales and localized hides of this layout page template structure rel element variation
-	 */
-	@Override
-	public Map<java.util.Locale, String> getHideMap() {
-		return model.getHideMap();
 	}
 
 	/**
@@ -600,6 +551,16 @@ public class LayoutPageTemplateStructureRelElementVariationWrapper
 		return model.getUuid();
 	}
 
+	/**
+	 * Returns <code>true</code> if this layout page template structure rel element variation is active.
+	 *
+	 * @return <code>true</code> if this layout page template structure rel element variation is active; <code>false</code> otherwise
+	 */
+	@Override
+	public boolean isActive() {
+		return model.isActive();
+	}
+
 	@Override
 	public void persist() {
 		model.persist();
@@ -618,6 +579,16 @@ public class LayoutPageTemplateStructureRelElementVariationWrapper
 		throws com.liferay.portal.kernel.exception.LocaleException {
 
 		model.prepareLocalizedFieldsForImport(defaultImportLocale);
+	}
+
+	/**
+	 * Sets whether this layout page template structure rel element variation is active.
+	 *
+	 * @param active the active of this layout page template structure rel element variation
+	 */
+	@Override
+	public void setActive(boolean active) {
+		model.setActive(active);
 	}
 
 	/**
@@ -678,59 +649,6 @@ public class LayoutPageTemplateStructureRelElementVariationWrapper
 	@Override
 	public void setHide(String hide) {
 		model.setHide(hide);
-	}
-
-	/**
-	 * Sets the localized hide of this layout page template structure rel element variation in the language.
-	 *
-	 * @param hide the localized hide of this layout page template structure rel element variation
-	 * @param locale the locale of the language
-	 */
-	@Override
-	public void setHide(String hide, java.util.Locale locale) {
-		model.setHide(hide, locale);
-	}
-
-	/**
-	 * Sets the localized hide of this layout page template structure rel element variation in the language, and sets the default locale.
-	 *
-	 * @param hide the localized hide of this layout page template structure rel element variation
-	 * @param locale the locale of the language
-	 * @param defaultLocale the default locale
-	 */
-	@Override
-	public void setHide(
-		String hide, java.util.Locale locale, java.util.Locale defaultLocale) {
-
-		model.setHide(hide, locale, defaultLocale);
-	}
-
-	@Override
-	public void setHideCurrentLanguageId(String languageId) {
-		model.setHideCurrentLanguageId(languageId);
-	}
-
-	/**
-	 * Sets the localized hides of this layout page template structure rel element variation from the map of locales and localized hides.
-	 *
-	 * @param hideMap the locales and localized hides of this layout page template structure rel element variation
-	 */
-	@Override
-	public void setHideMap(Map<java.util.Locale, String> hideMap) {
-		model.setHideMap(hideMap);
-	}
-
-	/**
-	 * Sets the localized hides of this layout page template structure rel element variation from the map of locales and localized hides, and sets the default locale.
-	 *
-	 * @param hideMap the locales and localized hides of this layout page template structure rel element variation
-	 * @param defaultLocale the default locale
-	 */
-	@Override
-	public void setHideMap(
-		Map<java.util.Locale, String> hideMap, java.util.Locale defaultLocale) {
-
-		model.setHideMap(hideMap, defaultLocale);
 	}
 
 	/**
@@ -1020,4 +938,4 @@ public class LayoutPageTemplateStructureRelElementVariationWrapper
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:387626618
+// LIFERAY-SERVICE-BUILDER-HASH:-1161587756

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationLocalService.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationLocalService.java
@@ -84,10 +84,11 @@ public interface LayoutPageTemplateStructureRelElementVariationLocalService
 	public LayoutPageTemplateStructureRelElementVariation
 			addOrUpdateLayoutPageTemplateStructureRelElementVariation(
 				String externalReferenceCode, long userId, long groupId,
-				String[] audienceEntryERCs, Map<Locale, String> hideMap,
+				String[] audienceEntryERCs, String hide,
 				Map<Locale, String> htmlMap, Map<Locale, String> jsMap,
 				String name, long plid, String segmentsExperienceERC,
-				String targetElement, ServiceContext serviceContext)
+				String targetElement, boolean active,
+				ServiceContext serviceContext)
 		throws PortalException;
 
 	/**
@@ -311,6 +312,11 @@ public interface LayoutPageTemplateStructureRelElementVariationLocalService
 		getLayoutPageTemplateStructureRelElementVariations(
 			long plid, String segmentsExperienceERC);
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<LayoutPageTemplateStructureRelElementVariation>
+		getLayoutPageTemplateStructureRelElementVariations(
+			long plid, String segmentsExperienceERC, boolean active);
+
 	/**
 	 * Returns all the layout page template structure rel element variations matching the UUID and company.
 	 *
@@ -398,4 +404,4 @@ public interface LayoutPageTemplateStructureRelElementVariationLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2123153812
+// LIFERAY-SERVICE-BUILDER-HASH:615384373

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationLocalServiceUtil.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationLocalServiceUtil.java
@@ -60,19 +60,19 @@ public class LayoutPageTemplateStructureRelElementVariationLocalServiceUtil {
 	public static LayoutPageTemplateStructureRelElementVariation
 			addOrUpdateLayoutPageTemplateStructureRelElementVariation(
 				String externalReferenceCode, long userId, long groupId,
-				String[] audienceEntryERCs,
-				Map<java.util.Locale, String> hideMap,
+				String[] audienceEntryERCs, String hide,
 				Map<java.util.Locale, String> htmlMap,
 				Map<java.util.Locale, String> jsMap, String name, long plid,
 				String segmentsExperienceERC, String targetElement,
+				boolean active,
 				com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
 		return getService().
 			addOrUpdateLayoutPageTemplateStructureRelElementVariation(
-				externalReferenceCode, userId, groupId, audienceEntryERCs,
-				hideMap, htmlMap, jsMap, name, plid, segmentsExperienceERC,
-				targetElement, serviceContext);
+				externalReferenceCode, userId, groupId, audienceEntryERCs, hide,
+				htmlMap, jsMap, name, plid, segmentsExperienceERC,
+				targetElement, active, serviceContext);
 	}
 
 	/**
@@ -374,6 +374,14 @@ public class LayoutPageTemplateStructureRelElementVariationLocalServiceUtil {
 			plid, segmentsExperienceERC);
 	}
 
+	public static List<LayoutPageTemplateStructureRelElementVariation>
+		getLayoutPageTemplateStructureRelElementVariations(
+			long plid, String segmentsExperienceERC, boolean active) {
+
+		return getService().getLayoutPageTemplateStructureRelElementVariations(
+			plid, segmentsExperienceERC, active);
+	}
+
 	/**
 	 * Returns all the layout page template structure rel element variations matching the UUID and company.
 	 *
@@ -476,4 +484,4 @@ public class LayoutPageTemplateStructureRelElementVariationLocalServiceUtil {
 					class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:175052173
+// LIFERAY-SERVICE-BUILDER-HASH:-83436783

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationLocalServiceWrapper.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationLocalServiceWrapper.java
@@ -60,19 +60,19 @@ public class LayoutPageTemplateStructureRelElementVariationLocalServiceWrapper
 	public LayoutPageTemplateStructureRelElementVariation
 			addOrUpdateLayoutPageTemplateStructureRelElementVariation(
 				String externalReferenceCode, long userId, long groupId,
-				String[] audienceEntryERCs,
-				java.util.Map<java.util.Locale, String> hideMap,
+				String[] audienceEntryERCs, String hide,
 				java.util.Map<java.util.Locale, String> htmlMap,
 				java.util.Map<java.util.Locale, String> jsMap, String name,
 				long plid, String segmentsExperienceERC, String targetElement,
+				boolean active,
 				com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _layoutPageTemplateStructureRelElementVariationLocalService.
 			addOrUpdateLayoutPageTemplateStructureRelElementVariation(
-				externalReferenceCode, userId, groupId, audienceEntryERCs,
-				hideMap, htmlMap, jsMap, name, plid, segmentsExperienceERC,
-				targetElement, serviceContext);
+				externalReferenceCode, userId, groupId, audienceEntryERCs, hide,
+				htmlMap, jsMap, name, plid, segmentsExperienceERC,
+				targetElement, active, serviceContext);
 	}
 
 	/**
@@ -423,6 +423,16 @@ public class LayoutPageTemplateStructureRelElementVariationLocalServiceWrapper
 				plid, segmentsExperienceERC);
 	}
 
+	@Override
+	public java.util.List<LayoutPageTemplateStructureRelElementVariation>
+		getLayoutPageTemplateStructureRelElementVariations(
+			long plid, String segmentsExperienceERC, boolean active) {
+
+		return _layoutPageTemplateStructureRelElementVariationLocalService.
+			getLayoutPageTemplateStructureRelElementVariations(
+				plid, segmentsExperienceERC, active);
+	}
+
 	/**
 	 * Returns all the layout page template structure rel element variations matching the UUID and company.
 	 *
@@ -571,4 +581,4 @@ public class LayoutPageTemplateStructureRelElementVariationLocalServiceWrapper
 		_layoutPageTemplateStructureRelElementVariationLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1279332914
+// LIFERAY-SERVICE-BUILDER-HASH:1605487834

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationService.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationService.java
@@ -51,10 +51,11 @@ public interface LayoutPageTemplateStructureRelElementVariationService
 	public LayoutPageTemplateStructureRelElementVariation
 			addOrUpdateLayoutPageTemplateStructureRelElementVariation(
 				String externalReferenceCode, long groupId,
-				String[] audienceEntryERCs, Map<Locale, String> hideMap,
+				String[] audienceEntryERCs, String hide,
 				Map<Locale, String> htmlMap, Map<Locale, String> jsMap,
 				String name, long plid, String segmentsExperienceERC,
-				String targetElement, ServiceContext serviceContext)
+				String targetElement, boolean active,
+				ServiceContext serviceContext)
 		throws PortalException;
 
 	public void deleteLayoutPageTemplateStructureRelElementVariation(
@@ -74,4 +75,4 @@ public interface LayoutPageTemplateStructureRelElementVariationService
 	public String getOSGiServiceIdentifier();
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1465290773
+// LIFERAY-SERVICE-BUILDER-HASH:-960037974

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationServiceUtil.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationServiceUtil.java
@@ -34,19 +34,19 @@ public class LayoutPageTemplateStructureRelElementVariationServiceUtil {
 	public static LayoutPageTemplateStructureRelElementVariation
 			addOrUpdateLayoutPageTemplateStructureRelElementVariation(
 				String externalReferenceCode, long groupId,
-				String[] audienceEntryERCs,
-				Map<java.util.Locale, String> hideMap,
+				String[] audienceEntryERCs, String hide,
 				Map<java.util.Locale, String> htmlMap,
 				Map<java.util.Locale, String> jsMap, String name, long plid,
 				String segmentsExperienceERC, String targetElement,
+				boolean active,
 				com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
 		return getService().
 			addOrUpdateLayoutPageTemplateStructureRelElementVariation(
-				externalReferenceCode, groupId, audienceEntryERCs, hideMap,
+				externalReferenceCode, groupId, audienceEntryERCs, hide,
 				htmlMap, jsMap, name, plid, segmentsExperienceERC,
-				targetElement, serviceContext);
+				targetElement, active, serviceContext);
 	}
 
 	public static void deleteLayoutPageTemplateStructureRelElementVariation(
@@ -87,4 +87,4 @@ public class LayoutPageTemplateStructureRelElementVariationServiceUtil {
 				LayoutPageTemplateStructureRelElementVariationService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:2068769419
+// LIFERAY-SERVICE-BUILDER-HASH:531895627

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationServiceWrapper.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationServiceWrapper.java
@@ -36,19 +36,19 @@ public class LayoutPageTemplateStructureRelElementVariationServiceWrapper
 	public LayoutPageTemplateStructureRelElementVariation
 			addOrUpdateLayoutPageTemplateStructureRelElementVariation(
 				String externalReferenceCode, long groupId,
-				String[] audienceEntryERCs,
-				java.util.Map<java.util.Locale, String> hideMap,
+				String[] audienceEntryERCs, String hide,
 				java.util.Map<java.util.Locale, String> htmlMap,
 				java.util.Map<java.util.Locale, String> jsMap, String name,
 				long plid, String segmentsExperienceERC, String targetElement,
+				boolean active,
 				com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _layoutPageTemplateStructureRelElementVariationService.
 			addOrUpdateLayoutPageTemplateStructureRelElementVariation(
-				externalReferenceCode, groupId, audienceEntryERCs, hideMap,
+				externalReferenceCode, groupId, audienceEntryERCs, hide,
 				htmlMap, jsMap, name, plid, segmentsExperienceERC,
-				targetElement, serviceContext);
+				targetElement, active, serviceContext);
 	}
 
 	@Override
@@ -101,4 +101,4 @@ public class LayoutPageTemplateStructureRelElementVariationServiceWrapper
 		_layoutPageTemplateStructureRelElementVariationService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1714054147
+// LIFERAY-SERVICE-BUILDER-HASH:832346261

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/persistence/LayoutPageTemplateStructureRelElementVariationPersistence.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/persistence/LayoutPageTemplateStructureRelElementVariationPersistence.java
@@ -411,6 +411,85 @@ public interface LayoutPageTemplateStructureRelElementVariationPersistence
 	public int countByP_SEERC(long plid, String segmentsExperienceERC);
 
 	/**
+	 * Returns an ordered range of all the layout page template structure rel element variations where plid = &#63; and segmentsExperienceERC = &#63; and active = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateStructureRelElementVariationModelImpl</code>.
+	 * </p>
+	 *
+	 * @param plid the plid
+	 * @param segmentsExperienceERC the segments experience erc
+	 * @param active the active
+	 * @param start the lower bound of the range of layout page template structure rel element variations
+	 * @param end the upper bound of the range of layout page template structure rel element variations (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching layout page template structure rel element variations
+	 */
+	public java.util.List<LayoutPageTemplateStructureRelElementVariation>
+		findByP_SEERC_A(
+			long plid, String segmentsExperienceERC, boolean active, int start,
+			int end,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<LayoutPageTemplateStructureRelElementVariation>
+					orderByComparator,
+			boolean useFinderCache);
+
+	/**
+	 * Returns the first layout page template structure rel element variation in the ordered set where plid = &#63; and segmentsExperienceERC = &#63; and active = &#63;.
+	 *
+	 * @param plid the plid
+	 * @param segmentsExperienceERC the segments experience erc
+	 * @param active the active
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching layout page template structure rel element variation
+	 * @throws NoSuchPageTemplateStructureRelElementVariationException if a matching layout page template structure rel element variation could not be found
+	 */
+	public LayoutPageTemplateStructureRelElementVariation findByP_SEERC_A_First(
+			long plid, String segmentsExperienceERC, boolean active,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<LayoutPageTemplateStructureRelElementVariation>
+					orderByComparator)
+		throws NoSuchPageTemplateStructureRelElementVariationException;
+
+	/**
+	 * Returns the first layout page template structure rel element variation in the ordered set where plid = &#63; and segmentsExperienceERC = &#63; and active = &#63;.
+	 *
+	 * @param plid the plid
+	 * @param segmentsExperienceERC the segments experience erc
+	 * @param active the active
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching layout page template structure rel element variation, or <code>null</code> if a matching layout page template structure rel element variation could not be found
+	 */
+	public LayoutPageTemplateStructureRelElementVariation
+		fetchByP_SEERC_A_First(
+			long plid, String segmentsExperienceERC, boolean active,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<LayoutPageTemplateStructureRelElementVariation>
+					orderByComparator);
+
+	/**
+	 * Removes all the layout page template structure rel element variations where plid = &#63; and segmentsExperienceERC = &#63; and active = &#63; from the database.
+	 *
+	 * @param plid the plid
+	 * @param segmentsExperienceERC the segments experience erc
+	 * @param active the active
+	 */
+	public void removeByP_SEERC_A(
+		long plid, String segmentsExperienceERC, boolean active);
+
+	/**
+	 * Returns the number of layout page template structure rel element variations where plid = &#63; and segmentsExperienceERC = &#63; and active = &#63;.
+	 *
+	 * @param plid the plid
+	 * @param segmentsExperienceERC the segments experience erc
+	 * @param active the active
+	 * @return the number of matching layout page template structure rel element variations
+	 */
+	public int countByP_SEERC_A(
+		long plid, String segmentsExperienceERC, boolean active);
+
+	/**
 	 * Returns the layout page template structure rel element variation where externalReferenceCode = &#63; and groupId = &#63; or throws a <code>NoSuchPageTemplateStructureRelElementVariationException</code> if it could not be found.
 	 *
 	 * @param externalReferenceCode the external reference code
@@ -823,5 +902,74 @@ public interface LayoutPageTemplateStructureRelElementVariationPersistence
 			plid, segmentsExperienceERC, start, end, orderByComparator, true);
 	}
 
+	/**
+	 * Returns all the layout page template structure rel element variations where plid = &#63; and segmentsExperienceERC = &#63; and active = &#63;.
+	 *
+	 * @param plid the plid
+	 * @param segmentsExperienceERC the segments experience erc
+	 * @param active the active
+	 * @return the matching layout page template structure rel element variations
+	 */
+	public default java.util.List
+		<LayoutPageTemplateStructureRelElementVariation> findByP_SEERC_A(
+			long plid, String segmentsExperienceERC, boolean active) {
+
+		return findByP_SEERC_A(
+			plid, segmentsExperienceERC, active,
+			com.liferay.portal.kernel.dao.orm.QueryUtil.ALL_POS,
+			com.liferay.portal.kernel.dao.orm.QueryUtil.ALL_POS, null, true);
+	}
+
+	/**
+	 * Returns a range of all the layout page template structure rel element variations where plid = &#63; and segmentsExperienceERC = &#63; and active = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateStructureRelElementVariationModelImpl</code>.
+	 * </p>
+	 *
+	 * @param plid the plid
+	 * @param segmentsExperienceERC the segments experience erc
+	 * @param active the active
+	 * @param start the lower bound of the range of layout page template structure rel element variations
+	 * @param end the upper bound of the range of layout page template structure rel element variations (not inclusive)
+	 * @return the range of matching layout page template structure rel element variations
+	 */
+	public default java.util.List
+		<LayoutPageTemplateStructureRelElementVariation> findByP_SEERC_A(
+			long plid, String segmentsExperienceERC, boolean active, int start,
+			int end) {
+
+		return findByP_SEERC_A(
+			plid, segmentsExperienceERC, active, start, end, null, true);
+	}
+
+	/**
+	 * Returns an ordered range of all the layout page template structure rel element variations where plid = &#63; and segmentsExperienceERC = &#63; and active = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateStructureRelElementVariationModelImpl</code>.
+	 * </p>
+	 *
+	 * @param plid the plid
+	 * @param segmentsExperienceERC the segments experience erc
+	 * @param active the active
+	 * @param start the lower bound of the range of layout page template structure rel element variations
+	 * @param end the upper bound of the range of layout page template structure rel element variations (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching layout page template structure rel element variations
+	 */
+	public default java.util.List
+		<LayoutPageTemplateStructureRelElementVariation> findByP_SEERC_A(
+			long plid, String segmentsExperienceERC, boolean active, int start,
+			int end,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<LayoutPageTemplateStructureRelElementVariation>
+					orderByComparator) {
+
+		return findByP_SEERC_A(
+			plid, segmentsExperienceERC, active, start, end, orderByComparator,
+			true);
+	}
+
 }
-// LIFERAY-SERVICE-BUILDER-HASH:706472755
+// LIFERAY-SERVICE-BUILDER-HASH:-1003777356

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/persistence/LayoutPageTemplateStructureRelElementVariationUtil.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/persistence/LayoutPageTemplateStructureRelElementVariationUtil.java
@@ -628,6 +628,105 @@ public class LayoutPageTemplateStructureRelElementVariationUtil {
 	}
 
 	/**
+	 * Returns an ordered range of all the layout page template structure rel element variations where plid = &#63; and segmentsExperienceERC = &#63; and active = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateStructureRelElementVariationModelImpl</code>.
+	 * </p>
+	 *
+	 * @param plid the plid
+	 * @param segmentsExperienceERC the segments experience erc
+	 * @param active the active
+	 * @param start the lower bound of the range of layout page template structure rel element variations
+	 * @param end the upper bound of the range of layout page template structure rel element variations (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching layout page template structure rel element variations
+	 */
+	public static List<LayoutPageTemplateStructureRelElementVariation>
+		findByP_SEERC_A(
+			long plid, String segmentsExperienceERC, boolean active, int start,
+			int end,
+			OrderByComparator<LayoutPageTemplateStructureRelElementVariation>
+				orderByComparator,
+			boolean useFinderCache) {
+
+		return getPersistence().findByP_SEERC_A(
+			plid, segmentsExperienceERC, active, start, end, orderByComparator,
+			useFinderCache);
+	}
+
+	/**
+	 * Returns the first layout page template structure rel element variation in the ordered set where plid = &#63; and segmentsExperienceERC = &#63; and active = &#63;.
+	 *
+	 * @param plid the plid
+	 * @param segmentsExperienceERC the segments experience erc
+	 * @param active the active
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching layout page template structure rel element variation
+	 * @throws NoSuchPageTemplateStructureRelElementVariationException if a matching layout page template structure rel element variation could not be found
+	 */
+	public static LayoutPageTemplateStructureRelElementVariation
+			findByP_SEERC_A_First(
+				long plid, String segmentsExperienceERC, boolean active,
+				OrderByComparator
+					<LayoutPageTemplateStructureRelElementVariation>
+						orderByComparator)
+		throws com.liferay.layout.page.template.exception.
+			NoSuchPageTemplateStructureRelElementVariationException {
+
+		return getPersistence().findByP_SEERC_A_First(
+			plid, segmentsExperienceERC, active, orderByComparator);
+	}
+
+	/**
+	 * Returns the first layout page template structure rel element variation in the ordered set where plid = &#63; and segmentsExperienceERC = &#63; and active = &#63;.
+	 *
+	 * @param plid the plid
+	 * @param segmentsExperienceERC the segments experience erc
+	 * @param active the active
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching layout page template structure rel element variation, or <code>null</code> if a matching layout page template structure rel element variation could not be found
+	 */
+	public static LayoutPageTemplateStructureRelElementVariation
+		fetchByP_SEERC_A_First(
+			long plid, String segmentsExperienceERC, boolean active,
+			OrderByComparator<LayoutPageTemplateStructureRelElementVariation>
+				orderByComparator) {
+
+		return getPersistence().fetchByP_SEERC_A_First(
+			plid, segmentsExperienceERC, active, orderByComparator);
+	}
+
+	/**
+	 * Removes all the layout page template structure rel element variations where plid = &#63; and segmentsExperienceERC = &#63; and active = &#63; from the database.
+	 *
+	 * @param plid the plid
+	 * @param segmentsExperienceERC the segments experience erc
+	 * @param active the active
+	 */
+	public static void removeByP_SEERC_A(
+		long plid, String segmentsExperienceERC, boolean active) {
+
+		getPersistence().removeByP_SEERC_A(plid, segmentsExperienceERC, active);
+	}
+
+	/**
+	 * Returns the number of layout page template structure rel element variations where plid = &#63; and segmentsExperienceERC = &#63; and active = &#63;.
+	 *
+	 * @param plid the plid
+	 * @param segmentsExperienceERC the segments experience erc
+	 * @param active the active
+	 * @return the number of matching layout page template structure rel element variations
+	 */
+	public static int countByP_SEERC_A(
+		long plid, String segmentsExperienceERC, boolean active) {
+
+		return getPersistence().countByP_SEERC_A(
+			plid, segmentsExperienceERC, active);
+	}
+
+	/**
 	 * Returns the layout page template structure rel element variation where externalReferenceCode = &#63; and groupId = &#63; or throws a <code>NoSuchPageTemplateStructureRelElementVariationException</code> if it could not be found.
 	 *
 	 * @param externalReferenceCode the external reference code
@@ -1052,6 +1151,71 @@ public class LayoutPageTemplateStructureRelElementVariationUtil {
 			plid, segmentsExperienceERC, start, end, orderByComparator);
 	}
 
+	/**
+	 * Returns all the layout page template structure rel element variations where plid = &#63; and segmentsExperienceERC = &#63; and active = &#63;.
+	 *
+	 * @param plid the plid
+	 * @param segmentsExperienceERC the segments experience erc
+	 * @param active the active
+	 * @return the matching layout page template structure rel element variations
+	 */
+	public static List<LayoutPageTemplateStructureRelElementVariation>
+		findByP_SEERC_A(
+			long plid, String segmentsExperienceERC, boolean active) {
+
+		return getPersistence().findByP_SEERC_A(
+			plid, segmentsExperienceERC, active);
+	}
+
+	/**
+	 * Returns a range of all the layout page template structure rel element variations where plid = &#63; and segmentsExperienceERC = &#63; and active = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateStructureRelElementVariationModelImpl</code>.
+	 * </p>
+	 *
+	 * @param plid the plid
+	 * @param segmentsExperienceERC the segments experience erc
+	 * @param active the active
+	 * @param start the lower bound of the range of layout page template structure rel element variations
+	 * @param end the upper bound of the range of layout page template structure rel element variations (not inclusive)
+	 * @return the range of matching layout page template structure rel element variations
+	 */
+	public static List<LayoutPageTemplateStructureRelElementVariation>
+		findByP_SEERC_A(
+			long plid, String segmentsExperienceERC, boolean active, int start,
+			int end) {
+
+		return getPersistence().findByP_SEERC_A(
+			plid, segmentsExperienceERC, active, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the layout page template structure rel element variations where plid = &#63; and segmentsExperienceERC = &#63; and active = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateStructureRelElementVariationModelImpl</code>.
+	 * </p>
+	 *
+	 * @param plid the plid
+	 * @param segmentsExperienceERC the segments experience erc
+	 * @param active the active
+	 * @param start the lower bound of the range of layout page template structure rel element variations
+	 * @param end the upper bound of the range of layout page template structure rel element variations (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching layout page template structure rel element variations
+	 */
+	public static List<LayoutPageTemplateStructureRelElementVariation>
+		findByP_SEERC_A(
+			long plid, String segmentsExperienceERC, boolean active, int start,
+			int end,
+			OrderByComparator<LayoutPageTemplateStructureRelElementVariation>
+				orderByComparator) {
+
+		return getPersistence().findByP_SEERC_A(
+			plid, segmentsExperienceERC, active, start, end, orderByComparator);
+	}
+
 	public static LayoutPageTemplateStructureRelElementVariationPersistence
 		getPersistence() {
 
@@ -1068,4 +1232,4 @@ public class LayoutPageTemplateStructureRelElementVariationUtil {
 		LayoutPageTemplateStructureRelElementVariationPersistence _persistence;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1497868585
+// LIFERAY-SERVICE-BUILDER-HASH:1025664715

--- a/modules/apps/layout/layout-page-template-service/service.xml
+++ b/modules/apps/layout/layout-page-template-service/service.xml
@@ -346,7 +346,7 @@
 
 		<!-- Other fields -->
 
-		<column localized="true" name="hide" type="String" />
+		<column name="hide" type="String" />
 		<column localized="true" name="html" type="String" />
 		<column localized="true" name="js" type="String" />
 		<column name="name" type="String" />

--- a/modules/apps/layout/layout-page-template-service/service.xml
+++ b/modules/apps/layout/layout-page-template-service/service.xml
@@ -353,6 +353,7 @@
 		<column name="plid" type="long" />
 		<column name="segmentsExperienceERC" type="String" />
 		<column name="targetElement" type="String" />
+		<column name="active" type="boolean" />
 
 		<!-- Finder methods -->
 
@@ -365,6 +366,11 @@
 		<finder name="P_SEERC" return-type="Collection">
 			<finder-column name="plid" />
 			<finder-column name="segmentsExperienceERC" />
+		</finder>
+		<finder name="P_SEERC_A" return-type="Collection">
+			<finder-column name="plid" />
+			<finder-column name="segmentsExperienceERC" />
+			<finder-column name="active" />
 		</finder>
 	</entity>
 	<entity external-reference-code="group" local-service="true" name="LayoutPageTemplateStructureRelElementVariationAudienceEntryRel" remote-service="true" table="LPTSREVAudienceEntryRel" uuid="true">

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v6_1_0/util/LayoutPageTemplateStructureRelElementVariationTable.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v6_1_0/util/LayoutPageTemplateStructureRelElementVariationTable.java
@@ -30,6 +30,6 @@ public class LayoutPageTemplateStructureRelElementVariationTable {
 	private static final String _TABLE_NAME = "LPTSRelElementVariation";
 
 	private static final String _TABLE_SQL_CREATE =
-		"create table LPTSRelElementVariation (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,lptsRelElementVariationId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,hide STRING null,html STRING null,js STRING null,name VARCHAR(75) null,plid LONG,segmentsExperienceERC VARCHAR(75) null,targetElement VARCHAR(1000) null,active_ BOOLEAN,primary key (lptsRelElementVariationId, ctCollectionId))";
+		"create table LPTSRelElementVariation (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,lptsRelElementVariationId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,hide TEXT null,html STRING null,js STRING null,name VARCHAR(75) null,plid LONG,segmentsExperienceERC VARCHAR(75) null,targetElement VARCHAR(1000) null,active_ BOOLEAN,primary key (lptsRelElementVariationId, ctCollectionId))";
 
 }

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v6_1_0/util/LayoutPageTemplateStructureRelElementVariationTable.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v6_1_0/util/LayoutPageTemplateStructureRelElementVariationTable.java
@@ -30,6 +30,6 @@ public class LayoutPageTemplateStructureRelElementVariationTable {
 	private static final String _TABLE_NAME = "LPTSRelElementVariation";
 
 	private static final String _TABLE_SQL_CREATE =
-		"create table LPTSRelElementVariation (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,lptsRelElementVariationId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,hide STRING null,html STRING null,js STRING null,name VARCHAR(75) null,plid LONG,segmentsExperienceERC VARCHAR(75) null,targetElement VARCHAR(1000) null,primary key (lptsRelElementVariationId, ctCollectionId))";
+		"create table LPTSRelElementVariation (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,lptsRelElementVariationId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,hide STRING null,html STRING null,js STRING null,name VARCHAR(75) null,plid LONG,segmentsExperienceERC VARCHAR(75) null,targetElement VARCHAR(1000) null,active_ BOOLEAN,primary key (lptsRelElementVariationId, ctCollectionId))";
 
 }

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/model/impl/LayoutPageTemplateStructureRelElementVariationCacheModel.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/model/impl/LayoutPageTemplateStructureRelElementVariationCacheModel.java
@@ -82,7 +82,7 @@ public class LayoutPageTemplateStructureRelElementVariationCacheModel
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(37);
+		StringBundler sb = new StringBundler(39);
 
 		sb.append("{mvccVersion=");
 		sb.append(mvccVersion);
@@ -120,6 +120,8 @@ public class LayoutPageTemplateStructureRelElementVariationCacheModel
 		sb.append(segmentsExperienceERC);
 		sb.append(", targetElement=");
 		sb.append(targetElement);
+		sb.append(", active=");
+		sb.append(active);
 		sb.append("}");
 
 		return sb.toString();
@@ -234,6 +236,8 @@ public class LayoutPageTemplateStructureRelElementVariationCacheModel
 				targetElement);
 		}
 
+		layoutPageTemplateStructureRelElementVariationImpl.setActive(active);
+
 		layoutPageTemplateStructureRelElementVariationImpl.
 			resetOriginalValues();
 
@@ -270,7 +274,7 @@ public class LayoutPageTemplateStructureRelElementVariationCacheModel
 		userName = objectInput.readUTF();
 		createDate = objectInput.readLong();
 		modifiedDate = objectInput.readLong();
-		hide = objectInput.readUTF();
+		hide = (String)objectInput.readObject();
 		html = objectInput.readUTF();
 		js = objectInput.readUTF();
 		name = objectInput.readUTF();
@@ -278,6 +282,8 @@ public class LayoutPageTemplateStructureRelElementVariationCacheModel
 		plid = objectInput.readLong();
 		segmentsExperienceERC = objectInput.readUTF();
 		targetElement = objectInput.readUTF();
+
+		active = objectInput.readBoolean();
 
 		audienceEntryERCs = (java.util.List)objectInput.readObject();
 	}
@@ -322,10 +328,10 @@ public class LayoutPageTemplateStructureRelElementVariationCacheModel
 		objectOutput.writeLong(modifiedDate);
 
 		if (hide == null) {
-			objectOutput.writeUTF("");
+			objectOutput.writeObject("");
 		}
 		else {
-			objectOutput.writeUTF(hide);
+			objectOutput.writeObject(hide);
 		}
 
 		if (html == null) {
@@ -365,6 +371,8 @@ public class LayoutPageTemplateStructureRelElementVariationCacheModel
 			objectOutput.writeUTF(targetElement);
 		}
 
+		objectOutput.writeBoolean(active);
+
 		objectOutput.writeObject(audienceEntryERCs);
 	}
 
@@ -386,6 +394,7 @@ public class LayoutPageTemplateStructureRelElementVariationCacheModel
 	public long plid;
 	public String segmentsExperienceERC;
 	public String targetElement;
+	public boolean active;
 	public volatile java.util.List audienceEntryERCs;
 
 	private static final MethodHandle _audienceEntryERCsMethodHandle;
@@ -404,4 +413,4 @@ public class LayoutPageTemplateStructureRelElementVariationCacheModel
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2108233286
+// LIFERAY-SERVICE-BUILDER-HASH:2122486880

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/model/impl/LayoutPageTemplateStructureRelElementVariationModelImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/model/impl/LayoutPageTemplateStructureRelElementVariationModelImpl.java
@@ -82,10 +82,10 @@ public class LayoutPageTemplateStructureRelElementVariationModelImpl
 		{"lptsRelElementVariationId", Types.BIGINT}, {"groupId", Types.BIGINT},
 		{"companyId", Types.BIGINT}, {"userId", Types.BIGINT},
 		{"userName", Types.VARCHAR}, {"createDate", Types.TIMESTAMP},
-		{"modifiedDate", Types.TIMESTAMP}, {"hide", Types.VARCHAR},
+		{"modifiedDate", Types.TIMESTAMP}, {"hide", Types.CLOB},
 		{"html", Types.VARCHAR}, {"js", Types.VARCHAR}, {"name", Types.VARCHAR},
 		{"plid", Types.BIGINT}, {"segmentsExperienceERC", Types.VARCHAR},
-		{"targetElement", Types.VARCHAR}
+		{"targetElement", Types.VARCHAR}, {"active_", Types.BOOLEAN}
 	};
 
 	public static final Map<String, Integer> TABLE_COLUMNS_MAP =
@@ -103,17 +103,18 @@ public class LayoutPageTemplateStructureRelElementVariationModelImpl
 		TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
 		TABLE_COLUMNS_MAP.put("modifiedDate", Types.TIMESTAMP);
-		TABLE_COLUMNS_MAP.put("hide", Types.VARCHAR);
+		TABLE_COLUMNS_MAP.put("hide", Types.CLOB);
 		TABLE_COLUMNS_MAP.put("html", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("js", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("name", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("plid", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("segmentsExperienceERC", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("targetElement", Types.VARCHAR);
+		TABLE_COLUMNS_MAP.put("active_", Types.BOOLEAN);
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table LPTSRelElementVariation (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,lptsRelElementVariationId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,hide STRING null,html STRING null,js STRING null,name VARCHAR(75) null,plid LONG,segmentsExperienceERC VARCHAR(75) null,targetElement VARCHAR(1000) null,primary key (lptsRelElementVariationId, ctCollectionId))";
+		"create table LPTSRelElementVariation (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,lptsRelElementVariationId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,hide TEXT null,html STRING null,js STRING null,name VARCHAR(75) null,plid LONG,segmentsExperienceERC VARCHAR(75) null,targetElement VARCHAR(1000) null,active_ BOOLEAN,primary key (lptsRelElementVariationId, ctCollectionId))";
 
 	public static final String TABLE_SQL_DROP =
 		"drop table LPTSRelElementVariation";
@@ -137,37 +138,43 @@ public class LayoutPageTemplateStructureRelElementVariationModelImpl
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long COMPANYID_COLUMN_BITMASK = 1L;
+	public static final long ACTIVE_COLUMN_BITMASK = 1L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long EXTERNALREFERENCECODE_COLUMN_BITMASK = 2L;
+	public static final long COMPANYID_COLUMN_BITMASK = 2L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long GROUPID_COLUMN_BITMASK = 4L;
+	public static final long EXTERNALREFERENCECODE_COLUMN_BITMASK = 4L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long PLID_COLUMN_BITMASK = 8L;
+	public static final long GROUPID_COLUMN_BITMASK = 8L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long SEGMENTSEXPERIENCEERC_COLUMN_BITMASK = 16L;
+	public static final long PLID_COLUMN_BITMASK = 16L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long UUID_COLUMN_BITMASK = 32L;
+	public static final long SEGMENTSEXPERIENCEERC_COLUMN_BITMASK = 32L;
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
+	 */
+	@Deprecated
+	public static final long UUID_COLUMN_BITMASK = 64L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
@@ -175,7 +182,7 @@ public class LayoutPageTemplateStructureRelElementVariationModelImpl
 	 */
 	@Deprecated
 	public static final long
-		LAYOUTPAGETEMPLATESTRUCTURERELELEMENTVARIATIONID_COLUMN_BITMASK = 64L;
+		LAYOUTPAGETEMPLATESTRUCTURERELELEMENTVARIATIONID_COLUMN_BITMASK = 128L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
@@ -368,6 +375,9 @@ public class LayoutPageTemplateStructureRelElementVariationModelImpl
 				"targetElement",
 				LayoutPageTemplateStructureRelElementVariation::
 					getTargetElement);
+			attributeGetterFunctions.put(
+				"active",
+				LayoutPageTemplateStructureRelElementVariation::getActive);
 
 			_attributeGetterFunctions = Collections.unmodifiableMap(
 				attributeGetterFunctions);
@@ -500,6 +510,12 @@ public class LayoutPageTemplateStructureRelElementVariationModelImpl
 					<LayoutPageTemplateStructureRelElementVariation, String>)
 						LayoutPageTemplateStructureRelElementVariation::
 							setTargetElement);
+			attributeSetterBiConsumers.put(
+				"active",
+				(BiConsumer
+					<LayoutPageTemplateStructureRelElementVariation, Boolean>)
+						LayoutPageTemplateStructureRelElementVariation::
+							setActive);
 
 			_attributeSetterBiConsumers = Collections.unmodifiableMap(
 				(Map)attributeSetterBiConsumers);
@@ -761,99 +777,12 @@ public class LayoutPageTemplateStructureRelElementVariationModelImpl
 	}
 
 	@Override
-	public String getHide(Locale locale) {
-		String languageId = LocaleUtil.toLanguageId(locale);
-
-		return getHide(languageId);
-	}
-
-	@Override
-	public String getHide(Locale locale, boolean useDefault) {
-		String languageId = LocaleUtil.toLanguageId(locale);
-
-		return getHide(languageId, useDefault);
-	}
-
-	@Override
-	public String getHide(String languageId) {
-		return LocalizationUtil.getLocalization(getHide(), languageId);
-	}
-
-	@Override
-	public String getHide(String languageId, boolean useDefault) {
-		return LocalizationUtil.getLocalization(
-			getHide(), languageId, useDefault);
-	}
-
-	@Override
-	public String getHideCurrentLanguageId() {
-		return _hideCurrentLanguageId;
-	}
-
-	@JSON
-	@Override
-	public String getHideCurrentValue() {
-		Locale locale = getLocale(_hideCurrentLanguageId);
-
-		return getHide(locale);
-	}
-
-	@Override
-	public Map<Locale, String> getHideMap() {
-		return LocalizationUtil.getLocalizationMap(getHide());
-	}
-
-	@Override
 	public void setHide(String hide) {
 		if (_columnOriginalValues == Collections.EMPTY_MAP) {
 			_setColumnOriginalValues();
 		}
 
 		_hide = hide;
-	}
-
-	@Override
-	public void setHide(String hide, Locale locale) {
-		setHide(hide, locale, LocaleUtil.getSiteDefault());
-	}
-
-	@Override
-	public void setHide(String hide, Locale locale, Locale defaultLocale) {
-		String languageId = LocaleUtil.toLanguageId(locale);
-		String defaultLanguageId = LocaleUtil.toLanguageId(defaultLocale);
-
-		if (Validator.isNotNull(hide)) {
-			setHide(
-				LocalizationUtil.updateLocalization(
-					getHide(), "Hide", hide, languageId, defaultLanguageId));
-		}
-		else {
-			setHide(
-				LocalizationUtil.removeLocalization(
-					getHide(), "Hide", languageId));
-		}
-	}
-
-	@Override
-	public void setHideCurrentLanguageId(String languageId) {
-		_hideCurrentLanguageId = languageId;
-	}
-
-	@Override
-	public void setHideMap(Map<Locale, String> hideMap) {
-		setHideMap(hideMap, LocaleUtil.getSiteDefault());
-	}
-
-	@Override
-	public void setHideMap(Map<Locale, String> hideMap, Locale defaultLocale) {
-		if (hideMap == null) {
-			return;
-		}
-
-		setHide(
-			LocalizationUtil.updateLocalization(
-				hideMap, getHide(), "Hide",
-				LocaleUtil.toLanguageId(defaultLocale)));
 	}
 
 	@JSON
@@ -1161,6 +1090,37 @@ public class LayoutPageTemplateStructureRelElementVariationModelImpl
 		_targetElement = targetElement;
 	}
 
+	@JSON
+	@Override
+	public boolean getActive() {
+		return _active;
+	}
+
+	@JSON
+	@Override
+	public boolean isActive() {
+		return _active;
+	}
+
+	@Override
+	public void setActive(boolean active) {
+		if (_columnOriginalValues == Collections.EMPTY_MAP) {
+			_setColumnOriginalValues();
+		}
+
+		_active = active;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #getColumnOriginalValue(String)}
+	 */
+	@Deprecated
+	public boolean getOriginalActive() {
+		return GetterUtil.getBoolean(
+			this.<Boolean>getColumnOriginalValue("active_"));
+	}
+
 	public List<String> getAudienceEntryERCs() {
 		return null;
 	}
@@ -1219,17 +1179,6 @@ public class LayoutPageTemplateStructureRelElementVariationModelImpl
 	public String[] getAvailableLanguageIds() {
 		Set<String> availableLanguageIds = new TreeSet<String>();
 
-		Map<Locale, String> hideMap = getHideMap();
-
-		for (Map.Entry<Locale, String> entry : hideMap.entrySet()) {
-			Locale locale = entry.getKey();
-			String value = entry.getValue();
-
-			if (Validator.isNotNull(value)) {
-				availableLanguageIds.add(LocaleUtil.toLanguageId(locale));
-			}
-		}
-
 		Map<Locale, String> htmlMap = getHtmlMap();
 
 		for (Map.Entry<Locale, String> entry : htmlMap.entrySet()) {
@@ -1258,7 +1207,7 @@ public class LayoutPageTemplateStructureRelElementVariationModelImpl
 
 	@Override
 	public String getDefaultLanguageId() {
-		String xml = getHide();
+		String xml = getHtml();
 
 		if (xml == null) {
 			return "";
@@ -1292,15 +1241,6 @@ public class LayoutPageTemplateStructureRelElementVariationModelImpl
 		Locale defaultLocale = LocaleUtil.getSiteDefault();
 
 		String modelDefaultLanguageId = getDefaultLanguageId();
-
-		String hide = getHide(defaultLocale);
-
-		if (Validator.isNull(hide)) {
-			setHide(getHide(modelDefaultLanguageId), defaultLocale);
-		}
-		else {
-			setHide(getHide(defaultLocale), defaultLocale, defaultLocale);
-		}
 
 		String html = getHtml(defaultLocale);
 
@@ -1375,6 +1315,8 @@ public class LayoutPageTemplateStructureRelElementVariationModelImpl
 			setSegmentsExperienceERC(getSegmentsExperienceERC());
 		layoutPageTemplateStructureRelElementVariationImpl.setTargetElement(
 			getTargetElement());
+		layoutPageTemplateStructureRelElementVariationImpl.setActive(
+			isActive());
 
 		layoutPageTemplateStructureRelElementVariationImpl.
 			resetOriginalValues();
@@ -1429,6 +1371,8 @@ public class LayoutPageTemplateStructureRelElementVariationModelImpl
 				this.<String>getColumnOriginalValue("segmentsExperienceERC"));
 		layoutPageTemplateStructureRelElementVariationImpl.setTargetElement(
 			this.<String>getColumnOriginalValue("targetElement"));
+		layoutPageTemplateStructureRelElementVariationImpl.setActive(
+			this.<Boolean>getColumnOriginalValue("active_"));
 
 		return layoutPageTemplateStructureRelElementVariationImpl;
 	}
@@ -1677,6 +1621,9 @@ public class LayoutPageTemplateStructureRelElementVariationModelImpl
 				targetElement = null;
 		}
 
+		layoutPageTemplateStructureRelElementVariationCacheModel.active =
+			isActive();
+
 		try {
 			layoutPageTemplateStructureRelElementVariationCacheModel.
 				audienceEntryERCs =
@@ -1770,7 +1717,6 @@ public class LayoutPageTemplateStructureRelElementVariationModelImpl
 	private Date _modifiedDate;
 	private boolean _setModifiedDate;
 	private String _hide;
-	private String _hideCurrentLanguageId;
 	private String _html;
 	private String _htmlCurrentLanguageId;
 	private String _js;
@@ -1779,6 +1725,7 @@ public class LayoutPageTemplateStructureRelElementVariationModelImpl
 	private long _plid;
 	private String _segmentsExperienceERC;
 	private String _targetElement;
+	private boolean _active;
 
 	public <T> T getColumnValue(String columnName) {
 		columnName = _attributeNames.getOrDefault(columnName, columnName);
@@ -1834,6 +1781,7 @@ public class LayoutPageTemplateStructureRelElementVariationModelImpl
 		_columnOriginalValues.put(
 			"segmentsExperienceERC", _segmentsExperienceERC);
 		_columnOriginalValues.put("targetElement", _targetElement);
+		_columnOriginalValues.put("active_", _active);
 	}
 
 	private static final Map<String, String> _attributeNames;
@@ -1845,6 +1793,7 @@ public class LayoutPageTemplateStructureRelElementVariationModelImpl
 		attributeNames.put(
 			"lptsRelElementVariationId",
 			"layoutPageTemplateStructureRelElementVariationId");
+		attributeNames.put("active_", "active");
 
 		_attributeNames = Collections.unmodifiableMap(attributeNames);
 	}
@@ -1896,6 +1845,8 @@ public class LayoutPageTemplateStructureRelElementVariationModelImpl
 
 		columnBitmasks.put("targetElement", 131072L);
 
+		columnBitmasks.put("active_", 262144L);
+
 		_columnBitmasks = Collections.unmodifiableMap(columnBitmasks);
 	}
 
@@ -1945,4 +1896,4 @@ public class LayoutPageTemplateStructureRelElementVariationModelImpl
 	private LayoutPageTemplateStructureRelElementVariation _escapedModel;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1763412238
+// LIFERAY-SERVICE-BUILDER-HASH:-69432844

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/http/LayoutPageTemplateStructureRelElementVariationServiceHttp.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/http/LayoutPageTemplateStructureRelElementVariationServiceHttp.java
@@ -45,12 +45,11 @@ public class LayoutPageTemplateStructureRelElementVariationServiceHttp {
 		LayoutPageTemplateStructureRelElementVariation
 				addOrUpdateLayoutPageTemplateStructureRelElementVariation(
 					HttpPrincipal httpPrincipal, String externalReferenceCode,
-					long groupId, String[] audienceEntryERCs,
-					java.util.Map<java.util.Locale, String> hideMap,
+					long groupId, String[] audienceEntryERCs, String hide,
 					java.util.Map<java.util.Locale, String> htmlMap,
 					java.util.Map<java.util.Locale, String> jsMap, String name,
 					long plid, String segmentsExperienceERC,
-					String targetElement,
+					String targetElement, boolean active,
 					com.liferay.portal.kernel.service.ServiceContext
 						serviceContext)
 			throws com.liferay.portal.kernel.exception.PortalException {
@@ -63,8 +62,8 @@ public class LayoutPageTemplateStructureRelElementVariationServiceHttp {
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, externalReferenceCode, groupId, audienceEntryERCs,
-				hideMap, htmlMap, jsMap, name, plid, segmentsExperienceERC,
-				targetElement, serviceContext);
+				hide, htmlMap, jsMap, name, plid, segmentsExperienceERC,
+				targetElement, active, serviceContext);
 
 			Object returnObj = null;
 
@@ -184,9 +183,9 @@ public class LayoutPageTemplateStructureRelElementVariationServiceHttp {
 	private static final Class<?>[]
 		_addOrUpdateLayoutPageTemplateStructureRelElementVariationParameterTypes0 =
 			new Class[] {
-				String.class, long.class, String[].class, java.util.Map.class,
+				String.class, long.class, String[].class, String.class,
 				java.util.Map.class, java.util.Map.class, String.class,
-				long.class, String.class, String.class,
+				long.class, String.class, String.class, boolean.class,
 				com.liferay.portal.kernel.service.ServiceContext.class
 			};
 	private static final Class<?>[]
@@ -197,4 +196,4 @@ public class LayoutPageTemplateStructureRelElementVariationServiceHttp {
 			new Class[] {long.class};
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1984029539
+// LIFERAY-SERVICE-BUILDER-HASH:-2000034751

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateStructureRelElementVariationLocalServiceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateStructureRelElementVariationLocalServiceImpl.java
@@ -40,10 +40,11 @@ public class LayoutPageTemplateStructureRelElementVariationLocalServiceImpl
 	public LayoutPageTemplateStructureRelElementVariation
 			addOrUpdateLayoutPageTemplateStructureRelElementVariation(
 				String externalReferenceCode, long userId, long groupId,
-				String[] audienceEntryERCs, Map<Locale, String> hideMap,
+				String[] audienceEntryERCs, String hide,
 				Map<Locale, String> htmlMap, Map<Locale, String> jsMap,
 				String name, long plid, String segmentsExperienceERC,
-				String targetElement, ServiceContext serviceContext)
+				String targetElement, boolean active,
+				ServiceContext serviceContext)
 		throws PortalException {
 
 		_validate(audienceEntryERCs, name, targetElement);
@@ -77,7 +78,7 @@ public class LayoutPageTemplateStructureRelElementVariationLocalServiceImpl
 
 		layoutPageTemplateStructureRelElementVariation.setModifiedDate(
 			serviceContext.getModifiedDate(new Date()));
-		layoutPageTemplateStructureRelElementVariation.setHideMap(hideMap);
+		layoutPageTemplateStructureRelElementVariation.setHide(hide);
 		layoutPageTemplateStructureRelElementVariation.setHtmlMap(htmlMap);
 		layoutPageTemplateStructureRelElementVariation.setJsMap(jsMap);
 		layoutPageTemplateStructureRelElementVariation.setName(name);
@@ -86,6 +87,7 @@ public class LayoutPageTemplateStructureRelElementVariationLocalServiceImpl
 			segmentsExperienceERC);
 		layoutPageTemplateStructureRelElementVariation.setTargetElement(
 			targetElement);
+		layoutPageTemplateStructureRelElementVariation.setActive(active);
 
 		layoutPageTemplateStructureRelElementVariation =
 			layoutPageTemplateStructureRelElementVariationPersistence.update(
@@ -140,6 +142,14 @@ public class LayoutPageTemplateStructureRelElementVariationLocalServiceImpl
 
 		return layoutPageTemplateStructureRelElementVariationPersistence.
 			findByP_SEERC(plid, segmentsExperienceERC);
+	}
+
+	public List<LayoutPageTemplateStructureRelElementVariation>
+		getLayoutPageTemplateStructureRelElementVariations(
+			long plid, String segmentsExperienceERC, boolean active) {
+
+		return layoutPageTemplateStructureRelElementVariationPersistence.
+			findByP_SEERC_A(plid, segmentsExperienceERC, active);
 	}
 
 	private void _validate(

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateStructureRelElementVariationServiceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateStructureRelElementVariationServiceImpl.java
@@ -34,10 +34,11 @@ public class LayoutPageTemplateStructureRelElementVariationServiceImpl
 	public LayoutPageTemplateStructureRelElementVariation
 			addOrUpdateLayoutPageTemplateStructureRelElementVariation(
 				String externalReferenceCode, long groupId,
-				String[] audienceEntryERCs, Map<Locale, String> hideMap,
+				String[] audienceEntryERCs, String hide,
 				Map<Locale, String> htmlMap, Map<Locale, String> jsMap,
 				String name, long plid, String segmentsExperienceERC,
-				String targetElement, ServiceContext serviceContext)
+				String targetElement, boolean active,
+				ServiceContext serviceContext)
 		throws PortalException {
 
 		_layoutModelResourcePermission.check(
@@ -46,8 +47,8 @@ public class LayoutPageTemplateStructureRelElementVariationServiceImpl
 		return layoutPageTemplateStructureRelElementVariationLocalService.
 			addOrUpdateLayoutPageTemplateStructureRelElementVariation(
 				externalReferenceCode, getUserId(), groupId, audienceEntryERCs,
-				hideMap, htmlMap, jsMap, name, plid, segmentsExperienceERC,
-				targetElement, serviceContext);
+				hide, htmlMap, jsMap, name, plid, segmentsExperienceERC,
+				targetElement, active, serviceContext);
 	}
 
 	public void deleteLayoutPageTemplateStructureRelElementVariation(

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/persistence/impl/LayoutPageTemplateStructureRelElementVariationPersistenceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/persistence/impl/LayoutPageTemplateStructureRelElementVariationPersistenceImpl.java
@@ -635,6 +635,114 @@ public class LayoutPageTemplateStructureRelElementVariationPersistenceImpl
 			finderCache, new Object[] {plid, segmentsExperienceERC});
 	}
 
+	private CollectionPersistenceFinder
+		<LayoutPageTemplateStructureRelElementVariation,
+		 NoSuchPageTemplateStructureRelElementVariationException>
+			_collectionPersistenceFinderByP_SEERC_A;
+
+	/**
+	 * Returns an ordered range of all the layout page template structure rel element variations where plid = &#63; and segmentsExperienceERC = &#63; and active = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>LayoutPageTemplateStructureRelElementVariationModelImpl</code>.
+	 * </p>
+	 *
+	 * @param plid the plid
+	 * @param segmentsExperienceERC the segments experience erc
+	 * @param active the active
+	 * @param start the lower bound of the range of layout page template structure rel element variations
+	 * @param end the upper bound of the range of layout page template structure rel element variations (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching layout page template structure rel element variations
+	 */
+	@Override
+	public List<LayoutPageTemplateStructureRelElementVariation> findByP_SEERC_A(
+		long plid, String segmentsExperienceERC, boolean active, int start,
+		int end,
+		OrderByComparator<LayoutPageTemplateStructureRelElementVariation>
+			orderByComparator,
+		boolean useFinderCache) {
+
+		return _collectionPersistenceFinderByP_SEERC_A.find(
+			finderCache, new Object[] {plid, segmentsExperienceERC, active},
+			start, end, orderByComparator, useFinderCache);
+	}
+
+	/**
+	 * Returns the first layout page template structure rel element variation in the ordered set where plid = &#63; and segmentsExperienceERC = &#63; and active = &#63;.
+	 *
+	 * @param plid the plid
+	 * @param segmentsExperienceERC the segments experience erc
+	 * @param active the active
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching layout page template structure rel element variation
+	 * @throws NoSuchPageTemplateStructureRelElementVariationException if a matching layout page template structure rel element variation could not be found
+	 */
+	@Override
+	public LayoutPageTemplateStructureRelElementVariation findByP_SEERC_A_First(
+			long plid, String segmentsExperienceERC, boolean active,
+			OrderByComparator<LayoutPageTemplateStructureRelElementVariation>
+				orderByComparator)
+		throws NoSuchPageTemplateStructureRelElementVariationException {
+
+		return _collectionPersistenceFinderByP_SEERC_A.findFirst(
+			finderCache, new Object[] {plid, segmentsExperienceERC, active},
+			orderByComparator);
+	}
+
+	/**
+	 * Returns the first layout page template structure rel element variation in the ordered set where plid = &#63; and segmentsExperienceERC = &#63; and active = &#63;.
+	 *
+	 * @param plid the plid
+	 * @param segmentsExperienceERC the segments experience erc
+	 * @param active the active
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching layout page template structure rel element variation, or <code>null</code> if a matching layout page template structure rel element variation could not be found
+	 */
+	@Override
+	public LayoutPageTemplateStructureRelElementVariation
+		fetchByP_SEERC_A_First(
+			long plid, String segmentsExperienceERC, boolean active,
+			OrderByComparator<LayoutPageTemplateStructureRelElementVariation>
+				orderByComparator) {
+
+		return _collectionPersistenceFinderByP_SEERC_A.fetchFirst(
+			finderCache, new Object[] {plid, segmentsExperienceERC, active},
+			orderByComparator);
+	}
+
+	/**
+	 * Removes all the layout page template structure rel element variations where plid = &#63; and segmentsExperienceERC = &#63; and active = &#63; from the database.
+	 *
+	 * @param plid the plid
+	 * @param segmentsExperienceERC the segments experience erc
+	 * @param active the active
+	 */
+	@Override
+	public void removeByP_SEERC_A(
+		long plid, String segmentsExperienceERC, boolean active) {
+
+		_collectionPersistenceFinderByP_SEERC_A.remove(
+			finderCache, new Object[] {plid, segmentsExperienceERC, active});
+	}
+
+	/**
+	 * Returns the number of layout page template structure rel element variations where plid = &#63; and segmentsExperienceERC = &#63; and active = &#63;.
+	 *
+	 * @param plid the plid
+	 * @param segmentsExperienceERC the segments experience erc
+	 * @param active the active
+	 * @return the number of matching layout page template structure rel element variations
+	 */
+	@Override
+	public int countByP_SEERC_A(
+		long plid, String segmentsExperienceERC, boolean active) {
+
+		return _collectionPersistenceFinderByP_SEERC_A.count(
+			finderCache, new Object[] {plid, segmentsExperienceERC, active});
+	}
+
 	private UniquePersistenceFinder
 		<LayoutPageTemplateStructureRelElementVariation,
 		 NoSuchPageTemplateStructureRelElementVariationException>
@@ -713,6 +821,7 @@ public class LayoutPageTemplateStructureRelElementVariationPersistenceImpl
 		dbColumnNames.put(
 			"layoutPageTemplateStructureRelElementVariationId",
 			"lptsRelElementVariationId");
+		dbColumnNames.put("active", "active_");
 
 		setDBColumnNames(dbColumnNames);
 
@@ -1139,6 +1248,7 @@ public class LayoutPageTemplateStructureRelElementVariationPersistenceImpl
 		ctMergeColumnNames.add("plid");
 		ctMergeColumnNames.add("segmentsExperienceERC");
 		ctMergeColumnNames.add("targetElement");
+		ctMergeColumnNames.add("active_");
 
 		_ctColumnNamesMap.put(
 			CTColumnResolutionType.CONTROL, ctControlColumnNames);
@@ -1341,6 +1451,57 @@ public class LayoutPageTemplateStructureRelElementVariationPersistenceImpl
 					LayoutPageTemplateStructureRelElementVariation::
 						getSegmentsExperienceERC));
 
+		_collectionPersistenceFinderByP_SEERC_A =
+			new CollectionPersistenceFinder<>(
+				this,
+				new FinderPath(
+					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByP_SEERC_A",
+					new String[] {
+						Long.class.getName(), String.class.getName(),
+						Boolean.class.getName(), Integer.class.getName(),
+						Integer.class.getName(),
+						OrderByComparator.class.getName()
+					},
+					new String[] {"plid", "segmentsExperienceERC", "active_"},
+					true),
+				new FinderPath(
+					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
+					"findByP_SEERC_A",
+					new String[] {
+						Long.class.getName(), String.class.getName(),
+						Boolean.class.getName()
+					},
+					new String[] {"plid", "segmentsExperienceERC", "active_"},
+					0, 2, true, null),
+				new FinderPath(
+					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
+					"countByP_SEERC_A",
+					new String[] {
+						Long.class.getName(), String.class.getName(),
+						Boolean.class.getName()
+					},
+					new String[] {"plid", "segmentsExperienceERC", "active_"},
+					0, 2, false, null),
+				_SQL_SELECT_LAYOUTPAGETEMPLATESTRUCTURERELELEMENTVARIATION_WHERE,
+				_SQL_COUNT_LAYOUTPAGETEMPLATESTRUCTURERELELEMENTVARIATION_WHERE,
+				LayoutPageTemplateStructureRelElementVariationModelImpl.
+					ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "", "", null,
+				new FinderColumn<>(
+					"layoutPageTemplateStructureRelElementVariation.", "plid",
+					FinderColumn.Type.LONG, "=", true, true,
+					LayoutPageTemplateStructureRelElementVariation::getPlid),
+				new FinderColumn<>(
+					"layoutPageTemplateStructureRelElementVariation.",
+					"segmentsExperienceERC", FinderColumn.Type.STRING, "=",
+					true, true,
+					LayoutPageTemplateStructureRelElementVariation::
+						getSegmentsExperienceERC),
+				new FinderColumn<>(
+					"layoutPageTemplateStructureRelElementVariation.", "active",
+					"active_", FinderColumn.Type.BOOLEAN, "=", true, true,
+					LayoutPageTemplateStructureRelElementVariation::isActive));
+
 		_uniquePersistenceFinderByERC_G = new UniquePersistenceFinder<>(
 			this,
 			createUniqueFinderPath(
@@ -1428,7 +1589,7 @@ public class LayoutPageTemplateStructureRelElementVariationPersistenceImpl
 
 	private static final Set<String> _badColumnNames = SetUtil.fromArray(
 		new String[] {
-			"uuid", "layoutPageTemplateStructureRelElementVariationId"
+			"uuid", "layoutPageTemplateStructureRelElementVariationId", "active"
 		});
 
 	@Override
@@ -1437,4 +1598,4 @@ public class LayoutPageTemplateStructureRelElementVariationPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:886004683
+// LIFERAY-SERVICE-BUILDER-HASH:663503448

--- a/modules/apps/layout/layout-page-template-service/src/main/resources/META-INF/module-hbm.xml
+++ b/modules/apps/layout/layout-page-template-service/src/main/resources/META-INF/module-hbm.xml
@@ -111,13 +111,14 @@
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="userName" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="createDate" type="timestamp" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="modifiedDate" type="timestamp" />
-		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="hide" type="com.liferay.portal.dao.orm.hibernate.StringType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="hide" type="com.liferay.portal.dao.orm.hibernate.StringClobType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="html" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="js" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="name" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="plid" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="segmentsExperienceERC" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="targetElement" type="com.liferay.portal.dao.orm.hibernate.StringType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" column="active_" name="active" type="com.liferay.portal.dao.orm.hibernate.BooleanType" />
 	</class>
 	<class dynamic-update="true" name="com.liferay.layout.page.template.model.impl.LayoutPageTemplateStructureRelElementVariationAudienceEntryRelImpl" table="LPTSREVAudienceEntryRel">
 		<id access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" column="lptsrevAudienceEntryRelId" name="layoutPageTemplateStructureRelElementVariationAudienceEntryRelId" type="long">

--- a/modules/apps/layout/layout-page-template-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/apps/layout/layout-page-template-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -100,7 +100,9 @@
 		<field name="userName" type="String" />
 		<field name="createDate" type="Date" />
 		<field name="modifiedDate" type="Date" />
-		<field localized="true" name="hide" type="String" />
+		<field name="hide" type="String">
+			<hint-collection name="CLOB" />
+		</field>
 		<field localized="true" name="html" type="String" />
 		<field localized="true" name="js" type="String" />
 		<field name="name" type="String" />
@@ -109,6 +111,7 @@
 		<field name="targetElement" type="String">
 			<hint name="max-length">1000</hint>
 		</field>
+		<field name="active" type="boolean" />
 	</model>
 	<model name="com.liferay.layout.page.template.model.LayoutPageTemplateStructureRelElementVariationAudienceEntryRel">
 		<field name="mvccVersion" type="long" />

--- a/modules/apps/layout/layout-page-template-service/src/main/resources/META-INF/sql/indexes.sql
+++ b/modules/apps/layout/layout-page-template-service/src/main/resources/META-INF/sql/indexes.sql
@@ -3,7 +3,7 @@ create index IX_3530024E on LPTSREVAudienceEntryRel (lptsRelElementVariationERC[
 create unique index IX_B988F085 on LPTSREVAudienceEntryRel (uuid_[$COLUMN_LENGTH:75$], groupId, ctCollectionId);
 
 create unique index IX_D4E7D564 on LPTSRelElementVariation (groupId, externalReferenceCode[$COLUMN_LENGTH:75$], ctCollectionId);
-create index IX_FEF237FE on LPTSRelElementVariation (plid, segmentsExperienceERC[$COLUMN_LENGTH:75$]);
+create index IX_E09954CB on LPTSRelElementVariation (plid, segmentsExperienceERC[$COLUMN_LENGTH:75$], active_);
 create index IX_22DF7069 on LPTSRelElementVariation (segmentsExperienceERC[$COLUMN_LENGTH:75$]);
 create unique index IX_BFCB1187 on LPTSRelElementVariation (uuid_[$COLUMN_LENGTH:75$], groupId, ctCollectionId);
 

--- a/modules/apps/layout/layout-page-template-service/src/main/resources/META-INF/sql/tables.sql
+++ b/modules/apps/layout/layout-page-template-service/src/main/resources/META-INF/sql/tables.sql
@@ -27,13 +27,14 @@ create table LPTSRelElementVariation (
 	userName VARCHAR(75) null,
 	createDate DATE null,
 	modifiedDate DATE null,
-	hide STRING null,
+	hide TEXT null,
 	html STRING null,
 	js STRING null,
 	name VARCHAR(75) null,
 	plid LONG,
 	segmentsExperienceERC VARCHAR(75) null,
 	targetElement VARCHAR(1000) null,
+	active_ BOOLEAN,
 	primary key (lptsRelElementVariationId, ctCollectionId)
 );
 

--- a/modules/apps/layout/layout-page-template-service/src/main/resources/service.properties
+++ b/modules/apps/layout/layout-page-template-service/src/main/resources/service.properties
@@ -13,5 +13,5 @@
 ##
 
     build.namespace=com.liferay.layout.page.template.service
-    build.number=10
-    build.date=1782890218648
+    build.number=11
+    build.date=1783950048525

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/persistence/test/LayoutPageTemplateStructureRelElementVariationPersistenceTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/persistence/test/LayoutPageTemplateStructureRelElementVariationPersistenceTest.java
@@ -176,6 +176,9 @@ public class LayoutPageTemplateStructureRelElementVariationPersistenceTest {
 		newLayoutPageTemplateStructureRelElementVariation.setTargetElement(
 			RandomTestUtil.randomString());
 
+		newLayoutPageTemplateStructureRelElementVariation.setActive(
+			RandomTestUtil.randomBoolean());
+
 		newLayoutPageTemplateStructureRelElementVariation = _persistence.update(
 			newLayoutPageTemplateStructureRelElementVariation);
 
@@ -263,6 +266,9 @@ public class LayoutPageTemplateStructureRelElementVariationPersistenceTest {
 				getTargetElement(),
 			newLayoutPageTemplateStructureRelElementVariation.
 				getTargetElement());
+		Assert.assertEquals(
+			existingLayoutPageTemplateStructureRelElementVariation.isActive(),
+			newLayoutPageTemplateStructureRelElementVariation.isActive());
 	}
 
 	@Test(
@@ -348,6 +354,18 @@ public class LayoutPageTemplateStructureRelElementVariationPersistenceTest {
 	}
 
 	@Test
+	public void testCountByP_SEERC_A() throws Exception {
+		_persistence.countByP_SEERC_A(
+			RandomTestUtil.nextLong(), "", RandomTestUtil.randomBoolean());
+
+		_persistence.countByP_SEERC_A(
+			0L, "null", RandomTestUtil.randomBoolean());
+
+		_persistence.countByP_SEERC_A(
+			0L, (String)null, RandomTestUtil.randomBoolean());
+	}
+
+	@Test
 	public void testCountByERC_G() throws Exception {
 		_persistence.countByERC_G("", RandomTestUtil.nextLong());
 
@@ -396,9 +414,9 @@ public class LayoutPageTemplateStructureRelElementVariationPersistenceTest {
 			true, "uuid", true, "externalReferenceCode", true,
 			"layoutPageTemplateStructureRelElementVariationId", true, "groupId",
 			true, "companyId", true, "userId", true, "userName", true,
-			"createDate", true, "modifiedDate", true, "hide", true, "html",
-			true, "js", true, "name", true, "plid", true,
-			"segmentsExperienceERC", true, "targetElement", true);
+			"createDate", true, "modifiedDate", true, "html", true, "js", true,
+			"name", true, "plid", true, "segmentsExperienceERC", true,
+			"targetElement", true, "active", true);
 	}
 
 	@Test
@@ -837,6 +855,9 @@ public class LayoutPageTemplateStructureRelElementVariationPersistenceTest {
 		layoutPageTemplateStructureRelElementVariation.setTargetElement(
 			RandomTestUtil.randomString());
 
+		layoutPageTemplateStructureRelElementVariation.setActive(
+			RandomTestUtil.randomBoolean());
+
 		_layoutPageTemplateStructureRelElementVariations.add(
 			_persistence.update(
 				layoutPageTemplateStructureRelElementVariation));
@@ -852,4 +873,4 @@ public class LayoutPageTemplateStructureRelElementVariationPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1881622989
+// LIFERAY-SERVICE-BUILDER-HASH:-1972421693

--- a/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/service/LayoutLocalServiceWrapper.java
+++ b/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/service/LayoutLocalServiceWrapper.java
@@ -559,7 +559,7 @@ public class LayoutLocalServiceWrapper
 					targetLayout.getGroupId(),
 					audienceEntryERCs.toArray(new String[0]),
 					sourceLayoutPageTemplateStructureRelElementVariation.
-						getHideMap(),
+						getHide(),
 					sourceLayoutPageTemplateStructureRelElementVariation.
 						getHtmlMap(),
 					sourceLayoutPageTemplateStructureRelElementVariation.
@@ -569,6 +569,8 @@ public class LayoutLocalServiceWrapper
 					targetLayout.getPlid(), segmentsExperienceERC,
 					sourceLayoutPageTemplateStructureRelElementVariation.
 						getTargetElement(),
+					sourceLayoutPageTemplateStructureRelElementVariation.
+						isActive(),
 					ServiceContextThreadLocal.getServiceContext());
 		}
 	}

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/service/test/LayoutLocalServiceCopyLayoutContentTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/service/test/LayoutLocalServiceCopyLayoutContentTest.java
@@ -1650,11 +1650,12 @@ public class LayoutLocalServiceCopyLayoutContentTest {
 				RandomTestUtil.randomString(), TestPropsValues.getUserId(),
 				layout.getGroupId(),
 				new String[] {RandomTestUtil.randomString()},
-				Collections.<Locale, String>emptyMap(),
+				RandomTestUtil.randomString(),
 				Collections.<Locale, String>emptyMap(),
 				Collections.<Locale, String>emptyMap(),
 				RandomTestUtil.randomString(), layout.getPlid(),
 				segmentsExperienceERC, RandomTestUtil.randomString(),
+				RandomTestUtil.randomBoolean(),
 				ServiceContextTestUtil.getServiceContext(
 					layout.getGroupId(), TestPropsValues.getUserId()));
 	}

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Disable as a Collection Provider
 disable-as-a-collection-provider-help=Disabling this as a collection provider will cause collection display fragments using the blueprint to return no results.
 disable-caching=Disable Caching
 disable-document-recording=Disable Document Recording
+disable-element-variation=Disable Element Variation
 disable-forwarding=Disable Forwarding
 disable-get-remote-methods=Disable getRemoteAddr() and getRemoteHost() Methods
 disable-get-remote-methods-help=If checked, the methods getRemoteAddr() and getRemoteHost() will be undefined within the Liferay.ThemeDisplay global object. This configuration is primarily implemented to mitigate privacy risks by avoiding the exposure of client IP/host information and to optimize performance by allowing public caching of pages for unauthenticated users. Note that checking this option will make custom code that relies on these methods fail.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=تعطيل كموفر للمجموعة
 disable-as-a-collection-provider-help=تعطيل موفر المجموعة هذا سوف يتسبب في جعل أجزاء عرض المجموعة التي تستخدم المخطط الأولي لا توفر أي نتائج.
 disable-caching=إبطال التخزين المؤقت
 disable-document-recording=تعطيل تسجيل المستندات
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=عطّل إعادة الإرسال
 disable-get-remote-methods=تعطيل الأسلوبين getRemoteAddr() و getRemoteHost()
 disable-get-remote-methods-help=في حال التفعيل، سيكون الأسلوبان getRemoteAddr() و getRemoteHost() غير مُعرّفتين ضمن الكائن العام Liferay.ThemeDisplay. يُطبّق هذا التكوين أساسًا للحدّ من مخاطر الخصوصية عن طريق تجنّب كشف معلومات عنوان IP/المضيف الخاص بالعميل، ولتحسين الأداء من خلال السماح بالتخزين المؤقت العام للصفحات للمستخدمين غير المُصادق عليهم. يُرجى ملاحظة أن تفعيل هذا الخيار سيؤدي إلى فشل أي كود برمجي مُخصّص يعتمد على هذين الأسلوبين.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Disable as a Collection Provider (Automatic Cop
 disable-as-a-collection-provider-help=Disabling this as a collection provider will cause collection display fragments using the blueprint to return no results. (Automatic Copy)
 disable-caching=Забраняване на кеширането
 disable-document-recording=Забрани записването на документи (Automatic Translation)
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=Забраняване на препращането
 disable-get-remote-methods=Disable getRemoteAddr() and getRemoteHost() Methods (Automatic Copy)
 disable-get-remote-methods-help=If checked, the methods getRemoteAddr() and getRemoteHost() will be undefined within the Liferay.ThemeDisplay global object. This configuration is primarily implemented to mitigate privacy risks by avoiding the exposure of client IP/host information and to optimize performance by allowing public caching of pages for unauthenticated users. Note that checking this option will make custom code that relies on these methods fail. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Deshabilita com a proveïdor de col·leccions
 disable-as-a-collection-provider-help=Si es deshabilita com a proveïdor de col·leccions, els fragments de visualització de col·leccions que utilitzin el plànol no retornaran cap resultat.
 disable-caching=Desactiva la memòria cau
 disable-document-recording=Desactiva el registre de documents
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=Desactiva l'enviament
 disable-get-remote-methods=Desactiva els mètodes getRemoteAddr() i getRemoteHost()
 disable-get-remote-methods-help=Si se selecciona aquesta opció, els mètodes getRemoteAddr() i getRemoteHost() no es definiran dins de l'objecte global Liferay.ThemeDisplay. Aquest paràmetre s'implementa principalment per mitigar els riscos de privadesa evitant l'exposició de la informació de l'IP/amfitrió del client i per optimitzar el rendiment permetent l'emmagatzematge en memòria cau de pàgines públiques d'usuaris no autenticats. Tingueu en compte que si se selecciona aquesta opció, el codi personalitzat que es basi en aquests mètodes fallarà.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Disable as a Collection Provider (Automatic Cop
 disable-as-a-collection-provider-help=Disabling this as a collection provider will cause collection display fragments using the blueprint to return no results. (Automatic Copy)
 disable-caching=Vypnout používání vyrovnávací paměti
 disable-document-recording=Disable Document Recording (Automatic Copy)
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=Vypnout přesměrování
 disable-get-remote-methods=Disable getRemoteAddr() and getRemoteHost() Methods (Automatic Copy)
 disable-get-remote-methods-help=If checked, the methods getRemoteAddr() and getRemoteHost() will be undefined within the Liferay.ThemeDisplay global object. This configuration is primarily implemented to mitigate privacy risks by avoiding the exposure of client IP/host information and to optimize performance by allowing public caching of pages for unauthenticated users. Note that checking this option will make custom code that relies on these methods fail. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Disable as a Collection Provider (Automatic Cop
 disable-as-a-collection-provider-help=Disabling this as a collection provider will cause collection display fragments using the blueprint to return no results. (Automatic Copy)
 disable-caching=Disable Caching (Automatic Copy)
 disable-document-recording=Deaktiver dokumentoptagelse (Automatic Translation)
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=Disable Forwarding (Automatic Copy)
 disable-get-remote-methods=Disable getRemoteAddr() and getRemoteHost() Methods (Automatic Copy)
 disable-get-remote-methods-help=If checked, the methods getRemoteAddr() and getRemoteHost() will be undefined within the Liferay.ThemeDisplay global object. This configuration is primarily implemented to mitigate privacy risks by avoiding the exposure of client IP/host information and to optimize performance by allowing public caching of pages for unauthenticated users. Note that checking this option will make custom code that relies on these methods fail. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Als Anbieter der Sammlung deaktivieren
 disable-as-a-collection-provider-help=Wenn dies als Anbieter der Sammlung deaktiviert wird, liefern Sammlungsfilterfragmente, die diese Blueprint verwenden, keine Ergebnisse mehr.
 disable-caching=Zwischenspeicher deaktivieren
 disable-document-recording=Dokumentaufzeichnung deaktivieren
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=Weiterleiten deaktivieren
 disable-get-remote-methods=Deaktivieren Sie die Methoden getRemoteAddr() und getRemoteHost()
 disable-get-remote-methods-help=Ist diese Option aktiviert, sind die Methoden getRemoteAddr() und getRemoteHost() im globalen Objekt Liferay.ThemeDisplay nicht definiert. Diese Konfiguration dient in erster Linie der Reduzierung von Datenschutzrisiken, indem die Offenlegung von Client-IP- bzw. Hostinformationen vermieden wird, sowie der Leistungsoptimierung durch die Ermöglichung des Cachings von öffentlichen Seiten für nicht authentifizierte Benutzer. Beachten Sie, dass durch die Aktivierung dieser Option benutzerdefinierter Code, der auf diesen Methoden basiert, nicht mehr funktioniert.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de_AT.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de_AT.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Als Anbieter der Sammlung deaktivieren
 disable-as-a-collection-provider-help=Wenn dies als Anbieter der Sammlung deaktiviert wird, liefern Sammlungsfilterfragmente, die diese Blueprint verwenden, keine Ergebnisse mehr.
 disable-caching=Zwischenspeicher deaktivieren
 disable-document-recording=Dokumentaufzeichnung deaktivieren
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=Weiterleiten deaktivieren
 disable-get-remote-methods=Deaktivieren Sie die Methoden getRemoteAddr() und getRemoteHost()
 disable-get-remote-methods-help=Ist diese Option aktiviert, sind die Methoden getRemoteAddr() und getRemoteHost() im globalen Objekt Liferay.ThemeDisplay nicht definiert. Diese Konfiguration dient in erster Linie der Reduzierung von Datenschutzrisiken, indem die Offenlegung von Client-IP- bzw. Hostinformationen vermieden wird, sowie der Leistungsoptimierung durch die Ermöglichung des öffentlichen Cachings von Seiten für nicht authentifizierte Benutzer. Beachten Sie, dass durch die Aktivierung dieser Option benutzerdefinierter Code, der auf diesen Methoden basiert, nicht mehr funktioniert.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de_CH.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de_CH.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Als Anbieter der Sammlung deaktivieren
 disable-as-a-collection-provider-help=Wenn dies als Anbieter der Sammlung deaktiviert wird, liefern Sammlungsfilterfragmente, die diese Blueprint verwenden, keine Ergebnisse mehr.
 disable-caching=Zwischenspeicher deaktivieren
 disable-document-recording=Dokumentaufzeichnung deaktivieren
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=Weiterleiten deaktivieren
 disable-get-remote-methods=Deaktivieren Sie die Methoden getRemoteAddr() und getRemoteHost()
 disable-get-remote-methods-help=Ist diese Option aktiviert, sind die Methoden getRemoteAddr() und getRemoteHost() im globalen Objekt Liferay.ThemeDisplay nicht definiert. Diese Konfiguration dient in erster Linie der Reduzierung von Datenschutzrisiken, indem die Offenlegung von Client-IP- bzw. Hostinformationen vermieden wird, sowie der Leistungsoptimierung durch die Ermöglichung des öffentlichen Cachings von Seiten für nicht authentifizierte Benutzer. Beachten Sie, dass durch die Aktivierung dieser Option benutzerdefinierter Code, der auf diesen Methoden basiert, nicht mehr funktioniert.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Disable as a Collection Provider (Automatic Cop
 disable-as-a-collection-provider-help=Disabling this as a collection provider will cause collection display fragments using the blueprint to return no results. (Automatic Copy)
 disable-caching=Απενεργοποίηση μνήμης cache
 disable-document-recording=Απενεργοποίηση εγγραφής εγγράφου (Automatic Translation)
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=Απενεργοποίηση προώθησης
 disable-get-remote-methods=Disable getRemoteAddr() and getRemoteHost() Methods (Automatic Copy)
 disable-get-remote-methods-help=If checked, the methods getRemoteAddr() and getRemoteHost() will be undefined within the Liferay.ThemeDisplay global object. This configuration is primarily implemented to mitigate privacy risks by avoiding the exposure of client IP/host information and to optimize performance by allowing public caching of pages for unauthenticated users. Note that checking this option will make custom code that relies on these methods fail. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Disable as a Collection Provider
 disable-as-a-collection-provider-help=Disabling this as a collection provider will cause collection display fragments using the blueprint to return no results.
 disable-caching=Disable Caching
 disable-document-recording=Disable Document Recording
+disable-element-variation=Disable Element Variation
 disable-forwarding=Disable Forwarding
 disable-get-remote-methods=Disable getRemoteAddr() and getRemoteHost() Methods
 disable-get-remote-methods-help=If checked, the methods getRemoteAddr() and getRemoteHost() will be undefined within the Liferay.ThemeDisplay global object. This configuration is primarily implemented to mitigate privacy risks by avoiding the exposure of client IP/host information and to optimize performance by allowing public caching of pages for unauthenticated users. Note that checking this option will make custom code that relies on these methods fail.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Disable as a Collection Provider (Automatic Cop
 disable-as-a-collection-provider-help=Disabling this as a collection provider will cause collection display fragments using the blueprint to return no results. (Automatic Copy)
 disable-caching=Disable Caching (Automatic Copy)
 disable-document-recording=Disable Document Recording (Automatic Copy)
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=Disable Forwarding (Automatic Copy)
 disable-get-remote-methods=Disable getRemoteAddr() and getRemoteHost() Methods (Automatic Copy)
 disable-get-remote-methods-help=If checked, the methods getRemoteAddr() and getRemoteHost() will be undefined within the Liferay.ThemeDisplay global object. This configuration is primarily implemented to mitigate privacy risks by avoiding the exposure of client IP/host information and to optimize performance by allowing public caching of pages for unauthenticated users. Note that checking this option will make custom code that relies on these methods fail. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_CA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_CA.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Disable as a Collection Provider (Automatic Cop
 disable-as-a-collection-provider-help=Disabling this as a collection provider will cause collection display fragments using the blueprint to return no results. (Automatic Copy)
 disable-caching=Disable Caching (Automatic Copy)
 disable-document-recording=Disable Document Recording (Automatic Copy)
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=Disable Forwarding (Automatic Copy)
 disable-get-remote-methods=Disable getRemoteAddr() and getRemoteHost() Methods (Automatic Copy)
 disable-get-remote-methods-help=If checked, the methods getRemoteAddr() and getRemoteHost() will be undefined within the Liferay.ThemeDisplay global object. This configuration is primarily implemented to mitigate privacy risks by avoiding the exposure of client IP/host information and to optimize performance by allowing public caching of pages for unauthenticated users. Note that checking this option will make custom code that relies on these methods fail. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Disable as a Collection Provider (Automatic Cop
 disable-as-a-collection-provider-help=Disabling this as a collection provider will cause collection display fragments using the blueprint to return no results. (Automatic Copy)
 disable-caching=Disable Caching (Automatic Copy)
 disable-document-recording=Disable Document Recording (Automatic Copy)
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=Disable Forwarding (Automatic Copy)
 disable-get-remote-methods=Disable getRemoteAddr() and getRemoteHost() Methods (Automatic Copy)
 disable-get-remote-methods-help=If checked, the methods getRemoteAddr() and getRemoteHost() will be undefined within the Liferay.ThemeDisplay global object. This configuration is primarily implemented to mitigate privacy risks by avoiding the exposure of client IP/host information and to optimize performance by allowing public caching of pages for unauthenticated users. Note that checking this option will make custom code that relies on these methods fail. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_IE.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_IE.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Disable as a Collection Provider (Automatic Cop
 disable-as-a-collection-provider-help=Disabling this as a collection provider will cause collection display fragments using the blueprint to return no results. (Automatic Copy)
 disable-caching=Disable Caching (Automatic Copy)
 disable-document-recording=Disable Document Recording (Automatic Copy)
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=Disable Forwarding (Automatic Copy)
 disable-get-remote-methods=Disable getRemoteAddr() and getRemoteHost() Methods (Automatic Copy)
 disable-get-remote-methods-help=If checked, the methods getRemoteAddr() and getRemoteHost() will be undefined within the Liferay.ThemeDisplay global object. This configuration is primarily implemented to mitigate privacy risks by avoiding the exposure of client IP/host information and to optimize performance by allowing public caching of pages for unauthenticated users. Note that checking this option will make custom code that relies on these methods fail. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Deshabilitar como proveedor de colecciones
 disable-as-a-collection-provider-help=Si se deshabilita esto como proveedor de colecciones, los fragmentos de visualización de la colección que utilizan el plano no devolverán resultados.
 disable-caching=Deshabilitar la caché
 disable-document-recording=Deshabilitar registro de documentos
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=Deshabilitar el reenvío
 disable-get-remote-methods=Deshabilitar los métodos getRemoteAddr() y getRemoteHost()
 disable-get-remote-methods-help=Si está marcada, los métodos getRemoteAddr() y getRemoteHost() no estarán definidos dentro del objeto global Liferay.ThemeDisplay. Esta configuración se implementa principalmente para mitigar los riesgos de privacidad al evitar la exposición de la información del host/IP del cliente y para optimizar el rendimiento al permitir el caching de páginas públicas para usuarios sin autenticar. Tenga en cuenta que al marcar esta opción hará que falle el código personalizado que dependa de estos métodos.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_AR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_AR.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Deshabilitar como proveedor de colecciones
 disable-as-a-collection-provider-help=Si se deshabilita esto como proveedor de colecciones, los fragmentos de visualización de la colección que utilizan el plano no devolverán resultados.
 disable-caching=Deshabilitar la caché
 disable-document-recording=Deshabilitar registro de documentos
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=Deshabilitar el reenvío
 disable-get-remote-methods=Deshabilitar los métodos getRemoteAddr() y getRemoteHost()
 disable-get-remote-methods-help=Si está marcada, los métodos getRemoteAddr() y getRemoteHost() no estarán definidos dentro del objeto global Liferay.ThemeDisplay. Esta configuración se implementa principalmente para mitigar los riesgos de privacidad al evitar la exposición de la información del host/IP del cliente y para optimizar el rendimiento al permitir el caching público de páginas para usuarios sin autenticar. Tenga en cuenta que al marcar esta opción hará que falle el código personalizado que dependa de estos métodos.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Deshabilitar como proveedor de colecciones
 disable-as-a-collection-provider-help=Si se deshabilita esto como proveedor de colecciones, los fragmentos de visualización de la colección que utilizan el plano no devolverán resultados.
 disable-caching=Deshabilitar la caché
 disable-document-recording=Deshabilitar registro de documentos
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=Deshabilitar el reenvío
 disable-get-remote-methods=Deshabilitar los métodos getRemoteAddr() y getRemoteHost()
 disable-get-remote-methods-help=Si está marcada, los métodos getRemoteAddr() y getRemoteHost() no estarán definidos dentro del objeto global Liferay.ThemeDisplay. Esta configuración se implementa principalmente para mitigar los riesgos de privacidad al evitar la exposición de la información del host/IP del cliente y para optimizar el rendimiento al permitir el caching público de páginas para usuarios sin autenticar. Tenga en cuenta que al marcar esta opción hará que falle el código personalizado que dependa de estos métodos.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_MX.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_MX.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Deshabilitar como proveedor de colecciones
 disable-as-a-collection-provider-help=Si se deshabilita esto como proveedor de colecciones, los fragmentos de visualización de la colección que utilizan el plano no devolverán resultados.
 disable-caching=Deshabilitar la caché
 disable-document-recording=Deshabilitar registro de documentos
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=Deshabilitar el reenvío
 disable-get-remote-methods=Deshabilitar los métodos getRemoteAddr() y getRemoteHost()
 disable-get-remote-methods-help=Si está marcada, los métodos getRemoteAddr() y getRemoteHost() no estarán definidos dentro del objeto global Liferay.ThemeDisplay. Esta configuración se implementa principalmente para mitigar los riesgos de privacidad al evitar la exposición de la información del host/IP del cliente y para optimizar el rendimiento al permitir el caching público de páginas para usuarios sin autenticar. Tenga en cuenta que al marcar esta opción hará que falle el código personalizado que dependa de estos métodos.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Disable as a Collection Provider (Automatic Cop
 disable-as-a-collection-provider-help=Disabling this as a collection provider will cause collection display fragments using the blueprint to return no results. (Automatic Copy)
 disable-caching=Blokeeri vahemällu salvestamine
 disable-document-recording=Keela dokumendi salvestamine (Automatic Translation)
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=Blokeeri edasisaatmine
 disable-get-remote-methods=Disable getRemoteAddr() and getRemoteHost() Methods (Automatic Copy)
 disable-get-remote-methods-help=If checked, the methods getRemoteAddr() and getRemoteHost() will be undefined within the Liferay.ThemeDisplay global object. This configuration is primarily implemented to mitigate privacy risks by avoiding the exposure of client IP/host information and to optimize performance by allowing public caching of pages for unauthenticated users. Note that checking this option will make custom code that relies on these methods fail. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Disable as a Collection Provider (Automatic Cop
 disable-as-a-collection-provider-help=Disabling this as a collection provider will cause collection display fragments using the blueprint to return no results. (Automatic Copy)
 disable-caching=Desgaitu Caching
 disable-document-recording=Disable Document Recording (Automatic Copy)
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=Desgaitu birbidaltzea
 disable-get-remote-methods=Disable getRemoteAddr() and getRemoteHost() Methods (Automatic Copy)
 disable-get-remote-methods-help=If checked, the methods getRemoteAddr() and getRemoteHost() will be undefined within the Liferay.ThemeDisplay global object. This configuration is primarily implemented to mitigate privacy risks by avoiding the exposure of client IP/host information and to optimize performance by allowing public caching of pages for unauthenticated users. Note that checking this option will make custom code that relies on these methods fail. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Disable as a Collection Provider (Automatic Cop
 disable-as-a-collection-provider-help=Disabling this as a collection provider will cause collection display fragments using the blueprint to return no results. (Automatic Copy)
 disable-caching=کش غیرفعال شود
 disable-document-recording=غیر فعال کردن ضبط اسناد (Automatic Translation)
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=غیر فعال کردن انتقال
 disable-get-remote-methods=Disable getRemoteAddr() and getRemoteHost() Methods (Automatic Copy)
 disable-get-remote-methods-help=If checked, the methods getRemoteAddr() and getRemoteHost() will be undefined within the Liferay.ThemeDisplay global object. This configuration is primarily implemented to mitigate privacy risks by avoiding the exposure of client IP/host information and to optimize performance by allowing public caching of pages for unauthenticated users. Note that checking this option will make custom code that relies on these methods fail. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Poista käytöstä kokoelman tarjoajana
 disable-as-a-collection-provider-help=Tämän kokoelman tarjoajan poistaminen käytöstä johtaa siihen, että blueprint-suunnitelmaa käyttävät näyttöfragmentit eivät palauta tuloksia.
 disable-caching=Poista välimuisti
 disable-document-recording=Poista Käytöstä Asiakirjan Tallennus
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=Poista uudelleenohjaus
 disable-get-remote-methods=Poista getRemoteAddr()- ja getRemoteHost()-metodit käytöstä
 disable-get-remote-methods-help=Jos tämä valitaan, metodit getRemoteAddr() ja getRemoteHost() ovat määrittelemättömiä Liferay.ThemeDisplay-globaalissa objektissa. Tämä määritys on ensisijaisesti toteutettu tietosuojariskien lieventämiseksi välttämällä asiakkaan IP- tai isäntätietojen paljastumista ja suorituskyvyn optimoimiseksi sallimalla sivujen julkinen välimuistiin tallentaminen todentamattomille käyttäjille. Huomaa, että tämän vaihtoehdon valitseminen estää näihin metodeihin perustuvan mukautetun koodin toiminnan.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Désactiver en tant que fournisseur de collecti
 disable-as-a-collection-provider-help=La désactivation de cette option en tant que fournisseur de collection entraînera l'affichage de fragments de collection utilisant le plan pour ne renvoyer aucun résultat.
 disable-caching=Désactiver le cache
 disable-document-recording=Désactiver l'enregistrement de documents
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=Empêcher la transmission
 disable-get-remote-methods=Désactiver les méthodes getRemoteAddr() et getRemoteHost()
 disable-get-remote-methods-help=Si cette option est activée, les méthodes getRemoteAddr() et getRemoteHost() seront indéfinies dans l'objet global Liferay.ThemeDisplay. Cette configuration vise principalement à atténuer les risques liés à la confidentialité en évitant la divulgation des informations d'adresse IP/hôte du client et à optimiser les performances en autorisant la mise en cache publique des pages pour les utilisateurs non authentifiés. Veuillez noter que l'activation de cette option entraînera l'échec du code personnalisé qui utilise ces méthodes.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_BE.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_BE.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Désactiver en tant que fournisseur de collecti
 disable-as-a-collection-provider-help=La désactivation de cette option en tant que fournisseur de collection entraînera l'affichage de fragments de collection utilisant le plan pour ne renvoyer aucun résultat.
 disable-caching=Désactiver le cache
 disable-document-recording=Désactiver l'enregistrement de documents
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=Empêcher la transmission
 disable-get-remote-methods=Désactiver les méthodes getRemoteAddr() et getRemoteHost()
 disable-get-remote-methods-help=Si cette option est activée, les méthodes getRemoteAddr() et getRemoteHost() seront indéfinies dans l'objet global Liferay.ThemeDisplay. Cette configuration vise principalement à atténuer les risques liés à la confidentialité en évitant la divulgation des informations d'adresse IP/hôte du client et à optimiser les performances en autorisant la mise en cache publique des pages pour les utilisateurs non authentifiés. Veuillez noter que l'activation de cette option entraînera l'échec du code personnalisé qui utilise ces méthodes.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Disable as a Collection Provider (Automatic Cop
 disable-as-a-collection-provider-help=Disabling this as a collection provider will cause collection display fragments using the blueprint to return no results. (Automatic Copy)
 disable-caching=Désactiver le cache
 disable-document-recording=Désactiver l'enregistrement de documents
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=Empêcher la transmission
 disable-get-remote-methods=Disable getRemoteAddr() and getRemoteHost() Methods (Automatic Copy)
 disable-get-remote-methods-help=If checked, the methods getRemoteAddr() and getRemoteHost() will be undefined within the Liferay.ThemeDisplay global object. This configuration is primarily implemented to mitigate privacy risks by avoiding the exposure of client IP/host information and to optimize performance by allowing public caching of pages for unauthenticated users. Note that checking this option will make custom code that relies on these methods fail. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CH.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CH.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Désactiver en tant que fournisseur de collecti
 disable-as-a-collection-provider-help=La désactivation de cette option en tant que fournisseur de collection entraînera l'affichage de fragments de collection utilisant le plan pour ne renvoyer aucun résultat.
 disable-caching=Désactiver le cache
 disable-document-recording=Désactiver l'enregistrement de documents
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=Empêcher la transmission
 disable-get-remote-methods=Désactiver les méthodes getRemoteAddr() et getRemoteHost()
 disable-get-remote-methods-help=Si cette option est activée, les méthodes getRemoteAddr() et getRemoteHost() seront indéfinies dans l'objet global Liferay.ThemeDisplay. Cette configuration vise principalement à atténuer les risques liés à la confidentialité en évitant la divulgation des informations d'adresse IP/hôte du client et à optimiser les performances en autorisant la mise en cache publique des pages pour les utilisateurs non authentifiés. Veuillez noter que l'activation de cette option entraînera l'échec du code personnalisé qui utilise ces méthodes.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Disable as a Collection Provider (Automatic Cop
 disable-as-a-collection-provider-help=Disabling this as a collection provider will cause collection display fragments using the blueprint to return no results. (Automatic Copy)
 disable-caching=Desactivar contidos temporais
 disable-document-recording=Desactivar a gravación de documentos
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=Desactivar o reenvío
 disable-get-remote-methods=Disable getRemoteAddr() and getRemoteHost() Methods (Automatic Copy)
 disable-get-remote-methods-help=If checked, the methods getRemoteAddr() and getRemoteHost() will be undefined within the Liferay.ThemeDisplay global object. This configuration is primarily implemented to mitigate privacy risks by avoiding the exposure of client IP/host information and to optimize performance by allowing public caching of pages for unauthenticated users. Note that checking this option will make custom code that relies on these methods fail. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Disable as a Collection Provider (Automatic Cop
 disable-as-a-collection-provider-help=Disabling this as a collection provider will cause collection display fragments using the blueprint to return no results. (Automatic Copy)
 disable-caching=Caching अक्षम करें
 disable-document-recording=दस्तावेज़ रिकॉर्डिंग अक्षम करें
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=Forwarding अक्षम करें
 disable-get-remote-methods=Disable getRemoteAddr() and getRemoteHost() Methods (Automatic Copy)
 disable-get-remote-methods-help=If checked, the methods getRemoteAddr() and getRemoteHost() will be undefined within the Liferay.ThemeDisplay global object. This configuration is primarily implemented to mitigate privacy risks by avoiding the exposure of client IP/host information and to optimize performance by allowing public caching of pages for unauthenticated users. Note that checking this option will make custom code that relies on these methods fail. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Disable as a Collection Provider (Automatic Cop
 disable-as-a-collection-provider-help=Disabling this as a collection provider will cause collection display fragments using the blueprint to return no results. (Automatic Copy)
 disable-caching=Onemogući predmemoriranje
 disable-document-recording=Disable Document Recording (Automatic Copy)
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=Onemogući prosljeđivanje
 disable-get-remote-methods=Disable getRemoteAddr() and getRemoteHost() Methods (Automatic Copy)
 disable-get-remote-methods-help=If checked, the methods getRemoteAddr() and getRemoteHost() will be undefined within the Liferay.ThemeDisplay global object. This configuration is primarily implemented to mitigate privacy risks by avoiding the exposure of client IP/host information and to optimize performance by allowing public caching of pages for unauthenticated users. Note that checking this option will make custom code that relies on these methods fail. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr_BA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr_BA.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Disable as a Collection Provider (Automatic Cop
 disable-as-a-collection-provider-help=Disabling this as a collection provider will cause collection display fragments using the blueprint to return no results. (Automatic Copy)
 disable-caching=Disable Caching (Automatic Copy)
 disable-document-recording=Disable Document Recording (Automatic Copy)
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=Disable Forwarding (Automatic Copy)
 disable-get-remote-methods=Disable getRemoteAddr() and getRemoteHost() Methods (Automatic Copy)
 disable-get-remote-methods-help=If checked, the methods getRemoteAddr() and getRemoteHost() will be undefined within the Liferay.ThemeDisplay global object. This configuration is primarily implemented to mitigate privacy risks by avoiding the exposure of client IP/host information and to optimize performance by allowing public caching of pages for unauthenticated users. Note that checking this option will make custom code that relies on these methods fail. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Letiltás gyűjteményszolgáltatóként
 disable-as-a-collection-provider-help=Ha letiltja ezt mint gyűjteményszolgáltatót, a tervrajzot használó gyűjtemény-megjelenítési töredékek nem adnak eredményt.
 disable-caching=Gyorsítótár tiltása
 disable-document-recording=Dokumentumfelvétel letiltása
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=Továbbítás tiltása
 disable-get-remote-methods=A getRemoteAddr() és getRemoteHost() metódusok letiltása
 disable-get-remote-methods-help=Ha be van jelölve, a getRemoteAddr() és getRemoteHost() metódusok nem lesznek definiálva a Liferay.ThemeDisplay globális objektumon belül. Ez a konfiguráció elsősorban az adatvédelemmel kapcsolatos kockázatok enyhítése érdekében van bevezetve, hogy elkerüljük az ügyfél IP/állomás információinak felfedését, valamint a teljesítmény optimalizálására az oldalak nyilvános gyorsítótárazásának lehetővé tételével a nem hitelesített felhasználók számára. Ne feledje, hogy az opció bejelölése esetén a fenti metódusokra épülő egyéni kódok nem fognak működni.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Disable as a Collection Provider (Automatic Cop
 disable-as-a-collection-provider-help=Disabling this as a collection provider will cause collection display fragments using the blueprint to return no results. (Automatic Copy)
 disable-caching=Menonaktifkan Caching
 disable-document-recording=Nonaktifkan Perekaman Dokumen (Automatic Translation)
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=Menonaktifkan Forwarding
 disable-get-remote-methods=Disable getRemoteAddr() and getRemoteHost() Methods (Automatic Copy)
 disable-get-remote-methods-help=If checked, the methods getRemoteAddr() and getRemoteHost() will be undefined within the Liferay.ThemeDisplay global object. This configuration is primarily implemented to mitigate privacy risks by avoiding the exposure of client IP/host information and to optimize performance by allowing public caching of pages for unauthenticated users. Note that checking this option will make custom code that relies on these methods fail. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
@@ -6656,6 +6656,7 @@ disable-as-a-collection-provider=Disable as a Collection Provider (Automatic Cop
 disable-as-a-collection-provider-help=Disabling this as a collection provider will cause collection display fragments using the blueprint to return no results. (Automatic Copy)
 disable-caching=Disabilita Caching
 disable-document-recording=Disabilita registrazione documenti (Automatic Translation)
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=Disabilita l'Inoltro
 disable-get-remote-methods=Disable getRemoteAddr() and getRemoteHost() Methods (Automatic Copy)
 disable-get-remote-methods-help=If checked, the methods getRemoteAddr() and getRemoteHost() will be undefined within the Liferay.ThemeDisplay global object. This configuration is primarily implemented to mitigate privacy risks by avoiding the exposure of client IP/host information and to optimize performance by allowing public caching of pages for unauthenticated users. Note that checking this option will make custom code that relies on these methods fail. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it_CH.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it_CH.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Disable as a Collection Provider (Automatic Cop
 disable-as-a-collection-provider-help=Disabling this as a collection provider will cause collection display fragments using the blueprint to return no results. (Automatic Copy)
 disable-caching=Disabilita Caching
 disable-document-recording=Disabilita registrazione documenti (Automatic Translation)
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=Disabilita l'Inoltro
 disable-get-remote-methods=Disable getRemoteAddr() and getRemoteHost() Methods (Automatic Copy)
 disable-get-remote-methods-help=If checked, the methods getRemoteAddr() and getRemoteHost() will be undefined within the Liferay.ThemeDisplay global object. This configuration is primarily implemented to mitigate privacy risks by avoiding the exposure of client IP/host information and to optimize performance by allowing public caching of pages for unauthenticated users. Note that checking this option will make custom code that relies on these methods fail. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Disable as a Collection Provider (Automatic Cop
 disable-as-a-collection-provider-help=Disabling this as a collection provider will cause collection display fragments using the blueprint to return no results. (Automatic Copy)
 disable-caching=בטל העברה לזיכרון מטמון
 disable-document-recording=הפוך הקלטת מסמך ללא זמינה (Automatic Translation)
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=בטל העברה הלאה
 disable-get-remote-methods=Disable getRemoteAddr() and getRemoteHost() Methods (Automatic Copy)
 disable-get-remote-methods-help=If checked, the methods getRemoteAddr() and getRemoteHost() will be undefined within the Liferay.ThemeDisplay global object. This configuration is primarily implemented to mitigate privacy risks by avoiding the exposure of client IP/host information and to optimize performance by allowing public caching of pages for unauthenticated users. Note that checking this option will make custom code that relies on these methods fail. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=コレクションプロバイダーとして�
 disable-as-a-collection-provider-help=これをコレクションプロバイダーとして無効にすると、ブループリントを使用するコレクション表示フラグメントが結果を返さなくなります。
 disable-caching=キャッシュを無効にする
 disable-document-recording=ドキュメントの記録を無効にする
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=転送を無効にする
 disable-get-remote-methods=getRemoteAddr() および getRemoteHost() メソッドを無効にする
 disable-get-remote-methods-help=有効な場合、getRemoteAddr() メソッドと getRemoteHost() メソッドが Liferay.ThemeDisplay グローバルオブジェクト内で undefined を返すようになります。この設定はクライアント IPとホスト情報をマスクすることでプライバシーリスクを軽減し、公開ページのキャッシュ処理を可能にすることでパフォーマンスを最適化します。このオプションを有効にすると、これらのメソッドに依存するカスタムコードが失敗することに注意してください。

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Disable as a Collection Provider (Automatic Cop
 disable-as-a-collection-provider-help=Disabling this as a collection provider will cause collection display fragments using the blueprint to return no results. (Automatic Copy)
 disable-caching=Disable Caching (Automatic Copy)
 disable-document-recording=Disable Document Recording (Automatic Copy)
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=Disable Forwarding (Automatic Copy)
 disable-get-remote-methods=Disable getRemoteAddr() and getRemoteHost() Methods (Automatic Copy)
 disable-get-remote-methods-help=If checked, the methods getRemoteAddr() and getRemoteHost() will be undefined within the Liferay.ThemeDisplay global object. This configuration is primarily implemented to mitigate privacy risks by avoiding the exposure of client IP/host information and to optimize performance by allowing public caching of pages for unauthenticated users. Note that checking this option will make custom code that relies on these methods fail. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_km.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_km.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Disable as a Collection Provider (Automatic Cop
 disable-as-a-collection-provider-help=Disabling this as a collection provider will cause collection display fragments using the blueprint to return no results. (Automatic Copy)
 disable-caching=Disable Caching
 disable-document-recording=Disable Document Recording
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=Disable Forwarding
 disable-get-remote-methods=Disable getRemoteAddr() and getRemoteHost() Methods (Automatic Copy)
 disable-get-remote-methods-help=If checked, the methods getRemoteAddr() and getRemoteHost() will be undefined within the Liferay.ThemeDisplay global object. This configuration is primarily implemented to mitigate privacy risks by avoiding the exposure of client IP/host information and to optimize performance by allowing public caching of pages for unauthenticated users. Note that checking this option will make custom code that relies on these methods fail. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Disable as a Collection Provider (Automatic Cop
 disable-as-a-collection-provider-help=Disabling this as a collection provider will cause collection display fragments using the blueprint to return no results. (Automatic Copy)
 disable-caching=무능 숨김
 disable-document-recording=문서 기록 비활성
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=운송을 무능하게 하십시요
 disable-get-remote-methods=Disable getRemoteAddr() and getRemoteHost() Methods (Automatic Copy)
 disable-get-remote-methods-help=If checked, the methods getRemoteAddr() and getRemoteHost() will be undefined within the Liferay.ThemeDisplay global object. This configuration is primarily implemented to mitigate privacy risks by avoiding the exposure of client IP/host information and to optimize performance by allowing public caching of pages for unauthenticated users. Note that checking this option will make custom code that relies on these methods fail. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=ປິດໃຊ້ງານໃນຖານະ C
 disable-as-a-collection-provider-help=ການປິດໃຊ້ງານນີ້ໃນຖານະ collection provider ຈະເຮັດໃຫ້ collection display fragments ທີ່ໃຊ້ blueprint ນີ້ບໍ່ສະແດງຜົນລຶບໃດໆ.
 disable-caching=ປິດການໃຊ້ງານຊົ່ວຄາວ
 disable-document-recording=ປິດໃຊ້ງານການບັນທຶກເອກະສານ
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=ປິດການຟໍເວັດ
 disable-get-remote-methods=ປິດໃຊ້ງານວິທີການ getRemoteAddr() ແລະ getRemoteHost()
 disable-get-remote-methods-help=ຖ້າເລືອກ, ວິທີການ getRemoteAddr() ແລະ getRemoteHost() ຈະບໍ່ຖືກກຳນົດພາຍໃນ Liferay.ThemeDisplay global object. ການຕັ້ງຄ່ານີ້ຖືກປະຕິບັດຕົ້ນຕໍເພື່ອຫຼຸດຜ່ອນຄວາມສ່ຽງດ້ານຄວາມເປັນສ່ວນຕົວ ໂດຍການຫຼີກເວັ້ນການເປີດເຜີຍຂໍ້ມູນ IP/host ຂອງ client ແລະ ເພື່ອປັບປຸງປະສິດທິພາບໂດຍການອະນຸຍາດໃຫ້ public caching ຂອງໜ້າສຳລັບຜູ້ໃຊ້ທີ່ບໍ່ໄດ້ກວດສອບສິດ. ໝາຍເຫດວ່າການເລືອກຕົວເລືອກນີ້ຈະເຮັດໃຫ້ໂຄ້ດ custom ທີ່ອີງໃສ່ວິທີການເຫຼົ່ານີ້ລົ້ມເຫຼວ.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Disable as a Collection Provider (Automatic Cop
 disable-as-a-collection-provider-help=Disabling this as a collection provider will cause collection display fragments using the blueprint to return no results. (Automatic Copy)
 disable-caching=Išjungti kaupimą talpykloje (Automatic Translation)
 disable-document-recording=Išjungti dokumento įrašymą (Automatic Translation)
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=Išjungti peradresavimą (Automatic Translation)
 disable-get-remote-methods=Disable getRemoteAddr() and getRemoteHost() Methods (Automatic Copy)
 disable-get-remote-methods-help=If checked, the methods getRemoteAddr() and getRemoteHost() will be undefined within the Liferay.ThemeDisplay global object. This configuration is primarily implemented to mitigate privacy risks by avoiding the exposure of client IP/host information and to optimize performance by allowing public caching of pages for unauthenticated users. Note that checking this option will make custom code that relies on these methods fail. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_mk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_mk.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Disable as a Collection Provider (Automatic Cop
 disable-as-a-collection-provider-help=Disabling this as a collection provider will cause collection display fragments using the blueprint to return no results. (Automatic Copy)
 disable-caching=Disable Caching (Automatic Copy)
 disable-document-recording=Disable Document Recording (Automatic Copy)
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=Disable Forwarding (Automatic Copy)
 disable-get-remote-methods=Disable getRemoteAddr() and getRemoteHost() Methods (Automatic Copy)
 disable-get-remote-methods-help=If checked, the methods getRemoteAddr() and getRemoteHost() will be undefined within the Liferay.ThemeDisplay global object. This configuration is primarily implemented to mitigate privacy risks by avoiding the exposure of client IP/host information and to optimize performance by allowing public caching of pages for unauthenticated users. Note that checking this option will make custom code that relies on these methods fail. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Disable as a Collection Provider (Automatic Cop
 disable-as-a-collection-provider-help=Disabling this as a collection provider will cause collection display fragments using the blueprint to return no results. (Automatic Copy)
 disable-caching=Nyahdayakan Caching (Automatic Translation)
 disable-document-recording=Nyahddayakan Rakaman Dokumen (Automatic Translation)
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=Nyahddayakan Pengemukaan (Automatic Translation)
 disable-get-remote-methods=Disable getRemoteAddr() and getRemoteHost() Methods (Automatic Copy)
 disable-get-remote-methods-help=If checked, the methods getRemoteAddr() and getRemoteHost() will be undefined within the Liferay.ThemeDisplay global object. This configuration is primarily implemented to mitigate privacy risks by avoiding the exposure of client IP/host information and to optimize performance by allowing public caching of pages for unauthenticated users. Note that checking this option will make custom code that relies on these methods fail. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_my.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_my.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Disable as a Collection Provider (Automatic Cop
 disable-as-a-collection-provider-help=Disabling this as a collection provider will cause collection display fragments using the blueprint to return no results. (Automatic Copy)
 disable-caching=Disable Caching (Automatic Copy)
 disable-document-recording=Disable Document Recording (Automatic Copy)
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=Disable Forwarding (Automatic Copy)
 disable-get-remote-methods=Disable getRemoteAddr() and getRemoteHost() Methods (Automatic Copy)
 disable-get-remote-methods-help=If checked, the methods getRemoteAddr() and getRemoteHost() will be undefined within the Liferay.ThemeDisplay global object. This configuration is primarily implemented to mitigate privacy risks by avoiding the exposure of client IP/host information and to optimize performance by allowing public caching of pages for unauthenticated users. Note that checking this option will make custom code that relies on these methods fail. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Disable as a Collection Provider (Automatic Cop
 disable-as-a-collection-provider-help=Disabling this as a collection provider will cause collection display fragments using the blueprint to return no results. (Automatic Copy)
 disable-caching=Deaktiver mellomlager
 disable-document-recording=Deaktiver dokumentinnspilling (Automatic Translation)
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=Blokkere videresending
 disable-get-remote-methods=Disable getRemoteAddr() and getRemoteHost() Methods (Automatic Copy)
 disable-get-remote-methods-help=If checked, the methods getRemoteAddr() and getRemoteHost() will be undefined within the Liferay.ThemeDisplay global object. This configuration is primarily implemented to mitigate privacy risks by avoiding the exposure of client IP/host information and to optimize performance by allowing public caching of pages for unauthenticated users. Note that checking this option will make custom code that relies on these methods fail. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Uitschakelen als collectieprovider
 disable-as-a-collection-provider-help=Indien u dit als collectieprovider uitschakelt, zullen collectieweergavefragmenten die gebruikmaken van de blauwdruk geen resultaten opleveren.
 disable-caching=Voorgeheugen uitschakelen
 disable-document-recording=Documentregistratie uitschakelen
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=Doorsturen uitschakelen
 disable-get-remote-methods=De methoden getRemoteAddr() en getRemoteHost() uitschakelen
 disable-get-remote-methods-help=Als deze optie is ingeschakeld, zijn de methoden getRemoteAddr() en getRemoteHost() niet gedefinieerd binnen het globale object Liferay.ThemeDisplay. Deze configuratie is primair geïmplementeerd om privacyrisico's te beperken door blootstelling van de client-IP/hostinformatie te vermijden en om de prestaties te optimaliseren door opslag in cache van openbare pagina's voor niet-geauthenticeerde gebruikers toe te staan. Houd er rekening mee dat bij het selecteren van deze optie aangepaste code die deze methoden gebruikt, mislukt.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Uitschakelen als collectieprovider
 disable-as-a-collection-provider-help=Indien u dit als collectieprovider uitschakelt, zullen collectieweergavefragmenten die gebruikmaken van de blauwdruk geen resultaten opleveren.
 disable-caching=Cache uitschakelen
 disable-document-recording=Documentregistratie uitschakelen
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=Forwarding uitschakelen
 disable-get-remote-methods=De methoden getRemoteAddr() en getRemoteHost() uitschakelen
 disable-get-remote-methods-help=Als deze optie is ingeschakeld, zijn de methoden getRemoteAddr() en getRemoteHost() niet gedefinieerd binnen het globale object Liferay.ThemeDisplay. Deze configuratie is primair geïmplementeerd om privacyrisico's te beperken door blootstelling van de client-IP/hostinformatie te vermijden en om de prestaties te optimaliseren door publieke opslag in cache van pagina's voor niet-geauthenticeerde gebruikers toe te staan. Houd er rekening mee dat bij het selecteren van deze optie aangepaste code die deze methoden gebruikt, mislukt.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_no.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_no.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Disable as a Collection Provider (Automatic Cop
 disable-as-a-collection-provider-help=Disabling this as a collection provider will cause collection display fragments using the blueprint to return no results. (Automatic Copy)
 disable-caching=Deaktiver mellomlager
 disable-document-recording=Deaktiver dokumentinnspilling (Automatic Translation)
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=Blokkere videresending
 disable-get-remote-methods=Disable getRemoteAddr() and getRemoteHost() Methods (Automatic Copy)
 disable-get-remote-methods-help=If checked, the methods getRemoteAddr() and getRemoteHost() will be undefined within the Liferay.ThemeDisplay global object. This configuration is primarily implemented to mitigate privacy risks by avoiding the exposure of client IP/host information and to optimize performance by allowing public caching of pages for unauthenticated users. Note that checking this option will make custom code that relies on these methods fail. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Disable as a Collection Provider (Automatic Cop
 disable-as-a-collection-provider-help=Disabling this as a collection provider will cause collection display fragments using the blueprint to return no results. (Automatic Copy)
 disable-caching=Wyłącz buforowanie
 disable-document-recording=Wyłączanie nagrywania dokumentów (Automatic Translation)
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=Wyłącz przekazywanie
 disable-get-remote-methods=Disable getRemoteAddr() and getRemoteHost() Methods (Automatic Copy)
 disable-get-remote-methods-help=If checked, the methods getRemoteAddr() and getRemoteHost() will be undefined within the Liferay.ThemeDisplay global object. This configuration is primarily implemented to mitigate privacy risks by avoiding the exposure of client IP/host information and to optimize performance by allowing public caching of pages for unauthenticated users. Note that checking this option will make custom code that relies on these methods fail. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Desativar como provedor de coleção
 disable-as-a-collection-provider-help=Desativar isso como provedor de coleção fará com que os fragmentos de exibição da coleção que usam o modelo não retornem resultados.
 disable-caching=Desabilitar cache
 disable-document-recording=Desabilitar a gravação de documento
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=Desabilitar encaminhar
 disable-get-remote-methods=Desativar os métodos getRemoteAddr() e getRemoteHost()
 disable-get-remote-methods-help=Se marcada, os métodos getRemoteAddr() e getRemoteHost() ficarão indefinidos no objeto global Liferay.ThemeDisplay. Essa configuração é usada principalmente para reduzir riscos de privacidade, evitando a exposição do IP/host do cliente, e para otimizar o desempenho, permitindo o cache público de páginas para usuários não autenticados. Observe que, ao ativar essa opção, códigos personalizados que dependem desses métodos deixarão de funcionar.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Desativar como provedor de coleção
 disable-as-a-collection-provider-help=Desativar isso como provedor de coleção fará com que os fragmentos de exibição da coleção que usam o modelo não retornem resultados.
 disable-caching=Desabilitar cache
 disable-document-recording=Desabilitar a gravação de documentos (Automatic Translation)
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=Desabilitar Encaminhamento
 disable-get-remote-methods=Desativar os métodos getRemoteAddr() e getRemoteHost()
 disable-get-remote-methods-help=Se marcada, os métodos getRemoteAddr() e getRemoteHost() ficarão indefinidos no objeto global Liferay.ThemeDisplay. Essa configuração é usada principalmente para reduzir riscos de privacidade, evitando a exposição do IP/host do cliente, e para otimizar o desempenho, permitindo o cache público de páginas para usuários não autenticados. Observe que, ao ativar essa opção, códigos personalizados que dependem desses métodos deixarão de funcionar.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Disable as a Collection Provider (Automatic Cop
 disable-as-a-collection-provider-help=Disabling this as a collection provider will cause collection display fragments using the blueprint to return no results. (Automatic Copy)
 disable-caching=Dezactivează Stocarea
 disable-document-recording=Dezactivare înregistrare document (Automatic Translation)
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=Dezactiveaza Transmiterea
 disable-get-remote-methods=Disable getRemoteAddr() and getRemoteHost() Methods (Automatic Copy)
 disable-get-remote-methods-help=If checked, the methods getRemoteAddr() and getRemoteHost() will be undefined within the Liferay.ThemeDisplay global object. This configuration is primarily implemented to mitigate privacy risks by avoiding the exposure of client IP/host information and to optimize performance by allowing public caching of pages for unauthenticated users. Note that checking this option will make custom code that relies on these methods fail. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Disable as a Collection Provider (Automatic Cop
 disable-as-a-collection-provider-help=Disabling this as a collection provider will cause collection display fragments using the blueprint to return no results. (Automatic Copy)
 disable-caching=Отключить кэширование
 disable-document-recording=Отключение записи документов (Automatic Translation)
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=Отключить пересылку
 disable-get-remote-methods=Disable getRemoteAddr() and getRemoteHost() Methods (Automatic Copy)
 disable-get-remote-methods-help=If checked, the methods getRemoteAddr() and getRemoteHost() will be undefined within the Liferay.ThemeDisplay global object. This configuration is primarily implemented to mitigate privacy risks by avoiding the exposure of client IP/host information and to optimize performance by allowing public caching of pages for unauthenticated users. Note that checking this option will make custom code that relies on these methods fail. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Disable as a Collection Provider (Automatic Cop
 disable-as-a-collection-provider-help=Disabling this as a collection provider will cause collection display fragments using the blueprint to return no results. (Automatic Copy)
 disable-caching=Vypnúť caching
 disable-document-recording=Zakázať nahrávanie dokumentov (Automatic Translation)
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=Vypnúť presmerovanie
 disable-get-remote-methods=Disable getRemoteAddr() and getRemoteHost() Methods (Automatic Copy)
 disable-get-remote-methods-help=If checked, the methods getRemoteAddr() and getRemoteHost() will be undefined within the Liferay.ThemeDisplay global object. This configuration is primarily implemented to mitigate privacy risks by avoiding the exposure of client IP/host information and to optimize performance by allowing public caching of pages for unauthenticated users. Note that checking this option will make custom code that relies on these methods fail. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Disable as a Collection Provider (Automatic Cop
 disable-as-a-collection-provider-help=Disabling this as a collection provider will cause collection display fragments using the blueprint to return no results. (Automatic Copy)
 disable-caching=Onemogoči caching
 disable-document-recording=Onemogoči snemanje dokumentov (Automatic Translation)
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=Onemogoči posredovanje
 disable-get-remote-methods=Disable getRemoteAddr() and getRemoteHost() Methods (Automatic Copy)
 disable-get-remote-methods-help=If checked, the methods getRemoteAddr() and getRemoteHost() will be undefined within the Liferay.ThemeDisplay global object. This configuration is primarily implemented to mitigate privacy risks by avoiding the exposure of client IP/host information and to optimize performance by allowing public caching of pages for unauthenticated users. Note that checking this option will make custom code that relies on these methods fail. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Disable as a Collection Provider (Automatic Cop
 disable-as-a-collection-provider-help=Disabling this as a collection provider will cause collection display fragments using the blueprint to return no results. (Automatic Copy)
 disable-caching=Онемогући Кеширање
 disable-document-recording=Disable Document Recording (Automatic Copy)
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=Онемогући Прослеђивање
 disable-get-remote-methods=Disable getRemoteAddr() and getRemoteHost() Methods (Automatic Copy)
 disable-get-remote-methods-help=If checked, the methods getRemoteAddr() and getRemoteHost() will be undefined within the Liferay.ThemeDisplay global object. This configuration is primarily implemented to mitigate privacy risks by avoiding the exposure of client IP/host information and to optimize performance by allowing public caching of pages for unauthenticated users. Note that checking this option will make custom code that relies on these methods fail. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Disable as a Collection Provider (Automatic Cop
 disable-as-a-collection-provider-help=Disabling this as a collection provider will cause collection display fragments using the blueprint to return no results. (Automatic Copy)
 disable-caching=Onemogući Keširanje
 disable-document-recording=Disable Document Recording (Automatic Copy)
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=Onemogući Prosleđivanje
 disable-get-remote-methods=Disable getRemoteAddr() and getRemoteHost() Methods (Automatic Copy)
 disable-get-remote-methods-help=If checked, the methods getRemoteAddr() and getRemoteHost() will be undefined within the Liferay.ThemeDisplay global object. This configuration is primarily implemented to mitigate privacy risks by avoiding the exposure of client IP/host information and to optimize performance by allowing public caching of pages for unauthenticated users. Note that checking this option will make custom code that relies on these methods fail. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Inaktivera som samlingsleverantör
 disable-as-a-collection-provider-help=Om detta inaktiveras som samlingsleverantör, ger inte samlingsdisplayfragment resultat med skissen.
 disable-caching=Deaktivera cache
 disable-document-recording=Inaktivera dokumentregistrering
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=Blockera vidarebefordring
 disable-get-remote-methods=Inaktivera metoderna getRemoteAddr() och getRemoteHost()
 disable-get-remote-methods-help=Om det markeras blir metoderna getRemoteAddr() och getRemoteHost() odefinierade i det globala objektet Liferay.ThemeDisplay. Konfigurationen implementeras primärt för att mildra integritetsriskerna genom att undvika exponering av klient-IP/värdinformation och för att optimera prestandan genom att aktivera cachelagring av offentliga sidor för icke verifierade användare. Obs! Om du markerar det här alternativet, misslyckas anpassad kod som förlitar sig på dessa metoder.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Disable as a Collection Provider (Automatic Cop
 disable-as-a-collection-provider-help=Disabling this as a collection provider will cause collection display fragments using the blueprint to return no results. (Automatic Copy)
 disable-caching=Caching-ஐ முடக்கு
 disable-document-recording=Disable Document Recording (Automatic Copy)
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=Disable Forwarding (Automatic Copy)
 disable-get-remote-methods=Disable getRemoteAddr() and getRemoteHost() Methods (Automatic Copy)
 disable-get-remote-methods-help=If checked, the methods getRemoteAddr() and getRemoteHost() will be undefined within the Liferay.ThemeDisplay global object. This configuration is primarily implemented to mitigate privacy risks by avoiding the exposure of client IP/host information and to optimize performance by allowing public caching of pages for unauthenticated users. Note that checking this option will make custom code that relies on these methods fail. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Disable as a Collection Provider (Automatic Cop
 disable-as-a-collection-provider-help=Disabling this as a collection provider will cause collection display fragments using the blueprint to return no results. (Automatic Copy)
 disable-caching=ปิดการใช้งานแคชชิ่ง
 disable-document-recording=ปิดใช้งานการบันทึกเอกสาร
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=ปิดใช้งานการส่งต่อ
 disable-get-remote-methods=Disable getRemoteAddr() and getRemoteHost() Methods (Automatic Copy)
 disable-get-remote-methods-help=If checked, the methods getRemoteAddr() and getRemoteHost() will be undefined within the Liferay.ThemeDisplay global object. This configuration is primarily implemented to mitigate privacy risks by avoiding the exposure of client IP/host information and to optimize performance by allowing public caching of pages for unauthenticated users. Note that checking this option will make custom code that relies on these methods fail. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Disable as a Collection Provider (Automatic Cop
 disable-as-a-collection-provider-help=Disabling this as a collection provider will cause collection display fragments using the blueprint to return no results. (Automatic Copy)
 disable-caching=Önbelleklemeyi durdur
 disable-document-recording=Belge Kaydını Devre Dışı Bırak (Automatic Translation)
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=Yönlendirmeyi durdur
 disable-get-remote-methods=Disable getRemoteAddr() and getRemoteHost() Methods (Automatic Copy)
 disable-get-remote-methods-help=If checked, the methods getRemoteAddr() and getRemoteHost() will be undefined within the Liferay.ThemeDisplay global object. This configuration is primarily implemented to mitigate privacy risks by avoiding the exposure of client IP/host information and to optimize performance by allowing public caching of pages for unauthenticated users. Note that checking this option will make custom code that relies on these methods fail. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Disable as a Collection Provider (Automatic Cop
 disable-as-a-collection-provider-help=Disabling this as a collection provider will cause collection display fragments using the blueprint to return no results. (Automatic Copy)
 disable-caching=Відключити кешування
 disable-document-recording=Вимкнути записування документів (Automatic Translation)
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=Відключити пересилку
 disable-get-remote-methods=Disable getRemoteAddr() and getRemoteHost() Methods (Automatic Copy)
 disable-get-remote-methods-help=If checked, the methods getRemoteAddr() and getRemoteHost() will be undefined within the Liferay.ThemeDisplay global object. This configuration is primarily implemented to mitigate privacy risks by avoiding the exposure of client IP/host information and to optimize performance by allowing public caching of pages for unauthenticated users. Note that checking this option will make custom code that relies on these methods fail. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Disable as a Collection Provider (Automatic Cop
 disable-as-a-collection-provider-help=Disabling this as a collection provider will cause collection display fragments using the blueprint to return no results. (Automatic Copy)
 disable-caching=Vô hiệu hóa bộ đệm
 disable-document-recording=Vô hiệu hóa Ghi Tài liệu (Automatic Translation)
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=Tắt chuyển tiếp
 disable-get-remote-methods=Disable getRemoteAddr() and getRemoteHost() Methods (Automatic Copy)
 disable-get-remote-methods-help=If checked, the methods getRemoteAddr() and getRemoteHost() will be undefined within the Liferay.ThemeDisplay global object. This configuration is primarily implemented to mitigate privacy risks by avoiding the exposure of client IP/host information and to optimize performance by allowing public caching of pages for unauthenticated users. Note that checking this option will make custom code that relies on these methods fail. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=作为集合提供程序禁用
 disable-as-a-collection-provider-help=禁用此项作为集合提供程序会导致使用该蓝图的集合显示片段不返回任何结果。
 disable-caching=禁用缓存
 disable-document-recording=禁用文档记录
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=禁用转发
 disable-get-remote-methods=禁用 getRemoteAddr() 和 getRemoteHost() 方法
 disable-get-remote-methods-help=启用后，Liferay.ThemeDisplay 全局对象中的 getRemoteAddr() 和 getRemoteHost() 方法将返回 undefined。此设置通过屏蔽客户端 IP 和主机信息来降低隐私风险；它还通过为未经身份验证的用户启用公共页面缓存来优化性能。请注意，启用此选项会导致依赖这些方法的自定义代码失效。

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
@@ -6657,6 +6657,7 @@ disable-as-a-collection-provider=Disable as a Collection Provider (Automatic Cop
 disable-as-a-collection-provider-help=Disabling this as a collection provider will cause collection display fragments using the blueprint to return no results. (Automatic Copy)
 disable-caching=停用快取
 disable-document-recording=關閉文件記錄
+disable-element-variation=Disable Element Variation (Automatic Copy)
 disable-forwarding=停用轉向
 disable-get-remote-methods=Disable getRemoteAddr() and getRemoteHost() Methods (Automatic Copy)
 disable-get-remote-methods-help=If checked, the methods getRemoteAddr() and getRemoteHost() will be undefined within the Liferay.ThemeDisplay global object. This configuration is primarily implemented to mitigate privacy risks by avoiding the exposure of client IP/host information and to optimize performance by allowing public caching of pages for unauthenticated users. Note that checking this option will make custom code that relies on these methods fail. (Automatic Copy)


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98144

## What Is Being Fixed

Element variations (behind the LPD-93951 feature flag) could not be individually disabled — every variation defined for an experience was always applied at runtime. In addition, the variation's hide flag was persisted as a localized map even though it only ever holds a single boolean toggle, unlike the genuinely localizable html and js content.

## How It Is Being Fixed

An active boolean column is added to the LayoutPageTemplateStructureRelElementVariation entity, along with a P_SEERC_A finder so variations can be queried by active state. Following the SegmentsExperience convention, the unfiltered listing method keeps returning every variation (the page editor needs to show active and disabled ones together) while a new overload with a trailing boolean lets the runtime provider apply only active variations. The page editor form gains a Disable Element Variation checkbox that drives the flag through the reducer and save service.

The hide field is de-localized to a plain string since it is a boolean toggle, while html and js stay localized. Because the entity is unreleased, the schema change folds into the existing 6.1.0 upgrade that creates the table rather than adding a new upgrade step.

## PR Check

**pr-check: PASS** — tested on `811aba4f05e9ea78086f0701a62854169a0538eb`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Full Portal Build | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "811aba4f05e9ea78086f0701a62854169a0538eb"} -->
