### PR TITLE
LPD-98327 Prevent ClassCastException when publishing localized inputs

### DIFF
--- a/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/input/template/parser/FragmentEntryInputTemplateNodeContextHelperImpl.java
+++ b/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/input/template/parser/FragmentEntryInputTemplateNodeContextHelperImpl.java
@@ -1004,6 +1004,11 @@ public class FragmentEntryInputTemplateNodeContextHelperImpl
 			infoField.getUniqueId());
 
 		if (!(infoParameterMapValue instanceof RelatedInfoFieldValue<?>)) {
+			if (infoParameterMapValue instanceof Map) {
+				return _parseLocalizedValues(
+					infoField, (Map<Locale, ?>)infoParameterMapValue);
+			}
+
 			return infoParameterMapValue;
 		}
 
@@ -1053,7 +1058,8 @@ public class FragmentEntryInputTemplateNodeContextHelperImpl
 			InfoLocalizedValue<?> infoLocalizedValue =
 				(InfoLocalizedValue<?>)value;
 
-			return infoLocalizedValue.getValues();
+			return _parseLocalizedValues(
+				infoField, infoLocalizedValue.getValues());
 		}
 
 		return String.valueOf(value);
@@ -1282,6 +1288,23 @@ public class FragmentEntryInputTemplateNodeContextHelperImpl
 		}
 
 		return false;
+	}
+
+	private Map<Locale, String> _parseLocalizedValues(
+		InfoField infoField, Map<Locale, ?> values) {
+
+		Map<Locale, String> localizedValues = new HashMap<>();
+
+		for (Map.Entry<Locale, ?> entry : values.entrySet()) {
+			localizedValues.put(
+				entry.getKey(),
+				String.valueOf(
+					_parseValue(
+						StringPool.BLANK, infoField, entry.getKey(),
+						entry.getValue())));
+		}
+
+		return localizedValues;
 	}
 
 	private Object _parseValue(

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/input/template/parser/test/FragmentEntryInputTemplateNodeContextHelperTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/input/template/parser/test/FragmentEntryInputTemplateNodeContextHelperTest.java
@@ -63,6 +63,7 @@ import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.servlet.SessionMessages;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.constants.TestDataConstants;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
@@ -163,6 +164,64 @@ public class FragmentEntryInputTemplateNodeContextHelperTest {
 				"myText", RandomTestUtil.randomString()
 			).build(),
 			ServiceContextTestUtil.getServiceContext());
+	}
+
+	@Test
+	@TestInfo("LPD-98327")
+	public void testToInputTemplateNodeWithBooleanInfoFieldType()
+		throws Exception {
+
+		HttpServletRequest httpServletRequest = _getHttpServletRequest();
+
+		SessionMessages.add(
+			httpServletRequest, "infoFormParameterMap",
+			HashMapBuilder.<String, Object>put(
+				"ObjectField_myBoolean",
+				HashMapBuilder.<Locale, Object>put(
+					LocaleUtil.SPAIN, Boolean.TRUE
+				).put(
+					LocaleUtil.US, Boolean.FALSE
+				).build()
+			).build());
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				_group, TestPropsValues.getUserId());
+
+		serviceContext.setRequest(httpServletRequest);
+
+		InfoItemFormProvider<?> infoItemFormProvider =
+			_infoItemServiceRegistry.getFirstInfoItemService(
+				InfoItemFormProvider.class, _objectDefinition.getClassName());
+
+		try {
+			ServiceContextThreadLocal.pushServiceContext(serviceContext);
+
+			InputTemplateNode inputTemplateNode =
+				_fragmentEntryInputTemplateNodeContextHelper.
+					toInputTemplateNode(
+						Collections.emptyMap(), "Default",
+						_addInputFragmentEntryLink("myBoolean"),
+						httpServletRequest,
+						infoItemFormProvider.getInfoForm(
+							StringPool.BLANK, _group.getGroupId()),
+						LocaleUtil.getSiteDefault());
+
+			Assert.assertEquals(
+				Boolean.FALSE.toString(), inputTemplateNode.getInputValue());
+			Assert.assertEquals(
+				HashMapBuilder.put(
+					LocaleUtil.toLanguageId(LocaleUtil.SPAIN),
+					Boolean.TRUE.toString()
+				).put(
+					LocaleUtil.toLanguageId(LocaleUtil.US),
+					Boolean.FALSE.toString()
+				).build(),
+				inputTemplateNode.getValueI18n());
+		}
+		finally {
+			ServiceContextThreadLocal.popServiceContext();
+		}
 	}
 
 	@Test

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/input/template/parser/test/FragmentEntryInputTemplateNodeContextHelperTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/input/template/parser/test/FragmentEntryInputTemplateNodeContextHelperTest.java
@@ -166,214 +166,9 @@ public class FragmentEntryInputTemplateNodeContextHelperTest {
 	}
 
 	@Test
