### PR TITLE
LPD-97411 Check permissions when referencing DM file entries

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -10,7 +10,8 @@ import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.model.DepotEntryModel;
 import com.liferay.depot.service.DepotEntryLocalService;
-import com.liferay.document.library.kernel.service.DLAppLocalService;
+import com.liferay.document.library.kernel.exception.NoSuchFileEntryException;
+import com.liferay.document.library.kernel.service.DLAppService;
 import com.liferay.exportimport.attachment.ExportImportAttachmentManager;
 import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.object.action.engine.ObjectActionEngine;
@@ -2315,6 +2316,36 @@ public class DefaultObjectEntryManagerImpl
 			dtoConverterContext.getUserId());
 	}
 
+	private com.liferay.portal.kernel.repository.model.FileEntry
+			_fetchServiceBuilderFileEntry(
+				FileEntry fileEntry, ObjectDefinition objectDefinition,
+				String scopeKey)
+		throws Exception {
+
+		try {
+			if (Validator.isNotNull(fileEntry.getExternalReferenceCode())) {
+				return _dlAppService.getFileEntryByExternalReferenceCode(
+					fileEntry.getExternalReferenceCode(),
+					_getFileEntryGroupId(
+						_getGroupExternalReferenceCode(fileEntry),
+						objectDefinition, scopeKey));
+			}
+
+			if (fileEntry.getId() != null) {
+				return _dlAppService.getFileEntry(fileEntry.getId());
+			}
+
+			return null;
+		}
+		catch (NoSuchFileEntryException noSuchFileEntryException) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(noSuchFileEntryException);
+			}
+
+			return null;
+		}
+	}
+
 	private String _getDateString(Date date) {
 		if (date == null) {
 			return StringPool.BLANK;
@@ -3166,7 +3197,7 @@ public class DefaultObjectEntryManagerImpl
 		if ((fileEntry == null) ||
 			((fileEntry.getExternalReferenceCode() == null) &&
 			 (fileEntry.getFileBase64() == null) &&
-			 (fileEntry.getFileURL() == null))) {
+			 (fileEntry.getFileURL() == null) && (fileEntry.getId() == null))) {
 
 			return 0;
 		}
@@ -3182,21 +3213,15 @@ public class DefaultObjectEntryManagerImpl
 				"File source " + fileSource + " is not supported");
 		}
 
-		if (Validator.isNotNull(fileEntry.getExternalReferenceCode())) {
-			com.liferay.portal.kernel.repository.model.FileEntry
-				serviceBuilderFileEntry =
-					_dlAppLocalService.fetchFileEntryByExternalReferenceCode(
-						_getFileEntryGroupId(
-							_getGroupExternalReferenceCode(fileEntry),
-							objectDefinition, scopeKey),
-						fileEntry.getExternalReferenceCode());
+		com.liferay.portal.kernel.repository.model.FileEntry
+			serviceBuilderFileEntry = _fetchServiceBuilderFileEntry(
+				fileEntry, objectDefinition, scopeKey);
 
-			if ((serviceBuilderFileEntry != null) &&
-				(objectField.getCompanyId() ==
-					serviceBuilderFileEntry.getCompanyId())) {
+		if ((serviceBuilderFileEntry != null) &&
+			(objectField.getCompanyId() ==
+				serviceBuilderFileEntry.getCompanyId())) {
 
-				return serviceBuilderFileEntry.getFileEntryId();
-			}
+			return serviceBuilderFileEntry.getFileEntryId();
 		}
 
 		byte[] fileContent = {};
@@ -3249,9 +3274,6 @@ public class DefaultObjectEntryManagerImpl
 
 			throw new IllegalArgumentException("File content is empty");
 		}
-
-		com.liferay.portal.kernel.repository.model.FileEntry
-			serviceBuilderFileEntry = null;
 
 		String groupExternalReferenceCode = _getGroupExternalReferenceCode(
 			fileEntry);
