### PR TITLE
LPD-98435 Cascade delete element variations and their audience rels

### DIFF
--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService.java
@@ -144,6 +144,10 @@ public interface
 		deleteLayoutPageTemplateStructureRelElementVariationAudienceEntryRels(
 			String layoutPageTemplateStructureRelElementVariationERC);
 
+	public void
+		deleteLayoutPageTemplateStructureRelElementVariationAudienceEntryRelsByAudienceEntryERC(
+			long companyId, String audienceEntryERC);
+
 	/**
 	 * @throws PortalException
 	 */
@@ -402,4 +406,4 @@ public interface
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-651643994
+// LIFERAY-SERVICE-BUILDER-HASH:1186327494

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalServiceUtil.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalServiceUtil.java
@@ -149,6 +149,15 @@ public class
 				layoutPageTemplateStructureRelElementVariationERC);
 	}
 
+	public static void
+		deleteLayoutPageTemplateStructureRelElementVariationAudienceEntryRelsByAudienceEntryERC(
+			long companyId, String audienceEntryERC) {
+
+		getService().
+			deleteLayoutPageTemplateStructureRelElementVariationAudienceEntryRelsByAudienceEntryERC(
+				companyId, audienceEntryERC);
+	}
+
 	/**
 	 * @throws PortalException
 	 */
@@ -481,4 +490,4 @@ public class
 				LayoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:2034933066
+// LIFERAY-SERVICE-BUILDER-HASH:310072702

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalServiceWrapper.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalServiceWrapper.java
@@ -155,6 +155,16 @@ public class
 				layoutPageTemplateStructureRelElementVariationERC);
 	}
 
+	@Override
+	public void
+		deleteLayoutPageTemplateStructureRelElementVariationAudienceEntryRelsByAudienceEntryERC(
+			long companyId, String audienceEntryERC) {
+
+		_layoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService.
+			deleteLayoutPageTemplateStructureRelElementVariationAudienceEntryRelsByAudienceEntryERC(
+				companyId, audienceEntryERC);
+	}
+
 	/**
 	 * @throws PortalException
 	 */
@@ -577,4 +587,4 @@ public class
 			_layoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1708431927
+// LIFERAY-SERVICE-BUILDER-HASH:220700058

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationLocalService.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationLocalService.java
@@ -143,6 +143,9 @@ public interface LayoutPageTemplateStructureRelElementVariationLocalService
 	public void deleteLayoutPageTemplateStructureRelElementVariation(
 		String externalReferenceCode, long groupId);
 
+	public void deleteLayoutPageTemplateStructureRelElementVariations(
+		long plid, String segmentsExperienceERC);
+
 	/**
 	 * @throws PortalException
 	 */
@@ -408,4 +411,4 @@ public interface LayoutPageTemplateStructureRelElementVariationLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1184717029
+// LIFERAY-SERVICE-BUILDER-HASH:-757430278

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationLocalServiceUtil.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationLocalServiceUtil.java
@@ -148,6 +148,13 @@ public class LayoutPageTemplateStructureRelElementVariationLocalServiceUtil {
 			externalReferenceCode, groupId);
 	}
 
+	public static void deleteLayoutPageTemplateStructureRelElementVariations(
+		long plid, String segmentsExperienceERC) {
+
+		getService().deleteLayoutPageTemplateStructureRelElementVariations(
+			plid, segmentsExperienceERC);
+	}
+
 	/**
 	 * @throws PortalException
 	 */
@@ -494,4 +501,4 @@ public class LayoutPageTemplateStructureRelElementVariationLocalServiceUtil {
 					class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:488687409
+// LIFERAY-SERVICE-BUILDER-HASH:1014700075

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationLocalServiceWrapper.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationLocalServiceWrapper.java
@@ -155,6 +155,15 @@ public class LayoutPageTemplateStructureRelElementVariationLocalServiceWrapper
 				externalReferenceCode, groupId);
 	}
 
+	@Override
+	public void deleteLayoutPageTemplateStructureRelElementVariations(
+		long plid, String segmentsExperienceERC) {
+
+		_layoutPageTemplateStructureRelElementVariationLocalService.
+			deleteLayoutPageTemplateStructureRelElementVariations(
+				plid, segmentsExperienceERC);
+	}
+
 	/**
 	 * @throws PortalException
 	 */
@@ -592,4 +601,4 @@ public class LayoutPageTemplateStructureRelElementVariationLocalServiceWrapper
 		_layoutPageTemplateStructureRelElementVariationLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:72931764
