### PR TITLE
LPD-98584 Prevent preview iframe navigation and clear stale highlight

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationsPreview.tsx
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationsPreview.tsx
@@ -4,6 +4,7 @@
  */
 
 import ClayLoadingIndicator from '@clayui/loading-indicator';
+import {preventIframeNavigation} from '@liferay/layout-js-components-web';
 import React, {
 	forwardRef,
 	useCallback,
@@ -209,7 +210,7 @@ const ElementVariationsPreview = forwardRef<ElementVariationsPreviewRef, Props>(
 
 				<iframe
 					className="border-0 flex-grow-1 w-100"
-					onLoad={() => {
+					onLoad={(event) => {
 						const iframeDocument =
 							iframeRef.current?.contentDocument;
 
@@ -223,6 +224,8 @@ const ElementVariationsPreview = forwardRef<ElementVariationsPreviewRef, Props>(
 								type: 'SET_EDITABLE_ELEMENT_OPTIONS',
 							});
 						}
+
+						preventIframeNavigation(event);
 
 						applyDraftElementVariation();
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/elementVariationsReducer.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/elementVariationsReducer.ts
@@ -119,6 +119,7 @@ export function reducer(state: State, action: Action): State {
 			return {
 				...state,
 				draftElementVariation: null,
+				highlightedTargetElement: null,
 				languageId: state.defaultLanguageId,
 			};
 
@@ -164,6 +165,7 @@ export function reducer(state: State, action: Action): State {
 								: elementVariation
 						)
 					: [...elementVariations, draftElementVariation],
+				highlightedTargetElement: null,
 				languageId: state.defaultLanguageId,
 			};
 		}

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/plugins/element_variations/elementVariationsReducer.test.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/plugins/element_variations/elementVariationsReducer.test.ts
@@ -217,6 +217,18 @@ describe('elementVariationsReducer', () => {
 			expect(state.languageId).toBe('en_US');
 		});
 
+		it('clears the highlighted target element on SAVE_ELEMENT_VARIATION_DRAFT', () => {
+			const state = reducer(
+				buildState({
+					draftElementVariation: buildElementVariation({key: 'new'}),
+					highlightedTargetElement: '.selector',
+				}),
+				{type: 'SAVE_ELEMENT_VARIATION_DRAFT'}
+			);
+
+			expect(state.highlightedTargetElement).toBeNull();
+		});
+
 		it('loads a variation into the draft on EDIT_ELEMENT_VARIATION', () => {
 			const elementVariation = buildElementVariation({key: 'key-1'});
 
@@ -268,6 +280,18 @@ describe('elementVariationsReducer', () => {
 
 			expect(state.draftElementVariation).toBeNull();
 			expect(state.languageId).toBe('en_US');
+		});
+
+		it('clears the highlighted target element on CANCEL_ELEMENT_VARIATION_DRAFT', () => {
+			const state = reducer(
+				buildState({
+					draftElementVariation: buildElementVariation(),
+					highlightedTargetElement: '.selector',
+				}),
+				{type: 'CANCEL_ELEMENT_VARIATION_DRAFT'}
+			);
+
+			expect(state.highlightedTargetElement).toBeNull();
 		});
 	});
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98584

## What Is Being Fixed

The element variations preview renders the target page inside an iframe. That iframe was fully navigable: clicking a link or submitting a form navigated it away from the preview, and because the rendered page runs SennaJS, single-page-app navigation was also triggered on click. Separately, the highlight outline drawn around the currently hovered page element could remain in the iframe after the user cancelled or saved a variation draft, leaving a stray border in the list view.

## How It Is Being Fixed

The preview now reuses the shared preventIframeNavigation utility on iframe load, which suppresses both anchor/form default navigation and the SennaJS beforeNavigate event. The reducer now clears the highlighted target element when a draft is cancelled or saved, so the highlight style is always removed when returning to the list.

## PR Check

**pr-check: PASS** — tested on `318cfe850bec1a0cb0889a01f7192a9fae3cf373`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "318cfe850bec1a0cb0889a01f7192a9fae3cf373"} -->
