### PR TITLE
LPD-98552 Reject duplicate audiences on an element variation target

### DIFF
--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/exception/DuplicateLayoutPageTemplateStructureRelElementVariationAudienceEntryRelException.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/exception/DuplicateLayoutPageTemplateStructureRelElementVariationAudienceEntryRelException.java
@@ -1,0 +1,38 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.page.template.exception;
+
+import com.liferay.portal.kernel.exception.PortalException;
+
+/**
+ * @author Víctor Galán
+ */
+public class
+	DuplicateLayoutPageTemplateStructureRelElementVariationAudienceEntryRelException
+		extends PortalException {
+
+	public DuplicateLayoutPageTemplateStructureRelElementVariationAudienceEntryRelException() {
+	}
+
+	public DuplicateLayoutPageTemplateStructureRelElementVariationAudienceEntryRelException(
+		String msg) {
+
+		super(msg);
+	}
+
+	public DuplicateLayoutPageTemplateStructureRelElementVariationAudienceEntryRelException(
+		String msg, Throwable throwable) {
+
+		super(msg, throwable);
+	}
+
+	public DuplicateLayoutPageTemplateStructureRelElementVariationAudienceEntryRelException(
+		Throwable throwable) {
+
+		super(throwable);
+	}
+
+}

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationLocalService.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationLocalService.java
@@ -411,4 +411,4 @@ public interface LayoutPageTemplateStructureRelElementVariationLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-757430278
+// LIFERAY-SERVICE-BUILDER-HASH:190826426

--- a/modules/apps/layout/layout-page-template-service/service.xml
+++ b/modules/apps/layout/layout-page-template-service/service.xml
@@ -410,6 +410,7 @@
 		<exception>DuplicateLayoutPageTemplateCollection</exception>
 		<exception>DuplicateLayoutPageTemplateCollectionType</exception>
 		<exception>DuplicateLayoutPageTemplateEntry</exception>
+		<exception>DuplicateLayoutPageTemplateStructureRelElementVariationAudienceEntryRel</exception>
 		<exception>LayoutPageTemplateCollectionGroupId</exception>
 		<exception>LayoutPageTemplateCollectionLayoutPageTemplateCollectionKey</exception>
 		<exception>LayoutPageTemplateCollectionName</exception>

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateStructureRelElementVariationLocalServiceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateStructureRelElementVariationLocalServiceImpl.java
@@ -5,12 +5,15 @@
 
 package com.liferay.layout.page.template.service.impl;
 
+import com.liferay.layout.page.template.exception.DuplicateLayoutPageTemplateStructureRelElementVariationAudienceEntryRelException;
 import com.liferay.layout.page.template.exception.LayoutPageTemplateStructureRelElementVariationAudienceEntryERCsException;
 import com.liferay.layout.page.template.exception.LayoutPageTemplateStructureRelElementVariationNameException;
 import com.liferay.layout.page.template.exception.LayoutPageTemplateStructureRelElementVariationTargetElementException;
 import com.liferay.layout.page.template.model.LayoutPageTemplateStructureRelElementVariation;
+import com.liferay.layout.page.template.model.LayoutPageTemplateStructureRelElementVariationAudienceEntryRel;
 import com.liferay.layout.page.template.service.LayoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService;
 import com.liferay.layout.page.template.service.base.LayoutPageTemplateStructureRelElementVariationLocalServiceBaseImpl;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.User;
