### PR TITLE
LPD-98300 Enable LPS-178052 feature flag in elementVariations test

### DIFF
--- a/modules/test/playwright/tests/layout-content-page-editor-web/main/elementVariations.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/main/elementVariations.spec.ts
@@ -23,6 +23,7 @@ const test = mergeTests(
 	dataApiHelpersTest,
 	featureFlagsTest({
 		'LPD-85746': {enabled: true},
+		'LPS-178052': {enabled: true},
 	}),
 	isolatedSiteTest,
 	loginTest(),


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98300

## What Is Being Fixed

The elementVariations Playwright test did not exercise the behavior gated behind the LPS-178052 feature flag, so that path was left uncovered.

## How It Is Being Fixed

The LPS-178052 feature flag is enabled in the test's featureFlagsTest set, alongside the existing LPD-85746 flag, so the elementVariations scenarios run with the flag on.

## Why Are There No Tests?

This change is itself a test-only change. It enables the LPS-178052 feature flag in the existing elementVariations Playwright spec so the suite covers the flagged behavior, so no additional test is warranted.

## PR Check

**pr-check: PASS** — tested on `e6d8abd6d3e4ca2169d0b306aa7244de915c22d7`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "e6d8abd6d3e4ca2169d0b306aa7244de915c22d7"} -->