@@ -4118,7 +4140,7 @@ public class DefaultObjectEntryManagerImpl
 	private DepotEntryLocalService _depotEntryLocalService;
 
 	@Reference
-	private DLAppLocalService _dlAppLocalService;
+	private DLAppService _dlAppService;
 
 	@Reference
 	private DTOConverterRegistry _dtoConverterRegistry;

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -1732,8 +1732,9 @@ public class DefaultObjectEntryManagerImplTest
 
 		// Regular user without permissions
 
-		try {
-			_defaultObjectEntryManager.addObjectEntry(
+		Assert.assertThrows(
+			PrincipalException.class,
+			() -> _defaultObjectEntryManager.addObjectEntry(
 				_simpleDTOConverterContext, objectDefinition,
 				new ObjectEntry() {
 					{
@@ -1745,16 +1746,11 @@ public class DefaultObjectEntryManagerImplTest
 						).build();
 					}
 				},
-				String.valueOf(group.getGroupId()));
+				String.valueOf(group.getGroupId())));
 
-			Assert.fail();
-		}
-		catch (PrincipalException principalException) {
-			Assert.assertNotNull(principalException);
-		}
-
-		try {
-			_defaultObjectEntryManager.addObjectEntry(
+		Assert.assertThrows(
+			PrincipalException.class,
+			() -> _defaultObjectEntryManager.addObjectEntry(
 				_simpleDTOConverterContext, objectDefinition,
 				new ObjectEntry() {
 					{
@@ -1767,13 +1763,7 @@ public class DefaultObjectEntryManagerImplTest
 						).build();
 					}
 				},
-				String.valueOf(group.getGroupId()));
-
-			Assert.fail();
-		}
-		catch (PrincipalException principalException) {
-			Assert.assertNotNull(principalException);
-		}
+				String.valueOf(group.getGroupId())));
 
 		objectDefinitionLocalService.deleteObjectDefinition(
 			objectDefinition.getObjectDefinitionId());
@@ -4108,24 +4098,20 @@ public class DefaultObjectEntryManagerImplTest
 			},
 			objectDefinition1, _user);
 
-		try {
-			_defaultObjectEntryManager.deleteObjectEntry(
-				companyId, _simpleDTOConverterContext, "externalReferenceCode1",
-				objectDefinition1, null);
+		ObjectRelationshipDeletionTypeException
+			objectRelationshipDeletionTypeException = Assert.assertThrows(
+				ObjectRelationshipDeletionTypeException.class,
+				() -> _defaultObjectEntryManager.deleteObjectEntry(
+					companyId, _simpleDTOConverterContext,
+					"externalReferenceCode1", objectDefinition1, null));
 
-			Assert.fail();
-		}
-		catch (ObjectRelationshipDeletionTypeException
-					objectRelationshipDeletionTypeException) {
-
-			Assert.assertThat(
-				objectRelationshipDeletionTypeException.getMessage(),
-				CoreMatchers.containsString(
-					StringBundler.concat(
-						"User ", _user.getUserId(),
-						" must have DELETE permission for ",
-						objectDefinition2.getClassName())));
-		}
+		Assert.assertThat(
+			objectRelationshipDeletionTypeException.getMessage(),
+			CoreMatchers.containsString(
+				StringBundler.concat(
+					"User ", _user.getUserId(),
+					" must have DELETE permission for ",
+					objectDefinition2.getClassName())));
 
 		// Relationship type disassociate
 
@@ -4140,16 +4126,11 @@ public class DefaultObjectEntryManagerImplTest
 			companyId, _simpleDTOConverterContext, "externalReferenceCode1",
 			objectDefinition1, null);
 
