### PR TITLE
LPD-98052 Fix project scope selection issues in vocabularies

### DIFF
--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyVocabularyResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyVocabularyResourceImpl.java
@@ -1180,7 +1180,7 @@ public class TaxonomyVocabularyResourceImpl
 		if (FeatureFlagManagerUtil.isEnabled(companyId, "LPD-17564") &&
 			group.isCMS()) {
 
-			if (ArrayUtil.isNotEmpty(taxonomyVocabulary.getProjects())) {
+			if (taxonomyVocabulary.getProjects() != null) {
 				_assetVocabularyGroupRelLocalService.
 					setAssetVocabularyGroupRels(
 						assetVocabulary.getVocabularyId(),
@@ -1189,7 +1189,7 @@ public class TaxonomyVocabularyResourceImpl
 						DepotConstants.TYPE_PROJECT);
 			}
 
-			if (ArrayUtil.isNotEmpty(taxonomyVocabulary.getAssetLibraries())) {
+			if (taxonomyVocabulary.getAssetLibraries() != null) {
 				_assetVocabularyGroupRelLocalService.
 					setAssetVocabularyGroupRels(
 						assetVocabulary.getVocabularyId(),

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyVocabularyResourceTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyVocabularyResourceTest.java
@@ -62,9 +62,11 @@ import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -366,10 +368,25 @@ public class TaxonomyVocabularyResourceTest
 		_testPutSiteTaxonomyVocabularyByExternalReferenceCodeWithNonexistentAssetLibrary();
 	}
 
+	@FeatureFlag("LPD-17564")
 	@Override
 	@Test
 	public void testPutTaxonomyVocabulary() throws Exception {
 		super.testPutTaxonomyVocabulary();
+
+		Group originalIrrelevantGroup = irrelevantGroup;
+		Group originalTestGroup = testGroup;
+
+		_addCMSGroup();
+
+		try {
+			_testPutTaxonomyVocabularyResetsProjectScope();
+			_testPutTaxonomyVocabularyResetsSpaceScope();
+		}
+		finally {
+			irrelevantGroup = originalIrrelevantGroup;
+			testGroup = originalTestGroup;
+		}
 
 		_testPutTaxonomyVocabularyUpdatesEmptyVocabulary();
 		_testPutTaxonomyVocabularyWithoutDescription();
@@ -464,6 +481,13 @@ public class TaxonomyVocabularyResourceTest
 		testGroup = GroupTestUtil.addGroup(
 			testDepotEntryGroup.getCompanyId(), TestPropsValues.getUserId(),
 			GroupConstants.DEFAULT_PARENT_GROUP_ID, GroupConstants.CMS);
+	}
+
+	private <T> void _assertSingletonArrayEquals(
+		long expected, T[] array, Function<T, Long> function) {
+
+		Assert.assertEquals(Arrays.toString(array), 1, array.length);
+		Assert.assertEquals(Long.valueOf(expected), function.apply(array[0]));
 	}
 
 	private Project _randomProjectAssetLibrary() throws Exception {
@@ -894,6 +918,63 @@ public class TaxonomyVocabularyResourceTest
 
 		Assert.assertTrue(
 			ArrayUtil.isEmpty(putTaxonomyVocabulary.getAssetLibraries()));
+	}
+
+	private void _testPutTaxonomyVocabularyResetsProjectScope()
+		throws Exception {
+
+		Project project = _randomProjectAssetLibrary();
+
+		TaxonomyVocabulary randomTaxonomyVocabulary =
+			randomTaxonomyVocabulary();
+
+		randomTaxonomyVocabulary.setProjects(new Project[] {project});
+
+		TaxonomyVocabulary postTaxonomyVocabulary =
+			taxonomyVocabularyResource.postSiteTaxonomyVocabulary(
+				testGroup.getGroupId(), randomTaxonomyVocabulary);
+
+		_assertSingletonArrayEquals(
+			project.getId(), postTaxonomyVocabulary.getProjects(),
+			Project::getId);
+
+		postTaxonomyVocabulary.setProjects(new Project[0]);
+
+		TaxonomyVocabulary putTaxonomyVocabulary =
+			taxonomyVocabularyResource.putTaxonomyVocabulary(
+				postTaxonomyVocabulary.getId(), postTaxonomyVocabulary);
+
+		_assertSingletonArrayEquals(
+			GroupConstants.GROUP_ID_ALL, putTaxonomyVocabulary.getProjects(),
+			Project::getId);
+	}
+
+	private void _testPutTaxonomyVocabularyResetsSpaceScope() throws Exception {
+		AssetLibrary assetLibrary = _randomSpaceAssetLibrary();
+
+		TaxonomyVocabulary randomTaxonomyVocabulary =
+			randomTaxonomyVocabulary();
+
+		randomTaxonomyVocabulary.setAssetLibraries(
+			new AssetLibrary[] {assetLibrary});
+
+		TaxonomyVocabulary postTaxonomyVocabulary =
+			taxonomyVocabularyResource.postSiteTaxonomyVocabulary(
+				testGroup.getGroupId(), randomTaxonomyVocabulary);
+
+		_assertSingletonArrayEquals(
+			assetLibrary.getId(), postTaxonomyVocabulary.getAssetLibraries(),
+			AssetLibrary::getId);
+
+		postTaxonomyVocabulary.setAssetLibraries(new AssetLibrary[0]);
+
+		TaxonomyVocabulary putTaxonomyVocabulary =
+			taxonomyVocabularyResource.putTaxonomyVocabulary(
+				postTaxonomyVocabulary.getId(), postTaxonomyVocabulary);
+
+		_assertSingletonArrayEquals(
+			GroupConstants.GROUP_ID_ALL,
+			putTaxonomyVocabulary.getAssetLibraries(), AssetLibrary::getId);
 	}
 
 	private void _testPutTaxonomyVocabularyUpdatesEmptyVocabulary()

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/categorization/vocabularies/EditVocabulary.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/categorization/vocabularies/EditVocabulary.tsx
@@ -295,9 +295,10 @@ export default function EditVocabulary({
 						displayType="primary"
 						onClick={() => {
 							if (
-								assetTypeChange ||
-								projectChange ||
-								spaceChange
+								!isNew &&
+								(assetTypeChange ||
+									projectChange ||
+									spaceChange)
 							) {
 								onOpenChange(true);
 							}

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/categorization/vocabularies/EditVocabulary.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/categorization/vocabularies/EditVocabulary.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import '@testing-library/jest-dom';
+import {render, screen, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+import CategorizationPermissionService from '../../../../../src/main/resources/META-INF/resources/js/common/services/CategorizationPermissionService';
+import VocabularyService from '../../../../../src/main/resources/META-INF/resources/js/common/services/VocabularyService';
+import EditVocabulary from '../../../../../src/main/resources/META-INF/resources/js/main_view/categorization/vocabularies/EditVocabulary';
+
+jest.mock(
+	'../../../../../src/main/resources/META-INF/resources/js/common/services/VocabularyService'
+);
+jest.mock(
+	'../../../../../src/main/resources/META-INF/resources/js/common/services/CategorizationPermissionService'
+);
+
+jest.mock(
+	'../../../../../src/main/resources/META-INF/resources/js/main_view/categorization/vocabularies/EditGeneralInfo',
+	() =>
+		({onChangeVocabulary, setProjectChange}: any) => {
+			const React = require('react');
+
+			return (
+				<div>
+					<button
+						onClick={() =>
+							onChangeVocabulary((vocabulary: any) => ({
+								...vocabulary,
+								name: 'Fruits',
+							}))
+						}
+					>
+						stub-set-name
+					</button>
+
+					<button onClick={() => setProjectChange(true)}>
+						stub-change-project
+					</button>
+				</div>
+			);
+		}
+);
+
+jest.mock(
+	'../../../../../src/main/resources/META-INF/resources/js/main_view/categorization/vocabularies/EditAssociatedAssetTypes',
+	() => () => null
+);
+
+jest.mock(
+	'../../../../../src/main/resources/META-INF/resources/js/main_view/categorization/vocabularies/ConfirmChangesModal',
+	() =>
+		({open}: any) => {
+			const React = require('react');
+
+			return open ? <div data-testid="confirm-changes-modal" /> : null;
+		}
+);
+
+const defaultProps = {
+	availableAssetTypes: [],
+	backURL: '/back',
+	cmsGroupId: 123,
+	defaultLanguageId: 'en_US',
+	externalReferenceCodeMaxLength: 75,
+	locales: [],
+	spritemap: '/sprite.svg',
+	vocabularyPermissionsAPIURL: '/permissions/{taxonomyVocabularyId}',
+};
+
+describe('EditVocabulary', () => {
+	beforeEach(() => {
+		(global as any).Liferay = {
+			...(global as any).Liferay,
+			Util: {
+				...(global as any).Liferay?.Util,
+				openToast: jest.fn(),
+				sub: (str: string) => str,
+			},
+		};
+
+		(VocabularyService.createVocabulary as jest.Mock).mockResolvedValue({
+			data: {id: 1},
+			error: null,
+			status: null,
+		});
+		(VocabularyService.updateVocabulary as jest.Mock).mockResolvedValue({
+			error: null,
+			status: null,
+		});
+		(
+			CategorizationPermissionService.putPermissions as jest.Mock
+		).mockResolvedValue({error: null});
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('does not warn about project removal when creating a vocabulary', async () => {
+		const user = userEvent.setup();
+
+		render(<EditVocabulary {...defaultProps} vocabularyId={0} />);
+
+		await user.click(screen.getByText('stub-set-name'));
+		await user.click(screen.getByText('stub-change-project'));
+
+		await user.click(screen.getByRole('button', {name: 'save'}));
+
+		expect(
+			screen.queryByTestId('confirm-changes-modal')
+		).not.toBeInTheDocument();
+
+		await waitFor(() => {
+			expect(VocabularyService.createVocabulary).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	it('warns about project removal when editing a vocabulary', async () => {
+		(VocabularyService.fetchVocabulary as jest.Mock).mockResolvedValue({
+			data: {
+				assetLibraries: [],
+				assetTypes: [],
+				id: 5,
+				name: 'Fruits',
+				projects: [],
+			},
+			error: null,
+		});
+
+		const user = userEvent.setup();
+
+		render(<EditVocabulary {...defaultProps} vocabularyId={5} />);
+
+		await waitFor(() => {
+			expect(VocabularyService.fetchVocabulary).toHaveBeenCalled();
+		});
+
+		await user.click(screen.getByText('stub-change-project'));
+
+		await user.click(screen.getByRole('button', {name: 'save'}));
+
+		expect(screen.getByTestId('confirm-changes-modal')).toBeInTheDocument();
+
+		expect(VocabularyService.updateVocabulary).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98052

## What Is Being Fixed

Two problems with scope selection when managing vocabularies in the CMS categorization UI.

First, an existing vocabulary's project or space (asset library) scope could not be reset back to "all". On update, the REST resource skipped any empty projects or asset libraries array, so clearing every selection left the previous scope in place instead of resetting it.

Second, when creating a brand new vocabulary, the "unsaved scope change" warning modal was shown on save even though there was no prior scope to change.

## How It Is Being Fixed

In TaxonomyVocabularyResourceImpl, the update path now distinguishes a null array (no change) from an empty array (reset). Replacing the ArrayUtil.isNotEmpty guard with a plain null check lets an explicit empty list clear the relations, which resets the scope to all spaces or projects (GROUP_ID_ALL); a null array continues to leave the existing scope untouched.

In EditVocabulary.tsx, the warning modal is now gated behind !isNew, so it only appears when editing an existing vocabulary and never interrupts creation.

Coverage is added at both layers: a Jest suite for the EditVocabulary save behavior and integration tests in TaxonomyVocabularyResourceTest that verify clearing the projects or asset libraries resets the vocabulary to the all-scope sentinel.

## PR Check

**pr-check: PASS** — tested on `522008f0126f8733b2427893b8ed7f5111854843`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "522008f0126f8733b2427893b8ed7f5111854843"} -->