-	public void testGetMultiselectPicklistSelectInfoFieldTypeValue()
+	public void testToInputTemplateNodeWithLocalizedInputValue()
 		throws Exception {
 
-		ListTypeEntry listTypeEntry2 = _listTypeEntries.get(1);
-		ListTypeEntry listTypeEntry3 = _listTypeEntries.get(2);
-
-		_assertInputTemplateNodeInputValue(
-			listTypeEntry2.getKey() + StringPool.COMMA +
-				listTypeEntry3.getKey(),
-			"ObjectField_myMultiselectPicklist");
-	}
-
-	@Test
-	public void testGetPicklistSelectInfoFieldTypeValue() throws Exception {
-		ListTypeEntry listTypeEntry = _listTypeEntries.get(0);
-
-		_assertInputTemplateNodeInputValue(
-			listTypeEntry.getKey(), "ObjectField_myPicklist");
-	}
-
-	@Test
-	public void testGetRelationshipInfoFieldTypeValue() throws Exception {
-		ObjectDefinition objectDefinition =
-			ObjectDefinitionTestUtil.publishObjectDefinition(
-				"ObjectDefinition",
-				Collections.singletonList(
-					ObjectFieldUtil.createObjectField(
-						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
-						ObjectFieldConstants.DB_TYPE_STRING, "myText", "myText",
-						false)),
-				ObjectDefinitionConstants.SCOPE_SITE);
-
-		ObjectRelationship objectRelationship =
-			ObjectRelationshipTestUtil.addObjectRelationship(
-				_objectRelationshipLocalService, _objectDefinition,
-				objectDefinition);
-
-		String relationshipObjectFieldName = StringBundler.concat(
-			"r_", StringUtil.toLowerCase(objectRelationship.getName()),
-			"_c_customObjectDefinitionId");
-
-		ObjectEntry objectEntry = _objectEntryLocalService.addObjectEntry(
-			_group.getGroupId(), TestPropsValues.getUserId(),
-			objectDefinition.getObjectDefinitionId(),
-			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
-			null,
-			HashMapBuilder.<String, Serializable>put(
-				relationshipObjectFieldName, _objectEntry.getObjectEntryId()
-			).put(
-				"myText", RandomTestUtil.randomString()
-			).build(),
-			ServiceContextTestUtil.getServiceContext());
-
-		HttpServletRequest httpServletRequest = _getHttpServletRequest();
-
-		LayoutDisplayPageProvider<?> layoutDisplayPageProvider =
-			_layoutDisplayPageProviderRegistry.
-				getLayoutDisplayPageProviderByClassName(
-					objectDefinition.getCompanyId(),
-					objectDefinition.getClassName());
-
-		httpServletRequest.setAttribute(
-			LayoutDisplayPageWebKeys.LAYOUT_DISPLAY_PAGE_OBJECT_PROVIDER,
-			layoutDisplayPageProvider.getLayoutDisplayPageObjectProvider(
-				new InfoItemReference(
-					objectDefinition.getClassName(),
-					objectEntry.getObjectEntryId())));
-
-		ServiceContext serviceContext =
-			ServiceContextTestUtil.getServiceContext(
-				_group, TestPropsValues.getUserId());
-
-		serviceContext.setRequest(httpServletRequest);
-
-		InfoItemFormProvider<?> infoItemFormProvider =
-			_infoItemServiceRegistry.getFirstInfoItemService(
-				InfoItemFormProvider.class, objectDefinition.getClassName());
-
-		try {
-			ServiceContextThreadLocal.pushServiceContext(serviceContext);
-
-			InputTemplateNode inputTemplateNode =
-				_fragmentEntryInputTemplateNodeContextHelper.
-					toInputTemplateNode(
-						Collections.emptyMap(), "Default",
-						_addInputFragmentEntryLink(
-							"ObjectField_" + relationshipObjectFieldName),
-						httpServletRequest,
-						infoItemFormProvider.getInfoForm(
-							StringPool.BLANK, _group.getGroupId()),
-						LocaleUtil.getSiteDefault());
-
-			Map<String, Object> attributes = inputTemplateNode.getAttributes();
-
-			Assert.assertEquals(
-				_objectEntry.getTitleValue(),
-				attributes.get("selectedOptionLabel"));
-			Assert.assertEquals(
-				String.valueOf(_objectEntry.getObjectEntryId()),
-				attributes.get("selectedOptionValue"));
-		}
-		finally {
-			ServiceContextThreadLocal.popServiceContext();
-		}
-	}
-
-	@Test
-	public void testGetRichTextSelectInfoFieldTypeValueWithInfoParametersMap()
-		throws Exception {
-
-		HttpServletRequest httpServletRequest = _getHttpServletRequest();
-
-		Map<Locale, String> localeMap = HashMapBuilder.put(
-			LocaleUtil.SPAIN, RandomTestUtil.randomString()
-		).put(
-			LocaleUtil.US, RandomTestUtil.randomString()
-		).build();
-
-		SessionMessages.add(
-			httpServletRequest, "infoFormParameterMap",
-			HashMapBuilder.<String, Object>put(
-				"ObjectField_myRichText", localeMap
-			).build());
-
-		ServiceContext serviceContext =
-			ServiceContextTestUtil.getServiceContext(
-				_group, TestPropsValues.getUserId());
-
-		serviceContext.setRequest(httpServletRequest);
-
-		InfoItemFormProvider<?> infoItemFormProvider =
-			_infoItemServiceRegistry.getFirstInfoItemService(
-				InfoItemFormProvider.class, _objectDefinition.getClassName());
-
-		try {
-			ServiceContextThreadLocal.pushServiceContext(serviceContext);
-
-			InputTemplateNode inputTemplateNode =
-				_fragmentEntryInputTemplateNodeContextHelper.
-					toInputTemplateNode(
-						Collections.emptyMap(), "Default",
-						_addInputFragmentEntryLink("myRichText"),
-						httpServletRequest,
-						infoItemFormProvider.getInfoForm(
-							StringPool.BLANK, _group.getGroupId()),
-						LocaleUtil.getSiteDefault());
-
-			Assert.assertEquals(
-				localeMap.get(LocaleUtil.getSiteDefault()),
-				inputTemplateNode.getInputValue());
-			Assert.assertEquals(
-				LocalizedMapUtil.getLanguageIdMap(localeMap),
-				inputTemplateNode.getValueI18n());
-		}
-		finally {
-			ServiceContextThreadLocal.popServiceContext();
-		}
-	}
-
-	@Test
-	public void testGetTextSelectInfoFieldTypeValueWithInfoParametersMap()
-		throws Exception {
-
-		HttpServletRequest httpServletRequest = _getHttpServletRequest();
-
-		String value = RandomTestUtil.randomString();
-
-		SessionMessages.add(
-			httpServletRequest, "infoFormParameterMap",
-			HashMapBuilder.<String, Object>put(
-				"ObjectField_myText", value
-			).build());
-
-		ServiceContext serviceContext =
-			ServiceContextTestUtil.getServiceContext(
-				_group, TestPropsValues.getUserId());
-
-		serviceContext.setRequest(httpServletRequest);
-
-		InfoItemFormProvider<?> infoItemFormProvider =
-			_infoItemServiceRegistry.getFirstInfoItemService(
-				InfoItemFormProvider.class, _objectDefinition.getClassName());
-
-		try {
-			ServiceContextThreadLocal.pushServiceContext(serviceContext);
-
-			InputTemplateNode inputTemplateNode =
-				_fragmentEntryInputTemplateNodeContextHelper.
-					toInputTemplateNode(
-						Collections.emptyMap(), "Default",
-						_addInputFragmentEntryLink("myText"),
-						httpServletRequest,
-						infoItemFormProvider.getInfoForm(
-							StringPool.BLANK, _group.getGroupId()),
-						LocaleUtil.getSiteDefault());
-
-			Assert.assertEquals(value, inputTemplateNode.getInputValue());
-
-			Assert.assertEquals(
-				Collections.emptyMap(), inputTemplateNode.getValueI18n());
-		}
-		finally {
-			ServiceContextThreadLocal.popServiceContext();
-		}
-	}
-
-	@Test
-	public void testToInputTemplateNodeLocalizedInputValue() throws Exception {
 		ObjectDefinition objectDefinition =
 			ObjectDefinitionTestUtil.publishObjectDefinition(
 				ListUtil.fromArray(
@@ -622,6 +417,217 @@ public class FragmentEntryInputTemplateNodeContextHelperTest {
 			).put(
 				LocaleUtil.US, enValue
 			).build());
+	}
+
+	@Test
+	public void testToInputTemplateNodeWithMultiselectPicklistSelectInfoFieldType()
+		throws Exception {
+
+		ListTypeEntry listTypeEntry2 = _listTypeEntries.get(1);
+		ListTypeEntry listTypeEntry3 = _listTypeEntries.get(2);
+
+		_assertInputTemplateNodeInputValue(
+			listTypeEntry2.getKey() + StringPool.COMMA +
+				listTypeEntry3.getKey(),
+			"ObjectField_myMultiselectPicklist");
+	}
+
+	@Test
+	public void testToInputTemplateNodeWithPicklistSelectInfoFieldType()
+		throws Exception {
+
+		ListTypeEntry listTypeEntry = _listTypeEntries.get(0);
+
+		_assertInputTemplateNodeInputValue(
+			listTypeEntry.getKey(), "ObjectField_myPicklist");
+	}
+
+	@Test
+	public void testToInputTemplateNodeWithRelationshipInfoFieldType()
+		throws Exception {
+
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				"ObjectDefinition",
+				Collections.singletonList(
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+						ObjectFieldConstants.DB_TYPE_STRING, "myText", "myText",
+						false)),
+				ObjectDefinitionConstants.SCOPE_SITE);
+
+		ObjectRelationship objectRelationship =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				_objectRelationshipLocalService, _objectDefinition,
+				objectDefinition);
+
+		String relationshipObjectFieldName = StringBundler.concat(
+			"r_", StringUtil.toLowerCase(objectRelationship.getName()),
+			"_c_customObjectDefinitionId");
+
+		ObjectEntry objectEntry = _objectEntryLocalService.addObjectEntry(
+			_group.getGroupId(), TestPropsValues.getUserId(),
+			objectDefinition.getObjectDefinitionId(),
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			null,
+			HashMapBuilder.<String, Serializable>put(
+				relationshipObjectFieldName, _objectEntry.getObjectEntryId()
+			).put(
+				"myText", RandomTestUtil.randomString()
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		HttpServletRequest httpServletRequest = _getHttpServletRequest();
+
+		LayoutDisplayPageProvider<?> layoutDisplayPageProvider =
+			_layoutDisplayPageProviderRegistry.
+				getLayoutDisplayPageProviderByClassName(
+					objectDefinition.getCompanyId(),
+					objectDefinition.getClassName());
+
+		httpServletRequest.setAttribute(
+			LayoutDisplayPageWebKeys.LAYOUT_DISPLAY_PAGE_OBJECT_PROVIDER,
+			layoutDisplayPageProvider.getLayoutDisplayPageObjectProvider(
+				new InfoItemReference(
+					objectDefinition.getClassName(),
+					objectEntry.getObjectEntryId())));
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				_group, TestPropsValues.getUserId());
+
+		serviceContext.setRequest(httpServletRequest);
+
+		InfoItemFormProvider<?> infoItemFormProvider =
+			_infoItemServiceRegistry.getFirstInfoItemService(
+				InfoItemFormProvider.class, objectDefinition.getClassName());
+
+		try {
+			ServiceContextThreadLocal.pushServiceContext(serviceContext);
+
+			InputTemplateNode inputTemplateNode =
+				_fragmentEntryInputTemplateNodeContextHelper.
+					toInputTemplateNode(
+						Collections.emptyMap(), "Default",
+						_addInputFragmentEntryLink(
+							"ObjectField_" + relationshipObjectFieldName),
+						httpServletRequest,
+						infoItemFormProvider.getInfoForm(
+							StringPool.BLANK, _group.getGroupId()),
+						LocaleUtil.getSiteDefault());
+
+			Map<String, Object> attributes = inputTemplateNode.getAttributes();
+
+			Assert.assertEquals(
+				_objectEntry.getTitleValue(),
+				attributes.get("selectedOptionLabel"));
+			Assert.assertEquals(
+				String.valueOf(_objectEntry.getObjectEntryId()),
+				attributes.get("selectedOptionValue"));
+		}
+		finally {
+			ServiceContextThreadLocal.popServiceContext();
+		}
+	}
+
+	@Test
+	public void testToInputTemplateNodeWithRichTextSelectInfoFieldType()
+		throws Exception {
+
+		HttpServletRequest httpServletRequest = _getHttpServletRequest();
+
+		Map<Locale, String> localeMap = HashMapBuilder.put(
+			LocaleUtil.SPAIN, RandomTestUtil.randomString()
+		).put(
+			LocaleUtil.US, RandomTestUtil.randomString()
+		).build();
+
+		SessionMessages.add(
+			httpServletRequest, "infoFormParameterMap",
+			HashMapBuilder.<String, Object>put(
+				"ObjectField_myRichText", localeMap
+			).build());
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				_group, TestPropsValues.getUserId());
+
+		serviceContext.setRequest(httpServletRequest);
+
+		InfoItemFormProvider<?> infoItemFormProvider =
+			_infoItemServiceRegistry.getFirstInfoItemService(
+				InfoItemFormProvider.class, _objectDefinition.getClassName());
+
+		try {
+			ServiceContextThreadLocal.pushServiceContext(serviceContext);
+
+			InputTemplateNode inputTemplateNode =
+				_fragmentEntryInputTemplateNodeContextHelper.
+					toInputTemplateNode(
+						Collections.emptyMap(), "Default",
+						_addInputFragmentEntryLink("myRichText"),
+						httpServletRequest,
+						infoItemFormProvider.getInfoForm(
+							StringPool.BLANK, _group.getGroupId()),
+						LocaleUtil.getSiteDefault());
+
+			Assert.assertEquals(
+				localeMap.get(LocaleUtil.getSiteDefault()),
+				inputTemplateNode.getInputValue());
+			Assert.assertEquals(
+				LocalizedMapUtil.getLanguageIdMap(localeMap),
+				inputTemplateNode.getValueI18n());
+		}
+		finally {
+			ServiceContextThreadLocal.popServiceContext();
+		}
+	}
+
+	@Test
+	public void testToInputTemplateNodeWithTextSelectInfoFieldType()
+		throws Exception {
+
+		HttpServletRequest httpServletRequest = _getHttpServletRequest();
+
+		String value = RandomTestUtil.randomString();
+
+		SessionMessages.add(
+			httpServletRequest, "infoFormParameterMap",
+			HashMapBuilder.<String, Object>put(
+				"ObjectField_myText", value
+			).build());
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				_group, TestPropsValues.getUserId());
+
+		serviceContext.setRequest(httpServletRequest);
+
+		InfoItemFormProvider<?> infoItemFormProvider =
+			_infoItemServiceRegistry.getFirstInfoItemService(
+				InfoItemFormProvider.class, _objectDefinition.getClassName());
+
+		try {
+			ServiceContextThreadLocal.pushServiceContext(serviceContext);
+
+			InputTemplateNode inputTemplateNode =
+				_fragmentEntryInputTemplateNodeContextHelper.
+					toInputTemplateNode(
+						Collections.emptyMap(), "Default",
+						_addInputFragmentEntryLink("myText"),
+						httpServletRequest,
+						infoItemFormProvider.getInfoForm(
+							StringPool.BLANK, _group.getGroupId()),
+						LocaleUtil.getSiteDefault());
+
+			Assert.assertEquals(value, inputTemplateNode.getInputValue());
+
+			Assert.assertEquals(
+				Collections.emptyMap(), inputTemplateNode.getValueI18n());
+		}
+		finally {
+			ServiceContextThreadLocal.popServiceContext();
+		}
 	}
 
 	private DLFileEntry _addDLFileEntry() throws Exception {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98327

## What Is Being Fixed

Publishing a fragment input whose value resolves to a localized map threw a ClassCastException. When an input parameter was neither a RelatedInfoFieldValue nor a plain scalar, the helper returned the raw localized Map, and downstream publishing code that expected String values cast it and failed. Localized boolean inputs were the reproducible trigger.

## How It Is Being Fixed

Localized values are normalized before being returned. A new _parseLocalizedValues method walks each locale entry, runs the value through the existing _parseValue conversion, and stores the String result. Both the localized-value branch and the map-valued parameter branch now route through this method, so every locale's value is published as a String.

## PR Check

**pr-check: PASS** — tested on `3e707f7a515f7a5e3686a1324fa5bdeec9a6bd61`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "3e707f7a515f7a5e3686a1324fa5bdeec9a6bd61"} -->
