### PR TITLE
LPD-96907 Update object OpenAPI test fixtures for schema drift

### DIFF
--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi.json
@@ -138,6 +138,7 @@
 				}
 			},
 			"CollaboratorBrief": {
+				"description": "Brief of the collaborator record for the user making the request, present only when this asset is shared with them.",
 				"properties": {
 					"actionIds": {
 						"description": "The sharing actions granted to the user making the request (e.g. VIEW, UPDATE).",
@@ -173,7 +174,7 @@
 				}
 			},
 			"Comment": {
-				"description": "Optional field with the comments associated with this object entry, can be embedded with nestedFields",
+				"description": "Represents a comment. See [Comment](https://www.schema.org/Comment) for more details.",
 				"properties": {
 					"actions": {
 						"additionalProperties": {
@@ -255,7 +256,7 @@
 				}
 			},
 			"Creator": {
-				"description": "The comment's author.",
+				"description": "Represents the user account of the content's creator/author. Properties follow the [creator](https://schema.org/creator) specification.",
 				"properties": {
 					"additionalName": {
 						"description": "The author's additional name (e.g., middle name).",
@@ -2635,6 +2636,10 @@
 						"description": "The scope's name.",
 						"type": "string"
 					},
+					"liveExternalReferenceCode": {
+						"description": "The scope's live group external reference code.",
+						"type": "string"
+					},
 					"type": {
 						"description": "The scope's type.",
 						"enum": [
@@ -2769,7 +2774,7 @@
 				}
 			},
 			"UserGroupBrief": {
-				"description": "A list of userGroups information.",
+				"description": "The author's user groups information.",
 				"properties": {
 					"id": {
 						"description": "The ID of the user group.",
@@ -3585,6 +3590,49 @@
 				]
 			}
 		},
+		"/by-external-reference-code/{currentExternalReferenceCode}/relationship1/{relatedExternalReferenceCode}/disassociate": {
+			"post": {
+				"operationId": "postByExternalReferenceCodeObject1Relationship1Object2Disassociate",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "currentExternalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "relatedExternalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Object2"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Object2"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Object1"
+				]
+			}
+		},
 		"/by-external-reference-code/{currentExternalReferenceCode}/relationship2": {
 			"get": {
 				"operationId": "getByExternalReferenceCodeObject1Relationship2Page",
@@ -3864,6 +3912,49 @@
 			},
 			"put": {
 				"operationId": "putByExternalReferenceCodeObject1Relationship2Object2",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "currentExternalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "relatedExternalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Object2"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Object2"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Object1"
+				]
+			}
+		},
+		"/by-external-reference-code/{currentExternalReferenceCode}/relationship2/{relatedExternalReferenceCode}/disassociate": {
+			"post": {
+				"operationId": "postByExternalReferenceCodeObject1Relationship2Object2Disassociate",
 				"parameters": [
 					{
 						"in": "path",
@@ -5102,6 +5193,14 @@
 				"parameters": [
 					{
 						"in": "path",
+						"name": "scopeKey",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
 						"name": "currentExternalReferenceCode",
 						"required": true,
 						"schema": {
@@ -5365,6 +5464,57 @@
 				]
 			}
 		},
+		"/scopes/{scopeKey}/by-external-reference-code/{currentExternalReferenceCode}/relationship1/{relatedExternalReferenceCode}/disassociate": {
+			"post": {
+				"operationId": "postScopeScopeKeyByExternalReferenceCodeObject1Relationship1Object2Disassociate",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "scopeKey",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "currentExternalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "relatedExternalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Object2"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Object2"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Object1"
+				]
+			}
+		},
 		"/scopes/{scopeKey}/by-external-reference-code/{currentExternalReferenceCode}/relationship2": {
 			"get": {
 				"operationId": "getScopeScopeKeyByExternalReferenceCodeObject1Relationship2Page",
@@ -5473,6 +5623,14 @@
 			"post": {
 				"operationId": "postScopeScopeKeyByExternalReferenceCodeObject1Relationship2",
 				"parameters": [
+					{
+						"in": "path",
+						"name": "scopeKey",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
 					{
 						"in": "path",
 						"name": "currentExternalReferenceCode",
@@ -5716,6 +5874,57 @@
 						}
 					}
 				},
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Object2"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Object2"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Object1"
+				]
+			}
+		},
+		"/scopes/{scopeKey}/by-external-reference-code/{currentExternalReferenceCode}/relationship2/{relatedExternalReferenceCode}/disassociate": {
+			"post": {
+				"operationId": "postScopeScopeKeyByExternalReferenceCodeObject1Relationship2Object2Disassociate",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "scopeKey",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "currentExternalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "relatedExternalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
 				"responses": {
 					"default": {
 						"content": {
@@ -7348,6 +7557,7 @@
 						}
 					},
 					{
+						"description": "The required language ID of the source text (e.g., \"en_US\").",
 						"in": "query",
 						"name": "sourceLanguageId",
 						"schema": {
@@ -7355,6 +7565,7 @@
 						}
 					},
 					{
+						"description": "A required list of language IDs for the target translations (e.g., \"es_ES\", \"fr_FR\").",
 						"in": "query",
 						"name": "targetLanguageIds",
 						"schema": {
@@ -7362,6 +7573,7 @@
 						}
 					},
 					{
+						"description": "The XLIFF specification version to export.",
 						"in": "query",
 						"name": "version",
 						"schema": {
@@ -7438,6 +7650,7 @@
 						}
 					},
 					{
+						"description": "The required language ID of the source text (e.g., \"en_US\").",
 						"in": "path",
 						"name": "languageId",
 						"required": true,
@@ -7446,6 +7659,7 @@
 						}
 					},
 					{
+						"description": "The required language ID for the target translation (e.g., \"en_US\").",
 						"in": "query",
 						"name": "targetLanguageId",
 						"schema": {

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions.json
@@ -138,6 +138,7 @@
 				}
 			},
 			"CollaboratorBrief": {
+				"description": "Brief of the collaborator record for the user making the request, present only when this asset is shared with them.",
 				"properties": {
 					"actionIds": {
 						"description": "The sharing actions granted to the user making the request (e.g. VIEW, UPDATE).",
@@ -173,7 +174,7 @@
 				}
 			},
 			"Comment": {
-				"description": "Optional field with the comments associated with this object entry, can be embedded with nestedFields",
+				"description": "Represents a comment. See [Comment](https://www.schema.org/Comment) for more details.",
 				"properties": {
 					"actions": {
 						"additionalProperties": {
@@ -255,7 +256,7 @@
 				}
 			},
 			"Creator": {
-				"description": "The comment's author.",
+				"description": "Represents the user account of the content's creator/author. Properties follow the [creator](https://schema.org/creator) specification.",
 				"properties": {
 					"additionalName": {
 						"description": "The author's additional name (e.g., middle name).",
@@ -1183,6 +1184,10 @@
 						"description": "The scope's name.",
 						"type": "string"
 					},
+					"liveExternalReferenceCode": {
+						"description": "The scope's live group external reference code.",
+						"type": "string"
+					},
 					"type": {
 						"description": "The scope's type.",
 						"enum": [
@@ -1317,7 +1322,7 @@
 				}
 			},
 			"UserGroupBrief": {
-				"description": "A list of userGroups information.",
+				"description": "The author's user groups information.",
 				"properties": {
 					"id": {
 						"description": "The ID of the user group.",
@@ -3930,6 +3935,7 @@
 						}
 					},
 					{
+						"description": "The required language ID of the source text (e.g., \"en_US\").",
 						"in": "query",
 						"name": "sourceLanguageId",
 						"schema": {
@@ -3937,6 +3943,7 @@
 						}
 					},
 					{
+						"description": "A required list of language IDs for the target translations (e.g., \"es_ES\", \"fr_FR\").",
 						"in": "query",
 						"name": "targetLanguageIds",
 						"schema": {
@@ -3944,6 +3951,7 @@
 						}
 					},
 					{
+						"description": "The XLIFF specification version to export.",
 						"in": "query",
 						"name": "version",
 						"schema": {
@@ -4020,6 +4028,7 @@
 						}
 					},
 					{
+						"description": "The required language ID of the source text (e.g., \"en_US\").",
 						"in": "path",
 						"name": "languageId",
 						"required": true,
@@ -4028,6 +4037,7 @@
 						}
 					},
 					{
+						"description": "The required language ID for the target translation (e.g., \"en_US\").",
 						"in": "query",
 						"name": "targetLanguageId",
 						"schema": {

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions_object_action.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions_object_action.json
@@ -138,6 +138,7 @@
 				}
 			},
 			"CollaboratorBrief": {
+				"description": "Brief of the collaborator record for the user making the request, present only when this asset is shared with them.",
 				"properties": {
 					"actionIds": {
 						"description": "The sharing actions granted to the user making the request (e.g. VIEW, UPDATE).",
@@ -173,7 +174,7 @@
 				}
 			},
 			"Comment": {
-				"description": "Optional field with the comments associated with this object entry, can be embedded with nestedFields",
+				"description": "Represents a comment. See [Comment](https://www.schema.org/Comment) for more details.",
 				"properties": {
 					"actions": {
 						"additionalProperties": {
@@ -255,7 +256,7 @@
 				}
 			},
 			"Creator": {
-				"description": "The comment's author.",
+				"description": "Represents the user account of the content's creator/author. Properties follow the [creator](https://schema.org/creator) specification.",
 				"properties": {
 					"additionalName": {
 						"description": "The author's additional name (e.g., middle name).",
@@ -1207,6 +1208,10 @@
 						"description": "The scope's name.",
 						"type": "string"
 					},
+					"liveExternalReferenceCode": {
+						"description": "The scope's live group external reference code.",
+						"type": "string"
+					},
 					"type": {
 						"description": "The scope's type.",
 						"enum": [
@@ -1341,7 +1346,7 @@
 				}
 			},
 			"UserGroupBrief": {
-				"description": "A list of userGroups information.",
+				"description": "The author's user groups information.",
 				"properties": {
 					"id": {
 						"description": "The ID of the user group.",
@@ -4012,6 +4017,7 @@
 						}
 					},
 					{
+						"description": "The required language ID of the source text (e.g., \"en_US\").",
 						"in": "query",
 						"name": "sourceLanguageId",
 						"schema": {
@@ -4019,6 +4025,7 @@
 						}
 					},
 					{
+						"description": "A required list of language IDs for the target translations (e.g., \"es_ES\", \"fr_FR\").",
 						"in": "query",
 						"name": "targetLanguageIds",
 						"schema": {
@@ -4026,6 +4033,7 @@
 						}
 					},
 					{
+						"description": "The XLIFF specification version to export.",
 						"in": "query",
 						"name": "version",
 						"schema": {
@@ -4102,6 +4110,7 @@
 						}
 					},
 					{
+						"description": "The required language ID of the source text (e.g., \"en_US\").",
 						"in": "path",
 						"name": "languageId",
 						"required": true,
@@ -4110,6 +4119,7 @@
 						}
 					},
 					{
+						"description": "The required language ID for the target translation (e.g., \"en_US\").",
 						"in": "query",
 						"name": "targetLanguageId",
 						"schema": {

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_categorization_disabled.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_categorization_disabled.json
@@ -138,6 +138,7 @@
 				}
 			},
 			"CollaboratorBrief": {
+				"description": "Brief of the collaborator record for the user making the request, present only when this asset is shared with them.",
 				"properties": {
 					"actionIds": {
 						"description": "The sharing actions granted to the user making the request (e.g. VIEW, UPDATE).",
@@ -173,7 +174,7 @@
 				}
 			},
 			"Comment": {
-				"description": "Optional field with the comments associated with this object entry, can be embedded with nestedFields",
+				"description": "Represents a comment. See [Comment](https://www.schema.org/Comment) for more details.",
 				"properties": {
 					"actions": {
 						"additionalProperties": {
@@ -255,7 +256,7 @@
 				}
 			},
 			"Creator": {
-				"description": "The comment's author.",
+				"description": "Represents the user account of the content's creator/author. Properties follow the [creator](https://schema.org/creator) specification.",
 				"properties": {
 					"additionalName": {
 						"description": "The author's additional name (e.g., middle name).",
@@ -878,6 +879,10 @@
 						"description": "The scope's name.",
 						"type": "string"
 					},
+					"liveExternalReferenceCode": {
+						"description": "The scope's live group external reference code.",
+						"type": "string"
+					},
 					"type": {
 						"description": "The scope's type.",
 						"enum": [
@@ -958,7 +963,7 @@
 				}
 			},
 			"UserGroupBrief": {
-				"description": "A list of userGroups information.",
+				"description": "The author's user groups information.",
 				"properties": {
 					"id": {
 						"description": "The ID of the user group.",
@@ -3571,6 +3576,7 @@
 						}
 					},
 					{
+						"description": "The required language ID of the source text (e.g., \"en_US\").",
 						"in": "query",
 						"name": "sourceLanguageId",
 						"schema": {
@@ -3578,6 +3584,7 @@
 						}
 					},
 					{
+						"description": "A required list of language IDs for the target translations (e.g., \"es_ES\", \"fr_FR\").",
 						"in": "query",
 						"name": "targetLanguageIds",
 						"schema": {
@@ -3585,6 +3592,7 @@
 						}
 					},
 					{
+						"description": "The XLIFF specification version to export.",
 						"in": "query",
 						"name": "version",
 						"schema": {
@@ -3661,6 +3669,7 @@
 						}
 					},
 					{
+						"description": "The required language ID of the source text (e.g., \"en_US\").",
 						"in": "path",
 						"name": "languageId",
 						"required": true,
@@ -3669,6 +3678,7 @@
 						}
 					},
 					{
+						"description": "The required language ID for the target translation (e.g., \"en_US\").",
 						"in": "query",
 						"name": "targetLanguageId",
 						"schema": {

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_related.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_related.json
@@ -138,6 +138,7 @@
 				}
 			},
 			"CollaboratorBrief": {
+				"description": "Brief of the collaborator record for the user making the request, present only when this asset is shared with them.",
 				"properties": {
 					"actionIds": {
 						"description": "The sharing actions granted to the user making the request (e.g. VIEW, UPDATE).",
@@ -173,7 +174,7 @@
 				}
 			},
 			"Comment": {
-				"description": "Optional field with the comments associated with this object entry, can be embedded with nestedFields",
+				"description": "Represents a comment. See [Comment](https://www.schema.org/Comment) for more details.",
 				"properties": {
 					"actions": {
 						"additionalProperties": {
@@ -255,7 +256,7 @@
 				}
 			},
 			"Creator": {
-				"description": "The comment's author.",
+				"description": "Represents the user account of the content's creator/author. Properties follow the [creator](https://schema.org/creator) specification.",
 				"properties": {
 					"additionalName": {
 						"description": "The author's additional name (e.g., middle name).",
@@ -3707,6 +3708,10 @@
 						"description": "The scope's name.",
 						"type": "string"
 					},
+					"liveExternalReferenceCode": {
+						"description": "The scope's live group external reference code.",
+						"type": "string"
+					},
 					"type": {
 						"description": "The scope's type.",
 						"enum": [
@@ -3841,7 +3846,7 @@
 				}
 			},
 			"UserGroupBrief": {
-				"description": "A list of userGroups information.",
+				"description": "The author's user groups information.",
 				"properties": {
 					"id": {
 						"description": "The ID of the user group.",
@@ -4657,6 +4662,49 @@
 				]
 			}
 		},
+		"/by-external-reference-code/{currentExternalReferenceCode}/relationship1/{relatedExternalReferenceCode}/disassociate": {
+			"post": {
+				"operationId": "postByExternalReferenceCodeObject2Relationship1Object1Disassociate",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "currentExternalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "relatedExternalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Object1"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Object1"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Object2"
+				]
+			}
+		},
 		"/by-external-reference-code/{currentExternalReferenceCode}/relationship3": {
 			"get": {
 				"operationId": "getByExternalReferenceCodeObject2Relationship3Page",
@@ -4976,6 +5024,49 @@
 				]
 			}
 		},
+		"/by-external-reference-code/{currentExternalReferenceCode}/relationship3/{relatedExternalReferenceCode}/disassociate": {
+			"post": {
+				"operationId": "postByExternalReferenceCodeObject2Relationship3Object3Disassociate",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "currentExternalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "relatedExternalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Object3"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Object3"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Object2"
+				]
+			}
+		},
 		"/by-external-reference-code/{currentExternalReferenceCode}/relationship4": {
 			"get": {
 				"operationId": "getByExternalReferenceCodeObject2Relationship4Page",
@@ -5255,6 +5346,49 @@
 			},
 			"put": {
 				"operationId": "putByExternalReferenceCodeObject2Relationship4Object3",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "currentExternalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "relatedExternalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Object3"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Object3"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Object2"
+				]
+			}
+		},
+		"/by-external-reference-code/{currentExternalReferenceCode}/relationship4/{relatedExternalReferenceCode}/disassociate": {
+			"post": {
+				"operationId": "postByExternalReferenceCodeObject2Relationship4Object3Disassociate",
 				"parameters": [
 					{
 						"in": "path",
@@ -6493,6 +6627,14 @@
 				"parameters": [
 					{
 						"in": "path",
+						"name": "scopeKey",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
 						"name": "currentExternalReferenceCode",
 						"required": true,
 						"schema": {
@@ -6756,6 +6898,57 @@
 				]
 			}
 		},
+		"/scopes/{scopeKey}/by-external-reference-code/{currentExternalReferenceCode}/relationship1/{relatedExternalReferenceCode}/disassociate": {
+			"post": {
+				"operationId": "postScopeScopeKeyByExternalReferenceCodeObject2Relationship1Object1Disassociate",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "scopeKey",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "currentExternalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "relatedExternalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Object1"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Object1"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Object2"
+				]
+			}
+		},
 		"/scopes/{scopeKey}/by-external-reference-code/{currentExternalReferenceCode}/relationship3": {
 			"get": {
 				"operationId": "getScopeScopeKeyByExternalReferenceCodeObject2Relationship3Page",
@@ -6864,6 +7057,14 @@
 			"post": {
 				"operationId": "postScopeScopeKeyByExternalReferenceCodeObject2Relationship3",
 				"parameters": [
+					{
+						"in": "path",
+						"name": "scopeKey",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
 					{
 						"in": "path",
 						"name": "currentExternalReferenceCode",
@@ -7129,6 +7330,57 @@
 				]
 			}
 		},
+		"/scopes/{scopeKey}/by-external-reference-code/{currentExternalReferenceCode}/relationship3/{relatedExternalReferenceCode}/disassociate": {
+			"post": {
+				"operationId": "postScopeScopeKeyByExternalReferenceCodeObject2Relationship3Object3Disassociate",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "scopeKey",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "currentExternalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "relatedExternalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Object3"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Object3"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Object2"
+				]
+			}
+		},
 		"/scopes/{scopeKey}/by-external-reference-code/{currentExternalReferenceCode}/relationship4": {
 			"get": {
 				"operationId": "getScopeScopeKeyByExternalReferenceCodeObject2Relationship4Page",
@@ -7237,6 +7489,14 @@
 			"post": {
 				"operationId": "postScopeScopeKeyByExternalReferenceCodeObject2Relationship4",
 				"parameters": [
+					{
+						"in": "path",
+						"name": "scopeKey",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
 					{
 						"in": "path",
 						"name": "currentExternalReferenceCode",
@@ -7480,6 +7740,57 @@
 						}
 					}
 				},
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Object3"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Object3"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Object2"
+				]
+			}
+		},
+		"/scopes/{scopeKey}/by-external-reference-code/{currentExternalReferenceCode}/relationship4/{relatedExternalReferenceCode}/disassociate": {
+			"post": {
+				"operationId": "postScopeScopeKeyByExternalReferenceCodeObject2Relationship4Object3Disassociate",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "scopeKey",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "currentExternalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "relatedExternalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
 				"responses": {
 					"default": {
 						"content": {
@@ -9403,6 +9714,7 @@
 						}
 					},
 					{
+						"description": "The required language ID of the source text (e.g., \"en_US\").",
 						"in": "query",
 						"name": "sourceLanguageId",
 						"schema": {
@@ -9410,6 +9722,7 @@
 						}
 					},
 					{
+						"description": "A required list of language IDs for the target translations (e.g., \"es_ES\", \"fr_FR\").",
 						"in": "query",
 						"name": "targetLanguageIds",
 						"schema": {
@@ -9417,6 +9730,7 @@
 						}
 					},
 					{
+						"description": "The XLIFF specification version to export.",
 						"in": "query",
 						"name": "version",
 						"schema": {
@@ -9493,6 +9807,7 @@
 						}
 					},
 					{
+						"description": "The required language ID of the source text (e.g., \"en_US\").",
 						"in": "path",
 						"name": "languageId",
 						"required": true,
@@ -9501,6 +9816,7 @@
 						}
 					},
 					{
+						"description": "The required language ID for the target translation (e.g., \"en_US\").",
 						"in": "query",
 						"name": "targetLanguageId",
 						"schema": {

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_site.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_site.json
@@ -138,6 +138,7 @@
 				}
 			},
 			"CollaboratorBrief": {
+				"description": "Brief of the collaborator record for the user making the request, present only when this asset is shared with them.",
 				"properties": {
 					"actionIds": {
 						"description": "The sharing actions granted to the user making the request (e.g. VIEW, UPDATE).",
@@ -173,7 +174,7 @@
 				}
 			},
 			"Comment": {
-				"description": "Optional field with the comments associated with this object entry, can be embedded with nestedFields",
+				"description": "Represents a comment. See [Comment](https://www.schema.org/Comment) for more details.",
 				"properties": {
 					"actions": {
 						"additionalProperties": {
@@ -255,7 +256,7 @@
 				}
 			},
 			"Creator": {
-				"description": "The comment's author.",
+				"description": "Represents the user account of the content's creator/author. Properties follow the [creator](https://schema.org/creator) specification.",
 				"properties": {
 					"additionalName": {
 						"description": "The author's additional name (e.g., middle name).",
@@ -904,6 +905,10 @@
 						"description": "The scope's name.",
 						"type": "string"
 					},
+					"liveExternalReferenceCode": {
+						"description": "The scope's live group external reference code.",
+						"type": "string"
+					},
 					"type": {
 						"description": "The scope's type.",
 						"enum": [
@@ -1038,7 +1043,7 @@
 				}
 			},
 			"UserGroupBrief": {
-				"description": "A list of userGroups information.",
+				"description": "The author's user groups information.",
 				"properties": {
 					"id": {
 						"description": "The ID of the user group.",
@@ -3103,6 +3108,7 @@
 						}
 					},
 					{
+						"description": "The required language ID of the source text (e.g., \"en_US\").",
 						"in": "query",
 						"name": "sourceLanguageId",
 						"schema": {
@@ -3110,6 +3116,7 @@
 						}
 					},
 					{
+						"description": "A required list of language IDs for the target translations (e.g., \"es_ES\", \"fr_FR\").",
 						"in": "query",
 						"name": "targetLanguageIds",
 						"schema": {
@@ -3117,6 +3124,7 @@
 						}
 					},
 					{
+						"description": "The XLIFF specification version to export.",
 						"in": "query",
 						"name": "version",
 						"schema": {
@@ -3209,6 +3217,7 @@
 						}
 					},
 					{
+						"description": "The required language ID of the source text (e.g., \"en_US\").",
 						"in": "path",
 						"name": "languageId",
 						"required": true,
@@ -3217,6 +3226,7 @@
 						}
 					},
 					{
+						"description": "The required language ID for the target translation (e.g., \"en_US\").",
 						"in": "query",
 						"name": "targetLanguageId",
 						"schema": {
@@ -4386,6 +4396,7 @@
 						}
 					},
 					{
+						"description": "The required language ID of the source text (e.g., \"en_US\").",
 						"in": "query",
 						"name": "sourceLanguageId",
 						"schema": {
@@ -4393,6 +4404,7 @@
 						}
 					},
 					{
+						"description": "A required list of language IDs for the target translations (e.g., \"es_ES\", \"fr_FR\").",
 						"in": "query",
 						"name": "targetLanguageIds",
 						"schema": {
@@ -4400,6 +4412,7 @@
 						}
 					},
 					{
+						"description": "The XLIFF specification version to export.",
 						"in": "query",
 						"name": "version",
 						"schema": {
@@ -4476,6 +4489,7 @@
 						}
 					},
 					{
+						"description": "The required language ID of the source text (e.g., \"en_US\").",
 						"in": "path",
 						"name": "languageId",
 						"required": true,
@@ -4484,6 +4498,7 @@
 						}
 					},
 					{
+						"description": "The required language ID for the target translation (e.g., \"en_US\").",
 						"in": "query",
 						"name": "targetLanguageId",
 						"schema": {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96907

## What Is Being Fixed

`OpenAPIResourceTest` (`testGetOpenAPI`, `testGetOpenAPIWithActions`) has been failing on the `ci:test:headless` Testray routine for several cycles (tracked in LPD-96906), because the recorded `expected_openapi*.json` fixtures under `object-rest-test` never caught up with several already-merged, intentional schema changes.

## How It Is Being Fixed

Each `JSONAssert` STRICT mismatch was traced to its actual source before touching any fixture: `Scope` gained `liveExternalReferenceCode` (LPD-96103), object relationships gained a by-external-reference-code `disassociate` endpoint and the scoped associate endpoint was already missing its `scopeKey` parameter (LPD-95305), and the shared `Comment`/`Creator`/`UserGroupBrief`/`CollaboratorBrief` schema descriptions and the `/translations` endpoint parameter descriptions changed in `headless-delivery-api`/`object-rest-impl`. None of this is a product regression, so the fix only updates the six `expected_openapi*.json` fixtures to match the current, correct OpenAPI output — no product code changed.

## Why Are There No Tests?

This PR only updates existing `expected_openapi*.json` test fixtures to match already-merged, intentional schema changes (`Scope.liveExternalReferenceCode`, the relationship disassociate endpoint, and updated `Comment`/`Creator`/`UserGroupBrief` descriptions). No product behavior changed, so no new test coverage is needed — the existing `OpenAPIResourceTest` already exercises this.

## PR Check

**pr-check: PASS** — tested on `fe171fd3aa7dc428b38c3e15d48fc6fef86f58ef`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "fe171fd3aa7dc428b38c3e15d48fc6fef86f58ef"} -->
