### PR TITLE
LPD-94024 Accept workflow-scoped delegate keys in service node validation

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-kaleo-definition-impl/src/main/java/com/liferay/portal/workflow/kaleo/definition/internal/parser/ServiceNodeValidator.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-definition-impl/src/main/java/com/liferay/portal/workflow/kaleo/definition/internal/parser/ServiceNodeValidator.java
@@ -42,7 +42,7 @@ public class ServiceNodeValidator extends BaseNodeValidator<ServiceNode> {
 		}
 
 		if (Validator.isNull(javaDelegate) ||
-			!javaDelegate.matches("[\\w.$]+#\\w+")) {
+			!javaDelegate.matches("[\\w.$]+(#\\w+)+")) {
 
 			throw new KaleoDefinitionValidationException(
 				StringBundler.concat(

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/internal/runtime/integration/test/WorkflowDefinitionManagerTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/internal/runtime/integration/test/WorkflowDefinitionManagerTest.java
@@ -455,46 +455,18 @@ public class WorkflowDefinitionManagerTest extends BaseWorkflowManagerTestCase {
 					RandomTestUtil.randomString(), TestPropsValues.getUserId());
 			});
 
-		InputStream inputStream = getResourceInputStream(
-			"service-node-workflow-definition.json");
+		byte[] bytes = FileUtil.getBytes(
+			getResourceInputStream("service-node-workflow-definition.json"));
 
-		WorkflowDefinition workflowDefinition =
-			_workflowDefinitionManager.deployWorkflowDefinition(
-				FileUtil.getBytes(inputStream), TestPropsValues.getCompanyId(),
-				RandomTestUtil.randomString(),
-				"Service Node Workflow Definition",
-				RandomTestUtil.randomString(), TestPropsValues.getUserId());
+		_assertServiceNodeWorkflowDefinition(
+			bytes, "com.example.Converter#convert");
 
-		List<WorkflowNode> workflowNodes =
-			workflowDefinition.getWorkflowNodes();
+		String content = StringUtil.replace(
+			new String(bytes), "com.example.Converter#convert",
+			"com.example.Converter#scope#convert");
 
-		WorkflowNode workflowNode = workflowNodes.get(2);
-
-		Assert.assertEquals(WorkflowNode.Type.SERVICE, workflowNode.getType());
-
-		_assertEquals(
-			List.of(
-				_createWorkflowNodeSetting(
-					"inputVariables",
-					JSONUtil.put(
-						JSONUtil.put(
-							"name", "input"
-						).put(
-							"type", "string"
-						)
-					).toString()),
-				_createWorkflowNodeSetting(
-					"javaDelegate", "com.example.Converter#convert"),
-				_createWorkflowNodeSetting(
-					"outputVariables",
-					JSONUtil.put(
-						JSONUtil.put(
-							"name", "output"
-						).put(
-							"type", "string"
-						)
-					).toString())),
-			workflowNode.getWorkflowNodeSettings());
+		_assertServiceNodeWorkflowDefinition(
+			content.getBytes(), "com.example.Converter#scope#convert");
 	}
 
 	@Test
@@ -941,6 +913,48 @@ public class WorkflowDefinitionManagerTest extends BaseWorkflowManagerTestCase {
 		}
 
 		return null;
+	}
+
+	private void _assertServiceNodeWorkflowDefinition(
+			byte[] bytes, String javaDelegate)
+		throws Exception {
+
+		WorkflowDefinition workflowDefinition =
+			_workflowDefinitionManager.deployWorkflowDefinition(
+				bytes, TestPropsValues.getCompanyId(),
+				RandomTestUtil.randomString(),
+				"Service Node Workflow Definition",
+				RandomTestUtil.randomString(), TestPropsValues.getUserId());
+
+		List<WorkflowNode> workflowNodes =
+			workflowDefinition.getWorkflowNodes();
+
+		WorkflowNode workflowNode = workflowNodes.get(2);
+
+		Assert.assertEquals(WorkflowNode.Type.SERVICE, workflowNode.getType());
+
+		_assertEquals(
+			List.of(
+				_createWorkflowNodeSetting(
+					"inputVariables",
+					JSONUtil.put(
+						JSONUtil.put(
+							"name", "input"
+						).put(
+							"type", "string"
+						)
+					).toString()),
+				_createWorkflowNodeSetting("javaDelegate", javaDelegate),
+				_createWorkflowNodeSetting(
+					"outputVariables",
+					JSONUtil.put(
+						JSONUtil.put(
+							"name", "output"
+						).put(
+							"type", "string"
+						)
+					).toString())),
+			workflowNode.getWorkflowNodeSettings());
 	}
 
 	private void _assertValid(InputStream inputStream) throws Exception {


### PR DESCRIPTION
Task: [LPD-94024](https://liferay.atlassian.net/browse/LPD-94024)
Review https://github.com/liferay-ai-hub/liferay-portal/pull/636

Split from the original AI Hub change so the portal-workflow part lands in the public repo. The AI Hub follow-up goes to liferay-portal-ee separately.

**What is being fixed:** `ServiceNodeValidator` rejected service node delegate keys that carried a workflow scope, so a scoped compose-output delegate key (`javaDelegate#GenerateContent#composeContentEntriesOutput`) failed validation.

**How it is being fixed:** The delegate-key regex now accepts the optional `#<scope>` segment, and `WorkflowDefinitionManagerTest` is updated to cover the scoped form.




**pr-check: PASS** — tested on `acae4b1f20d835df8c26a174a41ea60dfc9ff91c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

_Since the prior run the only change is a test-only private-method rename (`_assertServiceNode` → `_assertServiceNodeWorkflowDefinition`) in `WorkflowDefinitionManagerTest`; re-verified with formatSource (clean) and `compileTestIntegrationJava` (BUILD SUCCESSFUL). No product code changed, so the other validations carry over._

<!-- pr-check {"result": "success", "sha": "acae4b1f20d835df8c26a174a41ea60dfc9ff91c"} -->