### PR TITLE
LPD-98534 Add a source check banning catches that convert a lookup's not-found exception into the absence sentinel

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-image-service/src/main/java/com/liferay/adaptive/media/image/internal/exportimport/content/processor/AMImageHTMLExportImportContentProcessor.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-service/src/main/java/com/liferay/adaptive/media/image/internal/exportimport/content/processor/AMImageHTMLExportImportContentProcessor.java
@@ -100,17 +100,8 @@ public class AMImageHTMLExportImportContentProcessor
 		}
 	}
 
-	private FileEntry _getFileEntry(long fileEntryId) {
-		try {
-			return _dlAppLocalService.getFileEntry(fileEntryId);
-		}
-		catch (PortalException portalException) {
-			if (_log.isWarnEnabled()) {
-				_log.warn(portalException);
-			}
-
-			return null;
-		}
+	private FileEntry _getFileEntry(long fileEntryId) throws Exception {
+		return _dlAppLocalService.fetchFileEntry(fileEntryId);
 	}
 
 	private Document _parseDocument(String html) {

--- a/modules/apps/adaptive-media/adaptive-media-image-service/src/main/java/com/liferay/adaptive/media/image/internal/exportimport/content/processor/AMImageHTMLExportImportContentProcessor.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-service/src/main/java/com/liferay/adaptive/media/image/internal/exportimport/content/processor/AMImageHTMLExportImportContentProcessor.java
@@ -100,10 +100,6 @@ public class AMImageHTMLExportImportContentProcessor
 		}
 	}
 
