### PR TITLE
LPD-86008 As used [stable fix]

### DIFF
--- a/modules/apps/portal/portal-servlet-test/src/testIntegration/java/com/liferay/portal/servlet/filters/i18n/test/I18nFilterTest.java
+++ b/modules/apps/portal/portal-servlet-test/src/testIntegration/java/com/liferay/portal/servlet/filters/i18n/test/I18nFilterTest.java
@@ -432,8 +432,6 @@ public class I18nFilterTest {
 			boolean layoutFriendlyURLPublicServletMappingEnabled)
 		throws Exception {
 
-		long companyId = PortalInstances.getCompanyId(mockHttpServletRequest);
-
 		String i18nPath =
 			"/" + _portal.getI18nPathLanguageId(LocaleUtil.SPAIN, null);
 
@@ -462,6 +460,8 @@ public class I18nFilterTest {
 			PropsValues.LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING +
 				_group.getFriendlyURL());
 		mockHttpServletRequest.setServerName("localhost");
+
+		long companyId = PortalInstances.getCompanyId(mockHttpServletRequest);
 
 		try (AutoCloseable autoCloseable =
 				ReflectionTestUtil.setFieldValueWithAutoCloseable(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-86008

## What Is Being Fixed

Commit 13c05ad ("LPD-86008 As used") reordered `_testGetRedirectPublicServletMapping` in `I18nFilterTest` so that `long companyId = PortalInstances.getCompanyId(mockHttpServletRequest)` was placed above the `mockHttpServletRequest` declaration. That is a use-before-declaration, which fails to compile with `cannot find symbol` and breaks the `portal-servlet-test` testIntegration compile on master.

## How It Is Being Fixed

Move the `companyId` declaration down to immediately before its first use in the try-with-resources block, after `mockHttpServletRequest` is fully configured. This finishes the "as used" reorder correctly, mirrors the correctly-ordered sibling method in the same file, and evaluates `getCompanyId` against the fully-configured request.

## Why Are There No Tests?

The change is a mechanical statement reorder that fixes a use-before-declaration compile error in an existing integration test. It adds no new behavior to cover.

## PR Check

**pr-check: PASS** — tested on `2906275adb8299bd18f313f7b979b1d0631125e4`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "2906275adb8299bd18f313f7b979b1d0631125e4"} -->
