### PR TITLE
LPD-98247 Fix Widget Page card missing from Add Page wizard

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/layout/pagesadmin/PagesAdmin.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/layout/pagesadmin/PagesAdmin.macro
@@ -846,11 +846,20 @@ definition {
 			configurationName = "Deprecation",
 			configurationScope = "Virtual Instance Scope");
 
-		if (IsElementPresent(locator1 = "FeatureFlag#TOGGLE_ROW", title_row = ${featureFlagName}, toggle_state = "Disabled")) {
+		if (IsElementNotPresent(locator1 = "FeatureFlag#TOGGLE_ROW", title_row = ${featureFlagName}, toggle_state = "")) {
+			Search.searchCP(searchTerm = ${featureFlagName});
+		}
+
+		if (IsElementNotPresent(locator1 = "FeatureFlag#TOGGLE_ROW", title_row = ${featureFlagName}, toggle_state = "Enabled")) {
 			Check.checkToggleSwitch(
 				locator1 = "FeatureFlag#TOGGLE_ROW",
 				title_row = ${featureFlagName},
-				toggle_state = "Disabled");
+				toggle_state = "");
+
+			WaitForElementPresent(
+				locator1 = "FeatureFlag#TOGGLE_ROW",
+				title_row = ${featureFlagName},
+				toggle_state = "Enabled");
 		}
 
 		Navigator.openURL();

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/pgstaging/PGStagingUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/pgstaging/PGStagingUsecase.testcase
@@ -11,6 +11,10 @@ definition {
 		TestCase.setUpPortalInstance();
 
 		User.firstLoginPG();
+
+		task ("Enable widget pages") {
+			PagesAdmin.enableWidgetPages();
+		}
 	}
 
 	tearDown {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/usecase/RemoteStaging.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/usecase/RemoteStaging.testcase
@@ -16,6 +16,10 @@ definition {
 
 		User.firstLoginPG();
 
+		task ("Enable widget pages") {
+			PagesAdmin.enableWidgetPages();
+		}
+
 		task ("Enable dynamic and manual selection") {
 			AssetPublisherPortlet.enableDynamicAndManualSelection();
 		}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/usecase/StagingUsecaseWithOrganization.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/usecase/StagingUsecaseWithOrganization.testcase
@@ -11,6 +11,10 @@ definition {
 		TestCase.setUpPortalInstance();
 
 		User.firstLoginPG();
+
+		task ("Enable widget pages") {
+			PagesAdmin.enableWidgetPages();
+		}
 	}
 
 	tearDown {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98247

## What Is Being Fixed

Poshi tests that need the "Widget Page" layout type option in the Add Page wizard were failing because the Widget Pages deprecation flag (LPD-76864) was never reliably enabled. PagesAdmin.enableDeprecationFeatureFlag only checked whether the toggle happened to already be visible, so once the number of registered deprecation-type feature flags grew past a single page it silently failed to find (and click) the Widget Pages row, leaving the flag disabled and hiding the card. PGStagingUsecase, RemoteStaging, and StagingUsecaseWithOrganization never called the macro at all, so the flag stayed disabled for their entire run.

## How It Is Being Fixed

PagesAdmin.enableDeprecationFeatureFlag now searches for the feature flag's row when it isn't already visible, mirroring the existing FeatureFlag.toggleFeatureFlag pattern, and only clicks when the row isn't already showing "Enabled". PGStagingUsecase.testcase, RemoteStaging.testcase, and StagingUsecaseWithOrganization.testcase now call PagesAdmin.enableWidgetPages() in setUp, matching the pattern already used elsewhere in these files.

## Why Are There No Tests?

This fixes existing Poshi tests' setup so they correctly exercise already-existing coverage; no new product behavior is being introduced that needs new test coverage.

## PR Check

**pr-check: PASS** — tested on `9e36ea73ae9683d817a5960e4e85927fe04d9017`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | PASS |
| Poshi Syntax | PASS |

<!-- pr-check {"result": "success", "sha": "9e36ea73ae9683d817a5960e4e85927fe04d9017"} -->