-	private FileEntry _getFileEntry(long fileEntryId) throws Exception {
-		return _dlAppLocalService.fetchFileEntry(fileEntryId);
-	}
-
 	private Document _parseDocument(String html) {
 		Document document = Jsoup.parseBodyFragment(html);
 
@@ -143,7 +139,8 @@ public class AMImageHTMLExportImportContentProcessor
 
 			long fileEntryId = amEmbeddedReferenceSet.importReference(path);
 
-			FileEntry fileEntry = _getFileEntry(fileEntryId);
+			FileEntry fileEntry = _dlAppLocalService.fetchFileEntry(
+				fileEntryId);
 
 			if (fileEntry == null) {
 				continue;

--- a/modules/apps/commerce/commerce-media-impl/src/main/java/com/liferay/commerce/media/internal/servlet/CommerceMediaServlet.java
+++ b/modules/apps/commerce/commerce-media-impl/src/main/java/com/liferay/commerce/media/internal/servlet/CommerceMediaServlet.java
@@ -156,17 +156,8 @@ public class CommerceMediaServlet extends HttpServlet {
 		return _getFileEntry(cpAttachmentFileEntry.getFileEntryId());
 	}
 
-	private FileEntry _getFileEntry(long fileEntryId) {
-		try {
-			return _dlAppLocalService.getFileEntry(fileEntryId);
-		}
-		catch (PortalException portalException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(portalException);
-			}
-
-			return null;
-		}
+	private FileEntry _getFileEntry(long fileEntryId) throws PortalException {
+		return _dlAppLocalService.fetchFileEntry(fileEntryId);
 	}
 
 	private long _getGroupId(

--- a/modules/apps/commerce/commerce-media-impl/src/main/java/com/liferay/commerce/media/internal/servlet/CommerceMediaServlet.java
+++ b/modules/apps/commerce/commerce-media-impl/src/main/java/com/liferay/commerce/media/internal/servlet/CommerceMediaServlet.java
@@ -153,11 +153,8 @@ public class CommerceMediaServlet extends HttpServlet {
 			_cpAttachmentFileEntryLocalService.getCPAttachmentFileEntry(
 				GetterUtil.getLongStrict(cpAttachmentFileEntryIdParam));
 
-		return _getFileEntry(cpAttachmentFileEntry.getFileEntryId());
-	}
-
-	private FileEntry _getFileEntry(long fileEntryId) throws PortalException {
-		return _dlAppLocalService.fetchFileEntry(fileEntryId);
+		return _dlAppLocalService.fetchFileEntry(
+			cpAttachmentFileEntry.getFileEntryId());
 	}
 
 	private long _getGroupId(
@@ -328,7 +325,8 @@ public class CommerceMediaServlet extends HttpServlet {
 					return;
 				}
 
-				FileEntry fileEntry = _getFileEntry(fileEntryId);
+				FileEntry fileEntry = _dlAppLocalService.fetchFileEntry(
+					fileEntryId);
 
 				if (fileEntry == null) {
 					_sendError(
@@ -620,7 +618,7 @@ public class CommerceMediaServlet extends HttpServlet {
 					return;
 				}
 
-				fileEntry = _getFileEntry(fileEntryId);
+				fileEntry = _dlAppLocalService.fetchFileEntry(fileEntryId);
 			}
 
 			ServletResponseUtil.sendFile(

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/FileEntryStagedModelDataHandler.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/FileEntryStagedModelDataHandler.java
@@ -153,7 +153,7 @@ public class FileEntryStagedModelDataHandler
 		String uuid, long groupId) {
 
 		try {
-			return _dlAppLocalService.getFileEntryByUuidAndGroupId(
+			return _dlAppLocalService.fetchFileEntryByUuidAndGroupId(
 				uuid, groupId);
 		}
 		catch (PortalException portalException) {

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/FileShortcutStagedModelDataHandler.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/FileShortcutStagedModelDataHandler.java
@@ -259,7 +259,7 @@ public class FileShortcutStagedModelDataHandler
 
 	private FileEntry _fetchFileEntry(long fileEntryId) {
 		try {
-			return _dlAppLocalService.getFileEntry(fileEntryId);
+			return _dlAppLocalService.fetchFileEntry(fileEntryId);
 		}
 		catch (PortalException portalException) {
 			if (_log.isWarnEnabled()) {

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/PublishFolderMVCActionCommand.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/PublishFolderMVCActionCommand.java
@@ -70,7 +70,7 @@ public class PublishFolderMVCActionCommand extends BaseMVCActionCommand {
 
 	private Folder _getFolder(long folderId) {
 		try {
-			return _dlAppLocalService.getFolder(folderId);
+			return _dlAppLocalService.fetchFolder(folderId);
 		}
 		catch (PortalException portalException) {
 			if (_log.isWarnEnabled()) {

--- a/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/input/template/parser/FragmentEntryInputTemplateNodeContextHelperImpl.java
+++ b/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/input/template/parser/FragmentEntryInputTemplateNodeContextHelperImpl.java
@@ -822,7 +822,7 @@ public class FragmentEntryInputTemplateNodeContextHelperImpl
 
 	private FileEntry _fetchFileEntry(long fileEntryId) {
 		try {
-			return _dlAppLocalService.getFileEntry(fileEntryId);
+			return _dlAppLocalService.fetchFileEntry(fileEntryId);
 		}
 		catch (PortalException portalException) {
 			if (_log.isWarnEnabled()) {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/converter/SharedAssetDTOConverter.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/converter/SharedAssetDTOConverter.java
@@ -301,7 +301,9 @@ public class SharedAssetDTOConverter
 		return fileEntry;
 	}
 
-	private String _getMimeType(SharingEntry sharingEntry) {
+	private String _getMimeType(SharingEntry sharingEntry)
+		throws PortalException {
+
 		if (StringUtil.equals(
 				ObjectEntryFolder.class.getName(),
 				sharingEntry.getClassName())) {
@@ -357,16 +359,10 @@ public class SharedAssetDTOConverter
 			return null;
 		}
 
-		com.liferay.portal.kernel.repository.model.FileEntry fileEntry = null;
+		com.liferay.portal.kernel.repository.model.FileEntry fileEntry =
+			_dlAppLocalService.fetchFileEntry(file);
 
-		try {
-			fileEntry = _dlAppLocalService.getFileEntry(file);
-		}
-		catch (PortalException portalException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(portalException);
-			}
-
+		if (fileEntry == null) {
 			return null;
 		}
 

--- a/modules/apps/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/bulk/selection/MultipleUserNotificationEventBulkSelection.java
+++ b/modules/apps/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/bulk/selection/MultipleUserNotificationEventBulkSelection.java
@@ -10,11 +10,6 @@ import com.liferay.bulk.selection.BaseMultipleEntryBulkSelection;
 import com.liferay.bulk.selection.BulkSelection;
 import com.liferay.bulk.selection.BulkSelectionFactory;
 import com.liferay.bulk.selection.EmptyBulkSelection;
-import com.liferay.petra.reflect.ReflectionUtil;
-import com.liferay.portal.kernel.exception.NoSuchUserNotificationEventException;
-import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.UserNotificationEvent;
 import com.liferay.portal.kernel.service.UserNotificationEventLocalService;
 
@@ -49,26 +44,9 @@ public class MultipleUserNotificationEventBulkSelection
 
 	@Override
 	protected UserNotificationEvent fetchEntry(long entryId) {
-		try {
-			return _userNotificationEventLocalService.getUserNotificationEvent(
-				entryId);
-		}
-		catch (NoSuchUserNotificationEventException
-					noSuchUserNotificationEventException) {
-
-			if (_log.isWarnEnabled()) {
-				_log.warn(noSuchUserNotificationEventException);
-			}
-
-			return null;
-		}
-		catch (PortalException portalException) {
-			return ReflectionUtil.throwException(portalException);
-		}
+		return _userNotificationEventLocalService.fetchUserNotificationEvent(
+			entryId);
 	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		MultipleUserNotificationEventBulkSelection.class);
 
 	private final UserNotificationEventLocalService
 		_userNotificationEventLocalService;

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/BaseModelRetrieverImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/BaseModelRetrieverImpl.java
@@ -5,8 +5,6 @@
 
 package com.liferay.portal.search.internal.indexer;
 
-import com.liferay.petra.string.StringBundler;
-import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -47,19 +45,7 @@ public class BaseModelRetrieverImpl implements BaseModelRetriever {
 		PersistedModelLocalService persistedModelLocalService =
 			_getPersistedModelLocalService(className);
 
-		try {
-			return persistedModelLocalService.getPersistedModel(classPK);
-		}
-		catch (PortalException portalException) {
-			if (_log.isWarnEnabled()) {
-				_log.warn(
-					StringBundler.concat(
-						"No ", className, " found for class PK ", classPK),
-					portalException);
-			}
-
-			return null;
-		}
+		return persistedModelLocalService.fetchPersistedModel(classPK);
 	}
 
 	private PersistedModelLocalService _getPersistedModelLocalService(

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/impl/KaleoInstanceLocalServiceImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/impl/KaleoInstanceLocalServiceImpl.java
@@ -35,7 +35,6 @@ import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.workflow.kaleo.exception.NoSuchInstanceException;
 import com.liferay.portal.workflow.kaleo.internal.search.KaleoInstanceTokenField;
 import com.liferay.portal.workflow.kaleo.model.KaleoInstance;
 import com.liferay.portal.workflow.kaleo.runtime.util.WorkflowContextUtil;
@@ -201,18 +200,14 @@ public class KaleoInstanceLocalServiceImpl
 	public KaleoInstance deleteKaleoInstance(long kaleoInstanceId)
 		throws PortalException {
 
-		KaleoInstance kaleoInstance = null;
+		KaleoInstance kaleoInstance =
+			kaleoInstancePersistence.fetchByPrimaryKey(kaleoInstanceId);
 
-		try {
-			kaleoInstance = kaleoInstancePersistence.remove(kaleoInstanceId);
-		}
-		catch (NoSuchInstanceException noSuchInstanceException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(noSuchInstanceException);
-			}
-
+		if (kaleoInstance == null) {
 			return null;
 		}
+
+		kaleoInstancePersistence.remove(kaleoInstance);
 
 		// Kaleo instance tokens
 

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/odata/entity/EntityModelFieldMapper.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/odata/entity/EntityModelFieldMapper.java
@@ -10,10 +10,7 @@ import com.liferay.expando.kernel.model.ExpandoColumnConstants;
 import com.liferay.expando.kernel.service.ExpandoColumnLocalService;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.CamelCaseUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
@@ -61,18 +58,8 @@ public class EntityModelFieldMapper {
 	}
 
 	public ExpandoColumn getExpandoColumn(String entityFieldName) {
-		long expandoColumnId = getExpandoColumnId(entityFieldName);
-
-		try {
-			return _expandoColumnLocalService.getColumn(expandoColumnId);
-		}
-		catch (PortalException portalException) {
-			_log.error(
-				"Unable to find Expando Column with id " + expandoColumnId,
-				portalException);
-
-			return null;
-		}
+		return _expandoColumnLocalService.fetchExpandoColumn(
+			getExpandoColumnId(entityFieldName));
 	}
 
 	public String getExpandoColumnEntityFieldName(ExpandoColumn expandoColumn) {
@@ -310,9 +297,6 @@ public class EntityModelFieldMapper {
 
 		return "string";
 	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		EntityModelFieldMapper.class);
 
 	@Reference
 	private ExpandoColumnLocalService _expandoColumnLocalService;

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/upload/test/TestFileEntry.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/upload/test/TestFileEntry.java
@@ -154,7 +154,7 @@ public class TestFileEntry implements FileEntry {
 	@Override
 	public Folder getFolder() {
 		try {
-			return DLAppLocalServiceUtil.getFolder(_folderId);
+			return DLAppLocalServiceUtil.fetchFolder(_folderId);
 		}
 		catch (PortalException portalException) {
 			if (_log.isDebugEnabled()) {

--- a/modules/apps/wiki/wiki-api/bnd.bnd
+++ b/modules/apps/wiki/wiki-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Wiki API
 Bundle-SymbolicName: com.liferay.wiki.api
-Bundle-Version: 22.0.2
+Bundle-Version: 22.1.0
 Export-Package:\
 	com.liferay.wiki.configuration,\
 	com.liferay.wiki.configuration.definition,\

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiPageLocalService.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiPageLocalService.java
@@ -336,6 +336,9 @@ public interface WikiPageLocalService
 	public WikiPage fetchPage(long resourcePrimKey);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public WikiPage fetchPage(long resourcePrimKey, Boolean head);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public WikiPage fetchPage(long nodeId, String title);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
@@ -801,4 +804,4 @@ public interface WikiPageLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1265994469
+// LIFERAY-SERVICE-BUILDER-HASH:-1469070703

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiPageLocalServiceUtil.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiPageLocalServiceUtil.java
@@ -413,6 +413,10 @@ public class WikiPageLocalServiceUtil {
 		return getService().fetchPage(resourcePrimKey);
 	}
 
+	public static WikiPage fetchPage(long resourcePrimKey, Boolean head) {
+		return getService().fetchPage(resourcePrimKey, head);
+	}
+
 	public static WikiPage fetchPage(long nodeId, String title) {
 		return getService().fetchPage(nodeId, title);
 	}
@@ -1105,4 +1109,4 @@ public class WikiPageLocalServiceUtil {
 			WikiPageLocalServiceUtil.class, WikiPageLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2131732958
+// LIFERAY-SERVICE-BUILDER-HASH:-1715222725

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiPageLocalServiceWrapper.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiPageLocalServiceWrapper.java
@@ -460,6 +460,11 @@ public class WikiPageLocalServiceWrapper
 	}
 
 	@Override
+	public WikiPage fetchPage(long resourcePrimKey, Boolean head) {
+		return _wikiPageLocalService.fetchPage(resourcePrimKey, head);
+	}
+
+	@Override
 	public WikiPage fetchPage(long nodeId, String title) {
 		return _wikiPageLocalService.fetchPage(nodeId, title);
 	}
@@ -1287,4 +1292,4 @@ public class WikiPageLocalServiceWrapper
 	private WikiPageLocalService _wikiPageLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1924662821
+// LIFERAY-SERVICE-BUILDER-HASH:1709699507

--- a/modules/apps/wiki/wiki-api/src/main/resources/com/liferay/wiki/service/packageinfo
+++ b/modules/apps/wiki/wiki-api/src/main/resources/com/liferay/wiki/service/packageinfo
@@ -1,1 +1,1 @@
-version 6.0.0
+version 6.1.0

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/asset/validator/FrontPageAssetEntryValidatorExclusionRule.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/asset/validator/FrontPageAssetEntryValidatorExclusionRule.java
@@ -7,9 +7,6 @@ package com.liferay.wiki.internal.asset.validator;
 
 import com.liferay.asset.kernel.validator.AssetEntryValidatorExclusionRule;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
-import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.wiki.configuration.WikiGroupServiceConfiguration;
 import com.liferay.wiki.constants.WikiPageConstants;
@@ -46,16 +43,11 @@ public class FrontPageAssetEntryValidatorExclusionRule
 		}
 
 		if (wikiPage == null) {
-			try {
-				wikiPage = _wikiPageLocalService.getPage(classPK, false);
-			}
-			catch (PortalException portalException) {
-				if (_log.isWarnEnabled()) {
-					_log.warn(portalException);
-				}
+			wikiPage = _wikiPageLocalService.fetchPage(classPK, false);
+		}
 
-				return false;
-			}
+		if (wikiPage == null) {
+			return false;
 		}
 
 		if (StringUtil.equals(
@@ -75,9 +67,6 @@ public class FrontPageAssetEntryValidatorExclusionRule
 		_wikiGroupServiceConfiguration = ConfigurableUtil.createConfigurable(
 			WikiGroupServiceConfiguration.class, properties);
 	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		FrontPageAssetEntryValidatorExclusionRule.class);
 
 	private volatile WikiGroupServiceConfiguration
 		_wikiGroupServiceConfiguration;

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiPageLocalServiceImpl.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiPageLocalServiceImpl.java
@@ -918,6 +918,24 @@ public class WikiPageLocalServiceImpl extends WikiPageLocalServiceBaseImpl {
 	}
 
 	@Override
+	public WikiPage fetchPage(long resourcePrimKey, Boolean head) {
+		WikiPageResource pageResource =
+			_wikiPageResourcePersistence.fetchByPrimaryKey(resourcePrimKey);
+
+		if (pageResource == null) {
+			return null;
+		}
+
+		if (head == null) {
+			return wikiPagePersistence.fetchByN_T_First(
+				pageResource.getNodeId(), pageResource.getTitle(), null);
+		}
+
+		return wikiPagePersistence.fetchByN_T_H_First(
+			pageResource.getNodeId(), pageResource.getTitle(), head, null);
+	}
+
+	@Override
 	public WikiPage fetchPage(long nodeId, String title) {
 		return wikiPagePersistence.fetchByN_T_H_First(
 			nodeId, title, true, null);

--- a/modules/dxp/apps/commerce/commerce-machine-learning-forecast-alert-web/src/main/java/com/liferay/commerce/machine/learning/forecast/alert/web/internal/display/context/CommerceMLForecastAlertEntryListDisplayContext.java
+++ b/modules/dxp/apps/commerce/commerce-machine-learning-forecast-alert-web/src/main/java/com/liferay/commerce/machine/learning/forecast/alert/web/internal/display/context/CommerceMLForecastAlertEntryListDisplayContext.java
@@ -5,8 +5,6 @@
 
 package com.liferay.commerce.machine.learning.forecast.alert.web.internal.display.context;
 
-import com.liferay.account.model.AccountEntry;
-import com.liferay.account.service.AccountEntryLocalService;
 import com.liferay.commerce.machine.learning.forecast.alert.constants.CommerceMLForecastAlertActionKeys;
 import com.liferay.commerce.machine.learning.forecast.alert.constants.CommerceMLForecastAlertConstants;
 import com.liferay.commerce.machine.learning.forecast.alert.model.CommerceMLForecastAlertEntry;
@@ -27,22 +25,16 @@ import jakarta.portlet.RenderRequest;
 public class CommerceMLForecastAlertEntryListDisplayContext {
 
 	public CommerceMLForecastAlertEntryListDisplayContext(
-		AccountEntryLocalService accountEntryLocalService,
 		CommerceMLForecastAlertEntryService commerceMLForecastAlertEntryService,
 		PortletResourcePermission portletResourcePermission,
 		RenderRequest renderRequest) {
 
-		_accountEntryLocalService = accountEntryLocalService;
 		_commerceMLForecastAlertEntryService =
 			commerceMLForecastAlertEntryService;
 		_portletResourcePermission = portletResourcePermission;
 
 		_commerceMLForecastAlertEntryRequestHelper =
 			new CommerceMLForecastAlertEntryRequestHelper(renderRequest);
-	}
-
-	public AccountEntry getAccountEntry(long accountEntryId) {
-		return _accountEntryLocalService.fetchAccountEntry(accountEntryId);
 	}
 
 	public PortletURL getPortletURL() {
@@ -98,7 +90,6 @@ public class CommerceMLForecastAlertEntryListDisplayContext {
 			CommerceMLForecastAlertActionKeys.VIEW_ALERTS);
 	}
 
-	private final AccountEntryLocalService _accountEntryLocalService;
 	private final CommerceMLForecastAlertEntryRequestHelper
 		_commerceMLForecastAlertEntryRequestHelper;
 	private final CommerceMLForecastAlertEntryService

--- a/modules/dxp/apps/commerce/commerce-machine-learning-forecast-alert-web/src/main/java/com/liferay/commerce/machine/learning/forecast/alert/web/internal/display/context/CommerceMLForecastAlertEntryListDisplayContext.java
+++ b/modules/dxp/apps/commerce/commerce-machine-learning-forecast-alert-web/src/main/java/com/liferay/commerce/machine/learning/forecast/alert/web/internal/display/context/CommerceMLForecastAlertEntryListDisplayContext.java
@@ -14,8 +14,6 @@ import com.liferay.commerce.machine.learning.forecast.alert.service.CommerceMLFo
 import com.liferay.commerce.machine.learning.forecast.alert.web.internal.display.context.helper.CommerceMLForecastAlertEntryRequestHelper;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.security.permission.resource.PortletResourcePermission;
@@ -44,14 +42,7 @@ public class CommerceMLForecastAlertEntryListDisplayContext {
 	}
 
 	public AccountEntry getAccountEntry(long accountEntryId) {
-		try {
-			return _accountEntryLocalService.getAccountEntry(accountEntryId);
-		}
-		catch (PortalException portalException) {
-			_log.error(portalException);
-
-			return null;
-		}
+		return _accountEntryLocalService.fetchAccountEntry(accountEntryId);
 	}
 
 	public PortletURL getPortletURL() {
@@ -106,9 +97,6 @@ public class CommerceMLForecastAlertEntryListDisplayContext {
 			GroupConstants.DEFAULT_LIVE_GROUP_ID,
 			CommerceMLForecastAlertActionKeys.VIEW_ALERTS);
 	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		CommerceMLForecastAlertEntryListDisplayContext.class);
 
 	private final AccountEntryLocalService _accountEntryLocalService;
 	private final CommerceMLForecastAlertEntryRequestHelper

--- a/modules/dxp/apps/commerce/commerce-machine-learning-forecast-alert-web/src/main/java/com/liferay/commerce/machine/learning/forecast/alert/web/internal/portlet/CommerceMLForecastAlertPortlet.java
+++ b/modules/dxp/apps/commerce/commerce-machine-learning-forecast-alert-web/src/main/java/com/liferay/commerce/machine/learning/forecast/alert/web/internal/portlet/CommerceMLForecastAlertPortlet.java
@@ -5,7 +5,6 @@
 
 package com.liferay.commerce.machine.learning.forecast.alert.web.internal.portlet;
 
-import com.liferay.account.service.AccountEntryLocalService;
 import com.liferay.commerce.machine.learning.forecast.alert.constants.CommerceMLForecastAlertConstants;
 import com.liferay.commerce.machine.learning.forecast.alert.constants.CommerceMLForecastAlertPortletKeys;
 import com.liferay.commerce.machine.learning.forecast.alert.service.CommerceMLForecastAlertEntryService;
@@ -63,7 +62,6 @@ public class CommerceMLForecastAlertPortlet extends MVCPortlet {
 			CommerceMLForecastAlertEntryListDisplayContext
 				commerceMLForecastAlertEntryListDisplayContext =
 					new CommerceMLForecastAlertEntryListDisplayContext(
-						_accountEntryLocalService,
 						_commerceMLForecastAlertEntryService,
 						_portletResourcePermission, renderRequest);
 
@@ -81,9 +79,6 @@ public class CommerceMLForecastAlertPortlet extends MVCPortlet {
 
 		super.render(renderRequest, renderResponse);
 	}
-
-	@Reference
-	private AccountEntryLocalService _accountEntryLocalService;
 
 	@Reference
 	private CommerceMLForecastAlertEntryService

--- a/modules/dxp/apps/commerce/commerce-machine-learning-forecast-alert-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/dxp/apps/commerce/commerce-machine-learning-forecast-alert-web/src/main/resources/META-INF/resources/init.jsp
@@ -14,6 +14,7 @@ taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
 <%@ page import="com.liferay.account.model.AccountEntry" %><%@
+page import="com.liferay.account.service.AccountEntryLocalServiceUtil" %><%@
 page import="com.liferay.commerce.machine.learning.forecast.alert.constants.CommerceMLForecastAlertActionKeys" %><%@
 page import="com.liferay.commerce.machine.learning.forecast.alert.constants.CommerceMLForecastAlertConstants" %><%@
 page import="com.liferay.commerce.machine.learning.forecast.alert.model.CommerceMLForecastAlertEntry" %><%@

--- a/modules/dxp/apps/commerce/commerce-machine-learning-forecast-alert-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/dxp/apps/commerce/commerce-machine-learning-forecast-alert-web/src/main/resources/META-INF/resources/view.jsp
@@ -28,7 +28,7 @@ CommerceMLForecastAlertEntryListDisplayContext commerceMLForecastAlertEntryListD
 				>
 
 					<%
-					AccountEntry accountEntry = commerceMLForecastAlertEntryListDisplayContext.getAccountEntry(commerceMLForecastAlertEntry.getCommerceAccountId());
+					AccountEntry accountEntry = AccountEntryLocalServiceUtil.fetchAccountEntry(commerceMLForecastAlertEntry.getCommerceAccountId());
 
 					long logoId = accountEntry.getLogoId();
 					%>

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaFetchContractCatchCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaFetchContractCatchCheck.java
@@ -1,0 +1,417 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.check;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.source.formatter.parser.JavaTerm;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * @author Shuyang Zhou
+ */
+public class JavaFetchContractCatchCheck extends BaseJavaTermCheck {
+
+	@Override
+	public boolean isLiferaySourceCheck() {
+		return true;
+	}
+
+	@Override
+	protected String doProcess(
+		String fileName, String absolutePath, JavaTerm javaTerm,
+		String fileContent) {
+
+		String content = javaTerm.getContent();
+
+		if (_isAllowedFileName(
+				absolutePath,
+				getAttributeValues(_ALLOWED_FILE_NAMES_KEY, absolutePath))) {
+
+			return content;
+		}
+
+		Matcher matcher = _catchPattern.matcher(content);
+
+		while (matcher.find()) {
+			String exceptionClassName = matcher.group(1);
+
+			int x = exceptionClassName.lastIndexOf('.');
+
+			String simpleClassName = exceptionClassName.substring(x + 1);
+
+			// Only the Liferay checked not-found exceptions signal absence.
+			// The JDK "NoSuch*Exception" classes (reflection, crypto,
+			// collections) are unrelated and legitimately caught.
+
+			if (!simpleClassName.equals("PortalException") &&
+				(!simpleClassName.matches("NoSuch\\w*Exception") ||
+				 _jdkNoSuchExceptionClassNames.contains(simpleClassName))) {
+
+				continue;
+			}
+
+			String catchBlockBody = _getBlockBody(content, matcher.end());
+
+			if ((catchBlockBody == null) ||
+				!_isSwallowToSentinel(catchBlockBody)) {
+
+				continue;
+			}
+
+			String tryBlockBody = _getTryBlockBody(content, matcher.start());
+
+			if (tryBlockBody == null) {
+				continue;
+			}
+
+			String lookupCall = _getSoleLookupCall(tryBlockBody);
+
+			if (lookupCall == null) {
+				continue;
+			}
+
+			addMessage(
+				fileName,
+				StringBundler.concat(
+					"Do not catch \"", simpleClassName,
+					"\" around the lookup \"", lookupCall,
+					"\" to signal a missing entity, call the null-tolerant ",
+					"fetch sibling and check for null instead"),
+				javaTerm.getLineNumber(matcher.start()));
+		}
+
+		return content;
+	}
+
+	@Override
+	protected String[] getCheckableJavaTermNames() {
+		return new String[] {JAVA_METHOD};
+	}
+
+	private String _getBlockBody(String content, int openCurlyBracePos) {
+		int level = 1;
+
+		for (int i = openCurlyBracePos; i < content.length(); i++) {
+			char c = content.charAt(i);
+
+			if (c == '{') {
+				level++;
+			}
+			else if (c == '}') {
+				level--;
+
+				if (level == 0) {
+					return content.substring(openCurlyBracePos, i);
+				}
+			}
+		}
+
+		return null;
+	}
+
+	private int _getMatchingOpenCurlyBracePos(
+		String content, int closeCurlyBracePos) {
+
+		int level = 1;
+
+		for (int i = closeCurlyBracePos - 1; i >= 0; i--) {
+			char c = content.charAt(i);
+
+			if (c == '}') {
+				level++;
+			}
+			else if (c == '{') {
+				level--;
+
+				if (level == 0) {
+					return i;
+				}
+			}
+		}
+
+		return -1;
+	}
+
+	private String _getPrecedingWord(String content, int endPos) {
+		int i = endPos - 1;
+
+		while ((i >= 0) && Character.isWhitespace(content.charAt(i))) {
+			i--;
+		}
+
+		int wordEndPos = i + 1;
+
+		while ((i >= 0) && Character.isJavaIdentifierPart(content.charAt(i))) {
+			i--;
+		}
+
+		return content.substring(i + 1, wordEndPos);
+	}
+
+	private String _getSoleLookupCall(String tryBlockBody) {
+		Matcher matcher = _callPattern.matcher(tryBlockBody);
+
+		if (!matcher.find()) {
+			return null;
+		}
+
+		String receiver = matcher.group(1);
+		String method = matcher.group(2);
+
+		int callStartPos = matcher.start();
+		int argsStartPos = matcher.end();
+
+		if (matcher.find()) {
+			return null;
+		}
+
+		String lowerCaseReceiver = StringUtil.toLowerCase(receiver);
+
+		if (!lowerCaseReceiver.endsWith("localservice") &&
+			!lowerCaseReceiver.endsWith("localserviceutil") &&
+			!lowerCaseReceiver.endsWith("persistence")) {
+
+			return null;
+		}
+
+		if ((!method.startsWith("get") || method.equals("get")) &&
+			(!method.startsWith("findBy") || method.equals("findBy")) &&
+			(!method.equals("remove") ||
+			 !lowerCaseReceiver.endsWith("persistence"))) {
+
+			return null;
+		}
+
+		int level = 1;
+		int argsEndPos = -1;
+
+		for (int i = argsStartPos; i < tryBlockBody.length(); i++) {
+			char c = tryBlockBody.charAt(i);
+
+			if (c == '(') {
+				level++;
+			}
+			else if (c == ')') {
+				level--;
+
+				if (level == 0) {
+					argsEndPos = i;
+
+					break;
+				}
+			}
+		}
+
+		if (argsEndPos == -1) {
+			return null;
+		}
+
+		// The arguments must not contain nested invocations and the rest of
+		// the try block must not contain any other invocation or block, so
+		// that the lookup is provably the only statement able to throw the
+		// caught exception
+
+		String args = tryBlockBody.substring(argsStartPos, argsEndPos);
+
+		if (args.indexOf('(') != -1) {
+			return null;
+		}
+
+		String remainder =
+			tryBlockBody.substring(0, callStartPos) +
+				tryBlockBody.substring(argsEndPos + 1);
+
+		if ((remainder.indexOf('(') != -1) || (remainder.indexOf('{') != -1)) {
+			return null;
+		}
+
+		return receiver + "." + method;
+	}
+
+	private String _getTryBlockBody(String content, int catchStartPos) {
+		int i = catchStartPos - 1;
+
+		while (true) {
+			while ((i >= 0) && Character.isWhitespace(content.charAt(i))) {
+				i--;
+			}
+
+			if ((i < 0) || (content.charAt(i) != '}')) {
+				return null;
+			}
+
+			int openCurlyBracePos = _getMatchingOpenCurlyBracePos(content, i);
+
+			if (openCurlyBracePos == -1) {
+				return null;
+			}
+
+			int j = openCurlyBracePos - 1;
+
+			while ((j >= 0) && Character.isWhitespace(content.charAt(j))) {
+				j--;
+			}
+
+			if ((j >= 0) && (content.charAt(j) == ')')) {
+				int level = 1;
+				int k = j - 1;
+
+				while (k >= 0) {
+					char c = content.charAt(k);
+
+					if (c == ')') {
+						level++;
+					}
+					else if (c == '(') {
+						level--;
+
+						if (level == 0) {
+							break;
+						}
+					}
+
+					k--;
+				}
+
+				if (k < 0) {
+					return null;
+				}
+
+				String word = _getPrecedingWord(content, k);
+
+				if (word.equals("catch")) {
+					i = content.lastIndexOf("catch", k) - 1;
+
+					continue;
+				}
+
+				if (word.equals("try")) {
+					return content.substring(openCurlyBracePos + 1, i);
+				}
+
+				return null;
+			}
+
+			String word = _getPrecedingWord(content, j + 1);
+
+			if (word.equals("try")) {
+				return content.substring(openCurlyBracePos + 1, i);
+			}
+
+			return null;
+		}
+	}
+
+	private boolean _isAllowedFileName(
+		String absolutePath, List<String> allowedFileNames) {
+
+		for (String allowedFileName : allowedFileNames) {
+			if (absolutePath.endsWith(allowedFileName)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private boolean _isSwallowToSentinel(String catchBlockBody) {
+		String strippedBody = catchBlockBody;
+
+		// Remove comments
+
+		strippedBody = strippedBody.replaceAll("(?s)/\\*.*?\\*/", "");
+		strippedBody = strippedBody.replaceAll("(?m)//.*$", "");
+
+		// Remove the logging: an "if (_log.isXXXEnabled())" block and bare
+		// "_log" statements
+
+		strippedBody = strippedBody.replaceAll(
+			"(?s)if \\(_log\\.is\\w+Enabled\\(\\)\\) \\{[^{}]*\\}", "");
+
+		strippedBody = _stripLogStatements(strippedBody);
+
+		strippedBody = strippedBody.trim();
+
+		// A catch that does nothing but (optionally log and) return the
+		// null/false absence sentinel is using the exception as control flow
+
+		if (strippedBody.equals("return null;") ||
+			strippedBody.equals("return false;")) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	private String _stripLogStatements(String s) {
+		while (true) {
+			int x = s.indexOf("_log.");
+
+			if (x == -1) {
+				return s;
+			}
+
+			int y = s.indexOf('(', x);
+
+			if (y == -1) {
+				return s;
+			}
+
+			int level = 1;
+			int i = y + 1;
+
+			while ((i < s.length()) && (level > 0)) {
+				char c = s.charAt(i);
+
+				if (c == '(') {
+					level++;
+				}
+				else if (c == ')') {
+					level--;
+				}
+
+				i++;
+			}
+
+			while ((i < s.length()) &&
+				   ((s.charAt(i) == ';') ||
+					Character.isWhitespace(s.charAt(i)))) {
+
+				i++;
+
+				if (s.charAt(i - 1) == ';') {
+					break;
+				}
+			}
+
+			s = s.substring(0, x) + s.substring(i);
+		}
+	}
+
+	private static final String _ALLOWED_FILE_NAMES_KEY = "allowedFileNames";
+
+	private static final Pattern _callPattern = Pattern.compile(
+		"(\\w+)\\s*\\.\\s*(\\w+)\\s*\\(");
+	private static final Pattern _catchPattern = Pattern.compile(
+		"catch \\(([\\w.]+)\\s+\\w+\\)\\s*\\{");
+	private static final Set<String> _jdkNoSuchExceptionClassNames =
+		new HashSet<>(
+			Arrays.asList(
+				"NoSuchAlgorithmException", "NoSuchElementException",
+				"NoSuchFieldException", "NoSuchFileException",
+				"NoSuchMechanismException", "NoSuchMethodException",
+				"NoSuchObjectException", "NoSuchPaddingException",
+				"NoSuchProviderException"));
+
+}

--- a/modules/util/source-formatter/src/main/resources/documentation/check/java_fetch_contract_catch_check.md
+++ b/modules/util/source-formatter/src/main/resources/documentation/check/java_fetch_contract_catch_check.md
@@ -1,0 +1,31 @@
+## JavaFetchContractCatchCheck
+
+Do not catch `PortalException` or a `NoSuch*Exception` only to return the `null`
+or `false` absence sentinel when the try block holds a single local service or
+persistence lookup. Using a not-found exception as an absence signal is
+exception-based control flow, and every local service and persistence lookup
+has a null-tolerant `fetch` sibling.
+
+Call the `fetch` sibling and check the result for `null` instead. For example,
+replace
+
+```
+try {
+	return fooLocalService.getFoo(fooId);
+}
+catch (NoSuchFooException noSuchFooException) {
+	return null;
+}
+```
+
+with
+
+```
+return fooLocalService.fetchFoo(fooId);
+```
+
+The check only flags a try block whose sole invocation is the lookup itself,
+with no nested invocations in the arguments, so that the lookup is provably the
+only statement able to throw the caught exception. Catches that guard multiple
+statements, remote permission-checked services, or exceptions that encode more
+than absence are deliberately out of scope.

--- a/modules/util/source-formatter/src/main/resources/sourcechecks.xml
+++ b/modules/util/source-formatter/src/main/resources/sourcechecks.xml
@@ -821,6 +821,10 @@
 			<category name="Styling" />
 			<description name="Sorts the values in `@FeatureFlags` and `@TestInfo` annotation." />
 		</check>
+		<check name="JavaFetchContractCatchCheck">
+			<category name="Bug Prevention" />
+			<description name="Finds a catch of `PortalException` or a `NoSuch*Exception` that only returns the null or false absence sentinel, where the try block holds a single local service or persistence lookup, so the null-tolerant fetch sibling should be used instead." />
+		</check>
 		<check name="JavaFinderCacheCheck">
 			<category name="Bug Prevention" />
 			<description name="Checks that the method `BasePersistenceImpl.fetchByPrimaryKey` is overridden, when using `FinderPath`." />

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppLocalServiceImpl.java
@@ -619,6 +619,52 @@ public class DLAppLocalServiceImpl extends DLAppLocalServiceBaseImpl {
 	}
 
 	@Override
+	public FileEntry fetchFileEntryByUuidAndGroupId(String uuid, long groupId)
+		throws PortalException {
+
+		try {
+			LocalRepository localRepository = getLocalRepository(groupId);
+
+			return localRepository.getFileEntryByUuid(uuid);
+		}
+		catch (NoSuchFileEntryException noSuchFileEntryException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(noSuchFileEntryException);
+			}
+		}
+
+		List<Repository> repositories = _repositoryPersistence.findByGroupId(
+			groupId);
+
+		for (Repository repository : repositories) {
+			if (Objects.equals(
+					repository.getClassName(),
+					TemporaryFileEntryRepository.class.getName())) {
+
+				if (_log.isDebugEnabled()) {
+					_log.debug("Skipping temporary file entry repository");
+				}
+
+				continue;
+			}
+
+			try {
+				LocalRepository localRepository = getLocalRepository(
+					repository.getRepositoryId());
+
+				return localRepository.getFileEntryByUuid(uuid);
+			}
+			catch (NoSuchFileEntryException noSuchFileEntryException) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(noSuchFileEntryException);
+				}
+			}
+		}
+
+		return null;
+	}
+
+	@Override
 	public FileShortcut fetchFileShortcut(long fileShortcutId)
 		throws PortalException {
 
@@ -758,49 +804,16 @@ public class DLAppLocalServiceImpl extends DLAppLocalServiceBaseImpl {
 	public FileEntry getFileEntryByUuidAndGroupId(String uuid, long groupId)
 		throws PortalException {
 
-		try {
-			LocalRepository localRepository = getLocalRepository(groupId);
+		FileEntry fileEntry = fetchFileEntryByUuidAndGroupId(uuid, groupId);
 
-			return localRepository.getFileEntryByUuid(uuid);
-		}
-		catch (NoSuchFileEntryException noSuchFileEntryException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(noSuchFileEntryException);
-			}
+		if (fileEntry == null) {
+			throw new NoSuchFileEntryException(
+				StringBundler.concat(
+					"No DLFileEntry exists with the key {uuid=", uuid,
+					", groupId=", groupId, StringPool.CLOSE_CURLY_BRACE));
 		}
 
-		List<Repository> repositories = _repositoryPersistence.findByGroupId(
-			groupId);
-
-		for (Repository repository : repositories) {
-			if (Objects.equals(
-					repository.getClassName(),
-					TemporaryFileEntryRepository.class.getName())) {
-
-				if (_log.isDebugEnabled()) {
-					_log.debug("Skipping temporary file entry repository");
-				}
-
-				continue;
-			}
-
-			try {
-				LocalRepository localRepository = getLocalRepository(
-					repository.getRepositoryId());
-
-				return localRepository.getFileEntryByUuid(uuid);
-			}
-			catch (NoSuchFileEntryException noSuchFileEntryException) {
-				if (_log.isDebugEnabled()) {
-					_log.debug(noSuchFileEntryException);
-				}
-			}
-		}
-
-		throw new NoSuchFileEntryException(
-			StringBundler.concat(
-				"No DLFileEntry exists with the key {uuid=", uuid, ", groupId=",
-				groupId, StringPool.CLOSE_CURLY_BRACE));
+		return fileEntry;
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppLocalServiceImpl.java
@@ -6,6 +6,7 @@
 package com.liferay.portlet.documentlibrary.service.impl;
 
 import com.liferay.document.library.kernel.exception.NoSuchFileEntryException;
+import com.liferay.document.library.kernel.exception.NoSuchFolderException;
 import com.liferay.document.library.kernel.model.DLFolder;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.model.DLVersionNumberIncrease;
@@ -684,6 +685,23 @@ public class DLAppLocalServiceImpl extends DLAppLocalServiceBaseImpl {
 
 		return localRepository.fetchFileShortcutByExternalReferenceCode(
 			externalReferenceCode);
+	}
+
+	@Override
+	public Folder fetchFolder(long folderId) throws PortalException {
+		try {
+			LocalRepository localRepository =
+				RepositoryProviderUtil.getFolderLocalRepository(folderId);
+
+			return localRepository.getFolder(folderId);
+		}
+		catch (NoSuchFolderException noSuchFolderException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(noSuchFolderException);
+			}
+
+			return null;
+		}
 	}
 
 	@Override

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppLocalService.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppLocalService.java
@@ -363,6 +363,10 @@ public interface DLAppLocalService extends BaseLocalService {
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public FileEntry fetchFileEntryByUuidAndGroupId(String uuid, long groupId)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public FileShortcut fetchFileShortcut(long fileShortcutId)
 		throws PortalException;
 
@@ -815,4 +819,4 @@ public interface DLAppLocalService extends BaseLocalService {
 		throws PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1235902289
+// LIFERAY-SERVICE-BUILDER-HASH:-1008036570

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppLocalService.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppLocalService.java
@@ -376,6 +376,9 @@ public interface DLAppLocalService extends BaseLocalService {
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public Folder fetchFolder(long folderId) throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public Folder fetchFolderByExternalReferenceCode(
 			String externalReferenceCode, long groupId)
 		throws PortalException;
@@ -819,4 +822,4 @@ public interface DLAppLocalService extends BaseLocalService {
 		throws PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1008036570
+// LIFERAY-SERVICE-BUILDER-HASH:929140234

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppLocalServiceUtil.java
@@ -457,6 +457,13 @@ public class DLAppLocalServiceUtil {
 			externalReferenceCode, groupId);
 	}
 
+	public static com.liferay.portal.kernel.repository.model.Folder fetchFolder(
+			long folderId)
+		throws PortalException {
+
+		return getService().fetchFolder(folderId);
+	}
+
 	public static com.liferay.portal.kernel.repository.model.Folder
 			fetchFolderByExternalReferenceCode(
 				String externalReferenceCode, long groupId)
@@ -1039,4 +1046,4 @@ public class DLAppLocalServiceUtil {
 	private static volatile DLAppLocalService _service;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1621021125
+// LIFERAY-SERVICE-BUILDER-HASH:-1180157448

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppLocalServiceUtil.java
@@ -434,6 +434,13 @@ public class DLAppLocalServiceUtil {
 			groupId, externalReferenceCode);
 	}
 
+	public static com.liferay.portal.kernel.repository.model.FileEntry
+			fetchFileEntryByUuidAndGroupId(String uuid, long groupId)
+		throws PortalException {
+
+		return getService().fetchFileEntryByUuidAndGroupId(uuid, groupId);
+	}
+
 	public static com.liferay.portal.kernel.repository.model.FileShortcut
 			fetchFileShortcut(long fileShortcutId)
 		throws PortalException {
@@ -1032,4 +1039,4 @@ public class DLAppLocalServiceUtil {
 	private static volatile DLAppLocalService _service;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1812234655
+// LIFERAY-SERVICE-BUILDER-HASH:1621021125

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppLocalServiceWrapper.java
@@ -474,6 +474,14 @@ public class DLAppLocalServiceWrapper
 	}
 
 	@Override
+	public com.liferay.portal.kernel.repository.model.Folder fetchFolder(
+			long folderId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _dlAppLocalService.fetchFolder(folderId);
+	}
+
+	@Override
 	public com.liferay.portal.kernel.repository.model.Folder
 			fetchFolderByExternalReferenceCode(
 				String externalReferenceCode, long groupId)
@@ -1083,4 +1091,4 @@ public class DLAppLocalServiceWrapper
 	private DLAppLocalService _dlAppLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-543347863
+// LIFERAY-SERVICE-BUILDER-HASH:150245717

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppLocalServiceWrapper.java
@@ -448,6 +448,14 @@ public class DLAppLocalServiceWrapper
 	}
 
 	@Override
+	public com.liferay.portal.kernel.repository.model.FileEntry
+			fetchFileEntryByUuidAndGroupId(String uuid, long groupId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _dlAppLocalService.fetchFileEntryByUuidAndGroupId(uuid, groupId);
+	}
+
+	@Override
 	public com.liferay.portal.kernel.repository.model.FileShortcut
 			fetchFileShortcut(long fileShortcutId)
 		throws com.liferay.portal.kernel.exception.PortalException {
@@ -1075,4 +1083,4 @@ public class DLAppLocalServiceWrapper
 	private DLAppLocalService _dlAppLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1650995868
+// LIFERAY-SERVICE-BUILDER-HASH:-543347863

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/packageinfo
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/packageinfo
@@ -1,1 +1,1 @@
-version 21.6.2
+version 21.7.0

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -1226,9 +1226,7 @@
 
     source.check.JavaFetchContractCatchCheck.allowedFileNames=\
         modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/FileEntryStagedModelDataHandler.java,\
-        modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/FileShortcutStagedModelDataHandler.java,\
         modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/PublishFolderMVCActionCommand.java,\
-        modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/input/template/parser/FragmentEntryInputTemplateNodeContextHelperImpl.java,\
         modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/upload/test/TestFileEntry.java,\
         modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/asset/validator/FrontPageAssetEntryValidatorExclusionRule.java
 

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -1233,7 +1233,6 @@
         modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/input/template/parser/FragmentEntryInputTemplateNodeContextHelperImpl.java,\
         modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/converter/SharedAssetDTOConverter.java,\
         modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/BaseModelRetrieverImpl.java,\
-        modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/impl/KaleoInstanceLocalServiceImpl.java,\
         modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/odata/entity/EntityModelFieldMapper.java,\
         modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/upload/test/TestFileEntry.java,\
         modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/asset/validator/FrontPageAssetEntryValidatorExclusionRule.java,\

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -1232,7 +1232,6 @@
         modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/PublishFolderMVCActionCommand.java,\
         modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/input/template/parser/FragmentEntryInputTemplateNodeContextHelperImpl.java,\
         modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/converter/SharedAssetDTOConverter.java,\
-        modules/apps/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/bulk/selection/MultipleUserNotificationEventBulkSelection.java,\
         modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/BaseModelRetrieverImpl.java,\
         modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/impl/KaleoInstanceLocalServiceImpl.java,\
         modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/odata/entity/EntityModelFieldMapper.java,\

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -1232,7 +1232,6 @@
         modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/PublishFolderMVCActionCommand.java,\
         modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/input/template/parser/FragmentEntryInputTemplateNodeContextHelperImpl.java,\
         modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/converter/SharedAssetDTOConverter.java,\
-        modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/BaseModelRetrieverImpl.java,\
         modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/upload/test/TestFileEntry.java,\
         modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/asset/validator/FrontPageAssetEntryValidatorExclusionRule.java,\
         modules/dxp/apps/commerce/commerce-machine-learning-forecast-alert-web/src/main/java/com/liferay/commerce/machine/learning/forecast/alert/web/internal/display/context/CommerceMLForecastAlertEntryListDisplayContext.java

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -1225,8 +1225,6 @@
     source.check.JavaFeatureFlagManagerUtilCheck.enabled=true
 
     source.check.JavaFetchContractCatchCheck.allowedFileNames=\
-        modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/PublishFolderMVCActionCommand.java,\
-        modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/upload/test/TestFileEntry.java,\
         modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/asset/validator/FrontPageAssetEntryValidatorExclusionRule.java
 
     source.check.JavaFinalVariableCheck.enabled=true

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -1224,9 +1224,6 @@
 
     source.check.JavaFeatureFlagManagerUtilCheck.enabled=true
 
-    source.check.JavaFetchContractCatchCheck.allowedFileNames=\
-        modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/asset/validator/FrontPageAssetEntryValidatorExclusionRule.java
-
     source.check.JavaFinalVariableCheck.enabled=true
 
     source.check.JavaFinderCacheCheck.enabled=false

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -1225,13 +1225,10 @@
     source.check.JavaFeatureFlagManagerUtilCheck.enabled=true
 
     source.check.JavaFetchContractCatchCheck.allowedFileNames=\
-        modules/apps/adaptive-media/adaptive-media-image-service/src/main/java/com/liferay/adaptive/media/image/internal/exportimport/content/processor/AMImageHTMLExportImportContentProcessor.java,\
-        modules/apps/commerce/commerce-media-impl/src/main/java/com/liferay/commerce/media/internal/servlet/CommerceMediaServlet.java,\
         modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/FileEntryStagedModelDataHandler.java,\
         modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/FileShortcutStagedModelDataHandler.java,\
         modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/PublishFolderMVCActionCommand.java,\
         modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/input/template/parser/FragmentEntryInputTemplateNodeContextHelperImpl.java,\
-        modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/converter/SharedAssetDTOConverter.java,\
         modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/upload/test/TestFileEntry.java,\
         modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/asset/validator/FrontPageAssetEntryValidatorExclusionRule.java,\
         modules/dxp/apps/commerce/commerce-machine-learning-forecast-alert-web/src/main/java/com/liferay/commerce/machine/learning/forecast/alert/web/internal/display/context/CommerceMLForecastAlertEntryListDisplayContext.java

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -1233,7 +1233,6 @@
         modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/input/template/parser/FragmentEntryInputTemplateNodeContextHelperImpl.java,\
         modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/converter/SharedAssetDTOConverter.java,\
         modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/BaseModelRetrieverImpl.java,\
-        modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/odata/entity/EntityModelFieldMapper.java,\
         modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/upload/test/TestFileEntry.java,\
         modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/asset/validator/FrontPageAssetEntryValidatorExclusionRule.java,\
         modules/dxp/apps/commerce/commerce-machine-learning-forecast-alert-web/src/main/java/com/liferay/commerce/machine/learning/forecast/alert/web/internal/display/context/CommerceMLForecastAlertEntryListDisplayContext.java

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -1225,7 +1225,6 @@
     source.check.JavaFeatureFlagManagerUtilCheck.enabled=true
 
     source.check.JavaFetchContractCatchCheck.allowedFileNames=\
-        modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/FileEntryStagedModelDataHandler.java,\
         modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/PublishFolderMVCActionCommand.java,\
         modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/upload/test/TestFileEntry.java,\
         modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/asset/validator/FrontPageAssetEntryValidatorExclusionRule.java

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -1224,6 +1224,22 @@
 
     source.check.JavaFeatureFlagManagerUtilCheck.enabled=true
 
+    source.check.JavaFetchContractCatchCheck.allowedFileNames=\
+        modules/apps/adaptive-media/adaptive-media-image-service/src/main/java/com/liferay/adaptive/media/image/internal/exportimport/content/processor/AMImageHTMLExportImportContentProcessor.java,\
+        modules/apps/commerce/commerce-media-impl/src/main/java/com/liferay/commerce/media/internal/servlet/CommerceMediaServlet.java,\
+        modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/FileEntryStagedModelDataHandler.java,\
+        modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/FileShortcutStagedModelDataHandler.java,\
+        modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/PublishFolderMVCActionCommand.java,\
+        modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/input/template/parser/FragmentEntryInputTemplateNodeContextHelperImpl.java,\
+        modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/converter/SharedAssetDTOConverter.java,\
+        modules/apps/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/bulk/selection/MultipleUserNotificationEventBulkSelection.java,\
+        modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/BaseModelRetrieverImpl.java,\
+        modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/impl/KaleoInstanceLocalServiceImpl.java,\
+        modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/odata/entity/EntityModelFieldMapper.java,\
+        modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/upload/test/TestFileEntry.java,\
+        modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/asset/validator/FrontPageAssetEntryValidatorExclusionRule.java,\
+        modules/dxp/apps/commerce/commerce-machine-learning-forecast-alert-web/src/main/java/com/liferay/commerce/machine/learning/forecast/alert/web/internal/display/context/CommerceMLForecastAlertEntryListDisplayContext.java
+
     source.check.JavaFinalVariableCheck.enabled=true
 
     source.check.JavaFinderCacheCheck.enabled=false

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -1230,8 +1230,7 @@
         modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/PublishFolderMVCActionCommand.java,\
         modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/input/template/parser/FragmentEntryInputTemplateNodeContextHelperImpl.java,\
         modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/upload/test/TestFileEntry.java,\
-        modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/asset/validator/FrontPageAssetEntryValidatorExclusionRule.java,\
-        modules/dxp/apps/commerce/commerce-machine-learning-forecast-alert-web/src/main/java/com/liferay/commerce/machine/learning/forecast/alert/web/internal/display/context/CommerceMLForecastAlertEntryListDisplayContext.java
+        modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/asset/validator/FrontPageAssetEntryValidatorExclusionRule.java
 
     source.check.JavaFinalVariableCheck.enabled=true
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98534

## What Is Being Fixed

Methods that promise null on absence frequently resolve an entity through a throwing get or find lookup and catch PortalException or a NoSuch*Exception only to return the null or false absence sentinel, using a not-found exception as control flow, and nothing prevents new occurrences.

## How It Is Being Fixed

Add the JavaFetchContractCatchCheck source check, which flags that shape only when it is provably a true conversion target: the catch body only (optionally logs and) returns null or false, and the try block holds a single local service or persistence lookup with no other invocation and no nested invocations in its arguments, so the compiler guarantees the lookup is the only statement able to throw the caught checked exception. Then convert every occurrence the check flags to the null-tolerant fetch sibling with a null check (keeping the catch where it still guards genuine repository failures), inline the helpers that became one-line passthroughs, and add the three missing siblings the conversions needed: DLAppLocalService.fetchFileEntryByUuidAndGroupId, DLAppLocalService.fetchFolder, and WikiPageLocalService.fetchPage(resourcePrimKey, head). The check ships enabled with no whitelist because the cleanup converts every flagged occurrence.

## PR Check

| Validation | Result |
| --- | --- |
| Source Format (current branch, check live) | PASS |
| Baseline (wiki-api 22.1.0 / packageinfo 6.1.0) | PASS |
| Per-Module Compile (15 changed modules + portal-impl) | PASS |
| Integration Test Compile (portal-osgi-web-portlet-container-test) | PASS |
| Java Unit (source-formatter: 518 tests) | PASS (4 failures identical on clean upstream/master — pre-existing) |

<!-- pr-check {"result": "success", "sha": "e1ce49291686f25a587f1713f50b5da69c19e448"} -->
