### PR TITLE
LPD-98648 Fix LayoutLocalServiceTest

### DIFF
--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/service/test/LayoutLocalServiceTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/service/test/LayoutLocalServiceTest.java
@@ -977,7 +977,7 @@ public class LayoutLocalServiceTest {
 
 		layout = _layoutLocalService.updateLookAndFeel(
 			_group.getGroupId(), false, layout.getLayoutId(),
-			"dialect_WAR_dialecttheme", "01", StringPool.BLANK);
+			"classic_WAR_classictheme", "01", StringPool.BLANK);
 
 		Assert.assertEquals(StringPool.BLANK, layout.getCss());
 
@@ -987,7 +987,7 @@ public class LayoutLocalServiceTest {
 
 		Theme theme = layout.getTheme();
 
-		Assert.assertEquals("dialect_WAR_dialecttheme", theme.getThemeId());
+		Assert.assertEquals("classic_WAR_classictheme", theme.getThemeId());
 
 		LayoutTypePortlet layoutTypePortlet =
 			(LayoutTypePortlet)layout.getLayoutType();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98648

## What Is Being Fixed

The updateLookAndFeel test in LayoutLocalServiceTest asserted against the theme ID "dialect_WAR_dialecttheme". That theme is not reliably available in the integration test runtime, making the assertions fragile.

## How It Is Being Fixed

Switch the theme ID used in the updateLookAndFeel test to "classic_WAR_classictheme", the always-available theme, so the test is stable.

## Why Are There No Tests?

The change is itself a test fix. It only modifies LayoutLocalServiceTest and touches no production code, so there is nothing additional to cover.

## PR Check

**pr-check: PASS** — tested on `021225976bc1f636ad8c5affe832c3397ec1843e`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "021225976bc1f636ad8c5affe832c3397ec1843e"} -->