-		try {
-			_defaultObjectEntryManager.getObjectEntry(
+		Assert.assertThrows(
+			NoSuchObjectEntryException.class,
+			() -> _defaultObjectEntryManager.getObjectEntry(
 				companyId, _simpleDTOConverterContext, "externalReferenceCode1",
-				objectDefinition1, null);
-
-			Assert.fail();
-		}
-		catch (NoSuchObjectEntryException noSuchObjectEntryException) {
-			Assert.assertNotNull(noSuchObjectEntryException);
-		}
+				objectDefinition1, null));
 
 		PrincipalThreadLocal.setName(adminUser.getUserId());
 		PermissionThreadLocal.setPermissionChecker(
@@ -4177,23 +4158,15 @@ public class DefaultObjectEntryManagerImplTest
 				ObjectRelationshipConstants.DELETION_TYPE_PREVENT, false,
 				objectRelationship.getLabelMap(), null);
 
-		try {
-			_defaultObjectEntryManager.deleteObjectEntry(
+		AssertUtils.assertFailure(
+			RequiredObjectRelationshipException.class,
+			StringBundler.concat(
+				"Object relationship ",
+				objectRelationship.getObjectRelationshipId(),
+				" does not allow deletes"),
+			() -> _defaultObjectEntryManager.deleteObjectEntry(
 				companyId, _simpleDTOConverterContext, "externalReferenceCode3",
-				objectDefinition1, null);
-
-			Assert.fail();
-		}
-		catch (RequiredObjectRelationshipException
-					requiredObjectRelationshipException) {
-
-			Assert.assertEquals(
-				StringBundler.concat(
-					"Object relationship ",
-					objectRelationship.getObjectRelationshipId(),
-					" does not allow deletes"),
-				requiredObjectRelationshipException.getMessage());
-		}
+				objectDefinition1, null));
 
 		_roleLocalService.deleteRole(role.getRoleId());
 
@@ -4339,21 +4312,14 @@ public class DefaultObjectEntryManagerImplTest
 			ResourceConstants.SCOPE_COMPANY, String.valueOf(companyId),
 			role.getRoleId(), ActionKeys.DELETE);
 
-		try {
-			_defaultObjectEntryManager.deleteObjectEntry(
-				_objectDefinition3, objectEntry2.getId());
-
-			Assert.fail();
-		}
-		catch (Exception exception) {
-			Assert.assertEquals(
-				exception.getMessage(),
-				StringBundler.concat(
-					"User ", _user.getUserId(),
-					" must have DELETE permission for ",
-					_objectDefinition3.getClassName(), StringPool.SPACE,
-					objectEntry2.getId()));
-		}
+		AssertUtils.assertFailure(
+			Exception.class,
+			StringBundler.concat(
+				"User ", _user.getUserId(), " must have DELETE permission for ",
+				_objectDefinition3.getClassName(), StringPool.SPACE,
+				objectEntry2.getId()),
+			() -> _defaultObjectEntryManager.deleteObjectEntry(
+				_objectDefinition3, objectEntry2.getId()));
 
 		// Regular roles' individual permissions should not be restricted by
 		// account entry
@@ -4363,7 +4329,7 @@ public class DefaultObjectEntryManagerImplTest
 
 		PrincipalThreadLocal.setName(adminUser.getUserId());
 
-		objectEntry1 = _addObjectEntry(accountEntry1);
+		ObjectEntry objectEntry3 = _addObjectEntry(accountEntry1);
 
 		PermissionThreadLocal.setPermissionChecker(
 			PermissionCheckerFactoryUtil.create(_user));
@@ -4373,18 +4339,18 @@ public class DefaultObjectEntryManagerImplTest
 		_resourcePermissionLocalService.setResourcePermissions(
 			companyId, _objectDefinition3.getClassName(),
 			ResourceConstants.SCOPE_INDIVIDUAL,
-			String.valueOf(objectEntry1.getId()), role.getRoleId(),
+			String.valueOf(objectEntry3.getId()), role.getRoleId(),
 			new String[] {ActionKeys.DELETE});
 
 		_defaultObjectEntryManager.deleteObjectEntry(
-			_objectDefinition3, objectEntry1.getId());
+			_objectDefinition3, objectEntry3.getId());
 
 		PermissionThreadLocal.setPermissionChecker(
 			PermissionCheckerFactoryUtil.create(adminUser));
 
 		PrincipalThreadLocal.setName(adminUser.getUserId());
 
