### PR TITLE
LPD-94025 Add Generate Field Value workflow definition constants

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-api/src/main/java/com/liferay/portal/workflow/constants/WorkflowDefinitionConstants.java
+++ b/modules/apps/portal-workflow/portal-workflow-api/src/main/java/com/liferay/portal/workflow/constants/WorkflowDefinitionConstants.java
@@ -26,6 +26,9 @@ public class WorkflowDefinitionConstants {
 	public static final String EXTERNAL_REFERENCE_CODE_GENERATE_CONTENT =
 		"L_GENERATE_CONTENT";
 
+	public static final String EXTERNAL_REFERENCE_CODE_GENERATE_FIELD_VALUE =
+		"L_GENERATE_FIELD_VALUE";
+
 	public static final String EXTERNAL_REFERENCE_CODE_GENERATE_IMAGE =
 		"L_GENERATE_IMAGE";
 
@@ -64,6 +67,9 @@ public class WorkflowDefinitionConstants {
 		"Fix Spelling and Grammar";
 
 	public static final String NAME_GENERATE_CONTENT = "Generate Content";
+
+	public static final String NAME_GENERATE_FIELD_VALUE =
+		"Generate Field Value";
 
 	public static final String NAME_GENERATE_IMAGE = "Generate Image";
 


### PR DESCRIPTION
Task [LPD-94025](https://liferay.atlassian.net/browse/LPD-94025)
Review https://github.com/liferay-ai-hub/liferay-portal/pull/637

Split from the AI Hub change so the portal-workflow part lands in the public repo. The AI Hub part goes to liferay-portal-ee separately.

Adds the `GENERATE_FIELD_VALUE` external reference code and workflow definition name constants to `WorkflowDefinitionConstants`, which the Generate Field Value agent references.