### PR TITLE
LPD-78893 Grant global export/import via company control panel access

### DIFF
--- a/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/constants/ExportImportPortletKeys.java
+++ b/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/constants/ExportImportPortletKeys.java
@@ -10,12 +10,6 @@ package com.liferay.exportimport.constants;
  */
 public class ExportImportPortletKeys {
 
-	public static final String COMPANY_EXPORT =
-		"com_liferay_exportimport_web_portlet_CompanyExportPortlet";
-
-	public static final String COMPANY_IMPORT =
-		"com_liferay_exportimport_web_portlet_CompanyImportPortlet";
-
 	public static final String EXPORT =
 		"com_liferay_exportimport_web_portlet_ExportPortlet";
 

--- a/modules/apps/export-import/export-import-api/src/main/resources/com/liferay/exportimport/constants/packageinfo
+++ b/modules/apps/export-import/export-import-api/src/main/resources/com/liferay/exportimport/constants/packageinfo
@@ -1,1 +1,1 @@
-version 1.5.0
+version 2.0.0

--- a/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/util/PermissionUtil.java
+++ b/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/util/PermissionUtil.java
@@ -11,6 +11,7 @@ import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.permission.PortletPermissionUtil;
+import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.staging.StagingGroupHelper;
 import com.liferay.staging.StagingGroupHelperUtil;
 
@@ -23,7 +24,7 @@ public class PermissionUtil {
 		throws PortalException {
 
 		_checkPermission(
-			companyId, groupId, ExportImportPortletKeys.COMPANY_EXPORT,
+			companyId, groupId, PortletKeys.COMPANY_EXPORT,
 			ExportImportPortletKeys.EXPORT);
 	}
 
@@ -31,7 +32,7 @@ public class PermissionUtil {
 		throws PortalException {
 
 		_checkPermission(
-			companyId, groupId, ExportImportPortletKeys.COMPANY_IMPORT,
+			companyId, groupId, PortletKeys.COMPANY_IMPORT,
 			ExportImportPortletKeys.IMPORT);
 	}
 

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/ExportImportServiceTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/ExportImportServiceTest.java
@@ -1,0 +1,148 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.exportimport.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.exportimport.kernel.configuration.ExportImportConfigurationSettingsMapFactoryUtil;
+import com.liferay.exportimport.kernel.configuration.constants.ExportImportConfigurationConstants;
+import com.liferay.exportimport.kernel.model.ExportImportConfiguration;
+import com.liferay.exportimport.kernel.service.ExportImportConfigurationLocalServiceUtil;
+import com.liferay.exportimport.kernel.service.ExportImportServiceUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
+import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.context.ContextUserReplace;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.RoleTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.PortletKeys;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.io.Serializable;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Adolfo Pérez
+ */
+@RunWith(Arquillian.class)
+public class ExportImportServiceTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupLocalServiceUtil.getCompanyGroup(
+			TestPropsValues.getCompanyId());
+	}
+
+	@Test
+	@TestInfo("LPD-78893")
+	public void testExportLayoutsAsFileInBackground() throws Exception {
+		_testExportLayoutsAsFileInBackgroundWithControlPanelPermission();
+		_testExportLayoutsAsFileInBackgroundWithoutPermission();
+	}
+
+	private ExportImportConfiguration _addExportImportConfiguration(User user)
+		throws Exception {
+
+		Map<String, Serializable> settingsMap =
+			ExportImportConfigurationSettingsMapFactoryUtil.
+				buildExportLayoutSettingsMap(
+					user.getUserId(), _group.getGroupId(), false, new long[0],
+					new HashMap<>(), user.getLocale(), user.getTimeZone());
+
+		return ExportImportConfigurationLocalServiceUtil.
+			addExportImportConfiguration(
+				user.getUserId(), _group.getGroupId(),
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+				ExportImportConfigurationConstants.TYPE_EXPORT_LAYOUT,
+				settingsMap,
+				ServiceContextTestUtil.getServiceContext(
+					_group.getGroupId(), user.getUserId()));
+	}
+
+	private User _addUserWithControlPanelPermission(String portletId)
+		throws Exception {
+
+		User user = UserTestUtil.addUser();
+		Role role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
+
+		RoleLocalServiceUtil.addUserRole(user.getUserId(), role.getRoleId());
+
+		RoleTestUtil.addResourcePermission(
+			role, portletId, ResourceConstants.SCOPE_COMPANY,
+			String.valueOf(TestPropsValues.getCompanyId()),
+			ActionKeys.ACCESS_IN_CONTROL_PANEL);
+
+		return user;
+	}
+
+	private void _testExportLayoutsAsFileInBackgroundWithControlPanelPermission()
+		throws Exception {
+
+		User user = _addUserWithControlPanelPermission(
+			PortletKeys.COMPANY_EXPORT);
+
+		ExportImportConfiguration exportImportConfiguration =
+			_addExportImportConfiguration(user);
+
+		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
+				user)) {
+
+			long backgroundTaskId =
+				ExportImportServiceUtil.exportLayoutsAsFileInBackground(
+					exportImportConfiguration);
+
+			Assert.assertTrue(backgroundTaskId > 0);
+		}
+	}
+
+	private void _testExportLayoutsAsFileInBackgroundWithoutPermission()
+		throws Exception {
+
+		User user = UserTestUtil.addUser();
+
+		ExportImportConfiguration exportImportConfiguration =
+			_addExportImportConfiguration(user);
+
+		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
+				user)) {
+
+			Assert.assertThrows(
+				PrincipalException.class,
+				() -> ExportImportServiceUtil.exportLayoutsAsFileInBackground(
+					exportImportConfiguration));
+		}
+	}
+
+	private Group _group;
+
+}

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/application/list/CompanyExportPanelApp.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/application/list/CompanyExportPanelApp.java
@@ -8,10 +8,10 @@ package com.liferay.exportimport.web.internal.application.list;
 import com.liferay.application.list.BasePanelApp;
 import com.liferay.application.list.PanelApp;
 import com.liferay.application.list.constants.PanelCategoryKeys;