+// LIFERAY-SERVICE-BUILDER-HASH:652939744

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/persistence/LayoutPageTemplateStructureRelElementVariationAudienceEntryRelPersistence.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/persistence/LayoutPageTemplateStructureRelElementVariationAudienceEntryRelPersistence.java
@@ -293,6 +293,79 @@ public interface
 		String layoutPageTemplateStructureRelElementVariationERC);
 
 	/**
+	 * Returns an ordered range of all the layout page template structure rel element variation audience entry rels where companyId = &#63; and audienceEntryERC = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateStructureRelElementVariationAudienceEntryRelModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param audienceEntryERC the audience entry erc
+	 * @param start the lower bound of the range of layout page template structure rel element variation audience entry rels
+	 * @param end the upper bound of the range of layout page template structure rel element variation audience entry rels (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching layout page template structure rel element variation audience entry rels
+	 */
+	public java.util.List
+		<LayoutPageTemplateStructureRelElementVariationAudienceEntryRel>
+			findByC_AEERC(
+				long companyId, String audienceEntryERC, int start, int end,
+				com.liferay.portal.kernel.util.OrderByComparator
+					<LayoutPageTemplateStructureRelElementVariationAudienceEntryRel>
+						orderByComparator,
+				boolean useFinderCache);
+
+	/**
+	 * Returns the first layout page template structure rel element variation audience entry rel in the ordered set where companyId = &#63; and audienceEntryERC = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param audienceEntryERC the audience entry erc
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching layout page template structure rel element variation audience entry rel
+	 * @throws NoSuchPageTemplateStructureRelElementVariationAudienceEntryRelException if a matching layout page template structure rel element variation audience entry rel could not be found
+	 */
+	public LayoutPageTemplateStructureRelElementVariationAudienceEntryRel
+			findByC_AEERC_First(
+				long companyId, String audienceEntryERC,
+				com.liferay.portal.kernel.util.OrderByComparator
+					<LayoutPageTemplateStructureRelElementVariationAudienceEntryRel>
+						orderByComparator)
+		throws NoSuchPageTemplateStructureRelElementVariationAudienceEntryRelException;
+
+	/**
+	 * Returns the first layout page template structure rel element variation audience entry rel in the ordered set where companyId = &#63; and audienceEntryERC = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param audienceEntryERC the audience entry erc
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching layout page template structure rel element variation audience entry rel, or <code>null</code> if a matching layout page template structure rel element variation audience entry rel could not be found
+	 */
+	public LayoutPageTemplateStructureRelElementVariationAudienceEntryRel
+		fetchByC_AEERC_First(
+			long companyId, String audienceEntryERC,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<LayoutPageTemplateStructureRelElementVariationAudienceEntryRel>
+					orderByComparator);
+
+	/**
+	 * Removes all the layout page template structure rel element variation audience entry rels where companyId = &#63; and audienceEntryERC = &#63; from the database.
+	 *
+	 * @param companyId the company ID
+	 * @param audienceEntryERC the audience entry erc
+	 */
+	public void removeByC_AEERC(long companyId, String audienceEntryERC);
+
+	/**
+	 * Returns the number of layout page template structure rel element variation audience entry rels where companyId = &#63; and audienceEntryERC = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param audienceEntryERC the audience entry erc
+	 * @return the number of matching layout page template structure rel element variation audience entry rels
+	 */
+	public int countByC_AEERC(long companyId, String audienceEntryERC);
+
+	/**
 	 * Returns the layout page template structure rel element variation audience entry rel where externalReferenceCode = &#63; and groupId = &#63; or throws a <code>NoSuchPageTemplateStructureRelElementVariationAudienceEntryRelException</code> if it could not be found.
 	 *
 	 * @param externalReferenceCode the external reference code
@@ -605,5 +678,70 @@ public interface
 			orderByComparator, true);
 	}
 
+	/**
+	 * Returns all the layout page template structure rel element variation audience entry rels where companyId = &#63; and audienceEntryERC = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param audienceEntryERC the audience entry erc
+	 * @return the matching layout page template structure rel element variation audience entry rels
+	 */
+	public default java.util.List
+		<LayoutPageTemplateStructureRelElementVariationAudienceEntryRel>
+			findByC_AEERC(long companyId, String audienceEntryERC) {
+
+		return findByC_AEERC(
+			companyId, audienceEntryERC,
+			com.liferay.portal.kernel.dao.orm.QueryUtil.ALL_POS,
+			com.liferay.portal.kernel.dao.orm.QueryUtil.ALL_POS, null, true);
+	}
+
+	/**
+	 * Returns a range of all the layout page template structure rel element variation audience entry rels where companyId = &#63; and audienceEntryERC = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateStructureRelElementVariationAudienceEntryRelModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param audienceEntryERC the audience entry erc
+	 * @param start the lower bound of the range of layout page template structure rel element variation audience entry rels
+	 * @param end the upper bound of the range of layout page template structure rel element variation audience entry rels (not inclusive)
+	 * @return the range of matching layout page template structure rel element variation audience entry rels
+	 */
+	public default java.util.List
+		<LayoutPageTemplateStructureRelElementVariationAudienceEntryRel>
+			findByC_AEERC(
+				long companyId, String audienceEntryERC, int start, int end) {
+
+		return findByC_AEERC(
+			companyId, audienceEntryERC, start, end, null, true);
+	}
+
+	/**
+	 * Returns an ordered range of all the layout page template structure rel element variation audience entry rels where companyId = &#63; and audienceEntryERC = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateStructureRelElementVariationAudienceEntryRelModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param audienceEntryERC the audience entry erc
+	 * @param start the lower bound of the range of layout page template structure rel element variation audience entry rels
+	 * @param end the upper bound of the range of layout page template structure rel element variation audience entry rels (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching layout page template structure rel element variation audience entry rels
+	 */
+	public default java.util.List
+		<LayoutPageTemplateStructureRelElementVariationAudienceEntryRel>
+			findByC_AEERC(
+				long companyId, String audienceEntryERC, int start, int end,
+				com.liferay.portal.kernel.util.OrderByComparator
+					<LayoutPageTemplateStructureRelElementVariationAudienceEntryRel>
+						orderByComparator) {
+
+		return findByC_AEERC(
+			companyId, audienceEntryERC, start, end, orderByComparator, true);
+	}
+
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-470116764
+// LIFERAY-SERVICE-BUILDER-HASH:1258272629

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/persistence/LayoutPageTemplateStructureRelElementVariationAudienceEntryRelUtil.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/persistence/LayoutPageTemplateStructureRelElementVariationAudienceEntryRelUtil.java
@@ -487,6 +487,99 @@ public class
 	}
 
 	/**
+	 * Returns an ordered range of all the layout page template structure rel element variation audience entry rels where companyId = &#63; and audienceEntryERC = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateStructureRelElementVariationAudienceEntryRelModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param audienceEntryERC the audience entry erc
+	 * @param start the lower bound of the range of layout page template structure rel element variation audience entry rels
+	 * @param end the upper bound of the range of layout page template structure rel element variation audience entry rels (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching layout page template structure rel element variation audience entry rels
+	 */
+	public static List
+		<LayoutPageTemplateStructureRelElementVariationAudienceEntryRel>
+			findByC_AEERC(
+				long companyId, String audienceEntryERC, int start, int end,
+				OrderByComparator
+					<LayoutPageTemplateStructureRelElementVariationAudienceEntryRel>
+						orderByComparator,
+				boolean useFinderCache) {
+
+		return getPersistence().findByC_AEERC(
+			companyId, audienceEntryERC, start, end, orderByComparator,
+			useFinderCache);
+	}
+
+	/**
+	 * Returns the first layout page template structure rel element variation audience entry rel in the ordered set where companyId = &#63; and audienceEntryERC = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param audienceEntryERC the audience entry erc
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching layout page template structure rel element variation audience entry rel
+	 * @throws NoSuchPageTemplateStructureRelElementVariationAudienceEntryRelException if a matching layout page template structure rel element variation audience entry rel could not be found
+	 */
+	public static LayoutPageTemplateStructureRelElementVariationAudienceEntryRel
+			findByC_AEERC_First(
+				long companyId, String audienceEntryERC,
+				OrderByComparator
+					<LayoutPageTemplateStructureRelElementVariationAudienceEntryRel>
+						orderByComparator)
+		throws com.liferay.layout.page.template.exception.
+			NoSuchPageTemplateStructureRelElementVariationAudienceEntryRelException {
+
+		return getPersistence().findByC_AEERC_First(
+			companyId, audienceEntryERC, orderByComparator);
+	}
+
+	/**
+	 * Returns the first layout page template structure rel element variation audience entry rel in the ordered set where companyId = &#63; and audienceEntryERC = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param audienceEntryERC the audience entry erc
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching layout page template structure rel element variation audience entry rel, or <code>null</code> if a matching layout page template structure rel element variation audience entry rel could not be found
+	 */
+	public static LayoutPageTemplateStructureRelElementVariationAudienceEntryRel
+		fetchByC_AEERC_First(
+			long companyId, String audienceEntryERC,
+			OrderByComparator
+				<LayoutPageTemplateStructureRelElementVariationAudienceEntryRel>
+					orderByComparator) {
+
+		return getPersistence().fetchByC_AEERC_First(
+			companyId, audienceEntryERC, orderByComparator);
+	}
+
+	/**
+	 * Removes all the layout page template structure rel element variation audience entry rels where companyId = &#63; and audienceEntryERC = &#63; from the database.
+	 *
+	 * @param companyId the company ID
+	 * @param audienceEntryERC the audience entry erc
+	 */
+	public static void removeByC_AEERC(
+		long companyId, String audienceEntryERC) {
+
+		getPersistence().removeByC_AEERC(companyId, audienceEntryERC);
+	}
+
+	/**
+	 * Returns the number of layout page template structure rel element variation audience entry rels where companyId = &#63; and audienceEntryERC = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param audienceEntryERC the audience entry erc
+	 * @return the number of matching layout page template structure rel element variation audience entry rels
+	 */
+	public static int countByC_AEERC(long companyId, String audienceEntryERC) {
+		return getPersistence().countByC_AEERC(companyId, audienceEntryERC);
+	}
+
+	/**
 	 * Returns the layout page template structure rel element variation audience entry rel where externalReferenceCode = &#63; and groupId = &#63; or throws a <code>NoSuchPageTemplateStructureRelElementVariationAudienceEntryRelException</code> if it could not be found.
 	 *
 	 * @param externalReferenceCode the external reference code
@@ -829,6 +922,68 @@ public class
 				orderByComparator);
 	}
 
+	/**
+	 * Returns all the layout page template structure rel element variation audience entry rels where companyId = &#63; and audienceEntryERC = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param audienceEntryERC the audience entry erc
+	 * @return the matching layout page template structure rel element variation audience entry rels
+	 */
+	public static List
+		<LayoutPageTemplateStructureRelElementVariationAudienceEntryRel>
+			findByC_AEERC(long companyId, String audienceEntryERC) {
+
+		return getPersistence().findByC_AEERC(companyId, audienceEntryERC);
+	}
+
+	/**
+	 * Returns a range of all the layout page template structure rel element variation audience entry rels where companyId = &#63; and audienceEntryERC = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateStructureRelElementVariationAudienceEntryRelModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param audienceEntryERC the audience entry erc
+	 * @param start the lower bound of the range of layout page template structure rel element variation audience entry rels
+	 * @param end the upper bound of the range of layout page template structure rel element variation audience entry rels (not inclusive)
+	 * @return the range of matching layout page template structure rel element variation audience entry rels
+	 */
+	public static List
+		<LayoutPageTemplateStructureRelElementVariationAudienceEntryRel>
+			findByC_AEERC(
+				long companyId, String audienceEntryERC, int start, int end) {
+
+		return getPersistence().findByC_AEERC(
+			companyId, audienceEntryERC, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the layout page template structure rel element variation audience entry rels where companyId = &#63; and audienceEntryERC = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateStructureRelElementVariationAudienceEntryRelModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param audienceEntryERC the audience entry erc
+	 * @param start the lower bound of the range of layout page template structure rel element variation audience entry rels
+	 * @param end the upper bound of the range of layout page template structure rel element variation audience entry rels (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching layout page template structure rel element variation audience entry rels
+	 */
+	public static List
+		<LayoutPageTemplateStructureRelElementVariationAudienceEntryRel>
+			findByC_AEERC(
+				long companyId, String audienceEntryERC, int start, int end,
+				OrderByComparator
+					<LayoutPageTemplateStructureRelElementVariationAudienceEntryRel>
+						orderByComparator) {
+
+		return getPersistence().findByC_AEERC(
+			companyId, audienceEntryERC, start, end, orderByComparator);
+	}
+
 	public static
 		LayoutPageTemplateStructureRelElementVariationAudienceEntryRelPersistence
 			getPersistence() {
@@ -848,4 +1003,4 @@ public class
 			_persistence;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1071550684
+// LIFERAY-SERVICE-BUILDER-HASH:-540601816

--- a/modules/apps/layout/layout-page-template-service/build.gradle
+++ b/modules/apps/layout/layout-page-template-service/build.gradle
@@ -14,6 +14,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly project(":apps:asset:asset-display-page-api")
 	compileOnly project(":apps:asset:asset-list-api")
+	compileOnly project(":apps:audiences:audiences-api")
 	compileOnly project(":apps:batch-engine:batch-engine-api")
 	compileOnly project(":apps:change-tracking:change-tracking-spi")
 	compileOnly project(":apps:document-library:document-library-api")

--- a/modules/apps/layout/layout-page-template-service/service.xml
+++ b/modules/apps/layout/layout-page-template-service/service.xml
@@ -401,6 +401,10 @@
 		<finder name="LayoutPageTemplateStructureRelElementVariationERC" return-type="Collection">
 			<finder-column name="layoutPageTemplateStructureRelElementVariationERC" />
 		</finder>
+		<finder name="C_AEERC" return-type="Collection">
+			<finder-column name="companyId" />
+			<finder-column name="audienceEntryERC" />
+		</finder>
 	</entity>
 	<exceptions>
 		<exception>DuplicateLayoutPageTemplateCollection</exception>

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/model/listener/AudiencesEntryModelListener.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/model/listener/AudiencesEntryModelListener.java
@@ -1,0 +1,36 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.page.template.internal.model.listener;
+
+import com.liferay.audiences.model.AudiencesEntry;
+import com.liferay.layout.page.template.service.LayoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService;
+import com.liferay.portal.kernel.model.BaseModelListener;
+import com.liferay.portal.kernel.model.ModelListener;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Víctor Galán
+ */
+@Component(service = ModelListener.class)
+public class AudiencesEntryModelListener
+	extends BaseModelListener<AudiencesEntry> {
+
+	@Override
+	public void onBeforeRemove(AudiencesEntry audiencesEntry) {
+		_layoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService.
+			deleteLayoutPageTemplateStructureRelElementVariationAudienceEntryRelsByAudienceEntryERC(
+				audiencesEntry.getCompanyId(),
+				audiencesEntry.getExternalReferenceCode());
+	}
+
+	@Reference
+	private
+		LayoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService
+			_layoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService;
+
+}

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/model/listener/SegmentsExperienceModelListener.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/model/listener/SegmentsExperienceModelListener.java
@@ -7,6 +7,7 @@ package com.liferay.layout.page.template.internal.model.listener;
 
 import com.liferay.fragment.model.FragmentEntryLink;
 import com.liferay.fragment.service.FragmentEntryLinkLocalService;
+import com.liferay.layout.page.template.service.LayoutPageTemplateStructureRelElementVariationLocalService;
 import com.liferay.layout.page.template.service.LayoutPageTemplateStructureRelLocalService;
 import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.model.BaseModelListener;
@@ -28,6 +29,11 @@ public class SegmentsExperienceModelListener
 		throws ModelListenerException {
 
 		try {
+			_layoutPageTemplateStructureRelElementVariationLocalService.
+				deleteLayoutPageTemplateStructureRelElementVariations(
+					segmentsExperience.getPlid(),
+					segmentsExperience.getExternalReferenceCode());
+
 			_layoutPageTemplateStructureRelLocalService.
 				deleteLayoutPageTemplateStructureRelsBySegmentsExperienceId(
 					segmentsExperience.getSegmentsExperienceId());
@@ -50,6 +56,10 @@ public class SegmentsExperienceModelListener
 
 	@Reference(unbind = "-")
 	private FragmentEntryLinkLocalService _fragmentEntryLinkLocalService;
+
+	@Reference
+	private LayoutPageTemplateStructureRelElementVariationLocalService
+		_layoutPageTemplateStructureRelElementVariationLocalService;
 
 	@Reference(unbind = "-")
 	private LayoutPageTemplateStructureRelLocalService

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/model/impl/LayoutPageTemplateStructureRelElementVariationAudienceEntryRelModelImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/model/impl/LayoutPageTemplateStructureRelElementVariationAudienceEntryRelModelImpl.java
@@ -120,32 +120,38 @@ public class
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long COMPANYID_COLUMN_BITMASK = 1L;
+	public static final long AUDIENCEENTRYERC_COLUMN_BITMASK = 1L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long EXTERNALREFERENCECODE_COLUMN_BITMASK = 2L;
+	public static final long COMPANYID_COLUMN_BITMASK = 2L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long GROUPID_COLUMN_BITMASK = 4L;
+	public static final long EXTERNALREFERENCECODE_COLUMN_BITMASK = 4L;
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
+	 */
+	@Deprecated
+	public static final long GROUPID_COLUMN_BITMASK = 8L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
 	public static final long
-		LAYOUTPAGETEMPLATESTRUCTURERELELEMENTVARIATIONERC_COLUMN_BITMASK = 8L;
+		LAYOUTPAGETEMPLATESTRUCTURERELELEMENTVARIATIONERC_COLUMN_BITMASK = 16L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long UUID_COLUMN_BITMASK = 16L;
+	public static final long UUID_COLUMN_BITMASK = 32L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
@@ -154,7 +160,7 @@ public class
 	@Deprecated
 	public static final long
 		LAYOUTPAGETEMPLATESTRUCTURERELELEMENTVARIATIONAUDIENCEENTRYRELID_COLUMN_BITMASK =
-			32L;
+			64L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
@@ -745,6 +751,15 @@ public class
 		_audienceEntryERC = audienceEntryERC;
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #getColumnOriginalValue(String)}
+	 */
+	@Deprecated
+	public String getOriginalAudienceEntryERC() {
+		return getColumnOriginalValue("audienceEntryERC");
+	}
+
 	@JSON
 	@Override
 	public String getLayoutPageTemplateStructureRelElementVariationERC() {
@@ -1325,4 +1340,4 @@ public class
 		_escapedModel;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1550429739
+// LIFERAY-SERVICE-BUILDER-HASH:-281251879

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalServiceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalServiceImpl.java
@@ -75,6 +75,14 @@ public class
 				layoutPageTemplateStructureRelElementVariationERC);
 	}
 
+	public void
+		deleteLayoutPageTemplateStructureRelElementVariationAudienceEntryRelsByAudienceEntryERC(
+			long companyId, String audienceEntryERC) {
+
+		layoutPageTemplateStructureRelElementVariationAudienceEntryRelPersistence.
+			removeByC_AEERC(companyId, audienceEntryERC);
+	}
+
 	public List<LayoutPageTemplateStructureRelElementVariationAudienceEntryRel>
 		getLayoutPageTemplateStructureRelElementVariationAudienceEntryRels(
 			String layoutPageTemplateStructureRelElementVariationERC) {

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalServiceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalServiceImpl.java
@@ -29,6 +29,7 @@ public class
 	LayoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalServiceImpl
 		extends LayoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalServiceBaseImpl {
 
+	@Override
 	public LayoutPageTemplateStructureRelElementVariationAudienceEntryRel
 			addLayoutPageTemplateStructureRelElementVariationAudienceEntryRel(
 				long userId, long groupId, String audienceEntryERC,
@@ -66,6 +67,7 @@ public class
 				layoutPageTemplateStructureRelElementVariationAudienceEntryRel);
 	}
 
+	@Override
 	public void
 		deleteLayoutPageTemplateStructureRelElementVariationAudienceEntryRels(
 			String layoutPageTemplateStructureRelElementVariationERC) {
@@ -75,6 +77,7 @@ public class
 				layoutPageTemplateStructureRelElementVariationERC);
 	}
 
+	@Override
 	public void
 		deleteLayoutPageTemplateStructureRelElementVariationAudienceEntryRelsByAudienceEntryERC(
 			long companyId, String audienceEntryERC) {
@@ -83,6 +86,7 @@ public class
 			removeByC_AEERC(companyId, audienceEntryERC);
 	}
 
+	@Override
 	public List<LayoutPageTemplateStructureRelElementVariationAudienceEntryRel>
 		getLayoutPageTemplateStructureRelElementVariationAudienceEntryRels(
 			String layoutPageTemplateStructureRelElementVariationERC) {

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateStructureRelElementVariationLocalServiceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateStructureRelElementVariationLocalServiceImpl.java
@@ -128,6 +128,28 @@ public class LayoutPageTemplateStructureRelElementVariationLocalServiceImpl
 		}
 	}
 
+	public void deleteLayoutPageTemplateStructureRelElementVariations(
+		long plid, String segmentsExperienceERC) {
+
+		List<LayoutPageTemplateStructureRelElementVariation>
+			layoutPageTemplateStructureRelElementVariations =
+				layoutPageTemplateStructureRelElementVariationPersistence.
+					findByP_SEERC(plid, segmentsExperienceERC);
+
+		for (LayoutPageTemplateStructureRelElementVariation
+				layoutPageTemplateStructureRelElementVariation :
+					layoutPageTemplateStructureRelElementVariations) {
+
+			layoutPageTemplateStructureRelElementVariationPersistence.remove(
+				layoutPageTemplateStructureRelElementVariation);
+
+			_layoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService.
+				deleteLayoutPageTemplateStructureRelElementVariationAudienceEntryRels(
+					layoutPageTemplateStructureRelElementVariation.
+						getExternalReferenceCode());
+		}
+	}
+
 	public List<LayoutPageTemplateStructureRelElementVariation>
 		getLayoutPageTemplateStructureRelElementVariations(
 			boolean active, long plid, String segmentsExperienceERC) {

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateStructureRelElementVariationLocalServiceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateStructureRelElementVariationLocalServiceImpl.java
@@ -37,6 +37,7 @@ import org.osgi.service.component.annotations.Reference;
 public class LayoutPageTemplateStructureRelElementVariationLocalServiceImpl
 	extends LayoutPageTemplateStructureRelElementVariationLocalServiceBaseImpl {
 
+	@Override
 	public LayoutPageTemplateStructureRelElementVariation
 			addOrUpdateLayoutPageTemplateStructureRelElementVariation(
 				String externalReferenceCode, long userId, long groupId,
@@ -110,6 +111,7 @@ public class LayoutPageTemplateStructureRelElementVariationLocalServiceImpl
 		return layoutPageTemplateStructureRelElementVariation;
 	}
 
+	@Override
 	public void deleteLayoutPageTemplateStructureRelElementVariation(
 		String externalReferenceCode, long groupId) {
 
@@ -128,6 +130,7 @@ public class LayoutPageTemplateStructureRelElementVariationLocalServiceImpl
 		}
 	}
 
+	@Override
 	public void deleteLayoutPageTemplateStructureRelElementVariations(
 		long plid, String segmentsExperienceERC) {
 
@@ -150,6 +153,7 @@ public class LayoutPageTemplateStructureRelElementVariationLocalServiceImpl
 		}
 	}
 
+	@Override
 	public List<LayoutPageTemplateStructureRelElementVariation>
 		getLayoutPageTemplateStructureRelElementVariations(
 			boolean active, long plid, String segmentsExperienceERC) {
@@ -158,6 +162,7 @@ public class LayoutPageTemplateStructureRelElementVariationLocalServiceImpl
 			findByA_P_SEERC(active, plid, segmentsExperienceERC);
 	}
 
+	@Override
 	public List<LayoutPageTemplateStructureRelElementVariation>
 		getLayoutPageTemplateStructureRelElementVariations(long plid) {
 
@@ -165,6 +170,7 @@ public class LayoutPageTemplateStructureRelElementVariationLocalServiceImpl
 			findByPlid(plid);
 	}
 
+	@Override
 	public List<LayoutPageTemplateStructureRelElementVariation>
 		getLayoutPageTemplateStructureRelElementVariations(
 			long plid, String segmentsExperienceERC) {
@@ -173,6 +179,7 @@ public class LayoutPageTemplateStructureRelElementVariationLocalServiceImpl
 			findByP_SEERC(plid, segmentsExperienceERC);
 	}
 
+	@Override
 	public LayoutPageTemplateStructureRelElementVariation
 			updateLayoutPageTemplateStructureRelElementVariation(
 				String externalReferenceCode, long groupId, boolean active)

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateStructureRelElementVariationServiceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateStructureRelElementVariationServiceImpl.java
@@ -31,6 +31,7 @@ import org.osgi.service.component.annotations.Reference;
 public class LayoutPageTemplateStructureRelElementVariationServiceImpl
 	extends LayoutPageTemplateStructureRelElementVariationServiceBaseImpl {
 
+	@Override
 	public LayoutPageTemplateStructureRelElementVariation
 			addOrUpdateLayoutPageTemplateStructureRelElementVariation(
 				String externalReferenceCode, long groupId, boolean active,
@@ -50,6 +51,7 @@ public class LayoutPageTemplateStructureRelElementVariationServiceImpl
 				targetElement, audienceEntryERCs, serviceContext);
 	}
 
+	@Override
 	public void deleteLayoutPageTemplateStructureRelElementVariation(
 			String externalReferenceCode, long groupId, long plid)
 		throws PortalException {
@@ -62,6 +64,7 @@ public class LayoutPageTemplateStructureRelElementVariationServiceImpl
 				externalReferenceCode, groupId);
 	}
 
+	@Override
 	public List<LayoutPageTemplateStructureRelElementVariation>
 			getLayoutPageTemplateStructureRelElementVariations(long plid)
 		throws PortalException {
@@ -73,6 +76,7 @@ public class LayoutPageTemplateStructureRelElementVariationServiceImpl
 			getLayoutPageTemplateStructureRelElementVariations(plid);
 	}
 
+	@Override
 	public LayoutPageTemplateStructureRelElementVariation
 			updateLayoutPageTemplateStructureRelElementVariation(
 				String externalReferenceCode, long groupId, long plid,

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/persistence/impl/LayoutPageTemplateStructureRelElementVariationAudienceEntryRelPersistenceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/persistence/impl/LayoutPageTemplateStructureRelElementVariationAudienceEntryRelPersistenceImpl.java
@@ -490,6 +490,109 @@ public class
 				});
 	}
 
+	private CollectionPersistenceFinder
+		<LayoutPageTemplateStructureRelElementVariationAudienceEntryRel,
+		 NoSuchPageTemplateStructureRelElementVariationAudienceEntryRelException>
+			_collectionPersistenceFinderByC_AEERC;
+
+	/**
+	 * Returns an ordered range of all the layout page template structure rel element variation audience entry rels where companyId = &#63; and audienceEntryERC = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>LayoutPageTemplateStructureRelElementVariationAudienceEntryRelModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param audienceEntryERC the audience entry erc
+	 * @param start the lower bound of the range of layout page template structure rel element variation audience entry rels
+	 * @param end the upper bound of the range of layout page template structure rel element variation audience entry rels (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching layout page template structure rel element variation audience entry rels
+	 */
+	@Override
+	public List<LayoutPageTemplateStructureRelElementVariationAudienceEntryRel>
+		findByC_AEERC(
+			long companyId, String audienceEntryERC, int start, int end,
+			OrderByComparator
+				<LayoutPageTemplateStructureRelElementVariationAudienceEntryRel>
+					orderByComparator,
+			boolean useFinderCache) {
+
+		return _collectionPersistenceFinderByC_AEERC.find(
+			finderCache, new Object[] {companyId, audienceEntryERC}, start, end,
+			orderByComparator, useFinderCache);
+	}
+
+	/**
+	 * Returns the first layout page template structure rel element variation audience entry rel in the ordered set where companyId = &#63; and audienceEntryERC = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param audienceEntryERC the audience entry erc
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching layout page template structure rel element variation audience entry rel
+	 * @throws NoSuchPageTemplateStructureRelElementVariationAudienceEntryRelException if a matching layout page template structure rel element variation audience entry rel could not be found
+	 */
+	@Override
+	public LayoutPageTemplateStructureRelElementVariationAudienceEntryRel
+			findByC_AEERC_First(
+				long companyId, String audienceEntryERC,
+				OrderByComparator
+					<LayoutPageTemplateStructureRelElementVariationAudienceEntryRel>
+						orderByComparator)
+		throws NoSuchPageTemplateStructureRelElementVariationAudienceEntryRelException {
+
+		return _collectionPersistenceFinderByC_AEERC.findFirst(
+			finderCache, new Object[] {companyId, audienceEntryERC},
+			orderByComparator);
+	}
+
+	/**
+	 * Returns the first layout page template structure rel element variation audience entry rel in the ordered set where companyId = &#63; and audienceEntryERC = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param audienceEntryERC the audience entry erc
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching layout page template structure rel element variation audience entry rel, or <code>null</code> if a matching layout page template structure rel element variation audience entry rel could not be found
+	 */
+	@Override
+	public LayoutPageTemplateStructureRelElementVariationAudienceEntryRel
+		fetchByC_AEERC_First(
+			long companyId, String audienceEntryERC,
+			OrderByComparator
+				<LayoutPageTemplateStructureRelElementVariationAudienceEntryRel>
+					orderByComparator) {
+
+		return _collectionPersistenceFinderByC_AEERC.fetchFirst(
+			finderCache, new Object[] {companyId, audienceEntryERC},
+			orderByComparator);
+	}
+
+	/**
+	 * Removes all the layout page template structure rel element variation audience entry rels where companyId = &#63; and audienceEntryERC = &#63; from the database.
+	 *
+	 * @param companyId the company ID
+	 * @param audienceEntryERC the audience entry erc
+	 */
+	@Override
+	public void removeByC_AEERC(long companyId, String audienceEntryERC) {
+		_collectionPersistenceFinderByC_AEERC.remove(
+			finderCache, new Object[] {companyId, audienceEntryERC});
+	}
+
+	/**
+	 * Returns the number of layout page template structure rel element variation audience entry rels where companyId = &#63; and audienceEntryERC = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param audienceEntryERC the audience entry erc
+	 * @return the number of matching layout page template structure rel element variation audience entry rels
+	 */
+	@Override
+	public int countByC_AEERC(long companyId, String audienceEntryERC) {
+		return _collectionPersistenceFinderByC_AEERC.count(
+			finderCache, new Object[] {companyId, audienceEntryERC});
+	}
+
 	private UniquePersistenceFinder
 		<LayoutPageTemplateStructureRelElementVariationAudienceEntryRel,
 		 NoSuchPageTemplateStructureRelElementVariationAudienceEntryRelException>
@@ -1176,6 +1279,43 @@ public class
 					LayoutPageTemplateStructureRelElementVariationAudienceEntryRel::
 						getLayoutPageTemplateStructureRelElementVariationERC));
 
