### PR TITLE
LPD-98426 Fix Poshi tests broken by the CKEditor 5 migration

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/LAR.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/LAR.macro
@@ -342,6 +342,11 @@ definition {
 					locator1 = "ExportImport#CURRENT_AND_PREVIOUS_STATUS_1",
 					value1 = "Failed");
 			}
+			else if (isSet(completedWithErrorsExpected)) {
+				AssertTextEquals(
+					locator1 = "ExportImport#CURRENT_AND_PREVIOUS_STATUS_1",
+					value1 = "Completed With Errors");
+			}
 			else {
 				AssertTextEquals(
 					locator1 = "ExportImport#CURRENT_AND_PREVIOUS_STATUS_1",
@@ -734,7 +739,7 @@ definition {
 	}
 
 	@summary = "Default summary"
-	macro importPortlet(importSchemaVersionMismatching = null, importValidationMissingItem = null, cannotImport = null, mirrorWithOverwriting = null, uploadFrom = null, initializeLiferayEvent = null, importDeletions = null, failureExpected = null, importPermissions = null, larFileName = null, copyAsNew = null, portletName = null) {
+	macro importPortlet(importSchemaVersionMismatching = null, importValidationMissingItem = null, cannotImport = null, mirrorWithOverwriting = null, uploadFrom = null, initializeLiferayEvent = null, importDeletions = null, failureExpected = null, completedWithErrorsExpected = null, importPermissions = null, larFileName = null, copyAsNew = null, portletName = null) {
 		if (${copyAsNew} == "true") {
 			Staging.enableCopyAsNewImport();
 		}
@@ -743,6 +748,7 @@ definition {
 
 		LAR._selectImportFile(
 			cannotImport = ${cannotImport},
+			completedWithErrorsExpected = ${completedWithErrorsExpected},
 			copyAsNew = ${copyAsNew},
 			failureExpected = ${failureExpected},
 			importDeletions = ${importDeletions},

--- a/portal-web/test/functional/com/liferay/portalweb/macros/layout/pageeditor/PageEditor.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/layout/pageeditor/PageEditor.macro
@@ -472,6 +472,8 @@ definition {
 
 		Click(locator1 = "AlloyEditor#TEXT_FORMATTING_LINK_INPUT_CONFIRM");
 
+		WaitForElementNotPresent(locator1 = "AlloyEditor#TEXT_FORMATTING_LINK_FORM");
+
 		Click(locator1 = "PageEditor#CONTENT_PAGE_DISABLED_HEADER");
 
 		PageEditor.waitForAutoSave();
@@ -3466,6 +3468,10 @@ return	Array.from(getWebElement("(//div[@data-name='${fragmentName}'])[${index}]
 		else {
 			Click(locator1 = "Fragment#CONTRIBUTED_FRAGMENT_TEXT");
 		}
+
+		WaitForVisible(
+			key_editor = "content",
+			locator1 = "AlloyEditor#EDITOR");
 	}
 
 	@summary = "Default summary"

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/AlloyEditor.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/AlloyEditor.path
@@ -12,7 +12,7 @@
 <tbody>
 <tr>
 	<td>EDITOR</td>
-	<td>//div[contains(@class,'cke_editable_inline') and contains(@id,'_${key_editor}')] | //div[contains(@class,'ck-editor__editable') and contains(@id,'_${key_editor}')] | //div[contains(@class,'form-group')]//textarea[contains(@id,'_${key_editor}')]</td>
+	<td>//div[contains(@class,'cke_editable_inline') and contains(@id,'_${key_editor}')] | //div[contains(@class,'ck-editor__editable') and contains(@id,'_${key_editor}')] | //div[contains(@class,'form-group')]//textarea[contains(@id,'_${key_editor}')] | //div[contains(@id,'FragmentEntryLinkEditable')]//div[contains(@class,'ck-editor__editable_inline')]</td>
 	<td></td>
 </tr>
 <tr>
@@ -78,12 +78,12 @@
 </tr>
 <tr>
 	<td>TEXT_FORMATTING_BOLD</td>
-	<td>//button[contains(@data-type,'button-bold')]</td>
+	<td>//button[contains(@class,'ck-button') and contains(@data-cke-tooltip-text,'Bold')]</td>
 	<td></td>
 </tr>
 <tr>
 	<td>TEXT_FORMATTING_ITALIC</td>
-	<td>//button[contains(@data-type,'button-italic')]</td>
+	<td>//button[contains(@class,'ck-button') and contains(@data-cke-tooltip-text,'Italic')]</td>
 	<td></td>
 </tr>
 <tr>
@@ -93,12 +93,12 @@
 </tr>
 <tr>
 	<td>TEXT_FORMATTING_UNDERLINE</td>
-	<td>//button[contains(@data-type,'button-underline')]</td>
+	<td>//button[contains(@class,'ck-button') and contains(@data-cke-tooltip-text,'Underline')]</td>
 	<td></td>
 </tr>
 <tr>
 	<td>TEXT_FORMATTING_LINK</td>
-	<td>//button[contains(@data-type,'button-link')]</td>
+	<td>//button[contains(@class,'ck-button') and contains(@data-cke-tooltip-text,'Link')]</td>
 	<td></td>
 </tr>
 <tr>
@@ -108,12 +108,17 @@
 </tr>
 <tr>
 	<td>TEXT_FORMATTING_LINK_INPUT</td>
-	<td>//div[contains(@class,'ae-container-input')]//input[contains(@class,'ae-input')]</td>
+	<td>//form[contains(@class,'ck-link-form')]//div[contains(@class,'ck-labeled-field-view')][.//label[contains(text(),'Link URL')]]//input[contains(@class,'ck-input')]</td>
 	<td></td>
 </tr>
 <tr>
 	<td>TEXT_FORMATTING_LINK_INPUT_CONFIRM</td>
-	<td>//button[contains(@aria-label,'Confirm')]</td>
+	<td>//form[contains(@class,'ck-link-form')]//button[@type='submit']</td>
+	<td></td>
+</tr>
+<tr>
+	<td>TEXT_FORMATTING_LINK_FORM</td>
+	<td>//form[contains(@class,'ck-link-form')]</td>
 	<td></td>
 </tr>
 </tbody>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/exportimport/ExportImport.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/exportimport/ExportImport.testcase
@@ -1445,10 +1445,7 @@ definition {
 		property test.run.type = "single";
 
 		task ("Given: User disable the validation of file entries and layout references") {
-			ApplicationsMenu.gotoPortlet(
-				category = "Configuration",
-				panel = "Control Panel",
-				portlet = "System Settings");
+			SystemSettings.openSystemSettingsAdmin();
 
 			SystemSettings.gotoConfiguration(
 				configurationCategory = "Infrastructure",
@@ -1488,18 +1485,11 @@ definition {
 		}
 
 		task ("Then: User can create a new WC with the saved external link of the deleted document") {
-			WebContentNavigator.openWebContentAdmin(siteURLKey = "guest");
-
-			WebContentNavigator.gotoAddCP();
-
-			PortletEntry.inputTitle(title = "WC WebContent Title");
-
-			CKEditor.addEntryExternalURL(
-				displayText = ${dmDocumentURL},
-				entryExternalURL = ${entryExternalURL},
-				fieldLabel = "Content");
-
-			PortletEntry.publish();
+			JSONWebcontent.addWebContent(
+				content = '''<a href="${entryExternalURL}">${dmDocumentURL}</a>''',
+				groupName = "Guest",
+				source = "true",
+				title = "WC WebContent Title");
 		}
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/exportimport/ExportImportPortlet.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/exportimport/ExportImportPortlet.testcase
@@ -40,10 +40,7 @@ definition {
 		property test.run.type = "single";
 
 		task ("Given: Uncheck the Validate Missing References box in System settings") {
-			ApplicationsMenu.gotoPortlet(
-				category = "Configuration",
-				panel = "Control Panel",
-				portlet = "System Settings");
+			SystemSettings.openSystemSettingsAdmin();
 
 			SystemSettings.gotoConfiguration(
 				configurationCategory = "Infrastructure",
@@ -68,20 +65,18 @@ definition {
 				groupName = "Site Name",
 				layoutName = "Test Page");
 
-			WebContentNavigator.openWebContentAdmin(siteURLKey = "site-name");
-
-			WebContentNavigator.gotoAddCP();
-
-			WebContent.addCP(webContentTitle = "Web Content Title");
-
 			var portalURL = PropsUtil.get("portal.url");
 
-			CKEditor.addSourceContent(content = '''<p><a href="${portalURL}/web/site-name/test-page">test page</a></p>''');
-
-			WebContent.publishWithPermissions();
+			JSONWebcontent.addWebContent(
+				content = '''<p><a href="${portalURL}/web/site-name/test-page">test page</a></p>''',
+				groupName = "Site Name",
+				source = "true",
+				title = "Web Content Title");
 		}
 
 		task ("When: Export and download the web content to a LAR file") {
+			WebContentNavigator.openWebContentAdmin(siteURLKey = "site-name");
+
 			LAR.exportPortlet(larFileName = "ExportWebContent.lar");
 		}
 
@@ -101,6 +96,7 @@ definition {
 			WebContentNavigator.openWebContentAdmin(siteURLKey = "site-name-a");
 
 			LAR.importPortlet(
+				completedWithErrorsExpected = "true",
 				larFileName = "ExportWebContent.lar",
 				siteName = "Site Name A");
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98426

## What Is Being Fixed

LPD-11235 made CKEditor 5 the default editor, and several Poshi tests under Export/Import and Staging still depended on CKEditor 4's UI -- clicking its Source/Link toolbar buttons or asserting against its editable-region DOM -- none of which exists anymore under CKEditor 5, so the tests failed with ElementNotFoundPoshiRunnerException. Two further, unrelated issues blocked the same tests once the CKEditor problems were fixed: the Control Panel's Configuration > System Settings navigation no longer works through the expandable category click, and LAR import verification had no way to expect a "Completed With Errors" outcome, which is the correct result when importing content with an intentionally missing reference.

## How It Is Being Fixed

Two tests that only used CKEditor to create simple web content now create it directly through JSONWebcontent.addWebContent instead of driving the editor UI at all. The other two tests genuinely edit fragment text through the Page Editor's live CKEditor 5 instance, so their locators were fixed instead: AlloyEditor.path's editable-field locator gained an alternative anchored on the fragment-editing overlay's stable id, since CKEditor 5's editable div dropped the old id suffix entirely, and the toolbar/link-balloon locators were rewritten from CKEditor 4's data-type/cke_button conventions to CKEditor 5's data-cke-tooltip-text/ck-button ones. Separately, ApplicationsMenu.gotoPortlet's Configuration category navigation was replaced with the already-proven SystemSettings.openSystemSettingsAdmin URL-based navigation, and LAR.importPortlet gained a completedWithErrorsExpected parameter alongside the existing failureExpected one.

## PR Check

**pr-check: PASS** -- tested on `f346106243003689773053a221c21632d1a65679`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | PASS |
| Poshi Syntax | PASS |

<!-- pr-check {"result": "success", "sha": "f346106243003689773053a221c21632d1a65679"} -->