-		objectEntry1 = _addObjectEntry(accountEntry1);
+		ObjectEntry objectEntry4 = _addObjectEntry(accountEntry1);
 
 		// Account entry scope
 
@@ -4409,23 +4375,16 @@ public class DefaultObjectEntryManagerImplTest
 			_buyerRole.getRoleId());
 
 		_defaultObjectEntryManager.deleteObjectEntry(
-			_objectDefinition3, objectEntry1.getId());
+			_objectDefinition3, objectEntry4.getId());
 
-		try {
-			_defaultObjectEntryManager.deleteObjectEntry(
-				_objectDefinition3, objectEntry2.getId());
-
-			Assert.fail();
-		}
-		catch (Exception exception) {
-			Assert.assertEquals(
-				exception.getMessage(),
-				StringBundler.concat(
-					"User ", _user.getUserId(),
-					" must have DELETE permission for ",
-					_objectDefinition3.getClassName(), StringPool.SPACE,
-					objectEntry2.getId()));
-		}
+		AssertUtils.assertFailure(
+			Exception.class,
+			StringBundler.concat(
+				"User ", _user.getUserId(), " must have DELETE permission for ",
+				_objectDefinition3.getClassName(), StringPool.SPACE,
+				objectEntry2.getId()),
+			() -> _defaultObjectEntryManager.deleteObjectEntry(
+				_objectDefinition3, objectEntry2.getId()));
 
 		// Organization scope
 
@@ -4434,7 +4393,7 @@ public class DefaultObjectEntryManagerImplTest
 
 		PrincipalThreadLocal.setName(adminUser.getUserId());
 
-		objectEntry1 = _addObjectEntry(accountEntry1);
+		ObjectEntry objectEntry5 = _addObjectEntry(accountEntry1);
 
 		_user = _addUser();
 
@@ -4452,27 +4411,21 @@ public class DefaultObjectEntryManagerImplTest
 
 		_assertObjectEntriesSize1(1);
 
-		try {
-			_defaultObjectEntryManager.deleteObjectEntry(
-				_objectDefinition3, objectEntry1.getId());
-
-			Assert.fail();
-		}
-		catch (Exception exception) {
-			Assert.assertEquals(
-				exception.getMessage(),
-				StringBundler.concat(
-					"User ", _user.getUserId(), " must have DELETE permission ",
-					"for ", _objectDefinition3.getClassName(), StringPool.SPACE,
-					objectEntry1.getId()));
-		}
+		AssertUtils.assertFailure(
+			Exception.class,
+			StringBundler.concat(
+				"User ", _user.getUserId(), " must have DELETE permission for ",
+				_objectDefinition3.getClassName(), StringPool.SPACE,
+				objectEntry5.getId()),
+			() -> _defaultObjectEntryManager.deleteObjectEntry(
+				_objectDefinition3, objectEntry5.getId()));
 
 		_assertObjectEntriesSize1(1);
 
 		_addResourcePermission(ActionKeys.DELETE, _accountManagerRole);
 
 		_defaultObjectEntryManager.deleteObjectEntry(
-			_objectDefinition3, objectEntry1.getId());
+			_objectDefinition3, objectEntry5.getId());
 
 		_assertObjectEntriesSize1(0);
 
@@ -4486,7 +4439,7 @@ public class DefaultObjectEntryManagerImplTest
 
 		PrincipalThreadLocal.setName(adminUser.getUserId());
 