@@ -20,9 +23,12 @@ import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -47,7 +53,9 @@ public class LayoutPageTemplateStructureRelElementVariationLocalServiceImpl
 				String[] audienceEntryERCs, ServiceContext serviceContext)
 		throws PortalException {
 
-		_validate(audienceEntryERCs, name, targetElement);
+		_validate(
+			externalReferenceCode, name, plid, segmentsExperienceERC,
+			targetElement, audienceEntryERCs);
 
 		LayoutPageTemplateStructureRelElementVariation
 			layoutPageTemplateStructureRelElementVariation =
@@ -201,12 +209,80 @@ public class LayoutPageTemplateStructureRelElementVariationLocalServiceImpl
 	}
 
 	private void _validate(
-			String[] audienceEntryERCs, String name, String targetElement)
+			String externalReferenceCode, String name, long plid,
+			String segmentsExperienceERC, String targetElement,
+			String[] audienceEntryERCs)
 		throws PortalException {
 
 		if (ArrayUtil.isEmpty(audienceEntryERCs)) {
 			throw new LayoutPageTemplateStructureRelElementVariationAudienceEntryERCsException(
 				"Audience entry external reference codes must not be empty");
+		}
+
+		Set<String> audienceEntryERCsSet = new HashSet<>();
+
+		for (String audienceEntryERC : audienceEntryERCs) {
+			if (Validator.isNull(audienceEntryERC)) {
+				continue;
+			}
+
+			if (!audienceEntryERCsSet.add(audienceEntryERC)) {
+				throw new DuplicateLayoutPageTemplateStructureRelElementVariationAudienceEntryRelException(
+					"Duplicate audience entry external reference code " +
+						audienceEntryERC);
+			}
+		}
+
+		List<LayoutPageTemplateStructureRelElementVariation>
+			layoutPageTemplateStructureRelElementVariations =
+				layoutPageTemplateStructureRelElementVariationPersistence.
+					findByP_SEERC(plid, segmentsExperienceERC);
+
+		for (LayoutPageTemplateStructureRelElementVariation
+				layoutPageTemplateStructureRelElementVariation :
+					layoutPageTemplateStructureRelElementVariations) {
+
+			String existingExternalReferenceCode =
+				layoutPageTemplateStructureRelElementVariation.
+					getExternalReferenceCode();
+
+			if (Objects.equals(
+					externalReferenceCode, existingExternalReferenceCode)) {
+
+				continue;
+			}
+
+			String existingTargetElement =
+				layoutPageTemplateStructureRelElementVariation.
+					getTargetElement();
+
+			if (!Objects.equals(targetElement, existingTargetElement)) {
+				continue;
+			}
+
+			List<LayoutPageTemplateStructureRelElementVariationAudienceEntryRel>
+				layoutPageTemplateStructureRelElementVariationAudienceEntryRels =
+					_layoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService.
+						getLayoutPageTemplateStructureRelElementVariationAudienceEntryRels(
+							existingExternalReferenceCode);
+
+			for (LayoutPageTemplateStructureRelElementVariationAudienceEntryRel
+					layoutPageTemplateStructureRelElementVariationAudienceEntryRel :
+						layoutPageTemplateStructureRelElementVariationAudienceEntryRels) {
+
+				String audienceEntryERC =
+					layoutPageTemplateStructureRelElementVariationAudienceEntryRel.
+						getAudienceEntryERC();
+
+				if (audienceEntryERCsSet.contains(audienceEntryERC)) {
+					throw new LayoutPageTemplateStructureRelElementVariationTargetElementException(
+						StringBundler.concat(
+							"{audienceEntryERC=", audienceEntryERC, ", plid=",
+							plid, ", segmentsExperienceERC=",
+							segmentsExperienceERC, ", targetElement=",
+							targetElement, "}"));
+				}
+			}
 		}
 
 		if (Validator.isNull(name)) {

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/test/LayoutPageTemplateStructureRelElementVariationLocalServiceTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/test/LayoutPageTemplateStructureRelElementVariationLocalServiceTest.java
@@ -1,0 +1,241 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.page.template.service.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.layout.page.template.exception.DuplicateLayoutPageTemplateStructureRelElementVariationAudienceEntryRelException;
+import com.liferay.layout.page.template.exception.LayoutPageTemplateStructureRelElementVariationTargetElementException;
+import com.liferay.layout.page.template.model.LayoutPageTemplateStructureRelElementVariation;
+import com.liferay.layout.page.template.service.LayoutPageTemplateStructureRelElementVariationLocalService;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Víctor Galán
+ */
+@RunWith(Arquillian.class)
+public class LayoutPageTemplateStructureRelElementVariationLocalServiceTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_serviceContext = ServiceContextTestUtil.getServiceContext(
+			_group, TestPropsValues.getUserId());
+	}
+
+	@Test
+	public void testAddOrUpdateLayoutPageTemplateStructureRelElementVariation()
+		throws Exception {
+
+		_testAddOrUpdateLayoutPageTemplateStructureRelElementVariationWithDuplicateAudienceEntryERCForTargetElement();
+		_testAddOrUpdateLayoutPageTemplateStructureRelElementVariationWithDuplicateAudienceEntryERCs();
+		_testAddOrUpdateLayoutPageTemplateStructureRelElementVariationWithSameAudienceEntryERCForDifferentSegmentsExperience();
+		_testAddOrUpdateLayoutPageTemplateStructureRelElementVariationWithSameAudienceEntryERCForDifferentTargetElement();
+	}
+
+	private void _testAddOrUpdateLayoutPageTemplateStructureRelElementVariationWithDuplicateAudienceEntryERCForTargetElement()
+		throws Exception {
+
+		String audienceEntryERC = RandomTestUtil.randomString();
+
+		Layout layout = LayoutTestUtil.addTypeContentLayout(_group);
+
+		long plid = layout.getPlid();
+
+		String segmentsExperienceERC = RandomTestUtil.randomString();
+		String targetElement = RandomTestUtil.randomString();
+
+		_layoutPageTemplateStructureRelElementVariationLocalService.
+			addOrUpdateLayoutPageTemplateStructureRelElementVariation(
+				RandomTestUtil.randomString(), TestPropsValues.getUserId(),
+				_group.getGroupId(), RandomTestUtil.randomBoolean(),
+				RandomTestUtil.randomString(),
+				Collections.singletonMap(
+					LocaleUtil.US, RandomTestUtil.randomString()),
+				Collections.singletonMap(
+					LocaleUtil.US, RandomTestUtil.randomString()),
+				RandomTestUtil.randomString(), plid, segmentsExperienceERC,
+				targetElement, new String[] {audienceEntryERC},
+				_serviceContext);
+
+		Assert.assertThrows(
+			LayoutPageTemplateStructureRelElementVariationTargetElementException.class,
+			() ->
+				_layoutPageTemplateStructureRelElementVariationLocalService.
+					addOrUpdateLayoutPageTemplateStructureRelElementVariation(
+						RandomTestUtil.randomString(),
+						TestPropsValues.getUserId(), _group.getGroupId(),
+						RandomTestUtil.randomBoolean(),
+						RandomTestUtil.randomString(),
+						Collections.singletonMap(
+							LocaleUtil.US, RandomTestUtil.randomString()),
+						Collections.singletonMap(
+							LocaleUtil.US, RandomTestUtil.randomString()),
+						RandomTestUtil.randomString(), plid,
+						segmentsExperienceERC, targetElement,
+						new String[] {audienceEntryERC}, _serviceContext));
+	}
+
+	private void _testAddOrUpdateLayoutPageTemplateStructureRelElementVariationWithDuplicateAudienceEntryERCs()
+		throws Exception {
+
+		String audienceEntryERC = RandomTestUtil.randomString();
+
+		Layout layout = LayoutTestUtil.addTypeContentLayout(_group);
+
+		Assert.assertThrows(
+			DuplicateLayoutPageTemplateStructureRelElementVariationAudienceEntryRelException.class,
+			() ->
+				_layoutPageTemplateStructureRelElementVariationLocalService.
+					addOrUpdateLayoutPageTemplateStructureRelElementVariation(
+						RandomTestUtil.randomString(),
+						TestPropsValues.getUserId(), _group.getGroupId(),
+						RandomTestUtil.randomBoolean(),
+						RandomTestUtil.randomString(),
+						Collections.singletonMap(
+							LocaleUtil.US, RandomTestUtil.randomString()),
+						Collections.singletonMap(
+							LocaleUtil.US, RandomTestUtil.randomString()),
+						RandomTestUtil.randomString(), layout.getPlid(),
+						RandomTestUtil.randomString(),
+						RandomTestUtil.randomString(),
+						new String[] {audienceEntryERC, audienceEntryERC},
+						_serviceContext));
+	}
+
+	private void _testAddOrUpdateLayoutPageTemplateStructureRelElementVariationWithSameAudienceEntryERCForDifferentSegmentsExperience()
+		throws Exception {
+
+		String audienceEntryERC = RandomTestUtil.randomString();
+
+		Layout layout = LayoutTestUtil.addTypeContentLayout(_group);
+
+		long plid = layout.getPlid();
+
+		String targetElement = RandomTestUtil.randomString();
+
+		_layoutPageTemplateStructureRelElementVariationLocalService.
+			addOrUpdateLayoutPageTemplateStructureRelElementVariation(
+				RandomTestUtil.randomString(), TestPropsValues.getUserId(),
+				_group.getGroupId(), RandomTestUtil.randomBoolean(),
+				RandomTestUtil.randomString(),
+				Collections.singletonMap(
+					LocaleUtil.US, RandomTestUtil.randomString()),
+				Collections.singletonMap(
+					LocaleUtil.US, RandomTestUtil.randomString()),
+				RandomTestUtil.randomString(), plid,
+				RandomTestUtil.randomString(), targetElement,
+				new String[] {audienceEntryERC}, _serviceContext);
+
+		_layoutPageTemplateStructureRelElementVariationLocalService.
+			addOrUpdateLayoutPageTemplateStructureRelElementVariation(
+				RandomTestUtil.randomString(), TestPropsValues.getUserId(),
+				_group.getGroupId(), RandomTestUtil.randomBoolean(),
+				RandomTestUtil.randomString(),
+				Collections.singletonMap(
+					LocaleUtil.US, RandomTestUtil.randomString()),
+				Collections.singletonMap(
+					LocaleUtil.US, RandomTestUtil.randomString()),
+				RandomTestUtil.randomString(), plid,
+				RandomTestUtil.randomString(), targetElement,
+				new String[] {audienceEntryERC}, _serviceContext);
+
+		List<LayoutPageTemplateStructureRelElementVariation>
+			layoutPageTemplateStructureRelElementVariations =
+				_layoutPageTemplateStructureRelElementVariationLocalService.
+					getLayoutPageTemplateStructureRelElementVariations(plid);
+
+		Assert.assertEquals(
+			layoutPageTemplateStructureRelElementVariations.toString(), 2,
+			layoutPageTemplateStructureRelElementVariations.size());
+	}
+
+	private void _testAddOrUpdateLayoutPageTemplateStructureRelElementVariationWithSameAudienceEntryERCForDifferentTargetElement()
+		throws Exception {
+
+		String audienceEntryERC = RandomTestUtil.randomString();
+
+		Layout layout = LayoutTestUtil.addTypeContentLayout(_group);
+
+		long plid = layout.getPlid();
+
+		String segmentsExperienceERC = RandomTestUtil.randomString();
+
+		_layoutPageTemplateStructureRelElementVariationLocalService.
+			addOrUpdateLayoutPageTemplateStructureRelElementVariation(
+				RandomTestUtil.randomString(), TestPropsValues.getUserId(),
+				_group.getGroupId(), RandomTestUtil.randomBoolean(),
+				RandomTestUtil.randomString(),
+				Collections.singletonMap(
+					LocaleUtil.US, RandomTestUtil.randomString()),
+				Collections.singletonMap(
+					LocaleUtil.US, RandomTestUtil.randomString()),
+				RandomTestUtil.randomString(), plid, segmentsExperienceERC,
+				RandomTestUtil.randomString(), new String[] {audienceEntryERC},
+				_serviceContext);
+
+		_layoutPageTemplateStructureRelElementVariationLocalService.
+			addOrUpdateLayoutPageTemplateStructureRelElementVariation(
+				RandomTestUtil.randomString(), TestPropsValues.getUserId(),
+				_group.getGroupId(), RandomTestUtil.randomBoolean(),
+				RandomTestUtil.randomString(),
+				Collections.singletonMap(
+					LocaleUtil.US, RandomTestUtil.randomString()),
+				Collections.singletonMap(
+					LocaleUtil.US, RandomTestUtil.randomString()),
+				RandomTestUtil.randomString(), plid, segmentsExperienceERC,
+				RandomTestUtil.randomString(), new String[] {audienceEntryERC},
+				_serviceContext);
+
+		List<LayoutPageTemplateStructureRelElementVariation>
+			layoutPageTemplateStructureRelElementVariations =
+				_layoutPageTemplateStructureRelElementVariationLocalService.
+					getLayoutPageTemplateStructureRelElementVariations(
+						plid, segmentsExperienceERC);
+
+		Assert.assertEquals(
+			layoutPageTemplateStructureRelElementVariations.toString(), 2,
+			layoutPageTemplateStructureRelElementVariations.size());
+	}
+
+	private Group _group;
+
+	@Inject
+	private LayoutPageTemplateStructureRelElementVariationLocalService
+		_layoutPageTemplateStructureRelElementVariationLocalService;
+
+	private ServiceContext _serviceContext;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98552

## What Is Being Fixed

The element variations editor prevents an author from picking an audience already used by a sibling variation on the same target element (LPD-95644), but that enforcement is UI-only. The local service still accepts duplicates, so concurrent editors, page duplication, and headless callers can attach the same audience to two variations for one target element. At runtime that registers two handlers for the audience on that element, and the winner is undefined registration order.

## How It Is Being Fixed

`addOrUpdateLayoutPageTemplateStructureRelElementVariation` now validates audience uniqueness server-side. The audience checks in `_validate` are grouped: the incoming list must be non-empty, must not repeat an audience, and must not reuse an audience already attached to another variation on the same (plid, segments experience, target element). A duplicate within the submitted list throws `DuplicateLayoutPageTemplateStructureRelElementVariationAudienceEntryRelException`; an audience already used on the same target element throws `LayoutPageTemplateStructureRelElementVariationTargetElementException` with a `{audienceEntryERC=..., plid=..., segmentsExperienceERC=..., targetElement=...}` message. The check excludes the variation being saved, so re-saving a variation with its own audiences still succeeds. This is a service-level guard rather than a database constraint, so a concurrent double-insert race remains theoretically possible; it is proportionate for this flag-gated authoring flow.

## PR Check

**pr-check: PASS** — tested on `d177381ccffe6c4e6743f4b1d15f306f890337b2`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |

<!-- pr-check {"result": "success", "sha": "d177381ccffe6c4e6743f4b1d15f306f890337b2"} -->
