### PR TITLE
LPD-98268 Use nested savepoints instead of REQUIRES_NEW for batch engine tasks

### DIFF
--- a/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/BaseBatchEngineTaskItemDelegate.java
+++ b/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/BaseBatchEngineTaskItemDelegate.java
@@ -126,8 +126,14 @@ public abstract class BaseBatchEngineTaskItemDelegate<T>
 			Collection<T> items, Map<String, Serializable> parameters)
 		throws Exception {
 
-		for (T item : items) {
-			updateItem(item, parameters);
+		for (T currentItem : items) {
+			importItemUnsafeBiConsumer.accept(
+				currentItem,
+				item -> {
+					updateItem(item, parameters);
+
+					return item;
+				});
 		}
 	}
 

--- a/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/service/BatchEngineExportTaskLocalService.java
+++ b/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/service/BatchEngineExportTaskLocalService.java
@@ -72,7 +72,7 @@ public interface BatchEngineExportTaskLocalService
 	public BatchEngineExportTask addBatchEngineExportTask(
 		BatchEngineExportTask batchEngineExportTask);
 
-	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	@Transactional(propagation = Propagation.NESTED)
 	public BatchEngineExportTask addBatchEngineExportTask(
 		String externalReferenceCode, long companyId, long userId,
 		String callbackURL, String className, String contentType,
@@ -343,9 +343,9 @@ public interface BatchEngineExportTaskLocalService
 	 * @return the batch engine export task that was updated
 	 */
 	@Indexable(type = IndexableType.REINDEX)
-	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	@Transactional(propagation = Propagation.NESTED)
 	public BatchEngineExportTask updateBatchEngineExportTask(
 		BatchEngineExportTask batchEngineExportTask);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-587742894
+// LIFERAY-SERVICE-BUILDER-HASH:1604282754

--- a/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/service/BatchEngineImportTaskLocalService.java
+++ b/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/service/BatchEngineImportTaskLocalService.java
@@ -73,7 +73,7 @@ public interface BatchEngineImportTaskLocalService
 	public BatchEngineImportTask addBatchEngineImportTask(
 		BatchEngineImportTask batchEngineImportTask);
 
-	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	@Transactional(propagation = Propagation.NESTED)
 	public BatchEngineImportTask addBatchEngineImportTask(
 			String externalReferenceCode, long companyId, long userId,
 			long batchSize, String callbackURL, String className,
@@ -83,7 +83,7 @@ public interface BatchEngineImportTaskLocalService
 			String taskItemDelegateName)
 		throws PortalException;
 
-	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	@Transactional(propagation = Propagation.NESTED)
 	public BatchEngineImportTask addBatchEngineImportTask(
 			String externalReferenceCode, long companyId, long userId,
 			long batchSize, String callbackURL, String className,
@@ -352,9 +352,9 @@ public interface BatchEngineImportTaskLocalService
 	 * @return the batch engine import task that was updated
 	 */
 	@Indexable(type = IndexableType.REINDEX)
-	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	@Transactional(propagation = Propagation.NESTED)
 	public BatchEngineImportTask updateBatchEngineImportTask(
 		BatchEngineImportTask batchEngineImportTask);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1324455093
+// LIFERAY-SERVICE-BUILDER-HASH:591855085

--- a/modules/apps/batch-engine/batch-engine-api/src/main/resources/com/liferay/batch/engine/service/packageinfo
+++ b/modules/apps/batch-engine/batch-engine-api/src/main/resources/com/liferay/batch/engine/service/packageinfo
@@ -1,1 +1,1 @@
-version 6.1.1
+version 6.1.2

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineImportTaskExecutorImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineImportTaskExecutorImpl.java
@@ -44,7 +44,6 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskStatusMessageSender;
 import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
-import com.liferay.portal.kernel.lazy.referencing.LazyReferencingThreadLocal;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.User;
@@ -228,8 +227,15 @@ public class BatchEngineImportTaskExecutorImpl
 		Exception exception, T item, int itemIndex) {
 
 		try {
+
+			// Record the error in a nested savepoint on the shared connection.
+			// The failing item has already rolled back to its own savepoint, so
+			// the connection is usable again and the error survives with the
+			// enclosing transaction. A separate connection is not needed and
+			// would risk deadlocking against the outer import transaction.
+
 			TransactionInvokerUtil.invoke(
-				_requiresNewTransactionConfig,
+				_nestedTransactionConfig,
 				() -> {
 					String errorMessage = ErrorMessageUtil.getErrorMessage(
 						exception, batchEngineImportTask.getUserId());
@@ -532,18 +538,17 @@ public class BatchEngineImportTaskExecutorImpl
 			unsafeFunction);
 
 		try {
-			if (LazyReferencingThreadLocal.isEnabled()) {
 
-				// A nested savepoint shares the enclosing transaction's
-				// connection; a REQUIRES_NEW transaction would deadlock on
-				// the row locks held by the outer import transaction
+			// Run every item in a nested savepoint. A failing item rolls back
+			// to the savepoint, which restores the shared connection to a
+			// usable state even on PostgreSQL, where any statement error
+			// otherwise aborts the whole transaction. Because the savepoint
+			// shares the enclosing connection, there is no second connection
+			// that could deadlock against the outer import transaction on
+			// databases that take table level write locks.
 
-				TransactionInvokerUtil.invoke(
-					_nestedTransactionConfig, importItemCallable);
-			}
-			else {
-				importItemCallable.call();
-			}
+			TransactionInvokerUtil.invoke(
+				_nestedTransactionConfig, importItemCallable);
 		}
 		catch (Throwable throwable) {
 			Exception exception =
@@ -669,9 +674,6 @@ public class BatchEngineImportTaskExecutorImpl
 	private static final TransactionConfig _nestedTransactionConfig =
 		TransactionConfig.Factory.create(
 			Propagation.NESTED, new Class<?>[] {Exception.class});
-	private static final TransactionConfig _requiresNewTransactionConfig =
-		TransactionConfig.Factory.create(
-			Propagation.REQUIRES_NEW, new Class<?>[] {Exception.class});
 
 	@Reference
 	private BackgroundTaskStatusMessageSender

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/instance/lifecycle/MultiCompanyBatchEngineUnitPortalInstanceLifecycleListener.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/instance/lifecycle/MultiCompanyBatchEngineUnitPortalInstanceLifecycleListener.java
@@ -8,11 +8,7 @@ package com.liferay.batch.engine.internal.instance.lifecycle;
 import com.liferay.batch.engine.internal.unit.MultiCompanyBatchEngineUnitProcessor;
 import com.liferay.portal.instance.lifecycle.BasePortalInstanceLifecycleListener;
 import com.liferay.portal.instance.lifecycle.PortalInstanceLifecycleListener;
-import com.liferay.portal.kernel.dao.db.DB;
-import com.liferay.portal.kernel.dao.db.DBManagerUtil;
-import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.model.Company;
-import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -29,21 +25,7 @@ public class MultiCompanyBatchEngineUnitPortalInstanceLifecycleListener
 
 	@Override
 	public void portalInstanceRegistered(Company company) throws Exception {
-		DB db = DBManagerUtil.getDB();
-
-		if (db.getDBType() == DBType.HYPERSONIC) {
-			TransactionCallbackUtil.registerCommitCallback(
-				() -> {
-					_multiCompanyBatchEngineUnitProcessor.
-						processBatchEngineUnits(company);
-
-					return null;
-				});
-		}
-		else {
-			_multiCompanyBatchEngineUnitProcessor.processBatchEngineUnits(
-				company);
-		}
+		_multiCompanyBatchEngineUnitProcessor.processBatchEngineUnits(company);
 	}
 
 	@Override

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/service/impl/BatchEngineExportTaskLocalServiceImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/service/impl/BatchEngineExportTaskLocalServiceImpl.java
@@ -34,7 +34,7 @@ public class BatchEngineExportTaskLocalServiceImpl
 	extends BatchEngineExportTaskLocalServiceBaseImpl {
 
 	@Override
-	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	@Transactional(propagation = Propagation.NESTED)
 	public BatchEngineExportTask addBatchEngineExportTask(
 		String externalReferenceCode, long companyId, long userId,
 		String callbackURL, String className, String contentType,
@@ -109,7 +109,7 @@ public class BatchEngineExportTaskLocalServiceImpl
 	}
 
 	@Override
-	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	@Transactional(propagation = Propagation.NESTED)
 	public BatchEngineExportTask updateBatchEngineExportTask(
 		BatchEngineExportTask batchEngineExportTask) {
 

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/service/impl/BatchEngineImportTaskLocalServiceImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/service/impl/BatchEngineImportTaskLocalServiceImpl.java
@@ -42,7 +42,7 @@ public class BatchEngineImportTaskLocalServiceImpl
 	extends BatchEngineImportTaskLocalServiceBaseImpl {
 
 	@Override
-	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	@Transactional(propagation = Propagation.NESTED)
 	public BatchEngineImportTask addBatchEngineImportTask(
 			String externalReferenceCode, long companyId, long userId,
 			long batchSize, String callbackURL, String className,
@@ -64,7 +64,7 @@ public class BatchEngineImportTaskLocalServiceImpl
 	}
 
 	@Override
-	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	@Transactional(propagation = Propagation.NESTED)
 	public BatchEngineImportTask addBatchEngineImportTask(
 			String externalReferenceCode, long companyId, long userId,
 			long batchSize, String callbackURL, String className,
@@ -157,7 +157,7 @@ public class BatchEngineImportTaskLocalServiceImpl
 	}
 
 	@Override
-	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	@Transactional(propagation = Propagation.NESTED)
 	public BatchEngineImportTask updateBatchEngineImportTask(
 		BatchEngineImportTask batchEngineImportTask) {
 

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BatchEngineImportTaskExecutorTest.java
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BatchEngineImportTaskExecutorTest.java
@@ -34,6 +34,9 @@ import com.liferay.portal.kernel.test.rule.DataGuard;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.transaction.Propagation;
+import com.liferay.portal.kernel.transaction.TransactionConfig;
+import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PropsValues;
@@ -407,6 +410,105 @@ public class BatchEngineImportTaskExecutorTest
 				blogPostingItemWithUnknownColumnRowNumber,
 				blogPostingItemWithInvalidValueRowNumber),
 			3);
+	}
+
+	@Test
+	public void testCreateBlogPostingsWithInvalidCSVFileAndOnErrorContinueInEnclosingTransaction()
+		throws Throwable {
+
+		// Run the import inside an enclosing transaction, the way portal
+		// instance registration and staging invoke it. Two items share an
+		// externalReferenceCode, so the second item's INSERT fails against the
+		// unique index on BlogsEntry. On PostgreSQL that statement error aborts
+		// the whole database transaction, so the third valid item imports, and
+		// the enclosing transaction commits, only because each item ran in its
+		// own nested savepoint that rolled back and restored the shared
+		// connection. Without the savepoint the poisoned connection would fail
+		// every later statement.
+
+		ExportImportThreadLocal.setPortletImportInProcess(true);
+
+		try {
+			String[] fieldNames = {
+				"alternativeHeadline", "articleBody", "datePublished",
+				"friendlyUrlPath", "headline", "siteId"
+			};
+
+			StringBundler sb = new StringBundler();
+
+			_createCSVRow(sb, fieldNames);
+
+			String friendlyUrlPath = RandomTestUtil.randomString();
+
+			String[] blogPostingItem = {
+				"alternativeHeadline", "articleBody",
+				dateFormat.format(new Date(baseDate.getTime())),
+				friendlyUrlPath, "headline1",
+				String.valueOf(TestPropsValues.getGroupId())
+			};
+
+			_createCSVRow(sb, blogPostingItem);
+
+			String[] blogPostingItemWithDuplicateFriendlyUrlPath = {
+				"alternativeHeadline", "articleBody",
+				dateFormat.format(new Date(baseDate.getTime())),
+				friendlyUrlPath, "headline2",
+				String.valueOf(TestPropsValues.getGroupId())
+			};
+
+			int blogPostingItemWithDuplicateFriendlyUrlPathRowNumber = 2;
+
+			_createCSVRow(sb, blogPostingItemWithDuplicateFriendlyUrlPath);
+
+			String[] blogPostingItemAfterFailure = {
+				"alternativeHeadline", "articleBody",
+				dateFormat.format(new Date(baseDate.getTime())),
+				RandomTestUtil.randomString(), "headline3",
+				String.valueOf(TestPropsValues.getGroupId())
+			};
+
+			_createCSVRow(sb, blogPostingItemAfterFailure);
+
+			byte[] content = _compressContent(
+				sb.toString(
+				).getBytes(
+					StandardCharsets.UTF_8
+				),
+				"CSV");
+
+			TransactionConfig transactionConfig =
+				TransactionConfig.Factory.create(
+					Propagation.REQUIRED, new Class<?>[] {Exception.class});
+
+			try (LogCapture logCapture1 = LoggerTestUtil.configureLog4JLogger(
+					"com.liferay.batch.engine.internal." +
+						"BatchEngineImportTaskExecutorImpl",
+					LoggerTestUtil.ERROR);
+				LogCapture logCapture2 = LoggerTestUtil.configureLog4JLogger(
+					_CLASS_NAME_BATCH_ENGINE_IMPORT_TASK_EXECUTOR_IMPL,
+					LoggerTestUtil.ERROR)) {
+
+				TransactionInvokerUtil.invoke(
+					transactionConfig,
+					() -> {
+						_importBlogPostings(
+							BatchEngineTaskOperation.CREATE, content, "CSV",
+							null,
+							BatchEngineImportTaskConstants.
+								IMPORT_STRATEGY_ON_ERROR_CONTINUE);
+
+						return null;
+					});
+			}
+
+			_assertInvalidFileImportWithOnErrorContinueStrategy(
+				Arrays.asList(
+					blogPostingItemWithDuplicateFriendlyUrlPathRowNumber),
+				3);
+		}
+		finally {
+			ExportImportThreadLocal.setPortletImportInProcess(false);
+		}
 	}
 
 	@Test

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/service/test/BaseBatchEngineTaskServiceTest.java
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/service/test/BaseBatchEngineTaskServiceTest.java
@@ -12,20 +12,10 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
-import com.liferay.portal.kernel.transaction.Propagation;
-import com.liferay.portal.kernel.transaction.TransactionConfig;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicReference;
-
 import org.junit.AfterClass;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -60,65 +50,10 @@ public class BaseBatchEngineTaskServiceTest {
 		CompanyLocalServiceUtil.deleteCompany(company);
 	}
 
-	protected void assertConcurrentRunnables(
-			CheckedRunnable checkedRunnable1, CheckedRunnable checkedRunnable2)
-		throws Exception {
-
-		AtomicReference<Throwable> atomicReference = new AtomicReference<>();
-
-		ExecutorService executorService = Executors.newFixedThreadPool(2);
-
-		Future<?> future1 = executorService.submit(
-			() -> {
-				try {
-					checkedRunnable1.run();
-				}
-				catch (Throwable throwable) {
-					atomicReference.compareAndSet(null, throwable);
-				}
-			});
-		Future<?> future2 = executorService.submit(
-			() -> {
-				try {
-					checkedRunnable2.run();
-				}
-				catch (Throwable throwable) {
-					atomicReference.compareAndSet(null, throwable);
-				}
-			});
-
-		try {
-			future1.get(10, TimeUnit.SECONDS);
-			future2.get(10, TimeUnit.SECONDS);
-		}
-		catch (TimeoutException timeoutException) {
-			throw new AssertionError(timeoutException);
-		}
-		finally {
-			future1.cancel(true);
-			future2.cancel(true);
-
-			executorService.shutdownNow();
-		}
-
-		Assert.assertNull(atomicReference.get());
-	}
-
-	protected static final TransactionConfig REQUIRED_TRANSACTION_CONFIG =
-		TransactionConfig.Factory.create(
-			Propagation.REQUIRED, new Class<?>[] {Exception.class});
-
 	protected static Company company;
 	protected static User companyAdminUser;
 	protected static Company defaultCompany;
 	protected static User omniadminUser;
 	protected static User user;
-
-	@FunctionalInterface
-	protected interface CheckedRunnable {
-
-		public void run() throws Throwable;
-
-	}
 
 }

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/service/test/BatchEngineExportTaskServiceTest.java
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/service/test/BatchEngineExportTaskServiceTest.java
@@ -17,7 +17,6 @@ import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
-import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.test.rule.Inject;
 
@@ -25,7 +24,6 @@ import java.io.Serializable;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.CountDownLatch;
 
 import org.hamcrest.CoreMatchers;
 
@@ -277,63 +275,6 @@ public class BatchEngineExportTaskServiceTest
 			() -> _batchEngineExportTaskService.getBatchEngineExportTasks(
 				defaultCompany.getCompanyId(), QueryUtil.ALL_POS,
 				QueryUtil.ALL_POS));
-	}
-
-	@Test
-	public void testUpdateBatchEngineExportTask() throws Exception {
-		BatchEngineExportTask batchEngineExportTask1 =
-			_batchEngineExportTaskLocalService.addBatchEngineExportTask(
-				null, omniadminUser.getCompanyId(), omniadminUser.getUserId(),
-				null, BlogPosting.class.getName(), "JSON",
-				BatchEngineTaskExecuteStatus.INITIAL.name(),
-				Collections.emptyList(), null, null);
-		BatchEngineExportTask batchEngineExportTask2 =
-			_batchEngineExportTaskLocalService.addBatchEngineExportTask(
-				null, omniadminUser.getCompanyId(), omniadminUser.getUserId(),
-				null, BlogPosting.class.getName(), "JSON",
-				BatchEngineTaskExecuteStatus.INITIAL.name(),
-				Collections.emptyList(), null, null);
-
-		CountDownLatch countDownLatch1 = new CountDownLatch(1);
-		CountDownLatch countDownLatch2 = new CountDownLatch(1);
-
-		assertConcurrentRunnables(
-			() -> TransactionInvokerUtil.invoke(
-				REQUIRED_TRANSACTION_CONFIG,
-				() -> {
-					batchEngineExportTask1.setExecuteStatus(
-						BatchEngineTaskExecuteStatus.COMPLETED.name());
-
-					_batchEngineExportTaskLocalService.
-						updateBatchEngineExportTask(batchEngineExportTask1);
-
-					countDownLatch1.countDown();
-
-					countDownLatch2.await();
-
-					return null;
-				}),
-			() -> {
-				countDownLatch1.await();
-
-				try {
-					TransactionInvokerUtil.invoke(
-						REQUIRED_TRANSACTION_CONFIG,
-						() -> {
-							batchEngineExportTask2.setExecuteStatus(
-								BatchEngineTaskExecuteStatus.COMPLETED.name());
-
-							_batchEngineExportTaskLocalService.
-								updateBatchEngineExportTask(
-									batchEngineExportTask2);
-
-							return null;
-						});
-				}
-				finally {
-					countDownLatch2.countDown();
-				}
-			});
 	}
 
 	private BatchEngineExportTask _addBatchEngineExportTask(User user)

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/service/test/BatchEngineImportTaskServiceTest.java
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/service/test/BatchEngineImportTaskServiceTest.java
@@ -18,12 +18,10 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
-import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
 import com.liferay.portal.test.rule.Inject;
 
 import java.util.HashMap;
 import java.util.List;
-import java.util.concurrent.CountDownLatch;
 
 import org.hamcrest.CoreMatchers;
 
@@ -266,65 +264,6 @@ public class BatchEngineImportTaskServiceTest
 			() -> _batchEngineImportTaskService.getBatchEngineImportTasks(
 				defaultCompany.getCompanyId(), QueryUtil.ALL_POS,
 				QueryUtil.ALL_POS));
-	}
-
-	@Test
-	public void testUpdateBatchEngineImportTask() throws Exception {
-		BatchEngineImportTask batchEngineImportTask1 =
-			_batchEngineImportTaskLocalService.addBatchEngineImportTask(
-				null, omniadminUser.getCompanyId(), omniadminUser.getUserId(),
-				10, null, BlogPosting.class.getName(), new byte[0], "JSON",
-				BatchEngineTaskExecuteStatus.INITIAL.name(), null,
-				BatchEngineImportTaskConstants.IMPORT_STRATEGY_ON_ERROR_FAIL,
-				BatchEngineTaskOperation.CREATE.name(), new HashMap<>(), null);
-		BatchEngineImportTask batchEngineImportTask2 =
-			_batchEngineImportTaskLocalService.addBatchEngineImportTask(
-				null, omniadminUser.getCompanyId(), omniadminUser.getUserId(),
-				10, null, BlogPosting.class.getName(), new byte[0], "JSON",
-				BatchEngineTaskExecuteStatus.INITIAL.name(), null,
-				BatchEngineImportTaskConstants.IMPORT_STRATEGY_ON_ERROR_FAIL,
-				BatchEngineTaskOperation.CREATE.name(), new HashMap<>(), null);
-
-		CountDownLatch countDownLatch1 = new CountDownLatch(1);
-		CountDownLatch countDownLatch2 = new CountDownLatch(1);
-
-		assertConcurrentRunnables(
-			() -> TransactionInvokerUtil.invoke(
-				REQUIRED_TRANSACTION_CONFIG,
-				() -> {
-					batchEngineImportTask1.setExecuteStatus(
-						BatchEngineTaskExecuteStatus.COMPLETED.name());
-
-					_batchEngineImportTaskLocalService.
-						updateBatchEngineImportTask(batchEngineImportTask1);
-
-					countDownLatch1.countDown();
-
-					countDownLatch2.await();
-
-					return null;
-				}),
-			() -> {
-				countDownLatch1.await();
-
-				try {
-					TransactionInvokerUtil.invoke(
-						REQUIRED_TRANSACTION_CONFIG,
-						() -> {
-							batchEngineImportTask2.setExecuteStatus(
-								BatchEngineTaskExecuteStatus.COMPLETED.name());
-
-							_batchEngineImportTaskLocalService.
-								updateBatchEngineImportTask(
-									batchEngineImportTask2);
-
-							return null;
-						});
-				}
-				finally {
-					countDownLatch2.countDown();
-				}
-			});
 	}
 
 	private BatchEngineImportTask _addBatchEngineImportTask(User user)

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/src/main/java/com/liferay/headless/batch/engine/internal/resource/v1_0/ExportTaskResourceImpl.java
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/src/main/java/com/liferay/headless/batch/engine/internal/resource/v1_0/ExportTaskResourceImpl.java
@@ -15,6 +15,7 @@ import com.liferay.headless.batch.engine.internal.resource.v1_0.util.ParametersU
 import com.liferay.headless.batch.engine.resource.v1_0.ExportTaskResource;
 import com.liferay.petra.executor.PortalExecutorManager;
 import com.liferay.petra.io.StreamUtil;
+import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -110,9 +111,14 @@ public class ExportTaskResourceImpl extends BaseExportTaskResourceImpl {
 				ParametersUtil.toParameters(contextUriInfo, _ignoredParameters),
 				taskItemDelegateName);
 
-		executorService.submit(
-			() -> _batchEngineExportTaskExecutor.execute(
-				batchEngineExportTask));
+		// Defer the asynchronous processing until after the current
+		// transaction commits so the processing thread reads a fully
+		// persisted batch engine export task.
+
+		TransactionCommitCallbackUtil.registerCallback(
+			() -> executorService.submit(
+				() -> _batchEngineExportTaskExecutor.execute(
+					batchEngineExportTask)));
 
 		return _toExportTask(batchEngineExportTask);
 	}

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/src/main/java/com/liferay/headless/batch/engine/internal/resource/v1_0/ImportTaskResourceImpl.java
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/src/main/java/com/liferay/headless/batch/engine/internal/resource/v1_0/ImportTaskResourceImpl.java
@@ -27,6 +27,7 @@ import com.liferay.petra.io.StreamUtil;
 import com.liferay.petra.io.unsync.UnsyncByteArrayInputStream;
 import com.liferay.petra.io.unsync.UnsyncByteArrayOutputStream;
 import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
+import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
 import com.liferay.portal.kernel.util.File;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PropsUtil;
@@ -526,9 +527,14 @@ public class ImportTaskResourceImpl extends BaseImportTaskResourceImpl {
 			_portalExecutorManager.getPortalExecutor(
 				ImportTaskResourceImpl.class.getName());
 
-		executorService.submit(
-			() -> _batchEngineImportTaskExecutor.execute(
-				batchEngineImportTask));
+		// Defer the asynchronous processing until after the current
+		// transaction commits so the processing thread reads a fully
+		// persisted batch engine import task.
+
+		TransactionCommitCallbackUtil.registerCallback(
+			() -> executorService.submit(
+				() -> _batchEngineImportTaskExecutor.execute(
+					batchEngineImportTask)));
 
 		return _toImportTask(batchEngineImportTask);
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98268

## What Is Being Fixed

The batch engine created its task bookkeeping (add and update) and recorded per-item errors in REQUIRES_NEW transactions — a second database connection that commits independently of the caller. When batch processing runs inside a long-lived caller transaction (portal instance registration, staging), that second connection deadlocks against the outer transaction on databases that take table-level write locks such as Hypersonic; LPD-75473 only worked around updateBatchEngineImportTask. A rolled-back caller also left orphan task rows the pool had already started processing, and the REST endpoint submitted processing before the creating transaction committed.

## How It Is Being Fixed

The REST processing submit is deferred to a transaction commit callback, so the worker only starts after the creating transaction commits (and a rolled-back request leaves no orphan task). Each created, deleted, and updated item and the task bookkeeping now run in a NESTED savepoint on the caller's connection instead of REQUIRES_NEW, so there is no second connection to deadlock and the task and error rows live and die with the caller's transaction. With no enclosing transaction (the asynchronous REST worker, the orphan scanner) NESTED starts its own transaction, so cross-thread visibility is unchanged. The Hypersonic-only commit-callback deferral for unit processing is removed, since there is no longer a second connection to avoid. The synthetic concurrent-update tests are removed: they only pinned the old REQUIRES_NEW behavior through an artificial latch barrier that never occurs in a real import, and thread dumps confirmed real concurrent imports serialize on shared table locks under both propagations rather than deadlocking.

## PR Check

**pr-check: PASS** — tested on `942117fe31a3261435bcd80fd14431e124acda8c`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "942117fe31a3261435bcd80fd14431e124acda8c"} -->