-import com.liferay.exportimport.constants.ExportImportPortletKeys;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.staging.StagingGroupHelper;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -43,7 +43,7 @@ public class CompanyExportPanelApp extends BasePanelApp {
 
 	@Override
 	public String getPortletId() {
-		return ExportImportPortletKeys.COMPANY_EXPORT;
+		return PortletKeys.COMPANY_EXPORT;
 	}
 
 	@Override
@@ -56,7 +56,7 @@ public class CompanyExportPanelApp extends BasePanelApp {
 	private Portal _portal;
 
 	@Reference(
-		target = "(jakarta.portlet.name=" + ExportImportPortletKeys.COMPANY_EXPORT + ")"
+		target = "(jakarta.portlet.name=" + PortletKeys.COMPANY_EXPORT + ")"
 	)
 	private Portlet _portlet;
 

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/application/list/CompanyImportPanelApp.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/application/list/CompanyImportPanelApp.java
@@ -8,10 +8,10 @@ package com.liferay.exportimport.web.internal.application.list;
 import com.liferay.application.list.BasePanelApp;
 import com.liferay.application.list.PanelApp;
 import com.liferay.application.list.constants.PanelCategoryKeys;
-import com.liferay.exportimport.constants.ExportImportPortletKeys;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.staging.StagingGroupHelper;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -43,7 +43,7 @@ public class CompanyImportPanelApp extends BasePanelApp {
 
 	@Override
 	public String getPortletId() {
-		return ExportImportPortletKeys.COMPANY_IMPORT;
+		return PortletKeys.COMPANY_IMPORT;
 	}
 
 	@Override
@@ -56,7 +56,7 @@ public class CompanyImportPanelApp extends BasePanelApp {
 	private Portal _portal;
 
 	@Reference(
-		target = "(jakarta.portlet.name=" + ExportImportPortletKeys.COMPANY_IMPORT + ")"
+		target = "(jakarta.portlet.name=" + PortletKeys.COMPANY_IMPORT + ")"
 	)
 	private Portlet _portlet;
 

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/constants/ExportImportFDSNames.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/constants/ExportImportFDSNames.java
@@ -6,6 +6,7 @@
 package com.liferay.exportimport.web.internal.constants;
 
 import com.liferay.exportimport.constants.ExportImportPortletKeys;
+import com.liferay.portal.kernel.util.PortletKeys;
 
 /**
  * @author Jorge González
@@ -13,13 +14,13 @@ import com.liferay.exportimport.constants.ExportImportPortletKeys;
 public class ExportImportFDSNames {
 
 	public static final String COMPANY_EXPORT_PROCESSES =
-		ExportImportPortletKeys.COMPANY_EXPORT + "-exportProcesses";
+		PortletKeys.COMPANY_EXPORT + "-exportProcesses";
 
 	public static final String COMPANY_IMPORT_PROCESSES =
-		ExportImportPortletKeys.COMPANY_IMPORT + "-importProcesses";
+		PortletKeys.COMPANY_IMPORT + "-importProcesses";
 
 	public static final String COMPANY_IMPORT_REPORT_ENTRIES =
-		ExportImportPortletKeys.COMPANY_IMPORT + "-importReportEntries";
+		PortletKeys.COMPANY_IMPORT + "-importReportEntries";
 
 	public static final String EXPORT_PROCESSES =
 		ExportImportPortletKeys.EXPORT + "-exportProcesses";

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/CompanyExportPortlet.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/CompanyExportPortlet.java
@@ -5,8 +5,8 @@
 
 package com.liferay.exportimport.web.internal.portlet;
 
-import com.liferay.exportimport.constants.ExportImportPortletKeys;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
+import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.trash.TrashHelper;
 import com.liferay.trash.util.TrashWebKeys;
 
@@ -42,7 +42,7 @@ import org.osgi.service.component.annotations.Reference;
 		"jakarta.portlet.init-param.mvc-command-names-default-views=/export_import/view_export_layouts",
 		"jakarta.portlet.init-param.template-path=/META-INF/resources/",
 		"jakarta.portlet.init-param.view-template=/export/view_export_layouts.jsp",
-		"jakarta.portlet.name=" + ExportImportPortletKeys.COMPANY_EXPORT,
+		"jakarta.portlet.name=" + PortletKeys.COMPANY_EXPORT,
 		"jakarta.portlet.resource-bundle=content.Language",
 		"jakarta.portlet.security-role-ref=administrator",
 		"jakarta.portlet.version=4.0"

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/CompanyImportPortlet.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/CompanyImportPortlet.java
@@ -5,8 +5,8 @@
 
 package com.liferay.exportimport.web.internal.portlet;
 
-import com.liferay.exportimport.constants.ExportImportPortletKeys;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
+import com.liferay.portal.kernel.util.PortletKeys;
 
 import jakarta.portlet.Portlet;
 
@@ -34,7 +34,7 @@ import org.osgi.service.component.annotations.Component;
 		"jakarta.portlet.init-param.mvc-command-names-default-views=/export_import/view_import_layouts",
 		"jakarta.portlet.init-param.template-path=/META-INF/resources/",
 		"jakarta.portlet.init-param.view-template=/import/view_import_layouts.jsp",
-		"jakarta.portlet.name=" + ExportImportPortletKeys.COMPANY_IMPORT,
+		"jakarta.portlet.name=" + PortletKeys.COMPANY_IMPORT,
 		"jakarta.portlet.resource-bundle=content.Language",
 		"jakarta.portlet.security-role-ref=administrator",
 		"jakarta.portlet.version=4.0"

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/action/DeleteLayoutExportBackgroundTasksMVCActionCommand.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/action/DeleteLayoutExportBackgroundTasksMVCActionCommand.java
@@ -13,6 +13,7 @@ import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.PortletKeys;
 
 import jakarta.portlet.ActionRequest;
 import jakarta.portlet.ActionResponse;
@@ -25,8 +26,8 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	property = {
-		"jakarta.portlet.name=" + ExportImportPortletKeys.COMPANY_EXPORT,
 		"jakarta.portlet.name=" + ExportImportPortletKeys.EXPORT,
+		"jakarta.portlet.name=" + PortletKeys.COMPANY_EXPORT,
 		"mvc.command.name=/export_import/delete_layout_export_background_tasks"
 	},
 	service = MVCActionCommand.class

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/action/DeleteLayoutImportBackgroundTasksMVCActionCommand.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/action/DeleteLayoutImportBackgroundTasksMVCActionCommand.java
@@ -13,6 +13,7 @@ import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.PortletKeys;
 
 import jakarta.portlet.ActionRequest;
 import jakarta.portlet.ActionResponse;
@@ -25,8 +26,8 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	property = {
-		"jakarta.portlet.name=" + ExportImportPortletKeys.COMPANY_IMPORT,
 		"jakarta.portlet.name=" + ExportImportPortletKeys.IMPORT,
+		"jakarta.portlet.name=" + PortletKeys.COMPANY_IMPORT,
 		"mvc.command.name=/export_import/delete_layout_import_background_tasks"
 	},
 	service = MVCActionCommand.class

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/action/EditExportConfigurationMVCActionCommand.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/action/EditExportConfigurationMVCActionCommand.java
@@ -31,6 +31,7 @@ import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.SessionTreeJSClicks;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -55,8 +56,8 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	property = {
-		"jakarta.portlet.name=" + ExportImportPortletKeys.COMPANY_EXPORT,
 		"jakarta.portlet.name=" + ExportImportPortletKeys.EXPORT,
+		"jakarta.portlet.name=" + PortletKeys.COMPANY_EXPORT,
 		"mvc.command.name=/export_import/edit_export_configuration"
 	},
 	service = MVCActionCommand.class

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/action/EditExportConfigurationMVCRenderCommand.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/action/EditExportConfigurationMVCRenderCommand.java
@@ -7,6 +7,7 @@ package com.liferay.exportimport.web.internal.portlet.action;
 
 import com.liferay.exportimport.constants.ExportImportPortletKeys;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
+import com.liferay.portal.kernel.util.PortletKeys;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -15,8 +16,8 @@ import org.osgi.service.component.annotations.Component;
  */
 @Component(
 	property = {
-		"jakarta.portlet.name=" + ExportImportPortletKeys.COMPANY_EXPORT,
 		"jakarta.portlet.name=" + ExportImportPortletKeys.EXPORT,
+		"jakarta.portlet.name=" + PortletKeys.COMPANY_EXPORT,
 		"mvc.command.name=/export_import/edit_export_configuration"
 	},
 	service = MVCRenderCommand.class

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/action/EditExportConfigurationMVCResourceCommand.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/action/EditExportConfigurationMVCResourceCommand.java
@@ -8,6 +8,7 @@ package com.liferay.exportimport.web.internal.portlet.action;
 import com.liferay.exportimport.constants.ExportImportPortletKeys;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCResourceCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
+import com.liferay.portal.kernel.util.PortletKeys;
 
 import jakarta.portlet.PortletRequestDispatcher;
 import jakarta.portlet.ResourceRequest;
@@ -20,8 +21,8 @@ import org.osgi.service.component.annotations.Component;
  */
 @Component(
 	property = {
-		"jakarta.portlet.name=" + ExportImportPortletKeys.COMPANY_EXPORT,
 		"jakarta.portlet.name=" + ExportImportPortletKeys.EXPORT,
+		"jakarta.portlet.name=" + PortletKeys.COMPANY_EXPORT,
 		"mvc.command.name=/export_import/edit_export_configuration"
 	},
 	service = MVCResourceCommand.class

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/action/ExportLayoutsMVCActionCommand.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/action/ExportLayoutsMVCActionCommand.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.SessionTreeJSClicks;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -46,8 +47,8 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	property = {
-		"jakarta.portlet.name=" + ExportImportPortletKeys.COMPANY_EXPORT,
 		"jakarta.portlet.name=" + ExportImportPortletKeys.EXPORT,
+		"jakarta.portlet.name=" + PortletKeys.COMPANY_EXPORT,
 		"mvc.command.name=/export_import/export_layouts"
 	},
 	service = MVCActionCommand.class

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/action/ExportLayoutsMVCRenderCommand.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/action/ExportLayoutsMVCRenderCommand.java
@@ -7,6 +7,7 @@ package com.liferay.exportimport.web.internal.portlet.action;
 
 import com.liferay.exportimport.constants.ExportImportPortletKeys;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
+import com.liferay.portal.kernel.util.PortletKeys;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -15,8 +16,8 @@ import org.osgi.service.component.annotations.Component;
  */
 @Component(
 	property = {
-		"jakarta.portlet.name=" + ExportImportPortletKeys.COMPANY_EXPORT,
 		"jakarta.portlet.name=" + ExportImportPortletKeys.EXPORT,
+		"jakarta.portlet.name=" + PortletKeys.COMPANY_EXPORT,
 		"mvc.command.name=/export_import/export_layouts"
 	},
 	service = MVCRenderCommand.class

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/action/ExportLayoutsMVCResourceCommand.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/action/ExportLayoutsMVCResourceCommand.java
@@ -8,6 +8,7 @@ package com.liferay.exportimport.web.internal.portlet.action;
 import com.liferay.exportimport.constants.ExportImportPortletKeys;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCResourceCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
+import com.liferay.portal.kernel.util.PortletKeys;
 
 import jakarta.portlet.PortletRequestDispatcher;
 import jakarta.portlet.ResourceRequest;
@@ -20,8 +21,8 @@ import org.osgi.service.component.annotations.Component;
  */
 @Component(
 	property = {
-		"jakarta.portlet.name=" + ExportImportPortletKeys.COMPANY_EXPORT,
 		"jakarta.portlet.name=" + ExportImportPortletKeys.EXPORT,
+		"jakarta.portlet.name=" + PortletKeys.COMPANY_EXPORT,
 		"mvc.command.name=/export_import/export_layouts"
 	},
 	service = MVCResourceCommand.class

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/action/ImportLayoutsMVCActionCommand.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/action/ImportLayoutsMVCActionCommand.java
@@ -34,6 +34,7 @@ import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 
@@ -53,8 +54,8 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	property = {
-		"jakarta.portlet.name=" + ExportImportPortletKeys.COMPANY_IMPORT,
 		"jakarta.portlet.name=" + ExportImportPortletKeys.IMPORT,
+		"jakarta.portlet.name=" + PortletKeys.COMPANY_IMPORT,
 		"mvc.command.name=/export_import/import_layouts"
 	},
 	service = MVCActionCommand.class

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/action/ImportLayoutsMVCRenderCommand.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/action/ImportLayoutsMVCRenderCommand.java
@@ -7,6 +7,7 @@ package com.liferay.exportimport.web.internal.portlet.action;
 
 import com.liferay.exportimport.constants.ExportImportPortletKeys;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
+import com.liferay.portal.kernel.util.PortletKeys;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -15,8 +16,8 @@ import org.osgi.service.component.annotations.Component;
  */
 @Component(
 	property = {
-		"jakarta.portlet.name=" + ExportImportPortletKeys.COMPANY_IMPORT,
 		"jakarta.portlet.name=" + ExportImportPortletKeys.IMPORT,
+		"jakarta.portlet.name=" + PortletKeys.COMPANY_IMPORT,
 		"mvc.command.name=/export_import/import_layouts"
 	},
 	service = MVCRenderCommand.class

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/action/ImportLayoutsMVCResourceCommand.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/action/ImportLayoutsMVCResourceCommand.java
@@ -10,6 +10,7 @@ import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCResourceCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.PortletKeys;
 
 import jakarta.portlet.PortletRequestDispatcher;
 import jakarta.portlet.ResourceRequest;
@@ -22,8 +23,8 @@ import org.osgi.service.component.annotations.Component;
  */
 @Component(
 	property = {
-		"jakarta.portlet.name=" + ExportImportPortletKeys.COMPANY_IMPORT,
 		"jakarta.portlet.name=" + ExportImportPortletKeys.IMPORT,
+		"jakarta.portlet.name=" + PortletKeys.COMPANY_IMPORT,
 		"mvc.command.name=/export_import/import_layouts"
 	},
 	service = MVCResourceCommand.class

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/action/ViewExportConfigurationsMVCRenderCommand.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/action/ViewExportConfigurationsMVCRenderCommand.java
@@ -7,6 +7,7 @@ package com.liferay.exportimport.web.internal.portlet.action;
 
 import com.liferay.exportimport.constants.ExportImportPortletKeys;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
+import com.liferay.portal.kernel.util.PortletKeys;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -15,8 +16,8 @@ import org.osgi.service.component.annotations.Component;
  */
 @Component(
 	property = {
-		"jakarta.portlet.name=" + ExportImportPortletKeys.COMPANY_EXPORT,
 		"jakarta.portlet.name=" + ExportImportPortletKeys.EXPORT,
+		"jakarta.portlet.name=" + PortletKeys.COMPANY_EXPORT,
 		"mvc.command.name=/export_import/view_export_configurations"
 	},
 	service = MVCRenderCommand.class

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/action/ViewExportLayoutsMVCRenderCommand.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/action/ViewExportLayoutsMVCRenderCommand.java
@@ -7,6 +7,7 @@ package com.liferay.exportimport.web.internal.portlet.action;
 
 import com.liferay.exportimport.constants.ExportImportPortletKeys;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
+import com.liferay.portal.kernel.util.PortletKeys;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -15,8 +16,8 @@ import org.osgi.service.component.annotations.Component;
  */
 @Component(
 	property = {
-		"jakarta.portlet.name=" + ExportImportPortletKeys.COMPANY_EXPORT,
 		"jakarta.portlet.name=" + ExportImportPortletKeys.EXPORT,
+		"jakarta.portlet.name=" + PortletKeys.COMPANY_EXPORT,
 		"mvc.command.name=/export_import/view_export_layouts"
 	},
 	service = MVCRenderCommand.class

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/action/ViewImportLayoutsMVCRenderCommand.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/action/ViewImportLayoutsMVCRenderCommand.java
@@ -7,6 +7,7 @@ package com.liferay.exportimport.web.internal.portlet.action;
 
 import com.liferay.exportimport.constants.ExportImportPortletKeys;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
+import com.liferay.portal.kernel.util.PortletKeys;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -15,8 +16,8 @@ import org.osgi.service.component.annotations.Component;
  */
 @Component(
 	property = {
-		"jakarta.portlet.name=" + ExportImportPortletKeys.COMPANY_IMPORT,
 		"jakarta.portlet.name=" + ExportImportPortletKeys.IMPORT,
+		"jakarta.portlet.name=" + PortletKeys.COMPANY_IMPORT,
 		"mvc.command.name=/export_import/view_import_layouts"
 	},
 	service = MVCRenderCommand.class

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/action/ViewImportReportEntriesMVCRenderCommand.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/action/ViewImportReportEntriesMVCRenderCommand.java
@@ -7,6 +7,7 @@ package com.liferay.exportimport.web.internal.portlet.action;
 
 import com.liferay.exportimport.constants.ExportImportPortletKeys;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
+import com.liferay.portal.kernel.util.PortletKeys;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -15,9 +16,9 @@ import org.osgi.service.component.annotations.Component;
  */
 @Component(
 	property = {
-		"jakarta.portlet.name=" + ExportImportPortletKeys.COMPANY_IMPORT,
 		"jakarta.portlet.name=" + ExportImportPortletKeys.EXPORT_IMPORT,
 		"jakarta.portlet.name=" + ExportImportPortletKeys.IMPORT,
+		"jakarta.portlet.name=" + PortletKeys.COMPANY_IMPORT,
 		"mvc.command.name=/export_import/view_import_report_entries"
 	},
 	service = MVCRenderCommand.class

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/action/ViewImportReportEntryDetailMVCRenderCommand.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/action/ViewImportReportEntryDetailMVCRenderCommand.java
@@ -7,6 +7,7 @@ package com.liferay.exportimport.web.internal.portlet.action;
 
 import com.liferay.exportimport.constants.ExportImportPortletKeys;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
+import com.liferay.portal.kernel.util.PortletKeys;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -15,9 +16,9 @@ import org.osgi.service.component.annotations.Component;
  */
 @Component(
 	property = {
-		"jakarta.portlet.name=" + ExportImportPortletKeys.COMPANY_IMPORT,
 		"jakarta.portlet.name=" + ExportImportPortletKeys.EXPORT_IMPORT,
 		"jakarta.portlet.name=" + ExportImportPortletKeys.IMPORT,
+		"jakarta.portlet.name=" + PortletKeys.COMPANY_IMPORT,
 		"mvc.command.name=/export_import/view_import_report_entry_detail"
 	},
 	service = MVCRenderCommand.class

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/action/ViewNewExportMVCRenderCommand.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/action/ViewNewExportMVCRenderCommand.java
@@ -13,6 +13,7 @@ import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.staging.StagingGroupHelper;
 
 import jakarta.portlet.RenderRequest;
@@ -26,9 +27,9 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	property = {
-		"jakarta.portlet.name=" + ExportImportPortletKeys.COMPANY_EXPORT,
 		"jakarta.portlet.name=" + ExportImportPortletKeys.EXPORT,
 		"jakarta.portlet.name=" + ExportImportPortletKeys.EXPORT_IMPORT,
+		"jakarta.portlet.name=" + PortletKeys.COMPANY_EXPORT,
 		"mvc.command.name=/export_import/view_new_export"
 	},
 	service = MVCRenderCommand.class

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/configuration/icon/CompanyExportTemplatesPortletConfigurationIcon.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/configuration/icon/CompanyExportTemplatesPortletConfigurationIcon.java
@@ -5,8 +5,8 @@
 
 package com.liferay.exportimport.web.internal.portlet.configuration.icon;
 
-import com.liferay.exportimport.constants.ExportImportPortletKeys;
 import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
+import com.liferay.portal.kernel.util.PortletKeys;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -14,7 +14,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Carlos Correa
  */
 @Component(
-	property = "jakarta.portlet.name=" + ExportImportPortletKeys.COMPANY_EXPORT,
+	property = "jakarta.portlet.name=" + PortletKeys.COMPANY_EXPORT,
 	service = PortletConfigurationIcon.class
 )
 public class CompanyExportTemplatesPortletConfigurationIcon

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/service/test/LayoutServiceTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/service/test/LayoutServiceTest.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.LayoutService;
 import com.liferay.portal.kernel.service.RoleLocalService;
@@ -45,6 +46,7 @@ import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.FriendlyURLNormalizer;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.test.rule.Inject;
@@ -316,8 +318,34 @@ public class LayoutServiceTest {
 	}
 
 	@Test
-	@TestInfo("LPD-94951")
-	public void testGetTempFileNamesInsidePublication() throws Exception {
+	@TestInfo({"LPD-78893", "LPD-94951"})
+	public void testGetTempFileNames() throws Exception {
+		Group companyGroup = _groupLocalService.getCompanyGroup(
+			TestPropsValues.getCompanyId());
+
+		// Company group with control panel permission
+
+		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
+				_addUserWithControlPanelPermission(
+					PortletKeys.COMPANY_IMPORT))) {
+
+			_layoutService.getTempFileNames(
+				companyGroup.getGroupId(), RandomTestUtil.randomString());
+		}
+
+		// Company group without permission
+
+		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
+				UserTestUtil.addUser())) {
+
+			Assert.assertThrows(
+				PrincipalException.class,
+				() -> _layoutService.getTempFileNames(
+					companyGroup.getGroupId(), RandomTestUtil.randomString()));
+		}
+
+		// Inside publication
+
 		CTCollection ctCollection = _ctCollectionLocalService.addCTCollection(
 			null, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
 			0, RandomTestUtil.randomString(), null);
@@ -343,6 +371,38 @@ public class LayoutServiceTest {
 		}
 		finally {
 			_ctCollectionLocalService.deleteCTCollection(ctCollection);
+		}
+
+		// Site group with control panel permission
+
+		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
+				_addUserWithControlPanelPermission(
+					PortletKeys.COMPANY_IMPORT))) {
+
+			Assert.assertThrows(
+				PrincipalException.class,
+				() -> _layoutService.getTempFileNames(
+					_group.getGroupId(), RandomTestUtil.randomString()));
+		}
+
+		// Site group with export/import permission
+
+		User user = UserTestUtil.addUser();
+
+		Role role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
+
+		_roleLocalService.addUserRole(user.getUserId(), role.getRoleId());
+
+		RoleTestUtil.addResourcePermission(
+			role, Group.class.getName(), ResourceConstants.SCOPE_GROUP,
+			String.valueOf(_group.getGroupId()),
+			ActionKeys.EXPORT_IMPORT_LAYOUTS);
+
+		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
+				user)) {
+
+			_layoutService.getTempFileNames(
+				_group.getGroupId(), RandomTestUtil.randomString());
 		}
 	}
 
@@ -436,6 +496,23 @@ public class LayoutServiceTest {
 			null,
 			ServiceContextTestUtil.getServiceContext(
 				_group, TestPropsValues.getUserId()));
+	}
+
+	private User _addUserWithControlPanelPermission(String portletId)
+		throws Exception {
+
+		User user = UserTestUtil.addUser();
+
+		Role role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
+
+		_roleLocalService.addUserRole(user.getUserId(), role.getRoleId());
+
+		RoleTestUtil.addResourcePermission(
+			role, portletId, ResourceConstants.SCOPE_COMPANY,
+			String.valueOf(TestPropsValues.getCompanyId()),
+			ActionKeys.ACCESS_IN_CONTROL_PANEL);
+
+		return user;
 	}
 
 	private void _assertAddLayout(boolean privateLayout) throws Exception {
@@ -563,6 +640,9 @@ public class LayoutServiceTest {
 
 	@DeleteAfterTestRun
 	private Group _group;
+
+	@Inject
+	private GroupLocalService _groupLocalService;
 
 	@Inject
 	private LayoutLocalService _layoutLocalService;

--- a/portal-kernel/src/com/liferay/portal/kernel/service/permission/GroupPermissionUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/permission/GroupPermissionUtil.java
@@ -17,6 +17,7 @@ import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
 
@@ -164,6 +165,17 @@ public class GroupPermissionUtil {
 				 permissionChecker.hasPermission(
 					 originalGroup, Group.class.getName(), groupId,
 					 ActionKeys.PUBLISH_STAGING)) {
+
+			return true;
+		}
+		else if (actionId.equals(ActionKeys.EXPORT_IMPORT_LAYOUTS) &&
+				 group.isCompany() &&
+				 (PortletPermissionUtil.contains(
+					 permissionChecker, PortletKeys.COMPANY_EXPORT,
+					 ActionKeys.ACCESS_IN_CONTROL_PANEL) ||
+				  PortletPermissionUtil.contains(
+					  permissionChecker, PortletKeys.COMPANY_IMPORT,
+					  ActionKeys.ACCESS_IN_CONTROL_PANEL))) {
 
 			return true;
 		}

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PortletKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PortletKeys.java
@@ -38,6 +38,12 @@ public class PortletKeys {
 
 	public static final String CALENDAR = "8";
 
+	public static final String COMPANY_EXPORT =
+		"com_liferay_exportimport_web_portlet_CompanyExportPortlet";
+
+	public static final String COMPANY_IMPORT =
+		"com_liferay_exportimport_web_portlet_CompanyImportPortlet";
+
 	public static final String DIRECTORY =
 		"com_liferay_directory_web_portlet_DirectoryPortlet";
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-78893

## What Is Being Fixed

Global (company-level) export and import of layouts was gated solely on the `EXPORT_IMPORT_LAYOUTS` permission on the company group. A user granted access to the Company Export or Company Import applications in the control panel still could not export or import, because the permission check did not treat that control-panel access as sufficient for the company group.

## How It Is Being Fixed

`GroupPermissionUtil.contains` now grants `EXPORT_IMPORT_LAYOUTS` on a company group when the user has `ACCESS_IN_CONTROL_PANEL` on the Company Export or Company Import portlet. So the kernel permission utility can reference those portlets, their keys moved from the export-import module's `ExportImportPortletKeys` to the kernel `PortletKeys`, and the export-import web and REST code now consume the kernel constants. Integration tests in `LayoutServiceTest` and `ExportImportServiceTest` cover the company-group and site-group permission paths. The `com.liferay.exportimport.constants` package version is bumped to reflect the removed constants.

## PR Check

**pr-check: PASS** — tested on `bacd8934c5fdf2004c0419bd1a4b1d0c269991ae`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Portlet Title | PASS |
| Full Portal Build | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "bacd8934c5fdf2004c0419bd1a4b1d0c269991ae"} -->
