### PR TITLE
LPD-97637 Support Design Library scope in the Fragment portlet

### DIFF
--- a/modules/apps/document-library/document-library-taglib/bnd.bnd
+++ b/modules/apps/document-library/document-library-taglib/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Document Library Taglib
 Bundle-SymbolicName: com.liferay.document.library.taglib
-Bundle-Version: 6.1.3
+Bundle-Version: 6.2.0
 Export-Package: com.liferay.document.library.taglib.servlet.taglib
 Provide-Capability:\
 	osgi.extender;\

--- a/modules/apps/document-library/document-library-taglib/package.json
+++ b/modules/apps/document-library/document-library-taglib/package.json
@@ -10,5 +10,5 @@
 		"checkFormat": "node-scripts format --check",
 		"format": "node-scripts format"
 	},
-	"version": "6.1.3"
+	"version": "6.2.0"
 }

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/display/context/RepositoryBrowserTagDisplayContext.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/display/context/RepositoryBrowserTagDisplayContext.java
@@ -88,7 +88,7 @@ public class RepositoryBrowserTagDisplayContext {
 		boolean includeExtension, LiferayPortletRequest liferayPortletRequest,
 		LiferayPortletResponse liferayPortletResponse,
 		PortletRequest portletRequest, long repositoryId, long rootFolderId,
-		boolean viewableByGuest) {
+		boolean standaloneBreadcrumb, boolean viewableByGuest) {
 
 		_actions = actions;
 		_dlAppService = dlAppService;
@@ -104,6 +104,7 @@ public class RepositoryBrowserTagDisplayContext {
 		_portletRequest = portletRequest;
 		_repositoryId = repositoryId;
 		_rootFolderId = rootFolderId;
+		_standaloneBreadcrumb = standaloneBreadcrumb;
 		_viewableByGuest = viewableByGuest;
 
 		_themeDisplay = (ThemeDisplay)httpServletRequest.getAttribute(
@@ -384,6 +385,10 @@ public class RepositoryBrowserTagDisplayContext {
 		}
 
 		return true;
+	}
+
+	public boolean isStandaloneBreadcrumb() {
+		return _standaloneBreadcrumb;
 	}
 
 	public boolean isVerticalCard(RepositoryEntry repositoryEntry) {
@@ -720,6 +725,7 @@ public class RepositoryBrowserTagDisplayContext {
 	private final long _repositoryId;
 	private final long _rootFolderId;
 	private SearchContainer<Object> _searchContainer;
+	private final boolean _standaloneBreadcrumb;
 	private final ThemeDisplay _themeDisplay;
 	private final boolean _viewableByGuest;
 

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/servlet/taglib/RepositoryBrowserTag.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/servlet/taglib/RepositoryBrowserTag.java
@@ -139,7 +139,7 @@ public class RepositoryBrowserTag extends IncludeTag {
 				PortalUtil.getLiferayPortletRequest(portletRequest),
 				PortalUtil.getLiferayPortletResponse(portletResponse),
 				portletRequest, _getRepositoryId(), getFolderId(),
-				isViewableByGuest()));
+				isStandaloneBreadcrumb(), isViewableByGuest()));
 	}
 
 	private Set<String> _getActionsSet() {

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/servlet/taglib/RepositoryBrowserTag.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/servlet/taglib/RepositoryBrowserTag.java
@@ -59,6 +59,10 @@ public class RepositoryBrowserTag extends IncludeTag {
 		return _includeExtension;
 	}
 
+	public boolean isStandaloneBreadcrumb() {
+		return _standaloneBreadcrumb;
+	}
+
 	public boolean isViewableByGuest() {
 		return _viewableByGuest;
 	}
@@ -86,6 +90,10 @@ public class RepositoryBrowserTag extends IncludeTag {
 		_repositoryId = repositoryId;
 	}
 
+	public void setStandaloneBreadcrumb(boolean standaloneBreadcrumb) {
+		_standaloneBreadcrumb = standaloneBreadcrumb;
+	}
+
 	public void setViewableByGuest(boolean viewableByGuest) {
 		_viewableByGuest = viewableByGuest;
 	}
@@ -98,6 +106,7 @@ public class RepositoryBrowserTag extends IncludeTag {
 		_folderId = DLFolderConstants.DEFAULT_PARENT_FOLDER_ID;
 		_includeExtension = false;
 		_repositoryId = 0;
+		_standaloneBreadcrumb = false;
 		_viewableByGuest = false;
 	}
 
@@ -181,6 +190,7 @@ public class RepositoryBrowserTag extends IncludeTag {
 	private long _folderId = DLFolderConstants.DEFAULT_PARENT_FOLDER_ID;
 	private boolean _includeExtension;
 	private long _repositoryId;
+	private boolean _standaloneBreadcrumb;
 	private boolean _viewableByGuest;
 
 }

--- a/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/liferay-document-library.tld
+++ b/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/liferay-document-library.tld
@@ -53,6 +53,11 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
+			<name>standaloneBreadcrumb</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
 			<name>viewableByGuest</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>

--- a/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/page.jsp
+++ b/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/page.jsp
@@ -23,6 +23,7 @@ RepositoryBrowserTagDisplayContext repositoryBrowserTagDisplayContext = (Reposit
 
 	<liferay-site-navigation:breadcrumb
 		breadcrumbEntries="<%= repositoryBrowserTagDisplayContext.getBreadcrumbEntries() %>"
+		skipEntryContributors="<%= repositoryBrowserTagDisplayContext.isStandaloneBreadcrumb() %>"
 	/>
 
 	<input class="hide" id="<portlet:namespace />file" type="file" />

--- a/modules/apps/document-library/document-library-taglib/src/main/resources/com/liferay/document/library/taglib/servlet/taglib/packageinfo
+++ b/modules/apps/document-library/document-library-taglib/src/main/resources/com/liferay/document/library/taglib/servlet/taglib/packageinfo
@@ -1,1 +1,1 @@
-version 4.1.0
+version 4.2.0

--- a/modules/apps/fragment/fragment-web/build.gradle
+++ b/modules/apps/fragment/fragment-web/build.gradle
@@ -13,6 +13,7 @@ dependencies {
 	compileOnly project(":apps:application-list:application-list-api")
 	compileOnly project(":apps:change-tracking:change-tracking-spi")
 	compileOnly project(":apps:configuration-admin:configuration-admin-api")
+	compileOnly project(":apps:depot:depot-api")
 	compileOnly project(":apps:document-library:document-library-api")
 	compileOnly project(":apps:document-library:document-library-taglib")
 	compileOnly project(":apps:fragment:fragment-api")

--- a/modules/apps/fragment/fragment-web/build.gradle
+++ b/modules/apps/fragment/fragment-web/build.gradle
@@ -14,6 +14,7 @@ dependencies {
 	compileOnly project(":apps:change-tracking:change-tracking-spi")
 	compileOnly project(":apps:configuration-admin:configuration-admin-api")
 	compileOnly project(":apps:depot:depot-api")
+	compileOnly project(":apps:design-library:design-library-api")
 	compileOnly project(":apps:document-library:document-library-api")
 	compileOnly project(":apps:document-library:document-library-taglib")
 	compileOnly project(":apps:fragment:fragment-api")

--- a/modules/apps/fragment/fragment-web/build.gradle
+++ b/modules/apps/fragment/fragment-web/build.gradle
@@ -34,6 +34,7 @@ dependencies {
 	compileOnly project(":apps:portal-configuration:portal-configuration-module-configuration-api")
 	compileOnly project(":apps:portal:portal-aop-api")
 	compileOnly project(":apps:product-navigation:product-navigation-control-menu-api")
+	compileOnly project(":apps:site-navigation:site-navigation-taglib")
 	compileOnly project(":apps:staging:staging-api")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-persistence-api")

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/EditFragmentEntryDisplayContext.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/EditFragmentEntryDisplayContext.java
@@ -528,7 +528,7 @@ public class EditFragmentEntryDisplayContext {
 		).put(
 			"resources", resources
 		).put(
-			"showFieldTypes", _showFieldTypes()
+			"showFieldTypes", _isShowFieldTypes()
 		).put(
 			"spritemap", _themeDisplay.getPathThemeSpritemap()
 		).put(
@@ -629,7 +629,7 @@ public class EditFragmentEntryDisplayContext {
 		return _readOnly;
 	}
 
-	private boolean _showFieldTypes() {
+	private boolean _isShowFieldTypes() {
 		FragmentEntry fragmentEntry = getFragmentEntry();
 
 		if ((fragmentEntry == null) || !fragmentEntry.isTypeInput()) {

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/EditFragmentEntryDisplayContext.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/EditFragmentEntryDisplayContext.java
@@ -629,6 +629,16 @@ public class EditFragmentEntryDisplayContext {
 		return _readOnly;
 	}
 
+	private boolean _showFieldTypes() {
+		FragmentEntry fragmentEntry = getFragmentEntry();
+
+		if ((fragmentEntry == null) || !fragmentEntry.isTypeInput()) {
+			return false;
+		}
+
+		return true;
+	}
+
 	private void _updatePortletDisplay() {
 		PortletDisplay portletDisplay = _themeDisplay.getPortletDisplay();
 
@@ -658,16 +668,6 @@ public class EditFragmentEntryDisplayContext {
 					WorkflowConstants.getStatusLabel(
 						fragmentEntry.getStatus())),
 				")"));
-	}
-
-	private boolean _showFieldTypes() {
-		FragmentEntry fragmentEntry = getFragmentEntry();
-
-		if ((fragmentEntry == null) || !fragmentEntry.isTypeInput()) {
-			return false;
-		}
-
-		return true;
 	}
 
 	private static final InfoFieldType[] _INFO_FIELD_TYPES = {

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/EditFragmentEntryDisplayContext.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/EditFragmentEntryDisplayContext.java
@@ -18,6 +18,7 @@ import com.liferay.fragment.web.internal.info.field.type.CaptchaInfoFieldType;
 import com.liferay.fragment.web.internal.info.field.type.FormButtonInfoFieldType;
 import com.liferay.fragment.web.internal.info.field.type.LocalizationSelectInfoFieldType;
 import com.liferay.fragment.web.internal.info.field.type.StepperInfoFieldType;
+import com.liferay.fragment.web.internal.util.DesignLibraryUtil;
 import com.liferay.info.field.type.BooleanInfoFieldType;
 import com.liferay.info.field.type.DateInfoFieldType;
 import com.liferay.info.field.type.DateTimeInfoFieldType;
@@ -630,6 +631,12 @@ public class EditFragmentEntryDisplayContext {
 
 	private void _setViewAttributes() {
 		PortletDisplay portletDisplay = _themeDisplay.getPortletDisplay();
+
+		if (DesignLibraryUtil.isDesignLibraryScope(
+				_themeDisplay.getScopeGroup())) {
+
+			portletDisplay.setPortletDecoratorId("barebone");
+		}
 
 		portletDisplay.setShowBackIcon(true);
 		portletDisplay.setURLBack(getRedirect());

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/EditFragmentEntryDisplayContext.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/EditFragmentEntryDisplayContext.java
@@ -100,7 +100,7 @@ public class EditFragmentEntryDisplayContext {
 		_themeDisplay = (ThemeDisplay)httpServletRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
-		_setViewAttributes();
+		_updatePortletDisplay();
 	}
 
 	public long getFragmentCollectionId() {
@@ -629,7 +629,7 @@ public class EditFragmentEntryDisplayContext {
 		return _readOnly;
 	}
 
-	private void _setViewAttributes() {
+	private void _updatePortletDisplay() {
 		PortletDisplay portletDisplay = _themeDisplay.getPortletDisplay();
 
 		if (DesignLibraryUtil.isDesignLibraryScope(

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/FragmentDisplayContext.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/FragmentDisplayContext.java
@@ -18,6 +18,7 @@ import com.liferay.fragment.util.comparator.FragmentCollectionContributorNameCom
 import com.liferay.fragment.util.comparator.FragmentCompositionFragmentEntryNameComparator;
 import com.liferay.fragment.web.internal.constants.FragmentTypeConstants;
 import com.liferay.fragment.web.internal.security.permission.resource.FragmentPermission;
+import com.liferay.fragment.web.internal.util.DesignLibraryUtil;
 import com.liferay.fragment.web.internal.util.FragmentPortletUtil;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemListBuilder;
@@ -811,6 +812,11 @@ public class FragmentDisplayContext {
 		}
 
 		return _updatePermission;
+	}
+
+	public boolean isHideCollectionsPanel() {
+		return DesignLibraryUtil.isDesignLibraryScope(
+			_themeDisplay.getScopeGroup());
 	}
 
 	public boolean isLocked(FragmentCollection fragmentCollection) {

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/FragmentDisplayContext.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/FragmentDisplayContext.java
@@ -339,9 +339,32 @@ public class FragmentDisplayContext {
 			return _fragmentCollectionId;
 		}
 
-		_fragmentCollectionId = ParamUtil.getLong(
-			_httpServletRequest, "fragmentCollectionId",
-			_getDefaultFragmentCollectionId());
+		long fragmentCollectionId = ParamUtil.getLong(
+			_httpServletRequest, "fragmentCollectionId");
+
+		if (fragmentCollectionId == 0) {
+			String externalReferenceCode = ParamUtil.getString(
+				_httpServletRequest, "fragmentCollectionExternalReferenceCode");
+
+			if (Validator.isNotNull(externalReferenceCode)) {
+				FragmentCollection fragmentCollection =
+					FragmentCollectionLocalServiceUtil.
+						fetchFragmentCollectionByExternalReferenceCode(
+							externalReferenceCode,
+							_themeDisplay.getScopeGroupId());
+
+				if (fragmentCollection != null) {
+					fragmentCollectionId =
+						fragmentCollection.getFragmentCollectionId();
+				}
+			}
+		}
+
+		if (fragmentCollectionId == 0) {
+			fragmentCollectionId = _getDefaultFragmentCollectionId();
+		}
+
+		_fragmentCollectionId = fragmentCollectionId;
 
 		return _fragmentCollectionId;
 	}

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/FragmentDisplayContext.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/FragmentDisplayContext.java
@@ -91,7 +91,7 @@ public class FragmentDisplayContext {
 		_themeDisplay = (ThemeDisplay)httpServletRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
-		_setViewAttributes();
+		_updatePortletDisplay();
 	}
 
 	public List<DropdownItem> getActionDropdownItems() throws Exception {
@@ -1086,7 +1086,7 @@ public class FragmentDisplayContext {
 		return true;
 	}
 
-	private void _setViewAttributes() {
+	private void _updatePortletDisplay() {
 		if (!DesignLibraryUtil.isDesignLibraryScope(
 				_themeDisplay.getScopeGroup())) {
 

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/FragmentDisplayContext.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/FragmentDisplayContext.java
@@ -90,6 +90,8 @@ public class FragmentDisplayContext {
 					FragmentCollectionContributorRegistry.class.getName());
 		_themeDisplay = (ThemeDisplay)httpServletRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
+
+		_setViewAttributes();
 	}
 
 	public List<DropdownItem> getActionDropdownItems() throws Exception {
@@ -1082,6 +1084,32 @@ public class FragmentDisplayContext {
 		}
 
 		return true;
+	}
+
+	private void _setViewAttributes() {
+		if (!DesignLibraryUtil.isDesignLibraryScope(
+				_themeDisplay.getScopeGroup())) {
+
+			return;
+		}
+
+		PortletDisplay portletDisplay = _themeDisplay.getPortletDisplay();
+
+		portletDisplay.setPortletDecoratorId("barebone");
+		portletDisplay.setShowBackIcon(true);
+
+		String backURL = ParamUtil.getString(_httpServletRequest, "backURL");
+
+		if (Validator.isNull(backURL)) {
+			backURL = getRedirect();
+		}
+
+		if (Validator.isNull(backURL)) {
+			backURL = DesignLibraryUtil.getDesignLibraryResourcesURL(
+				_themeDisplay.getScopeGroup(), _httpServletRequest);
+		}
+
+		portletDisplay.setURLBack(backURL);
 	}
 
 	private SearchContainer<Object> _contributedEntriesSearchContainer;

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/product/navigation/control/menu/FragmentBreadcrumbProductNavigationControlMenuEntry.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/product/navigation/control/menu/FragmentBreadcrumbProductNavigationControlMenuEntry.java
@@ -1,0 +1,80 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.fragment.web.internal.product.navigation.control.menu;
+
+import com.liferay.fragment.constants.FragmentPortletKeys;
+import com.liferay.fragment.web.internal.util.DesignLibraryUtil;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.theme.PortletDisplay;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.product.navigation.control.menu.BaseJSPProductNavigationControlMenuEntry;
+import com.liferay.product.navigation.control.menu.ProductNavigationControlMenuEntry;
+import com.liferay.product.navigation.control.menu.constants.ProductNavigationControlMenuCategoryKeys;
+import com.liferay.product.navigation.control.menu.constants.ProductNavigationControlMenuWebKeys;
+
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.util.Objects;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Lourdes Fernández Besada
+ */
+@Component(
+	property = {
+		"product.navigation.control.menu.category.key=" + ProductNavigationControlMenuCategoryKeys.SITES,
+		"product.navigation.control.menu.entry.order:Integer=210"
+	},
+	service = ProductNavigationControlMenuEntry.class
+)
+public class FragmentBreadcrumbProductNavigationControlMenuEntry
+	extends BaseJSPProductNavigationControlMenuEntry
+	implements ProductNavigationControlMenuEntry {
+
+	@Override
+	public String getIconJspPath() {
+		return "/breadcrumb/fragment_breadcrumb.jsp";
+	}
+
+	@Override
+	public boolean isShow(HttpServletRequest httpServletRequest)
+		throws PortalException {
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		PortletDisplay portletDisplay = themeDisplay.getPortletDisplay();
+
+		if (!Objects.equals(
+				FragmentPortletKeys.FRAGMENT,
+				portletDisplay.getPortletName()) ||
+			!DesignLibraryUtil.isDesignLibraryScope(
+				themeDisplay.getScopeGroup())) {
+
+			return false;
+		}
+
+		httpServletRequest.setAttribute(
+			ProductNavigationControlMenuWebKeys.HIDE_PORTLET_HEADER,
+			Boolean.TRUE);
+
+		return true;
+	}
+
+	@Override
+	protected ServletContext getServletContext() {
+		return _servletContext;
+	}
+
+	@Reference(target = "(osgi.web.symbolicname=com.liferay.fragment.web)")
+	private ServletContext _servletContext;
+
+}

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/servlet/taglib/FragmentBreadcrumbEntryContributorImpl.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/servlet/taglib/FragmentBreadcrumbEntryContributorImpl.java
@@ -1,0 +1,195 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.fragment.web.internal.servlet.taglib;
+
+import com.liferay.fragment.constants.FragmentPortletKeys;
+import com.liferay.fragment.model.FragmentCollection;
+import com.liferay.fragment.model.FragmentEntry;
+import com.liferay.fragment.service.FragmentCollectionLocalService;
+import com.liferay.fragment.service.FragmentEntryLocalService;
+import com.liferay.fragment.web.internal.util.DesignLibraryUtil;
+import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
+import com.liferay.portal.kernel.servlet.taglib.ui.BreadcrumbEntry;
+import com.liferay.portal.kernel.servlet.taglib.ui.BreadcrumbEntryContributor;
+import com.liferay.portal.kernel.theme.PortletDisplay;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import jakarta.portlet.PortletRequest;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Lourdes Fernández Besada
+ */
+@Component(
+	property = "service.ranking:Integer=100",
+	service = BreadcrumbEntryContributor.class
+)
+public class FragmentBreadcrumbEntryContributorImpl
+	implements BreadcrumbEntryContributor {
+
+	@Override
+	public List<BreadcrumbEntry> getBreadcrumbEntries(
+		List<BreadcrumbEntry> originalBreadcrumbEntries,
+		HttpServletRequest httpServletRequest) {
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		PortletDisplay portletDisplay = themeDisplay.getPortletDisplay();
+
+		if (!Objects.equals(
+				FragmentPortletKeys.FRAGMENT,
+				portletDisplay.getPortletName()) ||
+			!DesignLibraryUtil.isDesignLibraryScope(
+				themeDisplay.getScopeGroup())) {
+
+			return originalBreadcrumbEntries;
+		}
+
+		FragmentEntry fragmentEntry = _getFragmentEntry(httpServletRequest);
+
+		FragmentCollection fragmentCollection = _getFragmentCollection(
+			fragmentEntry, httpServletRequest);
+
+		if (fragmentCollection == null) {
+			return originalBreadcrumbEntries;
+		}
+
+		List<BreadcrumbEntry> breadcrumbEntries = new ArrayList<>();
+
+		breadcrumbEntries.add(
+			_createFragmentCollectionBreadcrumbEntry(
+				fragmentCollection, httpServletRequest));
+
+		if (fragmentEntry != null) {
+			breadcrumbEntries.add(
+				_createFragmentEntryBreadcrumbEntry(fragmentEntry));
+		}
+
+		breadcrumbEntries.addAll(originalBreadcrumbEntries);
+
+		return breadcrumbEntries;
+	}
+
+	private BreadcrumbEntry _createFragmentCollectionBreadcrumbEntry(
+		FragmentCollection fragmentCollection,
+		HttpServletRequest httpServletRequest) {
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		BreadcrumbEntry breadcrumbEntry = new BreadcrumbEntry();
+
+		breadcrumbEntry.setTitle(fragmentCollection.getName());
+		breadcrumbEntry.setURL(
+			PortletURLBuilder.create(
+				_portal.getControlPanelPortletURL(
+					httpServletRequest, themeDisplay.getScopeGroup(),
+					FragmentPortletKeys.FRAGMENT, 0, 0,
+					PortletRequest.RENDER_PHASE)
+			).setParameter(
+				"fragmentCollectionId",
+				fragmentCollection.getFragmentCollectionId()
+			).buildString());
+
+		return breadcrumbEntry;
+	}
+
+	private BreadcrumbEntry _createFragmentEntryBreadcrumbEntry(
+		FragmentEntry fragmentEntry) {
+
+		BreadcrumbEntry breadcrumbEntry = new BreadcrumbEntry();
+
+		breadcrumbEntry.setTitle(fragmentEntry.getName());
+
+		return breadcrumbEntry;
+	}
+
+	private FragmentCollection _getFragmentCollection(
+		FragmentEntry fragmentEntry, HttpServletRequest httpServletRequest) {
+
+		if (fragmentEntry == null) {
+			return _getFragmentCollection(httpServletRequest);
+		}
+
+		return _fragmentCollectionLocalService.fetchFragmentCollection(
+			fragmentEntry.getFragmentCollectionId());
+	}
+
+	private FragmentCollection _getFragmentCollection(
+		HttpServletRequest httpServletRequest) {
+
+		String portletNamespace = _portal.getPortletNamespace(
+			FragmentPortletKeys.FRAGMENT);
+
+		long fragmentCollectionId = ParamUtil.getLong(
+			httpServletRequest, portletNamespace + "fragmentCollectionId",
+			ParamUtil.getLong(httpServletRequest, "fragmentCollectionId"));
+
+		if (fragmentCollectionId > 0) {
+			return _fragmentCollectionLocalService.fetchFragmentCollection(
+				fragmentCollectionId);
+		}
+
+		String externalReferenceCode = ParamUtil.getString(
+			httpServletRequest,
+			portletNamespace + "fragmentCollectionExternalReferenceCode",
+			ParamUtil.getString(
+				httpServletRequest, "fragmentCollectionExternalReferenceCode"));
+
+		if (Validator.isNull(externalReferenceCode)) {
+			return null;
+		}
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		return _fragmentCollectionLocalService.
+			fetchFragmentCollectionByExternalReferenceCode(
+				externalReferenceCode, themeDisplay.getScopeGroupId());
+	}
+
+	private FragmentEntry _getFragmentEntry(
+		HttpServletRequest httpServletRequest) {
+
+		long fragmentEntryId = ParamUtil.getLong(
+			httpServletRequest,
+			_portal.getPortletNamespace(FragmentPortletKeys.FRAGMENT) +
+				"fragmentEntryId",
+			ParamUtil.getLong(httpServletRequest, "fragmentEntryId"));
+
+		if (fragmentEntryId == 0) {
+			return null;
+		}
+
+		return _fragmentEntryLocalService.fetchFragmentEntry(fragmentEntryId);
+	}
+
+	@Reference
+	private FragmentCollectionLocalService _fragmentCollectionLocalService;
+
+	@Reference
+	private FragmentEntryLocalService _fragmentEntryLocalService;
+
+	@Reference
+	private Portal _portal;
+
+}

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/util/DesignLibraryUtil.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/util/DesignLibraryUtil.java
@@ -8,12 +8,41 @@ package com.liferay.fragment.web.internal.util;
 import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalServiceUtil;
+import com.liferay.design.library.constants.DesignLibraryAdminPortletKeys;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
+import com.liferay.portal.kernel.util.PortalUtil;
+
+import jakarta.portlet.PortletRequest;
+
+import jakarta.servlet.http.HttpServletRequest;
 
 /**
  * @author Lourdes Fernández Besada
  */
 public class DesignLibraryUtil {
+
+	public static String getDesignLibraryResourcesURL(
+		Group depotGroup, HttpServletRequest httpServletRequest) {
+
+		DepotEntry depotEntry = DepotEntryLocalServiceUtil.fetchGroupDepotEntry(
+			depotGroup.getGroupId());
+
+		if (depotEntry == null) {
+			return null;
+		}
+
+		return PortletURLBuilder.create(
+			PortalUtil.getControlPanelPortletURL(
+				httpServletRequest, depotGroup,
+				DesignLibraryAdminPortletKeys.DESIGN_LIBRARY_ADMIN, 0, 0,
+				PortletRequest.RENDER_PHASE)
+		).setMVCRenderCommandName(
+			"/design_library/design_library_resources"
+		).setParameter(
+			"designLibraryEntryId", depotEntry.getDepotEntryId()
+		).buildString();
+	}
 
 	public static boolean isDesignLibraryScope(Group group) {
 		if ((group == null) || !group.isDepot()) {

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/util/DesignLibraryUtil.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/util/DesignLibraryUtil.java
@@ -1,0 +1,35 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.fragment.web.internal.util;
+
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalServiceUtil;
+import com.liferay.portal.kernel.model.Group;
+
+/**
+ * @author Lourdes Fernández Besada
+ */
+public class DesignLibraryUtil {
+
+	public static boolean isDesignLibraryScope(Group group) {
+		if ((group == null) || !group.isDepot()) {
+			return false;
+		}
+
+		DepotEntry depotEntry = DepotEntryLocalServiceUtil.fetchGroupDepotEntry(
+			group.getGroupId());
+
+		if ((depotEntry == null) ||
+			(depotEntry.getType() != DepotConstants.TYPE_DESIGN_LIBRARY)) {
+
+			return false;
+		}
+
+		return true;
+	}
+
+}

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/breadcrumb/fragment_breadcrumb.jsp
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/breadcrumb/fragment_breadcrumb.jsp
@@ -1,0 +1,14 @@
+<%--
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+--%>
+
+<%@ include file="/init.jsp" %>
+
+<li class="control-menu-nav-item">
+	<liferay-site-navigation:breadcrumb
+		breadcrumbEntries="<%= Collections.<BreadcrumbEntry>emptyList() %>"
+	/>
+</li>

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/edit_fragment_collection.jsp
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/edit_fragment_collection.jsp
@@ -8,7 +8,7 @@
 <%@ include file="/init.jsp" %>
 
 <%
-long fragmentCollectionId = ParamUtil.getLong(request, "fragmentCollectionId");
+long fragmentCollectionId = fragmentDisplayContext.getFragmentCollectionId();
 
 FragmentCollection fragmentCollection = FragmentCollectionLocalServiceUtil.fetchFragmentCollection(fragmentCollectionId);
 

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/init.jsp
@@ -14,6 +14,7 @@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/document-library" prefix="liferay-document-library" %><%@
 taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/react" prefix="react" %><%@
+taglib uri="http://liferay.com/tld/site-navigation" prefix="liferay-site-navigation" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %><%@
 taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
@@ -60,6 +61,7 @@ page import="com.liferay.petra.string.StringPool" %><%@
 page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
 page import="com.liferay.portal.kernel.model.Group" %><%@
 page import="com.liferay.portal.kernel.service.GroupLocalServiceUtil" %><%@
+page import="com.liferay.portal.kernel.servlet.taglib.ui.BreadcrumbEntry" %><%@
 page import="com.liferay.portal.kernel.util.HashMapBuilder" %><%@
 page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
 page import="com.liferay.portal.kernel.util.ListUtil" %><%@
@@ -67,7 +69,8 @@ page import="com.liferay.portal.kernel.util.MapUtil" %><%@
 page import="com.liferay.portal.kernel.util.ParamUtil" %><%@
 page import="com.liferay.portal.kernel.util.StringUtil" %>
 
-<%@ page import="java.util.List" %><%@
+<%@ page import="java.util.Collections" %><%@
+page import="java.util.List" %><%@
 page import="java.util.Map" %><%@
 page import="java.util.Objects" %>
 

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/init.jsp
@@ -56,6 +56,7 @@ page import="com.liferay.fragment.web.internal.frontend.taglib.clay.servlet.tagl
 page import="com.liferay.fragment.web.internal.frontend.taglib.clay.servlet.taglib.FragmentEntryVerticalCardFactory" %><%@
 page import="com.liferay.fragment.web.internal.security.permission.resource.FragmentPermission" %><%@
 page import="com.liferay.fragment.web.internal.servlet.taglib.util.FragmentCollectionActionDropdownItemsProvider" %><%@
+page import="com.liferay.fragment.web.internal.util.DesignLibraryUtil" %><%@
 page import="com.liferay.frontend.taglib.servlet.taglib.util.EmptyResultMessageKeys" %><%@
 page import="com.liferay.petra.string.StringPool" %><%@
 page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view.jsp
@@ -43,139 +43,141 @@ ImportDisplayContext importDisplayContext = new ImportDisplayContext(request, re
 	size="xxxl"
 >
 	<clay:row>
-		<clay:col
-			lg="3"
-		>
-			<portlet:renderURL var="editFragmentCollectionURL">
-				<portlet:param name="mvcRenderCommandName" value="/fragment/edit_fragment_collection" />
-				<portlet:param name="redirect" value="<%= currentURL %>" />
-			</portlet:renderURL>
+		<c:if test="<%= !fragmentDisplayContext.isHideCollectionsPanel() %>">
+			<clay:col
+				lg="3"
+			>
+				<portlet:renderURL var="editFragmentCollectionURL">
+					<portlet:param name="mvcRenderCommandName" value="/fragment/edit_fragment_collection" />
+					<portlet:param name="redirect" value="<%= currentURL %>" />
+				</portlet:renderURL>
 
-			<c:choose>
-				<c:when test="<%= ListUtil.isNotEmpty(fragmentCollections) || ListUtil.isNotEmpty(fragmentCollectionContributors) || MapUtil.isNotEmpty(inheritedFragmentCollections) %>">
-					<clay:content-row
-						cssClass="mb-4"
-						verticalAlign="center"
-					>
-						<clay:content-col
-							expand="<%= true %>"
+				<c:choose>
+					<c:when test="<%= ListUtil.isNotEmpty(fragmentCollections) || ListUtil.isNotEmpty(fragmentCollectionContributors) || MapUtil.isNotEmpty(inheritedFragmentCollections) %>">
+						<clay:content-row
+							cssClass="mb-4"
+							verticalAlign="center"
 						>
-							<strong class="text-uppercase">
-								<liferay-ui:message key="fragment-sets" />
-							</strong>
-						</clay:content-col>
+							<clay:content-col
+								expand="<%= true %>"
+							>
+								<strong class="text-uppercase">
+									<liferay-ui:message key="fragment-sets" />
+								</strong>
+							</clay:content-col>
 
-						<clay:content-col>
-							<ul class="align-items-center navbar-nav">
-								<li>
-									<c:if test="<%= FragmentPermission.contains(permissionChecker, scopeGroupId, FragmentActionKeys.MANAGE_FRAGMENT_ENTRIES) %>">
-										<clay:link
-											borderless="<%= true %>"
-											cssClass="component-action lfr-portal-tooltip"
-											href="<%= editFragmentCollectionURL %>"
-											icon="plus"
-											title='<%= LanguageUtil.get(request, "add-fragment-set") %>'
-											type="button"
-										/>
-									</c:if>
-								</li>
-
-								<c:if test="<%= fragmentDisplayContext.isShowMarketplace() %>">
+							<clay:content-col>
+								<ul class="align-items-center navbar-nav">
 									<li>
-										<div>
-											<react:component
-												module="{MarketplaceButton} from layout-js-components-web"
-												props="<%= fragmentDisplayContext.getMarketplaceProps() %>"
+										<c:if test="<%= FragmentPermission.contains(permissionChecker, scopeGroupId, FragmentActionKeys.MANAGE_FRAGMENT_ENTRIES) %>">
+											<clay:link
+												borderless="<%= true %>"
+												cssClass="component-action lfr-portal-tooltip"
+												href="<%= editFragmentCollectionURL %>"
+												icon="plus"
+												title='<%= LanguageUtil.get(request, "add-fragment-set") %>'
+												type="button"
 											/>
-										</div>
+										</c:if>
 									</li>
-								</c:if>
 
-								<li>
+									<c:if test="<%= fragmentDisplayContext.isShowMarketplace() %>">
+										<li>
+											<div>
+												<react:component
+													module="{MarketplaceButton} from layout-js-components-web"
+													props="<%= fragmentDisplayContext.getMarketplaceProps() %>"
+												/>
+											</div>
+										</li>
+									</c:if>
 
-									<%
-									Map<String, Object> fragmentCollectionsViewContext = fragmentDisplayContext.getFragmentCollectionsViewContext();
-									%>
+									<li>
 
-									<clay:dropdown-actions
-										additionalProps='<%=
-											HashMapBuilder.<String, Object>put(
-												"deleteFragmentCollectionURL", fragmentCollectionsViewContext.get("deleteFragmentCollectionURL")
-											).put(
-												"exportFragmentCollectionsURL", fragmentCollectionsViewContext.get("exportFragmentCollectionsURL")
-											).put(
-												"importURL", fragmentCollectionsViewContext.get("importURL")
-											).put(
-												"viewDeleteFragmentCollectionsURL", fragmentCollectionsViewContext.get("viewDeleteFragmentCollectionsURL")
-											).put(
-												"viewExportFragmentCollectionsURL", fragmentCollectionsViewContext.get("viewExportFragmentCollectionsURL")
-											).put(
-												"viewImportURL", fragmentCollectionsViewContext.get("viewImportURL")
-											).build()
-										%>'
-										aria-label='<%= LanguageUtil.get(request, "show-actions") %>'
-										dropdownItems="<%= fragmentDisplayContext.getCollectionsDropdownItems() %>"
-										propsTransformer="{FragmentCollectionViewDefaultPropsTransformer} from fragment-web"
-										title='<%= LanguageUtil.get(request, "fragment-sets-options") %>'
-									/>
-								</li>
-							</ul>
-						</clay:content-col>
-					</clay:content-row>
+										<%
+										Map<String, Object> fragmentCollectionsViewContext = fragmentDisplayContext.getFragmentCollectionsViewContext();
+										%>
 
-					<c:if test="<%= ListUtil.isNotEmpty(fragmentCollectionContributors) || ListUtil.isNotEmpty(systemFragmentCollections) %>">
-						<span class="text-truncate">
-							<liferay-ui:message key="default" />
-						</span>
+										<clay:dropdown-actions
+											additionalProps='<%=
+												HashMapBuilder.<String, Object>put(
+													"deleteFragmentCollectionURL", fragmentCollectionsViewContext.get("deleteFragmentCollectionURL")
+												).put(
+													"exportFragmentCollectionsURL", fragmentCollectionsViewContext.get("exportFragmentCollectionsURL")
+												).put(
+													"importURL", fragmentCollectionsViewContext.get("importURL")
+												).put(
+													"viewDeleteFragmentCollectionsURL", fragmentCollectionsViewContext.get("viewDeleteFragmentCollectionsURL")
+												).put(
+													"viewExportFragmentCollectionsURL", fragmentCollectionsViewContext.get("viewExportFragmentCollectionsURL")
+												).put(
+													"viewImportURL", fragmentCollectionsViewContext.get("viewImportURL")
+												).build()
+											%>'
+											aria-label='<%= LanguageUtil.get(request, "show-actions") %>'
+											dropdownItems="<%= fragmentDisplayContext.getCollectionsDropdownItems() %>"
+											propsTransformer="{FragmentCollectionViewDefaultPropsTransformer} from fragment-web"
+											title='<%= LanguageUtil.get(request, "fragment-sets-options") %>'
+										/>
+									</li>
+								</ul>
+							</clay:content-col>
+						</clay:content-row>
 
-						<clay:vertical-nav
-							verticalNavItems="<%= fragmentDisplayContext.getVerticalNavItemList(systemFragmentCollections, fragmentCollectionContributors) %>"
+						<c:if test="<%= ListUtil.isNotEmpty(fragmentCollectionContributors) || ListUtil.isNotEmpty(systemFragmentCollections) %>">
+							<span class="text-truncate">
+								<liferay-ui:message key="default" />
+							</span>
+
+							<clay:vertical-nav
+								verticalNavItems="<%= fragmentDisplayContext.getVerticalNavItemList(systemFragmentCollections, fragmentCollectionContributors) %>"
+							/>
+						</c:if>
+
+						<%
+						for (Map.Entry<String, List<FragmentCollection>> entry : inheritedFragmentCollections.entrySet()) {
+						%>
+
+							<span class="text-truncate"><%= entry.getKey() %></span>
+
+							<clay:vertical-nav
+								verticalNavItems="<%= fragmentDisplayContext.getVerticalNavItemList(entry.getValue()) %>"
+							/>
+
+						<%
+						}
+						%>
+
+						<c:if test="<%= ListUtil.isNotEmpty(fragmentCollections) %>">
+							<span class="text-truncate"><%= HtmlUtil.escape(fragmentDisplayContext.getGroupName(scopeGroupId)) %></span>
+
+							<clay:vertical-nav
+								verticalNavItems="<%= fragmentDisplayContext.getVerticalNavItemList(fragmentCollections) %>"
+							/>
+						</c:if>
+					</c:when>
+					<c:otherwise>
+						<p class="text-uppercase">
+							<strong><liferay-ui:message key="fragment-sets" /></strong>
+						</p>
+
+						<liferay-frontend:empty-result-message
+							actionDropdownItems="<%= FragmentPermission.contains(permissionChecker, scopeGroupId, FragmentActionKeys.MANAGE_FRAGMENT_ENTRIES) ? fragmentDisplayContext.getActionDropdownItems() : null %>"
+							additionalProps="<%= fragmentDisplayContext.getFragmentCollectionsViewContext() %>"
+							animationType="<%= EmptyResultMessageKeys.AnimationType.NONE %>"
+							buttonPropsTransformer="{FragmentCollectionViewButtonPropsTransformer} from fragment-web"
+							description='<%= LanguageUtil.get(request, "fragment-sets-are-needed-to-create-fragments") %>'
+							elementType='<%= LanguageUtil.get(request, "fragment-sets") %>'
+							propsTransformer="{FragmentCollectionViewDefaultPropsTransformer} from fragment-web"
+							propsTransformerServletContext="<%= application %>"
 						/>
-					</c:if>
-
-					<%
-					for (Map.Entry<String, List<FragmentCollection>> entry : inheritedFragmentCollections.entrySet()) {
-					%>
-
-						<span class="text-truncate"><%= entry.getKey() %></span>
-
-						<clay:vertical-nav
-							verticalNavItems="<%= fragmentDisplayContext.getVerticalNavItemList(entry.getValue()) %>"
-						/>
-
-					<%
-					}
-					%>
-
-					<c:if test="<%= ListUtil.isNotEmpty(fragmentCollections) %>">
-						<span class="text-truncate"><%= HtmlUtil.escape(fragmentDisplayContext.getGroupName(scopeGroupId)) %></span>
-
-						<clay:vertical-nav
-							verticalNavItems="<%= fragmentDisplayContext.getVerticalNavItemList(fragmentCollections) %>"
-						/>
-					</c:if>
-				</c:when>
-				<c:otherwise>
-					<p class="text-uppercase">
-						<strong><liferay-ui:message key="fragment-sets" /></strong>
-					</p>
-
-					<liferay-frontend:empty-result-message
-						actionDropdownItems="<%= FragmentPermission.contains(permissionChecker, scopeGroupId, FragmentActionKeys.MANAGE_FRAGMENT_ENTRIES) ? fragmentDisplayContext.getActionDropdownItems() : null %>"
-						additionalProps="<%= fragmentDisplayContext.getFragmentCollectionsViewContext() %>"
-						animationType="<%= EmptyResultMessageKeys.AnimationType.NONE %>"
-						buttonPropsTransformer="{FragmentCollectionViewButtonPropsTransformer} from fragment-web"
-						description='<%= LanguageUtil.get(request, "fragment-sets-are-needed-to-create-fragments") %>'
-						elementType='<%= LanguageUtil.get(request, "fragment-sets") %>'
-						propsTransformer="{FragmentCollectionViewDefaultPropsTransformer} from fragment-web"
-						propsTransformerServletContext="<%= application %>"
-					/>
-				</c:otherwise>
-			</c:choose>
-		</clay:col>
+					</c:otherwise>
+				</c:choose>
+			</clay:col>
+		</c:if>
 
 		<clay:col
-			lg="9"
+			lg='<%= fragmentDisplayContext.isHideCollectionsPanel() ? "12" : "9" %>'
 		>
 
 			<%

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view_resources.jsp
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view_resources.jsp
@@ -15,5 +15,6 @@ FragmentCollectionResourcesDisplayContext fragmentCollectionResourcesDisplayCont
 	folderId="<%= fragmentCollectionResourcesDisplayContext.getFolderId() %>"
 	includeExtension="<%= true %>"
 	repositoryId="<%= fragmentCollectionResourcesDisplayContext.getRepositoryId() %>"
+	standaloneBreadcrumb="<%= DesignLibraryUtil.isDesignLibraryScope(themeDisplay.getScopeGroup()) %>"
 	viewableByGuest="<%= true %>"
 />

--- a/modules/apps/fragment/fragment-web/src/test/java/com/liferay/fragment/web/internal/product/navigation/control/menu/FragmentBreadcrumbProductNavigationControlMenuEntryTest.java
+++ b/modules/apps/fragment/fragment-web/src/test/java/com/liferay/fragment/web/internal/product/navigation/control/menu/FragmentBreadcrumbProductNavigationControlMenuEntryTest.java
@@ -1,0 +1,153 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.fragment.web.internal.product.navigation.control.menu;
+
+import com.liferay.fragment.constants.FragmentPortletKeys;
+import com.liferay.fragment.web.internal.util.DesignLibraryUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.theme.PortletDisplay;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.product.navigation.control.menu.constants.ProductNavigationControlMenuWebKeys;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Lourdes Fernández Besada
+ */
+public class FragmentBreadcrumbProductNavigationControlMenuEntryTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		ThemeDisplay themeDisplay = Mockito.mock(ThemeDisplay.class);
+
+		Mockito.when(
+			themeDisplay.getPortletDisplay()
+		).thenReturn(
+			_portletDisplay
+		);
+
+		Mockito.when(
+			themeDisplay.getScopeGroup()
+		).thenReturn(
+			_group
+		);
+
+		_mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, themeDisplay);
+	}
+
+	@After
+	public void tearDown() {
+		_designLibraryUtilMockedStatic.close();
+	}
+
+	@Test
+	public void testIsShow() throws Exception {
+		_testIsShowWhenPortletIsNotFragment();
+		_testIsShowWhenScopeIsNotDesignLibrary();
+		_testIsShowInFragmentPortletAndDesignLibraryScope();
+	}
+
+	private void _testIsShowInFragmentPortletAndDesignLibraryScope()
+		throws Exception {
+
+		Mockito.when(
+			_portletDisplay.getPortletName()
+		).thenReturn(
+			FragmentPortletKeys.FRAGMENT
+		);
+
+		_designLibraryUtilMockedStatic.when(
+			() -> DesignLibraryUtil.isDesignLibraryScope(_group)
+		).thenReturn(
+			true
+		);
+
+		Assert.assertTrue(
+			_fragmentBreadcrumbProductNavigationControlMenuEntry.isShow(
+				_mockHttpServletRequest));
+
+		Assert.assertEquals(
+			Boolean.TRUE,
+			_mockHttpServletRequest.getAttribute(
+				ProductNavigationControlMenuWebKeys.HIDE_PORTLET_HEADER));
+	}
+
+	private void _testIsShowWhenPortletIsNotFragment() throws Exception {
+		Mockito.when(
+			_portletDisplay.getPortletName()
+		).thenReturn(
+			RandomTestUtil.randomString()
+		);
+
+		_designLibraryUtilMockedStatic.when(
+			() -> DesignLibraryUtil.isDesignLibraryScope(_group)
+		).thenReturn(
+			true
+		);
+
+		Assert.assertFalse(
+			_fragmentBreadcrumbProductNavigationControlMenuEntry.isShow(
+				_mockHttpServletRequest));
+
+		Assert.assertNull(
+			_mockHttpServletRequest.getAttribute(
+				ProductNavigationControlMenuWebKeys.HIDE_PORTLET_HEADER));
+	}
+
+	private void _testIsShowWhenScopeIsNotDesignLibrary() throws Exception {
+		Mockito.when(
+			_portletDisplay.getPortletName()
+		).thenReturn(
+			FragmentPortletKeys.FRAGMENT
+		);
+
+		_designLibraryUtilMockedStatic.when(
+			() -> DesignLibraryUtil.isDesignLibraryScope(_group)
+		).thenReturn(
+			false
+		);
+
+		Assert.assertFalse(
+			_fragmentBreadcrumbProductNavigationControlMenuEntry.isShow(
+				_mockHttpServletRequest));
+
+		Assert.assertNull(
+			_mockHttpServletRequest.getAttribute(
+				ProductNavigationControlMenuWebKeys.HIDE_PORTLET_HEADER));
+	}
+
+	private final MockedStatic<DesignLibraryUtil>
+		_designLibraryUtilMockedStatic = Mockito.mockStatic(
+			DesignLibraryUtil.class);
+	private final FragmentBreadcrumbProductNavigationControlMenuEntry
+		_fragmentBreadcrumbProductNavigationControlMenuEntry =
+			new FragmentBreadcrumbProductNavigationControlMenuEntry();
+	private final Group _group = Mockito.mock(Group.class);
+	private final MockHttpServletRequest _mockHttpServletRequest =
+		new MockHttpServletRequest();
+	private final PortletDisplay _portletDisplay = Mockito.mock(
+		PortletDisplay.class);
+
+}

--- a/modules/apps/fragment/fragment-web/src/test/java/com/liferay/fragment/web/internal/product/navigation/control/menu/FragmentBreadcrumbProductNavigationControlMenuEntryTest.java
+++ b/modules/apps/fragment/fragment-web/src/test/java/com/liferay/fragment/web/internal/product/navigation/control/menu/FragmentBreadcrumbProductNavigationControlMenuEntryTest.java
@@ -64,7 +64,7 @@ public class FragmentBreadcrumbProductNavigationControlMenuEntryTest {
 
 	@Test
 	public void testIsShow() throws Exception {
-		_testIsShowWhenPortletIsNotFragment();
+		_testIsShowWhenNotInFragmentPortlet();
 		_testIsShowWhenScopeIsNotDesignLibrary();
 		_testIsShowInFragmentPortletAndDesignLibraryScope();
 	}
@@ -94,7 +94,7 @@ public class FragmentBreadcrumbProductNavigationControlMenuEntryTest {
 				ProductNavigationControlMenuWebKeys.HIDE_PORTLET_HEADER));
 	}
 
-	private void _testIsShowWhenPortletIsNotFragment() throws Exception {
+	private void _testIsShowWhenNotInFragmentPortlet() throws Exception {
 		Mockito.when(
 			_portletDisplay.getPortletName()
 		).thenReturn(

--- a/modules/apps/fragment/fragment-web/src/test/java/com/liferay/fragment/web/internal/servlet/taglib/FragmentBreadcrumbEntryContributorImplTest.java
+++ b/modules/apps/fragment/fragment-web/src/test/java/com/liferay/fragment/web/internal/servlet/taglib/FragmentBreadcrumbEntryContributorImplTest.java
@@ -65,11 +65,11 @@ public class FragmentBreadcrumbEntryContributorImplTest {
 	@Test
 	@TestInfo("LPD-97637")
 	public void testGetBreadcrumbEntries() {
-		_testGetBreadcrumbEntriesWhenPortletIsNotFragment();
+		_testGetBreadcrumbEntriesWhenNotInFragmentPortlet();
 		_testGetBreadcrumbEntriesWhenScopeIsNotDesignLibrary();
 		_testGetBreadcrumbEntriesForDefaultCollection();
 		_testGetBreadcrumbEntriesForSpecificCollection();
-		_testGetBreadcrumbEntriesForFragment();
+		_testGetBreadcrumbEntriesForFragmentEntry();
 	}
 
 	private FragmentCollection _mockFragmentCollection(
@@ -209,7 +209,7 @@ public class FragmentBreadcrumbEntryContributorImplTest {
 				originalBreadcrumbEntries, _mockHttpServletRequest));
 	}
 
-	private void _testGetBreadcrumbEntriesForFragment() {
+	private void _testGetBreadcrumbEntriesForFragmentEntry() {
 		_setUpFragmentPortletInDesignLibraryScope();
 
 		BreadcrumbEntry originalBreadcrumbEntry = new BreadcrumbEntry();
@@ -276,7 +276,7 @@ public class FragmentBreadcrumbEntryContributorImplTest {
 			breadcrumbEntries.toString(), 2, breadcrumbEntries.size());
 	}
 
-	private void _testGetBreadcrumbEntriesWhenPortletIsNotFragment() {
+	private void _testGetBreadcrumbEntriesWhenNotInFragmentPortlet() {
 		Mockito.when(
 			_portletDisplay.getPortletName()
 		).thenReturn(

--- a/modules/apps/fragment/fragment-web/src/test/java/com/liferay/fragment/web/internal/servlet/taglib/FragmentBreadcrumbEntryContributorImplTest.java
+++ b/modules/apps/fragment/fragment-web/src/test/java/com/liferay/fragment/web/internal/servlet/taglib/FragmentBreadcrumbEntryContributorImplTest.java
@@ -65,11 +65,11 @@ public class FragmentBreadcrumbEntryContributorImplTest {
 	@Test
 	@TestInfo("LPD-97637")
 	public void testGetBreadcrumbEntries() {
+		_testGetBreadcrumbEntriesForDefaultCollection();
+		_testGetBreadcrumbEntriesForFragmentEntry();
+		_testGetBreadcrumbEntriesForSpecificCollection();
 		_testGetBreadcrumbEntriesWhenNotInFragmentPortlet();
 		_testGetBreadcrumbEntriesWhenScopeIsNotDesignLibrary();
-		_testGetBreadcrumbEntriesForDefaultCollection();
-		_testGetBreadcrumbEntriesForSpecificCollection();
-		_testGetBreadcrumbEntriesForFragmentEntry();
 	}
 
 	private FragmentCollection _mockFragmentCollection(

--- a/modules/apps/fragment/fragment-web/src/test/java/com/liferay/fragment/web/internal/servlet/taglib/FragmentBreadcrumbEntryContributorImplTest.java
+++ b/modules/apps/fragment/fragment-web/src/test/java/com/liferay/fragment/web/internal/servlet/taglib/FragmentBreadcrumbEntryContributorImplTest.java
@@ -1,0 +1,341 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.fragment.web.internal.servlet.taglib;
+
+import com.liferay.fragment.constants.FragmentPortletKeys;
+import com.liferay.fragment.model.FragmentCollection;
+import com.liferay.fragment.model.FragmentEntry;
+import com.liferay.fragment.service.FragmentCollectionLocalService;
+import com.liferay.fragment.service.FragmentEntryLocalService;
+import com.liferay.fragment.web.internal.util.DesignLibraryUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.servlet.taglib.ui.BreadcrumbEntry;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.theme.PortletDisplay;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import jakarta.portlet.PortletRequest;
+import jakarta.portlet.PortletURL;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Lourdes Fernández Besada
+ */
+public class FragmentBreadcrumbEntryContributorImplTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		_setUpFragmentBreadcrumbEntryContributorImpl();
+		_setUpMockHttpServletRequest();
+		_setUpPortal();
+	}
+
+	@After
+	public void tearDown() {
+		_designLibraryUtilMockedStatic.close();
+	}
+
+	@Test
+	@TestInfo("LPD-97637")
+	public void testGetBreadcrumbEntries() {
+		_testGetBreadcrumbEntriesWhenPortletIsNotFragment();
+		_testGetBreadcrumbEntriesWhenScopeIsNotDesignLibrary();
+		_testGetBreadcrumbEntriesForDefaultCollection();
+		_testGetBreadcrumbEntriesForSpecificCollection();
+		_testGetBreadcrumbEntriesForFragment();
+	}
+
+	private FragmentCollection _mockFragmentCollection(
+		long fragmentCollectionId) {
+
+		FragmentCollection fragmentCollection = Mockito.mock(
+			FragmentCollection.class);
+
+		Mockito.when(
+			fragmentCollection.getFragmentCollectionId()
+		).thenReturn(
+			fragmentCollectionId
+		);
+
+		Mockito.when(
+			fragmentCollection.getName()
+		).thenReturn(
+			RandomTestUtil.randomString()
+		);
+
+		Mockito.when(
+			_fragmentCollectionLocalService.fetchFragmentCollection(
+				fragmentCollectionId)
+		).thenReturn(
+			fragmentCollection
+		);
+
+		return fragmentCollection;
+	}
+
+	private FragmentEntry _mockFragmentEntry() {
+		FragmentEntry fragmentEntry = Mockito.mock(FragmentEntry.class);
+
+		Mockito.when(
+			fragmentEntry.getFragmentCollectionId()
+		).thenReturn(
+			RandomTestUtil.randomLong()
+		);
+
+		Mockito.when(
+			fragmentEntry.getFragmentEntryId()
+		).thenReturn(
+			RandomTestUtil.randomLong()
+		);
+
+		Mockito.when(
+			fragmentEntry.getName()
+		).thenReturn(
+			RandomTestUtil.randomString()
+		);
+
+		Mockito.when(
+			_fragmentEntryLocalService.fetchFragmentEntry(
+				fragmentEntry.getFragmentEntryId())
+		).thenReturn(
+			fragmentEntry
+		);
+
+		return fragmentEntry;
+	}
+
+	private void _setParameter(String name, String value) {
+		_mockHttpServletRequest.removeAllParameters();
+
+		_mockHttpServletRequest.addParameter(name, value);
+	}
+
+	private void _setUpFragmentBreadcrumbEntryContributorImpl() {
+		ReflectionTestUtil.setFieldValue(
+			_fragmentBreadcrumbEntryContributorImpl,
+			"_fragmentCollectionLocalService", _fragmentCollectionLocalService);
+		ReflectionTestUtil.setFieldValue(
+			_fragmentBreadcrumbEntryContributorImpl,
+			"_fragmentEntryLocalService", _fragmentEntryLocalService);
+		ReflectionTestUtil.setFieldValue(
+			_fragmentBreadcrumbEntryContributorImpl, "_portal", _portal);
+	}
+
+	private void _setUpFragmentPortletInDesignLibraryScope() {
+		Mockito.when(
+			_portletDisplay.getPortletName()
+		).thenReturn(
+			FragmentPortletKeys.FRAGMENT
+		);
+
+		_designLibraryUtilMockedStatic.when(
+			() -> DesignLibraryUtil.isDesignLibraryScope(_group)
+		).thenReturn(
+			true
+		);
+	}
+
+	private void _setUpMockHttpServletRequest() {
+		ThemeDisplay themeDisplay = Mockito.mock(ThemeDisplay.class);
+
+		Mockito.when(
+			themeDisplay.getPortletDisplay()
+		).thenReturn(
+			_portletDisplay
+		);
+
+		Mockito.when(
+			themeDisplay.getScopeGroup()
+		).thenReturn(
+			_group
+		);
+
+		_mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, themeDisplay);
+	}
+
+	private void _setUpPortal() {
+		Mockito.when(
+			_portal.getPortletNamespace(FragmentPortletKeys.FRAGMENT)
+		).thenReturn(
+			RandomTestUtil.randomString()
+		);
+
+		Mockito.when(
+			_portal.getControlPanelPortletURL(
+				_mockHttpServletRequest, _group, FragmentPortletKeys.FRAGMENT,
+				0L, 0L, PortletRequest.RENDER_PHASE)
+		).thenReturn(
+			Mockito.mock(PortletURL.class)
+		);
+	}
+
+	private void _testGetBreadcrumbEntriesForDefaultCollection() {
+		_setUpFragmentPortletInDesignLibraryScope();
+
+		List<BreadcrumbEntry> originalBreadcrumbEntries =
+			Collections.singletonList(new BreadcrumbEntry());
+
+		Assert.assertSame(
+			originalBreadcrumbEntries,
+			_fragmentBreadcrumbEntryContributorImpl.getBreadcrumbEntries(
+				originalBreadcrumbEntries, _mockHttpServletRequest));
+	}
+
+	private void _testGetBreadcrumbEntriesForFragment() {
+		_setUpFragmentPortletInDesignLibraryScope();
+
+		BreadcrumbEntry originalBreadcrumbEntry = new BreadcrumbEntry();
+
+		FragmentEntry fragmentEntry = _mockFragmentEntry();
+
+		_setParameter(
+			"fragmentEntryId",
+			String.valueOf(fragmentEntry.getFragmentEntryId()));
+
+		FragmentCollection fragmentCollection = _mockFragmentCollection(
+			fragmentEntry.getFragmentCollectionId());
+
+		List<BreadcrumbEntry> breadcrumbEntries =
+			_fragmentBreadcrumbEntryContributorImpl.getBreadcrumbEntries(
+				Collections.singletonList(originalBreadcrumbEntry),
+				_mockHttpServletRequest);
+
+		BreadcrumbEntry fragmentCollectionBreadcrumbEntry =
+			breadcrumbEntries.get(0);
+
+		Assert.assertEquals(
+			fragmentCollection.getName(),
+			fragmentCollectionBreadcrumbEntry.getTitle());
+
+		BreadcrumbEntry fragmentEntryBreadcrumbEntry = breadcrumbEntries.get(1);
+
+		Assert.assertEquals(
+			fragmentEntry.getName(), fragmentEntryBreadcrumbEntry.getTitle());
+
+		Assert.assertSame(originalBreadcrumbEntry, breadcrumbEntries.get(2));
+
+		Assert.assertEquals(
+			breadcrumbEntries.toString(), 3, breadcrumbEntries.size());
+	}
+
+	private void _testGetBreadcrumbEntriesForSpecificCollection() {
+		_setUpFragmentPortletInDesignLibraryScope();
+
+		BreadcrumbEntry originalBreadcrumbEntry = new BreadcrumbEntry();
+
+		FragmentCollection fragmentCollection = _mockFragmentCollection(
+			RandomTestUtil.randomLong());
+
+		_setParameter(
+			"fragmentCollectionId",
+			String.valueOf(fragmentCollection.getFragmentCollectionId()));
+
+		List<BreadcrumbEntry> breadcrumbEntries =
+			_fragmentBreadcrumbEntryContributorImpl.getBreadcrumbEntries(
+				Collections.singletonList(originalBreadcrumbEntry),
+				_mockHttpServletRequest);
+
+		BreadcrumbEntry fragmentCollectionBreadcrumbEntry =
+			breadcrumbEntries.get(0);
+
+		Assert.assertEquals(
+			fragmentCollection.getName(),
+			fragmentCollectionBreadcrumbEntry.getTitle());
+
+		Assert.assertSame(originalBreadcrumbEntry, breadcrumbEntries.get(1));
+
+		Assert.assertEquals(
+			breadcrumbEntries.toString(), 2, breadcrumbEntries.size());
+	}
+
+	private void _testGetBreadcrumbEntriesWhenPortletIsNotFragment() {
+		Mockito.when(
+			_portletDisplay.getPortletName()
+		).thenReturn(
+			RandomTestUtil.randomString()
+		);
+
+		_designLibraryUtilMockedStatic.when(
+			() -> DesignLibraryUtil.isDesignLibraryScope(_group)
+		).thenReturn(
+			true
+		);
+
+		List<BreadcrumbEntry> originalBreadcrumbEntries =
+			Collections.singletonList(new BreadcrumbEntry());
+
+		Assert.assertSame(
+			originalBreadcrumbEntries,
+			_fragmentBreadcrumbEntryContributorImpl.getBreadcrumbEntries(
+				originalBreadcrumbEntries, _mockHttpServletRequest));
+	}
+
+	private void _testGetBreadcrumbEntriesWhenScopeIsNotDesignLibrary() {
+		Mockito.when(
+			_portletDisplay.getPortletName()
+		).thenReturn(
+			FragmentPortletKeys.FRAGMENT
+		);
+
+		_designLibraryUtilMockedStatic.when(
+			() -> DesignLibraryUtil.isDesignLibraryScope(_group)
+		).thenReturn(
+			false
+		);
+
+		List<BreadcrumbEntry> originalBreadcrumbEntries =
+			Collections.singletonList(new BreadcrumbEntry());
+
+		Assert.assertSame(
+			originalBreadcrumbEntries,
+			_fragmentBreadcrumbEntryContributorImpl.getBreadcrumbEntries(
+				originalBreadcrumbEntries, _mockHttpServletRequest));
+	}
+
+	private final MockedStatic<DesignLibraryUtil>
+		_designLibraryUtilMockedStatic = Mockito.mockStatic(
+			DesignLibraryUtil.class);
+	private final FragmentBreadcrumbEntryContributorImpl
+		_fragmentBreadcrumbEntryContributorImpl =
+			new FragmentBreadcrumbEntryContributorImpl();
+	private final FragmentCollectionLocalService
+		_fragmentCollectionLocalService = Mockito.mock(
+			FragmentCollectionLocalService.class);
+	private final FragmentEntryLocalService _fragmentEntryLocalService =
+		Mockito.mock(FragmentEntryLocalService.class);
+	private final Group _group = Mockito.mock(Group.class);
+	private final MockHttpServletRequest _mockHttpServletRequest =
+		new MockHttpServletRequest();
+	private final Portal _portal = Mockito.mock(Portal.class);
+	private final PortletDisplay _portletDisplay = Mockito.mock(
+		PortletDisplay.class);
+
+}

--- a/modules/apps/fragment/fragment-web/src/test/java/com/liferay/fragment/web/internal/util/DesignLibraryUtilTest.java
+++ b/modules/apps/fragment/fragment-web/src/test/java/com/liferay/fragment/web/internal/util/DesignLibraryUtilTest.java
@@ -1,0 +1,104 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.fragment.web.internal.util;
+
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalServiceUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author Lourdes Fernández Besada
+ */
+public class DesignLibraryUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@After
+	public void tearDown() {
+		_depotEntryLocalServiceUtilMockedStatic.close();
+	}
+
+	@Test
+	public void testIsDesignLibraryScope() {
+		Assert.assertFalse(DesignLibraryUtil.isDesignLibraryScope(null));
+
+		Group group = Mockito.mock(Group.class);
+
+		Mockito.when(
+			group.isDepot()
+		).thenReturn(
+			false
+		);
+
+		Assert.assertFalse(DesignLibraryUtil.isDesignLibraryScope(group));
+
+		Mockito.when(
+			group.getGroupId()
+		).thenReturn(
+			RandomTestUtil.randomLong()
+		);
+
+		Mockito.when(
+			group.isDepot()
+		).thenReturn(
+			true
+		);
+
+		_depotEntryLocalServiceUtilMockedStatic.when(
+			() -> DepotEntryLocalServiceUtil.fetchGroupDepotEntry(
+				group.getGroupId())
+		).thenReturn(
+			null
+		);
+
+		Assert.assertFalse(DesignLibraryUtil.isDesignLibraryScope(group));
+
+		DepotEntry depotEntry = Mockito.mock(DepotEntry.class);
+
+		Mockito.when(
+			depotEntry.getType()
+		).thenReturn(
+			DepotConstants.TYPE_ASSET_LIBRARY
+		);
+
+		_depotEntryLocalServiceUtilMockedStatic.when(
+			() -> DepotEntryLocalServiceUtil.fetchGroupDepotEntry(
+				group.getGroupId())
+		).thenReturn(
+			depotEntry
+		);
+
+		Assert.assertFalse(DesignLibraryUtil.isDesignLibraryScope(group));
+
+		Mockito.when(
+			depotEntry.getType()
+		).thenReturn(
+			DepotConstants.TYPE_DESIGN_LIBRARY
+		);
+
+		Assert.assertTrue(DesignLibraryUtil.isDesignLibraryScope(group));
+	}
+
+	private final MockedStatic<DepotEntryLocalServiceUtil>
+		_depotEntryLocalServiceUtilMockedStatic = Mockito.mockStatic(
+			DepotEntryLocalServiceUtil.class);
+
+}

--- a/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/display/context/EditStyleBookEntryDisplayContext.java
+++ b/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/display/context/EditStyleBookEntryDisplayContext.java
@@ -103,7 +103,7 @@ public class EditStyleBookEntryDisplayContext {
 		_themeDisplay = (ThemeDisplay)httpServletRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
-		_setViewAttributes();
+		_updatePortletDisplay();
 	}
 
 	public Map<String, Object> getStyleBookEditorData() throws Exception {
@@ -689,7 +689,7 @@ public class EditStyleBookEntryDisplayContext {
 		return styleBookEntry.getName();
 	}
 
-	private void _setViewAttributes() {
+	private void _updatePortletDisplay() {
 		PortletDisplay portletDisplay = _themeDisplay.getPortletDisplay();
 
 		portletDisplay.setShowBackIcon(true);


### PR DESCRIPTION
Resending on top of https://github.com/brianchandotcom/liferay-portal/pull/178714 as suggested in https://github.com/brianchandotcom/liferay-portal/pull/178714#issuecomment-5002468115. Three commits on top of PR 178714 rename the two ambiguous `Fragment` test helpers to disambiguate the entity from the portlet, and sort the helper calls in `testGetBreadcrumbEntries` alphabetically.

https://liferay.atlassian.net/browse/LPD-97637

## What Is Being Fixed

Opening the Fragment portlet from a Design Library resource entered the site-scoped Fragment admin: the collections panel was shown, the back arrow led out of the Design Library, and the ControlMenu breadcrumb rendered the site-scoped hierarchy instead of the Design Library one.

## How It Is Being Fixed

The Fragment portlet is adapted to render inside a Design Library scope. When the current group is a Design Library depot, the collections panel is hidden, the back arrow returns to the Design Library resources listing, and the ControlMenu shows a dedicated Fragment breadcrumb that walks the Design Library hierarchy. The breadcrumb contributor is skipped inside the resources browser so the standalone breadcrumb keeps its own entries, and Fragment Set entries are contributed to the Design Library breadcrumb. `FragmentCollection` lookup by external reference code is added to support the resolution.

## PR Check

**pr-check: PASS** — tested on `001cf83d24b53219e2fb8c5601b7e09b597f4e5a`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Module Registration | PASS |
| Portlet Title | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| JSP Compile | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "001cf83d24b53219e2fb8c5601b7e09b597f4e5a"} -->