### PR TITLE
LPD-58184 Warn about removed JournalServiceConfiguration keys/values

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -5172,6 +5172,16 @@
 		]
 	},
 	{
+		"from": "JournalServiceConfigurationKeys",
+		"hasMessage": true,
+		"issueKey": "LPD-58184"
+	},
+	{
+		"from": "JournalServiceConfigurationValues",
+		"hasMessage": true,
+		"issueKey": "LPD-58184"
+	},
+	{
 		"classNames": [
 			"DDMTemplateLocalService",
 			"DDMTemplateLocalServiceUtil"

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_58184.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_58184.testjava
@@ -1,0 +1,22 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+import com.liferay.journal.configuration.JournalServiceConfigurationKeys;
+import com.liferay.journal.configuration.JournalServiceConfigurationValues;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class LPD_58184 {
+
+	public void method() {
+		String key = JournalServiceConfigurationKeys.CHAR_BLACKLIST;
+		boolean enabled =
+			JournalServiceConfigurationValues.JOURNAL_ARTICLE_COMMENTS_ENABLED;
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-58184

## What Is Being Fixed

The `JournalServiceConfigurationKeys` and `JournalServiceConfigurationValues` classes were removed. Code that still references them no longer resolves, and nothing guided developers toward the replacement.

## How It Is Being Fixed

Two entries were added to the source formatter's `replacements.json` so the upgrade catch-all check warns whenever `JournalServiceConfigurationKeys` or `JournalServiceConfigurationValues` is referenced, directing callers to migrate to `JournalServiceConfiguration` injected via `@Reference`. A test covering both warnings was added.

## PR Check

**pr-check: PASS** — tested on `28172489075c50fff82db570149ef8483b7da523`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "28172489075c50fff82db570149ef8483b7da523"} -->