+		_collectionPersistenceFinderByC_AEERC =
+			new CollectionPersistenceFinder<>(
+				this,
+				new FinderPath(
+					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_AEERC",
+					new String[] {
+						Long.class.getName(), String.class.getName(),
+						Integer.class.getName(), Integer.class.getName(),
+						OrderByComparator.class.getName()
+					},
+					new String[] {"companyId", "audienceEntryERC"}, true),
+				new FinderPath(
+					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_AEERC",
+					new String[] {Long.class.getName(), String.class.getName()},
+					new String[] {"companyId", "audienceEntryERC"}, 0, 2, true,
+					null),
+				new FinderPath(
+					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_AEERC",
+					new String[] {Long.class.getName(), String.class.getName()},
+					new String[] {"companyId", "audienceEntryERC"}, 0, 2, false,
+					null),
+				_SQL_SELECT_LAYOUTPAGETEMPLATESTRUCTURERELELEMENTVARIATIONAUDIENCEENTRYREL_WHERE,
+				_SQL_COUNT_LAYOUTPAGETEMPLATESTRUCTURERELELEMENTVARIATIONAUDIENCEENTRYREL_WHERE,
+				LayoutPageTemplateStructureRelElementVariationAudienceEntryRelModelImpl.ORDER_BY_JPQL,
+				_ENTITY_ALIAS_PREFIX, "", "", null,
+				new FinderColumn<>(
+					"layoutPageTemplateStructureRelElementVariationAudienceEntryRel.",
+					"companyId", FinderColumn.Type.LONG, "=", true, true,
+					LayoutPageTemplateStructureRelElementVariationAudienceEntryRel::
+						getCompanyId),
+				new FinderColumn<>(
+					"layoutPageTemplateStructureRelElementVariationAudienceEntryRel.",
+					"audienceEntryERC", FinderColumn.Type.STRING, "=", true,
+					true,
+					LayoutPageTemplateStructureRelElementVariationAudienceEntryRel::
+						getAudienceEntryERC));
+
 		_uniquePersistenceFinderByERC_G = new UniquePersistenceFinder<>(
 			this,
 			createUniqueFinderPath(
@@ -1279,4 +1419,4 @@ public class
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1664422624
+// LIFERAY-SERVICE-BUILDER-HASH:-507220576

--- a/modules/apps/layout/layout-page-template-service/src/main/resources/META-INF/sql/indexes.sql
+++ b/modules/apps/layout/layout-page-template-service/src/main/resources/META-INF/sql/indexes.sql
@@ -1,3 +1,4 @@
+create index IX_11CEFB3 on LPTSREVAudienceEntryRel (companyId, audienceEntryERC[$COLUMN_LENGTH:75$]);
 create unique index IX_BB3F862 on LPTSREVAudienceEntryRel (groupId, externalReferenceCode[$COLUMN_LENGTH:75$], ctCollectionId);
 create index IX_3530024E on LPTSREVAudienceEntryRel (lptsRelElementVariationERC[$COLUMN_LENGTH:75$]);
 create unique index IX_B988F085 on LPTSREVAudienceEntryRel (uuid_[$COLUMN_LENGTH:75$], groupId, ctCollectionId);

--- a/modules/apps/layout/layout-page-template-service/src/main/resources/service.properties
+++ b/modules/apps/layout/layout-page-template-service/src/main/resources/service.properties
@@ -13,5 +13,5 @@
 ##
 
     build.namespace=com.liferay.layout.page.template.service
-    build.number=12
-    build.date=1784030532011
+    build.number=13
+    build.date=1784195813192

--- a/modules/apps/layout/layout-page-template-test/build.gradle
+++ b/modules/apps/layout/layout-page-template-test/build.gradle
@@ -11,6 +11,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:asset:asset-display-page-api")
 	testIntegrationImplementation project(":apps:asset:asset-link-api")
 	testIntegrationImplementation project(":apps:asset:asset-list-api")
+	testIntegrationImplementation project(":apps:audiences:audiences-api")
 	testIntegrationImplementation project(":apps:change-tracking:change-tracking-test-util")
 	testIntegrationImplementation project(":apps:depot:depot-api")
 	testIntegrationImplementation project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/model/listener/test/AudiencesEntryModelListenerTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/model/listener/test/AudiencesEntryModelListenerTest.java
@@ -1,0 +1,138 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.page.template.internal.model.listener.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.audiences.model.AudiencesEntry;
+import com.liferay.audiences.service.AudiencesEntryLocalService;
+import com.liferay.layout.page.template.model.LayoutPageTemplateStructureRelElementVariationAudienceEntryRel;
+import com.liferay.layout.page.template.service.LayoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService;
+import com.liferay.layout.page.template.service.LayoutPageTemplateStructureRelElementVariationLocalService;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Víctor Galán
+ */
+@RunWith(Arquillian.class)
+public class AudiencesEntryModelListenerTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_layout = LayoutTestUtil.addTypeContentLayout(_group);
+
+		_serviceContext = ServiceContextTestUtil.getServiceContext(
+			_group.getGroupId());
+	}
+
+	@Test
+	@TestInfo("LPD-98435")
+	public void testOnBeforeRemove() throws Exception {
+		AudiencesEntry audiencesEntry =
+			_audiencesEntryLocalService.addAudiencesEntry(
+				null, StringPool.BLANK, RandomTestUtil.randomString(),
+				_serviceContext);
+
+		String audienceEntryERC = RandomTestUtil.randomString();
+		String externalReferenceCode = RandomTestUtil.randomString();
+
+		_layoutPageTemplateStructureRelElementVariationLocalService.
+			addOrUpdateLayoutPageTemplateStructureRelElementVariation(
+				externalReferenceCode, TestPropsValues.getUserId(),
+				_group.getGroupId(), true, RandomTestUtil.randomString(),
+				Collections.emptyMap(), Collections.emptyMap(),
+				RandomTestUtil.randomString(), _layout.getPlid(),
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+				new String[] {
+					audiencesEntry.getExternalReferenceCode(), audienceEntryERC
+				},
+				_serviceContext);
+
+		List<LayoutPageTemplateStructureRelElementVariationAudienceEntryRel>
+			layoutPageTemplateStructureRelElementVariationAudienceEntryRels =
+				_layoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService.
+					getLayoutPageTemplateStructureRelElementVariationAudienceEntryRels(
+						externalReferenceCode);
+
+		Assert.assertEquals(
+			layoutPageTemplateStructureRelElementVariationAudienceEntryRels.
+				toString(),
+			2,
+			layoutPageTemplateStructureRelElementVariationAudienceEntryRels.
+				size());
+
+		_audiencesEntryLocalService.deleteAudiencesEntry(
+			audiencesEntry.getAudiencesEntryId());
+
+		layoutPageTemplateStructureRelElementVariationAudienceEntryRels =
+			_layoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService.
+				getLayoutPageTemplateStructureRelElementVariationAudienceEntryRels(
+					externalReferenceCode);
+
+		Assert.assertEquals(
+			layoutPageTemplateStructureRelElementVariationAudienceEntryRels.
+				toString(),
+			1,
+			layoutPageTemplateStructureRelElementVariationAudienceEntryRels.
+				size());
+
+		LayoutPageTemplateStructureRelElementVariationAudienceEntryRel
+			layoutPageTemplateStructureRelElementVariationAudienceEntryRel =
+				layoutPageTemplateStructureRelElementVariationAudienceEntryRels.
+					get(0);
+
+		Assert.assertEquals(
+			audienceEntryERC,
+			layoutPageTemplateStructureRelElementVariationAudienceEntryRel.
+				getAudienceEntryERC());
+	}
+
+	@Inject
+	private AudiencesEntryLocalService _audiencesEntryLocalService;
+
+	private Group _group;
+	private Layout _layout;
+
+	@Inject
+	private
+		LayoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService
+			_layoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService;
+
+	@Inject
+	private LayoutPageTemplateStructureRelElementVariationLocalService
+		_layoutPageTemplateStructureRelElementVariationLocalService;
+
+	private ServiceContext _serviceContext;
+
+}

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/model/listener/test/SegmentsExperienceModelListenerTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/model/listener/test/SegmentsExperienceModelListenerTest.java
@@ -7,8 +7,14 @@ package com.liferay.layout.page.template.internal.model.listener.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.fragment.constants.FragmentConstants;
+import com.liferay.fragment.model.FragmentEntryLink;
+import com.liferay.fragment.service.FragmentEntryLinkLocalService;
 import com.liferay.layout.page.template.internal.portlet.constants.LayoutPageTemplatePortletKeys;
 import com.liferay.layout.page.template.model.LayoutPageTemplateStructureRel;