-		objectEntry1 = _addObjectEntry(accountEntry1);
+		ObjectEntry objectEntry6 = _addObjectEntry(accountEntry1);
 
 		_user = _addUser();
 
@@ -4508,27 +4461,21 @@ public class DefaultObjectEntryManagerImplTest
 
 		_removeResourcePermission(ActionKeys.DELETE, _accountManagerRole);
 
-		try {
-			_defaultObjectEntryManager.deleteObjectEntry(
-				_objectDefinition3, objectEntry1.getId());
-
-			Assert.fail();
-		}
-		catch (Exception exception) {
-			Assert.assertEquals(
-				exception.getMessage(),
-				StringBundler.concat(
-					"User ", _user.getUserId(), " must have DELETE permission ",
-					"for ", _objectDefinition3.getClassName(), StringPool.SPACE,
-					objectEntry1.getId()));
-		}
+		AssertUtils.assertFailure(
+			Exception.class,
+			StringBundler.concat(
+				"User ", _user.getUserId(), " must have DELETE permission for ",
+				_objectDefinition3.getClassName(), StringPool.SPACE,
+				objectEntry6.getId()),
+			() -> _defaultObjectEntryManager.deleteObjectEntry(
+				_objectDefinition3, objectEntry6.getId()));
 
 		_assertObjectEntriesSize1(1);
 
 		_addResourcePermission(ActionKeys.DELETE, _accountManagerRole);
 
 		_defaultObjectEntryManager.deleteObjectEntry(
-			_objectDefinition3, objectEntry1.getId());
+			_objectDefinition3, objectEntry6.getId());
 
 		_assertObjectEntriesSize1(0);
 	}

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -1626,6 +1626,67 @@ public class DefaultObjectEntryManagerImplTest
 				).build()),
 			ObjectDefinitionConstants.SCOPE_SITE);
 
+		Group group = _groupLocalService.getGroup(
+			companyId, GroupConstants.GUEST);
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(group.getGroupId());
+
+		serviceContext.setAddGroupPermissions(false);
+		serviceContext.setAddGuestPermissions(false);
+
+		byte[] bytes = DLTestUtil.randomTextFileBytes();
+
+		String dlFileEntryExternalReferenceCode = RandomTestUtil.randomString();
+
+		DLFileEntry dlFileEntry = _dlFileEntryLocalService.addFileEntry(
+			dlFileEntryExternalReferenceCode, adminUser.getUserId(),
+			group.getGroupId(), group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			RandomTestUtil.randomString() + ".txt", ContentTypes.TEXT_PLAIN,
+			RandomTestUtil.randomString(), StringPool.BLANK, StringPool.BLANK,
+			StringPool.BLANK,
+			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT, null,
+			null, new ByteArrayInputStream(bytes), bytes.length, null, null,
+			null, serviceContext);
+
+		long fileEntryId = dlFileEntry.getFileEntryId();
+
+		// Administrator
+
+		Assert.assertNotNull(
+			_defaultObjectEntryManager.addObjectEntry(
+				_simpleDTOConverterContext, objectDefinition,
+				new ObjectEntry() {
+					{
+						properties = HashMapBuilder.<String, Object>put(
+							"attachmentObjectFieldName",
+							HashMapBuilder.<String, Object>put(
+								"id", fileEntryId
+							).build()
+						).build();
+					}
+				},
+				String.valueOf(group.getGroupId())));
+
+		Assert.assertNotNull(
+			_defaultObjectEntryManager.addObjectEntry(
+				_simpleDTOConverterContext, objectDefinition,
+				new ObjectEntry() {
+					{
+						properties = HashMapBuilder.<String, Object>put(
+							"attachmentObjectFieldName",
+							HashMapBuilder.<String, Object>put(
+								"externalReferenceCode",
+								dlFileEntryExternalReferenceCode
+							).build()
+						).build();
+					}
+				},
+				String.valueOf(group.getGroupId())));
+
+		// Regular user with permissions
+
 		_user = _addUser();
 
 		_addRoleUser(
@@ -1635,9 +1696,6 @@ public class DefaultObjectEntryManagerImplTest
 			objectDefinition, _user);
 
 		String fileName = RandomTestUtil.randomString() + ".txt";
