### PR TITLE
LPD-98144 Move audienceEntryERCs to the end of the parameter list

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/DeleteLayoutPageTemplateStructureRelElementVariationMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/DeleteLayoutPageTemplateStructureRelElementVariationMVCActionCommandTest.java
@@ -59,12 +59,12 @@ public class
 		_layoutPageTemplateStructureRelElementVariationLocalService.
 			addOrUpdateLayoutPageTemplateStructureRelElementVariation(
 				externalReferenceCode, TestPropsValues.getUserId(),
-				group.getGroupId(),
+				group.getGroupId(), RandomTestUtil.randomBoolean(),
+				RandomTestUtil.randomString(), Collections.emptyMap(),
+				Collections.emptyMap(), RandomTestUtil.randomString(),
+				layout.getPlid(), RandomTestUtil.randomString(),
+				RandomTestUtil.randomString(),
 				new String[] {RandomTestUtil.randomString()},
-				RandomTestUtil.randomBoolean(), RandomTestUtil.randomString(),
-				Collections.emptyMap(), Collections.emptyMap(),
-				RandomTestUtil.randomString(), layout.getPlid(),
-				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 				ServiceContextTestUtil.getServiceContext(
 					group, TestPropsValues.getUserId()));
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/SaveLayoutPageTemplateStructureRelElementVariationMVCActionCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/SaveLayoutPageTemplateStructureRelElementVariationMVCActionCommand.java
@@ -55,8 +55,6 @@ public class SaveLayoutPageTemplateStructureRelElementVariationMVCActionCommand
 			addOrUpdateLayoutPageTemplateStructureRelElementVariation(
 				jsonObject.getString("externalReferenceCode"),
 				themeDisplay.getScopeGroupId(),
-				JSONUtil.toStringArray(
-					jsonObject.getJSONArray("audienceEntryERCs")),
 				jsonObject.getBoolean("active", true),
 				jsonObject.getString("hide"),
 				_toLocalizedMap(jsonObject.getJSONObject("htmlMap")),
@@ -65,6 +63,8 @@ public class SaveLayoutPageTemplateStructureRelElementVariationMVCActionCommand
 				ParamUtil.getLong(actionRequest, "plid"),
 				jsonObject.getString("segmentsExperienceERC"),
 				jsonObject.getString("targetElement"),
+				JSONUtil.toStringArray(
+					jsonObject.getJSONArray("audienceEntryERCs")),
 				ServiceContextFactory.getInstance(actionRequest));
 
 		return _jsonFactory.createJSONObject();

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationLocalService.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationLocalService.java
@@ -84,10 +84,10 @@ public interface LayoutPageTemplateStructureRelElementVariationLocalService
 	public LayoutPageTemplateStructureRelElementVariation
 			addOrUpdateLayoutPageTemplateStructureRelElementVariation(
 				String externalReferenceCode, long userId, long groupId,
-				String[] audienceEntryERCs, boolean active, String hide,
-				Map<Locale, String> htmlMap, Map<Locale, String> jsMap,
-				String name, long plid, String segmentsExperienceERC,
-				String targetElement, ServiceContext serviceContext)
+				boolean active, String hide, Map<Locale, String> htmlMap,
+				Map<Locale, String> jsMap, String name, long plid,
+				String segmentsExperienceERC, String targetElement,
+				String[] audienceEntryERCs, ServiceContext serviceContext)
 		throws PortalException;
 
 	/**
@@ -403,4 +403,4 @@ public interface LayoutPageTemplateStructureRelElementVariationLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1298355169
+// LIFERAY-SERVICE-BUILDER-HASH:-473839327

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationLocalServiceUtil.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationLocalServiceUtil.java
@@ -60,18 +60,19 @@ public class LayoutPageTemplateStructureRelElementVariationLocalServiceUtil {
 	public static LayoutPageTemplateStructureRelElementVariation
 			addOrUpdateLayoutPageTemplateStructureRelElementVariation(
 				String externalReferenceCode, long userId, long groupId,
-				String[] audienceEntryERCs, boolean active, String hide,
+				boolean active, String hide,
 				Map<java.util.Locale, String> htmlMap,
 				Map<java.util.Locale, String> jsMap, String name, long plid,
 				String segmentsExperienceERC, String targetElement,
+				String[] audienceEntryERCs,
 				com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
 		return getService().
 			addOrUpdateLayoutPageTemplateStructureRelElementVariation(
-				externalReferenceCode, userId, groupId, audienceEntryERCs,
-				active, hide, htmlMap, jsMap, name, plid, segmentsExperienceERC,
-				targetElement, serviceContext);
+				externalReferenceCode, userId, groupId, active, hide, htmlMap,
+				jsMap, name, plid, segmentsExperienceERC, targetElement,
+				audienceEntryERCs, serviceContext);
 	}
 
 	/**
@@ -483,4 +484,4 @@ public class LayoutPageTemplateStructureRelElementVariationLocalServiceUtil {
 					class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:2083718361
+// LIFERAY-SERVICE-BUILDER-HASH:-1355106791

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationLocalServiceWrapper.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationLocalServiceWrapper.java
@@ -60,18 +60,19 @@ public class LayoutPageTemplateStructureRelElementVariationLocalServiceWrapper
 	public LayoutPageTemplateStructureRelElementVariation
 			addOrUpdateLayoutPageTemplateStructureRelElementVariation(
 				String externalReferenceCode, long userId, long groupId,
-				String[] audienceEntryERCs, boolean active, String hide,
+				boolean active, String hide,
 				java.util.Map<java.util.Locale, String> htmlMap,
 				java.util.Map<java.util.Locale, String> jsMap, String name,
 				long plid, String segmentsExperienceERC, String targetElement,
+				String[] audienceEntryERCs,
 				com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _layoutPageTemplateStructureRelElementVariationLocalService.
 			addOrUpdateLayoutPageTemplateStructureRelElementVariation(
-				externalReferenceCode, userId, groupId, audienceEntryERCs,
-				active, hide, htmlMap, jsMap, name, plid, segmentsExperienceERC,
-				targetElement, serviceContext);
+				externalReferenceCode, userId, groupId, active, hide, htmlMap,
+				jsMap, name, plid, segmentsExperienceERC, targetElement,
+				audienceEntryERCs, serviceContext);
 	}
 
 	/**
@@ -580,4 +581,4 @@ public class LayoutPageTemplateStructureRelElementVariationLocalServiceWrapper
 		_layoutPageTemplateStructureRelElementVariationLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-653705850
+// LIFERAY-SERVICE-BUILDER-HASH:1148139206

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationService.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationService.java
@@ -50,11 +50,11 @@ public interface LayoutPageTemplateStructureRelElementVariationService
 	 */
 	public LayoutPageTemplateStructureRelElementVariation
 			addOrUpdateLayoutPageTemplateStructureRelElementVariation(
-				String externalReferenceCode, long groupId,
-				String[] audienceEntryERCs, boolean active, String hide,
-				Map<Locale, String> htmlMap, Map<Locale, String> jsMap,
-				String name, long plid, String segmentsExperienceERC,
-				String targetElement, ServiceContext serviceContext)
+				String externalReferenceCode, long groupId, boolean active,
+				String hide, Map<Locale, String> htmlMap,
+				Map<Locale, String> jsMap, String name, long plid,
+				String segmentsExperienceERC, String targetElement,
+				String[] audienceEntryERCs, ServiceContext serviceContext)
 		throws PortalException;
 
 	public void deleteLayoutPageTemplateStructureRelElementVariation(
@@ -74,4 +74,4 @@ public interface LayoutPageTemplateStructureRelElementVariationService
 	public String getOSGiServiceIdentifier();
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1864405394
+// LIFERAY-SERVICE-BUILDER-HASH:-967527342

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationServiceUtil.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationServiceUtil.java
@@ -33,19 +33,19 @@ public class LayoutPageTemplateStructureRelElementVariationServiceUtil {
 	 */
 	public static LayoutPageTemplateStructureRelElementVariation
 			addOrUpdateLayoutPageTemplateStructureRelElementVariation(
-				String externalReferenceCode, long groupId,
-				String[] audienceEntryERCs, boolean active, String hide,
-				Map<java.util.Locale, String> htmlMap,
+				String externalReferenceCode, long groupId, boolean active,
+				String hide, Map<java.util.Locale, String> htmlMap,
 				Map<java.util.Locale, String> jsMap, String name, long plid,
 				String segmentsExperienceERC, String targetElement,
+				String[] audienceEntryERCs,
 				com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
 		return getService().
 			addOrUpdateLayoutPageTemplateStructureRelElementVariation(
-				externalReferenceCode, groupId, audienceEntryERCs, active, hide,
-				htmlMap, jsMap, name, plid, segmentsExperienceERC,
-				targetElement, serviceContext);
+				externalReferenceCode, groupId, active, hide, htmlMap, jsMap,
+				name, plid, segmentsExperienceERC, targetElement,
+				audienceEntryERCs, serviceContext);
 	}
 
 	public static void deleteLayoutPageTemplateStructureRelElementVariation(
@@ -86,4 +86,4 @@ public class LayoutPageTemplateStructureRelElementVariationServiceUtil {
 				LayoutPageTemplateStructureRelElementVariationService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1590048869
+// LIFERAY-SERVICE-BUILDER-HASH:1887344421

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationServiceWrapper.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationServiceWrapper.java
@@ -35,19 +35,19 @@ public class LayoutPageTemplateStructureRelElementVariationServiceWrapper
 	@Override
 	public LayoutPageTemplateStructureRelElementVariation
 			addOrUpdateLayoutPageTemplateStructureRelElementVariation(
-				String externalReferenceCode, long groupId,
-				String[] audienceEntryERCs, boolean active, String hide,
-				java.util.Map<java.util.Locale, String> htmlMap,
+				String externalReferenceCode, long groupId, boolean active,
+				String hide, java.util.Map<java.util.Locale, String> htmlMap,
 				java.util.Map<java.util.Locale, String> jsMap, String name,
 				long plid, String segmentsExperienceERC, String targetElement,
+				String[] audienceEntryERCs,
 				com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _layoutPageTemplateStructureRelElementVariationService.
 			addOrUpdateLayoutPageTemplateStructureRelElementVariation(
-				externalReferenceCode, groupId, audienceEntryERCs, active, hide,
-				htmlMap, jsMap, name, plid, segmentsExperienceERC,
-				targetElement, serviceContext);
+				externalReferenceCode, groupId, active, hide, htmlMap, jsMap,
+				name, plid, segmentsExperienceERC, targetElement,
+				audienceEntryERCs, serviceContext);
 	}
 
 	@Override
@@ -100,4 +100,4 @@ public class LayoutPageTemplateStructureRelElementVariationServiceWrapper
 		_layoutPageTemplateStructureRelElementVariationService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-898059985
+// LIFERAY-SERVICE-BUILDER-HASH:-622841873

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/http/LayoutPageTemplateStructureRelElementVariationServiceHttp.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/http/LayoutPageTemplateStructureRelElementVariationServiceHttp.java
@@ -45,12 +45,11 @@ public class LayoutPageTemplateStructureRelElementVariationServiceHttp {
 		LayoutPageTemplateStructureRelElementVariation
 				addOrUpdateLayoutPageTemplateStructureRelElementVariation(
 					HttpPrincipal httpPrincipal, String externalReferenceCode,
-					long groupId, String[] audienceEntryERCs, boolean active,
-					String hide,
+					long groupId, boolean active, String hide,
 					java.util.Map<java.util.Locale, String> htmlMap,
 					java.util.Map<java.util.Locale, String> jsMap, String name,
 					long plid, String segmentsExperienceERC,
-					String targetElement,
+					String targetElement, String[] audienceEntryERCs,
 					com.liferay.portal.kernel.service.ServiceContext
 						serviceContext)
 			throws com.liferay.portal.kernel.exception.PortalException {
@@ -62,9 +61,9 @@ public class LayoutPageTemplateStructureRelElementVariationServiceHttp {
 				_addOrUpdateLayoutPageTemplateStructureRelElementVariationParameterTypes0);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, externalReferenceCode, groupId, audienceEntryERCs,
-				active, hide, htmlMap, jsMap, name, plid, segmentsExperienceERC,
-				targetElement, serviceContext);
+				methodKey, externalReferenceCode, groupId, active, hide,
+				htmlMap, jsMap, name, plid, segmentsExperienceERC,
+				targetElement, audienceEntryERCs, serviceContext);
 
 			Object returnObj = null;
 
@@ -184,9 +183,9 @@ public class LayoutPageTemplateStructureRelElementVariationServiceHttp {
 	private static final Class<?>[]
 		_addOrUpdateLayoutPageTemplateStructureRelElementVariationParameterTypes0 =
 			new Class[] {
-				String.class, long.class, String[].class, boolean.class,
-				String.class, java.util.Map.class, java.util.Map.class,
-				String.class, long.class, String.class, String.class,
+				String.class, long.class, boolean.class, String.class,
+				java.util.Map.class, java.util.Map.class, String.class,
+				long.class, String.class, String.class, String[].class,
 				com.liferay.portal.kernel.service.ServiceContext.class
 			};
 	private static final Class<?>[]
@@ -197,4 +196,4 @@ public class LayoutPageTemplateStructureRelElementVariationServiceHttp {
 			new Class[] {long.class};
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-180312841
+// LIFERAY-SERVICE-BUILDER-HASH:1122815085

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateStructureRelElementVariationLocalServiceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateStructureRelElementVariationLocalServiceImpl.java
@@ -40,10 +40,10 @@ public class LayoutPageTemplateStructureRelElementVariationLocalServiceImpl
 	public LayoutPageTemplateStructureRelElementVariation
 			addOrUpdateLayoutPageTemplateStructureRelElementVariation(
 				String externalReferenceCode, long userId, long groupId,
-				String[] audienceEntryERCs, boolean active, String hide,
-				Map<Locale, String> htmlMap, Map<Locale, String> jsMap,
-				String name, long plid, String segmentsExperienceERC,
-				String targetElement, ServiceContext serviceContext)
+				boolean active, String hide, Map<Locale, String> htmlMap,
+				Map<Locale, String> jsMap, String name, long plid,
+				String segmentsExperienceERC, String targetElement,
+				String[] audienceEntryERCs, ServiceContext serviceContext)
 		throws PortalException {
 
 		_validate(audienceEntryERCs, name, targetElement);

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateStructureRelElementVariationServiceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateStructureRelElementVariationServiceImpl.java
@@ -33,11 +33,11 @@ public class LayoutPageTemplateStructureRelElementVariationServiceImpl
 
 	public LayoutPageTemplateStructureRelElementVariation
 			addOrUpdateLayoutPageTemplateStructureRelElementVariation(
-				String externalReferenceCode, long groupId,
-				String[] audienceEntryERCs, boolean active, String hide,
-				Map<Locale, String> htmlMap, Map<Locale, String> jsMap,
-				String name, long plid, String segmentsExperienceERC,
-				String targetElement, ServiceContext serviceContext)
+				String externalReferenceCode, long groupId, boolean active,
+				String hide, Map<Locale, String> htmlMap,
+				Map<Locale, String> jsMap, String name, long plid,
+				String segmentsExperienceERC, String targetElement,
+				String[] audienceEntryERCs, ServiceContext serviceContext)
 		throws PortalException {
 
 		_layoutModelResourcePermission.check(
@@ -45,9 +45,9 @@ public class LayoutPageTemplateStructureRelElementVariationServiceImpl
 
 		return layoutPageTemplateStructureRelElementVariationLocalService.
 			addOrUpdateLayoutPageTemplateStructureRelElementVariation(
-				externalReferenceCode, getUserId(), groupId, audienceEntryERCs,
-				active, hide, htmlMap, jsMap, name, plid, segmentsExperienceERC,
-				targetElement, serviceContext);
+				externalReferenceCode, getUserId(), groupId, active, hide,
+				htmlMap, jsMap, name, plid, segmentsExperienceERC,
+				targetElement, audienceEntryERCs, serviceContext);
 	}
 
 	public void deleteLayoutPageTemplateStructureRelElementVariation(

--- a/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/service/LayoutLocalServiceWrapper.java
+++ b/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/service/LayoutLocalServiceWrapper.java
@@ -557,7 +557,6 @@ public class LayoutLocalServiceWrapper
 				addOrUpdateLayoutPageTemplateStructureRelElementVariation(
 					PortalUUIDUtil.generate(), user.getUserId(),
 					targetLayout.getGroupId(),
-					audienceEntryERCs.toArray(new String[0]),
 					sourceLayoutPageTemplateStructureRelElementVariation.
 						isActive(),
 					sourceLayoutPageTemplateStructureRelElementVariation.
@@ -571,6 +570,7 @@ public class LayoutLocalServiceWrapper
 					targetLayout.getPlid(), segmentsExperienceERC,
 					sourceLayoutPageTemplateStructureRelElementVariation.
 						getTargetElement(),
+					audienceEntryERCs.toArray(new String[0]),
 					ServiceContextThreadLocal.getServiceContext());
 		}
 	}

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/service/test/LayoutLocalServiceCopyLayoutContentTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/service/test/LayoutLocalServiceCopyLayoutContentTest.java
@@ -1648,13 +1648,13 @@ public class LayoutLocalServiceCopyLayoutContentTest {
 		return _layoutPageTemplateStructureRelElementVariationLocalService.
 			addOrUpdateLayoutPageTemplateStructureRelElementVariation(
 				RandomTestUtil.randomString(), TestPropsValues.getUserId(),
-				layout.getGroupId(),
-				new String[] {RandomTestUtil.randomString()},
-				RandomTestUtil.randomBoolean(), RandomTestUtil.randomString(),
+				layout.getGroupId(), RandomTestUtil.randomBoolean(),
+				RandomTestUtil.randomString(),
 				Collections.<Locale, String>emptyMap(),
 				Collections.<Locale, String>emptyMap(),
 				RandomTestUtil.randomString(), layout.getPlid(),
 				segmentsExperienceERC, RandomTestUtil.randomString(),
+				new String[] {RandomTestUtil.randomString()},
 				ServiceContextTestUtil.getServiceContext(
 					layout.getGroupId(), TestPropsValues.getUserId()));
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98144

## What Is Being Fixed

Follow-up to the element variation active-column work. The addOrUpdate service method took audienceEntryERCs in the middle of its parameter list, between the entity's reference/id parameters and its column-backed fields. audienceEntryERCs is a related-entity concern rather than a column, so its position was inconsistent with the field ordering.

## How It Is Being Fixed

The audienceEntryERCs parameter is moved to just before the ServiceContext on the local and remote addOrUpdate methods, after all the column-backed parameters. The change is propagated through the regenerated Service Builder service API and every caller.

## Why Are There No Tests?

This change only reorders a service method parameter; behavior is unchanged and the existing integration tests, adapted to the new signature, continue to cover it.

## PR Check

**pr-check: PASS** — tested on `166b747f2ed33db7a7041093136a1129c05fbbdc`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |

<!-- pr-check {"result": "success", "sha": "166b747f2ed33db7a7041093136a1129c05fbbdc"} -->