+import com.liferay.layout.page.template.model.LayoutPageTemplateStructureRelElementVariation;
+import com.liferay.layout.page.template.model.LayoutPageTemplateStructureRelElementVariationAudienceEntryRel;
+import com.liferay.layout.page.template.service.LayoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService;
+import com.liferay.layout.page.template.service.LayoutPageTemplateStructureRelElementVariationLocalService;
 import com.liferay.layout.page.template.service.LayoutPageTemplateStructureRelLocalService;
 import com.liferay.layout.test.util.ContentLayoutTestUtil;
 import com.liferay.layout.test.util.LayoutTestUtil;
@@ -30,13 +36,13 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.PortletKeys;
-import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.segments.model.SegmentsExperience;
 import com.liferay.segments.service.SegmentsExperienceLocalService;
 import com.liferay.segments.test.util.SegmentsTestUtil;
 
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.After;
@@ -78,13 +84,128 @@ public class SegmentsExperienceModelListenerTest {
 	}
 
 	@Test
-	public void test() throws Exception {
+	@TestInfo({"LPD-75847", "LPD-98435"})
+	public void testOnBeforeRemove() throws Exception {
+		_testOnBeforeRemoveWithFragmentEntryLinks();
+		_testOnBeforeRemoveWithLayoutPageTemplateStructureRelElementVariation();
+		_testOnBeforeRemoveWithLayoutPageTemplateStructureRels();
+		_testOnBeforeRemoveWithPortletPreferences();
+	}
+
+	private SegmentsExperience _getSegmentsExperience(String portletId)
+		throws Exception {
+
 		SegmentsExperience segmentsExperience =
-			_segmentsExperienceLocalService.addSegmentsExperience(
-				null, TestPropsValues.getUserId(), _group.getGroupId(),
-				RandomTestUtil.randomString(), null, _layout.getPlid(),
-				RandomTestUtil.randomLocaleStringMap(), true,
-				new UnicodeProperties(true), _serviceContext);
+			SegmentsTestUtil.addSegmentsExperience(
+				_group.getGroupId(), _layout.getPlid());
+
+		ContentLayoutTestUtil.addFragmentEntryLinkToLayout(
+			JSONUtil.put(
+				"portletId", portletId
+			).toString(),
+			StringPool.BLANK, StringPool.BLANK, null, null, StringPool.BLANK,
+			StringPool.BLANK, _layout, StringPool.BLANK,
+			segmentsExperience.getSegmentsExperienceId(),
+			FragmentConstants.TYPE_PORTLET);
+
+		return segmentsExperience;
+	}
+
+	private void _testOnBeforeRemoveWithFragmentEntryLinks() throws Exception {
+		SegmentsExperience segmentsExperience =
+			SegmentsTestUtil.addSegmentsExperience(
+				_group.getGroupId(), _layout.getPlid());
+
+		ContentLayoutTestUtil.addFragmentEntryLinkToLayout(
+			"{}", _layout, segmentsExperience.getSegmentsExperienceId());
+
+		List<FragmentEntryLink> fragmentEntryLinks =
+			_fragmentEntryLinkLocalService.
+				getFragmentEntryLinksBySegmentsExperienceId(
+					_group.getGroupId(),
+					segmentsExperience.getSegmentsExperienceId(),
+					_layout.getPlid());
+
+		Assert.assertEquals(
+			fragmentEntryLinks.toString(), 1, fragmentEntryLinks.size());
+
+		_segmentsExperienceLocalService.deleteSegmentsExperience(
+			segmentsExperience);
+
+		fragmentEntryLinks =
+			_fragmentEntryLinkLocalService.
+				getFragmentEntryLinksBySegmentsExperienceId(
+					_group.getGroupId(),
+					segmentsExperience.getSegmentsExperienceId(),
+					_layout.getPlid());
+
+		Assert.assertEquals(
+			fragmentEntryLinks.toString(), 0, fragmentEntryLinks.size());
+	}
+
+	private void _testOnBeforeRemoveWithLayoutPageTemplateStructureRelElementVariation()
+		throws Exception {
+
+		SegmentsExperience segmentsExperience =
+			SegmentsTestUtil.addSegmentsExperience(
+				_group.getGroupId(), _layout.getPlid());
+
+		String externalReferenceCode = RandomTestUtil.randomString();
+
+		_layoutPageTemplateStructureRelElementVariationLocalService.
+			addOrUpdateLayoutPageTemplateStructureRelElementVariation(
+				externalReferenceCode, TestPropsValues.getUserId(),
+				_group.getGroupId(), true, RandomTestUtil.randomString(),
+				Collections.emptyMap(), Collections.emptyMap(),
+				RandomTestUtil.randomString(), _layout.getPlid(),
+				segmentsExperience.getExternalReferenceCode(),
+				RandomTestUtil.randomString(),
+				new String[] {RandomTestUtil.randomString()}, _serviceContext);
+
+		List<LayoutPageTemplateStructureRelElementVariation>
+			layoutPageTemplateStructureRelElementVariations =
+				_layoutPageTemplateStructureRelElementVariationLocalService.
+					getLayoutPageTemplateStructureRelElementVariations(
+						_layout.getPlid(),
+						segmentsExperience.getExternalReferenceCode());
+
+		Assert.assertEquals(
+			layoutPageTemplateStructureRelElementVariations.toString(), 1,
+			layoutPageTemplateStructureRelElementVariations.size());
+
+		_segmentsExperienceLocalService.deleteSegmentsExperience(
+			segmentsExperience);
+
+		layoutPageTemplateStructureRelElementVariations =
+			_layoutPageTemplateStructureRelElementVariationLocalService.
+				getLayoutPageTemplateStructureRelElementVariations(
+					_layout.getPlid(),
+					segmentsExperience.getExternalReferenceCode());
+
+		Assert.assertEquals(
+			layoutPageTemplateStructureRelElementVariations.toString(), 0,
+			layoutPageTemplateStructureRelElementVariations.size());
+
+		List<LayoutPageTemplateStructureRelElementVariationAudienceEntryRel>
+			layoutPageTemplateStructureRelElementVariationAudienceEntryRels =
+				_layoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService.
+					getLayoutPageTemplateStructureRelElementVariationAudienceEntryRels(
+						externalReferenceCode);
+
+		Assert.assertEquals(
+			layoutPageTemplateStructureRelElementVariationAudienceEntryRels.
+				toString(),
+			0,
+			layoutPageTemplateStructureRelElementVariationAudienceEntryRels.
+				size());
+	}
+
+	private void _testOnBeforeRemoveWithLayoutPageTemplateStructureRels()
+		throws Exception {
+
+		SegmentsExperience segmentsExperience =
+			SegmentsTestUtil.addSegmentsExperience(
+				_group.getGroupId(), _layout.getPlid());
 
 		int count = 5;
 
@@ -120,11 +241,7 @@ public class SegmentsExperienceModelListenerTest {
 			layoutPageTemplateStructureRels.size());
 	}
 
-	@Test
-	@TestInfo("LPD-75847")
-	public void testDeleteSegmentsExperienceKeepsNoninstanceablePortletPreferences()
-		throws Exception {
-
+	private void _testOnBeforeRemoveWithPortletPreferences() throws Exception {
 		String portletId = PortletIdCodec.encode(
 			LayoutPageTemplatePortletKeys.
 				LAYOUT_PAGE_TEMPLATE_NONINSTANCEABLE_TEST_PORTLET,
@@ -163,29 +280,22 @@ public class SegmentsExperienceModelListenerTest {
 				portletId));
 	}
 
-	private SegmentsExperience _getSegmentsExperience(String portletId)
-		throws Exception {
-
-		SegmentsExperience segmentsExperience =
-			SegmentsTestUtil.addSegmentsExperience(
-				_group.getGroupId(), _layout.getPlid());
-
-		ContentLayoutTestUtil.addFragmentEntryLinkToLayout(
-			JSONUtil.put(
-				"portletId", portletId
-			).toString(),
-			StringPool.BLANK, StringPool.BLANK, null, null, StringPool.BLANK,
-			StringPool.BLANK, _layout, StringPool.BLANK,
-			segmentsExperience.getSegmentsExperienceId(),
-			FragmentConstants.TYPE_PORTLET);
-
-		return segmentsExperience;
-	}
+	@Inject
+	private FragmentEntryLinkLocalService _fragmentEntryLinkLocalService;
 
 	@DeleteAfterTestRun
 	private Group _group;
 
 	private Layout _layout;
+
+	@Inject
+	private
+		LayoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService
+			_layoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService;
+
+	@Inject
+	private LayoutPageTemplateStructureRelElementVariationLocalService
+		_layoutPageTemplateStructureRelElementVariationLocalService;
 
 	@Inject
 	private LayoutPageTemplateStructureRelLocalService

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/persistence/test/LayoutPageTemplateStructureRelElementVariationAudienceEntryRelPersistenceTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/persistence/test/LayoutPageTemplateStructureRelElementVariationAudienceEntryRelPersistenceTest.java
@@ -331,6 +331,15 @@ public class
 	}
 
 	@Test
+	public void testCountByC_AEERC() throws Exception {
+		_persistence.countByC_AEERC(RandomTestUtil.nextLong(), "");
+
+		_persistence.countByC_AEERC(0L, "null");
+
+		_persistence.countByC_AEERC(0L, (String)null);
+	}
+
+	@Test
 	public void testCountByERC_G() throws Exception {
 		_persistence.countByERC_G("", RandomTestUtil.nextLong());
 
@@ -856,4 +865,4 @@ public class
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1649911216
+// LIFERAY-SERVICE-BUILDER-HASH:-1928368371


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98435

## What Is Being Fixed

Element variation data was orphaned when the audiences and segments experiences it referenced were deleted. Deleting an audience entry left element variation audience entry rels pointing at it, and deleting a segments experience left the element variations bound to that experience, so stale rows accumulated with no way to reach or clean them up.

## How It Is Being Fixed

Two model listeners now cascade the deletes. A new AudiencesEntryModelListener removes the element variation audience entry rels that reference a deleted audience entry, and the SegmentsExperienceModelListener removes the element variations tied to a deleted segments experience along with their audience entry rels. The local services gained the delete-by-reference methods these listeners need, and both cascade paths are covered by integration tests. This branch also adds the missing @Override annotations on the element variation service implementations, per review feedback.

## PR Check

**pr-check: PASS** — tested on `fa0814d4f197313b205951825c40193c5c3100cb`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "fa0814d4f197313b205951825c40193c5c3100cb"} -->