-
-		Group group = _groupLocalService.getGroup(
-			companyId, GroupConstants.GUEST);
 
 		_defaultObjectEntryManager.addObjectEntry(
 			_simpleDTOConverterContext, objectDefinition,
@@ -1671,6 +1729,51 @@ public class DefaultObjectEntryManagerImplTest
 		Assert.assertNotNull(
 			_dlFileEntryService.getFileEntryByFileName(
 				group.getGroupId(), dlFolder.getFolderId(), fileName));
+
+		// Regular user without permissions
+
+		try {
+			_defaultObjectEntryManager.addObjectEntry(
+				_simpleDTOConverterContext, objectDefinition,
+				new ObjectEntry() {
+					{
+						properties = HashMapBuilder.<String, Object>put(
+							"attachmentObjectFieldName",
+							HashMapBuilder.<String, Object>put(
+								"id", fileEntryId
+							).build()
+						).build();
+					}
+				},
+				String.valueOf(group.getGroupId()));
+
+			Assert.fail();
+		}
+		catch (PrincipalException principalException) {
+			Assert.assertNotNull(principalException);
+		}
+
+		try {
+			_defaultObjectEntryManager.addObjectEntry(
+				_simpleDTOConverterContext, objectDefinition,
+				new ObjectEntry() {
+					{
+						properties = HashMapBuilder.<String, Object>put(
+							"attachmentObjectFieldName",
+							HashMapBuilder.<String, Object>put(
+								"externalReferenceCode",
+								dlFileEntryExternalReferenceCode
+							).build()
+						).build();
+					}
+				},
+				String.valueOf(group.getGroupId()));
+
+			Assert.fail();
+		}
+		catch (PrincipalException principalException) {
+			Assert.assertNotNull(principalException);
+		}
 
 		objectDefinitionLocalService.deleteObjectDefinition(
 			objectDefinition.getObjectDefinitionId());

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -1592,6 +1592,9 @@ public class DefaultObjectEntryManagerImplTest
 
 	@Test
 	public void testAddObjectEntryWithAttachmentObjectField() throws Exception {
+
+		// Administrator
+
 		String dlFolderName = RandomTestUtil.randomString();
 
 		ObjectDefinition objectDefinition = _addObjectDefinition(
@@ -1651,8 +1654,6 @@ public class DefaultObjectEntryManagerImplTest
 			null, serviceContext);
 
 		long fileEntryId = dlFileEntry.getFileEntryId();
-
-		// Administrator
 
 		Assert.assertNotNull(
 			_defaultObjectEntryManager.addObjectEntry(


### PR DESCRIPTION
### What

An object entry's attachment field can reference an existing document by ID or by external reference code. The reference was resolved through the permissionless local service, so a user holding only the "Add Entry" permission on an object definition could attach — and then read — any document in the company, including files they were never granted access to (IDOR / CWE-639).

`DefaultObjectEntryManagerImpl` now resolves the referenced file through the permission-checked `DLAppService` (for both the ID and external-reference-code paths), so the requester must be allowed to view the file before it can be associated with the entry. A `NoSuchFileEntryException` (absent file) is tolerated as before; a `PrincipalException` (no view permission) propagates.

### Commits

- `LPD-97411 Check permissions when referencing DM file entries` — the fix.
- `LPD-97411 Integration tests` — consolidated attachment coverage: an admin can reference an unviewable file by ID and by ERC, a user with only `ADD_OBJECT_ENTRY` can still upload a new file, but cannot reference the admin's unviewable file by ID or by ERC.

**pr-check: PASS** — tested on `4f69638533bca`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |