### PR TITLE
LPD-98379 Ban CompletableFuture usage in the source formatter

### DIFF
--- a/modules/apps/portal/portal-cluster-multiple/src/main/java/com/liferay/portal/cluster/multiple/internal/ClusterExecutorImpl.java
+++ b/modules/apps/portal/portal-cluster-multiple/src/main/java/com/liferay/portal/cluster/multiple/internal/ClusterExecutorImpl.java
@@ -8,6 +8,7 @@ package com.liferay.portal.cluster.multiple.internal;
 import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerList;
 import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerListFactory;
 import com.liferay.petra.concurrent.ConcurrentReferenceValueHashMap;
+import com.liferay.petra.concurrent.DefaultNoticeableFuture;
 import com.liferay.petra.executor.PortalExecutorManager;
 import com.liferay.petra.lang.HashUtil;
 import com.liferay.petra.memory.FinalizeManager;
@@ -55,7 +56,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -284,12 +284,12 @@ public class ClusterExecutorImpl implements ClusterExecutor {
 	}
 
 	protected String getClusterNodeId(Address address) {
-		CompletableFuture<String> completableFuture =
-			_clusterNodeIdCompletableFutures.computeIfAbsent(
-				address, key -> new CompletableFuture<>());
+		DefaultNoticeableFuture<String> defaultNoticeableFuture =
+			_clusterNodeIdDefaultNoticeableFutures.computeIfAbsent(
+				address, key -> new DefaultNoticeableFuture<>());
 
 		try {
-			return completableFuture.get(
+			return defaultNoticeableFuture.get(
 				clusterExecutorConfiguration.clusterNodeAddressTimeout(),
 				TimeUnit.MILLISECONDS);
 		}
@@ -406,7 +406,7 @@ public class ClusterExecutorImpl implements ClusterExecutor {
 
 	protected void memberRemoved(List<Address> departAddresses) {
 		for (Address address : departAddresses) {
-			_clusterNodeIdCompletableFutures.remove(address);
+			_clusterNodeIdDefaultNoticeableFutures.remove(address);
 		}
 
 		List<ClusterNode> departClusterNodes = new ArrayList<>();
@@ -524,12 +524,12 @@ public class ClusterExecutorImpl implements ClusterExecutor {
 	}
 
 	private boolean _memberJoined(ClusterNodeStatus clusterNodeStatus) {
-		CompletableFuture<String> completableFuture =
-			_clusterNodeIdCompletableFutures.computeIfAbsent(
+		DefaultNoticeableFuture<String> defaultNoticeableFuture =
+			_clusterNodeIdDefaultNoticeableFutures.computeIfAbsent(
 				clusterNodeStatus.getAddress(),
-				key -> new CompletableFuture<>());
+				key -> new DefaultNoticeableFuture<>());
 
-		completableFuture.complete(clusterNodeStatus.getClusterNodeId());
+		defaultNoticeableFuture.set(clusterNodeStatus.getClusterNodeId());
 
 		ClusterNodeStatus oldClusterNodeStatus = _clusterNodeStatuses.put(
 			clusterNodeStatus.getClusterNodeId(), clusterNodeStatus);
@@ -559,8 +559,8 @@ public class ClusterExecutorImpl implements ClusterExecutor {
 
 	private ClusterChannel _clusterChannel;
 	private volatile ClusterChannelFactory _clusterChannelFactory;
-	private final Map<Address, CompletableFuture<String>>
-		_clusterNodeIdCompletableFutures = new ConcurrentHashMap<>();
+	private final Map<Address, DefaultNoticeableFuture<String>>
+		_clusterNodeIdDefaultNoticeableFutures = new ConcurrentHashMap<>();
 	private final Map<String, ClusterNodeStatus> _clusterNodeStatuses =
 		new ConcurrentHashMap<>();
 	private boolean _enabled;

--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/ClusterLicenseTest.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/ClusterLicenseTest.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.license.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.concurrent.DefaultNoticeableFuture;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.license.util.LicenseManagerUtil;
@@ -32,7 +33,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -588,23 +588,24 @@ public class ClusterLicenseTest extends BaseLicenseTestCase {
 
 			String nodeName = message.substring(0, index + 1);
 
-			Map<String[], CompletableFuture<String>> completableFutures =
-				_completableFuturesMap.get(nodeName);
+			Map<String[], DefaultNoticeableFuture<String>>
+				defaultNoticeableFutures = _defaultNoticeableFuturesMap.get(
+					nodeName);
 
-			if (completableFutures == null) {
+			if (defaultNoticeableFutures == null) {
 				return;
 			}
 
-			Set<Map.Entry<String[], CompletableFuture<String>>> entries =
-				completableFutures.entrySet();
+			Set<Map.Entry<String[], DefaultNoticeableFuture<String>>> entries =
+				defaultNoticeableFutures.entrySet();
 
 			entries.removeIf(
 				entry -> {
 					if (_hasKeyword(entry.getKey(), message)) {
-						CompletableFuture<String> completableFuture =
-							entry.getValue();
+						DefaultNoticeableFuture<String>
+							defaultNoticeableFuture = entry.getValue();
 
-						completableFuture.complete(message);
+						defaultNoticeableFuture.set(message);
 
 						return true;
 					}
@@ -614,16 +615,17 @@ public class ClusterLicenseTest extends BaseLicenseTestCase {
 		}
 
 		public Future<String> register(int nodeId, String... keywords) {
-			CompletableFuture<String> completableFuture =
-				new CompletableFuture<>();
+			DefaultNoticeableFuture<String> defaultNoticeableFuture =
+				new DefaultNoticeableFuture<>();
 
-			Map<String[], CompletableFuture<String>> completableFutures =
-				_completableFuturesMap.computeIfAbsent(
-					_getKey(nodeId), key -> new ConcurrentHashMap<>());
+			Map<String[], DefaultNoticeableFuture<String>>
+				defaultNoticeableFutures =
+					_defaultNoticeableFuturesMap.computeIfAbsent(
+						_getKey(nodeId), key -> new ConcurrentHashMap<>());
 
-			completableFutures.put(keywords, completableFuture);
+			defaultNoticeableFutures.put(keywords, defaultNoticeableFuture);
 
-			return completableFuture;
+			return defaultNoticeableFuture;
 		}
 
 		private String _getKey(int nodeId) {
@@ -642,8 +644,9 @@ public class ClusterLicenseTest extends BaseLicenseTestCase {
 
 		private static final String _PREFIX = "[TomcatNode-";
 
-		private final Map<String, Map<String[], CompletableFuture<String>>>
-			_completableFuturesMap = new ConcurrentHashMap<>();
+		private final Map
+			<String, Map<String[], DefaultNoticeableFuture<String>>>
+				_defaultNoticeableFuturesMap = new ConcurrentHashMap<>();
 
 	}
 

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/agent/util/AgentUtil.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/agent/util/AgentUtil.java
@@ -5,6 +5,7 @@
 
 package com.liferay.ai.hub.internal.agent.util;
 
+import com.liferay.petra.concurrent.DefaultNoticeableFuture;
 import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.MapUtil;
@@ -13,7 +14,6 @@ import com.liferay.portal.kernel.workflow.WorkflowInstance;
 import java.io.Serializable;
 
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
@@ -25,21 +25,23 @@ import java.util.concurrent.TimeUnit;
 public class AgentUtil {
 
 	public static void complete(Message message) {
-		CompletableFuture<Map<String, Serializable>> completableFuture =
-			_completableFutures.remove(message.getLong("workflowInstanceId"));
+		DefaultNoticeableFuture<Map<String, Serializable>>
+			defaultNoticeableFuture = _defaultNoticeableFutures.remove(
+				message.getLong("workflowInstanceId"));
 
-		if (completableFuture != null) {
-			completableFuture.complete(
+		if (defaultNoticeableFuture != null) {
+			defaultNoticeableFuture.set(
 				(Map<String, Serializable>)message.get("workflowContext"));
 		}
 	}
 
 	public static void completeExceptionally(Message message) {
-		CompletableFuture<Map<String, Serializable>> completableFuture =
-			_completableFutures.remove(message.getLong("workflowInstanceId"));
+		DefaultNoticeableFuture<Map<String, Serializable>>
+			defaultNoticeableFuture = _defaultNoticeableFutures.remove(
+				message.getLong("workflowInstanceId"));
 
-		if (completableFuture != null) {
-			completableFuture.complete(
+		if (defaultNoticeableFuture != null) {
+			defaultNoticeableFuture.set(
 				HashMapBuilder.<String, Serializable>put(
 					"exception", (Exception)message.get("exception")
 				).build());
@@ -49,13 +51,13 @@ public class AgentUtil {
 	public static String getOutput(WorkflowInstance workflowInstance)
 		throws Exception {
 
-		CompletableFuture<Map<String, Serializable>> completableFuture =
-			new CompletableFuture<>();
+		DefaultNoticeableFuture<Map<String, Serializable>>
+			defaultNoticeableFuture = new DefaultNoticeableFuture<>();
 
-		_completableFutures.put(
-			workflowInstance.getWorkflowInstanceId(), completableFuture);
+		_defaultNoticeableFutures.put(
+			workflowInstance.getWorkflowInstanceId(), defaultNoticeableFuture);
 
-		Map<String, Serializable> workflowContext = completableFuture.get(
+		Map<String, Serializable> workflowContext = defaultNoticeableFuture.get(
 			1, TimeUnit.MINUTES);
 
 		if (workflowContext.containsKey("exception")) {
@@ -66,7 +68,7 @@ public class AgentUtil {
 	}
 
 	private static final ConcurrentMap
-		<Long, CompletableFuture<Map<String, Serializable>>>
-			_completableFutures = new ConcurrentHashMap<>();
+		<Long, DefaultNoticeableFuture<Map<String, Serializable>>>
+			_defaultNoticeableFutures = new ConcurrentHashMap<>();
 
 }

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/credential/FileWatcher.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/credential/FileWatcher.java
@@ -24,10 +24,10 @@ import java.nio.file.WatchService;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -112,8 +112,7 @@ public class FileWatcher implements Closeable {
 
 				List<WatchEvent<?>> watchEvents = watchKey.pollEvents();
 
-				List<CompletableFuture<Void>> completableFutures =
-					new ArrayList<>();
+				List<Future<?>> futures = new ArrayList<>();
 
 				for (Path path : _paths) {
 					for (WatchEvent<?> watchEvent : watchEvents) {
@@ -126,20 +125,22 @@ public class FileWatcher implements Closeable {
 							continue;
 						}
 
-						completableFutures.add(
-							CompletableFuture.runAsync(
-								() -> _consumer.accept(watchEventPath),
-								notificationsExecutorService));
+						futures.add(
+							notificationsExecutorService.submit(
+								() -> _consumer.accept(watchEventPath)));
 					}
 				}
 
-				CompletableFuture<Void> completableFuture =
-					CompletableFuture.allOf(
-						completableFutures.toArray(new CompletableFuture[0]));
-
 				try {
-					completableFuture.get(
-						notificationTimeout, notificationTimeUnit);
+					long deadline =
+						System.currentTimeMillis() +
+							notificationTimeUnit.toMillis(notificationTimeout);
+
+					for (Future<?> future : futures) {
+						future.get(
+							Math.max(0, deadline - System.currentTimeMillis()),
+							TimeUnit.MILLISECONDS);
+					}
 				}
 				catch (ExecutionException | InterruptedException |
 					   TimeoutException exception) {

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/IllegalImportsCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/IllegalImportsCheck.java
@@ -176,6 +176,20 @@ public class IllegalImportsCheck extends BaseFileCheck {
 		if (!absolutePath.contains("/modules/integrations/") &&
 			!absolutePath.contains("/modules/sdk/")) {
 
+			if (isAttributeValue(_AVOID_COMPLETABLE_FUTURE_KEY, absolutePath) &&
+				content.contains("java.util.concurrent.CompletableFuture") &&
+				!_isAllowedFileName(
+					absolutePath,
+					getAttributeValues(
+						_ALLOWED_COMPLETABLE_FUTURE_FILE_NAMES_KEY,
+						absolutePath))) {
+
+				addMessage(
+					fileName,
+					"Do not use java.util.concurrent.CompletableFuture, use " +
+						"DefaultNoticeableFuture instead");
+			}
+
 			if (isAttributeValue(_AVOID_OPTIONAL_KEY, absolutePath) &&
 				content.contains("java.util.Optional") &&
 				!_isAllowedFileName(
@@ -259,11 +273,17 @@ public class IllegalImportsCheck extends BaseFileCheck {
 		return false;
 	}
 
+	private static final String _ALLOWED_COMPLETABLE_FUTURE_FILE_NAMES_KEY =
+		"allowedCompletableFutureFileNames";
+
 	private static final String _ALLOWED_OPTIONAL_FILE_NAMES_KEY =
 		"allowedOptionalFileNames";
 
 	private static final String _ALLOWED_STREAM_FILE_NAMES_KEY =
 		"allowedStreamFileNames";
+
+	private static final String _AVOID_COMPLETABLE_FUTURE_KEY =
+		"avoidCompletableFuture";
 
 	private static final String _AVOID_OPTIONAL_KEY = "avoidOptional";
 

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -968,10 +968,23 @@
 
     source.check.IfStatementCheck.enabled=true
 
+    source.check.IllegalImportsCheck.allowedCompletableFutureFileNames=\
+        modules/apps/mail/mail-outlook-auth-connector-provider/src/main/java/com/liferay/mail/outlook/auth/connector/provider/internal/token/provider/MailOutlookMailAuthTokenProvider.java,\
+        modules/apps/portal-store/portal-store-s3/src/main/java/com/liferay/portal/store/s3/S3Store.java,\
+        modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java,\
+        modules/apps/push-notifications/push-notifications-sender/push-notifications-sender-apple/src/main/java/com/liferay/push/notifications/sender/apple/internal/ApplePushNotificationsSender.java,\
+        modules/core/shielded-container-impl/src/main/java/com/liferay/shielded/container/internal/ShieldedContainerServletContainerInitializer.java,\
+        modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/util/SseEventSourceTestUtil.java,\
+        modules/dxp/apps/sharepoint-rest/sharepoint-rest-repository/src/main/java/com/liferay/sharepoint/rest/repository/internal/document/library/repository/authorization/oauth2/SharepointRepositoryTokenBroker.java,\
+        portal-test/src/com/liferay/portal/test/cluster/tomcat/TomcatNode.java,\
+        support-tomcat/src/com/liferay/support/tomcat/session/LiferayDeltaManager.java
+
     source.check.IllegalImportsCheck.allowedOptionalFileNames=\
         modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/resource/OpenAPIResourceImpl.java,\
         modules/apps/push-notifications/push-notifications-sender/push-notifications-sender-apple/src/main/java/com/liferay/push/notifications/sender/apple/internal/ApplePushNotificationsSender.java,\
         modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-fido2-web/src/main/java/com/liferay/multi/factor/authentication/fido2/web/internal/yubico/webauthn/MFAFIDO2CredentialRepository.java
+
+    source.check.IllegalImportsCheck.avoidCompletableFuture=true
 
     source.check.IllegalImportsCheck.avoidOptional=true
 


### PR DESCRIPTION
[LPD-98379](https://liferay.atlassian.net/browse/LPD-98379)

## What Is Being Fixed

Liferay discourages the `java.util.concurrent.CompletableFuture` composition model. Internal completable promises should use `com.liferay.petra.concurrent.DefaultNoticeableFuture`, and a future forced by a third-party or platform library should be resolved to its result or exception at the boundary rather than composed on. Nothing enforced this, so raw `CompletableFuture` usage could accumulate.

## How It Is Being Fixed

Removed the removable `CompletableFuture` usages:

- `AgentUtil` (ai-hub) and `ClusterExecutorImpl` (portal-cluster-multiple) now use `DefaultNoticeableFuture`.
- `FileWatcher` (saml) now uses a plain executor `Future`, draining all futures within one overall deadline.
- The cluster license test now uses `DefaultNoticeableFuture`.

Added an `avoidCompletableFuture` rule to `IllegalImportsCheck`, mirroring the existing `avoidStream` and `avoidOptional` bans, plus an `allowedCompletableFutureFileNames` whitelist of the remaining accepted usages (library-forced futures resolved at the boundary, the genuinely asynchronous push notification sender, the cross-classloader shielded container initializer, and test and cluster infrastructure). New `CompletableFuture` usage is now rejected by the source formatter.

## PR Check

| Validation | Result |
| --- | --- |
| Source Format | pass |
| Per-Module Compile | pass |
| Integration Test Compile | pass |
| Baseline | pass (no exported API change) |

<!-- pr-check {"result":"success","sha":"c52fefc944327f3833e056810cbe33d6e379e3b7"} -->
