### PR TITLE
LPD-97670 Fix unpermitted add-task and enable day-slot creation

### DIFF
--- a/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/display/context/BaseTasksSectionDisplayContext.java
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/display/context/BaseTasksSectionDisplayContext.java
@@ -88,6 +88,8 @@ public abstract class BaseTasksSectionDisplayContext
 
 	public Map<String, Object> getAdditionalProps() throws Exception {
 		return HashMapBuilder.<String, Object>put(
+			"hasAddTaskPermission", hasAddObjectEntryPortletResourcePermission()
+		).put(
 			"projectId",
 			() -> {
 				if (assetEntry == null) {

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/modal/CreateTaskModal.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/modal/CreateTaskModal.tsx
@@ -31,6 +31,7 @@ type CreateTaskModalProps = {
 	closeModal: () => void;
 	dueDate?: string;
 	loadData: Function;
+	onItemsChange?: Function;
 	projectId?: string;
 	projectObjectDefinitionId: number;
 	state: string;
@@ -40,6 +41,7 @@ export default function CreateTaskModal({
 	closeModal,
 	dueDate = '',
 	loadData,
+	onItemsChange,
 	projectId,
 	projectObjectDefinitionId,
 	state,
@@ -71,7 +73,7 @@ export default function CreateTaskModal({
 			title: '',
 		},
 		onSubmit: async (values) => {
-			const {error} = await postTaskByScope({
+			const {data, error} = await postTaskByScope({
 				body: {
 					...values,
 					keywords: [
@@ -85,7 +87,15 @@ export default function CreateTaskModal({
 			if (!error) {
 				closeModal();
 
-				loadData();
+				if (onItemsChange && data) {
+					onItemsChange({
+						itemKey: 'embedded.id',
+						items: [{embedded: data}],
+					});
+				}
+				else {
+					loadData();
+				}
 
 				displayCreateSuccessToast(values.title);
 			}

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/ProjectTasksFDSPropsTransformer.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/ProjectTasksFDSPropsTransformer.tsx
@@ -67,6 +67,7 @@ export default function ProjectTasksFDSPropsTransformer({
 		component: (props: any) =>
 			CalendarView({
 				...props,
+				hasAddTaskPermission: additionalProps.hasAddTaskPermission,
 				projectId: additionalProps.projectId,
 				projectObjectDefinitionId:
 					additionalProps.projectObjectDefinitionId,
@@ -92,6 +93,7 @@ export default function ProjectTasksFDSPropsTransformer({
 		component: (props: any) =>
 			KanbanView({
 				...props,
+				hasAddTaskPermission: additionalProps.hasAddTaskPermission,
 				projectId: additionalProps.projectId,
 				projectObjectDefinitionId:
 					additionalProps.projectObjectDefinitionId,

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarView.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarView.tsx
@@ -191,6 +191,7 @@ export default function CalendarView({
 					closeModal={closeModal}
 					dueDate={dueDate}
 					loadData={loadData}
+					onItemsChange={onItemsChange}
 					projectId={projectId}
 					projectObjectDefinitionId={projectObjectDefinitionId}
 					state={DEFAULT_TASK_STATE_KEY}

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarView.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarView.tsx
@@ -8,7 +8,7 @@ import ClayDatePicker from '@clayui/date-picker';
 import ClayIcon from '@clayui/icon';
 import ClayLayout from '@clayui/layout';
 import dayGridPlugin from '@fullcalendar/daygrid';
-import interactionPlugin from '@fullcalendar/interaction';
+import interactionPlugin, {DateClickArg} from '@fullcalendar/interaction';
 import FullCalendar from '@fullcalendar/react';
 import {
 	FrontendDataSetContext,
@@ -38,6 +38,8 @@ import UnscheduledTasksPanel from './components/UnscheduledTasksPanel';
 import './CalendarView.scss';
 
 import type {FirstDayOfWeekLocale} from 'frontend-js-web';
+
+const ADD_TASK_BUTTON_CLASS_NAME = 'lfr__calendar-view-add-task-button';
 
 interface CalendarViewProps {
 	hasAddTaskPermission: boolean;
@@ -510,6 +512,19 @@ export default function CalendarView({
 				plugins={[dayGridPlugin, interactionPlugin]}
 				ref={calendarRef}
 				{...(hasAddTaskPermission && {
+					dateClick: (arg: DateClickArg) => {
+						const target = arg.jsEvent.target as HTMLElement;
+
+						// Don't open the create task modal if the add task
+						// button is clicked, since its own click handler
+						// already opens it.
+
+						if (target.closest(`.${ADD_TASK_BUTTON_CLASS_NAME}`)) {
+							return;
+						}
+
+						openCreateTaskModal(arg.dateStr);
+					},
 					dayCellContent: (arg) => (
 						<>
 							{arg.dayNumberText || String(arg.date.getDate())}
@@ -517,7 +532,7 @@ export default function CalendarView({
 							<ClayButtonWithIcon
 								aria-label={Liferay.Language.get('add-task')}
 								borderless
-								className="lfr__calendar-view-add-task-button"
+								className={ADD_TASK_BUTTON_CLASS_NAME}
 								displayType="secondary"
 								onClick={() =>
 									openCreateTaskModal(

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarView.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarView.tsx
@@ -40,6 +40,7 @@ import './CalendarView.scss';
 import type {FirstDayOfWeekLocale} from 'frontend-js-web';
 
 interface CalendarViewProps {
+	hasAddTaskPermission: boolean;
 	items: ITask[];
 	itemsActions: IItemsActions[];
 	projectId?: string;
@@ -53,6 +54,7 @@ interface MoreLinkPopover {
 }
 
 export default function CalendarView({
+	hasAddTaskPermission,
 	items,
 	itemsActions,
 	projectId,
@@ -414,27 +416,6 @@ export default function CalendarView({
 					setCurrentView(view.type);
 					setTitle(view.title);
 				}}
-				dayCellContent={(arg) => (
-					<>
-						{arg.dayNumberText || String(arg.date.getDate())}
-
-						<ClayButtonWithIcon
-							aria-label={Liferay.Language.get('add-task')}
-							borderless
-							className="lfr__calendar-view-add-task-button"
-							displayType="secondary"
-							onClick={() =>
-								openCreateTaskModal(
-									dateUtils.format(arg.date, 'yyyy-MM-dd')
-								)
-							}
-							rounded
-							size="xs"
-							symbol="plus"
-							title={Liferay.Language.get('add-task')}
-						/>
-					</>
-				)}
 				dayHeaderFormat={{weekday: 'long'}}
 				dayMaxEvents
 				drop={async (arg) => {
@@ -528,6 +509,29 @@ export default function CalendarView({
 				moreLinkHint={Liferay.Language.get('view-all-tasks')}
 				plugins={[dayGridPlugin, interactionPlugin]}
 				ref={calendarRef}
+				{...(hasAddTaskPermission && {
+					dayCellContent: (arg) => (
+						<>
+							{arg.dayNumberText || String(arg.date.getDate())}
+
+							<ClayButtonWithIcon
+								aria-label={Liferay.Language.get('add-task')}
+								borderless
+								className="lfr__calendar-view-add-task-button"
+								displayType="secondary"
+								onClick={() =>
+									openCreateTaskModal(
+										dateUtils.format(arg.date, 'yyyy-MM-dd')
+									)
+								}
+								rounded
+								size="xs"
+								symbol="plus"
+								title={Liferay.Language.get('add-task')}
+							/>
+						</>
+					),
+				})}
 			/>
 
 			{moreLinkPopover && (

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarView.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarView.tsx
@@ -414,6 +414,27 @@ export default function CalendarView({
 					setCurrentView(view.type);
 					setTitle(view.title);
 				}}
+				dayCellContent={(arg) => (
+					<>
+						{arg.dayNumberText || String(arg.date.getDate())}
+
+						<ClayButtonWithIcon
+							aria-label={Liferay.Language.get('add-task')}
+							borderless
+							className="lfr__calendar-view-add-task-button"
+							displayType="secondary"
+							onClick={() =>
+								openCreateTaskModal(
+									dateUtils.format(arg.date, 'yyyy-MM-dd')
+								)
+							}
+							rounded
+							size="xs"
+							symbol="plus"
+							title={Liferay.Language.get('add-task')}
+						/>
+					</>
+				)}
 				dayHeaderFormat={{weekday: 'long'}}
 				dayMaxEvents
 				drop={async (arg) => {
@@ -507,29 +528,6 @@ export default function CalendarView({
 				moreLinkHint={Liferay.Language.get('view-all-tasks')}
 				plugins={[dayGridPlugin, interactionPlugin]}
 				ref={calendarRef}
-				{...(Liferay.FeatureFlags['LPD-69885'] && {
-					dayCellContent: (arg) => (
-						<>
-							{arg.dayNumberText || String(arg.date.getDate())}
-
-							<ClayButtonWithIcon
-								aria-label={Liferay.Language.get('add-task')}
-								borderless
-								className="lfr__calendar-view-add-task-button"
-								displayType="secondary"
-								onClick={() =>
-									openCreateTaskModal(
-										dateUtils.format(arg.date, 'yyyy-MM-dd')
-									)
-								}
-								rounded
-								size="xs"
-								symbol="plus"
-								title={Liferay.Language.get('add-task')}
-							/>
-						</>
-					),
-				})}
 			/>
 
 			{moreLinkPopover && (

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/components/UnscheduledTasksPanel.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/components/UnscheduledTasksPanel.tsx
@@ -9,6 +9,7 @@ import {ClayDropDownWithItems} from '@clayui/drop-down';
 import ClayEmptyState from '@clayui/empty-state';
 import {ClayInput} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
+import ClayLink from '@clayui/link';
 import ClayList from '@clayui/list';
 import {Draggable} from '@fullcalendar/interaction';
 import {FrontendDataSetContext} from '@liferay/frontend-data-set-web';
@@ -16,6 +17,7 @@ import {AssigneeAvatar} from '@liferay/object-dynamic-data-mapping-form-field-ty
 import React, {useContext, useEffect, useMemo, useState} from 'react';
 
 import {TASK_DRAGGING_CLASS_NAME} from '../../../../../utils/constants';
+import getActionURL from '../../../../../utils/getActionURL';
 import getTaskItemsActions from '../../../../../utils/getTaskItemsActions';
 import {ITaskObjectEntry} from '../../../../../utils/types';
 import StateLabel from '../../../../StateLabel';
@@ -166,6 +168,14 @@ export default function UnscheduledTasksPanel({
 								{actions: task.actions, embedded: task}
 							);
 
+							const viewURL = task.actions?.get
+								? getActionURL({
+										actionId: 'actionLink',
+										itemsActions: itemsActions ?? [],
+										task: {embedded: task},
+									})
+								: undefined;
+
 							return (
 								<ClayList.Item
 									className={DRAGGABLE_ITEM_CLASS_NAME}
@@ -182,9 +192,19 @@ export default function UnscheduledTasksPanel({
 
 									<ClayList.ItemField expand>
 										<ClayList.ItemTitle>
-											<span data-testid="calendarUnscheduledTaskTitle">
-												{task.title}
-											</span>
+											{viewURL ? (
+												<ClayLink
+													data-testid="calendarUnscheduledTaskTitle"
+													draggable={false}
+													href={viewURL}
+												>
+													{task.title}
+												</ClayLink>
+											) : (
+												<span data-testid="calendarUnscheduledTaskTitle">
+													{task.title}
+												</span>
+											)}
 										</ClayList.ItemTitle>
 
 										<ClayList.ItemText>

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/kanban_view/KanbanView.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/kanban_view/KanbanView.tsx
@@ -17,6 +17,7 @@ import {KanbanViewContext} from './context';
 import {useOptimisticBoard} from './hooks/useOptimisticBoard';
 
 interface KanbanViewProps {
+	hasAddTaskPermission: boolean;
 	items: ITask[];
 	itemsActions: IItemsActions[];
 	projectId: string;
@@ -61,6 +62,7 @@ function KanbanView(props: KanbanViewProps) {
 			value={{
 				boardData,
 				changeTaskStatus,
+				hasAddTaskPermission: props.hasAddTaskPermission,
 				itemsActions: props.itemsActions,
 				loadData,
 				projectId: props.projectId,

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/kanban_view/components/Column.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/kanban_view/components/Column.tsx
@@ -43,8 +43,13 @@ export function ColumnView({
 	column: {icon, key, name, tasks},
 	stateFlow,
 }: IColumnViewProps) {
-	const {changeTaskStatus, loadData, projectId, projectObjectDefinitionId} =
-		useContext(KanbanViewContext);
+	const {
+		changeTaskStatus,
+		hasAddTaskPermission,
+		loadData,
+		projectId,
+		projectObjectDefinitionId,
+	} = useContext(KanbanViewContext);
 
 	const canTransition = (taskStateKey: string) => {
 		if (!stateFlow) {
@@ -113,37 +118,39 @@ export function ColumnView({
 						})}
 					</div>
 
-					<ClayButton
-						borderless
-						className="lfr__kaban-view-column-state-add-button"
-						displayType="secondary"
-						onClick={async () => {
-							await openCMPModal({
-								center: true,
-								contentComponent: ({
-									closeModal,
-								}: {
-									closeModal: () => void;
-								}) => (
-									<CreateTaskModal
-										closeModal={closeModal}
-										loadData={loadData}
-										projectId={projectId}
-										projectObjectDefinitionId={
-											projectObjectDefinitionId
-										}
-										state={key}
-									/>
-								),
-								size: 'md',
-							});
-						}}
-						size="xs"
-					>
-						<ClayIcon symbol="plus" />
+					{hasAddTaskPermission && (
+						<ClayButton
+							borderless
+							className="lfr__kaban-view-column-state-add-button"
+							displayType="secondary"
+							onClick={async () => {
+								await openCMPModal({
+									center: true,
+									contentComponent: ({
+										closeModal,
+									}: {
+										closeModal: () => void;
+									}) => (
+										<CreateTaskModal
+											closeModal={closeModal}
+											loadData={loadData}
+											projectId={projectId}
+											projectObjectDefinitionId={
+												projectObjectDefinitionId
+											}
+											state={key}
+										/>
+									),
+									size: 'md',
+								});
+							}}
+							size="xs"
+						>
+							<ClayIcon symbol="plus" />
 
-						{Liferay.Language.get('add-task')}
-					</ClayButton>
+							{Liferay.Language.get('add-task')}
+						</ClayButton>
+					)}
 				</div>
 			</Col>
 		</div>

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/kanban_view/context.ts
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/kanban_view/context.ts
@@ -17,6 +17,7 @@ interface IKanbanContext {
 			name: string;
 		}
 	) => void;
+	hasAddTaskPermission: boolean;
 	itemsActions: IItemsActions[];
 	loadData: Function;
 	projectId: string;

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/CalendarView.spec.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/CalendarView.spec.tsx
@@ -1,0 +1,62 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import '@testing-library/jest-dom';
+import {render, screen} from '@testing-library/react';
+import React from 'react';
+
+import CalendarView from '../../js/components/props_transformer/views/calendar_view/CalendarView';
+
+jest.mock('@fullcalendar/daygrid', () => ({}));
+
+jest.mock('@fullcalendar/interaction', () => ({}));
+
+// FullCalendar cannot run under jsdom, so render only the day cell
+// content to test what CalendarView feeds it.
+
+jest.mock('@fullcalendar/react', () => {
+	const React = require('react');
+
+	return {
+		__esModule: true,
+		default: React.forwardRef((props: any, _ref: unknown) => (
+			<div>
+				{props.dayCellContent?.({
+					date: new Date(2026, 6, 15),
+					dayNumberText: '15',
+				})}
+			</div>
+		)),
+	};
+});
+
+const renderCalendarView = (hasAddTaskPermission: boolean) =>
+	render(
+		<CalendarView
+			hasAddTaskPermission={hasAddTaskPermission}
+			items={[]}
+			itemsActions={[]}
+			projectId="123"
+			projectObjectDefinitionId={456}
+		/>
+	);
+
+describe('CalendarView', () => {
+	beforeEach(() => {
+		(globalThis as any).Liferay.fire = jest.fn();
+	});
+
+	it('hides the add task button without add task permission', () => {
+		renderCalendarView(false);
+
+		expect(screen.queryByLabelText('add-task')).not.toBeInTheDocument();
+	});
+
+	it('shows the add task button with add task permission', () => {
+		renderCalendarView(true);
+
+		expect(screen.getByLabelText('add-task')).toBeInTheDocument();
+	});
+});

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/Column.spec.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/Column.spec.tsx
@@ -49,6 +49,7 @@ const renderColumnView = (props: any, contextProps: any = {}) =>
 			value={{
 				boardData: {},
 				changeTaskStatus: jest.fn(),
+				hasAddTaskPermission: true,
 				loadData: () => {},
 				...contextProps,
 			}}
@@ -172,6 +173,18 @@ describe('Kanban ColumnView', () => {
 		});
 	});
 
+	it('hides the add task button without add task permission', () => {
+		const {queryByText} = renderColumnView(
+			{
+				column: defaultColumn,
+				stateFlow: mockStateFlow,
+			},
+			{hasAddTaskPermission: false}
+		);
+
+		expect(queryByText('add-task')).not.toBeInTheDocument();
+	});
+
 	it('renders header and tasks', () => {
 		const {getAllByTestId, getByText} = renderColumnView({
 			column: defaultColumn,
@@ -180,5 +193,14 @@ describe('Kanban ColumnView', () => {
 
 		expect(getByText('In Progress')).toBeInTheDocument();
 		expect(getAllByTestId('task').length).toBe(1);
+	});
+
+	it('shows the add task button with add task permission', () => {
+		const {getByText} = renderColumnView({
+			column: defaultColumn,
+			stateFlow: mockStateFlow,
+		});
+
+		expect(getByText('add-task')).toBeInTheDocument();
 	});
 });

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/CreateTaskModal.spec.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/CreateTaskModal.spec.tsx
@@ -4,13 +4,14 @@
  */
 
 import '@testing-library/jest-dom';
-import {render, waitFor} from '@testing-library/react';
+import {fireEvent, render, waitFor} from '@testing-library/react';
 import React from 'react';
 
 import CreateTaskModal from '../../js/components/modal/CreateTaskModal';
 
 const mockGetAllProjects = jest.fn();
 const mockGetAllStates = jest.fn();
+const mockPostTaskByScope = jest.fn();
 
 jest.mock('@clayui/button', () => {
 	const Button = ({children, ...props}: any) => (
@@ -70,7 +71,7 @@ jest.mock('@liferay/site-cms-site-initializer', () => ({
 jest.mock('../../js/utils/api', () => ({
 	getAllProjects: (...args: any[]) => mockGetAllProjects(...args),
 	getAllStates: (...args: any[]) => mockGetAllStates(...args),
-	postTaskByScope: () => {},
+	postTaskByScope: (...args: any[]) => mockPostTaskByScope(...args),
 }));
 
 jest.mock('../../js/components/StateSelector', () => ({
@@ -122,9 +123,17 @@ describe('CreateTaskModal', () => {
 				items: [{key: 'in-progress', name: 'In Progress'}],
 			},
 		});
+
+		mockPostTaskByScope.mockResolvedValue({
+			data: {id: 42, title: 'New Task'},
+			error: null,
+		});
 	});
 
-	const renderModal = (projectId?: string) =>
+	const renderModal = (
+		projectId?: string,
+		props: Partial<React.ComponentProps<typeof CreateTaskModal>> = {}
+	) =>
 		render(
 			<CreateTaskModal
 				closeModal={() => {}}
@@ -132,6 +141,7 @@ describe('CreateTaskModal', () => {
 				projectId={projectId}
 				projectObjectDefinitionId={123}
 				state=""
+				{...props}
 			/>
 		);
 
@@ -158,6 +168,47 @@ describe('CreateTaskModal', () => {
 
 			expect(projectPicker).not.toBeDisabled();
 			expect(projectPicker.value).toBe('0');
+		});
+	});
+
+	it('inserts the created task into the data set instead of reloading when onItemsChange is provided', async () => {
+		const loadData = jest.fn();
+		const onItemsChange = jest.fn();
+
+		const {getByLabelText, getByText} = renderModal('1', {
+			loadData,
+			onItemsChange,
+		});
+
+		await waitFor(() => {
+			expect(getByLabelText('project')).toBeDisabled();
+		});
+
+		fireEvent.click(getByText('save'));
+
+		await waitFor(() => {
+			expect(onItemsChange).toHaveBeenCalledWith({
+				itemKey: 'embedded.id',
+				items: [{embedded: {id: 42, title: 'New Task'}}],
+			});
+		});
+
+		expect(loadData).not.toHaveBeenCalled();
+	});
+
+	it('reloads the data set when onItemsChange is not provided', async () => {
+		const loadData = jest.fn();
+
+		const {getByLabelText, getByText} = renderModal('1', {loadData});
+
+		await waitFor(() => {
+			expect(getByLabelText('project')).toBeDisabled();
+		});
+
+		fireEvent.click(getByText('save'));
+
+		await waitFor(() => {
+			expect(loadData).toHaveBeenCalled();
 		});
 	});
 });

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/KanbanView.spec.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/KanbanView.spec.tsx
@@ -43,6 +43,7 @@ describe('KanbanView mapping and lifecycle', () => {
 
 		const {unmount} = render(
 			<KanbanView
+				hasAddTaskPermission
 				items={items}
 				itemsActions={[]}
 				projectId=""

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/Task.spec.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/Task.spec.tsx
@@ -106,6 +106,7 @@ describe('Kanban Task', () => {
 				value={{
 					boardData: {},
 					changeTaskStatus: jest.fn(),
+					hasAddTaskPermission: true,
 					itemsActions,
 					loadData: mockLoadData,
 					projectId,
@@ -216,6 +217,7 @@ describe('Kanban Task', () => {
 				value={{
 					boardData: {},
 					changeTaskStatus: jest.fn(),
+					hasAddTaskPermission: true,
 					itemsActions: [],
 					loadData: mockLoadData,
 					projectId: '123',
@@ -285,6 +287,7 @@ describe('Kanban Task', () => {
 					value={{
 						boardData: {},
 						changeTaskStatus: jest.fn(),
+						hasAddTaskPermission: true,
 						itemsActions: [],
 						loadData: mockLoadData,
 						projectId: '',
@@ -319,6 +322,7 @@ describe('Kanban Task', () => {
 					value={{
 						boardData: {},
 						changeTaskStatus: jest.fn(),
+						hasAddTaskPermission: true,
 						itemsActions: [],
 						loadData: mockLoadData,
 						projectId: '',

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/UnscheduledTasksPanel.spec.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/UnscheduledTasksPanel.spec.tsx
@@ -9,8 +9,14 @@ import {fireEvent, render} from '@testing-library/react';
 import React from 'react';
 
 import UnscheduledTasksPanel from '../../js/components/props_transformer/views/calendar_view/components/UnscheduledTasksPanel';
+import getActionURL from '../../js/utils/getActionURL';
 import getTaskItemsActions from '../../js/utils/getTaskItemsActions';
 import {ITaskObjectEntry} from '../../js/utils/types';
+
+jest.mock('../../js/utils/getActionURL', () => ({
+	__esModule: true,
+	default: jest.fn(() => '/view/1'),
+}));
 
 jest.mock('../../js/utils/getTaskItemsActions', () => ({
 	__esModule: true,
@@ -85,6 +91,7 @@ function renderUnscheduledTasksPanel(
 describe('UnscheduledTasksPanel', () => {
 	beforeEach(() => {
 		(getTaskItemsActions as jest.Mock).mockReturnValue([]);
+		(getActionURL as jest.Mock).mockReturnValue('/view/1');
 	});
 
 	it('filters the tasks by title as the user types', () => {
@@ -187,6 +194,22 @@ describe('UnscheduledTasksPanel', () => {
 		const {getByText} = renderUnscheduledTasksPanel([createTask()]);
 
 		expect(getByText('In Progress')).toBeInTheDocument();
+	});
+
+	it('renders the task title as a link to the view page when the user can view it', () => {
+		const {getByRole} = renderUnscheduledTasksPanel([
+			createTask({actions: {get: {href: '/view', method: 'GET'}}}),
+		]);
+
+		expect(
+			getByRole('link', {name: 'Design the landing page'})
+		).toHaveAttribute('href', '/view/1');
+	});
+
+	it('renders the task title as plain text when the user cannot view it', () => {
+		const {queryByRole} = renderUnscheduledTasksPanel([createTask()]);
+
+		expect(queryByRole('link')).not.toBeInTheDocument();
 	});
 
 	it('shows the empty state when the search matches no tasks', () => {

--- a/modules/test/playwright/tests/site-cmp-site-initializer/main/tasks.spec.ts
+++ b/modules/test/playwright/tests/site-cmp-site-initializer/main/tasks.spec.ts
@@ -810,7 +810,7 @@ test(
 
 test(
 	'Create a task from the calendar by clicking a day',
-	{tag: ['@LPD-93258']},
+	{tag: ['@LPD-93258', '@LPD-97621']},
 	async ({page, projectPage, projectsPage, tasksPage}) => {
 		const taskTitle = getRandomString();
 
@@ -871,6 +871,33 @@ test(
 			await expect(
 				dayCell.getByText(taskTitle, {exact: true})
 			).toBeVisible();
+		});
+
+		await test.step('Clicking a day slot opens the create task modal with that day pre-filled', async () => {
+			const daySlotDate = new Date();
+
+			daySlotDate.setDate(10);
+
+			await clickAndExpectToBeVisible({
+				target: tasksPage.titleInput,
+				trigger: tasksPage.getCalendarDayCell(daySlotDate),
+			});
+
+			const locale = await page.evaluate(() =>
+				Liferay.ThemeDisplay.getBCP47LanguageId()
+			);
+
+			await expect(page.getByLabel('Due Date')).toHaveValue(
+				daySlotDate.toLocaleDateString(locale, {
+					day: '2-digit',
+					month: '2-digit',
+					year: 'numeric',
+				})
+			);
+
+			await page.getByRole('button', {name: 'Cancel'}).click();
+
+			await expect(tasksPage.titleInput).toBeHidden();
 		});
 	}
 );

--- a/modules/test/playwright/tests/site-cmp-site-initializer/main/tasks.spec.ts
+++ b/modules/test/playwright/tests/site-cmp-site-initializer/main/tasks.spec.ts
@@ -899,6 +899,33 @@ test(
 
 			await expect(tasksPage.titleInput).toBeHidden();
 		});
+
+		await test.step('Saving from a day slot keeps the calendar on the navigated month', async () => {
+			const nextMonthTaskTitle = getRandomString();
+
+			const nextMonthDate = new Date();
+
+			nextMonthDate.setDate(15);
+			nextMonthDate.setMonth(nextMonthDate.getMonth() + 1);
+
+			await tasksPage.calendarView.nextMonthButton.click();
+
+			const nextMonthDayCell =
+				tasksPage.getCalendarDayCell(nextMonthDate);
+
+			await clickAndExpectToBeVisible({
+				target: tasksPage.titleInput,
+				trigger: nextMonthDayCell,
+			});
+
+			await tasksPage.titleInput.fill(nextMonthTaskTitle);
+
+			await tasksPage.saveButton.click();
+
+			await expect(
+				nextMonthDayCell.getByText(nextMonthTaskTitle, {exact: true})
+			).toBeVisible();
+		});
 	}
 );
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97670
https://liferay.atlassian.net/browse/LPD-97621

## What Is Being Fixed

Users without task creation permission could still open the New Task modal through the calendar day cell's add-task button and the kanban columns' add-task buttons, even though the FDS creation menu already hid it for them. Separately, clicking a day slot in the calendar did nothing, so there was no quick way to create a task on a specific date, and a redundant LPD-69885 feature flag check guarded code that only ever runs with the flag enabled.

## How It Is Being Fixed

The task creation permission is exposed from getAdditionalProps as hasAddTaskPermission and threaded into the calendar and kanban views, which now render their add-task buttons only when it is granted. Clicking a day cell in the calendar opens the New Task modal prefilled with that date under the same permission, excluding the add-task button's own click so it does not double-fire, and the created task is inserted directly into the shared FrontendDataSet data instead of forcing a full reload. The redundant LPD-69885 flag check around dayCellContent was removed since the calendar view only mounts when the flag is enabled, and unscheduled task titles now render as links.

## PR Check

**pr-check: PASS** — tested on `40907d8e6afc260c72c2bb4e9740f9f98535ac17`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "40907d8e6afc260c72c2bb4e9740f9f98535ac17"} -->
