### PR TITLE
LPD-98666 Combine redundant Map/Set existence checks with their operations

### DIFF
--- a/modules/apps/analytics/analytics-settings-impl/src/main/java/com/liferay/analytics/settings/internal/configuration/AnalyticsConfigurationRegistryImpl.java
+++ b/modules/apps/analytics/analytics-settings-impl/src/main/java/com/liferay/analytics/settings/internal/configuration/AnalyticsConfigurationRegistryImpl.java
@@ -979,9 +979,7 @@ public class AnalyticsConfigurationRegistryImpl
 					AnalyticsConfiguration.class, dictionary));
 		}
 
-		if (!_initializedCompanyIds.contains(companyId)) {
-			_initializedCompanyIds.add(companyId);
-
+		if (_initializedCompanyIds.add(companyId)) {
 			if (Validator.isNull(dictionary.get("previousToken"))) {
 				_activatedCompanyIds.remove(companyId);
 			}

--- a/modules/apps/archived/portal-search-solr8-impl/src/main/java/com/liferay/portal/search/solr8/internal/search/engine/adapter/search/SearchSolrQueryAssembler.java
+++ b/modules/apps/archived/portal-search-solr8-impl/src/main/java/com/liferay/portal/search/solr8/internal/search/engine/adapter/search/SearchSolrQueryAssembler.java
@@ -201,9 +201,7 @@ public class SearchSolrQueryAssembler {
 		Set<String> selectedFieldNames = SetUtil.fromArray(
 			searchSearchRequest.getSelectedFieldNames());
 
-		if (!selectedFieldNames.contains(Field.UID)) {
-			selectedFieldNames.add(Field.UID);
-		}
+		selectedFieldNames.add(Field.UID);
 
 		solrQuery.setFields(selectedFieldNames.toArray(new String[0]));
 	}

--- a/modules/apps/archived/portal-search-solr8-impl/src/main/java/com/liferay/portal/search/solr8/internal/search/engine/adapter/search/SearchSolrQueryAssembler.java
+++ b/modules/apps/archived/portal-search-solr8-impl/src/main/java/com/liferay/portal/search/solr8/internal/search/engine/adapter/search/SearchSolrQueryAssembler.java
@@ -231,11 +231,9 @@ public class SearchSolrQueryAssembler {
 
 			String sortFieldName = getSortFieldName(sort, "score");
 
-			if (sortFieldNames.contains(sortFieldName)) {
+			if (!sortFieldNames.add(sortFieldName)) {
 				continue;
 			}
-
-			sortFieldNames.add(sortFieldName);
 
 			solrQuery.addSort(getSortClause(sort, sortFieldName));
 		}

--- a/modules/apps/asset/asset-auto-tagger-service/src/main/java/com/liferay/asset/auto/tagger/internal/configuration/AssetAutoTaggerConfigurationFactoryImpl.java
+++ b/modules/apps/asset/asset-auto-tagger-service/src/main/java/com/liferay/asset/auto/tagger/internal/configuration/AssetAutoTaggerConfigurationFactoryImpl.java
@@ -205,12 +205,12 @@ public class AssetAutoTaggerConfigurationFactoryImpl
 				UnicodeProperties typeSettingsUnicodeProperties =
 					_group.getTypeSettingsProperties();
 
-				if (typeSettingsUnicodeProperties.containsKey(
-						"assetAutoTaggingEnabled")) {
+				String assetAutoTaggingEnabledString =
+					typeSettingsUnicodeProperties.get(
+						"assetAutoTaggingEnabled");
 
-					return GetterUtil.getBoolean(
-						typeSettingsUnicodeProperties.get(
-							"assetAutoTaggingEnabled"));
+				if (assetAutoTaggingEnabledString != null) {
+					return GetterUtil.getBoolean(assetAutoTaggingEnabledString);
 				}
 
 				AssetAutoTaggerGroupConfiguration

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/exportimport/portlet/preferences/processor/AssetPublisherExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/exportimport/portlet/preferences/processor/AssetPublisherExportImportPortletPreferencesProcessor.java
@@ -1434,9 +1434,7 @@ public class AssetPublisherExportImportPortletPreferencesProcessor
 				if (Validator.isNumber(oldValue)) {
 					long groupId = Long.valueOf(oldValue);
 
-					if (groupIds.containsKey(groupId)) {
-						groupId = groupIds.get(groupId);
-					}
+					groupId = groupIds.getOrDefault(groupId, groupId);
 
 					Group group = groupLocalService.fetchGroup(groupId);
 

--- a/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/info/collection/provider/AssetEntriesWithSameAssetCategoryRelatedInfoItemCollectionProvider.java
+++ b/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/info/collection/provider/AssetEntriesWithSameAssetCategoryRelatedInfoItemCollectionProvider.java
@@ -283,20 +283,15 @@ public class AssetEntriesWithSameAssetCategoryRelatedInfoItemCollectionProvider
 
 			assetCategoryIds.add(assetEntryAssetCategoryId);
 
-			if (!otherAssetCategoriesAssetVocabulariesMap.containsKey(
-					assetCategory.getVocabularyId())) {
-
-				otherAssetCategoriesAssetVocabulariesMap.put(
-					assetCategory.getVocabularyId(),
-					ListUtil.filter(
-						ListUtil.toList(
-							_assetCategoryLocalService.getVocabularyCategories(
-								assetCategory.getVocabularyId(),
-								QueryUtil.ALL_POS, QueryUtil.ALL_POS, null),
-							AssetCategory.CATEGORY_ID_ACCESSOR),
-						categoryId -> !ArrayUtil.contains(
-							assetEntry.getCategoryIds(), categoryId)));
-			}
+			otherAssetCategoriesAssetVocabulariesMap.computeIfAbsent(
+				assetCategory.getVocabularyId(),
+				key -> ListUtil.filter(
+					ListUtil.toList(
+						_assetCategoryLocalService.getVocabularyCategories(
+							key, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null),
+						AssetCategory.CATEGORY_ID_ACCESSOR),
+					categoryId -> !ArrayUtil.contains(
+						assetEntry.getCategoryIds(), categoryId)));
 		}
 
 		List<BooleanFilter> booleanFilters = new ArrayList<>();

--- a/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/util/AssetHelperImpl.java
+++ b/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/util/AssetHelperImpl.java
@@ -191,22 +191,11 @@ public class AssetHelperImpl implements AssetHelper {
 
 					long assetVocabularyId = assetCategory.getVocabularyId();
 
-					if (assetVocabularyAssetCategoryIds.containsKey(
-							assetVocabularyId)) {
-
-						String assetCategoryIds =
-							assetVocabularyAssetCategoryIds.get(
-								assetVocabularyId);
-
-						assetVocabularyAssetCategoryIds.put(
-							assetVocabularyId,
-							assetCategoryIds + StringPool.COMMA +
-								assetCategoryId);
-					}
-					else {
-						assetVocabularyAssetCategoryIds.put(
-							assetVocabularyId, String.valueOf(assetCategoryId));
-					}
+					assetVocabularyAssetCategoryIds.merge(
+						assetVocabularyId, String.valueOf(assetCategoryId),
+						(currentAssetCategoryIds, newAssetCategoryId) ->
+							currentAssetCategoryIds + StringPool.COMMA +
+								newAssetCategoryId);
 				}
 
 				for (Map.Entry<Long, String> entry :

--- a/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/util/StagingAssetEntryHelperImpl.java
+++ b/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/util/StagingAssetEntryHelperImpl.java
@@ -95,8 +95,10 @@ public class StagingAssetEntryHelperImpl implements StagingAssetEntryHelper {
 
 		// Try to fetch the existing staged model from the importing group
 
-		if (assetEntryMap.containsKey(groupId)) {
-			return assetEntryMap.get(groupId);
+		AssetEntry groupAssetEntry = assetEntryMap.get(groupId);
+
+		if (groupAssetEntry != null) {
+			return groupAssetEntry;
 		}
 
 		// Try to fetch the existing staged model from parent sites
@@ -106,13 +108,10 @@ public class StagingAssetEntryHelperImpl implements StagingAssetEntryHelper {
 		Group parentGroup = group.getParentGroup();
 
 		while (parentGroup != null) {
-			if (assetEntryMap.containsKey(parentGroup.getGroupId())) {
-				AssetEntry assetEntry = assetEntryMap.get(
-					parentGroup.getGroupId());
+			AssetEntry assetEntry = assetEntryMap.get(parentGroup.getGroupId());
 
-				if (isAssetEntryApplicable(assetEntry)) {
-					return assetEntry;
-				}
+			if ((assetEntry != null) && isAssetEntryApplicable(assetEntry)) {
+				return assetEntry;
 			}
 
 			parentGroup = parentGroup.getParentGroup();
@@ -123,8 +122,11 @@ public class StagingAssetEntryHelperImpl implements StagingAssetEntryHelper {
 		Group companyGroup = _groupLocalService.fetchCompanyGroup(
 			group.getCompanyId());
 
-		if (assetEntryMap.containsKey(companyGroup.getGroupId())) {
-			return assetEntryMap.get(companyGroup.getGroupId());
+		AssetEntry companyGroupAssetEntry = assetEntryMap.get(
+			companyGroup.getGroupId());
+
+		if (companyGroupAssetEntry != null) {
+			return companyGroupAssetEntry;
 		}
 
 		// Try to fetch the existing staged model from the company

--- a/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/internal/display/context/AssetTagsNavigationDisplayContext.java
+++ b/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/internal/display/context/AssetTagsNavigationDisplayContext.java
@@ -232,8 +232,10 @@ public class AssetTagsNavigationDisplayContext {
 	}
 
 	private Integer _getVisibleAssetsTagsCount(String tagName) {
-		if (_assetTagCounts.containsKey(tagName)) {
-			return _assetTagCounts.get(tagName);
+		Integer assetTagCount = _assetTagCounts.get(tagName);
+
+		if (assetTagCount != null) {
+			return assetTagCount;
 		}
 
 		int count = AssetTagServiceUtil.getVisibleAssetsTagsCount(

--- a/modules/apps/bean-portlet/bean-portlet-cdi-extension/src/main/java/com/liferay/bean/portlet/cdi/extension/internal/mvc/ConfigurationImpl.java
+++ b/modules/apps/bean-portlet/bean-portlet-cdi-extension/src/main/java/com/liferay/bean/portlet/cdi/extension/internal/mvc/ConfigurationImpl.java
@@ -49,9 +49,7 @@ public class ConfigurationImpl implements Configuration {
 				portletContext.getInitParameter(initParameterName));
 		}
 
-		if (!_properties.containsKey(DEFAULT_VIEW_EXTENSION)) {
-			_properties.put(DEFAULT_VIEW_EXTENSION, "jsp");
-		}
+		_properties.putIfAbsent(DEFAULT_VIEW_EXTENSION, "jsp");
 	}
 
 	@Override

--- a/modules/apps/bean-portlet/bean-portlet-spring-extension/src/main/java/com/liferay/bean/portlet/spring/extension/internal/mvc/ConfigurationImpl.java
+++ b/modules/apps/bean-portlet/bean-portlet-spring-extension/src/main/java/com/liferay/bean/portlet/spring/extension/internal/mvc/ConfigurationImpl.java
@@ -119,9 +119,7 @@ public class ConfigurationImpl implements Configuration {
 				_portletContext.getInitParameter(initParameterName));
 		}
 
-		if (!_properties.containsKey(DEFAULT_VIEW_EXTENSION)) {
-			_properties.put(DEFAULT_VIEW_EXTENSION, "jsp");
-		}
+		_properties.putIfAbsent(DEFAULT_VIEW_EXTENSION, "jsp");
 	}
 
 	@Autowired

--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarBookingLocalServiceImpl.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarBookingLocalServiceImpl.java
@@ -1809,10 +1809,10 @@ public class CalendarBookingLocalServiceImpl
 			long secondReminder = calendarBooking.getSecondReminder();
 			String secondReminderType = calendarBooking.getSecondReminderType();
 
-			if (childCalendarBookingMap.containsKey(calendarId)) {
-				CalendarBooking oldChildCalendarBooking =
-					childCalendarBookingMap.get(calendarId);
+			CalendarBooking oldChildCalendarBooking =
+				childCalendarBookingMap.get(calendarId);
 
+			if (oldChildCalendarBooking != null) {
 				firstReminder = oldChildCalendarBooking.getFirstReminder();
 				firstReminderType =
 					oldChildCalendarBooking.getFirstReminderType();
@@ -1853,9 +1853,9 @@ public class CalendarBookingLocalServiceImpl
 
 			serviceContext.setAttribute("sendNotification", Boolean.TRUE);
 
-			if (childCalendarBookingMap.containsKey(calendarId)) {
-				CalendarBooking oldChildCalendarBooking =
-					childCalendarBookingMap.get(calendarId);
+			oldChildCalendarBooking = childCalendarBookingMap.get(calendarId);
+
+			if (oldChildCalendarBooking != null) {
 				int workflowAction = GetterUtil.getInteger(
 					serviceContext.getAttribute("workflowAction"));
 

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/closure/CTClosureFactoryImpl.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/closure/CTClosureFactoryImpl.java
@@ -308,9 +308,7 @@ public class CTClosureFactoryImpl implements CTClosureFactory {
 					Node childNode = new Node(
 						childClassNameId, resultSet.getLong(2));
 
-					if (!nodes.contains(parentNode)) {
-						nodes.add(parentNode);
-
+					if (nodes.add(parentNode)) {
 						if (newParentPrimaryKeys == null) {
 							newParentPrimaryKeys = new ArrayList<>();
 						}

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/search/spi/model/index/contributor/CTEntryModelDocumentContributor.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/search/spi/model/index/contributor/CTEntryModelDocumentContributor.java
@@ -211,11 +211,13 @@ public class CTEntryModelDocumentContributor
 		else {
 			Map<String, Object> modelAttributes = model.getModelAttributes();
 
-			if (modelAttributes.containsKey("groupId")) {
-				groupId = (long)modelAttributes.get("groupId");
+			if (modelAttributes.get("groupId") instanceof Long groupIdValue) {
+				groupId = groupIdValue;
 			}
-			else if (modelAttributes.containsKey("plid")) {
-				long plid = (long)modelAttributes.get("plid");
+			else {
+				if (!(modelAttributes.get("plid") instanceof Long plid)) {
+					return null;
+				}
 
 				try (SafeCloseable safeCloseable =
 						CTCollectionThreadLocal.
@@ -355,15 +357,11 @@ public class CTEntryModelDocumentContributor
 
 		Map<String, Object> modelAttributes = model.getModelAttributes();
 
-		if (modelAttributes.containsKey("plid")) {
-			long plid = (long)modelAttributes.get("plid");
-
+		if (modelAttributes.get("plid") instanceof Long plid) {
 			document.addKeyword("plid", plid);
 		}
 
-		if (modelAttributes.containsKey("status")) {
-			int status = (int)modelAttributes.get("status");
-
+		if (modelAttributes.get("status") instanceof Integer status) {
 			document.addKeyword(Field.STATUS, status);
 			document.addLocalizedKeyword(
 				"statusLabel",

--- a/modules/apps/change-tracking/change-tracking-spi/src/main/java/com/liferay/change/tracking/spi/display/BaseCTDisplayRenderer.java
+++ b/modules/apps/change-tracking/change-tracking-spi/src/main/java/com/liferay/change/tracking/spi/display/BaseCTDisplayRenderer.java
@@ -181,10 +181,10 @@ public abstract class BaseCTDisplayRenderer<T extends BaseModel<T>>
 		Map<String, Function<T, Object>> attributeGetterFunctions =
 			model.getAttributeGetterFunctions();
 
-		if (attributeGetterFunctions.containsKey("DDMStructureId")) {
-			Function<T, Object> ddmStructureIdGetterFunction =
-				attributeGetterFunctions.get("DDMStructureId");
+		Function<T, Object> ddmStructureIdGetterFunction =
+			attributeGetterFunctions.get("DDMStructureId");
 
+		if (ddmStructureIdGetterFunction != null) {
 			Function<T, Object> idGetterFunction = attributeGetterFunctions.get(
 				"id");
 

--- a/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/display/context/ViewChangesDisplayContext.java
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/display/context/ViewChangesDisplayContext.java
@@ -468,7 +468,7 @@ public class ViewChangesDisplayContext {
 				ModelInfoKey selectedModelInfoKey = new ModelInfoKey(
 					_modelClassNameId, _modelClassPK);
 
-				if (!modelInfoMap.containsKey(selectedModelInfoKey)) {
+				if (modelInfoMap.get(selectedModelInfoKey) == null) {
 					modelInfoMap.put(
 						selectedModelInfoKey, new ModelInfo(modelKeyCounter++));
 
@@ -489,7 +489,7 @@ public class ViewChangesDisplayContext {
 						ModelInfoKey modelInfoKey = new ModelInfoKey(
 							classNameId, classPK);
 
-						if (!modelInfoMap.containsKey(modelInfoKey)) {
+						if (modelInfoMap.get(modelInfoKey) == null) {
 							modelInfoMap.put(
 								modelInfoKey, new ModelInfo(modelKeyCounter++));
 

--- a/modules/apps/commerce/commerce-order-rule-service/src/main/java/com/liferay/commerce/order/rule/internal/validator/CORCommerceOrderValidator.java
+++ b/modules/apps/commerce/commerce-order-rule-service/src/main/java/com/liferay/commerce/order/rule/internal/validator/CORCommerceOrderValidator.java
@@ -275,9 +275,7 @@ public class CORCommerceOrderValidator implements CommerceOrderValidator {
 		for (COREntry corEntry : corEntries) {
 			String type = corEntry.getType();
 
-			if (!validatedRuleType.contains(type)) {
-				validatedRuleType.add(type);
-
+			if (validatedRuleType.add(type)) {
 				COREntryType corEntryType =
 					_corEntryTypeRegistry.getCOREntryType(type);
 

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/helper/CPInstanceHelperImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/helper/CPInstanceHelperImpl.java
@@ -787,20 +787,8 @@ public class CPInstanceHelperImpl implements CPInstanceHelper {
 				continue;
 			}
 
-			if (cpInstanceCPInstanceOptionValueHits.containsKey(
-					cpInstanceOptionValueRel.getCPInstanceId())) {
-
-				int value = cpInstanceCPInstanceOptionValueHits.get(
-					cpInstanceOptionValueRel.getCPInstanceId());
-
-				cpInstanceCPInstanceOptionValueHits.put(
-					cpInstanceOptionValueRel.getCPInstanceId(), value + 1);
-
-				continue;
-			}
-
-			cpInstanceCPInstanceOptionValueHits.put(
-				cpInstanceOptionValueRel.getCPInstanceId(), 1);
+			cpInstanceCPInstanceOptionValueHits.merge(
+				cpInstanceOptionValueRel.getCPInstanceId(), 1, Integer::sum);
 		}
 
 		if (cpInstanceCPInstanceOptionValueHits.isEmpty()) {
@@ -869,20 +857,8 @@ public class CPInstanceHelperImpl implements CPInstanceHelper {
 				continue;
 			}
 
-			if (cpInstanceCPInstanceOptionValueHits.containsKey(
-					cpInstanceOptionValueRel.getCPInstanceId())) {
-
-				int value = cpInstanceCPInstanceOptionValueHits.get(
-					cpInstanceOptionValueRel.getCPInstanceId());
-
-				cpInstanceCPInstanceOptionValueHits.put(
-					cpInstanceOptionValueRel.getCPInstanceId(), value + 1);
-
-				continue;
-			}
-
-			cpInstanceCPInstanceOptionValueHits.put(
-				cpInstanceOptionValueRel.getCPInstanceId(), 1);
+			cpInstanceCPInstanceOptionValueHits.merge(
+				cpInstanceOptionValueRel.getCPInstanceId(), 1, Integer::sum);
 		}
 
 		if (cpInstanceCPInstanceOptionValueHits.isEmpty()) {

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/helper/CPInstanceHelperImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/helper/CPInstanceHelperImpl.java
@@ -770,17 +770,12 @@ public class CPInstanceHelperImpl implements CPInstanceHelper {
 		for (CPInstanceOptionValueRel cpInstanceOptionValueRel :
 				cpDefinitionCPInstanceOptionValueRels) {
 
-			if (!cpDefinitionOptionRelCPDefinitionOptionValueRelIds.containsKey(
-					cpInstanceOptionValueRel.getCPDefinitionOptionRelId())) {
-
-				continue;
-			}
-
 			List<Long> cpDefinitionOptionValueIds =
 				cpDefinitionOptionRelCPDefinitionOptionValueRelIds.get(
 					cpInstanceOptionValueRel.getCPDefinitionOptionRelId());
 
-			if (!cpDefinitionOptionValueIds.contains(
+			if ((cpDefinitionOptionValueIds == null) ||
+				!cpDefinitionOptionValueIds.contains(
 					cpInstanceOptionValueRel.
 						getCPDefinitionOptionValueRelId())) {
 
@@ -840,17 +835,12 @@ public class CPInstanceHelperImpl implements CPInstanceHelper {
 		for (CPInstanceOptionValueRel cpInstanceOptionValueRel :
 				cpDefinitionCPInstanceOptionValueRels) {
 
-			if (!cpDefinitionOptionRelCPDefinitionOptionValueRelIds.containsKey(
-					cpInstanceOptionValueRel.getCPDefinitionOptionRelId())) {
-
-				continue;
-			}
-
 			List<Long> cpDefinitionOptionValueIds =
 				cpDefinitionOptionRelCPDefinitionOptionValueRelIds.get(
 					cpInstanceOptionValueRel.getCPDefinitionOptionRelId());
 
-			if (!cpDefinitionOptionValueIds.contains(
+			if ((cpDefinitionOptionValueIds == null) ||
+				!cpDefinitionOptionValueIds.contains(
 					cpInstanceOptionValueRel.
 						getCPDefinitionOptionValueRelId())) {
 

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/search/spi/model/query/contributor/CPSpecificationOptionModelPreFilterContributor.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/search/spi/model/query/contributor/CPSpecificationOptionModelPreFilterContributor.java
@@ -42,11 +42,11 @@ public class CPSpecificationOptionModelPreFilterContributor
 
 		Map<String, Serializable> attributes = searchContext.getAttributes();
 
-		if (attributes.containsKey(CPField.FACETABLE)) {
-			boolean facetable = GetterUtil.getBoolean(
-				attributes.get(CPField.FACETABLE));
+		Serializable facetable = attributes.get(CPField.FACETABLE);
 
-			booleanFilter.addRequiredTerm(CPField.FACETABLE, facetable);
+		if (facetable != null) {
+			booleanFilter.addRequiredTerm(
+				CPField.FACETABLE, GetterUtil.getBoolean(facetable));
 		}
 	}
 
@@ -55,11 +55,11 @@ public class CPSpecificationOptionModelPreFilterContributor
 
 		Map<String, Serializable> attributes = searchContext.getAttributes();
 
-		if (attributes.containsKey(CPField.VISIBLE)) {
-			boolean visible = GetterUtil.getBoolean(
-				attributes.get(CPField.VISIBLE));
+		Serializable visible = attributes.get(CPField.VISIBLE);
 
-			booleanFilter.addRequiredTerm(CPField.VISIBLE, visible);
+		if (visible != null) {
+			booleanFilter.addRequiredTerm(
+				CPField.VISIBLE, GetterUtil.getBoolean(visible));
 		}
 	}
 

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPDefinitionLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPDefinitionLocalServiceImpl.java
@@ -1936,19 +1936,10 @@ public class CPDefinitionLocalServiceImpl
 						key, searchContext.getLanguageId());
 				}
 
-				List<String> facetValues = null;
-
-				if (facetMap.containsKey(key)) {
-					facetValues = facetMap.get(key);
-				}
-
-				if (facetValues == null) {
-					facetValues = new ArrayList<>();
-				}
+				List<String> facetValues = facetMap.computeIfAbsent(
+					key, curKey -> new ArrayList<>());
 
 				facetValues.add(value);
-
-				facetMap.put(key, facetValues);
 			}
 
 			for (Map.Entry<String, List<String>> entry : facetMap.entrySet()) {

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/object/action/executor/SplitCommerceOrderByCatalogObjectActionExecutorImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/object/action/executor/SplitCommerceOrderByCatalogObjectActionExecutorImpl.java
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -378,26 +379,12 @@ public class SplitCommerceOrderByCatalogObjectActionExecutorImpl
 					CPDefinition cpDefinition =
 						commerceOrderItem.getCPDefinition();
 
-					CommerceCatalog commerceCatalog =
-						cpDefinition.getCommerceCatalog();
+					List<CommerceOrderItem> splitCommerceOrderItems =
+						commerceCatalogCommerceOrderItemsMap.computeIfAbsent(
+							cpDefinition.getCommerceCatalog(),
+							key -> new ArrayList<>());
 
-					if (commerceCatalogCommerceOrderItemsMap.containsKey(
-							commerceCatalog)) {
-
-						List<CommerceOrderItem> splitCommerceOrderItems =
-							commerceCatalogCommerceOrderItemsMap.get(
-								commerceCatalog);
-
-						splitCommerceOrderItems.add(commerceOrderItem);
-
-						commerceCatalogCommerceOrderItemsMap.put(
-							commerceCatalog, splitCommerceOrderItems);
-					}
-					else {
-						commerceCatalogCommerceOrderItemsMap.put(
-							commerceCatalog,
-							ListUtil.toList(commerceOrderItem));
-					}
+					splitCommerceOrderItems.add(commerceOrderItem);
 				}
 				catch (Exception exception) {
 					throw new RuntimeException(exception);

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/object/system/CPDefinitionSystemObjectDefinitionManager.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/object/system/CPDefinitionSystemObjectDefinitionManager.java
@@ -310,8 +310,10 @@ public class CPDefinitionSystemObjectDefinitionManager
 		Map<String, Object> variables = super.getVariables(
 			contentType, objectDefinition, oldValues, payloadJSONObject);
 
-		if (variables.containsKey("CProductId")) {
-			variables.put("productId", variables.get("CProductId"));
+		Object cProductId = variables.get("CProductId");
+
+		if (cProductId != null) {
+			variables.put("productId", cProductId);
 		}
 
 		return variables;

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/object/system/CommerceOrderNoteSystemObjectDefinitionManager.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/object/system/CommerceOrderNoteSystemObjectDefinitionManager.java
@@ -194,10 +194,12 @@ public class CommerceOrderNoteSystemObjectDefinitionManager
 		Map<String, Object> variables = super.getVariables(
 			contentType, objectDefinition, oldValues, payloadJSONObject);
 
-		if (variables.containsKey("commerceOrderId")) {
+		Object commerceOrderId = variables.get("commerceOrderId");
+
+		if (commerceOrderId != null) {
 			CommerceOrder commerceOrder =
 				_commerceOrderLocalService.fetchCommerceOrder(
-					GetterUtil.getLong(variables.get("commerceOrderId")));
+					GetterUtil.getLong(commerceOrderId));
 
 			if (commerceOrder == null) {
 				return variables;

--- a/modules/apps/commerce/commerce-tax-service/src/main/java/com/liferay/commerce/tax/internal/CommerceTaxCalculationImpl.java
+++ b/modules/apps/commerce/commerce-tax-service/src/main/java/com/liferay/commerce/tax/internal/CommerceTaxCalculationImpl.java
@@ -68,14 +68,12 @@ public class CommerceTaxCalculationImpl implements CommerceTaxCalculation {
 				commerceOrderItem.getFinalPrice());
 
 			for (CommerceTaxValue commerceTaxValue : commerceTaxValues) {
-				CommerceTaxValue aggregatedCommerceTaxValue = null;
+				CommerceTaxValue aggregatedCommerceTaxValue = taxValueMap.get(
+					commerceTaxValue.getName());
 
 				BigDecimal amount = commerceTaxValue.getAmount();
 
-				if (taxValueMap.containsKey(commerceTaxValue.getName())) {
-					aggregatedCommerceTaxValue = taxValueMap.get(
-						commerceTaxValue.getName());
-
+				if (aggregatedCommerceTaxValue != null) {
 					amount = amount.add(aggregatedCommerceTaxValue.getAmount());
 				}
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/ProductOptionResourceTest.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/ProductOptionResourceTest.java
@@ -262,11 +262,10 @@ public class ProductOptionResourceTest
 		Collection<ProductOption> productOptions) {
 
 		for (ProductOption productOption : productOptions) {
-			long optionId = productOption.getOptionId();
+			ProductOption curProductOption = _productOptions.putIfAbsent(
+				productOption.getOptionId(), productOption);
 
-			if (!_productOptions.containsKey(optionId)) {
-				_productOptions.put(optionId, productOption);
-
+			if (curProductOption == null) {
 				return productOption;
 			}
 		}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/CartResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/CartResourceImpl.java
@@ -1110,14 +1110,12 @@ public class CartResourceImpl extends BaseCartResourceImpl {
 					commerceOrderItem.getCommerceOrderItemId(),
 					contextAcceptLanguage.getPreferredLocale()));
 
-			if (commerceOrderValidatorResults.containsKey(
-					commerceOrderItem.getCommerceOrderItemId())) {
+			List<CommerceOrderValidatorResult>
+				commerceOrderItemValidatorResults =
+					commerceOrderValidatorResults.get(
+						commerceOrderItem.getCommerceOrderItemId());
 
-				List<CommerceOrderValidatorResult>
-					commerceOrderItemValidatorResults =
-						commerceOrderValidatorResults.get(
-							commerceOrderItem.getCommerceOrderItemId());
-
+			if (commerceOrderItemValidatorResults != null) {
 				boolean cartItemValid = true;
 
 				for (CommerceOrderValidatorResult commerceOrderValidatorResult :

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/DataDefinitionResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/DataDefinitionResourceImpl.java
@@ -1852,10 +1852,10 @@ public class DataDefinitionResourceImpl extends BaseDataDefinitionResourceImpl {
 		Map<String, Object> customProperties =
 			dataDefinitionField.getCustomProperties();
 
-		if (customProperties.containsKey("fieldReference")) {
-			customProperties.put(
-				"fieldReference",
-				"CopyOf" + customProperties.get("fieldReference"));
+		Object fieldReference = customProperties.get("fieldReference");
+
+		if (fieldReference != null) {
+			customProperties.put("fieldReference", "CopyOf" + fieldReference);
 		}
 
 		if (!customProperties.containsKey("structureId") &&

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/DataDefinitionResourceTest.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/DataDefinitionResourceTest.java
@@ -1171,9 +1171,11 @@ public class DataDefinitionResourceTest
 				customProperties1.containsKey("fieldReference"),
 				customProperties2.containsKey("fieldReference"));
 
-			if (customProperties1.containsKey("fieldReference")) {
+			Object fieldReference = customProperties1.get("fieldReference");
+
+			if (fieldReference != null) {
 				Assert.assertEquals(
-					"CopyOf" + customProperties1.get("fieldReference"),
+					"CopyOf" + fieldReference,
 					customProperties2.get("fieldReference"));
 			}
 

--- a/modules/apps/dispatch/dispatch-talend-api/src/main/java/com/liferay/dispatch/talend/archive/TalendArchiveParserUtil.java
+++ b/modules/apps/dispatch/dispatch-talend-api/src/main/java/com/liferay/dispatch/talend/archive/TalendArchiveParserUtil.java
@@ -85,9 +85,10 @@ public class TalendArchiveParserUtil {
 			if (talendArchive.hasJVMOptions()) {
 				String newJVMOptions = talendArchive.getJVMOptions();
 
-				if (unicodeProperties.containsKey("JAVA_OPTS")) {
-					newJVMOptions = getJVMOptions(
-						newJVMOptions, unicodeProperties.get("JAVA_OPTS"));
+				String jvmOptions = unicodeProperties.get("JAVA_OPTS");
+
+				if (jvmOptions != null) {
+					newJVMOptions = getJVMOptions(newJVMOptions, jvmOptions);
 				}
 
 				unicodeProperties.put("JAVA_OPTS", newJVMOptions);

--- a/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/java/com/liferay/document/library/opener/google/drive/web/internal/oauth/OAuth2Manager.java
+++ b/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/java/com/liferay/document/library/opener/google/drive/web/internal/oauth/OAuth2Manager.java
@@ -209,10 +209,10 @@ public class OAuth2Manager {
 				dlGoogleDriveCompanyConfiguration =
 					_getDLGoogleDriveCompanyConfiguration(companyId);
 
-			if (_googleAuthorizationCodeFlows.containsKey(companyId)) {
-				GoogleAuthorizationCodeFlow googleAuthorizationCodeFlow =
-					_googleAuthorizationCodeFlows.get(companyId);
+			GoogleAuthorizationCodeFlow googleAuthorizationCodeFlow =
+				_googleAuthorizationCodeFlows.get(companyId);
 
+			if (googleAuthorizationCodeFlow != null) {
 				ClientParametersAuthentication clientParametersAuthentication =
 					(ClientParametersAuthentication)
 						googleAuthorizationCodeFlow.getClientAuthentication();
@@ -248,7 +248,7 @@ public class OAuth2Manager {
 				googleAuthorizationCodeFlowBuilder.setDataStoreFactory(
 					new StoredCredentialDataStoreFactory(companyId));
 
-			GoogleAuthorizationCodeFlow googleAuthorizationCodeFlow =
+			googleAuthorizationCodeFlow =
 				googleAuthorizationCodeFlowBuilder.build();
 
 			_googleAuthorizationCodeFlows.put(

--- a/modules/apps/document-library/document-library-document-conversion/src/main/java/com/liferay/document/library/document/conversion/internal/LiferayDocumentFormatRegistry.java
+++ b/modules/apps/document-library/document-library-document-conversion/src/main/java/com/liferay/document/library/document/conversion/internal/LiferayDocumentFormatRegistry.java
@@ -22,8 +22,11 @@ public class LiferayDocumentFormatRegistry implements DocumentFormatRegistry {
 
 	@Override
 	public DocumentFormat getFormatByFileExtension(String extension) {
-		if (_documentFormatsByExtension.containsKey(extension)) {
-			return _documentFormatsByExtension.get(extension);
+		DocumentFormat documentFormat = _documentFormatsByExtension.get(
+			extension);
+
+		if (documentFormat != null) {
+			return documentFormat;
 		}
 
 		return _documentFormatRegistry.getFormatByFileExtension(extension);
@@ -31,8 +34,11 @@ public class LiferayDocumentFormatRegistry implements DocumentFormatRegistry {
 
 	@Override
 	public DocumentFormat getFormatByMimeType(String mimeType) {
-		if (_documentFormatsByMimeType.containsKey(mimeType)) {
-			return _documentFormatsByMimeType.get(mimeType);
+		DocumentFormat documentFormat = _documentFormatsByMimeType.get(
+			mimeType);
+
+		if (documentFormat != null) {
+			return documentFormat;
 		}
 
 		return _documentFormatRegistry.getFormatByMimeType(mimeType);

--- a/modules/apps/document-library/document-library-repository-external-api/src/main/java/com/liferay/document/library/repository/external/model/ExtRepositoryObjectAdapter.java
+++ b/modules/apps/document-library/document-library-repository-external-api/src/main/java/com/liferay/document/library/repository/external/model/ExtRepositoryObjectAdapter.java
@@ -33,8 +33,10 @@ public abstract class ExtRepositoryObjectAdapter<T>
 			PermissionChecker permissionChecker, String actionId)
 		throws PortalException {
 
-		if (_unsupportedActionIds.containsKey(actionId)) {
-			return _unsupportedActionIds.get(actionId);
+		Boolean unsupportedActionIdValue = _unsupportedActionIds.get(actionId);
+
+		if (unsupportedActionIdValue != null) {
+			return unsupportedActionIdValue;
 		}
 
 		try {

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/configuration/admin/service/DLFileOrderManagedServiceFactory.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/configuration/admin/service/DLFileOrderManagedServiceFactory.java
@@ -124,8 +124,11 @@ public class DLFileOrderManagedServiceFactory implements ManagedServiceFactory {
 		Map<T, DLFileOrderConfiguration> dlFileOrderConfigurations, T key,
 		Supplier<DLFileOrderConfiguration> supplier) {
 
-		if (dlFileOrderConfigurations.containsKey(key)) {
-			return dlFileOrderConfigurations.get(key);
+		DLFileOrderConfiguration dlFileOrderConfiguration =
+			dlFileOrderConfigurations.get(key);
+
+		if (dlFileOrderConfiguration != null) {
+			return dlFileOrderConfiguration;
 		}
 
 		return supplier.get();
@@ -144,17 +147,20 @@ public class DLFileOrderManagedServiceFactory implements ManagedServiceFactory {
 	}
 
 	private void _unmapPid(String pid) {
-		if (_companyIds.containsKey(pid)) {
-			long companyId = _companyIds.remove(pid);
+		Long companyId = _companyIds.remove(pid);
 
+		if (companyId != null) {
 			_companyDLFileOrderConfigurations.remove(companyId);
 
 			_groupDLFileOrderConfigurations.clear();
 			_groupKeys.clear();
-		}
-		else if (_groupKeys.containsKey(pid)) {
-			String groupKey = _groupKeys.remove(pid);
 
+			return;
+		}
+
+		String groupKey = _groupKeys.remove(pid);
+
+		if (groupKey != null) {
 			_groupDLFileOrderConfigurations.remove(groupKey);
 		}
 	}

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/configuration/helper/DLFileEntryConfigurationHelper.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/configuration/helper/DLFileEntryConfigurationHelper.java
@@ -78,17 +78,20 @@ public class DLFileEntryConfigurationHelper {
 	}
 
 	public void unmapPid(String pid) {
-		if (_companyIds.containsKey(pid)) {
-			long companyId = _companyIds.remove(pid);
+		Long companyId = _companyIds.remove(pid);
 
+		if (companyId != null) {
 			_companyConfigurationBeans.remove(companyId);
 
 			_groupConfigurationBeans.clear();
 			_groupKeys.clear();
-		}
-		else if (_groupKeys.containsKey(pid)) {
-			String groupKey = _groupKeys.remove(pid);
 
+			return;
+		}
+
+		String groupKey = _groupKeys.remove(pid);
+
+		if (groupKey != null) {
 			_groupConfigurationBeans.remove(groupKey);
 		}
 	}
@@ -135,8 +138,11 @@ public class DLFileEntryConfigurationHelper {
 		T key, Map<T, DLFileEntryConfiguration> configurationBeans,
 		Supplier<DLFileEntryConfiguration> supplier) {
 
-		if (configurationBeans.containsKey(key)) {
-			return configurationBeans.get(key);
+		DLFileEntryConfiguration dlFileEntryConfiguration =
+			configurationBeans.get(key);
+
+		if (dlFileEntryConfiguration != null) {
+			return dlFileEntryConfiguration;
 		}
 
 		return supplier.get();

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/configuration/helper/DLSizeLimitConfigurationHelper.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/configuration/helper/DLSizeLimitConfigurationHelper.java
@@ -142,17 +142,20 @@ public class DLSizeLimitConfigurationHelper {
 	}
 
 	public void unmapPid(String pid) {
-		if (_companyIds.containsKey(pid)) {
-			long companyId = _companyIds.remove(pid);
+		Long companyId = _companyIds.remove(pid);
 
+		if (companyId != null) {
 			_companyConfigurationBeans.remove(companyId);
 			_companyMimeTypeSizeLimitsMap.remove(companyId);
 
 			_groupMimeTypeSizeLimitsMap.clear();
-		}
-		else if (_groupKeys.containsKey(pid)) {
-			String groupKey = _groupKeys.remove(pid);
 
+			return;
+		}
+
+		String groupKey = _groupKeys.remove(pid);
+
+		if (groupKey != null) {
 			_groupConfigurationBeans.remove(groupKey);
 			_groupMimeTypeSizeLimitsMap.remove(groupKey);
 		}
@@ -231,8 +234,11 @@ public class DLSizeLimitConfigurationHelper {
 		T key, Map<T, DLSizeLimitConfiguration> configurationBeans,
 		Supplier<DLSizeLimitConfiguration> supplier) {
 
-		if (configurationBeans.containsKey(key)) {
-			return configurationBeans.get(key);
+		DLSizeLimitConfiguration dlSizeLimitConfiguration =
+			configurationBeans.get(key);
+
+		if (dlSizeLimitConfiguration != null) {
+			return dlSizeLimitConfiguration;
 		}
 
 		return supplier.get();

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/exporter/DDLCSVExporter.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/exporter/DDLCSVExporter.java
@@ -111,10 +111,10 @@ public class DDLCSVExporter extends BaseDDLExporter {
 			for (Map.Entry<String, DDMFormField> entry :
 					ddmFormFields.entrySet()) {
 
-				if (values.containsKey(entry.getKey())) {
-					DDMFormFieldRenderedValue ddmFormFieldRenderedValue =
-						values.get(entry.getKey());
+				DDMFormFieldRenderedValue ddmFormFieldRenderedValue =
+					values.get(entry.getKey());
 
+				if (ddmFormFieldRenderedValue != null) {
 					sb.append(
 						CSVUtil.encode(ddmFormFieldRenderedValue.getValue()));
 				}

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/exporter/DDLXLSExporter.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/internal/exporter/DDLXLSExporter.java
@@ -189,10 +189,10 @@ public class DDLXLSExporter extends BaseDDLExporter {
 
 			cell.setCellStyle(style);
 
-			if (values.containsKey(entry.getKey())) {
-				DDMFormFieldRenderedValue ddmFormFieldRenderedValue =
-					values.get(entry.getKey());
+			DDMFormFieldRenderedValue ddmFormFieldRenderedValue = values.get(
+				entry.getKey());
 
+			if (ddmFormFieldRenderedValue != null) {
 				cell.setCellValue(
 					GetterUtil.getString(ddmFormFieldRenderedValue.getValue()));
 			}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/util/DDMFormValuesTransformer.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/util/DDMFormValuesTransformer.java
@@ -85,10 +85,12 @@ public class DDMFormValuesTransformer {
 				type = DDMFormFieldTypeConstants.RICH_TEXT;
 			}
 
-			if (_ddmFormFieldValueTransformersMap.containsKey(type)) {
+			DDMFormFieldValueTransformer ddmFormFieldValueTransformer =
+				_ddmFormFieldValueTransformersMap.get(type);
+
+			if (ddmFormFieldValueTransformer != null) {
 				performTransformation(
-					ddmFormFieldValues,
-					_ddmFormFieldValueTransformersMap.get(type));
+					ddmFormFieldValues, ddmFormFieldValueTransformer);
 			}
 
 			for (DDMFormFieldValue ddmFormFieldValue : ddmFormFieldValues) {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/java/com/liferay/dynamic/data/mapping/form/builder/internal/context/helper/DDMFormBuilderContextFactoryHelper.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/java/com/liferay/dynamic/data/mapping/form/builder/internal/context/helper/DDMFormBuilderContextFactoryHelper.java
@@ -523,9 +523,8 @@ public class DDMFormBuilderContextFactoryHelper {
 			for (Map<String, Object> field : fields) {
 				_fieldConsumer.accept(field);
 
-				if (field.containsKey("nestedFields")) {
-					traverseFields(
-						(List<Map<String, Object>>)field.get("nestedFields"));
+				if (field.get("nestedFields") instanceof List<?> nestedFields) {
+					traverseFields((List<Map<String, Object>>)nestedFields);
 				}
 			}
 		}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/java/com/liferay/dynamic/data/mapping/form/builder/internal/converter/DDMFormRuleConverterImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/java/com/liferay/dynamic/data/mapping/form/builder/internal/converter/DDMFormRuleConverterImpl.java
@@ -107,7 +107,9 @@ public class DDMFormRuleConverterImpl implements SPIDDMFormRuleConverter {
 		List<SPIDDMFormRuleCondition.Operand> operands =
 			spiDDMFormRuleCondition.getOperands();
 
-		if (_operators.containsKey(operator)) {
+		String operatorText = _operators.get(operator);
+
+		if (operatorText != null) {
 			if (operands.size() < 2) {
 				return StringPool.BLANK;
 			}
@@ -116,7 +118,7 @@ public class DDMFormRuleConverterImpl implements SPIDDMFormRuleConverter {
 				_COMPARISON_EXPRESSION_FORMAT,
 				_convertOperand(
 					operands.get(0), spiDDMFormRuleSerializerContext),
-				_operators.get(operator),
+				operatorText,
 				_convertOperand(
 					operands.get(1), spiDDMFormRuleSerializerContext));
 		}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/rich/text/RichTextDDMFormFieldTemplateContextContributor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/rich/text/RichTextDDMFormFieldTemplateContextContributor.java
@@ -129,8 +129,10 @@ public class RichTextDDMFormFieldTemplateContextContributor
 		Map<String, Object> data = editorConfiguration.getData();
 
 		for (String key : data.keySet()) {
-			if (ddmFormFieldProperties.containsKey(key)) {
-				data.put(key, ddmFormFieldProperties.get(key));
+			Object value = ddmFormFieldProperties.get(key);
+
+			if (value != null) {
+				data.put(key, value);
 			}
 		}
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v1_1_1/DDMFormFieldSettingsUpgradeProcess.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v1_1_1/DDMFormFieldSettingsUpgradeProcess.java
@@ -121,10 +121,10 @@ public class DDMFormFieldSettingsUpgradeProcess extends UpgradeProcess {
 		for (DDMFormField ddmFormField : ddmForm.getDDMFormFields()) {
 			Map<String, Object> properties = ddmFormField.getProperties();
 
-			if (properties.containsKey("ddmDataProviderInstanceId")) {
-				String ddmDataProviderInstanceId = GetterUtil.getString(
-					properties.get("ddmDataProviderInstanceId"));
+			String ddmDataProviderInstanceId = GetterUtil.getString(
+				properties.get("ddmDataProviderInstanceId"), null);
 
+			if (ddmDataProviderInstanceId != null) {
 				ddmFormField.setProperty(
 					"ddmDataProviderInstanceId",
 					"[\"" + ddmDataProviderInstanceId + "\"]");

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v2_0_1/AutocompleteDDMTextFieldSettingUpgradeProcess.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v2_0_1/AutocompleteDDMTextFieldSettingUpgradeProcess.java
@@ -128,10 +128,8 @@ public class AutocompleteDDMTextFieldSettingUpgradeProcess
 			if (Objects.equals(ddmFormField.getType(), "text")) {
 				Map<String, Object> properties = ddmFormField.getProperties();
 
-				if (!properties.containsKey("autocomplete")) {
-					properties.put(
-						"autocomplete", _isAutocompleteEnabled(properties));
-				}
+				properties.putIfAbsent(
+					"autocomplete", _isAutocompleteEnabled(properties));
 			}
 		}
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMFieldLocalServiceImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMFieldLocalServiceImpl.java
@@ -878,13 +878,14 @@ public class DDMFieldLocalServiceImpl extends DDMFieldLocalServiceBaseImpl {
 				for (DDMFieldAttributeInfo ddmFieldAttributeInfo :
 						ddmFieldAttributeInfos) {
 
-					if ((ddmField != null) &&
-						ddmFieldsAttributesMap.containsKey(
-							ddmField.getFieldId())) {
+					Map<String, DDMFieldAttribute> ddmFieldAttributesMap = null;
 
-						Map<String, DDMFieldAttribute> ddmFieldAttributesMap =
-							ddmFieldsAttributesMap.get(ddmField.getFieldId());
+					if (ddmField != null) {
+						ddmFieldAttributesMap = ddmFieldsAttributesMap.get(
+							ddmField.getFieldId());
+					}
 
+					if (ddmFieldAttributesMap != null) {
 						DDMFieldAttribute ddmFieldAttribute =
 							ddmFieldAttributesMap.remove(
 								_getKey(
@@ -1100,9 +1101,14 @@ public class DDMFieldLocalServiceImpl extends DDMFieldLocalServiceBaseImpl {
 		Map<Long, Map<String, DDMFieldAttribute>> ddmFieldsAttributesMap,
 		Map<String, DDMFormField> ddmFormFieldsMap) {
 
-		if ((ddmField == null) ||
-			!ddmFieldsAttributesMap.containsKey(ddmField.getFieldId())) {
+		if (ddmField == null) {
+			return false;
+		}
 
+		Map<String, DDMFieldAttribute> ddmFieldAttributesMap =
+			ddmFieldsAttributesMap.get(ddmField.getFieldId());
+
+		if (ddmFieldAttributesMap == null) {
 			return false;
 		}
 
@@ -1115,9 +1121,6 @@ public class DDMFieldLocalServiceImpl extends DDMFieldLocalServiceBaseImpl {
 
 			return false;
 		}
-
-		Map<String, DDMFieldAttribute> ddmFieldAttributesMap =
-			ddmFieldsAttributesMap.get(ddmField.getFieldId());
 
 		for (DDMFieldAttribute ddmFieldAttribute :
 				ddmFieldAttributesMap.values()) {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMFieldLocalServiceImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMFieldLocalServiceImpl.java
@@ -785,15 +785,13 @@ public class DDMFieldLocalServiceImpl extends DDMFieldLocalServiceBaseImpl {
 				ddmField));
 
 		for (DDMFieldInfo ddmFieldInfo : ddmFieldInfosMap.values()) {
-			String key = _getKey(
-				ddmFieldInfo._fieldName, ddmFieldInfo._instanceId);
+			DDMField ddmField = ddmFieldsMap.remove(
+				_getKey(ddmFieldInfo._fieldName, ddmFieldInfo._instanceId));
 
-			if (ddmFieldsMap.containsKey(key)) {
+			if (ddmField != null) {
 				ddmFieldEntries.add(
 					new AbstractMap.SimpleImmutableEntry<>(
-						ddmFieldsMap.get(key), ddmFieldInfo));
-
-				ddmFieldsMap.remove(key);
+						ddmField, ddmFieldInfo));
 
 				continue;
 			}
@@ -805,14 +803,13 @@ public class DDMFieldLocalServiceImpl extends DDMFieldLocalServiceBaseImpl {
 			if (!com.liferay.portal.kernel.util.StringUtil.equals(
 					ddmFieldInfo._fieldName, legacyDDMFormFieldName)) {
 
-				key = _getKey(legacyDDMFormFieldName, ddmFieldInfo._instanceId);
+				ddmField = ddmFieldsMap.remove(
+					_getKey(legacyDDMFormFieldName, ddmFieldInfo._instanceId));
 
-				if (ddmFieldsMap.containsKey(key)) {
+				if (ddmField != null) {
 					ddmFieldEntries.add(
 						new AbstractMap.SimpleImmutableEntry<>(
-							ddmFieldsMap.get(key), ddmFieldInfo));
-
-					ddmFieldsMap.remove(key);
+							ddmField, ddmFieldInfo));
 
 					continue;
 				}
@@ -888,17 +885,16 @@ public class DDMFieldLocalServiceImpl extends DDMFieldLocalServiceBaseImpl {
 						Map<String, DDMFieldAttribute> ddmFieldAttributesMap =
 							ddmFieldsAttributesMap.get(ddmField.getFieldId());
 
-						String key = _getKey(
-							ddmFieldAttributeInfo._attributeName,
-							ddmFieldAttributeInfo._languageId);
+						DDMFieldAttribute ddmFieldAttribute =
+							ddmFieldAttributesMap.remove(
+								_getKey(
+									ddmFieldAttributeInfo._attributeName,
+									ddmFieldAttributeInfo._languageId));
 
-						if (ddmFieldAttributesMap.containsKey(key)) {
+						if (ddmFieldAttribute != null) {
 							ddmFieldAttributeEntries.add(
 								new AbstractMap.SimpleImmutableEntry<>(
-									ddmFieldAttributesMap.get(key),
-									ddmFieldAttributeInfo));
-
-							ddmFieldAttributesMap.remove(key);
+									ddmFieldAttribute, ddmFieldAttributeInfo));
 
 							if (MapUtil.isEmpty(ddmFieldAttributesMap)) {
 								ddmFieldsAttributesMap.remove(

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/configuration/ExportImportConfigurationParameterMapFactoryImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/configuration/ExportImportConfigurationParameterMapFactoryImpl.java
@@ -84,13 +84,11 @@ public class ExportImportConfigurationParameterMapFactoryImpl
 			_replaceParameterMap(parameterMap);
 		}
 
-		if (!parameterMap.containsKey(PortletDataHandlerKeys.DATA_STRATEGY)) {
-			parameterMap.put(
-				PortletDataHandlerKeys.DATA_STRATEGY,
-				new String[] {
-					PortletDataHandlerKeys.DATA_STRATEGY_MIRROR_OVERWRITE
-				});
-		}
+		parameterMap.putIfAbsent(
+			PortletDataHandlerKeys.DATA_STRATEGY,
+			new String[] {
+				PortletDataHandlerKeys.DATA_STRATEGY_MIRROR_OVERWRITE
+			});
 
 		/*if (!parameterMap.containsKey(
 				PortletDataHandlerKeys.DELETE_MISSING_LAYOUTS)) {
@@ -100,99 +98,57 @@ public class ExportImportConfigurationParameterMapFactoryImpl
 				new String[] {Boolean.TRUE.toString()});
 		}*/
 
-		if (!parameterMap.containsKey(PortletDataHandlerKeys.DELETE_LAYOUTS)) {
-			parameterMap.put(
-				PortletDataHandlerKeys.DELETE_LAYOUTS,
-				new String[] {Boolean.FALSE.toString()});
-		}
+		parameterMap.putIfAbsent(
+			PortletDataHandlerKeys.DELETE_LAYOUTS,
+			new String[] {Boolean.FALSE.toString()});
 
-		if (!parameterMap.containsKey(
-				PortletDataHandlerKeys.DELETE_PORTLET_DATA)) {
+		parameterMap.putIfAbsent(
+			PortletDataHandlerKeys.DELETE_PORTLET_DATA,
+			new String[] {Boolean.FALSE.toString()});
 
-			parameterMap.put(
-				PortletDataHandlerKeys.DELETE_PORTLET_DATA,
-				new String[] {Boolean.FALSE.toString()});
-		}
+		parameterMap.putIfAbsent(
+			PortletDataHandlerKeys.FAVICON,
+			new String[] {Boolean.TRUE.toString()});
 
-		if (!parameterMap.containsKey(PortletDataHandlerKeys.FAVICON)) {
-			parameterMap.put(
-				PortletDataHandlerKeys.FAVICON,
-				new String[] {Boolean.TRUE.toString()});
-		}
+		parameterMap.putIfAbsent(
+			PortletDataHandlerKeys.LAYOUT_SET_PROTOTYPE_LINK_ENABLED,
+			new String[] {Boolean.FALSE.toString()});
 
-		if (!parameterMap.containsKey(
-				PortletDataHandlerKeys.LAYOUT_SET_PROTOTYPE_LINK_ENABLED)) {
+		parameterMap.putIfAbsent(
+			PortletDataHandlerKeys.LAYOUT_SET_PROTOTYPE_SETTINGS,
+			new String[] {Boolean.FALSE.toString()});
 
-			parameterMap.put(
-				PortletDataHandlerKeys.LAYOUT_SET_PROTOTYPE_LINK_ENABLED,
-				new String[] {Boolean.FALSE.toString()});
-		}
+		parameterMap.putIfAbsent(
+			PortletDataHandlerKeys.LAYOUT_SET_SETTINGS,
+			new String[] {Boolean.FALSE.toString()});
 
-		if (!parameterMap.containsKey(
-				PortletDataHandlerKeys.LAYOUT_SET_PROTOTYPE_SETTINGS)) {
+		parameterMap.putIfAbsent(
+			PortletDataHandlerKeys.LOGO,
+			new String[] {Boolean.FALSE.toString()});
 
-			parameterMap.put(
-				PortletDataHandlerKeys.LAYOUT_SET_PROTOTYPE_SETTINGS,
-				new String[] {Boolean.FALSE.toString()});
-		}
+		parameterMap.putIfAbsent(
+			PortletDataHandlerKeys.PORTLET_CONFIGURATION,
+			new String[] {Boolean.TRUE.toString()});
 
-		if (!parameterMap.containsKey(
-				PortletDataHandlerKeys.LAYOUT_SET_SETTINGS)) {
+		parameterMap.putIfAbsent(
+			PortletDataHandlerKeys.PORTLET_DATA,
+			new String[] {Boolean.FALSE.toString()});
 
-			parameterMap.put(
-				PortletDataHandlerKeys.LAYOUT_SET_SETTINGS,
-				new String[] {Boolean.FALSE.toString()});
-		}
+		parameterMap.putIfAbsent(
+			PortletDataHandlerKeys.PORTLET_DATA_ALL,
+			new String[] {Boolean.FALSE.toString()});
 
-		if (!parameterMap.containsKey(PortletDataHandlerKeys.LOGO)) {
-			parameterMap.put(
-				PortletDataHandlerKeys.LOGO,
-				new String[] {Boolean.FALSE.toString()});
-		}
+		parameterMap.putIfAbsent(
+			PortletDataHandlerKeys.THEME_REFERENCE,
+			new String[] {Boolean.FALSE.toString()});
 
-		if (!parameterMap.containsKey(
-				PortletDataHandlerKeys.PORTLET_CONFIGURATION)) {
+		parameterMap.putIfAbsent(
+			PortletDataHandlerKeys.UPDATE_LAST_PUBLISH_DATE,
+			new String[] {Boolean.TRUE.toString()});
 
-			parameterMap.put(
-				PortletDataHandlerKeys.PORTLET_CONFIGURATION,
-				new String[] {Boolean.TRUE.toString()});
-		}
-
-		if (!parameterMap.containsKey(PortletDataHandlerKeys.PORTLET_DATA)) {
-			parameterMap.put(
-				PortletDataHandlerKeys.PORTLET_DATA,
-				new String[] {Boolean.FALSE.toString()});
-		}
-
-		if (!parameterMap.containsKey(
-				PortletDataHandlerKeys.PORTLET_DATA_ALL)) {
-
-			parameterMap.put(
-				PortletDataHandlerKeys.PORTLET_DATA_ALL,
-				new String[] {Boolean.FALSE.toString()});
-		}
-
-		if (!parameterMap.containsKey(PortletDataHandlerKeys.THEME_REFERENCE)) {
-			parameterMap.put(
-				PortletDataHandlerKeys.THEME_REFERENCE,
-				new String[] {Boolean.FALSE.toString()});
-		}
-
-		if (!parameterMap.containsKey(
-				PortletDataHandlerKeys.UPDATE_LAST_PUBLISH_DATE)) {
-
-			parameterMap.put(
-				PortletDataHandlerKeys.UPDATE_LAST_PUBLISH_DATE,
-				new String[] {Boolean.TRUE.toString()});
-		}
-
-		if (!parameterMap.containsKey(
-				PortletDataHandlerKeys.USER_ID_STRATEGY)) {
-
-			parameterMap.put(
-				PortletDataHandlerKeys.USER_ID_STRATEGY,
-				new String[] {UserIdStrategy.CURRENT_USER_ID});
-		}
+		parameterMap.putIfAbsent(
+			PortletDataHandlerKeys.USER_ID_STRATEGY,
+			new String[] {UserIdStrategy.CURRENT_USER_ID});
 
 		return parameterMap;
 	}
@@ -541,9 +497,7 @@ public class ExportImportConfigurationParameterMapFactoryImpl
 			return;
 		}
 
-		if (!parameterMap.containsKey("portletResourceNames")) {
-			parameterMap.put("portletResourceNames", new String[0]);
-		}
+		parameterMap.putIfAbsent("portletResourceNames", new String[0]);
 
 		String[] portletResourceNames = parameterMap.get(
 			"portletResourceNames");
@@ -557,9 +511,7 @@ public class ExportImportConfigurationParameterMapFactoryImpl
 	private void _populateStagedModelTypes(
 		Map<String, String[]> parameterMap, Portlet dataSiteLevelPortlet) {
 
-		if (!parameterMap.containsKey("stagedModelTypes")) {
-			parameterMap.put("stagedModelTypes", new String[0]);
-		}
+		parameterMap.putIfAbsent("stagedModelTypes", new String[0]);
 
 		PortletDataHandler portletDataHandler =
 			dataSiteLevelPortlet.getPortletDataHandlerInstance();

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/DLReferencesExportImportContentProcessor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/DLReferencesExportImportContentProcessor.java
@@ -276,9 +276,11 @@ public class DLReferencesExportImportContentProcessor
 		Map<Long, Long> groupIds) {
 
 		try {
-			if (groupIds.containsKey(documentLibraryReference.getGroupId())) {
-				return _groupLocalService.getGroup(
-					groupIds.get(documentLibraryReference.getGroupId()));
+			Long liveGroupId = groupIds.get(
+				documentLibraryReference.getGroupId());
+
+			if (liveGroupId != null) {
+				return _groupLocalService.getGroup(liveGroupId);
 			}
 
 			return _groupLocalService.fetchFriendlyURLGroup(

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/DLReferencesReverseIterator.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/DLReferencesReverseIterator.java
@@ -320,12 +320,9 @@ public class DLReferencesReverseIterator
 
 			map = HttpComponentsUtil.parameterMapFromString(dlReference);
 
-			String[] imageIds = null;
+			String[] imageIds = map.get("img_id");
 
-			if (map.containsKey("img_id")) {
-				imageIds = map.get("img_id");
-			}
-			else if (map.containsKey("i_id")) {
+			if (imageIds == null) {
 				imageIds = map.get("i_id");
 			}
 

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/PortletDataContextImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/PortletDataContextImpl.java
@@ -413,9 +413,7 @@ public class PortletDataContextImpl implements PortletDataContext {
 				return referenceElement;
 			}
 
-			if (!_missingReferences.contains(referenceKey)) {
-				_missingReferences.add(referenceKey);
-
+			if (_missingReferences.add(referenceKey)) {
 				_addReferenceElement(
 					referrerClassedModel, null, classedModel, className,
 					binPath, referenceType, true);
@@ -552,11 +550,7 @@ public class PortletDataContextImpl implements PortletDataContext {
 
 	@Override
 	public void cleanUpMissingReferences(ClassedModel classedModel) {
-		String referenceKey = _getReferenceKey(classedModel);
-
-		if (_missingReferences.contains(referenceKey)) {
-			_missingReferences.remove(referenceKey);
-
+		if (_missingReferences.remove(_getReferenceKey(classedModel))) {
 			Element missingReferenceElement = getMissingReferenceElement(
 				classedModel);
 

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/search/spi/model/index/contributor/ExportImportConfigurationModelDocumentContributor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/search/spi/model/index/contributor/ExportImportConfigurationModelDocumentContributor.java
@@ -83,21 +83,19 @@ public class ExportImportConfigurationModelDocumentContributor
 	private void _populateLayoutIds(
 		Document document, Map<String, Serializable> settingsMap) {
 
-		if (!settingsMap.containsKey("layoutIdMap") &&
-			!settingsMap.containsKey("layoutIds")) {
+		Serializable layoutIdMap = settingsMap.get("layoutIdMap");
+		Serializable layoutIdsSetting = settingsMap.get("layoutIds");
 
+		if ((layoutIdMap == null) && (layoutIdsSetting == null)) {
 			return;
 		}
 
-		long[] layoutIds = GetterUtil.getLongValues(
-			settingsMap.get("layoutIds"));
+		long[] layoutIds = GetterUtil.getLongValues(layoutIdsSetting);
 
 		if (ArrayUtil.isEmpty(layoutIds)) {
-			Map<Long, Boolean> layoutIdMap =
-				(Map<Long, Boolean>)settingsMap.get("layoutIdMap");
-
 			try {
-				layoutIds = _exportImportHelper.getLayoutIds(layoutIdMap);
+				layoutIds = _exportImportHelper.getLayoutIds(
+					(Map<Long, Boolean>)layoutIdMap);
 			}
 			catch (PortalException portalException) {
 
@@ -123,12 +121,11 @@ public class ExportImportConfigurationModelDocumentContributor
 	private void _populateParameterMap(
 		Document document, Map<String, Serializable> settingsMap) {
 
-		if (!settingsMap.containsKey("parameterMap")) {
+		if (!(settingsMap.get("parameterMap") instanceof Map<?, ?> map)) {
 			return;
 		}
 
-		Map<String, String[]> parameterMap =
-			(Map<String, String[]>)settingsMap.get("parameterMap");
+		Map<String, String[]> parameterMap = (Map<String, String[]>)map;
 
 		for (Map.Entry<String, String[]> entry : parameterMap.entrySet()) {
 			String parameterName = entry.getKey();

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/search/spi/model/index/contributor/ExportImportConfigurationModelDocumentContributor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/search/spi/model/index/contributor/ExportImportConfigurationModelDocumentContributor.java
@@ -71,15 +71,11 @@ public class ExportImportConfigurationModelDocumentContributor
 	private void _populateDates(
 		Document document, Map<String, Serializable> settingsMap) {
 
-		if (settingsMap.containsKey("endDate")) {
-			Date endDate = (Date)settingsMap.get("endDate");
-
+		if (settingsMap.get("endDate") instanceof Date endDate) {
 			document.addDate(_PREFIX_SETTING + "endDate", endDate);
 		}
 
-		if (settingsMap.containsKey("startDate")) {
-			Date startDate = (Date)settingsMap.get("startDate");
-
+		if (settingsMap.get("startDate") instanceof Date startDate) {
 			document.addDate(_PREFIX_SETTING + "startDate", startDate);
 		}
 	}

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/util/ExportImportPermissionUtil.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/util/ExportImportPermissionUtil.java
@@ -107,9 +107,10 @@ public class ExportImportPermissionUtil {
 
 			long roleId = roleIdsToActionIds.getKey();
 
-			if (importedRoleIdsToActionIds.containsKey(roleId)) {
-				mergedRoleIdsToActionIds.put(
-					roleId, importedRoleIdsToActionIds.remove(roleId));
+			String[] actionIds = importedRoleIdsToActionIds.remove(roleId);
+
+			if (actionIds != null) {
+				mergedRoleIdsToActionIds.put(roleId, actionIds);
 			}
 		}
 

--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-drop-zone/src/main/java/com/liferay/fragment/entry/processor/drop/zone/DropZoneDocumentFragmentEntryProcessor.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-drop-zone/src/main/java/com/liferay/fragment/entry/processor/drop/zone/DropZoneDocumentFragmentEntryProcessor.java
@@ -200,9 +200,11 @@ public class DropZoneDocumentFragmentEntryProcessor
 				for (Element element : elements) {
 					String dropZoneId = element.attr("data-lfr-drop-zone-id");
 
-					if (fragmentDropZoneIdsMap.containsKey(dropZoneId)) {
-						element.attr(
-							"uuid", fragmentDropZoneIdsMap.get(dropZoneId));
+					String fragmentDropZoneItemId = fragmentDropZoneIdsMap.get(
+						dropZoneId);
+
+					if (fragmentDropZoneItemId != null) {
+						element.attr("uuid", fragmentDropZoneItemId);
 					}
 					else if (ListUtil.isNotEmpty(noFragmentDropZoneItemIds)) {
 						element.attr(

--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-impl/src/main/java/com/liferay/fragment/entry/processor/internal/helper/FragmentEntryProcessorHelperImpl.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-impl/src/main/java/com/liferay/fragment/entry/processor/internal/helper/FragmentEntryProcessorHelperImpl.java
@@ -938,13 +938,14 @@ public class FragmentEntryProcessorHelperImpl
 	}
 
 	private String _getDefaultPattern(Locale locale) {
-		if (_defaultPatterns.containsKey(locale)) {
-			return _defaultPatterns.get(locale);
+		String defaultPattern = _defaultPatterns.get(locale);
+
+		if (defaultPattern != null) {
+			return defaultPattern;
 		}
 
-		String defaultPattern =
-			DateTimeFormatterBuilder.getLocalizedDateTimePattern(
-				FormatStyle.SHORT, null, IsoChronology.INSTANCE, locale);
+		defaultPattern = DateTimeFormatterBuilder.getLocalizedDateTimePattern(
+			FormatStyle.SHORT, null, IsoChronology.INSTANCE, locale);
 
 		_defaultPatterns.put(locale, defaultPattern);
 
@@ -1085,18 +1086,20 @@ public class FragmentEntryProcessorHelperImpl
 	}
 
 	private String _getShortTimeStylePattern(Locale locale) {
-		if (_shortTimeStylePatterns.containsKey(locale)) {
-			return _shortTimeStylePatterns.get(locale);
+		String shortTimeStylePattern = _shortTimeStylePatterns.get(locale);
+
+		if (shortTimeStylePattern != null) {
+			return shortTimeStylePattern;
 		}
 
-		String sortTimeStylePattern =
+		shortTimeStylePattern =
 			DateTimeFormatterBuilder.getLocalizedDateTimePattern(
 				FormatStyle.SHORT, FormatStyle.SHORT, IsoChronology.INSTANCE,
 				locale);
 
-		_shortTimeStylePatterns.put(locale, sortTimeStylePattern);
+		_shortTimeStylePatterns.put(locale, shortTimeStylePattern);
 
-		return sortTimeStylePattern;
+		return shortTimeStylePattern;
 	}
 
 	private <T> T _getSpecificIteration(

--- a/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/importer/FragmentsImporterImpl.java
+++ b/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/importer/FragmentsImporterImpl.java
@@ -793,8 +793,10 @@ public class FragmentsImporterImpl implements FragmentsImporter {
 			long repositoryId, long userId)
 		throws Exception {
 
-		if (folderIdsMap.containsKey(folderPath)) {
-			return folderIdsMap.get(folderPath);
+		Long folderId = folderIdsMap.get(folderPath);
+
+		if (folderId != null) {
+			return folderId;
 		}
 
 		String folderName = folderPath;

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLocalServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLocalServiceImpl.java
@@ -933,8 +933,10 @@ public class FragmentEntryLocalServiceImpl
 			long userId)
 		throws Exception {
 
-		if (folderIdMap.containsKey(folderPath)) {
-			return folderIdMap.get(folderPath);
+		Long folderId = folderIdMap.get(folderPath);
+
+		if (folderId != null) {
+			return folderId;
 		}
 
 		String folderName = folderPath;

--- a/modules/apps/frontend-js/frontend-js-web/src/main/java/com/liferay/frontend/js/web/internal/servlet/taglib/aui/PortletDataRendererImpl.java
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/java/com/liferay/frontend/js/web/internal/servlet/taglib/aui/PortletDataRendererImpl.java
@@ -187,9 +187,9 @@ public class PortletDataRendererImpl implements PortletDataRenderer {
 
 					String alias = amdRequire.getAlias();
 
-					if (usedAliases.containsKey(alias)) {
-						IntegerWrapper integerWrapper = usedAliases.get(alias);
+					IntegerWrapper integerWrapper = usedAliases.get(alias);
 
+					if (integerWrapper != null) {
 						alias += integerWrapper.getValue();
 
 						integerWrapper.increment();
@@ -244,10 +244,9 @@ public class PortletDataRendererImpl implements PortletDataRenderer {
 					String alias = esImport.getAlias();
 
 					if (!Validator.isBlank(alias)) {
-						if (usedAliases.containsKey(alias)) {
-							IntegerWrapper integerWrapper = usedAliases.get(
-								alias);
+						IntegerWrapper integerWrapper = usedAliases.get(alias);
 
+						if (integerWrapper != null) {
 							alias += integerWrapper.getValue();
 
 							integerWrapper.increment();

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/util/FieldTypeUtil.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/util/FieldTypeUtil.java
@@ -30,8 +30,11 @@ public class FieldTypeUtil {
 	}
 
 	public static String toInternalFieldType(FieldType externalFieldType) {
-		if (_externalToInternalValuesMap.containsKey(externalFieldType)) {
-			return _externalToInternalValuesMap.get(externalFieldType);
+		String internalFieldType = _externalToInternalValuesMap.get(
+			externalFieldType);
+
+		if (internalFieldType != null) {
+			return internalFieldType;
 		}
 
 		throw new UnsupportedOperationException();

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/UtilityPageDTOConverter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/UtilityPageDTOConverter.java
@@ -112,8 +112,11 @@ public class UtilityPageDTOConverter
 	}
 
 	private UtilityPage.Type _getType(String type) {
-		if (_internalToExternalValuesMap.containsKey(type)) {
-			return _internalToExternalValuesMap.get(type);
+		UtilityPage.Type utilityPageType = _internalToExternalValuesMap.get(
+			type);
+
+		if (utilityPageType != null) {
+			return utilityPageType;
 		}
 
 		throw new UnsupportedOperationException();

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/util/ActionInteractionTypeUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/util/ActionInteractionTypeUtil.java
@@ -30,8 +30,10 @@ public class ActionInteractionTypeUtil {
 	}
 
 	public static String toInternalType(ActionInteraction.Type externalType) {
-		if (_externalToInternalValuesMap.containsKey(externalType)) {
-			return _externalToInternalValuesMap.get(externalType);
+		String internalType = _externalToInternalValuesMap.get(externalType);
+
+		if (internalType != null) {
+			return internalType;
 		}
 
 		throw new UnsupportedOperationException();

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/util/ContextualMenuTypeUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/util/ContextualMenuTypeUtil.java
@@ -19,8 +19,11 @@ public class ContextualMenuTypeUtil {
 	public static ContextualMenuNavigationMenuValue.ContextualMenuType
 		toExternalType(String internalType) {
 
-		if (_internalToExternalValuesMap.containsKey(internalType)) {
-			return _internalToExternalValuesMap.get(internalType);
+		ContextualMenuNavigationMenuValue.ContextualMenuType
+			contextualMenuType = _internalToExternalValuesMap.get(internalType);
+
+		if (contextualMenuType != null) {
+			return contextualMenuType;
 		}
 
 		throw new UnsupportedOperationException();

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/util/FragmentConfigurationFieldValueTypeUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/util/FragmentConfigurationFieldValueTypeUtil.java
@@ -19,8 +19,11 @@ public class FragmentConfigurationFieldValueTypeUtil {
 	public static FragmentConfigurationFieldValue.Type toExternalType(
 		String internalType) {
 
-		if (_internalToExternalValuesMap.containsKey(internalType)) {
-			return _internalToExternalValuesMap.get(internalType);
+		FragmentConfigurationFieldValue.Type fragmentConfigurationFieldType =
+			_internalToExternalValuesMap.get(internalType);
+
+		if (fragmentConfigurationFieldType != null) {
+			return fragmentConfigurationFieldType;
 		}
 
 		throw new UnsupportedOperationException();

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/util/SitePageTypeUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/util/SitePageTypeUtil.java
@@ -35,8 +35,10 @@ public class SitePageTypeUtil {
 	}
 
 	public static String toInternalType(SitePage.Type externalType) {
-		if (_externalToInternalValuesMap.containsKey(externalType)) {
-			return _externalToInternalValuesMap.get(externalType);
+		String internalType = _externalToInternalValuesMap.get(externalType);
+
+		if (internalType != null) {
+			return internalType;
 		}
 
 		throw new UnsupportedOperationException();

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SiteResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SiteResourceImpl.java
@@ -900,10 +900,11 @@ public class SiteResourceImpl extends BaseSiteResourceImpl {
 		}
 
 		for (String excludedTypeSetting : _EXCLUDED_TYPE_SETTINGS) {
-			if (oldUnicodeProperties.containsKey(excludedTypeSetting)) {
-				unicodeProperties.put(
-					excludedTypeSetting,
-					oldUnicodeProperties.get(excludedTypeSetting));
+			String typeSettingValue = oldUnicodeProperties.get(
+				excludedTypeSetting);
+
+			if (typeSettingValue != null) {
+				unicodeProperties.put(excludedTypeSetting, typeSettingValue);
 			}
 		}
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/UtilityPageResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/UtilityPageResourceImpl.java
@@ -469,8 +469,10 @@ public class UtilityPageResourceImpl
 	}
 
 	private String _getType(UtilityPage.Type type) {
-		if (_externalToInternalValuesMap.containsKey(type)) {
-			return _externalToInternalValuesMap.get(type);
+		String internalType = _externalToInternalValuesMap.get(type);
+
+		if (internalType != null) {
+			return internalType;
 		}
 
 		throw new IllegalArgumentException(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
@@ -853,10 +853,13 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 
 		for (Map.Entry<Locale, String> entry : friendlyURLMap.entrySet()) {
 			List<String> friendlyURLs = ListUtil.fromArray(entry.getValue());
+
 			String languageId = LocaleUtil.toBCP47LanguageId(entry.getKey());
 
-			if (newFriendlyURLsMap.containsKey(languageId)) {
-				friendlyURLs.add(newFriendlyURLsMap.get(languageId));
+			String newFriendlyURL = newFriendlyURLsMap.get(languageId);
+
+			if (newFriendlyURL != null) {
+				friendlyURLs.add(newFriendlyURL);
 			}
 
 			expectedFriendlyURLsMap.put(languageId, friendlyURLs);

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/util/FragmentConfigurationFieldValueTestUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/util/FragmentConfigurationFieldValueTestUtil.java
@@ -347,12 +347,11 @@ public class FragmentConfigurationFieldValueTestUtil {
 				map.get("item"), scopeGroupId));
 		itemValue.setTemplateReference(
 			() -> {
-				if (!map.containsKey("template")) {
+				if (!(map.get("template") instanceof Map<?, ?> template)) {
 					return null;
 				}
 
-				Map<String, String> templateMap = (Map<String, String>)map.get(
-					"template");
+				Map<String, String> templateMap = (Map<String, String>)template;
 
 				return new TemplateReference() {
 					{
@@ -429,7 +428,10 @@ public class FragmentConfigurationFieldValueTestUtil {
 			return null;
 		}
 
-		if (map.containsKey("contextualMenu")) {
+		if (map.get("contextualMenu") instanceof
+				ContextualMenuNavigationMenuValue.ContextualMenuType
+					contextualMenuType) {
+
 			ContextualMenuNavigationMenuValue
 				contextualMenuNavigationMenuValue =
 					new ContextualMenuNavigationMenuValue() {
@@ -440,14 +442,14 @@ public class FragmentConfigurationFieldValueTestUtil {
 					};
 
 			contextualMenuNavigationMenuValue.setContextualMenuType(
-				() ->
-					(ContextualMenuNavigationMenuValue.ContextualMenuType)
-						map.get("contextualMenu"));
+				() -> contextualMenuType);
 
 			return contextualMenuNavigationMenuValue;
 		}
 
-		if (map.containsKey("siteNavigationMenu")) {
+		Object siteNavigationMenu = map.get("siteNavigationMenu");
+
+		if (siteNavigationMenu != null) {
 			SiteMenuNavigationMenuValue siteMenuNavigationMenuValue =
 				new SiteMenuNavigationMenuValue() {
 					{
@@ -458,7 +460,7 @@ public class FragmentConfigurationFieldValueTestUtil {
 
 			siteMenuNavigationMenuValue.setNavigationMenuItemExternalReference(
 				() -> ReferencesTestUtil.getItemExternalReference(
-					map.get("siteNavigationMenu"), scopeGroupId));
+					siteNavigationMenu, scopeGroupId));
 
 			siteMenuNavigationMenuValue.setParentMenuItemExternalReferenceCode(
 				() -> GetterUtil.getString(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/util/FragmentConfigurationFieldValueTestUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/util/FragmentConfigurationFieldValueTestUtil.java
@@ -587,10 +587,12 @@ public class FragmentConfigurationFieldValueTestUtil {
 	private static URLValue _getURLValue(
 		Map<String, Object> map, long scopeGroupId) {
 
-		if (map.containsKey("href")) {
+		String href = GetterUtil.getString(map.get("href"), null);
+
+		if (href != null) {
 			return new HrefURLValue() {
 				{
-					setHref(() -> GetterUtil.getString(map.get("href")));
+					setHref(() -> href);
 					setUrlType(() -> UrlType.HREF);
 				}
 			};

--- a/modules/apps/headless/headless-discovery/headless-discovery-impl/src/main/java/com/liferay/headless/discovery/internal/jaxrs/resource/v1_0/HeadlessDiscoveryOpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-discovery/headless-discovery-impl/src/main/java/com/liferay/headless/discovery/internal/jaxrs/resource/v1_0/HeadlessDiscoveryOpenAPIResourceImpl.java
@@ -225,10 +225,9 @@ public class HeadlessDiscoveryOpenAPIResourceImpl {
 					return false;
 				}
 
-				if (_companyIds.containsKey(applicationDTO.base)) {
-					List<String> companyIds = _companyIds.get(
-						applicationDTO.base);
+				List<String> companyIds = _companyIds.get(applicationDTO.base);
 
+				if (companyIds != null) {
 					return companyIds.contains(
 						String.valueOf(CompanyThreadLocal.getCompanyId()));
 				}

--- a/modules/apps/headless/headless-site/headless-site-impl/src/main/java/com/liferay/headless/site/internal/resource/v1_0/SiteResourceImpl.java
+++ b/modules/apps/headless/headless-site/headless-site-impl/src/main/java/com/liferay/headless/site/internal/resource/v1_0/SiteResourceImpl.java
@@ -557,10 +557,11 @@ public class SiteResourceImpl extends BaseSiteResourceImpl {
 		}
 
 		for (String excludedTypeSetting : _EXCLUDED_TYPE_SETTINGS) {
-			if (oldUnicodeProperties.containsKey(excludedTypeSetting)) {
-				unicodeProperties.put(
-					excludedTypeSetting,
-					oldUnicodeProperties.get(excludedTypeSetting));
+			String typeSettingValue = oldUnicodeProperties.get(
+				excludedTypeSetting);
+
+			if (typeSettingValue != null) {
+				unicodeProperties.put(excludedTypeSetting, typeSettingValue);
 			}
 		}
 

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_1_6/AssetDisplayPageEntryUpgradeProcess.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_1_6/AssetDisplayPageEntryUpgradeProcess.java
@@ -60,27 +60,13 @@ public class AssetDisplayPageEntryUpgradeProcess extends UpgradeProcess {
 			return PortalUUIDUtil.generate();
 		}
 
-		long liveGroupId = groupId;
+		long liveGroupId = _liveGroupIdsMap.getOrDefault(groupId, groupId);
 
-		if (_liveGroupIdsMap.containsKey(groupId)) {
-			liveGroupId = _liveGroupIdsMap.get(groupId);
-		}
+		Map<String, String> uuids = _uuidsMaps.computeIfAbsent(
+			liveGroupId, key -> new HashMap<>());
 
-		if (!_uuidsMaps.containsKey(liveGroupId)) {
-			_uuidsMaps.put(liveGroupId, new HashMap<>());
-		}
-
-		Map<String, String> uuids = _uuidsMaps.get(liveGroupId);
-
-		if (uuids.containsKey(journalArticleUuid)) {
-			return uuids.get(journalArticleUuid);
-		}
-
-		String newUuid = PortalUUIDUtil.generate();
-
-		uuids.put(journalArticleUuid, newUuid);
-
-		return newUuid;
+		return uuids.computeIfAbsent(
+			journalArticleUuid, key -> PortalUUIDUtil.generate());
 	}
 
 	private void _init(long companyId) throws Exception {

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/helper/JournalRSSHelper.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/helper/JournalRSSHelper.java
@@ -265,16 +265,20 @@ public class JournalRSSHelper {
 			parameters.containsKey("i_id")) {
 
 			try {
+				String[] imageIdStrings = parameters.get("image_id");
+
+				if (imageIdStrings == null) {
+					imageIdStrings = parameters.get("img_id");
+				}
+
+				if (imageIdStrings == null) {
+					imageIdStrings = parameters.get("i_id");
+				}
+
 				long imageId = 0;
 
-				if (parameters.containsKey("image_id")) {
-					imageId = GetterUtil.getLong(parameters.get("image_id")[0]);
-				}
-				else if (parameters.containsKey("img_id")) {
-					imageId = GetterUtil.getLong(parameters.get("img_id")[0]);
-				}
-				else if (parameters.containsKey("i_id")) {
-					imageId = GetterUtil.getLong(parameters.get("i_id")[0]);
+				if (imageIdStrings != null) {
+					imageId = GetterUtil.getLong(imageIdStrings[0]);
 				}
 
 				image = _imageLocalService.getImage(imageId);

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/helper/JournalRSSHelper.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/helper/JournalRSSHelper.java
@@ -188,19 +188,19 @@ public class JournalRSSHelper {
 				}
 			}
 		}
-		else if (parameters.containsKey("uuid") &&
-				 parameters.containsKey("groupId")) {
+		else {
+			String[] uuids = parameters.get("uuid");
+			String[] groupIds = parameters.get("groupId");
 
-			try {
-				String uuid = parameters.get("uuid")[0];
-				long groupId = GetterUtil.getLong(parameters.get("groupId")[0]);
-
-				fileEntry = _dlAppLocalService.getFileEntryByUuidAndGroupId(
-					uuid, groupId);
-			}
-			catch (Exception exception) {
-				if (_log.isWarnEnabled()) {
-					_log.warn(exception);
+			if ((uuids != null) && (groupIds != null)) {
+				try {
+					fileEntry = _dlAppLocalService.getFileEntryByUuidAndGroupId(
+						uuids[0], GetterUtil.getLong(groupIds[0]));
+				}
+				catch (Exception exception) {
+					if (_log.isWarnEnabled()) {
+						_log.warn(exception);
+					}
 				}
 			}
 		}

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/util/KnowledgeBaseUtil.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/util/KnowledgeBaseUtil.java
@@ -436,8 +436,10 @@ public class KnowledgeBaseUtil {
 		kbArticles.clear();
 
 		for (long resourcePrimKey : resourcePrimKeys) {
-			if (map.containsKey(resourcePrimKey)) {
-				kbArticles.add(map.get(resourcePrimKey));
+			KBArticle kbArticle = map.get(resourcePrimKey);
+
+			if (kbArticle != null) {
+				kbArticles.add(kbArticle);
 			}
 		}
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/PublishLayoutMVCActionCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/PublishLayoutMVCActionCommand.java
@@ -186,31 +186,31 @@ public class PublishLayoutMVCActionCommand
 			UnicodeProperties updatedTypeSettingsUnicodeProperties =
 				layout.getTypeSettingsProperties();
 
-			if (originalTypeSettingsUnicodeProperties.containsKey(
-					LayoutTypePortletConstants.SITEMAP_CHANGEFREQ)) {
+			String sitemapChangefreq =
+				originalTypeSettingsUnicodeProperties.get(
+					LayoutTypePortletConstants.SITEMAP_CHANGEFREQ);
 
+			if (sitemapChangefreq != null) {
 				updatedTypeSettingsUnicodeProperties.put(
 					LayoutTypePortletConstants.SITEMAP_CHANGEFREQ,
-					originalTypeSettingsUnicodeProperties.get(
-						LayoutTypePortletConstants.SITEMAP_CHANGEFREQ));
+					sitemapChangefreq);
 			}
 
-			if (originalTypeSettingsUnicodeProperties.containsKey(
-					LayoutTypePortletConstants.SITEMAP_INCLUDE)) {
+			String sitemapInclude = originalTypeSettingsUnicodeProperties.get(
+				LayoutTypePortletConstants.SITEMAP_INCLUDE);
 
+			if (sitemapInclude != null) {
 				updatedTypeSettingsUnicodeProperties.put(
-					LayoutTypePortletConstants.SITEMAP_INCLUDE,
-					originalTypeSettingsUnicodeProperties.get(
-						LayoutTypePortletConstants.SITEMAP_INCLUDE));
+					LayoutTypePortletConstants.SITEMAP_INCLUDE, sitemapInclude);
 			}
 
-			if (originalTypeSettingsUnicodeProperties.containsKey(
-					LayoutTypePortletConstants.SITEMAP_PRIORITY)) {
+			String sitemapPriority = originalTypeSettingsUnicodeProperties.get(
+				LayoutTypePortletConstants.SITEMAP_PRIORITY);
 
+			if (sitemapPriority != null) {
 				updatedTypeSettingsUnicodeProperties.put(
 					LayoutTypePortletConstants.SITEMAP_PRIORITY,
-					originalTypeSettingsUnicodeProperties.get(
-						LayoutTypePortletConstants.SITEMAP_PRIORITY));
+					sitemapPriority);
 			}
 
 			_cleanWidgetLayoutTypeSettings(

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/UpdateFragmentsHighlightedConfigurationMVCActionCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/UpdateFragmentsHighlightedConfigurationMVCActionCommand.java
@@ -200,10 +200,9 @@ public class UpdateFragmentsHighlightedConfigurationMVCActionCommand
 			Map<String, Map<String, Object>> layoutElementMaps =
 				_getLayoutElementMaps(themeDisplay.getPermissionChecker());
 
-			if (layoutElementMaps.containsKey(key)) {
-				Map<String, Object> layoutElementMap = layoutElementMaps.get(
-					key);
+			Map<String, Object> layoutElementMap = layoutElementMaps.get(key);
 
+			if (layoutElementMap != null) {
 				String label = _language.get(
 					themeDisplay.getLocale(),
 					(String)layoutElementMap.get("languageKey"));

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/helper/structure/LayoutStructureRulesHelperImpl.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/helper/structure/LayoutStructureRulesHelperImpl.java
@@ -126,9 +126,7 @@ public class LayoutStructureRulesHelperImpl
 			String itemId = jsonObject.getString("itemId");
 
 			if (Objects.equals(action, Action.DISABLE.getValue())) {
-				if (enabledItemIds.contains(itemId)) {
-					enabledItemIds.remove(itemId);
-				}
+				enabledItemIds.remove(itemId);
 
 				disabledItemIds.add(itemId);
 			}
@@ -136,9 +134,7 @@ public class LayoutStructureRulesHelperImpl
 						jsonObject.getString("action"),
 						Action.SHOW.getValue())) {
 
-				if (hiddenItemIds.contains(itemId)) {
-					hiddenItemIds.remove(itemId);
-				}
+				hiddenItemIds.remove(itemId);
 
 				displayedItemIds.add(itemId);
 			}
@@ -146,16 +142,12 @@ public class LayoutStructureRulesHelperImpl
 						jsonObject.getString("action"),
 						Action.ENABLE.getValue())) {
 
-				if (disabledItemIds.contains(itemId)) {
-					disabledItemIds.remove(itemId);
-				}
+				disabledItemIds.remove(itemId);
 
 				enabledItemIds.add(itemId);
 			}
 			else {
-				if (displayedItemIds.contains(itemId)) {
-					displayedItemIds.remove(itemId);
-				}
+				displayedItemIds.remove(itemId);
 
 				hiddenItemIds.add(itemId);
 			}

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/LayoutsImporterImpl.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/LayoutsImporterImpl.java
@@ -2366,12 +2366,17 @@ public class LayoutsImporterImpl implements LayoutsImporter {
 					}
 				}
 			}
-			else if (favIconMap.containsKey("externalReferenceCode")) {
-				_addClientExtensionEntryRel(
-					String.valueOf(favIconMap.get("externalReferenceCode")),
-					layout, serviceContext,
-					ClientExtensionEntryConstants.TYPE_THEME_FAVICON, null,
-					userId);
+			else {
+				Object externalReferenceCode = favIconMap.get(
+					"externalReferenceCode");
+
+				if (externalReferenceCode != null) {
+					_addClientExtensionEntryRel(
+						String.valueOf(externalReferenceCode), layout,
+						serviceContext,
+						ClientExtensionEntryConstants.TYPE_THEME_FAVICON, null,
+						userId);
+				}
 			}
 		}
 

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/structure/util/BaseLayoutStructureItemImporter.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/structure/util/BaseLayoutStructureItemImporter.java
@@ -464,9 +464,9 @@ public abstract class BaseLayoutStructureItemImporter {
 
 		if (Validator.isNull(textAlign)) {
 			for (String alignKey : _ALIGN_KEYS) {
-				if (styles.containsKey(alignKey)) {
-					textAlign = GetterUtil.getString(styles.get(alignKey));
+				textAlign = GetterUtil.getString(styles.get(alignKey), null);
 
+				if (textAlign != null) {
 					break;
 				}
 			}

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/structure/util/BaseLayoutStructureItemImporter.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/structure/util/BaseLayoutStructureItemImporter.java
@@ -402,44 +402,38 @@ public abstract class BaseLayoutStructureItemImporter {
 
 		jsonObject.put("backgroundColor", styles.get("backgroundColor"));
 
-		if (styles.containsKey("backgroundFragmentImage") ||
-			styles.containsKey("backgroundImage")) {
+		Map<String, Object> childStyleMap = (Map<String, Object>)styles.get(
+			"backgroundFragmentImage");
 
+		if (MapUtil.isEmpty(childStyleMap)) {
+			childStyleMap = (Map<String, Object>)styles.get("backgroundImage");
+		}
+
+		if (MapUtil.isNotEmpty(childStyleMap)) {
 			JSONObject backgroundImageJSONObject =
 				JSONFactoryUtil.createJSONObject();
 
-			Map<String, Object> childStyleMap = (Map<String, Object>)styles.get(
-				"backgroundFragmentImage");
+			Map<String, Object> titleMap =
+				(Map<String, Object>)childStyleMap.get("title");
 
-			if (MapUtil.isEmpty(childStyleMap)) {
-				childStyleMap = (Map<String, Object>)styles.get(
-					"backgroundImage");
+			if (titleMap != null) {
+				backgroundImageJSONObject.put(
+					"title", getLocalizedValue(titleMap));
 			}
 
-			if (MapUtil.isNotEmpty(childStyleMap)) {
-				Map<String, Object> titleMap =
-					(Map<String, Object>)childStyleMap.get("title");
+			Map<String, Object> urlMap = (Map<String, Object>)childStyleMap.get(
+				"url");
 
-				if (titleMap != null) {
-					backgroundImageJSONObject.put(
-						"title", getLocalizedValue(titleMap));
-				}
+			if (urlMap != null) {
+				backgroundImageJSONObject.put("url", getLocalizedValue(urlMap));
 
-				Map<String, Object> urlMap =
-					(Map<String, Object>)childStyleMap.get("url");
-
-				if (urlMap != null) {
-					backgroundImageJSONObject.put(
-						"url", getLocalizedValue(urlMap));
-
-					processMapping(
-						backgroundImageJSONObject,
-						layoutStructureItemImporterContext,
-						(Map<String, Object>)urlMap.get("mapping"));
-				}
-
-				jsonObject.put("backgroundImage", backgroundImageJSONObject);
+				processMapping(
+					backgroundImageJSONObject,
+					layoutStructureItemImporterContext,
+					(Map<String, Object>)urlMap.get("mapping"));
 			}
+
+			jsonObject.put("backgroundImage", backgroundImageJSONObject);
 		}
 
 		Object borderColor = styles.get("borderColor");
@@ -464,9 +458,12 @@ public abstract class BaseLayoutStructureItemImporter {
 
 		if (Validator.isNull(textAlign)) {
 			for (String alignKey : _ALIGN_KEYS) {
-				textAlign = GetterUtil.getString(styles.get(alignKey), null);
+				Map.Entry<String, Object> alignEntry = MapUtil.getEntry(
+					styles, alignKey);
 
-				if (textAlign != null) {
+				if (alignEntry != null) {
+					textAlign = GetterUtil.getString(alignEntry.getValue());
+
 					break;
 				}
 			}

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/structure/util/CollectionLayoutStructureItemImporter.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/structure/util/CollectionLayoutStructureItemImporter.java
@@ -90,12 +90,12 @@ public class CollectionLayoutStructureItemImporter
 					collectionConfig, layoutStructureItemImporterContext));
 		}
 
-		if (definitionMap.containsKey("collectionViewports")) {
-			List<Map<String, Object>> collectionViewports =
-				(List<Map<String, Object>>)definitionMap.get(
-					"collectionViewports");
+		if (definitionMap.get("collectionViewports") instanceof
+				List<?> collectionViewports) {
 
-			for (Map<String, Object> collectionViewport : collectionViewports) {
+			for (Map<String, Object> collectionViewport :
+					(List<Map<String, Object>>)collectionViewports) {
+
 				_processCollectionViewportDefinition(
 					collectionStyledLayoutStructureItem,
 					(Map<String, Object>)collectionViewport.get(
@@ -161,12 +161,12 @@ public class CollectionLayoutStructureItemImporter
 		collectionStyledLayoutStructureItem.setTemplateKey(
 			(String)definitionMap.get("templateKey"));
 
-		if (definitionMap.containsKey("fragmentViewports")) {
-			List<Map<String, Object>> fragmentViewports =
-				(List<Map<String, Object>>)definitionMap.get(
-					"fragmentViewports");
+		if (definitionMap.get("fragmentViewports") instanceof
+				List<?> fragmentViewports) {
 
-			for (Map<String, Object> fragmentViewport : fragmentViewports) {
+			for (Map<String, Object> fragmentViewport :
+					(List<Map<String, Object>>)fragmentViewports) {
+
 				JSONObject jsonObject = JSONUtil.put(
 					(String)fragmentViewport.get("id"),
 					toFragmentViewportStylesJSONObject(fragmentViewport));
@@ -205,9 +205,10 @@ public class CollectionLayoutStructureItemImporter
 			}
 		}
 
-		if (definitionMap.containsKey("name")) {
-			collectionStyledLayoutStructureItem.setName(
-				GetterUtil.getString(definitionMap.get("name")));
+		String name = GetterUtil.getString(definitionMap.get("name"), null);
+
+		if (name != null) {
+			collectionStyledLayoutStructureItem.setName(name);
 		}
 
 		return collectionStyledLayoutStructureItem;

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/structure/util/CollectionLayoutStructureItemImporter.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/structure/util/CollectionLayoutStructureItemImporter.java
@@ -347,14 +347,16 @@ public class CollectionLayoutStructureItemImporter
 			{
 				setDisplayMessage(
 					() -> {
-						if (!emptyCollectionConfig.containsKey(
-								"displayMessage")) {
+						Map.Entry<String, Object> displayMessageEntry =
+							MapUtil.getEntry(
+								emptyCollectionConfig, "displayMessage");
 
+						if (displayMessageEntry == null) {
 							return null;
 						}
 
 						return GetterUtil.getBoolean(
-							emptyCollectionConfig.get("displayMessage"), true);
+							displayMessageEntry.getValue(), true);
 					});
 				setMessage(
 					() -> (Map<String, String>)emptyCollectionConfig.get(
@@ -390,14 +392,16 @@ public class CollectionLayoutStructureItemImporter
 			JSONUtil.put(
 				"numberOfColumns",
 				() -> {
-					if (!collectionViewportDefinitionMap.containsKey(
-							"numberOfColumns")) {
+					Map.Entry<String, Object> numberOfColumnsEntry =
+						MapUtil.getEntry(
+							collectionViewportDefinitionMap, "numberOfColumns");
 
+					if (numberOfColumnsEntry == null) {
 						return null;
 					}
 
 					return GetterUtil.getInteger(
-						collectionViewportDefinitionMap.get("numberOfColumns"));
+						numberOfColumnsEntry.getValue());
 				}));
 	}
 

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/structure/util/ColumnLayoutStructureItemImporter.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/structure/util/ColumnLayoutStructureItemImporter.java
@@ -48,11 +48,12 @@ public class ColumnLayoutStructureItemImporter
 
 		columnLayoutStructureItem.setSize((Integer)definitionMap.get("size"));
 
-		if (definitionMap.containsKey("columnViewports")) {
-			List<Map<String, Object>> columnViewports =
-				(List<Map<String, Object>>)definitionMap.get("columnViewports");
+		if (definitionMap.get("columnViewports") instanceof
+				List<?> columnViewports) {
 
-			for (Map<String, Object> columnViewport : columnViewports) {
+			for (Map<String, Object> columnViewport :
+					(List<Map<String, Object>>)columnViewports) {
+
 				_processColumnViewportDefinition(
 					columnLayoutStructureItem,
 					(Map<String, Object>)columnViewport.get(
@@ -60,16 +61,20 @@ public class ColumnLayoutStructureItemImporter
 					(String)columnViewport.get("id"));
 			}
 		}
-		else if (definitionMap.containsKey("columnViewportConfig")) {
-			Map<String, Object> columnViewportConfigurations =
-				(Map<String, Object>)definitionMap.get("columnViewportConfig");
+		else {
+			if (definitionMap.get("columnViewportConfig") instanceof
+					Map<?, ?> columnViewportConfigurations) {
 
-			for (Map.Entry<String, Object> entry :
-					columnViewportConfigurations.entrySet()) {
+				Map<String, Object> columnViewportConfigurationsMap =
+					(Map<String, Object>)columnViewportConfigurations;
 
-				_processColumnViewportDefinition(
-					columnLayoutStructureItem,
-					(Map<String, Object>)entry.getValue(), entry.getKey());
+				for (Map.Entry<String, Object> entry :
+						columnViewportConfigurationsMap.entrySet()) {
+
+					_processColumnViewportDefinition(
+						columnLayoutStructureItem,
+						(Map<String, Object>)entry.getValue(), entry.getKey());
+				}
 			}
 		}
 

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/structure/util/ColumnLayoutStructureItemImporter.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/structure/util/ColumnLayoutStructureItemImporter.java
@@ -12,6 +12,7 @@ import com.liferay.layout.util.structure.LayoutStructure;
 import com.liferay.layout.util.structure.LayoutStructureItem;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.MapUtil;
 
 import java.util.List;
 import java.util.Map;
@@ -96,12 +97,14 @@ public class ColumnLayoutStructureItemImporter
 			JSONUtil.put(
 				"size",
 				() -> {
-					if (!columnViewportDefinitionMap.containsKey("size")) {
+					Map.Entry<String, Object> sizeEntry = MapUtil.getEntry(
+						columnViewportDefinitionMap, "size");
+
+					if (sizeEntry == null) {
 						return null;
 					}
 
-					return GetterUtil.getInteger(
-						columnViewportDefinitionMap.get("size"));
+					return GetterUtil.getInteger(sizeEntry.getValue());
 				}));
 	}
 

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/structure/util/ContainerLayoutStructureItemImporter.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/structure/util/ContainerLayoutStructureItemImporter.java
@@ -109,25 +109,24 @@ public class ContainerLayoutStructureItemImporter
 					contentVisibility));
 		}
 
-		if (definitionMap.containsKey("cssClasses")) {
-			List<String> cssClasses = (List<String>)definitionMap.get(
-				"cssClasses");
-
+		if (definitionMap.get("cssClasses") instanceof List<?> cssClasses) {
 			containerStyledLayoutStructureItem.setCssClasses(
-				new HashSet<>(cssClasses));
+				new HashSet<>((List<String>)cssClasses));
 		}
 
-		if (definitionMap.containsKey("customCSS")) {
+		Object customCSS = definitionMap.get("customCSS");
+
+		if (customCSS != null) {
 			containerStyledLayoutStructureItem.setCustomCSS(
-				String.valueOf(definitionMap.get("customCSS")));
+				String.valueOf(customCSS));
 		}
 
-		if (definitionMap.containsKey("customCSSViewports")) {
-			List<Map<String, Object>> customCSSViewports =
-				(List<Map<String, Object>>)definitionMap.get(
-					"customCSSViewports");
+		if (definitionMap.get("customCSSViewports") instanceof
+				List<?> customCSSViewports) {
 
-			for (Map<String, Object> customCSSViewport : customCSSViewports) {
+			for (Map<String, Object> customCSSViewport :
+					(List<Map<String, Object>>)customCSSViewports) {
+
 				containerStyledLayoutStructureItem.setCustomCSSViewport(
 					(String)customCSSViewport.get("id"),
 					(String)customCSSViewport.get("customCSS"));
@@ -362,12 +361,12 @@ public class ContainerLayoutStructureItemImporter
 			containerStyledLayoutStructureItem.updateItemConfig(jsonObject);
 		}
 
-		if (definitionMap.containsKey("fragmentViewports")) {
-			List<Map<String, Object>> fragmentViewports =
-				(List<Map<String, Object>>)definitionMap.get(
-					"fragmentViewports");
+		if (definitionMap.get("fragmentViewports") instanceof
+				List<?> fragmentViewports) {
 
-			for (Map<String, Object> fragmentViewport : fragmentViewports) {
+			for (Map<String, Object> fragmentViewport :
+					(List<Map<String, Object>>)fragmentViewports) {
+
 				JSONObject jsonObject = JSONUtil.put(
 					(String)fragmentViewport.get("id"),
 					toFragmentViewportStylesJSONObject(fragmentViewport));
@@ -376,14 +375,17 @@ public class ContainerLayoutStructureItemImporter
 			}
 		}
 
-		if (definitionMap.containsKey("indexed")) {
+		Object indexed = definitionMap.get("indexed");
+
+		if (indexed != null) {
 			containerStyledLayoutStructureItem.setIndexed(
-				GetterUtil.getBoolean(definitionMap.get("indexed")));
+				GetterUtil.getBoolean(indexed));
 		}
 
-		if (definitionMap.containsKey("name")) {
-			containerStyledLayoutStructureItem.setName(
-				GetterUtil.getString(definitionMap.get("name")));
+		String name = GetterUtil.getString(definitionMap.get("name"), null);
+
+		if (name != null) {
+			containerStyledLayoutStructureItem.setName(name);
 		}
 
 		return containerStyledLayoutStructureItem;

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/structure/util/FormLayoutStructureItemImporter.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/structure/util/FormLayoutStructureItemImporter.java
@@ -307,15 +307,16 @@ public class FormLayoutStructureItemImporter
 		).put(
 			"unlocalizedFieldsState",
 			() -> {
-				if (!localizationConfigResultMap.containsKey(
-						"unlocalizedFieldsState")) {
+				Map.Entry<String, Object> unlocalizedFieldsStateEntry =
+					MapUtil.getEntry(
+						localizationConfigResultMap, "unlocalizedFieldsState");
 
+				if (unlocalizedFieldsStateEntry == null) {
 					return null;
 				}
 
 				if (Objects.equals(
-						localizationConfigResultMap.get(
-							"unlocalizedFieldsState"),
+						unlocalizedFieldsStateEntry.getValue(),
 						LocalizationConfig.UnlocalizedFieldsState.DISABLED)) {
 
 					return "disabled";
@@ -362,7 +363,10 @@ public class FormLayoutStructureItemImporter
 			return null;
 		}
 
-		if (formSuccessSubmissionResultMap.containsKey("messageType")) {
+		Map.Entry<String, Object> messageTypeEntry = MapUtil.getEntry(
+			formSuccessSubmissionResultMap, "messageType");
+
+		if (messageTypeEntry != null) {
 			JSONObject messageJSONObject = _setNotificationText(
 				JSONUtil.put(
 					"message",
@@ -371,8 +375,7 @@ public class FormLayoutStructureItemImporter
 				formSuccessSubmissionResultMap);
 
 			if (Objects.equals(
-					String.valueOf(
-						formSuccessSubmissionResultMap.get("messageType")),
+					String.valueOf(messageTypeEntry.getValue()),
 					MessageFormSubmissionResult.MessageType.EMBEDDED.
 						getValue())) {
 
@@ -441,14 +444,15 @@ public class FormLayoutStructureItemImporter
 		).put(
 			"showNotification",
 			() -> {
-				if (!formSuccessSubmissionResultMap.containsKey(
-						"showNotification")) {
+				Map.Entry<String, Object> showNotificationEntry =
+					MapUtil.getEntry(
+						formSuccessSubmissionResultMap, "showNotification");
 
+				if (showNotificationEntry == null) {
 					return null;
 				}
 
-				return GetterUtil.getBoolean(
-					formSuccessSubmissionResultMap.get("showNotification"));
+				return GetterUtil.getBoolean(showNotificationEntry.getValue());
 			}
 		);
 	}

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/structure/util/FormLayoutStructureItemImporter.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/structure/util/FormLayoutStructureItemImporter.java
@@ -67,25 +67,24 @@ public class FormLayoutStructureItemImporter
 			return formStyledLayoutStructureItem;
 		}
 
-		if (definitionMap.containsKey("cssClasses")) {
-			List<String> cssClasses = (List<String>)definitionMap.get(
-				"cssClasses");
-
+		if (definitionMap.get("cssClasses") instanceof List<?> cssClasses) {
 			formStyledLayoutStructureItem.setCssClasses(
-				new HashSet<>(cssClasses));
+				new HashSet<>((List<String>)cssClasses));
 		}
 
-		if (definitionMap.containsKey("customCSS")) {
+		Object customCSS = definitionMap.get("customCSS");
+
+		if (customCSS != null) {
 			formStyledLayoutStructureItem.setCustomCSS(
-				String.valueOf(definitionMap.get("customCSS")));
+				String.valueOf(customCSS));
 		}
 
-		if (definitionMap.containsKey("customCSSViewports")) {
-			List<Map<String, Object>> customCSSViewports =
-				(List<Map<String, Object>>)definitionMap.get(
-					"customCSSViewports");
+		if (definitionMap.get("customCSSViewports") instanceof
+				List<?> customCSSViewports) {
 
-			for (Map<String, Object> customCSSViewport : customCSSViewports) {
+			for (Map<String, Object> customCSSViewport :
+					(List<Map<String, Object>>)customCSSViewports) {
+
 				formStyledLayoutStructureItem.setCustomCSSViewport(
 					(String)customCSSViewport.get("id"),
 					(String)customCSSViewport.get("customCSS"));
@@ -134,9 +133,8 @@ public class FormLayoutStructureItemImporter
 					FormStyledLayoutStructureItem.FORM_CONFIG_OTHER_ITEM_TYPE);
 			}
 
-			if (sourceMap.containsKey("formType")) {
-				formStyledLayoutStructureItem.setFormType(
-					(String)sourceMap.get("formType"));
+			if (sourceMap.get("formType") instanceof String formType) {
+				formStyledLayoutStructureItem.setFormType(formType);
 			}
 
 			JSONObject localizationConfigJSONObject =
@@ -147,9 +145,11 @@ public class FormLayoutStructureItemImporter
 					localizationConfigJSONObject);
 			}
 
-			if (sourceMap.containsKey("numberOfSteps")) {
+			Object numberOfSteps = sourceMap.get("numberOfSteps");
+
+			if (numberOfSteps != null) {
 				formStyledLayoutStructureItem.setNumberOfSteps(
-					GetterUtil.getInteger(sourceMap.get("numberOfSteps")));
+					GetterUtil.getInteger(numberOfSteps));
 			}
 
 			JSONObject successMessageJSONObject = _getSuccessMessageJSONObject(
@@ -173,12 +173,12 @@ public class FormLayoutStructureItemImporter
 			formStyledLayoutStructureItem.updateItemConfig(jsonObject);
 		}
 
-		if (definitionMap.containsKey("fragmentViewports")) {
-			List<Map<String, Object>> fragmentViewports =
-				(List<Map<String, Object>>)definitionMap.get(
-					"fragmentViewports");
+		if (definitionMap.get("fragmentViewports") instanceof
+				List<?> fragmentViewports) {
 
-			for (Map<String, Object> fragmentViewport : fragmentViewports) {
+			for (Map<String, Object> fragmentViewport :
+					(List<Map<String, Object>>)fragmentViewports) {
+
 				JSONObject jsonObject = JSONUtil.put(
 					(String)fragmentViewport.get("id"),
 					toFragmentViewportStylesJSONObject(fragmentViewport));
@@ -187,9 +187,11 @@ public class FormLayoutStructureItemImporter
 			}
 		}
 
-		if (definitionMap.containsKey("indexed")) {
+		Object indexed = definitionMap.get("indexed");
+
+		if (indexed != null) {
 			formStyledLayoutStructureItem.setIndexed(
-				GetterUtil.getBoolean(definitionMap.get("indexed")));
+				GetterUtil.getBoolean(indexed));
 		}
 
 		Map<String, Object> formLayout = (Map<String, Object>)definitionMap.get(
@@ -237,9 +239,10 @@ public class FormLayoutStructureItemImporter
 			}
 		}
 
-		if (definitionMap.containsKey("name")) {
-			formStyledLayoutStructureItem.setName(
-				GetterUtil.getString(definitionMap.get("name")));
+		String name = GetterUtil.getString(definitionMap.get("name"), null);
+
+		if (name != null) {
+			formStyledLayoutStructureItem.setName(name);
 		}
 
 		return formStyledLayoutStructureItem;
@@ -378,24 +381,23 @@ public class FormLayoutStructureItemImporter
 
 			return messageJSONObject.put("type", "none");
 		}
-		else if (formSuccessSubmissionResultMap.containsKey("itemReference")) {
-			Map<String, Object> itemReference =
-				(Map<String, Object>)formSuccessSubmissionResultMap.get(
-					"itemReference");
+
+		if (formSuccessSubmissionResultMap.get("itemReference") instanceof
+				Map<?, ?> itemReference) {
 
 			return _setNotificationText(
 				JSONUtil.put(
 					"layout",
 					getLayoutFromItemReferenceJSONObject(
-						itemReference, layoutStructureItemImporterContext)),
+						(Map<String, Object>)itemReference,
+						layoutStructureItemImporterContext)),
 				formSuccessSubmissionResultMap
 			).put(
 				"type", "page"
 			);
 		}
-		else if (formSuccessSubmissionResultMap.containsKey(
-					"defaultDisplayPage")) {
 
+		if (formSuccessSubmissionResultMap.containsKey("defaultDisplayPage")) {
 			JSONObject displayPageTemplateJSONObject =
 				toDisplayPageFormSubmissionResultJSONObject(
 					formSuccessSubmissionResultMap,
@@ -404,7 +406,8 @@ public class FormLayoutStructureItemImporter
 			return _setNotificationText(
 				displayPageTemplateJSONObject, formSuccessSubmissionResultMap);
 		}
-		else if (formSuccessSubmissionResultMap.containsKey("url")) {
+
+		if (formSuccessSubmissionResultMap.containsKey("url")) {
 			return JSONUtil.put(
 				"type", "url"
 			).put(

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/structure/util/FormRelationshipLayoutStructureItemImporter.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/structure/util/FormRelationshipLayoutStructureItemImporter.java
@@ -59,30 +59,31 @@ public class FormRelationshipLayoutStructureItemImporter
 				_getLocalizedValuesJSONObject("buttonLabel", definitionMap));
 		}
 
-		if (definitionMap.containsKey("contentType")) {
+		Object contentType = definitionMap.get("contentType");
+
+		if (contentType != null) {
 			formRelationshipStyledLayoutStructureItem.setContentType(
-				String.valueOf(definitionMap.get("contentType")));
+				String.valueOf(contentType));
 		}
 
-		if (definitionMap.containsKey("cssClasses")) {
-			List<String> cssClasses = (List<String>)definitionMap.get(
-				"cssClasses");
-
+		if (definitionMap.get("cssClasses") instanceof List<?> cssClasses) {
 			formRelationshipStyledLayoutStructureItem.setCssClasses(
-				new HashSet<>(cssClasses));
+				new HashSet<>((List<String>)cssClasses));
 		}
 
-		if (definitionMap.containsKey("customCSS")) {
+		Object customCSS = definitionMap.get("customCSS");
+
+		if (customCSS != null) {
 			formRelationshipStyledLayoutStructureItem.setCustomCSS(
-				String.valueOf(definitionMap.get("customCSS")));
+				String.valueOf(customCSS));
 		}
 
-		if (definitionMap.containsKey("customCSSViewports")) {
-			List<Map<String, Object>> customCSSViewports =
-				(List<Map<String, Object>>)definitionMap.get(
-					"customCSSViewports");
+		if (definitionMap.get("customCSSViewports") instanceof
+				List<?> customCSSViewports) {
 
-			for (Map<String, Object> customCSSViewport : customCSSViewports) {
+			for (Map<String, Object> customCSSViewport :
+					(List<Map<String, Object>>)customCSSViewports) {
+
 				formRelationshipStyledLayoutStructureItem.setCustomCSSViewport(
 					(String)customCSSViewport.get("id"),
 					(String)customCSSViewport.get("customCSS"));
@@ -102,12 +103,12 @@ public class FormRelationshipLayoutStructureItemImporter
 				jsonObject);
 		}
 
-		if (definitionMap.containsKey("fragmentViewports")) {
-			List<Map<String, Object>> fragmentViewports =
-				(List<Map<String, Object>>)definitionMap.get(
-					"fragmentViewports");
+		if (definitionMap.get("fragmentViewports") instanceof
+				List<?> fragmentViewports) {
 
-			for (Map<String, Object> fragmentViewport : fragmentViewports) {
+			for (Map<String, Object> fragmentViewport :
+					(List<Map<String, Object>>)fragmentViewports) {
+
 				JSONObject jsonObject = JSONUtil.put(
 					(String)fragmentViewport.get("id"),
 					toFragmentViewportStylesJSONObject(fragmentViewport));
@@ -117,14 +118,18 @@ public class FormRelationshipLayoutStructureItemImporter
 			}
 		}
 
-		if (definitionMap.containsKey("name")) {
+		Object name = definitionMap.get("name");
+
+		if (name != null) {
 			formRelationshipStyledLayoutStructureItem.setName(
-				String.valueOf(definitionMap.get("name")));
+				String.valueOf(name));
 		}
 
-		if (definitionMap.containsKey("repeatable")) {
+		Object repeatable = definitionMap.get("repeatable");
+
+		if (repeatable != null) {
 			formRelationshipStyledLayoutStructureItem.setRepeatable(
-				GetterUtil.getBoolean(definitionMap.get("repeatable")));
+				GetterUtil.getBoolean(repeatable));
 		}
 
 		return formRelationshipStyledLayoutStructureItem;

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/structure/util/FormStepContainerLayoutStructureItemImporter.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/structure/util/FormStepContainerLayoutStructureItemImporter.java
@@ -51,25 +51,24 @@ public class FormStepContainerLayoutStructureItemImporter
 			return formStepContainerStyledLayoutStructureItem;
 		}
 
-		if (definitionMap.containsKey("cssClasses")) {
-			List<String> cssClasses = (List<String>)definitionMap.get(
-				"cssClasses");
-
+		if (definitionMap.get("cssClasses") instanceof List<?> cssClasses) {
 			formStepContainerStyledLayoutStructureItem.setCssClasses(
-				new HashSet<>(cssClasses));
+				new HashSet<>((List<String>)cssClasses));
 		}
 
-		if (definitionMap.containsKey("customCSS")) {
+		Object customCSS = definitionMap.get("customCSS");
+
+		if (customCSS != null) {
 			formStepContainerStyledLayoutStructureItem.setCustomCSS(
-				String.valueOf(definitionMap.get("customCSS")));
+				String.valueOf(customCSS));
 		}
 
-		if (definitionMap.containsKey("customCSSViewports")) {
-			List<Map<String, Object>> customCSSViewports =
-				(List<Map<String, Object>>)definitionMap.get(
-					"customCSSViewports");
+		if (definitionMap.get("customCSSViewports") instanceof
+				List<?> customCSSViewports) {
 
-			for (Map<String, Object> customCSSViewport : customCSSViewports) {
+			for (Map<String, Object> customCSSViewport :
+					(List<Map<String, Object>>)customCSSViewports) {
+
 				formStepContainerStyledLayoutStructureItem.setCustomCSSViewport(
 					(String)customCSSViewport.get("id"),
 					(String)customCSSViewport.get("customCSS"));
@@ -89,12 +88,12 @@ public class FormStepContainerLayoutStructureItemImporter
 				jsonObject);
 		}
 
-		if (definitionMap.containsKey("fragmentViewports")) {
-			List<Map<String, Object>> fragmentViewports =
-				(List<Map<String, Object>>)definitionMap.get(
-					"fragmentViewports");
+		if (definitionMap.get("fragmentViewports") instanceof
+				List<?> fragmentViewports) {
 
-			for (Map<String, Object> fragmentViewport : fragmentViewports) {
+			for (Map<String, Object> fragmentViewport :
+					(List<Map<String, Object>>)fragmentViewports) {
+
 				JSONObject jsonObject = JSONUtil.put(
 					(String)fragmentViewport.get("id"),
 					toFragmentViewportStylesJSONObject(fragmentViewport));

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/structure/util/FragmentLayoutStructureItemImporter.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/structure/util/FragmentLayoutStructureItemImporter.java
@@ -154,25 +154,24 @@ public class FragmentLayoutStructureItemImporter
 			return fragmentStyledLayoutStructureItem;
 		}
 
-		if (definitionMap.containsKey("cssClasses")) {
-			List<String> cssClasses = (List<String>)definitionMap.get(
-				"cssClasses");
-
+		if (definitionMap.get("cssClasses") instanceof List<?> cssClasses) {
 			fragmentStyledLayoutStructureItem.setCssClasses(
-				new HashSet<>(cssClasses));
+				new HashSet<>((List<String>)cssClasses));
 		}
 
-		if (definitionMap.containsKey("customCSS")) {
+		Object customCSS = definitionMap.get("customCSS");
+
+		if (customCSS != null) {
 			fragmentStyledLayoutStructureItem.setCustomCSS(
-				String.valueOf(definitionMap.get("customCSS")));
+				String.valueOf(customCSS));
 		}
 
-		if (definitionMap.containsKey("customCSSViewports")) {
-			List<Map<String, Object>> customCSSViewports =
-				(List<Map<String, Object>>)definitionMap.get(
-					"customCSSViewports");
+		if (definitionMap.get("customCSSViewports") instanceof
+				List<?> customCSSViewports) {
 
-			for (Map<String, Object> customCSSViewport : customCSSViewports) {
+			for (Map<String, Object> customCSSViewport :
+					(List<Map<String, Object>>)customCSSViewports) {
+
 				fragmentStyledLayoutStructureItem.setCustomCSSViewport(
 					(String)customCSSViewport.get("id"),
 					(String)customCSSViewport.get("customCSS"));
@@ -223,12 +222,12 @@ public class FragmentLayoutStructureItemImporter
 			fragmentStyledLayoutStructureItem.updateItemConfig(jsonObject);
 		}
 
-		if (definitionMap.containsKey("fragmentViewports")) {
-			List<Map<String, Object>> fragmentViewports =
-				(List<Map<String, Object>>)definitionMap.get(
-					"fragmentViewports");
+		if (definitionMap.get("fragmentViewports") instanceof
+				List<?> fragmentViewports) {
 
-			for (Map<String, Object> fragmentViewport : fragmentViewports) {
+			for (Map<String, Object> fragmentViewport :
+					(List<Map<String, Object>>)fragmentViewports) {
+
 				JSONObject jsonObject = JSONUtil.put(
 					(String)fragmentViewport.get("id"),
 					toFragmentViewportStylesJSONObject(fragmentViewport));
@@ -237,14 +236,17 @@ public class FragmentLayoutStructureItemImporter
 			}
 		}
 
-		if (definitionMap.containsKey("indexed")) {
+		Object indexed = definitionMap.get("indexed");
+
+		if (indexed != null) {
 			fragmentStyledLayoutStructureItem.setIndexed(
-				GetterUtil.getBoolean(definitionMap.get("indexed")));
+				GetterUtil.getBoolean(indexed));
 		}
 
-		if (definitionMap.containsKey("name")) {
-			fragmentStyledLayoutStructureItem.setName(
-				GetterUtil.getString(definitionMap.get("name")));
+		String name = GetterUtil.getString(definitionMap.get("name"), null);
+
+		if (name != null) {
+			fragmentStyledLayoutStructureItem.setName(name);
 		}
 
 		return fragmentStyledLayoutStructureItem;
@@ -1364,29 +1366,33 @@ public class FragmentLayoutStructureItemImporter
 					JSONFactoryUtil.createJSONObject();
 
 				if (fragmentImageMap != null) {
-					if (fragmentImageMap.containsKey("url")) {
+					if (fragmentImageMap.get("url") instanceof
+							Map<?, ?> urlMap) {
+
 						baseFragmentFieldJSONObject =
 							_createBaseFragmentFieldJSONObject(
 								layoutStructureItemImporterContext,
-								(Map<String, Object>)fragmentImageMap.get(
-									"url"));
+								(Map<String, Object>)urlMap);
 					}
 
-					if (fragmentImageMap.containsKey(
-							"fragmentImageClassPKReference")) {
+					if (
+							fragmentImageMap.get(
+								"fragmentImageClassPKReference") instanceof
+									Map<?, ?>
+										fragmentImageClassPKReferenceMap) {
 
-						Map<String, Object> fragmentImageClassPKReferenceMap =
-							(Map<String, Object>)fragmentImageMap.get(
-								"fragmentImageClassPKReference");
+						Map<String, Object> fragmentImageClassPKReferences =
+							(Map<String, Object>)
+								fragmentImageClassPKReferenceMap;
 
 						baseFragmentFieldJSONObject = _createImageJSONObject(
 							(Map<String, Object>)
-								fragmentImageClassPKReferenceMap.get(
+								fragmentImageClassPKReferences.get(
 									"classPKReferences"));
 
 						Map<String, String> fragmentImageConfigurationMap =
 							(Map<String, String>)
-								fragmentImageClassPKReferenceMap.get(
+								fragmentImageClassPKReferences.get(
 									"fragmentImageConfiguration");
 
 						JSONObject amImageConfigurationJSONObject =

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/structure/util/FragmentLayoutStructureItemImporter.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/structure/util/FragmentLayoutStructureItemImporter.java
@@ -1009,14 +1009,9 @@ public class FragmentLayoutStructureItemImporter
 				"interaction",
 				ActionEditableElementConstants.INTERACTION_DISPLAY_PAGE);
 
-			if ((valueMap == null) || !valueMap.containsKey("mapping")) {
-				return;
-			}
+			if ((valueMap == null) ||
+				!(valueMap.get("mapping") instanceof Map<?, ?> mappingMap)) {
 
-			Map<String, Object> mappingMap = (Map<String, Object>)valueMap.get(
-				"mapping");
-
-			if (mappingMap == null) {
 				return;
 			}
 
@@ -1087,21 +1082,18 @@ public class FragmentLayoutStructureItemImporter
 			resultJSONObject.put(
 				"interaction", ActionEditableElementConstants.INTERACTION_PAGE);
 
-			if ((valueMap == null) || !valueMap.containsKey("itemReference")) {
-				return;
-			}
+			if ((valueMap == null) ||
+				!(valueMap.get("itemReference") instanceof
+					Map<?, ?> itemReference)) {
 
-			Map<String, Object> itemReference =
-				(Map<String, Object>)valueMap.get("itemReference");
-
-			if (itemReference == null) {
 				return;
 			}
 
 			resultJSONObject.put(
 				"page",
 				getLayoutFromItemReferenceJSONObject(
-					itemReference, layoutStructureItemImporterContext));
+					(Map<String, Object>)itemReference,
+					layoutStructureItemImporterContext));
 		}
 		else if (Objects.equals(
 					onResultMap.get("type"),

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/structure/util/RowLayoutStructureItemImporter.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/structure/util/RowLayoutStructureItemImporter.java
@@ -50,25 +50,24 @@ public class RowLayoutStructureItemImporter
 			return rowStyledLayoutStructureItem;
 		}
 
-		if (definitionMap.containsKey("cssClasses")) {
-			List<String> cssClasses = (List<String>)definitionMap.get(
-				"cssClasses");
-
+		if (definitionMap.get("cssClasses") instanceof List<?> cssClasses) {
 			rowStyledLayoutStructureItem.setCssClasses(
-				new HashSet<>(cssClasses));
+				new HashSet<>((List<String>)cssClasses));
 		}
 
-		if (definitionMap.containsKey("customCSS")) {
+		Object customCSS = definitionMap.get("customCSS");
+
+		if (customCSS != null) {
 			rowStyledLayoutStructureItem.setCustomCSS(
-				String.valueOf(definitionMap.get("customCSS")));
+				String.valueOf(customCSS));
 		}
 
-		if (definitionMap.containsKey("customCSSViewports")) {
-			List<Map<String, Object>> customCSSViewports =
-				(List<Map<String, Object>>)definitionMap.get(
-					"customCSSViewports");
+		if (definitionMap.get("customCSSViewports") instanceof
+				List<?> customCSSViewports) {
 
-			for (Map<String, Object> customCSSViewport : customCSSViewports) {
+			for (Map<String, Object> customCSSViewport :
+					(List<Map<String, Object>>)customCSSViewports) {
+
 				rowStyledLayoutStructureItem.setCustomCSSViewport(
 					(String)customCSSViewport.get("id"),
 					(String)customCSSViewport.get("customCSS"));
@@ -78,14 +77,17 @@ public class RowLayoutStructureItemImporter
 		rowStyledLayoutStructureItem.setGutters(
 			(Boolean)definitionMap.get("gutters"));
 
-		if (definitionMap.containsKey("indexed")) {
+		Object indexed = definitionMap.get("indexed");
+
+		if (indexed != null) {
 			rowStyledLayoutStructureItem.setIndexed(
-				GetterUtil.getBoolean(definitionMap.get("indexed")));
+				GetterUtil.getBoolean(indexed));
 		}
 
-		if (definitionMap.containsKey("name")) {
-			rowStyledLayoutStructureItem.setName(
-				GetterUtil.getString(definitionMap.get("name")));
+		String name = GetterUtil.getString(definitionMap.get("name"), null);
+
+		if (name != null) {
+			rowStyledLayoutStructureItem.setName(name);
 		}
 
 		rowStyledLayoutStructureItem.setNumberOfColumns(
@@ -98,16 +100,17 @@ public class RowLayoutStructureItemImporter
 				(Boolean)definitionMap.get("reverseOrder"));
 		}
 
-		if (definitionMap.containsKey("verticalAlignment")) {
+		if (definitionMap.get("verticalAlignment") instanceof
+				String verticalAlignment) {
+
 			rowStyledLayoutStructureItem.setVerticalAlignment(
-				(String)definitionMap.get("verticalAlignment"));
+				verticalAlignment);
 		}
 
-		if (definitionMap.containsKey("rowViewports")) {
-			List<Map<String, Object>> rowViewports =
-				(List<Map<String, Object>>)definitionMap.get("rowViewports");
+		if (definitionMap.get("rowViewports") instanceof List<?> rowViewports) {
+			for (Map<String, Object> rowViewport :
+					(List<Map<String, Object>>)rowViewports) {
 
-			for (Map<String, Object> rowViewport : rowViewports) {
 				_processRowViewportDefinition(
 					rowStyledLayoutStructureItem,
 					(Map<String, Object>)rowViewport.get(
@@ -115,16 +118,20 @@ public class RowLayoutStructureItemImporter
 					(String)rowViewport.get("id"));
 			}
 		}
-		else if (definitionMap.containsKey("rowViewportConfig")) {
-			Map<String, Object> rowViewportConfigurations =
-				(Map<String, Object>)definitionMap.get("rowViewportConfig");
+		else {
+			if (definitionMap.get("rowViewportConfig") instanceof
+					Map<?, ?> rowViewportConfigurations) {
 
-			for (Map.Entry<String, Object> entry :
-					rowViewportConfigurations.entrySet()) {
+				Map<String, Object> rowViewportConfigurationsMap =
+					(Map<String, Object>)rowViewportConfigurations;
 
-				_processRowViewportDefinition(
-					rowStyledLayoutStructureItem,
-					(Map<String, Object>)entry.getValue(), entry.getKey());
+				for (Map.Entry<String, Object> entry :
+						rowViewportConfigurationsMap.entrySet()) {
+
+					_processRowViewportDefinition(
+						rowStyledLayoutStructureItem,
+						(Map<String, Object>)entry.getValue(), entry.getKey());
+				}
 			}
 		}
 
@@ -140,12 +147,12 @@ public class RowLayoutStructureItemImporter
 			rowStyledLayoutStructureItem.updateItemConfig(jsonObject);
 		}
 
-		if (definitionMap.containsKey("fragmentViewports")) {
-			List<Map<String, Object>> fragmentViewports =
-				(List<Map<String, Object>>)definitionMap.get(
-					"fragmentViewports");
+		if (definitionMap.get("fragmentViewports") instanceof
+				List<?> fragmentViewports) {
 
-			for (Map<String, Object> fragmentViewport : fragmentViewports) {
+			for (Map<String, Object> fragmentViewport :
+					(List<Map<String, Object>>)fragmentViewports) {
+
 				JSONObject jsonObject = JSONUtil.put(
 					(String)fragmentViewport.get("id"),
 					toFragmentViewportStylesJSONObject(fragmentViewport));

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/structure/util/RowLayoutStructureItemImporter.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/structure/util/RowLayoutStructureItemImporter.java
@@ -14,6 +14,7 @@ import com.liferay.layout.util.structure.RowStyledLayoutStructureItem;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.MapUtil;
 
 import java.util.HashSet;
 import java.util.List;
@@ -93,11 +94,14 @@ public class RowLayoutStructureItemImporter
 		rowStyledLayoutStructureItem.setNumberOfColumns(
 			(Integer)definitionMap.get("numberOfColumns"));
 
-		if (definitionMap.containsKey("reverseOrder")) {
-			rowStyledLayoutStructureItem.setModulesPerRow(
-				(Integer)definitionMap.get("modulesPerRow"));
-			rowStyledLayoutStructureItem.setReverseOrder(
-				(Boolean)definitionMap.get("reverseOrder"));
+		if (definitionMap.get("reverseOrder") instanceof Boolean reverseOrder) {
+			if (definitionMap.get("modulesPerRow") instanceof
+					Integer modulesPerRow) {
+
+				rowStyledLayoutStructureItem.setModulesPerRow(modulesPerRow);
+			}
+
+			rowStyledLayoutStructureItem.setReverseOrder(reverseOrder);
 		}
 
 		if (definitionMap.get("verticalAlignment") instanceof
@@ -178,36 +182,42 @@ public class RowLayoutStructureItemImporter
 			JSONUtil.put(
 				"modulesPerRow",
 				() -> {
-					if (!rowViewportDefinitionMap.containsKey(
-							"modulesPerRow")) {
+					Map.Entry<String, Object> modulesPerRowEntry =
+						MapUtil.getEntry(
+							rowViewportDefinitionMap, "modulesPerRow");
 
+					if (modulesPerRowEntry == null) {
 						return null;
 					}
 
-					return GetterUtil.getInteger(
-						rowViewportDefinitionMap.get("modulesPerRow"));
+					return GetterUtil.getInteger(modulesPerRowEntry.getValue());
 				}
 			).put(
 				"reverseOrder",
 				() -> {
-					if (!rowViewportDefinitionMap.containsKey("reverseOrder")) {
+					Map.Entry<String, Object> reverseOrderEntry =
+						MapUtil.getEntry(
+							rowViewportDefinitionMap, "reverseOrder");
+
+					if (reverseOrderEntry == null) {
 						return null;
 					}
 
-					return GetterUtil.getBoolean(
-						rowViewportDefinitionMap.get("reverseOrder"));
+					return GetterUtil.getBoolean(reverseOrderEntry.getValue());
 				}
 			).put(
 				"verticalAlignment",
 				() -> {
-					if (!rowViewportDefinitionMap.containsKey(
-							"verticalAlignment")) {
+					Map.Entry<String, Object> verticalAlignmentEntry =
+						MapUtil.getEntry(
+							rowViewportDefinitionMap, "verticalAlignment");
 
+					if (verticalAlignmentEntry == null) {
 						return null;
 					}
 
 					return GetterUtil.getString(
-						rowViewportDefinitionMap.get("verticalAlignment"));
+						verticalAlignmentEntry.getValue());
 				}
 			));
 	}

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/structure/util/WidgetLayoutStructureItemImporter.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/structure/util/WidgetLayoutStructureItemImporter.java
@@ -93,25 +93,24 @@ public class WidgetLayoutStructureItemImporter
 			return fragmentStyledLayoutStructureItem;
 		}
 
-		if (definitionMap.containsKey("cssClasses")) {
-			List<String> cssClasses = (List<String>)definitionMap.get(
-				"cssClasses");
-
+		if (definitionMap.get("cssClasses") instanceof List<?> cssClasses) {
 			fragmentStyledLayoutStructureItem.setCssClasses(
-				new HashSet<>(cssClasses));
+				new HashSet<>((List<String>)cssClasses));
 		}
 
-		if (definitionMap.containsKey("customCSS")) {
+		Object customCSS = definitionMap.get("customCSS");
+
+		if (customCSS != null) {
 			fragmentStyledLayoutStructureItem.setCustomCSS(
-				String.valueOf(definitionMap.get("customCSS")));
+				String.valueOf(customCSS));
 		}
 
-		if (definitionMap.containsKey("customCSSViewports")) {
-			List<Map<String, Object>> customCSSViewports =
-				(List<Map<String, Object>>)definitionMap.get(
-					"customCSSViewports");
+		if (definitionMap.get("customCSSViewports") instanceof
+				List<?> customCSSViewports) {
 
-			for (Map<String, Object> customCSSViewport : customCSSViewports) {
+			for (Map<String, Object> customCSSViewport :
+					(List<Map<String, Object>>)customCSSViewports) {
+
 				fragmentStyledLayoutStructureItem.setCustomCSSViewport(
 					(String)customCSSViewport.get("id"),
 					(String)customCSSViewport.get("customCSS"));
@@ -130,12 +129,12 @@ public class WidgetLayoutStructureItemImporter
 			fragmentStyledLayoutStructureItem.updateItemConfig(jsonObject);
 		}
 
-		if (definitionMap.containsKey("fragmentViewports")) {
-			List<Map<String, Object>> fragmentViewports =
-				(List<Map<String, Object>>)definitionMap.get(
-					"fragmentViewports");
+		if (definitionMap.get("fragmentViewports") instanceof
+				List<?> fragmentViewports) {
 
-			for (Map<String, Object> fragmentViewport : fragmentViewports) {
+			for (Map<String, Object> fragmentViewport :
+					(List<Map<String, Object>>)fragmentViewports) {
+
 				JSONObject jsonObject = JSONUtil.put(
 					(String)fragmentViewport.get("id"),
 					toFragmentViewportStylesJSONObject(fragmentViewport));
@@ -144,9 +143,10 @@ public class WidgetLayoutStructureItemImporter
 			}
 		}
 
-		if (definitionMap.containsKey("name")) {
-			fragmentStyledLayoutStructureItem.setName(
-				GetterUtil.getString(definitionMap.get("name")));
+		String name = GetterUtil.getString(definitionMap.get("name"), null);
+
+		if (name != null) {
+			fragmentStyledLayoutStructureItem.setName(name);
 		}
 
 		return fragmentStyledLayoutStructureItem;

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v3_3_0/LayoutPageTemplateStructureRelUpgradeProcess.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v3_3_0/LayoutPageTemplateStructureRelUpgradeProcess.java
@@ -54,11 +54,14 @@ public class LayoutPageTemplateStructureRelUpgradeProcess
 	}
 
 	private List<PortletPreferences> _getPortletPreferencesByPlid(long plid) {
-		if (_portletPreferencesMap.containsKey(plid)) {
-			return _portletPreferencesMap.get(plid);
+		List<PortletPreferences> portletPreferencesList =
+			_portletPreferencesMap.get(plid);
+
+		if (portletPreferencesList != null) {
+			return portletPreferencesList;
 		}
 
-		List<PortletPreferences> portletPreferencesList =
+		portletPreferencesList =
 			_portletPreferencesLocalService.getPortletPreferencesByPlid(plid);
 
 		_portletPreferencesMap.put(

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v3_4_2/LayoutPageTemplateStructureRelUpgradeProcess.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v3_4_2/LayoutPageTemplateStructureRelUpgradeProcess.java
@@ -85,9 +85,10 @@ public class LayoutPageTemplateStructureRelUpgradeProcess
 		String borderRadius = fragmentConfigValuesJSONObject.getString(
 			"borderRadius");
 
-		if (_borderRadiuses.containsKey(borderRadius)) {
-			stylesJSONObject.put(
-				"borderRadius", _borderRadiuses.get(borderRadius));
+		String borderRadiusValue = _borderRadiuses.get(borderRadius);
+
+		if (borderRadiusValue != null) {
+			stylesJSONObject.put("borderRadius", borderRadiusValue);
 		}
 	}
 
@@ -129,8 +130,10 @@ public class LayoutPageTemplateStructureRelUpgradeProcess
 		String shadowCssClass = fragmentConfigValuesJSONObject.getString(
 			"boxShadow");
 
-		if (_shadows.containsKey(shadowCssClass)) {
-			stylesJSONObject.put("shadow", _shadows.get(shadowCssClass));
+		String shadow = _shadows.get(shadowCssClass);
+
+		if (shadow != null) {
+			stylesJSONObject.put("shadow", shadow);
 		}
 	}
 

--- a/modules/apps/layout/layout-set-prototype-impl/src/main/java/com/liferay/layout/set/prototype/internal/helper/LayoutSetPrototypeHelperImpl.java
+++ b/modules/apps/layout/layout-set-prototype-impl/src/main/java/com/liferay/layout/set/prototype/internal/helper/LayoutSetPrototypeHelperImpl.java
@@ -248,12 +248,11 @@ public class LayoutSetPrototypeHelperImpl implements LayoutSetPrototypeHelper {
 			layoutPrototypeLayout.getTypeSettingsProperties();
 
 		if (newMergeFailCount == 0) {
-			if (prototypeTypeSettingsUnicodeProperties.containsKey(
-					Sites.MERGE_FAIL_COUNT)) {
-
+			String mergeFailCount =
 				prototypeTypeSettingsUnicodeProperties.remove(
 					Sites.MERGE_FAIL_COUNT);
 
+			if (mergeFailCount != null) {
 				updateLayoutPrototypeLayout = true;
 			}
 		}

--- a/modules/apps/marketplace/marketplace-store-web/src/main/java/com/liferay/marketplace/store/web/internal/portlet/MarketplaceStorePortlet.java
+++ b/modules/apps/marketplace/marketplace-store-web/src/main/java/com/liferay/marketplace/store/web/internal/portlet/MarketplaceStorePortlet.java
@@ -660,11 +660,9 @@ public class MarketplaceStorePortlet extends MVCPortlet {
 			"clientBuild",
 			new String[] {String.valueOf(MarketplaceConstants.CLIENT_BUILD)});
 
-		if (!parameterMap.containsKey("compatibility")) {
-			parameterMap.put(
-				"compatibility",
-				new String[] {String.valueOf(ReleaseInfo.getBuildNumber())});
-		}
+		parameterMap.putIfAbsent(
+			"compatibility",
+			new String[] {String.valueOf(ReleaseInfo.getBuildNumber())});
 
 		parameterMap.put(
 			"installedPatches", PatcherValues.INSTALLED_PATCH_NAMES);

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
@@ -438,9 +438,7 @@ public class OpenAPIUtil {
 			allOfSchemaMap.put("required", List.copyOf(requiredPropertyNames));
 		}
 
-		if (!allOfSchemaMap.containsKey("type")) {
-			allOfSchemaMap.put("type", "object");
-		}
+		allOfSchemaMap.putIfAbsent("type", "object");
 
 		_filterReadOnlyProperties(allOfSchemaMap);
 

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/dto/v1_0/util/ObjectFieldUtil.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/dto/v1_0/util/ObjectFieldUtil.java
@@ -118,9 +118,7 @@ public class ObjectFieldUtil {
 
 				String key = objectStateJSONObject.getString("key");
 
-				if (listTypeEntries.containsKey(key)) {
-					listTypeEntries.remove(key);
-
+				if (listTypeEntries.remove(key) != null) {
 					continue;
 				}
 
@@ -148,9 +146,7 @@ public class ObjectFieldUtil {
 		String defaultObjectFieldSettingValue = GetterUtil.getString(
 			defaultObjectFieldSettings[0].getValue());
 
-		if (listTypeEntries.containsKey(defaultObjectFieldSettingValue)) {
-			listTypeEntries.remove(defaultObjectFieldSettingValue);
-		}
+		listTypeEntries.remove(defaultObjectFieldSettingValue);
 
 		listTypeEntryLocalService.addListTypeEntry(
 			null, userId, listTypeDefinition.getListTypeDefinitionId(),

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/entry/util/ObjectEntryValuesUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/entry/util/ObjectEntryValuesUtil.java
@@ -52,14 +52,18 @@ public class ObjectEntryValuesUtil {
 		String siteDefaultLanguageId = LanguageUtil.getLanguageId(
 			LocaleUtil.getSiteDefault());
 
-		if (localizedValues.containsKey(siteDefaultLanguageId)) {
-			return localizedValues.get(siteDefaultLanguageId);
+		Object localizedValue = localizedValues.get(siteDefaultLanguageId);
+
+		if (localizedValue != null) {
+			return localizedValue;
 		}
 
-		if ((user != null) &&
-			localizedValues.containsKey(user.getLanguageId())) {
+		if (user != null) {
+			localizedValue = localizedValues.get(user.getLanguageId());
 
-			return localizedValues.get(user.getLanguageId());
+			if (localizedValue != null) {
+				return localizedValue;
+			}
 		}
 
 		return localizedValues.get(

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/entry/util/ObjectEntryValuesUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/entry/util/ObjectEntryValuesUtil.java
@@ -29,13 +29,17 @@ public class ObjectEntryValuesUtil {
 		String businessType, Map<String, Object> modelAttributes,
 		ObjectField objectField, User user, Map<String, ?> values) {
 
-		String objectFieldName = objectField.getName();
+		Map.Entry<String, ?> valueEntry = null;
 
-		if ((values == null) || !values.containsKey(objectFieldName)) {
+		if (values != null) {
+			valueEntry = MapUtil.getEntry(values, objectField.getName());
+		}
+
+		if (valueEntry == null) {
 			return modelAttributes.get(objectField.getDBColumnName());
 		}
 
-		Object value = values.get(objectFieldName);
+		Object value = valueEntry.getValue();
 
 		if (StringUtil.equals(
 				businessType, ObjectFieldConstants.BUSINESS_TYPE_BOOLEAN)) {

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/entity/v1_0/ObjectEntryEntityModel.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/entity/v1_0/ObjectEntryEntityModel.java
@@ -167,14 +167,14 @@ public class ObjectEntryEntityModel implements EntityModel {
 	private Map<String, EntityField> _getObjectDefinitionEntityFieldsMap(
 		ObjectDefinition objectDefinition) {
 
-		if (_entityFieldsMaps.containsKey(
-				objectDefinition.getObjectDefinitionId())) {
+		Map<String, EntityField> entityFieldsMap = _entityFieldsMaps.get(
+			objectDefinition.getObjectDefinitionId());
 
-			return _entityFieldsMaps.get(
-				objectDefinition.getObjectDefinitionId());
+		if (entityFieldsMap != null) {
+			return entityFieldsMap;
 		}
 
-		Map<String, EntityField> entityFieldsMap = _getStringEntityFieldsMap(
+		entityFieldsMap = _getStringEntityFieldsMap(
 			objectDefinition,
 			ObjectFieldLocalServiceUtil.getObjectFields(
 				objectDefinition.getObjectDefinitionId()));

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/action/util/ObjectEntryVariablesUtil.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/action/util/ObjectEntryVariablesUtil.java
@@ -227,11 +227,8 @@ public class ObjectEntryVariablesUtil {
 				objectDefinition.getObjectDefinitionId());
 
 		for (ObjectField objectField : objectFields) {
-			if (!allowedVariables.containsKey(objectField.getName())) {
-				allowedVariables.put(
-					objectField.getName(),
-					variables.get(objectField.getName()));
-			}
+			allowedVariables.putIfAbsent(
+				objectField.getName(), variables.get(objectField.getName()));
 		}
 
 		return allowedVariables;

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/field/business/type/RelationshipObjectFieldBusinessType.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/field/business/type/RelationshipObjectFieldBusinessType.java
@@ -167,8 +167,11 @@ public class RelationshipObjectFieldBusinessType
 
 		PortalException portalException1 = null;
 
-		if (values.containsKey(objectField.getName())) {
-			Object value = values.get(objectField.getName());
+		Map.Entry<String, Object> valueEntry = MapUtil.getEntry(
+			values, objectField.getName());
+
+		if (valueEntry != null) {
+			Object value = valueEntry.getValue();
 
 			if (value == null) {
 				return 0;

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/field/business/type/RelationshipObjectFieldBusinessType.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/field/business/type/RelationshipObjectFieldBusinessType.java
@@ -104,29 +104,29 @@ public class RelationshipObjectFieldBusinessType
 			1
 		);
 
+		Map.Entry<String, Object> relatedElementEntry = MapUtil.getEntry(
+			values, relationshipName);
+
 		if (Objects.equals(
 				objectField.getRelationshipType(),
 				ObjectRelationshipConstants.TYPE_ONE_TO_MANY) &&
-			values.containsKey(relationshipName)) {
+			(relatedElementEntry != null)) {
 
 			ObjectRelationship objectRelationship =
 				_objectRelationshipLocalService.
 					fetchObjectRelationshipByObjectDefinitionId(
 						objectField.getObjectDefinitionId(), relationshipName);
 
-			if (objectRelationship == null) {
-				return 0;
-			}
+			Object relatedElement = relatedElementEntry.getValue();
 
-			Object relatedElement = values.get(relationshipName);
+			if ((objectRelationship == null) ||
+				!(relatedElement instanceof Map)) {
 
-			if (!(relatedElement instanceof Map)) {
 				return 0;
 			}
 
 			String externalReferenceCode = MapUtil.getString(
-				(Map<String, Object>)values.get(relationshipName),
-				"externalReferenceCode");
+				(Map<String, Object>)relatedElement, "externalReferenceCode");
 
 			if (Validator.isNull(externalReferenceCode)) {
 				return 0;
@@ -226,9 +226,12 @@ public class RelationshipObjectFieldBusinessType
 					NAME_OBJECT_RELATIONSHIP_ERC_OBJECT_FIELD_NAME,
 				objectField);
 
-		if (values.containsKey(objectRelationshipERCObjectFieldName)) {
-			String externalReferenceCode = MapUtil.getString(
-				values, objectRelationshipERCObjectFieldName);
+		Map.Entry<String, Object> externalReferenceCodeEntry = MapUtil.getEntry(
+			values, objectRelationshipERCObjectFieldName);
+
+		if (externalReferenceCodeEntry != null) {
+			String externalReferenceCode = GetterUtil.getString(
+				externalReferenceCodeEntry.getValue());
 
 			if (Validator.isNull(externalReferenceCode)) {
 				return 0;

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/system/AddressSystemObjectDefinitionManager.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/system/AddressSystemObjectDefinitionManager.java
@@ -292,8 +292,10 @@ public class AddressSystemObjectDefinitionManager
 		Map<String, Object> variables = super.getVariables(
 			contentType, objectDefinition, oldValues, payloadJSONObject);
 
-		if (variables.containsKey("street1")) {
-			variables.put("streetAddressLine1", variables.get("street1"));
+		Object street1 = variables.get("street1");
+
+		if (street1 != null) {
+			variables.put("streetAddressLine1", street1);
 		}
 
 		return variables;

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/system/UserSystemObjectDefinitionManager.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/system/UserSystemObjectDefinitionManager.java
@@ -243,20 +243,28 @@ public class UserSystemObjectDefinitionManager
 		Map<String, Object> variables = super.getVariables(
 			contentType, objectDefinition, oldValues, payloadJSONObject);
 
-		if (variables.containsKey("firstName")) {
-			variables.put("givenName", variables.get("firstName"));
+		Object firstName = variables.get("firstName");
+
+		if (firstName != null) {
+			variables.put("givenName", firstName);
 		}
 
-		if (variables.containsKey("lastName")) {
-			variables.put("familyName", variables.get("lastName"));
+		Object lastName = variables.get("lastName");
+
+		if (lastName != null) {
+			variables.put("familyName", lastName);
 		}
 
-		if (variables.containsKey("middleName")) {
-			variables.put("additionalName", variables.get("middleName"));
+		Object middleName = variables.get("middleName");
+
+		if (middleName != null) {
+			variables.put("additionalName", middleName);
 		}
 
-		if (variables.containsKey("screenName")) {
-			variables.put("alternateName", variables.get("screenName"));
+		Object screenName = variables.get("screenName");
+
+		if (screenName != null) {
+			variables.put("alternateName", screenName);
 		}
 
 		return variables;

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemObjectProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemObjectProvider.java
@@ -90,10 +90,11 @@ public class ObjectEntryInfoItemObjectProvider
 		Map<InfoItemIdentifier, ObjectEntry> objectEntries = _getObjectEntries(
 			serviceContext.getRequest());
 
-		if (objectEntries.containsKey(ercInfoItemIdentifier)) {
+		ObjectEntry curObjectEntry = objectEntries.get(ercInfoItemIdentifier);
+
+		if (curObjectEntry != null) {
 			return _resolveLatestApprovedObjectEntry(
-				objectEntries.get(ercInfoItemIdentifier),
-				ercInfoItemIdentifier.getVersion());
+				curObjectEntry, ercInfoItemIdentifier.getVersion());
 		}
 
 		Group group = null;

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/updater/ObjectEntryInfoItemFieldValuesUpdater.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/updater/ObjectEntryInfoItemFieldValuesUpdater.java
@@ -44,6 +44,7 @@ import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
@@ -164,19 +165,25 @@ public class ObjectEntryInfoItemFieldValuesUpdater
 
 				dtoObjectEntry.setDisplayDate(
 					() -> {
-						if (curProperties.containsKey("displayDate")) {
+						Map.Entry<String, Object> displayDateEntry =
+							MapUtil.getEntry(curProperties, "displayDate");
+
+						if (displayDateEntry != null) {
 							return GetterUtil.getDate(
-								curProperties.get("displayDate"),
-								_dateTimeFormatter, null);
+								displayDateEntry.getValue(), _dateTimeFormatter,
+								null);
 						}
 
 						return objectEntry.getDisplayDate();
 					});
 				dtoObjectEntry.setExpirationDate(
 					() -> {
-						if (curProperties.containsKey("expirationDate")) {
+						Map.Entry<String, Object> expirationDateEntry =
+							MapUtil.getEntry(curProperties, "expirationDate");
+
+						if (expirationDateEntry != null) {
 							return GetterUtil.getDate(
-								curProperties.get("expirationDate"),
+								expirationDateEntry.getValue(),
 								_dateTimeFormatter, null);
 						}
 
@@ -184,10 +191,13 @@ public class ObjectEntryInfoItemFieldValuesUpdater
 					});
 				dtoObjectEntry.setReviewDate(
 					() -> {
-						if (curProperties.containsKey("reviewDate")) {
+						Map.Entry<String, Object> reviewDateEntry =
+							MapUtil.getEntry(curProperties, "reviewDate");
+
+						if (reviewDateEntry != null) {
 							return GetterUtil.getDate(
-								curProperties.get("reviewDate"),
-								_dateTimeFormatter, null);
+								reviewDateEntry.getValue(), _dateTimeFormatter,
+								null);
 						}
 
 						return objectEntry.getReviewDate();

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/util/ObjectEntryUtil.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/util/ObjectEntryUtil.java
@@ -357,7 +357,10 @@ public class ObjectEntryUtil {
 				objectDefinition.getObjectDefinitionId());
 
 		for (ObjectRelationship objectRelationship : objectRelationships) {
-			if (!fieldsMap.containsKey(objectRelationship.getName())) {
+			Map<String, Object> objectRelationshipValues = fieldsMap.get(
+				objectRelationship.getName());
+
+			if (objectRelationshipValues == null) {
 				continue;
 			}
 
@@ -369,13 +372,6 @@ public class ObjectEntryUtil {
 					objectDefinitionId);
 
 			if (relatedObjectDefinition == null) {
-				continue;
-			}
-
-			Map<String, Object> objectRelationshipValues = fieldsMap.get(
-				objectRelationship.getName());
-
-			if (objectRelationshipValues == null) {
 				continue;
 			}
 
@@ -425,17 +421,15 @@ public class ObjectEntryUtil {
 					Map<String, Object> childProperties =
 						(Map<String, Object>)entry.getValue();
 
-					if (!childProperties.containsKey("externalReferenceCode")) {
-						String externalReferenceCode = GetterUtil.getString(
-							entry.getKey());
+					String externalReferenceCode = GetterUtil.getString(
+						entry.getKey());
 
-						childProperties.put(
-							"externalReferenceCode", externalReferenceCode);
-					}
+					childProperties.putIfAbsent(
+						"externalReferenceCode", externalReferenceCode);
 
 					_addRelatedProperties(
-						fieldsMap, relatedObjectDefinition, entry.getKey(),
-						childProperties);
+						fieldsMap, relatedObjectDefinition,
+						externalReferenceCode, childProperties);
 
 					relatedProperties.add(childProperties);
 				}

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/util/ObjectEntryUtil.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/util/ObjectEntryUtil.java
@@ -399,12 +399,8 @@ public class ObjectEntryUtil {
 						String externalReferenceCode = GetterUtil.getString(
 							childEntry.getKey());
 
-						if (!childProperties.containsKey(
-								"externalReferenceCode")) {
-
-							childProperties.put(
-								"externalReferenceCode", externalReferenceCode);
-						}
+						childProperties.putIfAbsent(
+							"externalReferenceCode", externalReferenceCode);
 
 						_addRelatedProperties(
 							fieldsMap, relatedObjectDefinition,

--- a/modules/apps/portal-odata/portal-odata-impl/src/main/java/com/liferay/portal/odata/internal/filter/EntityModelSchemaBasedEdmProvider.java
+++ b/modules/apps/portal-odata/portal-odata-impl/src/main/java/com/liferay/portal/odata/internal/filter/EntityModelSchemaBasedEdmProvider.java
@@ -79,11 +79,14 @@ public class EntityModelSchemaBasedEdmProvider extends SchemaBasedEdmProvider {
 
 		ComplexEntityField complexEntityField = (ComplexEntityField)entityField;
 
-		if (_csdlComplexTypes.containsKey(complexEntityField.getTypeKey())) {
-			return _csdlComplexTypes.get(complexEntityField.getTypeKey());
+		CsdlComplexType csdlComplexType = _csdlComplexTypes.get(
+			complexEntityField.getTypeKey());
+
+		if (csdlComplexType != null) {
+			return csdlComplexType;
 		}
 
-		CsdlComplexType csdlComplexType = new CsdlComplexType();
+		csdlComplexType = new CsdlComplexType();
 
 		_csdlComplexTypes.put(complexEntityField.getTypeKey(), csdlComplexType);
 

--- a/modules/apps/portal-remote/portal-remote-cors-impl/src/main/java/com/liferay/portal/remote/cors/internal/configuration/admin/service/PortalCORSManagedServiceFactory.java
+++ b/modules/apps/portal-remote/portal-remote-cors-impl/src/main/java/com/liferay/portal/remote/cors/internal/configuration/admin/service/PortalCORSManagedServiceFactory.java
@@ -125,9 +125,7 @@ public class PortalCORSManagedServiceFactory implements ManagedServiceFactory {
 		for (String urlPattern :
 				portalCORSConfiguration.filterMappingURLPatterns()) {
 
-			if (!corsSupports.containsKey(urlPattern)) {
-				corsSupports.put(urlPattern, corsSupport);
-			}
+			corsSupports.putIfAbsent(urlPattern, corsSupport);
 		}
 	}
 

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/range/BaseRangeFacetPortletSharedSearchContributor.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/range/BaseRangeFacetPortletSharedSearchContributor.java
@@ -100,8 +100,10 @@ public abstract class BaseRangeFacetPortletSharedSearchContributor {
 		Map<String, String> rangesMap = _getRangesMap(rangesJSONArray);
 
 		for (String selectedRange : selectedRanges) {
-			if (rangesMap.containsKey(selectedRange)) {
-				selectedRangeStrings.add(rangesMap.get(selectedRange));
+			String selectedRangeString = rangesMap.get(selectedRange);
+
+			if (selectedRangeString != null) {
+				selectedRangeStrings.add(selectedRangeString);
 			}
 			else if (aggregationType.equals("dateRange")) {
 				String rangeString = DateRangeFactoryUtil.getRangeString(

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
@@ -2032,10 +2032,7 @@ public class LDAPUserImporterImpl implements LDAPUserImporter {
 			if (userGroup.isAddedByLDAPImport()) {
 				long userGroupId = userGroup.getUserGroupId();
 
-				if (userGroupIds.contains(userGroupId)) {
-					userGroupIds.remove(userGroupId);
-				}
-				else {
+				if (!userGroupIds.remove(userGroupId)) {
 					ExpandoColumn expandoColumn = _getOrAddExpandoColumn(
 						userGroup.getCompanyId());
 

--- a/modules/apps/portal-template/portal-template-velocity/src/main/java/com/liferay/portal/template/velocity/internal/LiferaySecureUberspector.java
+++ b/modules/apps/portal-template/portal-template-velocity/src/main/java/com/liferay/portal/template/velocity/internal/LiferaySecureUberspector.java
@@ -189,15 +189,15 @@ public class LiferaySecureUberspector extends SecureUberspector {
 	private void _checkMethodIsRestricted(Class<?> clazz, String methodName) {
 		String className = clazz.getName();
 
-		if (_restrictedMethodNames.containsKey(className)) {
-			Set<String> methodNames = _restrictedMethodNames.get(className);
+		Set<String> methodNames = _restrictedMethodNames.get(className);
 
-			if (methodNames.contains(StringUtil.toLowerCase(methodName))) {
-				throw new IllegalArgumentException(
-					StringBundler.concat(
-						"Denied access to method ", methodName, " of ",
-						clazz.getName()));
-			}
+		if ((methodNames != null) &&
+			methodNames.contains(StringUtil.toLowerCase(methodName))) {
+
+			throw new IllegalArgumentException(
+				StringBundler.concat(
+					"Denied access to method ", methodName, " of ",
+					clazz.getName()));
 		}
 	}
 

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/GroupUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/GroupUtil.java
@@ -70,16 +70,23 @@ public class GroupUtil {
 	}
 
 	public static String getScopeKey(Map<String, Serializable> parameters) {
-		if (parameters.containsKey("scopeKey")) {
-			return String.valueOf(parameters.get("scopeKey"));
+		Serializable scopeKey = parameters.get("scopeKey");
+
+		if (scopeKey != null) {
+			return String.valueOf(scopeKey);
 		}
 
-		if (parameters.containsKey("siteExternalReferenceCode")) {
-			return String.valueOf(parameters.get("siteExternalReferenceCode"));
+		Serializable siteExternalReferenceCode = parameters.get(
+			"siteExternalReferenceCode");
+
+		if (siteExternalReferenceCode != null) {
+			return String.valueOf(siteExternalReferenceCode);
 		}
 
-		if (parameters.containsKey("siteId")) {
-			return String.valueOf(parameters.get("siteId"));
+		Serializable siteId = parameters.get("siteId");
+
+		if (siteId != null) {
+			return String.valueOf(siteId);
 		}
 
 		return null;

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/LocalizedMapUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/LocalizedMapUtil.java
@@ -57,8 +57,10 @@ public class LocalizedMapUtil {
 		for (Locale locale : availableLocales) {
 			String languageId = LocaleUtil.toLanguageId(locale);
 
-			if (localizedMap.containsKey(languageId)) {
-				i18nMap.put(languageId, localizedMap.get(languageId));
+			String value = localizedMap.get(languageId);
+
+			if (value != null) {
+				i18nMap.put(languageId, value);
 			}
 		}
 

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
@@ -315,11 +315,11 @@ public class GraphQLServletExtender {
 
 				String registeredClassNamesKey = clazz.getName() + "_" + input;
 
-				if (_registeredClassNames.containsKey(
-						registeredClassNamesKey)) {
+				String registeredClassName = _registeredClassNames.get(
+					registeredClassNamesKey);
 
-					typeName = _registeredClassNames.get(
-						registeredClassNamesKey);
+				if (registeredClassName != null) {
+					typeName = registeredClassName;
 				}
 				else if (graphQLType != null) {
 					String name = clazz.getName();
@@ -980,8 +980,10 @@ public class GraphQLServletExtender {
 		}
 
 		synchronized (_servletDataServiceTrackerList) {
-			if (_servlets.containsKey(companyId)) {
-				return _servlets.get(companyId);
+			servlet = _servlets.get(companyId);
+
+			if (servlet != null) {
+				return servlet;
 			}
 
 			PropertyDataFetcher.clearReflectionCache();
@@ -1025,11 +1027,8 @@ public class GraphQLServletExtender {
 
 						Class<?> clazz = graphQLTypeExtension.value();
 
-						if (!classesMap.containsKey(clazz)) {
-							classesMap.put(clazz, new HashSet<>());
-						}
-
-						Set<Class<?>> classes = classesMap.get(clazz);
+						Set<Class<?>> classes = classesMap.computeIfAbsent(
+							clazz, key -> new HashSet<>());
 
 						classes.add(innerClasses);
 
@@ -1901,18 +1900,19 @@ public class GraphQLServletExtender {
 				_toGraphQLType(clazz.getComponentType(), graphQLTypes, input));
 		}
 
-		String key = (input ? "Input" : "") + clazz.getSimpleName();
+		GraphQLType graphQLType = graphQLTypes.get(
+			(input ? "Input" : "") + clazz.getSimpleName());
 
-		if (graphQLTypes.containsKey(key)) {
-			return graphQLTypes.get(key);
+		if (graphQLType != null) {
+			return graphQLType;
 		}
 
-		key =
+		graphQLType = graphQLTypes.get(
 			(input ? "Input" : "") +
-				StringUtil.replace(clazz.getName(), '.', '_');
+				StringUtil.replace(clazz.getName(), '.', '_'));
 
-		if (graphQLTypes.containsKey(key)) {
-			return graphQLTypes.get(key);
+		if (graphQLType != null) {
+			return graphQLType;
 		}
 
 		return _mapGraphQLScalarType;

--- a/modules/apps/portal-workflow/portal-workflow-api/src/main/java/com/liferay/portal/workflow/portlet/tab/BaseWorkflowPortletTab.java
+++ b/modules/apps/portal-workflow/portal-workflow-api/src/main/java/com/liferay/portal/workflow/portlet/tab/BaseWorkflowPortletTab.java
@@ -72,11 +72,7 @@ public abstract class BaseWorkflowPortletTab
 	protected Log getLog() {
 		Class<? extends BaseWorkflowPortletTab> clazz = getClass();
 
-		if (!_logs.containsKey(clazz)) {
-			_logs.put(clazz, LogFactoryUtil.getLog(clazz));
-		}
-
-		return _logs.get(clazz);
+		return _logs.computeIfAbsent(clazz, LogFactoryUtil::getLog);
 	}
 
 	private static final Map<Class<? extends BaseWorkflowPortletTab>, Log>

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/DefaultTaskManagerImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/DefaultTaskManagerImpl.java
@@ -414,11 +414,7 @@ public class DefaultTaskManagerImpl
 			for (Map.Entry<String, Serializable> entry :
 					storedWorkflowContext.entrySet()) {
 
-				String key = entry.getKey();
-
-				if (!workflowContext.containsKey(key)) {
-					workflowContext.put(key, entry.getValue());
-				}
+				workflowContext.putIfAbsent(entry.getKey(), entry.getValue());
 			}
 		}
 

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/manager/DefaultPortalKaleoManager.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/manager/DefaultPortalKaleoManager.java
@@ -72,12 +72,9 @@ public class DefaultPortalKaleoManager
 					Group companyGroup = groupLocalService.getCompanyGroup(
 						companyId);
 
-					String definitionName =
-						WorkflowDefinitionConstants.NAME_SINGLE_APPROVER;
-
-					if (_definitionAssets.containsKey(assetClassName)) {
-						definitionName = _definitionAssets.get(assetClassName);
-					}
+					String definitionName = _definitionAssets.getOrDefault(
+						assetClassName,
+						WorkflowDefinitionConstants.NAME_SINGLE_APPROVER);
 
 					ServiceContext serviceContext = new ServiceContext();
 

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/impl/KaleoInstanceLocalServiceImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/impl/KaleoInstanceLocalServiceImpl.java
@@ -107,13 +107,12 @@ public class KaleoInstanceLocalServiceImpl
 			(String)workflowContext.get(
 				WorkflowConstants.CONTEXT_ENTRY_CLASS_NAME));
 
-		if (workflowContext.containsKey(
-				WorkflowConstants.CONTEXT_ENTRY_CLASS_PK)) {
+		if (
+				workflowContext.get(
+					WorkflowConstants.CONTEXT_ENTRY_CLASS_PK) instanceof
+						String classPK) {
 
-			kaleoInstance.setClassPK(
-				GetterUtil.getLong(
-					(String)workflowContext.get(
-						WorkflowConstants.CONTEXT_ENTRY_CLASS_PK)));
+			kaleoInstance.setClassPK(GetterUtil.getLong(classPK));
 		}
 
 		kaleoInstance.setCompleted(false);

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/impl/KaleoInstanceTokenLocalServiceImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/impl/KaleoInstanceTokenLocalServiceImpl.java
@@ -92,13 +92,12 @@ public class KaleoInstanceTokenLocalServiceImpl
 			(String)workflowContext.get(
 				WorkflowConstants.CONTEXT_ENTRY_CLASS_NAME));
 
-		if (workflowContext.containsKey(
-				WorkflowConstants.CONTEXT_ENTRY_CLASS_PK)) {
+		if (
+				workflowContext.get(
+					WorkflowConstants.CONTEXT_ENTRY_CLASS_PK) instanceof
+						String classPK) {
 
-			kaleoInstanceToken.setClassPK(
-				GetterUtil.getLong(
-					(String)workflowContext.get(
-						WorkflowConstants.CONTEXT_ENTRY_CLASS_PK)));
+			kaleoInstanceToken.setClassPK(GetterUtil.getLong(classPK));
 		}
 
 		kaleoInstanceToken.setCompleted(false);

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/impl/KaleoTaskInstanceTokenLocalServiceImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/impl/KaleoTaskInstanceTokenLocalServiceImpl.java
@@ -125,13 +125,12 @@ public class KaleoTaskInstanceTokenLocalServiceImpl
 				(String)workflowContext.get(
 					WorkflowConstants.CONTEXT_ENTRY_CLASS_NAME));
 
-			if (workflowContext.containsKey(
-					WorkflowConstants.CONTEXT_ENTRY_CLASS_PK)) {
+			if (
+					workflowContext.get(
+						WorkflowConstants.CONTEXT_ENTRY_CLASS_PK) instanceof
+							String classPK) {
 
-				kaleoTaskInstanceToken.setClassPK(
-					GetterUtil.getLong(
-						(String)workflowContext.get(
-							WorkflowConstants.CONTEXT_ENTRY_CLASS_PK)));
+				kaleoTaskInstanceToken.setClassPK(GetterUtil.getLong(classPK));
 			}
 		}
 

--- a/modules/apps/portal/portal-http-impl/src/main/java/com/liferay/portal/http/internal/HttpImpl.java
+++ b/modules/apps/portal/portal-http-impl/src/main/java/com/liferay/portal/http/internal/HttpImpl.java
@@ -410,9 +410,10 @@ public class HttpImpl implements Http {
 			MultipartEntityBuilder multipartEntityBuilder =
 				MultipartEntityBuilder.create();
 
-			if (headers.containsKey(HttpHeaders.CONTENT_TYPE)) {
-				ContentType contentType = ContentType.parse(
-					headers.get(HttpHeaders.CONTENT_TYPE));
+			String contentTypeValue = headers.get(HttpHeaders.CONTENT_TYPE);
+
+			if (contentTypeValue != null) {
+				ContentType contentType = ContentType.parse(contentTypeValue);
 
 				String boundary = contentType.getParameter("boundary");
 

--- a/modules/apps/portal/portal-json-web-service-client/src/main/java/com/liferay/portal/json/web/service/client/internal/JSONWebServiceClientImpl.java
+++ b/modules/apps/portal/portal-json-web-service-client/src/main/java/com/liferay/portal/json/web/service/client/internal/JSONWebServiceClientImpl.java
@@ -63,9 +63,10 @@ public class JSONWebServiceClientImpl extends BaseJSONWebServiceClientImpl {
 			setProxyPassword(getString("proxyPassword", properties));
 		}
 
-		if (properties.containsKey("trustSelfSignedCertificates")) {
-			setTrustSelfSignedCertificates(
-				(boolean)properties.get("trustSelfSignedCertificates"));
+		if (properties.get("trustSelfSignedCertificates") instanceof
+				Boolean trustSelfSignedCertificates) {
+
+			setTrustSelfSignedCertificates(trustSelfSignedCertificates);
 		}
 
 		afterPropertiesSet();

--- a/modules/apps/portal/portal-json-web-service-client/src/main/java/com/liferay/portal/json/web/service/client/internal/JSONWebServiceClientImpl.java
+++ b/modules/apps/portal/portal-json-web-service-client/src/main/java/com/liferay/portal/json/web/service/client/internal/JSONWebServiceClientImpl.java
@@ -73,11 +73,13 @@ public class JSONWebServiceClientImpl extends BaseJSONWebServiceClientImpl {
 	}
 
 	protected String getString(String key, Map<String, Object> properties) {
-		if (!properties.containsKey(key)) {
+		Object value = properties.get(key);
+
+		if (value == null) {
 			return null;
 		}
 
-		return String.valueOf(properties.get(key));
+		return String.valueOf(value);
 	}
 
 	@Override

--- a/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/java/com/liferay/portlet/configuration/css/web/internal/portlet/PortletConfigurationCSSPortlet.java
+++ b/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/java/com/liferay/portlet/configuration/css/web/internal/portlet/PortletConfigurationCSSPortlet.java
@@ -108,11 +108,7 @@ public class PortletConfigurationCSSPortlet extends MVCPortlet {
 		for (Locale locale : locales) {
 			String languageId = LocaleUtil.toLanguageId(locale);
 
-			String title = null;
-
-			if (customTitleMap.containsKey(locale)) {
-				title = customTitleMap.get(locale);
-			}
+			String title = customTitleMap.get(locale);
 
 			String rootPortletId = PortletIdCodec.decodePortletName(portletId);
 

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/java/com/liferay/portlet/configuration/web/internal/portlet/action/ActionUtil.java
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/java/com/liferay/portlet/configuration/web/internal/portlet/action/ActionUtil.java
@@ -88,11 +88,7 @@ public class ActionUtil {
 			for (PublicRenderParameter publicRenderParameter :
 					portlet.getPublicRenderParameters()) {
 
-				if (!identifiers.contains(
-						publicRenderParameter.getIdentifier())) {
-
-					identifiers.add(publicRenderParameter.getIdentifier());
-
+				if (identifiers.add(publicRenderParameter.getIdentifier())) {
 					publicRenderParameters.add(publicRenderParameter);
 				}
 			}

--- a/modules/apps/product-navigation/product-navigation-personal-menu-web/src/main/java/com/liferay/product/navigation/personal/menu/web/internal/configuration/PersonalMenuConfigurationRegistryImpl.java
+++ b/modules/apps/product-navigation/product-navigation-personal-menu-web/src/main/java/com/liferay/product/navigation/personal/menu/web/internal/configuration/PersonalMenuConfigurationRegistryImpl.java
@@ -40,11 +40,8 @@ public class PersonalMenuConfigurationRegistryImpl
 	public PersonalMenuConfiguration getCompanyPersonalMenuConfiguration(
 		long companyId) {
 
-		if (_companyPersonalMenuConfigurations.containsKey(companyId)) {
-			return _companyPersonalMenuConfigurations.get(companyId);
-		}
-
-		return _systemPersonalMenuConfiguration;
+		return _companyPersonalMenuConfigurations.getOrDefault(
+			companyId, _systemPersonalMenuConfiguration);
 	}
 
 	@Activate
@@ -75,9 +72,9 @@ public class PersonalMenuConfigurationRegistryImpl
 	}
 
 	private void _unmapPid(String pid) {
-		if (_companyIds.containsKey(pid)) {
-			long companyId = _companyIds.remove(pid);
+		Long companyId = _companyIds.remove(pid);
 
+		if (companyId != null) {
 			_companyPersonalMenuConfigurations.remove(companyId);
 		}
 	}

--- a/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/internal/provider/RedirectProviderImpl.java
+++ b/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/internal/provider/RedirectProviderImpl.java
@@ -174,9 +174,9 @@ public class RedirectProviderImpl implements RedirectProvider {
 	}
 
 	private void _unmapPid(String pid) {
-		if (_groupIds.containsKey(pid)) {
-			Long groupId = _groupIds.remove(pid);
+		Long groupId = _groupIds.remove(pid);
 
+		if (groupId != null) {
 			_redirectPatternEntries.remove(groupId);
 		}
 	}

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/configuration/SharingConfigurationFactoryImpl.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/configuration/SharingConfigurationFactoryImpl.java
@@ -144,9 +144,11 @@ public class SharingConfigurationFactoryImpl
 			UnicodeProperties typeSettingsUnicodeProperties =
 				_group.getTypeSettingsProperties();
 
-			if (typeSettingsUnicodeProperties.containsKey("sharingEnabled")) {
-				return GetterUtil.getBoolean(
-					typeSettingsUnicodeProperties.get("sharingEnabled"));
+			String sharingEnabled = typeSettingsUnicodeProperties.get(
+				"sharingEnabled");
+
+			if (sharingEnabled != null) {
+				return GetterUtil.getBoolean(sharingEnabled);
 			}
 
 			if (_sharingGroupConfiguration == null) {

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
@@ -2765,9 +2765,8 @@ public class BundleSiteInitializer implements SiteInitializer {
 		Locale siteDefaultLocale = _portal.getSiteDefaultLocale(
 			serviceContext.getScopeGroupId());
 
-		if (!nameMap.containsKey(siteDefaultLocale)) {
-			nameMap.put(siteDefaultLocale, pageJSONObject.getString("name"));
-		}
+		nameMap.putIfAbsent(
+			siteDefaultLocale, pageJSONObject.getString("name"));
 
 		String type = StringUtil.toLowerCase(pageJSONObject.getString("type"));
 
@@ -2785,10 +2784,8 @@ public class BundleSiteInitializer implements SiteInitializer {
 			SiteInitializerUtil.toMap(
 				pageJSONObject.getString("friendlyURL_i18n")));
 
-		if (!friendlyURLMap.containsKey(siteDefaultLocale)) {
-			friendlyURLMap.put(
-				siteDefaultLocale, pageJSONObject.getString("friendlyURL"));
-		}
+		friendlyURLMap.putIfAbsent(
+			siteDefaultLocale, pageJSONObject.getString("friendlyURL"));
 
 		UnicodeProperties unicodeProperties = new UnicodeProperties(true);
 

--- a/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/util/SitesImpl.java
+++ b/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/util/SitesImpl.java
@@ -254,10 +254,8 @@ public class SitesImpl implements Sites {
 		UnicodeProperties prototypeTypeSettingsUnicodeProperties =
 			layoutPrototypeLayout.getTypeSettingsProperties();
 
-		if (prototypeTypeSettingsUnicodeProperties.containsKey(
-				MERGE_FAIL_COUNT)) {
-
-			prototypeTypeSettingsUnicodeProperties.remove(MERGE_FAIL_COUNT);
+		if (prototypeTypeSettingsUnicodeProperties.remove(MERGE_FAIL_COUNT) !=
+				null) {
 
 			_layoutLocalService.updateLayout(layoutPrototypeLayout);
 		}

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-servlet-context-helper-impl/src/main/java/com/liferay/portal/osgi/web/servlet/context/helper/internal/definition/WebXMLDefinitionLoader.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-servlet-context-helper-impl/src/main/java/com/liferay/portal/osgi/web/servlet/context/helper/internal/definition/WebXMLDefinitionLoader.java
@@ -630,11 +630,8 @@ public class WebXMLDefinitionLoader extends DefaultHandler {
 		for (Map.Entry<String, String> entry :
 				fragmentContextParameters.entrySet()) {
 
-			String name = entry.getKey();
-
-			if (!assembledContextParameters.containsKey(name)) {
-				assembledContextParameters.put(name, entry.getValue());
-			}
+			assembledContextParameters.putIfAbsent(
+				entry.getKey(), entry.getValue());
 		}
 	}
 
@@ -649,9 +646,11 @@ public class WebXMLDefinitionLoader extends DefaultHandler {
 
 			String filterName = entry.getKey();
 
-			if (!assembledFilterDefinitions.containsKey(filterName)) {
-				assembledFilterDefinitions.put(filterName, entry.getValue());
+			FilterDefinition curFilterDefinition =
+				assembledFilterDefinitions.putIfAbsent(
+					filterName, entry.getValue());
 
+			if (curFilterDefinition == null) {
 				continue;
 			}
 
@@ -774,9 +773,11 @@ public class WebXMLDefinitionLoader extends DefaultHandler {
 
 			String servletName = entry.getKey();
 
-			if (!assembledServletDefinitions.containsKey(servletName)) {
-				assembledServletDefinitions.put(servletName, entry.getValue());
+			ServletDefinition curServletDefinition =
+				assembledServletDefinitions.putIfAbsent(
+					servletName, entry.getValue());
 
+			if (curServletDefinition == null) {
 				continue;
 			}
 

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/registration/ServletRegistrationImpl.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/registration/ServletRegistrationImpl.java
@@ -24,9 +24,7 @@ public class ServletRegistrationImpl implements ServletRegistration.Dynamic {
 	@Override
 	public Set<String> addMapping(String... urlPatterns) {
 		for (String urlPattern : urlPatterns) {
-			if (!_mappings.contains(urlPattern)) {
-				_mappings.add(urlPattern);
-			}
+			_mappings.add(urlPattern);
 		}
 
 		return new HashSet<>();

--- a/modules/apps/template/template-service/src/main/java/com/liferay/template/internal/info/field/transformer/DateInfoFieldTypeTemplateNodeTransformer.java
+++ b/modules/apps/template/template-service/src/main/java/com/liferay/template/internal/info/field/transformer/DateInfoFieldTypeTemplateNodeTransformer.java
@@ -127,13 +127,14 @@ public class DateInfoFieldTypeTemplateNodeTransformer
 	}
 
 	private String _getDefaultPattern(Locale locale) {
-		if (_defaultPatterns.containsKey(locale)) {
-			return _defaultPatterns.get(locale);
+		String defaultPattern = _defaultPatterns.get(locale);
+
+		if (defaultPattern != null) {
+			return defaultPattern;
 		}
 
-		String defaultPattern =
-			DateTimeFormatterBuilder.getLocalizedDateTimePattern(
-				FormatStyle.SHORT, null, IsoChronology.INSTANCE, locale);
+		defaultPattern = DateTimeFormatterBuilder.getLocalizedDateTimePattern(
+			FormatStyle.SHORT, null, IsoChronology.INSTANCE, locale);
 
 		_defaultPatterns.put(locale, defaultPattern);
 
@@ -141,18 +142,20 @@ public class DateInfoFieldTypeTemplateNodeTransformer
 	}
 
 	private String _getShortTimeStylePattern(Locale locale) {
-		if (_shortTimeStylePatterns.containsKey(locale)) {
-			return _shortTimeStylePatterns.get(locale);
+		String shortTimeStylePattern = _shortTimeStylePatterns.get(locale);
+
+		if (shortTimeStylePattern != null) {
+			return shortTimeStylePattern;
 		}
 
-		String sortTimeStylePattern =
+		shortTimeStylePattern =
 			DateTimeFormatterBuilder.getLocalizedDateTimePattern(
 				FormatStyle.SHORT, FormatStyle.SHORT, IsoChronology.INSTANCE,
 				locale);
 
-		_shortTimeStylePatterns.put(locale, sortTimeStylePattern);
+		_shortTimeStylePatterns.put(locale, shortTimeStylePattern);
 
-		return sortTimeStylePattern;
+		return shortTimeStylePattern;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/template/template-service/src/main/java/com/liferay/template/internal/info/field/transformer/SelectInfoFieldTypeTemplateNodeTransformer.java
+++ b/modules/apps/template/template-service/src/main/java/com/liferay/template/internal/info/field/transformer/SelectInfoFieldTypeTemplateNodeTransformer.java
@@ -56,11 +56,7 @@ public class SelectInfoFieldTypeTemplateNodeTransformer
 
 		String key = selectedOptionValuesJSONArray.getString(0);
 
-		if (optionsMap.containsKey(key)) {
-			return optionsMap.get(key);
-		}
-
-		return StringPool.BLANK;
+		return optionsMap.getOrDefault(key, StringPool.BLANK);
 	}
 
 	@Override

--- a/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/display/context/ExportTranslationDisplayContext.java
+++ b/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/display/context/ExportTranslationDisplayContext.java
@@ -188,12 +188,7 @@ public class ExportTranslationDisplayContext {
 			availableSourceLocales.add(LocaleUtil.fromLanguageId(languageId));
 		}
 
-		if (!availableSourceLocales.contains(
-				PortalUtil.getSiteDefaultLocale(_groupId))) {
-
-			availableSourceLocales.add(
-				PortalUtil.getSiteDefaultLocale(_groupId));
-		}
+		availableSourceLocales.add(PortalUtil.getSiteDefaultLocale(_groupId));
 
 		return availableSourceLocales;
 	}

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/dao/search/UADHierarchyResultRowSplitter.java
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/dao/search/UADHierarchyResultRowSplitter.java
@@ -43,10 +43,10 @@ public class UADHierarchyResultRowSplitter implements ResultRowSplitter {
 		for (ResultRow resultRow : resultRows) {
 			UADEntity<?> uadEntity = (UADEntity<?>)resultRow.getObject();
 
-			if (classResultRowsMap.containsKey(uadEntity.getTypeKey())) {
-				List<ResultRow> classResultRows = classResultRowsMap.get(
-					uadEntity.getTypeKey());
+			List<ResultRow> classResultRows = classResultRowsMap.get(
+				uadEntity.getTypeKey());
 
+			if (classResultRows != null) {
 				classResultRows.add(resultRow);
 			}
 		}

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/display/UADHierarchyDisplay.java
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/display/UADHierarchyDisplay.java
@@ -479,11 +479,8 @@ public class UADHierarchyDisplay {
 		Map<String, List<Serializable>> entitiesMap,
 		List<Serializable> entities, String typeKey) {
 
-		if (!entitiesMap.containsKey(typeKey)) {
-			entitiesMap.put(typeKey, new ArrayList<>());
-		}
-
-		List<Serializable> entitiesList = entitiesMap.get(typeKey);
+		List<Serializable> entitiesList = entitiesMap.computeIfAbsent(
+			typeKey, key -> new ArrayList<>());
 
 		entitiesList.addAll(entities);
 	}

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/portlet/action/BaseUADMVCActionCommand.java
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/portlet/action/BaseUADMVCActionCommand.java
@@ -229,10 +229,11 @@ public abstract class BaseUADMVCActionCommand extends BaseMVCActionCommand {
 		Map<Class<?>, String> exceptionMessageMap =
 			uadAnonymizer.getExceptionMessageMap(themeDisplay.getLocale());
 
-		if (exceptionMessageMap.containsKey(exception.getClass())) {
+		String exceptionMessage = exceptionMessageMap.get(exception.getClass());
+
+		if (exceptionMessage != null) {
 			SessionErrors.add(
-				actionRequest, "deleteUADEntityException",
-				exceptionMessageMap.get(exception.getClass()));
+				actionRequest, "deleteUADEntityException", exceptionMessage);
 
 			String redirect = ParamUtil.getString(actionRequest, "redirect");
 

--- a/modules/apps/wiki/wiki-engine-creole/src/main/java/com/liferay/wiki/engine/creole/internal/antlrwiki/translator/XhtmlTranslator.java
+++ b/modules/apps/wiki/wiki-engine-creole/src/main/java/com/liferay/wiki/engine/creole/internal/antlrwiki/translator/XhtmlTranslator.java
@@ -309,8 +309,10 @@ public class XhtmlTranslator extends XhtmlTranslationVisitor {
 
 		String postfix = StringPool.BLANK;
 
-		if (textCounts.containsKey(text)) {
-			postfix = StringPool.DASH + textCounts.get(text);
+		Integer textCount = textCounts.get(text);
+
+		if (textCount != null) {
+			postfix = StringPool.DASH + textCount;
 		}
 
 		return StringUtil.replace(

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiPageLocalServiceImpl.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiPageLocalServiceImpl.java
@@ -1226,9 +1226,7 @@ public class WikiPageLocalServiceImpl extends WikiPageLocalServiceBaseImpl {
 			if (exists) {
 				WikiPage curPage = getPage(nodeId, curTitle);
 
-				if (!pages.containsKey(curPage.getTitle())) {
-					pages.put(curPage.getTitle(), curPage);
-				}
+				pages.putIfAbsent(curPage.getTitle(), curPage);
 			}
 			else {
 				WikiPageImpl wikiPageImpl = new WikiPageImpl();
@@ -1237,9 +1235,7 @@ public class WikiPageLocalServiceImpl extends WikiPageLocalServiceBaseImpl {
 				wikiPageImpl.setNodeId(nodeId);
 				wikiPageImpl.setTitle(curTitle);
 
-				if (!pages.containsKey(curTitle)) {
-					pages.put(curTitle, wikiPageImpl);
-				}
+				pages.putIfAbsent(curTitle, wikiPageImpl);
 			}
 		}
 

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/agent/util/AgentUtil.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/agent/util/AgentUtil.java
@@ -60,8 +60,8 @@ public class AgentUtil {
 		Map<String, Serializable> workflowContext = defaultNoticeableFuture.get(
 			1, TimeUnit.MINUTES);
 
-		if (workflowContext.containsKey("exception")) {
-			throw (Exception)workflowContext.get("exception");
+		if (workflowContext.get("exception") instanceof Exception exception) {
+			throw exception;
 		}
 
 		return MapUtil.getString(workflowContext, "output");

--- a/modules/dxp/apps/osb/osb-patcher/osb-patcher-api/src/main/java/com/liferay/osb/patcher/util/PatcherBuildUtil.java
+++ b/modules/dxp/apps/osb/osb-patcher/osb-patcher-api/src/main/java/com/liferay/osb/patcher/util/PatcherBuildUtil.java
@@ -1154,19 +1154,12 @@ public class PatcherBuildUtil {
 		}
 
 		for (PatcherFix rebasePatcherFix : rebasePatcherFixes) {
-			List<Long> patcherFixIds = new ArrayList<>();
-
-			if (patcherProjectVersionIdPatcherFixIdsMap.containsKey(
-					rebasePatcherFix.getPatcherProjectVersionId())) {
-
-				patcherFixIds = patcherProjectVersionIdPatcherFixIdsMap.get(
-					rebasePatcherFix.getPatcherProjectVersionId());
-			}
+			List<Long> patcherFixIds =
+				patcherProjectVersionIdPatcherFixIdsMap.computeIfAbsent(
+					rebasePatcherFix.getPatcherProjectVersionId(),
+					key -> new ArrayList<>());
 
 			patcherFixIds.add(rebasePatcherFix.getPatcherFixId());
-
-			patcherProjectVersionIdPatcherFixIdsMap.put(
-				rebasePatcherFix.getPatcherProjectVersionId(), patcherFixIds);
 		}
 
 		return patcherProjectVersionIdPatcherFixIdsMap;

--- a/modules/dxp/apps/osb/osb-patcher/osb-patcher-api/src/main/java/com/liferay/osb/patcher/util/PatcherFixRadix.java
+++ b/modules/dxp/apps/osb/osb-patcher/osb-patcher-api/src/main/java/com/liferay/osb/patcher/util/PatcherFixRadix.java
@@ -6,8 +6,8 @@
 package com.liferay.osb.patcher.util;
 
 import com.liferay.osb.patcher.model.PatcherFix;
-import com.liferay.portal.kernel.util.ListUtil;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -22,24 +22,18 @@ public class PatcherFixRadix {
 			_currentBucket = bucket;
 		}
 
-		if (!_map.containsKey(bucket)) {
-			_map.put(bucket, ListUtil.fromArray(patcherFix));
-		}
-		else {
-			List<PatcherFix> patcherFixes = _map.get(bucket);
+		List<PatcherFix> patcherFixes = _map.computeIfAbsent(
+			bucket, key -> new ArrayList<>());
 
-			patcherFixes.add(patcherFix);
-		}
+		patcherFixes.add(patcherFix);
 	}
 
 	public PatcherFix getPatcherFix() {
 		while (_currentBucket > 0) {
-			if (_map.containsKey(_currentBucket)) {
-				List<PatcherFix> patcherFixes = _map.get(_currentBucket);
+			List<PatcherFix> patcherFixes = _map.get(_currentBucket);
 
-				if (!patcherFixes.isEmpty()) {
-					return patcherFixes.remove(0);
-				}
+			if ((patcherFixes != null) && !patcherFixes.isEmpty()) {
+				return patcherFixes.remove(0);
 			}
 
 			_currentBucket--;

--- a/modules/dxp/apps/osb/osb-patcher/osb-patcher-api/src/main/java/com/liferay/osb/patcher/util/PatcherFixUtil.java
+++ b/modules/dxp/apps/osb/osb-patcher/osb-patcher-api/src/main/java/com/liferay/osb/patcher/util/PatcherFixUtil.java
@@ -270,17 +270,11 @@ public class PatcherFixUtil {
 
 			String dependentComponentName = componentNames[0];
 
-			Set<String> prerequisiteComponentNames = new HashSet<>();
-
-			if (componentDependencies.containsKey(dependentComponentName)) {
-				prerequisiteComponentNames = componentDependencies.get(
-					dependentComponentName);
-			}
+			Set<String> prerequisiteComponentNames =
+				componentDependencies.computeIfAbsent(
+					dependentComponentName, key -> new HashSet<>());
 
 			prerequisiteComponentNames.add(componentNames[1]);
-
-			componentDependencies.put(
-				dependentComponentName, prerequisiteComponentNames);
 		}
 
 		return componentDependencies;
@@ -580,28 +574,32 @@ public class PatcherFixUtil {
 			statusPatcherFixMap.put(patcherFix.getStatus(), patcherFix);
 		}
 
-		if (statusPatcherFixMap.containsKey(
-				WorkflowConstants.STATUS_FIX_REBASE_CONFLICT)) {
+		PatcherFix patcherFix = statusPatcherFixMap.get(
+			WorkflowConstants.STATUS_FIX_REBASE_CONFLICT);
 
-			return statusPatcherFixMap.get(
-				WorkflowConstants.STATUS_FIX_REBASE_CONFLICT);
+		if (patcherFix != null) {
+			return patcherFix;
 		}
-		else if (statusPatcherFixMap.containsKey(
-					WorkflowConstants.STATUS_FIX_REBASING)) {
 
-			return statusPatcherFixMap.get(
-				WorkflowConstants.STATUS_FIX_REBASING);
+		patcherFix = statusPatcherFixMap.get(
+			WorkflowConstants.STATUS_FIX_REBASING);
+
+		if (patcherFix != null) {
+			return patcherFix;
 		}
-		else if (statusPatcherFixMap.containsKey(
-					WorkflowConstants.STATUS_FIX_CONFLICT)) {
 
-			return statusPatcherFixMap.get(
-				WorkflowConstants.STATUS_FIX_CONFLICT);
+		patcherFix = statusPatcherFixMap.get(
+			WorkflowConstants.STATUS_FIX_CONFLICT);
+
+		if (patcherFix != null) {
+			return patcherFix;
 		}
-		else if (statusPatcherFixMap.containsKey(
-					WorkflowConstants.STATUS_FIX_ADDING)) {
 
-			return statusPatcherFixMap.get(WorkflowConstants.STATUS_FIX_ADDING);
+		patcherFix = statusPatcherFixMap.get(
+			WorkflowConstants.STATUS_FIX_ADDING);
+
+		if (patcherFix != null) {
+			return patcherFix;
 		}
 
 		return statusPatcherFixMap.get(WorkflowConstants.STATUS_FIX_COMPLETE);

--- a/modules/dxp/apps/osb/osb-patcher/osb-patcher-api/src/main/java/com/liferay/osb/patcher/util/PatcherScanUtil.java
+++ b/modules/dxp/apps/osb/osb-patcher/osb-patcher-api/src/main/java/com/liferay/osb/patcher/util/PatcherScanUtil.java
@@ -578,15 +578,11 @@ public class PatcherScanUtil {
 
 			foundPatcherFixTickets.removeAll(missingTickets);
 
-			if (patcherFixPackFixNamePatcherFixPackFixMap.containsKey(
-					StringUtil.merge(
-						foundPatcherFixTickets, StringPool.COMMA))) {
+			PatcherFix patcherFixPackFix =
+				patcherFixPackFixNamePatcherFixPackFixMap.get(
+					StringUtil.merge(foundPatcherFixTickets, StringPool.COMMA));
 
-				PatcherFix patcherFixPackFix =
-					patcherFixPackFixNamePatcherFixPackFixMap.get(
-						StringUtil.merge(
-							foundPatcherFixTickets, StringPool.COMMA));
-
+			if (patcherFixPackFix != null) {
 				patcherFixPackFixIds.remove(
 					patcherFixPackFix.getPatcherFixId());
 

--- a/modules/dxp/apps/osb/osb-patcher/osb-patcher-web/src/main/java/com/liferay/osb/patcher/web/internal/validator/PatcherFixValidator.java
+++ b/modules/dxp/apps/osb/osb-patcher/osb-patcher-web/src/main/java/com/liferay/osb/patcher/web/internal/validator/PatcherFixValidator.java
@@ -396,25 +396,13 @@ public class PatcherFixValidator {
 				continue;
 			}
 
-			Set<String> patcherFixComponentNameDependencies = new HashSet<>();
+			Set<String> patcherFixComponentNameDependencies =
+				patcherFixComponentDependencies.getOrDefault(
+					patcherFixComponent.getName(), Collections.emptySet());
 
-			if (patcherFixComponentDependencies.containsKey(
-					patcherFixComponent.getName())) {
-
-				patcherFixComponentNameDependencies =
-					patcherFixComponentDependencies.get(
-						patcherFixComponent.getName());
-			}
-
-			Set<String> requestComponentNameDependencies = new HashSet<>();
-
-			if (requestComponentDependencies.containsKey(
-					patcherFixComponent.getName())) {
-
-				requestComponentNameDependencies =
-					requestComponentDependencies.get(
-						patcherFixComponent.getName());
-			}
+			Set<String> requestComponentNameDependencies =
+				requestComponentDependencies.getOrDefault(
+					patcherFixComponent.getName(), Collections.emptySet());
 
 			if (!requestComponentNameDependencies.equals(
 					patcherFixComponentNameDependencies)) {

--- a/modules/dxp/apps/osb/osb-patcher/osb-patcher-web/src/main/java/com/liferay/osb/patcher/web/internal/validator/PatcherFixValidator.java
+++ b/modules/dxp/apps/osb/osb-patcher/osb-patcher-web/src/main/java/com/liferay/osb/patcher/web/internal/validator/PatcherFixValidator.java
@@ -373,16 +373,13 @@ public class PatcherFixValidator {
 				PatcherFixPackLocalServiceUtil.getPatcherFixPack(
 					patcherFixPackId);
 
-			if (patcherFixComponentIds.contains(
+			if (!patcherFixComponentIds.add(
 					patcherFixPack.getPatcherFixComponentId())) {
 
 				throw new PortalException(
 					"the-fix-cannot-be-in-multiple-fix-packs-with-the-same-" +
 						"component");
 			}
-
-			patcherFixComponentIds.add(
-				patcherFixPack.getPatcherFixComponentId());
 
 			PatcherFixComponent patcherFixComponent =
 				PatcherFixComponentLocalServiceUtil.getPatcherFixComponent(

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/helper/WorkflowMetricsRESTTestHelper.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/helper/WorkflowMetricsRESTTestHelper.java
@@ -1372,8 +1372,10 @@ public class WorkflowMetricsRESTTestHelper {
 	}
 
 	private Object _getIndexer(String className) throws Exception {
-		if (_indexers.containsKey(className)) {
-			return _indexers.get(className);
+		Object indexer = _indexers.get(className);
+
+		if (indexer != null) {
+			return indexer;
 		}
 
 		Bundle bundle = FrameworkUtil.getBundle(
@@ -1405,7 +1407,7 @@ public class WorkflowMetricsRESTTestHelper {
 		}
 		while (serviceReference == null);
 
-		Object indexer = bundleContext.getService(serviceReference);
+		indexer = bundleContext.getService(serviceReference);
 
 		_indexers.put(className, indexer);
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/sla/processor/WorkflowMetricsSLAProcessor.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/sla/processor/WorkflowMetricsSLAProcessor.java
@@ -355,13 +355,14 @@ public class WorkflowMetricsSLAProcessor {
 				}
 			}
 
-			if (startTimeMarkers.containsKey(nodeId)) {
-				if (Objects.equals(startTimeMarkers.get(nodeId), "enter")) {
+			String startTimeMarker = startTimeMarkers.get(nodeId);
+
+			if (startTimeMarker != null) {
+				if (Objects.equals(startTimeMarker, "enter")) {
 					workflowMetricsSLAStopwatch.run(
 						taskInterval._startLocalDateTime);
 				}
-				else if (Objects.equals(
-							startTimeMarkers.get(nodeId), "leave") &&
+				else if (Objects.equals(startTimeMarker, "leave") &&
 						 (taskInterval._endLocalDateTime != null)) {
 
 					workflowMetricsSLAStopwatch.run(
@@ -369,12 +370,14 @@ public class WorkflowMetricsSLAProcessor {
 				}
 			}
 
-			if (stopTimeMarkers.containsKey(nodeId)) {
-				if (Objects.equals(stopTimeMarkers.get(nodeId), "enter")) {
+			String stopTimeMarker = stopTimeMarkers.get(nodeId);
+
+			if (stopTimeMarker != null) {
+				if (Objects.equals(stopTimeMarker, "enter")) {
 					workflowMetricsSLAStopwatch.stop(
 						taskInterval._startLocalDateTime);
 				}
-				else if (Objects.equals(stopTimeMarkers.get(nodeId), "leave") &&
+				else if (Objects.equals(stopTimeMarker, "leave") &&
 						 (taskInterval._endLocalDateTime != null)) {
 
 					workflowMetricsSLAStopwatch.stop(

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/sla/processor/WorkflowMetricsSLAProcessor.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/sla/processor/WorkflowMetricsSLAProcessor.java
@@ -343,8 +343,10 @@ public class WorkflowMetricsSLAProcessor {
 			TaskInterval taskInterval = _toTaskInterval(
 				document, lastCheckLocalDateTime, null);
 
+			String stopTimeMarker = stopTimeMarkers.get(nodeId);
+
 			if (pauseTimeMarkers.containsKey(nodeId) &&
-				!stopTimeMarkers.containsKey(nodeId)) {
+				(stopTimeMarker == null)) {
 
 				workflowMetricsSLAStopwatch.pause(
 					taskInterval._startLocalDateTime);
@@ -369,8 +371,6 @@ public class WorkflowMetricsSLAProcessor {
 						taskInterval._endLocalDateTime);
 				}
 			}
-
-			String stopTimeMarker = stopTimeMarkers.get(nodeId);
 
 			if (stopTimeMarker != null) {
 				if (Objects.equals(stopTimeMarker, "enter")) {

--- a/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/resource/v1_0/ResourceTypesResourceImpl.java
+++ b/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/resource/v1_0/ResourceTypesResourceImpl.java
@@ -56,9 +56,10 @@ public class ResourceTypesResourceImpl extends BaseResourceTypesResourceImpl {
 	private String _getResourceTypeJSON(String id)
 		throws AbstractCharonException {
 
-		if (_resourceTypeFileNames.containsKey(id)) {
-			JSONObject resourceTypeJSONObject = _read(
-				_resourceTypeFileNames.get(id));
+		String resourceTypeFileName = _resourceTypeFileNames.get(id);
+
+		if (resourceTypeFileName != null) {
+			JSONObject resourceTypeJSONObject = _read(resourceTypeFileName);
 
 			return resourceTypeJSONObject.toString();
 		}

--- a/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/resource/v1_0/SchemaResourceImpl.java
+++ b/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/resource/v1_0/SchemaResourceImpl.java
@@ -54,8 +54,10 @@ public class SchemaResourceImpl extends BaseSchemaResourceImpl {
 	}
 
 	private String _getSchemaJSON(String id) throws AbstractCharonException {
-		if (_schemaFileNames.containsKey(id)) {
-			JSONObject schemaJSONObject = _read(_schemaFileNames.get(id));
+		String schemaFileName = _schemaFileNames.get(id);
+
+		if (schemaFileName != null) {
+			JSONObject schemaJSONObject = _read(schemaFileName);
 
 			return schemaJSONObject.toString();
 		}

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/parameter/DateSXPParameter.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/parameter/DateSXPParameter.java
@@ -80,8 +80,10 @@ public class DateSXPParameter extends BaseSXPParameter {
 
 		Date date = _value;
 
-		if (options.containsKey("modifier")) {
-			date = _modify(date, options.get("modifier"));
+		String modifier = options.get("modifier");
+
+		if (modifier != null) {
+			date = _modify(date, modifier);
 		}
 
 		String dateFormatString = options.get("date_format");

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/test/java/com/liferay/search/experiences/internal/blueprint/property/PropertyExpanderTest.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/test/java/com/liferay/search/experiences/internal/blueprint/property/PropertyExpanderTest.java
@@ -58,9 +58,10 @@ public class PropertyExpanderTest {
 
 			String value = "gamma";
 
-			if (options.containsKey("len")) {
-				value = StringUtil.shorten(
-					value, GetterUtil.getInteger(options.get("len")));
+			String len = options.get("len");
+
+			if (len != null) {
+				value = StringUtil.shorten(value, GetterUtil.getInteger(len));
 			}
 
 			if (options.containsKey("up")) {

--- a/modules/dxp/apps/sharepoint-rest/sharepoint-rest-repository/src/main/java/com/liferay/sharepoint/rest/repository/internal/document/library/repository/external/SharepointCachingExtRepository.java
+++ b/modules/dxp/apps/sharepoint-rest/sharepoint-rest-repository/src/main/java/com/liferay/sharepoint/rest/repository/internal/document/library/repository/external/SharepointCachingExtRepository.java
@@ -245,12 +245,15 @@ public class SharepointCachingExtRepository implements ExtRepository {
 		String extRepositoryModelKey =
 			extRepositoryFileEntry.getExtRepositoryModelKey();
 
-		if (extRepositoryFileVersionCache.containsKey(extRepositoryModelKey)) {
-			return extRepositoryFileVersionCache.get(extRepositoryModelKey);
+		List<ExtRepositoryFileVersion> extRepositoryFileVersions =
+			extRepositoryFileVersionCache.get(extRepositoryModelKey);
+
+		if (extRepositoryFileVersions != null) {
+			return extRepositoryFileVersions;
 		}
 
-		List<ExtRepositoryFileVersion> extRepositoryFileVersions =
-			_extRepository.getExtRepositoryFileVersions(extRepositoryFileEntry);
+		extRepositoryFileVersions = _extRepository.getExtRepositoryFileVersions(
+			extRepositoryFileEntry);
 
 		extRepositoryFileVersionCache.put(
 			extRepositoryModelKey, extRepositoryFileVersions);
@@ -267,11 +270,14 @@ public class SharepointCachingExtRepository implements ExtRepository {
 		Map<String, ExtRepositoryObject> extRepositoryObjectCache =
 			_extRepositoryObjectCache.get();
 
-		if (extRepositoryObjectCache.containsKey(extRepositoryObjectKey)) {
-			return (T)extRepositoryObjectCache.get(extRepositoryObjectKey);
+		T extRepositoryObject = (T)extRepositoryObjectCache.get(
+			extRepositoryObjectKey);
+
+		if (extRepositoryObject != null) {
+			return extRepositoryObject;
 		}
 
-		T extRepositoryObject = _extRepository.getExtRepositoryObject(
+		extRepositoryObject = _extRepository.getExtRepositoryObject(
 			extRepositoryObjectType, extRepositoryObjectKey);
 
 		extRepositoryObjectCache.put(
@@ -299,12 +305,14 @@ public class SharepointCachingExtRepository implements ExtRepository {
 		Map<String, List<ExtRepositoryObject>> extRepositoryObjectsCache =
 			_extRepositoryObjectsCache.get();
 
-		if (extRepositoryObjectsCache.containsKey(extRepositoryFolderKey)) {
-			return (List<T>)extRepositoryObjectsCache.get(
-				extRepositoryFolderKey);
+		List<T> extRepositoryObjects = (List<T>)extRepositoryObjectsCache.get(
+			extRepositoryFolderKey);
+
+		if (extRepositoryObjects != null) {
+			return extRepositoryObjects;
 		}
 
-		List<T> extRepositoryObjects = _extRepository.getExtRepositoryObjects(
+		extRepositoryObjects = _extRepository.getExtRepositoryObjects(
 			extRepositoryObjectType, extRepositoryFolderKey);
 
 		Map<String, ExtRepositoryObject> extRepositoryObjectCache =
@@ -341,15 +349,16 @@ public class SharepointCachingExtRepository implements ExtRepository {
 		Map<String, ExtRepositoryFolder> extRepositoryParentFolderCache =
 			_extRepositoryParentFolderCache.get();
 
-		if (extRepositoryParentFolderCache.containsKey(
-				extRepositoryObject.getExtRepositoryModelKey())) {
-
-			return extRepositoryParentFolderCache.get(
+		ExtRepositoryFolder extRepositoryParentFolder =
+			extRepositoryParentFolderCache.get(
 				extRepositoryObject.getExtRepositoryModelKey());
+
+		if (extRepositoryParentFolder != null) {
+			return extRepositoryParentFolder;
 		}
 
-		ExtRepositoryFolder extRepositoryParentFolder =
-			_extRepository.getExtRepositoryParentFolder(extRepositoryObject);
+		extRepositoryParentFolder = _extRepository.getExtRepositoryParentFolder(
+			extRepositoryObject);
 
 		extRepositoryParentFolderCache.put(
 			extRepositoryObject.getExtRepositoryModelKey(),

--- a/modules/integrations/talend/talend-common/src/main/java/com/liferay/talend/common/json/JsonFinder.java
+++ b/modules/integrations/talend/talend-common/src/main/java/com/liferay/talend/common/json/JsonFinder.java
@@ -44,11 +44,7 @@ public class JsonFinder {
 		String locatorExpression, JsonObject jsonObject) {
 
 		if (!locatorExpression.contains(">")) {
-			if (jsonObject.containsKey(locatorExpression)) {
-				return jsonObject.get(locatorExpression);
-			}
-
-			return JsonValue.NULL;
+			return jsonObject.getOrDefault(locatorExpression, JsonValue.NULL);
 		}
 
 		int sublocationEndIdx = locatorExpression.indexOf(">");

--- a/modules/integrations/talend/talend-runtime/src/main/java/com/liferay/talend/avro/IndexedRecordJsonObjectConverter.java
+++ b/modules/integrations/talend/talend-runtime/src/main/java/com/liferay/talend/avro/IndexedRecordJsonObjectConverter.java
@@ -97,13 +97,9 @@ public class IndexedRecordJsonObjectConverter extends RejectHandler {
 					continue;
 				}
 
-				if (!nestedJsonObjectBuilders.containsKey(nameParts[0])) {
-					nestedJsonObjectBuilders.put(
-						nameParts[0], Json.createObjectBuilder());
-				}
-
-				currentJsonObjectBuilder = nestedJsonObjectBuilders.get(
-					nameParts[0]);
+				currentJsonObjectBuilder =
+					nestedJsonObjectBuilders.computeIfAbsent(
+						nameParts[0], key -> Json.createObjectBuilder());
 
 				fieldName = nameParts[1];
 			}

--- a/modules/sdk/ant-bnd/src/main/java/com/liferay/ant/bnd/jsp/JspAnalyzerPlugin.java
+++ b/modules/sdk/ant-bnd/src/main/java/com/liferay/ant/bnd/jsp/JspAnalyzerPlugin.java
@@ -227,9 +227,9 @@ public class JspAnalyzerPlugin implements AnalyzerPlugin {
 		else {
 			String fqnToPath = Descriptors.fqnToPath(content);
 
-			if (resourceMap.containsKey(fqnToPath)) {
-				Resource resource = resourceMap.get(fqnToPath);
+			Resource resource = resourceMap.get(fqnToPath);
 
+			if (resource != null) {
 				addResourceApiUses(analyzer, content, resource);
 			}
 		}

--- a/modules/sdk/ant-bnd/src/main/java/com/liferay/ant/bnd/jsp/JspAnalyzerPlugin.java
+++ b/modules/sdk/ant-bnd/src/main/java/com/liferay/ant/bnd/jsp/JspAnalyzerPlugin.java
@@ -277,8 +277,8 @@ public class JspAnalyzerPlugin implements AnalyzerPlugin {
 
 			Matcher matcher = _packagePattern.matcher(packageRef.getFQN());
 
-			if (matcher.matches() && !packages.containsKey(packageRef)) {
-				packages.put(packageRef, new Attrs());
+			if (matcher.matches()) {
+				packages.putIfAbsent(packageRef, new Attrs());
 			}
 		}
 	}
@@ -328,11 +328,9 @@ public class JspAnalyzerPlugin implements AnalyzerPlugin {
 		Set<String> taglibRequirements = new TreeSet<>();
 
 		for (String uri : getTaglibURIs(content)) {
-			if (taglibURIs.contains(uri)) {
+			if (!taglibURIs.add(uri)) {
 				continue;
 			}
-
-			taglibURIs.add(uri);
 
 			// Check to see if the JAR provides this TLD itself which would
 			// indicate that it already has access to the required classes

--- a/modules/sdk/gradle-plugins-baseline/src/main/java/com/liferay/gradle/plugins/baseline/BaselineProcessor.java
+++ b/modules/sdk/gradle-plugins-baseline/src/main/java/com/liferay/gradle/plugins/baseline/BaselineProcessor.java
@@ -125,12 +125,17 @@ public class BaselineProcessor extends Analyzer {
 					// current
 					// project
 
-				} else if (attrs.containsKey("file")) {
+				} else {
+					String file = attrs.get("file");
+
+					if (file == null) {
+						throw new IllegalArgumentException("Instruction must contain the version or file attribute!");
+					}
 
 					// Can be useful to specify a file
 					// for example when copying a bundle with a public api
 
-					File f = getFile(attrs.get("file"));
+					File f = getFile(file);
 					if (f != null && f.isFile()) {
 						Jar jar = new Jar(f);
 						addClose(jar);
@@ -138,9 +143,6 @@ public class BaselineProcessor extends Analyzer {
 					}
 					error("Specified file for baseline but could not find it %s", f);
 					return null;
-				}
-				else {
-					throw new IllegalArgumentException("Instruction must contain the version or file attribute!");
 				}
 
 				// Fetch the revision

--- a/modules/sdk/gradle-plugins-baseline/src/main/java/com/liferay/gradle/plugins/baseline/BaselineProcessor.java
+++ b/modules/sdk/gradle-plugins-baseline/src/main/java/com/liferay/gradle/plugins/baseline/BaselineProcessor.java
@@ -89,22 +89,22 @@ public class BaselineProcessor extends Analyzer {
 				Attrs attrs = e.getValue();
 				Version target;
 
-				if (attrs.containsKey("version")) {
+				String v = attrs.get("version");
+
+				if (v != null) {
 					SortedSet<Version> versions = removeStagedAndFilter(repo.versions(bsn), repo, bsn);
 
 					if (versions.isEmpty()) {
 						// We have a repo
-						Version v = new Version(getVersion());
-						if (v.getWithoutQualifier().compareTo(Version.ONE) > 0) {
+						if (version.getWithoutQualifier().compareTo(Version.ONE) > 0) {
 							warning("There is no baseline for %s in the baseline repo %s. The build is for version %s, which is <= 1.0.0 which suggests that there should be a prior version.",
-									getBsn(), repo, v);
+									getBsn(), repo, version);
 						}
 						return null;
 					}
 
 					// Specified version!
 
-					String v = attrs.get("version");
 					if (!Verifier.isVersion(v)) {
 						error("Not a valid version in %s %s", Constants.BASELINE, v);
 						return null;

--- a/modules/sdk/gradle-plugins-dependency-checker/src/main/java/com/liferay/gradle/plugins/dependency/checker/DependencyCheckerExtension.java
+++ b/modules/sdk/gradle-plugins-dependency-checker/src/main/java/com/liferay/gradle/plugins/dependency/checker/DependencyCheckerExtension.java
@@ -146,9 +146,9 @@ public class DependencyCheckerExtension {
 		Map<Object, Object> extractedArgs = new HashMap<>();
 
 		for (Object key : keys) {
-			if (args.containsKey(key)) {
-				Object value = args.remove(key);
+			Object value = args.remove(key);
 
+			if (value != null) {
 				extractedArgs.put(key, value);
 			}
 		}

--- a/modules/sdk/gradle-plugins-node/src/main/java/com/liferay/gradle/plugins/node/NodeExtension.java
+++ b/modules/sdk/gradle-plugins-node/src/main/java/com/liferay/gradle/plugins/node/NodeExtension.java
@@ -133,11 +133,7 @@ public class NodeExtension {
 				String npmVersion = getNpmVersion();
 
 				if (OSDetector.isWindows() && Validator.isNull(npmVersion)) {
-					String nodeVersion = getNodeVersion();
-
-					if (_npmVersions.containsKey(nodeVersion)) {
-						npmVersion = _npmVersions.get(nodeVersion);
-					}
+					npmVersion = _npmVersions.get(getNodeVersion());
 				}
 
 				if (Validator.isNull(npmVersion)) {

--- a/modules/sdk/gradle-plugins-poshi-runner/src/main/java/com/liferay/gradle/plugins/poshi/runner/PoshiRunnerPlugin.java
+++ b/modules/sdk/gradle-plugins-poshi-runner/src/main/java/com/liferay/gradle/plugins/poshi/runner/PoshiRunnerPlugin.java
@@ -845,8 +845,11 @@ public class PoshiRunnerPlugin implements Plugin<Project> {
 			Integer chromeMajorVersion = Integer.parseInt(
 				matcher.group("majorVersion"));
 
-			if (_chromeDriverVersions.containsKey(chromeMajorVersion)) {
-				return _chromeDriverVersions.get(chromeMajorVersion);
+			String chromeDriverVersion = _chromeDriverVersions.get(
+				chromeMajorVersion);
+
+			if (chromeDriverVersion != null) {
+				return chromeDriverVersion;
 			}
 
 			try {
@@ -870,7 +873,7 @@ public class PoshiRunnerPlugin implements Plugin<Project> {
 					_LEGACY_CHROME_DRIVER_BASE_URL + "LATEST_RELEASE_" +
 						chromeMajorVersion.toString());
 
-				String chromeDriverVersion = StringUtil.read(url.openStream());
+				chromeDriverVersion = StringUtil.read(url.openStream());
 
 				return chromeDriverVersion.trim();
 			}

--- a/modules/sdk/gradle-plugins-test-integration/src/main/java/com/liferay/gradle/plugins/test/integration/TestIntegrationPlugin.java
+++ b/modules/sdk/gradle-plugins-test-integration/src/main/java/com/liferay/gradle/plugins/test/integration/TestIntegrationPlugin.java
@@ -793,11 +793,8 @@ public class TestIntegrationPlugin implements Plugin<Project> {
 	private int _updateStartedAppServerStopCounters(
 		File binDir, boolean increment) {
 
-		int originalCounter = 0;
-
-		if (_startedAppServerStopCounters.containsKey(binDir)) {
-			originalCounter = _startedAppServerStopCounters.get(binDir);
-		}
+		int originalCounter = _startedAppServerStopCounters.getOrDefault(
+			binDir, 0);
 
 		int counter = originalCounter;
 

--- a/modules/sdk/gradle-plugins-test-integration/src/main/java/com/liferay/gradle/plugins/test/integration/TestIntegrationPlugin.java
+++ b/modules/sdk/gradle-plugins-test-integration/src/main/java/com/liferay/gradle/plugins/test/integration/TestIntegrationPlugin.java
@@ -655,9 +655,7 @@ public class TestIntegrationPlugin implements Plugin<Project> {
 		Map<String, Object> systemProperties =
 			javaForkOptions.getSystemProperties();
 
-		if (!systemProperties.containsKey(key)) {
-			systemProperties.put(key, FileUtil.getAbsolutePath(file));
-		}
+		systemProperties.putIfAbsent(key, FileUtil.getAbsolutePath(file));
 	}
 
 	@SuppressWarnings("serial")

--- a/modules/sdk/gradle-plugins-workspace/src/main/java/com/liferay/gradle/plugins/workspace/task/CreateClientExtensionConfigTask.java
+++ b/modules/sdk/gradle-plugins-workspace/src/main/java/com/liferay/gradle/plugins/workspace/task/CreateClientExtensionConfigTask.java
@@ -205,9 +205,7 @@ public class CreateClientExtensionConfigTask extends DefaultTask {
 			StringUtil.suffixIfNotBlank(
 				_project.getName(), _virtualInstanceId));
 
-		if (!pluginPackageProperties.containsKey("module-group-id")) {
-			pluginPackageProperties.put("module-group-id", "liferay");
-		}
+		pluginPackageProperties.putIfAbsent("module-group-id", "liferay");
 
 		_writeToOutputFile(
 			ResourceUtil.readString(

--- a/modules/sdk/project-templates/project-templates-extensions/src/main/java/com/liferay/project/templates/extensions/util/ProjectTemplatesUtil.java
+++ b/modules/sdk/project-templates/project-templates-extensions/src/main/java/com/liferay/project/templates/extensions/util/ProjectTemplatesUtil.java
@@ -33,8 +33,10 @@ import java.util.jar.JarFile;
 public class ProjectTemplatesUtil {
 
 	public static File getArchetypeFile(String artifactId) throws IOException {
-		if (_archetypeFiles.containsKey(artifactId)) {
-			return _archetypeFiles.get(artifactId);
+		File archetypeFile = _archetypeFiles.get(artifactId);
+
+		if (archetypeFile != null) {
+			return archetypeFile;
 		}
 
 		Properties projectTemplateJarVersionsProperties =
@@ -59,7 +61,7 @@ public class ProjectTemplatesUtil {
 				inputStream, archetypePath,
 				StandardCopyOption.REPLACE_EXISTING);
 
-			File archetypeFile = archetypePath.toFile();
+			archetypeFile = archetypePath.toFile();
 
 			_archetypeFiles.put(artifactId, archetypeFile);
 

--- a/modules/sdk/project-templates/project-templates-extensions/src/main/java/com/liferay/project/templates/extensions/util/ProjectTemplatesUtil.java
+++ b/modules/sdk/project-templates/project-templates-extensions/src/main/java/com/liferay/project/templates/extensions/util/ProjectTemplatesUtil.java
@@ -42,15 +42,15 @@ public class ProjectTemplatesUtil {
 		Properties projectTemplateJarVersionsProperties =
 			getProjectTemplateJarVersionsProperties();
 
-		if (!projectTemplateJarVersionsProperties.containsKey(artifactId)) {
+		Object version = projectTemplateJarVersionsProperties.get(artifactId);
+
+		if (version == null) {
 			return null;
 		}
 
-		String version = String.valueOf(
-			projectTemplateJarVersionsProperties.get(artifactId));
-
 		try {
-			String jarName = getArchetypeJarName(artifactId, version);
+			String jarName = getArchetypeJarName(
+				artifactId, String.valueOf(version));
 
 			InputStream inputStream =
 				ProjectTemplatesUtil.class.getResourceAsStream(jarName);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
@@ -1192,11 +1192,7 @@ public abstract class BaseBuild implements Build {
 
 	@Override
 	public long getStatusDuration(String status) {
-		if (_statusDurations.containsKey(status)) {
-			return _statusDurations.get(status);
-		}
-
-		return 0;
+		return _statusDurations.getOrDefault(status, 0L);
 	}
 
 	@Override

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuildReport.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuildReport.java
@@ -200,8 +200,10 @@ public abstract class BaseBuildReport implements BuildReport {
 
 	@Override
 	public synchronized URL getTestrayAttachmentURLBySuffix(String suffix) {
-		if (_testrayAttachmentURLsBySuffix.containsKey(suffix)) {
-			return _testrayAttachmentURLsBySuffix.get(suffix);
+		URL url = _testrayAttachmentURLsBySuffix.get(suffix);
+
+		if (url != null) {
+			return url;
 		}
 
 		URL matchedURL = null;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseDownstreamBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseDownstreamBuild.java
@@ -509,16 +509,11 @@ public class BaseDownstreamBuild extends BaseBuild implements DownstreamBuild {
 		for (TestResult testResult : testResults) {
 			String testResultClassName = testResult.getClassName();
 
-			if (untestedTestClassMethodNamesMap.containsKey(
-					testResultClassName)) {
+			List<String> testClassMethodNames =
+				untestedTestClassMethodNamesMap.get(testResultClassName);
 
-				List<String> testClassMethodNames =
-					untestedTestClassMethodNamesMap.get(testResultClassName);
-
+			if (testClassMethodNames != null) {
 				testClassMethodNames.remove(testResult.getTestName());
-
-				untestedTestClassMethodNamesMap.put(
-					testResultClassName, testClassMethodNames);
 			}
 		}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseParentBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseParentBuild.java
@@ -528,11 +528,8 @@ public abstract class BaseParentBuild extends BaseBuild implements ParentBuild {
 
 			String jenkinsMasterName = jenkinsMaster.getName();
 
-			if (!callableGroupCounter.containsKey(jenkinsMasterName)) {
-				callableGroupCounter.put(jenkinsMasterName, 0);
-			}
-
-			Integer buildCounter = callableGroupCounter.get(jenkinsMasterName);
+			Integer buildCounter = callableGroupCounter.computeIfAbsent(
+				jenkinsMasterName, key -> 0);
 
 			String sequentialCallableGroupName = jenkinsMasterName;
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
@@ -443,11 +443,7 @@ public abstract class BaseWorkspaceGitRepository
 
 				commitsJSONArray.put(localGitCommit.toJSONObject());
 
-				String sha = localGitCommit.getSHA();
-
-				if (requiredCommitSHAs.contains(sha)) {
-					requiredCommitSHAs.remove(sha);
-				}
+				requiredCommitSHAs.remove(localGitCommit.getSHA());
 
 				if (requiredCommitSHAs.isEmpty()) {
 					break;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BuildReportFactory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BuildReportFactory.java
@@ -83,13 +83,9 @@ public class BuildReportFactory {
 		String buildURLString = JenkinsResultsParserUtil.getRemoteURL(
 			buildJSONObject.getString("url"));
 
-		if (!_topLevelBuildReports.containsKey(buildURLString)) {
-			_topLevelBuildReports.put(
-				buildURLString,
-				new URLTopLevelBuildReport(buildJSONObject, jobReport));
-		}
-
-		return _topLevelBuildReports.get(buildURLString);
+		return _topLevelBuildReports.computeIfAbsent(
+			buildURLString,
+			key -> new URLTopLevelBuildReport(buildJSONObject, jobReport));
 	}
 
 	public static TopLevelBuildReport newTopLevelBuildReport(
@@ -104,12 +100,9 @@ public class BuildReportFactory {
 		String buildURLString = JenkinsResultsParserUtil.getRemoteURL(
 			String.valueOf(topLevelBuildURL));
 
-		if (!_topLevelBuildReports.containsKey(buildURLString)) {
-			_topLevelBuildReports.put(
-				buildURLString, new TestrayTopLevelBuildReport(testrayBuild));
-		}
-
-		return _topLevelBuildReports.get(buildURLString);
+		return _topLevelBuildReports.computeIfAbsent(
+			buildURLString,
+			key -> new TestrayTopLevelBuildReport(testrayBuild));
 	}
 
 	public static TopLevelBuildReport newTopLevelBuildReport(
@@ -122,12 +115,8 @@ public class BuildReportFactory {
 		String buildURLString = JenkinsResultsParserUtil.getRemoteURL(
 			String.valueOf(buildURL));
 
-		if (!_topLevelBuildReports.containsKey(buildURLString)) {
-			_topLevelBuildReports.put(
-				buildURLString, new URLTopLevelBuildReport(buildURLString));
-		}
-
-		return _topLevelBuildReports.get(buildURLString);
+		return _topLevelBuildReports.computeIfAbsent(
+			buildURLString, URLTopLevelBuildReport::new);
 	}
 
 	private static final Map<String, TopLevelBuildReport>

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GenerateReportsControllerBuildRunner.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GenerateReportsControllerBuildRunner.java
@@ -166,9 +166,7 @@ public class GenerateReportsControllerBuildRunner
 			long defaultStartTime =
 				buildData.getStartTime() - _getReportStaleDuration(reportName);
 
-			if (!latestReportUpdateTimes.containsKey(reportName)) {
-				latestReportUpdateTimes.put(reportName, defaultStartTime);
-			}
+			latestReportUpdateTimes.putIfAbsent(reportName, defaultStartTime);
 		}
 
 		return latestReportUpdateTimes;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitCommitFactory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitCommitFactory.java
@@ -30,8 +30,11 @@ public class GitCommitFactory {
 		String gitHubCommitURL = _getGitHubCommitURL(
 			gitHubUsername, gitRepositoryName, sha);
 
-		if (_gitHubRemoteGitCommits.containsKey(gitHubCommitURL)) {
-			return _gitHubRemoteGitCommits.get(gitHubCommitURL);
+		GitHubRemoteGitCommit gitHubRemoteGitCommit =
+			_gitHubRemoteGitCommits.get(gitHubCommitURL);
+
+		if (gitHubRemoteGitCommit != null) {
+			return gitHubRemoteGitCommit;
 		}
 
 		try {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitHubDevSyncUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitHubDevSyncUtil.java
@@ -475,13 +475,9 @@ public class GitHubDevSyncUtil {
 				String baseCacheBranchName = remoteGitBranchName.replaceAll(
 					"(.*)-\\d+", "$1");
 
-				if (!remoteGitBranchesMap.containsKey(baseCacheBranchName)) {
-					remoteGitBranchesMap.put(
-						baseCacheBranchName, new ArrayList<RemoteGitBranch>());
-				}
-
 				List<RemoteGitBranch> timestampedRemoteGitBranches =
-					remoteGitBranchesMap.get(baseCacheBranchName);
+					remoteGitBranchesMap.computeIfAbsent(
+						baseCacheBranchName, key -> new ArrayList<>());
 
 				timestampedRemoteGitBranches.add(remoteGitBranch);
 			}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitHubRemoteGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitHubRemoteGitRepository.java
@@ -116,8 +116,10 @@ public class GitHubRemoteGitRepository extends BaseRemoteGitRepository {
 	public List<Label> getLabels() {
 		String labelRequestURL = getLabelRequestURL();
 
-		if (_labelsLists.containsKey(labelRequestURL)) {
-			return _labelsLists.get(labelRequestURL);
+		List<Label> labelsList = _labelsLists.get(labelRequestURL);
+
+		if (labelsList != null) {
+			return labelsList;
 		}
 
 		JSONArray labelsJSONArray;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -610,18 +610,11 @@ public class GitWorkingDirectory {
 			RemoteGitRepository remoteGitRepository =
 				remoteGitBranch.getRemoteGitRepository();
 
-			String remoteURL = remoteGitRepository.getRemoteURL();
-
-			if (!remoteURLGitBranchNameMap.containsKey(remoteURL)) {
-				remoteURLGitBranchNameMap.put(remoteURL, new HashSet<String>());
-			}
-
-			Set<String> remoteGitBranchNames = remoteURLGitBranchNameMap.get(
-				remoteURL);
+			Set<String> remoteGitBranchNames =
+				remoteURLGitBranchNameMap.computeIfAbsent(
+					remoteGitRepository.getRemoteURL(), key -> new HashSet<>());
 
 			remoteGitBranchNames.add(remoteGitBranch.getName());
-
-			remoteURLGitBranchNameMap.put(remoteURL, remoteGitBranchNames);
 		}
 
 		List<Callable<Boolean>> callables = new ArrayList<>(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -1611,7 +1611,10 @@ public class GitWorkingDirectory {
 			getLocalGitBranchesShaMap();
 
 		for (String localGitBranchName : localGitBranchNames) {
-			if (!localGitBranchesShaMap.containsKey(localGitBranchName)) {
+			String localGitBranchSHA = localGitBranchesShaMap.get(
+				localGitBranchName);
+
+			if (localGitBranchSHA == null) {
 				System.out.println(
 					"Unable to find SHA for local Git branch " +
 						localGitBranchName);
@@ -1627,8 +1630,7 @@ public class GitWorkingDirectory {
 
 			localGitBranches.add(
 				GitBranchFactory.newLocalGitBranch(
-					localGitRepository, localGitBranchName,
-					localGitBranchesShaMap.get(localGitBranchName),
+					localGitRepository, localGitBranchName, localGitBranchSHA,
 					upstreamRemoteGitBranch));
 		}
 
@@ -2916,10 +2918,15 @@ public class GitWorkingDirectory {
 
 		String command = String.join(" ", commands);
 
-		if (_cacheBashCommands && _executionResults.containsKey(command)) {
-			System.out.println("Using cached execution for: " + command);
+		if (_cacheBashCommands) {
+			GitUtil.ExecutionResult executionResult = _executionResults.get(
+				command);
 
-			return _executionResults.get(command);
+			if (executionResult != null) {
+				System.out.println("Using cached execution for: " + command);
+
+				return executionResult;
+			}
 		}
 
 		GitUtil.ExecutionResult executionResult = GitUtil.executeBashCommands(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectoryFactory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectoryFactory.java
@@ -69,11 +69,12 @@ public class GitWorkingDirectoryFactory {
 				gitRepositoryDirPath, "-", upstreamBranchName);
 
 			synchronized (_gitWorkingDirectories) {
-				if (_gitWorkingDirectories.containsKey(key)) {
-					return _gitWorkingDirectories.get(key);
-				}
+				GitWorkingDirectory gitWorkingDirectory =
+					_gitWorkingDirectories.get(key);
 
-				GitWorkingDirectory gitWorkingDirectory = null;
+				if (gitWorkingDirectory != null) {
+					return gitWorkingDirectory;
+				}
 
 				if (gitRepositoryName.startsWith("com-liferay-") ||
 					gitRepositoryDirPath.matches(".*/com-liferay-[^/]*")) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/HostFactory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/HostFactory.java
@@ -14,13 +14,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class HostFactory {
 
 	public static Host newHost(String name) {
-		if (_hosts.containsKey(name)) {
-			return _hosts.get(name);
-		}
-
-		_hosts.put(name, new DefaultHost(name));
-
-		return _hosts.get(name);
+		return _hosts.computeIfAbsent(name, DefaultHost::new);
 	}
 
 	private static final Map<String, Host> _hosts = new ConcurrentHashMap<>();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JIRAUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JIRAUtil.java
@@ -103,11 +103,17 @@ public class JIRAUtil {
 	}
 
 	public static Map<String, Transition> getTransitions(Issue issue) {
-		if (!_transitionsMap.containsKey(issue.getKey())) {
-			_initTransitions(issue);
+		String issueKey = issue.getKey();
+
+		Map<String, Transition> transitions = _transitionsMap.get(issueKey);
+
+		if (transitions != null) {
+			return transitions;
 		}
 
-		return _transitionsMap.get(issue.getKey());
+		_initTransitions(issue);
+
+		return _transitionsMap.get(issueKey);
 	}
 
 	private static IssueRestClient _initIssueRestClient() {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JIRAUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JIRAUtil.java
@@ -64,9 +64,9 @@ public class JIRAUtil {
 			return null;
 		}
 
-		if (_cachedIssues.containsKey(issueKey)) {
-			CachedIssue cachedIssue = _cachedIssues.get(issueKey);
+		CachedIssue cachedIssue = _cachedIssues.get(issueKey);
 
+		if (cachedIssue != null) {
 			if (!cachedIssue.isExpired()) {
 				return cachedIssue.issue;
 			}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
@@ -37,11 +37,7 @@ import org.json.JSONObject;
 public class JenkinsCohort {
 
 	public static synchronized JenkinsCohort getInstance(String cohortName) {
-		if (!_jenkinsCohorts.containsKey(cohortName)) {
-			_jenkinsCohorts.put(cohortName, new JenkinsCohort(cohortName));
-		}
-
-		return _jenkinsCohorts.get(cohortName);
+		return _jenkinsCohorts.computeIfAbsent(cohortName, JenkinsCohort::new);
 	}
 
 	public Set<String> getASGPrimaryLabels() {
@@ -742,11 +738,9 @@ public class JenkinsCohort {
 			jobName = jobName.replace("-downstream", "");
 		}
 
-		if (!_jenkinsCohortJobsMap.containsKey(jobName)) {
-			_jenkinsCohortJobsMap.put(jobName, new JenkinsCohortJob(jobName));
-		}
-
-		JenkinsCohortJob jenkinsCohortJob = _jenkinsCohortJobsMap.get(jobName);
+		JenkinsCohortJob jenkinsCohortJob =
+			_jenkinsCohortJobsMap.computeIfAbsent(
+				jobName, JenkinsCohortJob::new);
 
 		if (downstreamJobName == null) {
 			jenkinsCohortJob.addTopLevelBuildURL(buildURL);
@@ -786,13 +780,9 @@ public class JenkinsCohort {
 					jobName = jobName.replace("-downstream", "");
 				}
 
-				if (!_jenkinsCohortJobsMap.containsKey(jobName)) {
-					_jenkinsCohortJobsMap.put(
-						jobName, new JenkinsCohortJob(jobName));
-				}
-
-				JenkinsCohortJob jenkinsCohortJob = _jenkinsCohortJobsMap.get(
-					jobName);
+				JenkinsCohortJob jenkinsCohortJob =
+					_jenkinsCohortJobsMap.computeIfAbsent(
+						jobName, JenkinsCohortJob::new);
 
 				if (downstreamJobName == null) {
 					jenkinsCohortJob.addQueuedTopLevelBuildJsonMapEntry(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsConsoleTextLoader.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsConsoleTextLoader.java
@@ -45,8 +45,11 @@ public class JenkinsConsoleTextLoader {
 				".liferay.com/job/", jobName, "/",
 				matcher.group("buildNumber"));
 
-			if (_jenkinsConsoleTextLoaders.containsKey(buildURL)) {
-				return _jenkinsConsoleTextLoaders.get(buildURL);
+			JenkinsConsoleTextLoader jenkinsConsoleTextLoader =
+				_jenkinsConsoleTextLoaders.get(buildURL);
+
+			if (jenkinsConsoleTextLoader != null) {
+				return jenkinsConsoleTextLoader;
 			}
 
 			if (jobName.contains("-batch") || jobName.contains("-downstream") ||

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -39,11 +39,7 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 	public static final Integer SLAVES_PER_HOST_DEFAULT = 2;
 
 	public static synchronized JenkinsMaster getInstance(String masterName) {
-		if (!_jenkinsMasters.containsKey(masterName)) {
-			_jenkinsMasters.put(masterName, new JenkinsMaster(masterName));
-		}
-
-		return _jenkinsMasters.get(masterName);
+		return _jenkinsMasters.computeIfAbsent(masterName, JenkinsMaster::new);
 	}
 
 	public static Integer getSlaveRAMMinimumDefault() {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -1430,8 +1430,11 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 	}
 
 	private List<String> _getLabels(String labelExpression) {
-		if (_labelExpressionLabels.containsKey(labelExpression)) {
-			return _labelExpressionLabels.get(labelExpression);
+		List<String> labelExpressionLabels = _labelExpressionLabels.get(
+			labelExpression);
+
+		if (labelExpressionLabels != null) {
+			return labelExpressionLabels;
 		}
 
 		Set<String> labels = new HashSet<>();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -291,11 +291,8 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		List<DefaultBuild> oldDefaultBuilds = new ArrayList<>();
 
 		for (DefaultBuild defaultBuild : _defaultBuilds) {
-			if (!buildURLs.contains(defaultBuild.getBuildURL())) {
+			if (!buildURLs.remove(defaultBuild.getBuildURL())) {
 				oldDefaultBuilds.add(defaultBuild);
-			}
-			else {
-				buildURLs.remove(defaultBuild.getBuildURL());
 			}
 		}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -1762,11 +1762,9 @@ public class JenkinsResultsParserUtil {
 			String timeStamp = String.valueOf(getCurrentTimeMillis());
 
 			synchronized (_timeStamps) {
-				if (_timeStamps.contains(timeStamp)) {
+				if (!_timeStamps.add(timeStamp)) {
 					continue;
 				}
-
-				_timeStamps.add(timeStamp);
 			}
 
 			return timeStamp;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -1246,8 +1246,10 @@ public class JenkinsResultsParserUtil {
 		Map<String, String> buildParameters = getBuildParameters(
 			buildURL, parentBuild);
 
-		if (buildParameters.containsKey(key)) {
-			return buildParameters.get(key);
+		String buildParameter = buildParameters.get(key);
+
+		if (buildParameter != null) {
+			return buildParameter;
 		}
 
 		throw new RuntimeException(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JobReport.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JobReport.java
@@ -35,14 +35,9 @@ public class JobReport {
 	}
 
 	public static JobReport getInstance(URL jenkinsJobURL) {
-		String key = JenkinsResultsParserUtil.getRemoteURL(
-			jenkinsJobURL.toString());
-
-		if (!_jobReports.containsKey(key)) {
-			_jobReports.put(key, new JobReport(jenkinsJobURL));
-		}
-
-		return _jobReports.get(key);
+		return _jobReports.computeIfAbsent(
+			JenkinsResultsParserUtil.getRemoteURL(jenkinsJobURL.toString()),
+			key -> new JobReport(jenkinsJobURL));
 	}
 
 	public JenkinsMaster getJenkinsMaster() {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LoadBalancerUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LoadBalancerUtil.java
@@ -32,18 +32,12 @@ public class LoadBalancerUtil {
 		String blacklistString, String masterPrefix, Properties properties,
 		boolean verbose) {
 
-		List<JenkinsMaster> allJenkinsMasters = null;
-
-		if (_jenkinsMastersMap.containsKey(masterPrefix)) {
-			allJenkinsMasters = _jenkinsMastersMap.get(masterPrefix);
-		}
-		else {
-			allJenkinsMasters = JenkinsResultsParserUtil.getJenkinsMasters(
-				properties, JenkinsMaster.getSlaveRAMMinimumDefault(),
-				JenkinsMaster.getSlavesPerHostDefault(), masterPrefix);
-
-			_jenkinsMastersMap.put(masterPrefix, allJenkinsMasters);
-		}
+		List<JenkinsMaster> allJenkinsMasters =
+			_jenkinsMastersMap.computeIfAbsent(
+				masterPrefix,
+				key -> JenkinsResultsParserUtil.getJenkinsMasters(
+					properties, JenkinsMaster.getSlaveRAMMinimumDefault(),
+					JenkinsMaster.getSlavesPerHostDefault(), masterPrefix));
 
 		List<String> blacklist = _getBlacklist(
 			properties, blacklistString, verbose);
@@ -97,18 +91,11 @@ public class LoadBalancerUtil {
 			return null;
 		}
 
-		AtomicInteger counter = null;
-
-		if (_roundRobinCounters.containsKey(masterPrefix)) {
-			counter = _roundRobinCounters.get(masterPrefix);
-		}
-		else {
-			counter = new AtomicInteger(
+		AtomicInteger counter = _roundRobinCounters.computeIfAbsent(
+			masterPrefix,
+			key -> new AtomicInteger(
 				JenkinsResultsParserUtil.getRandomValue(
-					0, availableJenkinsMasters.size() - 1));
-
-			_roundRobinCounters.put(masterPrefix, counter);
-		}
+					0, availableJenkinsMasters.size() - 1)));
 
 		int index = Math.floorMod(
 			counter.getAndIncrement(), availableJenkinsMasters.size());

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/ParallelExecutor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/ParallelExecutor.java
@@ -527,14 +527,8 @@ public class ParallelExecutor<T> {
 
 						if (_parallelExecutor._excludeNulls == false) {
 							for (Callable<T> callable : _callables) {
-								int callableIndex = _callables.indexOf(
-									callable);
-
-								if (!_resultsSortedMap.containsKey(
-										callableIndex)) {
-
-									_resultsSortedMap.put(callableIndex, null);
-								}
+								_resultsSortedMap.putIfAbsent(
+									_callables.indexOf(callable), null);
 							}
 						}
 
@@ -604,16 +598,11 @@ public class ParallelExecutor<T> {
 					queueName = _PARALLEL_QUEUE_NAME;
 				}
 
-				if (!callablesMap.containsKey(queueName)) {
-					callablesMap.put(queueName, new ArrayList<Callable<T>>());
-				}
-
-				Collection<Callable<T>> callablesCollection = callablesMap.get(
-					queueName);
+				Collection<Callable<T>> callablesCollection =
+					callablesMap.computeIfAbsent(
+						queueName, key -> new ArrayList<>());
 
 				callablesCollection.add(callable);
-
-				callablesMap.put(queueName, callablesCollection);
 			}
 
 			return callablesMap;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
@@ -69,8 +69,10 @@ public abstract class SecretsUtil {
 		String secretReference = _getSecretReference(
 			vaultName, itemTitle, fieldLabel);
 
-		if (_connectSecrets.containsKey(secretReference)) {
-			return _connectSecrets.get(secretReference);
+		String secret = _connectSecrets.get(secretReference);
+
+		if (secret != null) {
+			return secret;
 		}
 
 		String cachedSecret = _getCachedSecret(secretReference);
@@ -81,7 +83,7 @@ public abstract class SecretsUtil {
 
 		_loadConnectSecrets();
 
-		String secret = _connectSecrets.get(secretReference);
+		secret = _connectSecrets.get(secretReference);
 
 		if (secret == null) {
 			System.out.println("Unable to find secret " + secretReference);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SlaveOfflineRule.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SlaveOfflineRule.java
@@ -294,12 +294,7 @@ public class SlaveOfflineRule {
 
 		offlineSibling = configurationsMap.get("offlineSiblings");
 
-		if (configurationsMap.containsKey("shutdown")) {
-			shutdown = Boolean.parseBoolean(configurationsMap.get("shutdown"));
-		}
-		else {
-			shutdown = false;
-		}
+		shutdown = Boolean.parseBoolean(configurationsMap.get("shutdown"));
 	}
 
 	private static final Pattern _configurationsPattern = Pattern.compile(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UpstreamFailureUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UpstreamFailureUtil.java
@@ -29,11 +29,13 @@ public class UpstreamFailureUtil {
 	public static synchronized List<String> getUpstreamJobFailures(
 		String type, TopLevelBuild topLevelBuild) {
 
-		if (_upstreamFailures.containsKey(type)) {
-			return _upstreamFailures.get(type);
+		List<String> upstreamFailures = _upstreamFailures.get(type);
+
+		if (upstreamFailures != null) {
+			return upstreamFailures;
 		}
 
-		List<String> upstreamFailures = new ArrayList<>();
+		upstreamFailures = new ArrayList<>();
 
 		_upstreamFailures.put(type, upstreamFailures);
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/job/property/BaseGlobJobProperty.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/job/property/BaseGlobJobProperty.java
@@ -74,25 +74,11 @@ public abstract class BaseGlobJobProperty
 
 				relativeGlob = testClassGlob;
 
-				List<String> testClassMethodNames;
+				List<String> testClassMethodNames =
+					_globTestClassMethodNamesMap.computeIfAbsent(
+						testClassGlob, key -> new ArrayList<>());
 
-				if (_globTestClassMethodNamesMap.containsKey(testClassGlob)) {
-					testClassMethodNames = _globTestClassMethodNamesMap.get(
-						testClassGlob);
-
-					testClassMethodNames.add(testClassMethodName);
-
-					_globTestClassMethodNamesMap.replace(
-						relativeGlob, testClassMethodNames);
-				}
-				else {
-					testClassMethodNames = new ArrayList<>();
-
-					testClassMethodNames.add(testClassMethodName);
-
-					_globTestClassMethodNamesMap.put(
-						relativeGlob, testClassMethodNames);
-				}
+				testClassMethodNames.add(testClassMethodName);
 			}
 
 			relativeGlobs.add(relativeGlob);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/metrics/BuildHistory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/metrics/BuildHistory.java
@@ -634,9 +634,7 @@ public class BuildHistory {
 		long totalValue = 0L;
 
 		for (String dateString : dateStrings) {
-			if (dailyValueMap.containsKey(dateString)) {
-				totalValue += dailyValueMap.get(dateString);
-			}
+			totalValue += dailyValueMap.getOrDefault(dateString, 0L);
 		}
 
 		return totalValue;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/metrics/BuildHistory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/metrics/BuildHistory.java
@@ -548,13 +548,7 @@ public class BuildHistory {
 	}
 
 	private void _addData(Map<String, Long> dataMap, String key, Long value) {
-		if (!dataMap.containsKey(key)) {
-			dataMap.put(key, value);
-
-			return;
-		}
-
-		dataMap.put(key, dataMap.get(key) + value);
+		dataMap.merge(key, value, Long::sum);
 	}
 
 	private String _getBuildIdentifier(BuildJSONObject buildJSONObject) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/metrics/BuildHistoryProcessor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/metrics/BuildHistoryProcessor.java
@@ -572,9 +572,9 @@ public class BuildHistoryProcessor {
 
 			Map<String, String> parameters = buildJSONObject.getParameters();
 
-			if (parameters.containsKey("JOB_VARIANT")) {
-				String jobVariant = parameters.get("JOB_VARIANT");
+			String jobVariant = parameters.get("JOB_VARIANT");
 
+			if (jobVariant != null) {
 				if (jobVariant.contains("functional")) {
 					return TestBatchType.POSHI.toString();
 				}
@@ -669,24 +669,20 @@ public class BuildHistoryProcessor {
 				Map<String, String> parameters =
 					buildJSONObject.getParameters();
 
-				if (parameters.containsKey("CI_TEST_SUITE")) {
-					_topLevelBuildTestSuiteMap.put(
-						buildJSONObject.getURL(),
-						parameters.get("CI_TEST_SUITE"));
+				String ciTestSuite = parameters.get("CI_TEST_SUITE");
 
-					return parameters.get("CI_TEST_SUITE");
+				if (ciTestSuite != null) {
+					_topLevelBuildTestSuiteMap.put(
+						buildJSONObject.getURL(), ciTestSuite);
+
+					return ciTestSuite;
 				}
 
 				return "[Unknown]";
 			}
 
-			String topLevelBuildURL = buildJSONObject.getTopLevelBuildURL();
-
-			if (_topLevelBuildTestSuiteMap.containsKey(topLevelBuildURL)) {
-				return _topLevelBuildTestSuiteMap.get(topLevelBuildURL);
-			}
-
-			return "[Unknown]";
+			return _topLevelBuildTestSuiteMap.getOrDefault(
+				buildJSONObject.getTopLevelBuildURL(), "[Unknown]");
 		}
 
 		private final Map<String, String> _topLevelBuildTestSuiteMap =

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/metrics/BuildHistoryProcessor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/metrics/BuildHistoryProcessor.java
@@ -140,19 +140,13 @@ public class BuildHistoryProcessor {
 					for (Map.Entry<String, Set<BuildJSONObject>> entry :
 							groupedBuildDataJSONObjectsMap.entrySet()) {
 
-						String key = entry.getKey();
+						BuildHistory buildHistory =
+							buildHistories.computeIfAbsent(
+								entry.getKey(),
+								key -> new BuildHistory(
+									duration, key, startTime));
 
-						if (!buildHistories.containsKey(key)) {
-							BuildHistory buildHistory = new BuildHistory(
-								duration, key, startTime);
-
-							buildHistories.put(key, buildHistory);
-						}
-
-						BuildHistory buildHistory = buildHistories.get(key);
-
-						buildHistory.addBuildJSONObjects(
-							groupedBuildDataJSONObjectsMap.get(key));
+						buildHistory.addBuildJSONObjects(entry.getValue());
 					}
 				}
 
@@ -250,14 +244,9 @@ public class BuildHistoryProcessor {
 		for (Map.Entry<String, Set<BuildJSONObject>> entry :
 				groupedBuildDataJSONObjectsMap.entrySet()) {
 
-			if (!buildHistoriesMap.containsKey(entry.getKey())) {
-				BuildHistory buildHistory = new BuildHistory(
-					duration, entry.getKey(), startTime);
-
-				buildHistoriesMap.put(entry.getKey(), buildHistory);
-			}
-
-			BuildHistory buildHistory = buildHistoriesMap.get(entry.getKey());
+			BuildHistory buildHistory = buildHistoriesMap.computeIfAbsent(
+				entry.getKey(),
+				key -> new BuildHistory(duration, key, startTime));
 
 			buildHistory.addBuildJSONObjects(entry.getValue());
 		}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/metrics/BuildHistoryProcessor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/metrics/BuildHistoryProcessor.java
@@ -388,13 +388,9 @@ public class BuildHistoryProcessor {
 		for (BuildJSONObject buildJSONObject : buildJSONObjects) {
 			String groupName = groupingFunction.apply(buildJSONObject);
 
-			if (!groupedBuildDataJSONObjectsMap.containsKey(groupName)) {
-				groupedBuildDataJSONObjectsMap.put(
-					groupName, new HashSet<BuildJSONObject>());
-			}
-
 			Set<BuildJSONObject> groupedBuildJSONObjects =
-				groupedBuildDataJSONObjectsMap.get(groupName);
+				groupedBuildDataJSONObjectsMap.computeIfAbsent(
+					groupName, key -> new HashSet<>());
 
 			groupedBuildJSONObjects.add(buildJSONObject);
 		}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/persistent/resource/PersistentResourceFactory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/persistent/resource/PersistentResourceFactory.java
@@ -28,11 +28,11 @@ public class PersistentResourceFactory {
 
 		String key = buildDatabase.getBuildDatabaseFile() + "/" + type;
 
-		if (_persistentResources.containsKey(key)) {
-			return _persistentResources.get(key);
-		}
+		PersistentResource persistentResource = _persistentResources.get(key);
 
-		PersistentResource persistentResource = null;
+		if (persistentResource != null) {
+			return persistentResource;
+		}
 
 		if (type == PersistentResource.Type.ASAH_BUNDLE) {
 			persistentResource = new AsahBundlePersistentResource(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/scancode/ScanCodeCloudObjectFactory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/scancode/ScanCodeCloudObjectFactory.java
@@ -27,16 +27,8 @@ public class ScanCodeCloudObjectFactory {
 		String mapKey = JenkinsResultsParserUtil.combine(
 			scanCodeCloudBucket.getName(), "/", blob.getName());
 
-		if (_scanCodeCloudObjects.containsKey(mapKey)) {
-			return _scanCodeCloudObjects.get(mapKey);
-		}
-
-		ScanCodeCloudObject scanCodeCloudObject = new ScanCodeCloudObject(
-			blob, scanCodeCloudBucket);
-
-		_scanCodeCloudObjects.put(mapKey, scanCodeCloudObject);
-
-		return scanCodeCloudObject;
+		return _scanCodeCloudObjects.computeIfAbsent(
+			mapKey, key -> new ScanCodeCloudObject(blob, scanCodeCloudBucket));
 	}
 
 	private static final Map<String, ScanCodeCloudObject>

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/TestClassFactory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/TestClassFactory.java
@@ -229,11 +229,12 @@ public class TestClassFactory {
 				File canonicalFile = _getCanonicalFile(
 					testClassFile, jsonObject);
 
-				if (_modulesJUnitTestClasses.containsKey(canonicalFile)) {
-					return _modulesJUnitTestClasses.get(canonicalFile);
-				}
+				ModulesJUnitTestClass modulesJUnitTestClass =
+					_modulesJUnitTestClasses.get(canonicalFile);
 
-				ModulesJUnitTestClass modulesJUnitTestClass = null;
+				if (modulesJUnitTestClass != null) {
+					return modulesJUnitTestClass;
+				}
 
 				if (jsonObject != null) {
 					modulesJUnitTestClass = new ModulesJUnitTestClass(
@@ -253,11 +254,12 @@ public class TestClassFactory {
 				File canonicalFile = _getCanonicalFile(
 					testClassFile, jsonObject);
 
-				if (_jUnitTestClasses.containsKey(canonicalFile)) {
-					return _jUnitTestClasses.get(canonicalFile);
-				}
+				JUnitTestClass jUnitTestClass = _jUnitTestClasses.get(
+					canonicalFile);
 
-				JUnitTestClass jUnitTestClass = null;
+				if (jUnitTestClass != null) {
+					return jUnitTestClass;
+				}
 
 				if (jsonObject != null) {
 					jUnitTestClass = new JUnitTestClass(
@@ -278,11 +280,11 @@ public class TestClassFactory {
 				File canonicalFile = _getCanonicalFile(
 					testClassFile, jsonObject);
 
-				if (_npmTestClasses.containsKey(canonicalFile)) {
-					return _npmTestClasses.get(canonicalFile);
-				}
+				NPMTestClass npmTestClass = _npmTestClasses.get(canonicalFile);
 
-				NPMTestClass npmTestClass = null;
+				if (npmTestClass != null) {
+					return npmTestClass;
+				}
 
 				if (jsonObject != null) {
 					npmTestClass = new NPMTestClass(
@@ -303,11 +305,12 @@ public class TestClassFactory {
 				File canonicalFile = _getCanonicalFile(
 					testClassFile, jsonObject);
 
-				if (_playwrightJUnitTestClasses.containsKey(canonicalFile)) {
-					return _playwrightJUnitTestClasses.get(canonicalFile);
-				}
+				PlaywrightJUnitTestClass playwrightJUnitTestClass =
+					_playwrightJUnitTestClasses.get(canonicalFile);
 
-				PlaywrightJUnitTestClass playwrightJUnitTestClass = null;
+				if (playwrightJUnitTestClass != null) {
+					return playwrightJUnitTestClass;
+				}
 
 				if (jsonObject != null) {
 					playwrightJUnitTestClass = new PlaywrightJUnitTestClass(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/BatchTestClassGroup.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/BatchTestClassGroup.java
@@ -162,11 +162,7 @@ public abstract class BatchTestClassGroup extends BaseTestClassGroup {
 			_initializeCachedReports();
 		}
 
-		if (_cachedDownstreamBuildReportsMap.containsKey(axisName)) {
-			return _cachedDownstreamBuildReportsMap.get(axisName);
-		}
-
-		return null;
+		return _cachedDownstreamBuildReportsMap.get(axisName);
 	}
 
 	public TestClassReport getCachedTestClassReport(String testName) {
@@ -180,11 +176,7 @@ public abstract class BatchTestClassGroup extends BaseTestClassGroup {
 			_initializeCachedReports();
 		}
 
-		if (_cachedTestClassReportsMap.containsKey(testName)) {
-			return _cachedTestClassReportsMap.get(testName);
-		}
-
-		return null;
+		return _cachedTestClassReportsMap.get(testName);
 	}
 
 	public List<TestClassReport> getCachedTestClassReportByPrefix(
@@ -211,11 +203,7 @@ public abstract class BatchTestClassGroup extends BaseTestClassGroup {
 			_initializeCachedReports();
 		}
 
-		if (_cachedTestReportsMap.containsKey(testName)) {
-			return _cachedTestReportsMap.get(testName);
-		}
-
-		return null;
+		return _cachedTestReportsMap.get(testName);
 	}
 
 	public String getCohortName() {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/BatchTestClassGroup.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/BatchTestClassGroup.java
@@ -755,7 +755,7 @@ public abstract class BatchTestClassGroup extends BaseTestClassGroup {
 		}
 
 		if (testPropertiesFile.exists() &&
-			!traversedPropertyFileSet.contains(testPropertiesFile)) {
+			traversedPropertyFileSet.add(testPropertiesFile)) {
 
 			JobProperty jobProperty = getJobProperty(
 				basePropertyName, file, jobType);
@@ -767,8 +767,6 @@ public abstract class BatchTestClassGroup extends BaseTestClassGroup {
 
 				jobPropertiesList.add(jobProperty);
 			}
-
-			traversedPropertyFileSet.add(testPropertiesFile);
 		}
 
 		JobProperty ignoreParentsJobProperty = getJobProperty(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/suite/RelevantRuleEngine.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/suite/RelevantRuleEngine.java
@@ -231,9 +231,7 @@ public class RelevantRuleEngine {
 		String testPropertiesFilePath =
 			JenkinsResultsParserUtil.getCanonicalPath(testPropertiesFile);
 
-		if (testPropertiesFile.exists() &&
-			!testPropertiesFilePaths.contains(testPropertiesFilePath)) {
-
+		if (testPropertiesFile.exists()) {
 			testPropertiesFilePaths.add(testPropertiesFilePath);
 		}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/suite/RelevantRuleEngine.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/suite/RelevantRuleEngine.java
@@ -257,15 +257,9 @@ public class RelevantRuleEngine {
 			for (String testPropertiesFilePath :
 					_getTestPropertiesFilePaths(modifiedFile, null)) {
 
-				if (!testPropertiesModifiedFilesMap.containsKey(
-						testPropertiesFilePath)) {
-
-					testPropertiesModifiedFilesMap.put(
-						testPropertiesFilePath, new HashSet<File>());
-				}
-
 				Set<File> testPropertiesModifiedFiles =
-					testPropertiesModifiedFilesMap.get(testPropertiesFilePath);
+					testPropertiesModifiedFilesMap.computeIfAbsent(
+						testPropertiesFilePath, key -> new HashSet<>());
 
 				testPropertiesModifiedFiles.add(modifiedFile);
 			}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/BuildTestrayCaseResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/BuildTestrayCaseResult.java
@@ -110,8 +110,10 @@ public abstract class BuildTestrayCaseResult extends TestrayCaseResult {
 	protected synchronized TestrayAttachment getTestrayAttachment(
 		BuildReport buildReport, String name, String key) {
 
-		if (_testrayAttachments.containsKey(key)) {
-			return _testrayAttachments.get(key);
+		TestrayAttachment testrayAttachment = _testrayAttachments.get(key);
+
+		if (testrayAttachment != null) {
+			return testrayAttachment;
 		}
 
 		if ((buildReport == null) ||
@@ -145,7 +147,7 @@ public abstract class BuildTestrayCaseResult extends TestrayCaseResult {
 			return null;
 		}
 
-		TestrayAttachment testrayAttachment = new CloudObjectTestrayAttachment(
+		testrayAttachment = new CloudObjectTestrayAttachment(
 			this, name, cloudObjectPath);
 
 		_testrayAttachments.put(key, testrayAttachment);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayCloudObjectFactory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayCloudObjectFactory.java
@@ -27,17 +27,16 @@ public class TestrayCloudObjectFactory {
 		String mapKey = JenkinsResultsParserUtil.combine(
 			testrayCloudBucket.getName(), "/", blob.getName());
 
-		if (_testrayCloudObjects.containsKey(mapKey)) {
-			TestrayCloudObject testrayCloudObject = _testrayCloudObjects.get(
-				mapKey);
+		TestrayCloudObject testrayCloudObject = _testrayCloudObjects.get(
+			mapKey);
 
+		if (testrayCloudObject != null) {
 			testrayCloudObject.setBlob(blob);
 
 			return testrayCloudObject;
 		}
 
-		TestrayCloudObject testrayCloudObject = new TestrayCloudObject(
-			testrayCloudBucket, blob);
+		testrayCloudObject = new TestrayCloudObject(testrayCloudBucket, blob);
 
 		_testrayCloudObjects.put(mapKey, testrayCloudObject);
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayFactory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayFactory.java
@@ -764,8 +764,12 @@ public class TestrayFactory {
 
 		Long testrayBuildId = testrayBuild.getId();
 
-		if (_topLevelBuildTestrayCaseResults.containsKey(testrayBuildId)) {
-			return _topLevelBuildTestrayCaseResults.get(testrayBuildId);
+		TopLevelStandaloneBuildTestrayCaseResult
+			topLevelStandaloneBuildTestrayCaseResult =
+				_topLevelBuildTestrayCaseResults.get(testrayBuildId);
+
+		if (topLevelStandaloneBuildTestrayCaseResult != null) {
+			return topLevelStandaloneBuildTestrayCaseResult;
 		}
 
 		if (testrayBuild == null) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayServer.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayServer.java
@@ -70,8 +70,10 @@ public class TestrayServer {
 	}
 
 	public TestrayBuild getTestrayBuildById(long buildId) {
-		if (_testrayBuilds.containsKey(buildId)) {
-			return _testrayBuilds.get(buildId);
+		TestrayBuild testrayBuild = _testrayBuilds.get(buildId);
+
+		if (testrayBuild != null) {
+			return testrayBuild;
 		}
 
 		try {
@@ -100,7 +102,7 @@ public class TestrayServer {
 				testrayProject.getTestrayRoutineById(
 					routineJSONObject.getLong("id"));
 
-			TestrayBuild testrayBuild = TestrayFactory.newTestrayBuild(
+			testrayBuild = TestrayFactory.newTestrayBuild(
 				testrayRoutine, entityJSONObject);
 
 			_testrayBuilds.put(testrayBuild.getId(), testrayBuild);
@@ -191,8 +193,10 @@ public class TestrayServer {
 	}
 
 	public TestrayProject getTestrayProjectById(long projectId) {
-		if (_testrayProjects.containsKey(projectId)) {
-			return _testrayProjects.get(projectId);
+		TestrayProject testrayProject = _testrayProjects.get(projectId);
+
+		if (testrayProject != null) {
+			return testrayProject;
 		}
 
 		try {
@@ -206,7 +210,7 @@ public class TestrayServer {
 
 			Iterator<JSONObject> iterator = entityJSONObjects.iterator();
 
-			TestrayProject testrayProject = TestrayFactory.newTestrayProject(
+			testrayProject = TestrayFactory.newTestrayProject(
 				this, iterator.next());
 
 			_testrayProjects.put(testrayProject.getId(), testrayProject);
@@ -272,8 +276,10 @@ public class TestrayServer {
 	}
 
 	public TestrayRoutine getTestrayRoutineById(long routineId) {
-		if (_testrayRoutines.containsKey(routineId)) {
-			return _testrayRoutines.get(routineId);
+		TestrayRoutine testrayRoutine = _testrayRoutines.get(routineId);
+
+		if (testrayRoutine != null) {
+			return testrayRoutine;
 		}
 
 		try {
@@ -295,7 +301,7 @@ public class TestrayServer {
 			TestrayProject testrayProject = getTestrayProjectById(
 				projectJSONObject.getLong("id"));
 
-			TestrayRoutine testrayRoutine = TestrayFactory.newTestrayRoutine(
+			testrayRoutine = TestrayFactory.newTestrayRoutine(
 				testrayProject, entityJSONObject);
 
 			_testrayRoutines.put(testrayRoutine.getId(), testrayRoutine);

--- a/modules/test/poshi/poshi-core/src/main/java/com/liferay/poshi/core/PoshiContext.java
+++ b/modules/test/poshi/poshi-core/src/main/java/com/liferay/poshi/core/PoshiContext.java
@@ -291,20 +291,23 @@ public class PoshiContext {
 		String pathLocator = _pathLocators.get(
 			namespace + "." + pathLocatorKey);
 
-		String className =
-			PoshiGetterUtil.getClassNameFromNamespacedClassCommandName(
-				pathLocatorKey);
-
-		if ((pathLocator == null) &&
-			_pathExtensions.containsKey(namespace + "." + className)) {
+		if (pathLocator == null) {
+			String className =
+				PoshiGetterUtil.getClassNameFromNamespacedClassCommandName(
+					pathLocatorKey);
 
 			String pathExtension = _pathExtensions.get(
 				namespace + "." + className);
-			String commandName =
-				PoshiGetterUtil.getCommandNameFromNamespacedClassCommandName(
-					pathLocatorKey);
 
-			return getPathLocator(pathExtension + "#" + commandName, namespace);
+			if (pathExtension != null) {
+				String commandName =
+					PoshiGetterUtil.
+						getCommandNameFromNamespacedClassCommandName(
+							pathLocatorKey);
+
+				return getPathLocator(
+					pathExtension + "#" + commandName, namespace);
+			}
 		}
 
 		return pathLocator;

--- a/modules/test/poshi/poshi-core/src/main/java/com/liferay/poshi/core/PoshiContext.java
+++ b/modules/test/poshi/poshi-core/src/main/java/com/liferay/poshi/core/PoshiContext.java
@@ -203,11 +203,7 @@ public class PoshiContext {
 
 		String functionLocatorCountKey = namespace + "." + className;
 
-		if (_functionLocatorCounts.containsKey(functionLocatorCountKey)) {
-			return _functionLocatorCounts.get(functionLocatorCountKey);
-		}
-
-		return 0;
+		return _functionLocatorCounts.getOrDefault(functionLocatorCountKey, 0);
 	}
 
 	public static int getFunctionMaxArgumentCount() {
@@ -1969,10 +1965,9 @@ public class PoshiContext {
 
 				String namespacedFileName = _namespace + "." + fileName;
 
-				if (_filePaths.containsKey(namespacedFileName)) {
-					String duplicateFilePath = _filePaths.get(
-						namespacedFileName);
+				String duplicateFilePath = _filePaths.get(namespacedFileName);
 
+				if (duplicateFilePath != null) {
 					throw new RuntimeException(
 						StringUtil.combine(
 							"Duplicate file name '", fileName,

--- a/modules/test/poshi/poshi-core/src/main/java/com/liferay/poshi/core/PoshiGetterUtil.java
+++ b/modules/test/poshi/poshi-core/src/main/java/com/liferay/poshi/core/PoshiGetterUtil.java
@@ -392,8 +392,10 @@ public class PoshiGetterUtil {
 	}
 
 	public static String getUtilityClassName(String simpleClassName) {
-		if (_utilityClassMap.containsKey(simpleClassName)) {
-			return _utilityClassMap.get(simpleClassName);
+		String utilityClassName = _utilityClassMap.get(simpleClassName);
+
+		if (utilityClassName != null) {
+			return utilityClassName;
 		}
 
 		throw new IllegalArgumentException(

--- a/modules/test/poshi/poshi-core/src/main/java/com/liferay/poshi/core/PoshiStackTrace.java
+++ b/modules/test/poshi/poshi-core/src/main/java/com/liferay/poshi/core/PoshiStackTrace.java
@@ -24,19 +24,14 @@ import org.dom4j.Element;
 public final class PoshiStackTrace {
 
 	public static void clear(String classCommandName) {
-		if (_poshiStackTraces.containsKey(classCommandName)) {
-			_poshiStackTraces.remove(classCommandName);
-		}
+		_poshiStackTraces.remove(classCommandName);
 	}
 
 	public static synchronized PoshiStackTrace getPoshiStackTrace(
 		String classCommandName) {
 
-		if (!_poshiStackTraces.containsKey(classCommandName)) {
-			_poshiStackTraces.put(classCommandName, new PoshiStackTrace());
-		}
-
-		return _poshiStackTraces.get(classCommandName);
+		return _poshiStackTraces.computeIfAbsent(
+			classCommandName, key -> new PoshiStackTrace());
 	}
 
 	public void emptyStackTrace() {

--- a/modules/test/poshi/poshi-core/src/main/java/com/liferay/poshi/core/PoshiValidation.java
+++ b/modules/test/poshi/poshi-core/src/main/java/com/liferay/poshi/core/PoshiValidation.java
@@ -991,9 +991,7 @@ public class PoshiValidation {
 
 			String propertyName = propertyPoshiElement.attributeValue("name");
 
-			if (requiredPropertyNames.contains(propertyName)) {
-				requiredPropertyNames.remove(propertyName);
-			}
+			requiredPropertyNames.remove(propertyName);
 		}
 
 		if (requiredPropertyNames.isEmpty()) {
@@ -1808,7 +1806,7 @@ public class PoshiValidation {
 		List<String> possibleTagElementNames = Arrays.asList(
 			"command", "property", "set-up", "tear-down", "var");
 
-		List<String> propertyNames = new ArrayList<>();
+		Set<String> propertyNames = new HashSet<>();
 
 		for (PoshiElement childPoshiElement : childPoshiElements) {
 			String childPoshiElementName = childPoshiElement.getName();
@@ -1839,10 +1837,7 @@ public class PoshiValidation {
 
 				String propertyName = childPoshiElement.attributeValue("name");
 
-				if (!propertyNames.contains(propertyName)) {
-					propertyNames.add(propertyName);
-				}
-				else {
+				if (!propertyNames.add(propertyName)) {
 					_exceptions.add(
 						new PoshiElementException(
 							childPoshiElement, "Duplicate property name ",

--- a/modules/test/poshi/poshi-core/src/main/java/com/liferay/poshi/core/PoshiValidation.java
+++ b/modules/test/poshi/poshi-core/src/main/java/com/liferay/poshi/core/PoshiValidation.java
@@ -520,7 +520,9 @@ public class PoshiValidation {
 
 		String filePath = filePathURL.getFile();
 
-		if (_deprecatedMethodNames.containsKey(functionName)) {
+		String deprecatedMethodName = _deprecatedMethodNames.get(functionName);
+
+		if (deprecatedMethodName != null) {
 			String className = PoshiGetterUtil.getClassNameFromFilePath(
 				filePath);
 
@@ -528,10 +530,9 @@ public class PoshiValidation {
 
 			_logger.warning(
 				"Deprecated method \"selenium." + functionName +
-					"\" should be replaced with " +
-						_deprecatedMethodNames.get(functionName) + " at:\n" +
-							filePath + ":" +
-								poshiElement.getPoshiScriptLineNumber());
+					"\" should be replaced with " + deprecatedMethodName +
+						" at:\n" + filePath + ":" +
+							poshiElement.getPoshiScriptLineNumber());
 		}
 
 		if (_deprecatedFunctionNames.contains(functionName)) {

--- a/modules/test/poshi/poshi-core/src/main/java/com/liferay/poshi/core/PoshiVariablesContext.java
+++ b/modules/test/poshi/poshi-core/src/main/java/com/liferay/poshi/core/PoshiVariablesContext.java
@@ -22,20 +22,14 @@ import java.util.regex.Pattern;
 public class PoshiVariablesContext {
 
 	public static void clear(String classCommandName) {
-		if (_poshiVariablesContexts.containsKey(classCommandName)) {
-			_poshiVariablesContexts.remove(classCommandName);
-		}
+		_poshiVariablesContexts.remove(classCommandName);
 	}
 
 	public static synchronized PoshiVariablesContext getPoshiVariablesContext(
 		String classCommandName) {
 
-		if (!_poshiVariablesContexts.containsKey(classCommandName)) {
-			_poshiVariablesContexts.put(
-				classCommandName, new PoshiVariablesContext());
-		}
-
-		return _poshiVariablesContexts.get(classCommandName);
+		return _poshiVariablesContexts.computeIfAbsent(
+			classCommandName, key -> new PoshiVariablesContext());
 	}
 
 	public boolean containsKeyInCommandMap(String key) {

--- a/modules/test/poshi/poshi-core/src/main/java/com/liferay/poshi/core/selenium/LiferaySeleniumMethod.java
+++ b/modules/test/poshi/poshi-core/src/main/java/com/liferay/poshi/core/selenium/LiferaySeleniumMethod.java
@@ -35,9 +35,11 @@ public class LiferaySeleniumMethod {
 	}
 
 	public List<String> getParameterNames() {
-		if (_liferaySeleniumMethodNames.containsKey(getMethodName())) {
-			return Arrays.asList(
-				_liferaySeleniumMethodNames.get(getMethodName()));
+		String[] parameterNames = _liferaySeleniumMethodNames.get(
+			getMethodName());
+
+		if (parameterNames != null) {
+			return Arrays.asList(parameterNames);
 		}
 
 		int parameterCount = getParameterCount();

--- a/modules/test/poshi/poshi-runner/src/main/java/com/liferay/poshi/runner/exception/PoshiRunnerWarningException.java
+++ b/modules/test/poshi/poshi-runner/src/main/java/com/liferay/poshi/runner/exception/PoshiRunnerWarningException.java
@@ -74,12 +74,8 @@ public class PoshiRunnerWarningException extends Exception {
 	}
 
 	private static void _initPoshiRunnerWarningExceptions() {
-		String threadName = _getThreadName();
-
-		if (!_threadBasedPoshiRunnerWarningExceptions.containsKey(threadName)) {
-			_threadBasedPoshiRunnerWarningExceptions.put(
-				threadName, new ArrayList<>());
-		}
+		_threadBasedPoshiRunnerWarningExceptions.putIfAbsent(
+			_getThreadName(), new ArrayList<>());
 	}
 
 	private static final Map<String, List<PoshiRunnerWarningException>>

--- a/modules/test/poshi/poshi-runner/src/main/java/com/liferay/poshi/runner/logger/ParallelPrintStream.java
+++ b/modules/test/poshi/poshi-runner/src/main/java/com/liferay/poshi/runner/logger/ParallelPrintStream.java
@@ -306,8 +306,10 @@ public class ParallelPrintStream extends PrintStream {
 
 		String currentThreadName = currentThread.getName();
 
-		if (_printStreams.containsKey(currentThreadName)) {
-			return _printStreams.get(currentThreadName);
+		PrintStream printStream = _printStreams.get(currentThreadName);
+
+		if (printStream != null) {
+			return printStream;
 		}
 
 		try {

--- a/modules/test/poshi/poshi-runner/src/main/java/com/liferay/poshi/runner/logger/SummaryLogger.java
+++ b/modules/test/poshi/poshi-runner/src/main/java/com/liferay/poshi/runner/logger/SummaryLogger.java
@@ -36,26 +36,19 @@ import org.dom4j.Element;
 public final class SummaryLogger {
 
 	public static void clear(String testNamespacedClassCommandName) {
-		if (_summaryLoggers.containsKey(testNamespacedClassCommandName)) {
-			SummaryLogger summaryLogger = _summaryLoggers.get(
-				testNamespacedClassCommandName);
+		SummaryLogger summaryLogger = _summaryLoggers.remove(
+			testNamespacedClassCommandName);
 
+		if (summaryLogger != null) {
 			summaryLogger.stopRunning();
-
-			_summaryLoggers.remove(testNamespacedClassCommandName);
 		}
 	}
 
 	public static synchronized SummaryLogger getSummaryLogger(
 		String testNamespacedClassCommandName) {
 
-		if (!_summaryLoggers.containsKey(testNamespacedClassCommandName)) {
-			_summaryLoggers.put(
-				testNamespacedClassCommandName,
-				new SummaryLogger(testNamespacedClassCommandName));
-		}
-
-		return _summaryLoggers.get(testNamespacedClassCommandName);
+		return _summaryLoggers.computeIfAbsent(
+			testNamespacedClassCommandName, SummaryLogger::new);
 	}
 
 	public void createSummaryReport() throws Exception {

--- a/modules/test/poshi/poshi-runner/src/main/java/com/liferay/poshi/runner/report/PoshiReportGenerator.java
+++ b/modules/test/poshi/poshi-runner/src/main/java/com/liferay/poshi/runner/report/PoshiReportGenerator.java
@@ -182,18 +182,10 @@ public class PoshiReportGenerator {
 		if ((element instanceof ExecutePoshiElement) &&
 			Validator.isNotNull(macroName)) {
 
-			Set<Element> elements = new HashSet<>();
+			Set<Element> elements = _executeMacroElementMap.computeIfAbsent(
+				macroName, key -> new HashSet<>());
 
-			if (_executeMacroElementMap.containsKey(macroName)) {
-				elements = _executeMacroElementMap.get(macroName);
-
-				elements.add(element);
-			}
-			else {
-				elements.add(element);
-
-				_executeMacroElementMap.put(macroName, elements);
-			}
+			elements.add(element);
 		}
 
 		List<Element> childElements = element.elements();

--- a/modules/test/poshi/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/BaseWebDriverImpl.java
+++ b/modules/test/poshi/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/BaseWebDriverImpl.java
@@ -3051,10 +3051,10 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 			List<CharSequence> charSequences = new ArrayList<>();
 
 			for (String key : value.split(",")) {
-				CharSequence charSequence = key;
+				CharSequence charSequence = _keysMap.get(key);
 
-				if (_keysMap.containsKey(key)) {
-					charSequence = _keysMap.get(key);
+				if (charSequence == null) {
+					charSequence = key;
 				}
 
 				charSequences.add(charSequence);

--- a/modules/test/poshi/poshi-runner/src/main/java/com/liferay/poshi/runner/util/JSONCurlUtil.java
+++ b/modules/test/poshi/poshi-runner/src/main/java/com/liferay/poshi/runner/util/JSONCurlUtil.java
@@ -339,11 +339,7 @@ public class JSONCurlUtil {
 		}
 
 		public String getRequestOptionType() {
-			if (_customOptionsMap.containsKey(_optionType)) {
-				return _customOptionsMap.get(_optionType);
-			}
-
-			return _optionType;
+			return _customOptionsMap.getOrDefault(_optionType, _optionType);
 		}
 
 		public String toString() {

--- a/modules/test/poshi/poshi-runner/src/main/java/com/liferay/poshi/runner/util/RuntimeVariables.java
+++ b/modules/test/poshi/poshi-runner/src/main/java/com/liferay/poshi/runner/util/RuntimeVariables.java
@@ -39,9 +39,11 @@ public class RuntimeVariables {
 			while (matcher.find()) {
 				String variableKey = matcher.group(1);
 
-				if (context.containsKey(variableKey)) {
+				String variableValue = context.get(variableKey);
+
+				if (variableValue != null) {
 					locatorValue = locatorValue.replaceFirst(
-						regex, context.get(variableKey));
+						regex, variableValue);
 				}
 				else {
 					throw new Exception(

--- a/modules/test/poshi/poshi-runner/src/main/java/com/liferay/poshi/runner/util/RuntimeVariables.java
+++ b/modules/test/poshi/poshi-runner/src/main/java/com/liferay/poshi/runner/util/RuntimeVariables.java
@@ -72,7 +72,9 @@ public class RuntimeVariables {
 			if (statementMatcher.find()) {
 				String operand = statementMatcher.group(1);
 
-				if (!context.containsKey(operand)) {
+				String operandValue = context.get(operand);
+
+				if (operandValue == null) {
 					continue;
 				}
 
@@ -88,8 +90,6 @@ public class RuntimeVariables {
 				}
 
 				String method = statementMatcher.group(2);
-
-				String operandValue = context.get(operand);
 
 				String replaceRegex = "\\$\\{([^}]*?)\\}";
 
@@ -135,13 +135,13 @@ public class RuntimeVariables {
 			else {
 				String varName = statement;
 
-				if (!context.containsKey(varName)) {
+				String result = context.get(varName);
+
+				if (result == null) {
 					continue;
 				}
 
 				String replaceRegex = "\\$\\{([^}]*?)\\}";
-
-				String result = context.get(varName);
 
 				result = Matcher.quoteReplacement(result);
 
@@ -163,11 +163,11 @@ public class RuntimeVariables {
 	public static boolean isVariableSet(
 		String varName, Map<String, String> context) {
 
-		if (!context.containsKey(varName)) {
+		String varValue = context.get(varName);
+
+		if (varValue == null) {
 			return false;
 		}
-
-		String varValue = context.get(varName);
 
 		varValue = StringUtil.replace(varValue, "${line.separator}", "");
 

--- a/modules/util/portal-tools-db-partition-migration-validator/src/main/java/com/liferay/portal/tools/db/partition/migration/validator/util/ValidatorUtil.java
+++ b/modules/util/portal-tools-db-partition-migration-validator/src/main/java/com/liferay/portal/tools/db/partition/migration/validator/util/ValidatorUtil.java
@@ -142,10 +142,8 @@ public class ValidatorUtil {
 			targetLiferayDatabase.getTableNames());
 
 		for (String sourcePartitionedTableName : sourcePartitionedTableNames) {
-			if (targetPartitionedTableNames.contains(
+			if (targetPartitionedTableNames.remove(
 					sourcePartitionedTableName)) {
-
-				targetPartitionedTableNames.remove(sourcePartitionedTableName);
 
 				continue;
 			}

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/CompanyTestEntityResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/CompanyTestEntityResourceImpl.java
@@ -59,24 +59,21 @@ public class CompanyTestEntityResourceImpl
 		CompanyTestEntity companyTestEntity = doGetCompanyTestEntity(
 			companyTestEntityId);
 
-		if (!_permissions.containsKey(companyTestEntity.getId())) {
-			_permissions.put(
-				companyTestEntity.getId(),
-				new Permission[] {
-					new Permission() {
-						{
-							setActionIds(
-								new String[] {
-									"DELETE", "PERMISSIONS", "UPDATE", "VIEW"
-								});
-							setRoleName("Owner");
-						}
+		Permission[] permissions = _permissions.computeIfAbsent(
+			companyTestEntity.getId(),
+			key -> new Permission[] {
+				new Permission() {
+					{
+						setActionIds(
+							new String[] {
+								"DELETE", "PERMISSIONS", "UPDATE", "VIEW"
+							});
+						setRoleName("Owner");
 					}
-				});
-		}
+				}
+			});
 
-		return Page.of(
-			Arrays.asList(_permissions.get(companyTestEntity.getId())));
+		return Page.of(Arrays.asList(permissions));
 	}
 
 	@Override
@@ -227,11 +224,7 @@ public class CompanyTestEntityResourceImpl
 	private CompanyTestEntity _fetchCompanyTestEntity(long id)
 		throws Exception {
 
-		if (_companyTestEntities.containsKey(id)) {
-			return _companyTestEntities.get(id);
-		}
-
-		return null;
+		return _companyTestEntities.get(id);
 	}
 
 	private CompanyTestEntity _fetchCompanyTestEntity(

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/SiteTestEntityResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/SiteTestEntityResourceImpl.java
@@ -62,23 +62,21 @@ public class SiteTestEntityResourceImpl extends BaseSiteTestEntityResourceImpl {
 
 		SiteTestEntity siteTestEntity = doGetSiteTestEntity(siteTestEntityId);
 
-		if (!_permissions.containsKey(siteTestEntity.getId())) {
-			_permissions.put(
-				siteTestEntity.getId(),
-				new Permission[] {
-					new Permission() {
-						{
-							setActionIds(
-								new String[] {
-									"DELETE", "PERMISSIONS", "UPDATE", "VIEW"
-								});
-							setRoleName("Owner");
-						}
+		Permission[] permissions = _permissions.computeIfAbsent(
+			siteTestEntity.getId(),
+			key -> new Permission[] {
+				new Permission() {
+					{
+						setActionIds(
+							new String[] {
+								"DELETE", "PERMISSIONS", "UPDATE", "VIEW"
+							});
+						setRoleName("Owner");
 					}
-				});
-		}
+				}
+			});
 
-		return Page.of(Arrays.asList(_permissions.get(siteTestEntity.getId())));
+		return Page.of(Arrays.asList(permissions));
 	}
 
 	@Override

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
@@ -205,16 +205,19 @@ public class FreeMarkerTool {
 				List<String> tags = operation.getTags();
 
 				for (String tag : tags) {
-					if (!schemas.containsKey(tag)) {
-						if ((allExternalSchemas != null) &&
-							allExternalSchemas.containsKey(tag)) {
+					schemas.computeIfAbsent(
+						tag,
+						key -> {
+							if (allExternalSchemas != null) {
+								Schema schema = allExternalSchemas.get(key);
 
-							schemas.put(tag, allExternalSchemas.get(tag));
-						}
-						else {
-							schemas.put(tag, new Schema());
-						}
-					}
+								if (schema != null) {
+									return schema;
+								}
+							}
+
+							return new Schema();
+						});
 				}
 			}
 		}
@@ -1542,9 +1545,9 @@ public class FreeMarkerTool {
 			String returnSchema = returnType.substring(
 				returnType.lastIndexOf(".") + 1);
 
-			if (schemas.containsKey(returnSchema)) {
-				Schema schema = schemas.get(returnSchema);
+			Schema schema = schemas.get(returnSchema);
 
+			if (schema != null) {
 				Map<String, Schema> propertySchemas =
 					schema.getPropertySchemas();
 
@@ -1702,9 +1705,9 @@ public class FreeMarkerTool {
 			String schemaName = parameterType.substring(
 				parameterType.lastIndexOf(".") + 1);
 
-			if (schemas.containsKey(schemaName)) {
-				Schema schema = schemas.get(schemaName);
+			Schema schema = schemas.get(schemaName);
 
+			if (schema != null) {
 				Map<String, Schema> propertySchemas =
 					schema.getPropertySchemas();
 

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/util/OpenAPIUtil.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/util/OpenAPIUtil.java
@@ -263,9 +263,10 @@ public class OpenAPIUtil {
 						String schemaKey = StringUtil.upperCaseFirstLetter(
 							iterator.next());
 
-						if (!allSchemas.containsKey(schemaKey)) {
-							allSchemas.put(schemaKey, oneOfSchema);
+						Schema curSchema = allSchemas.putIfAbsent(
+							schemaKey, oneOfSchema);
 
+						if (curSchema == null) {
 							queue.add(schemas);
 						}
 					}

--- a/modules/util/portal-tools-service-builder/src/main/java/com/liferay/portal/tools/service/builder/ServiceBuilder.java
+++ b/modules/util/portal-tools-service-builder/src/main/java/com/liferay/portal/tools/service/builder/ServiceBuilder.java
@@ -4827,11 +4827,7 @@ public class ServiceBuilder {
 					sb.append(sequenceName);
 					sb.append(";");
 
-					String sequenceSQL = sb.toString();
-
-					if (!sequenceSQLs.contains(sequenceSQL)) {
-						sequenceSQLs.add(sequenceSQL);
-					}
+					sequenceSQLs.add(sb.toString());
 				}
 			}
 		}

--- a/modules/util/portal-tools-service-builder/src/main/java/com/liferay/portal/tools/service/builder/ServiceBuilder.java
+++ b/modules/util/portal-tools-service-builder/src/main/java/com/liferay/portal/tools/service/builder/ServiceBuilder.java
@@ -7048,9 +7048,7 @@ public class ServiceBuilder {
 				EntityMapping entityMapping = new EntityMapping(
 					mappingTableName, entityName, columnEntityName);
 
-				if (!_entityMappings.containsKey(mappingTableName)) {
-					_entityMappings.put(mappingTableName, entityMapping);
-				}
+				_entityMappings.putIfAbsent(mappingTableName, entityMapping);
 			}
 		}
 
@@ -7539,16 +7537,11 @@ public class ServiceBuilder {
 		_entities.add(entity);
 
 		if (entity.isUADEnabled()) {
-			if (!_uadApplicationEntities.containsKey(uadApplicationName)) {
-				_uadApplicationEntities.put(
-					uadApplicationName, ListUtil.fromArray(entity));
-			}
-			else {
-				List<Entity> uadApplicationEntities =
-					_uadApplicationEntities.get(uadApplicationName);
+			List<Entity> uadApplicationEntities =
+				_uadApplicationEntities.computeIfAbsent(
+					uadApplicationName, key -> new ArrayList<>());
 
-				uadApplicationEntities.add(entity);
-			}
+			uadApplicationEntities.add(entity);
 		}
 
 		if (versioned) {

--- a/portal-impl/src/com/liferay/portal/db/index/IndexUpdaterUtil.java
+++ b/portal-impl/src/com/liferay/portal/db/index/IndexUpdaterUtil.java
@@ -281,9 +281,7 @@ public class IndexUpdaterUtil {
 			String tableName = element.substring(
 				element.indexOf("create table ") + 13, element.indexOf(" ("));
 
-			if (!indexesSQLMap.containsKey(tableName)) {
-				indexesSQLMap.put(tableName, StringPool.BLANK);
-			}
+			indexesSQLMap.putIfAbsent(tableName, StringPool.BLANK);
 		}
 
 		return indexesSQLMap;

--- a/portal-impl/src/com/liferay/portal/language/LanguageImpl.java
+++ b/portal-impl/src/com/liferay/portal/language/LanguageImpl.java
@@ -2158,11 +2158,10 @@ public class LanguageImpl implements Language, Serializable {
 					languageCode = languageId.substring(0, pos);
 				}
 
-				if (_languageCodeLocalesMap.containsKey(languageCode)) {
+				if (_languageCodeLocalesMap.putIfAbsent(languageCode, locale) !=
+						null) {
+
 					duplicateLanguageCodes.add(languageCode);
-				}
-				else {
-					_languageCodeLocalesMap.put(languageCode, locale);
 				}
 
 				linkedHashMapWrapper.put(languageId, locale);

--- a/portal-impl/src/com/liferay/portal/language/LanguageImpl.java
+++ b/portal-impl/src/com/liferay/portal/language/LanguageImpl.java
@@ -1807,9 +1807,7 @@ public class LanguageImpl implements Language, Serializable {
 				languageCode = languageId.substring(0, pos);
 			}
 
-			if (!groupLanguageCodeLocalesMap.containsKey(languageCode)) {
-				groupLanguageCodeLocalesMap.put(languageCode, locale);
-			}
+			groupLanguageCodeLocalesMap.putIfAbsent(languageCode, locale);
 
 			groupLanguageIdLocalesMap.put(languageId, locale);
 		}

--- a/portal-impl/src/com/liferay/portal/model/impl/LayoutTemplateImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/LayoutTemplateImpl.java
@@ -85,10 +85,10 @@ public class LayoutTemplateImpl
 
 		String servletContextName = getServletContextName();
 
-		if (ServletContextPool.containsKey(servletContextName)) {
-			ServletContext servletContext = ServletContextPool.get(
-				servletContextName);
+		ServletContext servletContext = ServletContextPool.get(
+			servletContextName);
 
+		if (servletContext != null) {
 			return servletContext.getContextPath();
 		}
 

--- a/portal-impl/src/com/liferay/portal/model/impl/ThemeImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/ThemeImpl.java
@@ -130,10 +130,10 @@ public class ThemeImpl extends PluginBaseImpl implements Theme {
 
 		String servletContextName = getServletContextName();
 
-		if (ServletContextPool.containsKey(servletContextName)) {
-			ServletContext servletContext = ServletContextPool.get(
-				servletContextName);
+		ServletContext servletContext = ServletContextPool.get(
+			servletContextName);
 
+		if (servletContext != null) {
 			String proxyPath = PortalUtil.getPathProxy();
 
 			return proxyPath.concat(servletContext.getContextPath());

--- a/portal-impl/src/com/liferay/portal/plugin/PluginPackageUtil.java
+++ b/portal-impl/src/com/liferay/portal/plugin/PluginPackageUtil.java
@@ -526,9 +526,7 @@ public class PluginPackageUtil {
 		List<String> types = _readList(
 			pluginPackageElement.element("types"), "type");
 
-		if (types.contains("layout-template")) {
-			types.remove("layout-template");
-
+		if (types.remove("layout-template")) {
 			types.add(Plugin.TYPE_LAYOUT_TEMPLATE);
 		}
 

--- a/portal-impl/src/com/liferay/portal/repository/registry/RepositoryClassDefinition.java
+++ b/portal-impl/src/com/liferay/portal/repository/registry/RepositoryClassDefinition.java
@@ -69,8 +69,10 @@ public class RepositoryClassDefinition
 			_localRepositoriesMap.computeIfAbsent(
 				_getCompanyId(repositoryId), key -> new ConcurrentHashMap<>());
 
-		if (localRepositories.containsKey(repositoryId)) {
-			return localRepositories.get(repositoryId);
+		LocalRepository localRepository = localRepositories.get(repositoryId);
+
+		if (localRepository != null) {
+			return localRepository;
 		}
 
 		InitializedLocalRepository initializedLocalRepository =
@@ -91,8 +93,8 @@ public class RepositoryClassDefinition
 		defaultCapabilityRegistry.registerCapabilityRepositoryEvents(
 			defaultRepositoryEventRegistry);
 
-		LocalRepository localRepository =
-			_repositoryFactory.createLocalRepository(repositoryId);
+		localRepository = _repositoryFactory.createLocalRepository(
+			repositoryId);
 
 		LocalRepository wrappedLocalRepository =
 			defaultCapabilityRegistry.invokeCapabilityWrappers(localRepository);
@@ -117,8 +119,10 @@ public class RepositoryClassDefinition
 		Map<Long, Repository> repositories = _repositoriesMap.computeIfAbsent(
 			_getCompanyId(repositoryId), key -> new ConcurrentHashMap<>());
 
-		if (repositories.containsKey(repositoryId)) {
-			return repositories.get(repositoryId);
+		Repository repository = repositories.get(repositoryId);
+
+		if (repository != null) {
+			return repository;
 		}
 
 		InitializedRepository initializedRepository =
@@ -136,8 +140,7 @@ public class RepositoryClassDefinition
 			initializedRepository, defaultCapabilityRegistry,
 			defaultRepositoryEventRegistry);
 
-		Repository repository = _repositoryFactory.createRepository(
-			repositoryId);
+		repository = _repositoryFactory.createRepository(repositoryId);
 
 		defaultCapabilityRegistry.registerCapabilityRepositoryEvents(
 			defaultRepositoryEventRegistry);

--- a/portal-impl/src/com/liferay/portal/service/impl/RoleLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/RoleLocalServiceImpl.java
@@ -546,9 +546,7 @@ public class RoleLocalServiceImpl extends RoleLocalServiceBaseImpl {
 							"defaultSiteRoleIds"),
 						0L));
 
-				if (defaultSiteRoleIds.contains(role.getRoleId())) {
-					defaultSiteRoleIds.remove(role.getRoleId());
-
+				if (defaultSiteRoleIds.remove(role.getRoleId())) {
 					typeSettingsUnicodeProperties.setProperty(
 						"defaultSiteRoleIds",
 						ListUtil.toString(

--- a/portal-impl/src/com/liferay/portal/service/impl/TeamLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/TeamLocalServiceImpl.java
@@ -118,9 +118,7 @@ public class TeamLocalServiceImpl extends TeamLocalServiceBaseImpl {
 						"defaultTeamIds"),
 					0L));
 
-			if (defaultTeamIds.contains(team.getTeamId())) {
-				defaultTeamIds.remove(team.getTeamId());
-
+			if (defaultTeamIds.remove(team.getTeamId())) {
 				typeSettingsUnicodeUnicodeProperties.setProperty(
 					"defaultTeamIds",
 					ListUtil.toString(defaultTeamIds, StringPool.BLANK));

--- a/portal-impl/src/com/liferay/portal/service/impl/ThemeLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ThemeLocalServiceImpl.java
@@ -832,9 +832,7 @@ public class ThemeLocalServiceImpl extends ThemeLocalServiceBaseImpl {
 				}
 			}
 
-			if (!_themes.containsKey(themeId)) {
-				_themes.put(themeId, theme);
-			}
+			_themes.putIfAbsent(themeId, theme);
 
 			_readPortletDecorators(
 				themeElement, theme.getPortletDecoratorsMap(),

--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -6951,10 +6951,7 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		userGroupRoles = new ArrayList<>(userGroupRoles);
 
 		for (UserGroupRole userGroupRole : previousUserGroupRoles) {
-			if (userGroupRoles.contains(userGroupRole)) {
-				userGroupRoles.remove(userGroupRole);
-			}
-			else {
+			if (!userGroupRoles.remove(userGroupRole)) {
 				_userGroupRoleLocalService.deleteUserGroupRole(userGroupRole);
 			}
 		}

--- a/portal-impl/src/com/liferay/portal/servlet/filters/authverifier/AuthVerifierFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/authverifier/AuthVerifierFilter.java
@@ -78,36 +78,29 @@ public class AuthVerifierFilter extends BasePortalFilter {
 			}
 		}
 
-		if (_initParametersMap.containsKey("guest.allowed")) {
-			_guestAllowed = GetterUtil.getBoolean(
-				_initParametersMap.get("guest.allowed"), true);
+		Object guestAllowed = _initParametersMap.remove("guest.allowed");
 
-			_initParametersMap.remove("guest.allowed");
+		if (guestAllowed != null) {
+			_guestAllowed = GetterUtil.getBoolean(guestAllowed, true);
 		}
 
-		if (_initParametersMap.containsKey("hosts.allowed")) {
-			String hostsAllowedString = (String)_initParametersMap.get(
-				"hosts.allowed");
+		if (_initParametersMap.remove("hosts.allowed") instanceof
+				String hostsAllowedString) {
 
 			String[] hostsAllowed = StringUtil.split(hostsAllowedString);
 
 			for (String hostAllowed : hostsAllowed) {
 				_hostsAllowed.add(hostAllowed);
 			}
-
-			_initParametersMap.remove("hosts.allowed");
 		}
 
-		if (_initParametersMap.containsKey("https.required")) {
-			_httpsRequired = GetterUtil.getBoolean(
-				_initParametersMap.get("https.required"));
+		Object httpsRequired = _initParametersMap.remove("https.required");
 
-			_initParametersMap.remove("https.required");
+		if (httpsRequired != null) {
+			_httpsRequired = GetterUtil.getBoolean(httpsRequired);
 		}
 
-		if (_initParametersMap.containsKey("use_permission_checker")) {
-			_initParametersMap.remove("use_permission_checker");
-
+		if (_initParametersMap.remove("use_permission_checker") != null) {
 			if (_log.isWarnEnabled()) {
 				_log.warn("use_permission_checker is deprecated");
 			}

--- a/portal-impl/src/com/liferay/portal/upload/UploadServletRequestImpl.java
+++ b/portal-impl/src/com/liferay/portal/upload/UploadServletRequestImpl.java
@@ -125,12 +125,8 @@ public class UploadServletRequestImpl
 				if (fileItem.isFormField()) {
 					String fieldName = fileItem.getFieldName();
 
-					if (!_regularParameters.containsKey(fieldName)) {
-						_regularParameters.put(
-							fieldName, new ArrayList<String>());
-					}
-
-					List<String> values = _regularParameters.get(fieldName);
+					List<String> values = _regularParameters.computeIfAbsent(
+						fieldName, key -> new ArrayList<>());
 
 					if (fileItem.getSize() > FileItem.THRESHOLD_SIZE) {
 						UploadException uploadException = new UploadException(

--- a/portal-impl/src/com/liferay/portal/webdav/methods/BasePropMethodImpl.java
+++ b/portal-impl/src/com/liferay/portal/webdav/methods/BasePropMethodImpl.java
@@ -99,9 +99,7 @@ public abstract class BasePropMethodImpl implements Method {
 
 		// Check DAV properties
 
-		if (props.contains(ALLPROP)) {
-			props.remove(ALLPROP);
-
+		if (props.remove(ALLPROP)) {
 			if (resource.isCollection()) {
 				props.addAll(_allCollectionProps);
 			}
@@ -110,9 +108,7 @@ public abstract class BasePropMethodImpl implements Method {
 			}
 		}
 
-		if (props.contains(CREATIONDATE)) {
-			props.remove(CREATIONDATE);
-
+		if (props.remove(CREATIONDATE)) {
 			Element successCreationDateElement = successPropElement.addElement(
 				CREATIONDATE);
 
@@ -122,9 +118,7 @@ public abstract class BasePropMethodImpl implements Method {
 			hasSuccess = true;
 		}
 
-		if (props.contains(DISPLAYNAME)) {
-			props.remove(DISPLAYNAME);
-
+		if (props.remove(DISPLAYNAME)) {
 			Element successDisplayNameElement = successPropElement.addElement(
 				DISPLAYNAME);
 
@@ -134,9 +128,7 @@ public abstract class BasePropMethodImpl implements Method {
 			hasSuccess = true;
 		}
 
-		if (props.contains(GETLASTMODIFIED)) {
-			props.remove(GETLASTMODIFIED);
-
+		if (props.remove(GETLASTMODIFIED)) {
 			Element successGetLastModifiedElement =
 				successPropElement.addElement(GETLASTMODIFIED);
 
@@ -146,9 +138,7 @@ public abstract class BasePropMethodImpl implements Method {
 			hasSuccess = true;
 		}
 
-		if (props.contains(GETCONTENTTYPE)) {
-			props.remove(GETCONTENTTYPE);
-
+		if (props.remove(GETCONTENTTYPE)) {
 			Element successGetContentTypeElement =
 				successPropElement.addElement(GETCONTENTTYPE);
 
@@ -158,9 +148,7 @@ public abstract class BasePropMethodImpl implements Method {
 			hasSuccess = true;
 		}
 
-		if (props.contains(GETCONTENTLENGTH)) {
-			props.remove(GETCONTENTLENGTH);
-
+		if (props.remove(GETCONTENTLENGTH)) {
 			if (!resource.isCollection()) {
 				Element successGetContentLengthElement =
 					successPropElement.addElement(GETCONTENTLENGTH);
@@ -177,9 +165,7 @@ public abstract class BasePropMethodImpl implements Method {
 			}
 		}
 
-		if (props.contains(ISREADONLY)) {
-			props.remove(ISREADONLY);
-
+		if (props.remove(ISREADONLY)) {
 			Element successIsReadOnlyElement = successPropElement.addElement(
 				ISREADONLY);
 
@@ -195,9 +181,7 @@ public abstract class BasePropMethodImpl implements Method {
 			hasSuccess = true;
 		}
 
-		if (props.contains(LOCKDISCOVERY)) {
-			props.remove(LOCKDISCOVERY);
-
+		if (props.remove(LOCKDISCOVERY)) {
 			Lock lock = resource.getLock();
 
 			if (lock != null) {
@@ -275,9 +259,7 @@ public abstract class BasePropMethodImpl implements Method {
 			}
 		}
 
-		if (props.contains(RESOURCETYPE)) {
-			props.remove(RESOURCETYPE);
-
+		if (props.remove(RESOURCETYPE)) {
 			Element resourceTypeElement = successPropElement.addElement(
 				RESOURCETYPE);
 

--- a/portal-impl/src/com/liferay/portlet/internal/BaseMutablePortletParameters.java
+++ b/portal-impl/src/com/liferay/portlet/internal/BaseMutablePortletParameters.java
@@ -89,9 +89,9 @@ public abstract class BaseMutablePortletParameters
 
 		Map<String, String[]> parameterMap = getParameterMap();
 
-		if (parameterMap.containsKey(name)) {
-			parameterMap.remove(name);
+		Set<String> parameterNames = parameterMap.keySet();
 
+		if (parameterNames.remove(name)) {
 			_mutated = true;
 
 			return true;

--- a/portal-impl/src/com/liferay/portlet/internal/PortletRequestImpl.java
+++ b/portal-impl/src/com/liferay/portlet/internal/PortletRequestImpl.java
@@ -912,6 +912,8 @@ public abstract class PortletRequestImpl implements LiferayPortletRequest {
 				RenderParametersPool.get(
 					httpServletRequest, plid, _portletName);
 
+			Set<String> nullValueParameterNames = new HashSet<>();
+
 			if (privateRenderParameters != null) {
 				for (Map.Entry<String, String[]> entry :
 						privateRenderParameters.entrySet()) {
@@ -947,6 +949,10 @@ public abstract class PortletRequestImpl implements LiferayPortletRequest {
 						}
 					}
 
+					if (values == null) {
+						nullValueParameterNames.add(privateRenderParameterName);
+					}
+
 					allRenderParameters.put(privateRenderParameterName, values);
 				}
 			}
@@ -954,10 +960,10 @@ public abstract class PortletRequestImpl implements LiferayPortletRequest {
 			for (String privateRenderParameterName :
 					privateRenderParameterNames) {
 
-				if (!allRenderParameters.containsKey(
+				if (!nullValueParameterNames.contains(
 						privateRenderParameterName)) {
 
-					allRenderParameters.put(
+					allRenderParameters.putIfAbsent(
 						privateRenderParameterName,
 						dynamicServletRequest.getParameterValues(
 							privateRenderParameterName));

--- a/portal-impl/src/com/liferay/portlet/internal/PortletURLImpl.java
+++ b/portal-impl/src/com/liferay/portlet/internal/PortletURLImpl.java
@@ -598,9 +598,7 @@ public class PortletURLImpl
 
 		if (_portletSpecMajorVersion < 3) {
 			if (value == null) {
-				if (_portletURLParameterMap.containsKey(name)) {
-					_portletURLParameterMap.remove(name);
-				}
+				_portletURLParameterMap.remove(name);
 
 				return;
 			}

--- a/portal-kernel/src/com/liferay/exportimport/kernel/lar/ManifestSummary.java
+++ b/portal-kernel/src/com/liferay/exportimport/kernel/lar/ManifestSummary.java
@@ -274,7 +274,10 @@ public class ManifestSummary implements Serializable {
 	public void incrementModelAdditionCount(StagedModelType stagedModelType) {
 		String manifestSummaryKey = getManifestSummaryKey(stagedModelType);
 
-		if (!_modelAdditionCounters.containsKey(manifestSummaryKey)) {
+		LongWrapper modelAdditionCounter = _modelAdditionCounters.get(
+			manifestSummaryKey);
+
+		if (modelAdditionCounter == null) {
 			_modelAdditionCounters.put(manifestSummaryKey, new LongWrapper(1));
 
 			_manifestSummaryKeys.add(manifestSummaryKey);
@@ -282,25 +285,22 @@ public class ManifestSummary implements Serializable {
 			return;
 		}
 
-		LongWrapper modelAdditionCounter = _modelAdditionCounters.get(
-			manifestSummaryKey);
-
 		modelAdditionCounter.increment();
 	}
 
 	public void incrementModelDeletionCount(StagedModelType stagedModelType) {
 		String manifestSummaryKey = getManifestSummaryKey(stagedModelType);
 
-		if (!_modelDeletionCounters.containsKey(manifestSummaryKey)) {
+		LongWrapper modelDeletionCounter = _modelDeletionCounters.get(
+			manifestSummaryKey);
+
+		if (modelDeletionCounter == null) {
 			_modelDeletionCounters.put(manifestSummaryKey, new LongWrapper(1));
 
 			_manifestSummaryKeys.add(manifestSummaryKey);
 
 			return;
 		}
-
-		LongWrapper modelDeletionCounter = _modelDeletionCounters.get(
-			manifestSummaryKey);
 
 		modelDeletionCounter.increment();
 	}

--- a/portal-kernel/src/com/liferay/exportimport/kernel/lar/ManifestSummary.java
+++ b/portal-kernel/src/com/liferay/exportimport/kernel/lar/ManifestSummary.java
@@ -194,12 +194,12 @@ public class ManifestSummary implements Serializable {
 	}
 
 	public long getModelAdditionCount(String manifestSummaryKey) {
-		if (!_modelAdditionCounters.containsKey(manifestSummaryKey)) {
-			return -1;
-		}
-
 		LongWrapper modelAdditionCounter = _modelAdditionCounters.get(
 			manifestSummaryKey);
+
+		if (modelAdditionCounter == null) {
+			return -1;
+		}
 
 		return modelAdditionCounter.getValue();
 	}
@@ -245,12 +245,12 @@ public class ManifestSummary implements Serializable {
 	}
 
 	public long getModelDeletionCount(String manifestSummaryKey) {
-		if (!_modelDeletionCounters.containsKey(manifestSummaryKey)) {
-			return -1;
-		}
-
 		LongWrapper modelDeletionCounter = _modelDeletionCounters.get(
 			manifestSummaryKey);
+
+		if (modelDeletionCounter == null) {
+			return -1;
+		}
 
 		return modelDeletionCounter.getValue();
 	}
@@ -260,11 +260,14 @@ public class ManifestSummary implements Serializable {
 	}
 
 	public String getStagedModelAssetTitle(String manifestSummaryKey) {
-		if (!_stagedModelAssetTitles.containsKey(manifestSummaryKey)) {
+		String stagedModelAssetTitle = _stagedModelAssetTitles.get(
+			manifestSummaryKey);
+
+		if (stagedModelAssetTitle == null) {
 			return StringPool.BLANK;
 		}
 
-		return _stagedModelAssetTitles.get(manifestSummaryKey);
+		return stagedModelAssetTitle;
 	}
 
 	public Map<String, String> getStagedModelAssetTitles() {

--- a/portal-kernel/src/com/liferay/portal/kernel/cluster/ClusterableInvokerUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/cluster/ClusterableInvokerUtil.java
@@ -120,37 +120,17 @@ public class ClusterableInvokerUtil {
 	private static void _populateContextFromThreadLocals(
 		Map<String, Serializable> context) {
 
-		if (!context.containsKey("companyId")) {
-			context.put("companyId", CompanyThreadLocal.getCompanyId());
-		}
-
-		if (!context.containsKey("defaultLocale")) {
-			context.put("defaultLocale", LocaleThreadLocal.getDefaultLocale());
-		}
-
-		if (!context.containsKey("groupId")) {
-			context.put("groupId", GroupThreadLocal.getGroupId());
-		}
-
-		if (!context.containsKey("principalName")) {
-			context.put("principalName", PrincipalThreadLocal.getName());
-		}
-
-		if (!context.containsKey("principalPassword")) {
-			context.put(
-				"principalPassword", PrincipalThreadLocal.getPassword());
-		}
-
-		if (!context.containsKey("siteDefaultLocale")) {
-			context.put(
-				"siteDefaultLocale", LocaleThreadLocal.getSiteDefaultLocale());
-		}
-
-		if (!context.containsKey("themeDisplayLocale")) {
-			context.put(
-				"themeDisplayLocale",
-				LocaleThreadLocal.getThemeDisplayLocale());
-		}
+		context.putIfAbsent("companyId", CompanyThreadLocal.getCompanyId());
+		context.putIfAbsent(
+			"defaultLocale", LocaleThreadLocal.getDefaultLocale());
+		context.putIfAbsent("groupId", GroupThreadLocal.getGroupId());
+		context.putIfAbsent("principalName", PrincipalThreadLocal.getName());
+		context.putIfAbsent(
+			"principalPassword", PrincipalThreadLocal.getPassword());
+		context.putIfAbsent(
+			"siteDefaultLocale", LocaleThreadLocal.getSiteDefaultLocale());
+		context.putIfAbsent(
+			"themeDisplayLocale", LocaleThreadLocal.getThemeDisplayLocale());
 	}
 
 	private static void _populateThreadLocalsFromContext(

--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/JasperVersionDetector.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/JasperVersionDetector.java
@@ -77,11 +77,11 @@ public class JasperVersionDetector {
 				}
 			}
 
-			if (attributes.containsKey(
-					Attributes.Name.IMPLEMENTATION_VERSION)) {
+			Object implementationVersion = attributes.get(
+				Attributes.Name.IMPLEMENTATION_VERSION);
 
-				_jasperVersion = GetterUtil.getString(
-					attributes.get(Attributes.Name.IMPLEMENTATION_VERSION));
+			if (implementationVersion != null) {
+				_jasperVersion = GetterUtil.getString(implementationVersion);
 
 				if (_isValidJasperVersion(_jasperVersion)) {
 					return;
@@ -91,9 +91,10 @@ public class JasperVersionDetector {
 			Attributes.Name bundleVersionAttributesName = new Attributes.Name(
 				"Bundle-Version");
 
-			if (attributes.containsKey(bundleVersionAttributesName)) {
-				_jasperVersion = GetterUtil.getString(
-					attributes.get(bundleVersionAttributesName));
+			Object bundleVersion = attributes.get(bundleVersionAttributesName);
+
+			if (bundleVersion != null) {
+				_jasperVersion = GetterUtil.getString(bundleVersion);
 
 				if (_isValidJasperVersion(_jasperVersion)) {
 					return;

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/data/cleanup/UserAllTablesOrphanReferencesDataCleanupPreupgradeProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/data/cleanup/UserAllTablesOrphanReferencesDataCleanupPreupgradeProcess.java
@@ -160,8 +160,10 @@ public class UserAllTablesOrphanReferencesDataCleanupPreupgradeProcess
 	private long _getAdminUserId(Connection connection, long companyId)
 		throws Exception {
 
-		if (_adminUserIds.containsKey(companyId)) {
-			return _adminUserIds.get(companyId);
+		Long adminUserId = _adminUserIds.get(companyId);
+
+		if (adminUserId != null) {
+			return adminUserId;
 		}
 
 		DBInspector dbInspector = new DBInspector(connection);

--- a/portal-kernel/src/com/liferay/portal/kernel/util/MapUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/MapUtil.java
@@ -12,6 +12,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 
 import java.lang.reflect.Constructor;
 
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Dictionary;
@@ -114,6 +115,18 @@ public class MapUtil {
 		}
 
 		return GetterUtil.getDouble(String.valueOf(value), defaultValue);
+	}
+
+	public static <K, V> Map.Entry<K, V> getEntry(Map<K, V> map, K key) {
+		Map<K, Object> objectMap = (Map<K, Object>)map;
+
+		Object value = objectMap.getOrDefault(key, _ABSENT_VALUE);
+
+		if (value == _ABSENT_VALUE) {
+			return null;
+		}
+
+		return new AbstractMap.SimpleImmutableEntry<>(key, (V)value);
 	}
 
 	public static int getInteger(Map<String, ?> map, String key) {
@@ -449,6 +462,8 @@ public class MapUtil {
 
 		return sb.toString();
 	}
+
+	private static final Object _ABSENT_VALUE = new Object();
 
 	private static final Log _log = LogFactoryUtil.getLog(MapUtil.class);
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/OrderedProperties.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/OrderedProperties.java
@@ -28,9 +28,7 @@ public class OrderedProperties extends Properties {
 
 	@Override
 	public Object put(Object key, Object value) {
-		if (_names.contains(key)) {
-			_names.remove(key);
-		}
+		_names.remove(key);
 
 		_names.add((String)key);
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/ResourceBundleUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/ResourceBundleUtil.java
@@ -26,7 +26,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
-import java.util.Set;
 
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleReference;
@@ -190,7 +189,7 @@ public class ResourceBundleUtil {
 		}
 
 		if (resourceBundleLoader == null) {
-			if (!_portalResourceBundleClassLoaders.contains(classLoader)) {
+			if (_portalResourceBundleClassLoaders.get(classLoader) == null) {
 				try {
 					return ResourceBundle.getBundle(
 						baseName, locale, classLoader, UTF8Control.INSTANCE);
@@ -200,7 +199,8 @@ public class ResourceBundleUtil {
 						_log.debug(missingResourceException);
 					}
 
-					_portalResourceBundleClassLoaders.add(classLoader);
+					_portalResourceBundleClassLoaders.put(
+						classLoader, Boolean.TRUE);
 				}
 			}
 
@@ -214,9 +214,8 @@ public class ResourceBundleUtil {
 	private static final Log _log = LogFactoryUtil.getLog(
 		ResourceBundleUtil.class);
 
-	private static final Set<ClassLoader> _portalResourceBundleClassLoaders =
-		Collections.newSetFromMap(
-			new ConcurrentReferenceKeyHashMap<>(
-				FinalizeManager.WEAK_REFERENCE_FACTORY));
+	private static final Map<ClassLoader, Boolean>
+		_portalResourceBundleClassLoaders = new ConcurrentReferenceKeyHashMap<>(
+			FinalizeManager.WEAK_REFERENCE_FACTORY);
 
 }

--- a/util-java/src/com/liferay/util/transport/MulticastClientTool.java
+++ b/util-java/src/com/liferay/util/transport/MulticastClientTool.java
@@ -97,13 +97,8 @@ public class MulticastClientTool {
 			}
 		}
 
-		if (!argsMap.containsKey("gzip")) {
-			argsMap.put("gzip", Boolean.FALSE);
-		}
-
-		if (!argsMap.containsKey("short")) {
-			argsMap.put("short", Boolean.FALSE);
-		}
+		argsMap.putIfAbsent("gzip", Boolean.FALSE);
+		argsMap.putIfAbsent("short", Boolean.FALSE);
 
 		return argsMap;
 	}

--- a/workspaces/liferay-learn-workspace/client-extensions/liferay-learn-etc-cron-1/src/main/java/com/liferay/learn/Main.java
+++ b/workspaces/liferay-learn-workspace/client-extensions/liferay-learn-etc-cron-1/src/main/java/com/liferay/learn/Main.java
@@ -361,13 +361,11 @@ public class Main {
 				StructuredContent structuredContent = _toStructuredContent(
 					fileName);
 
-				if (externalReferenceCodeStructuredContents.containsKey(
-						structuredContent.getExternalReferenceCode())) {
+				StructuredContent siteStructuredContent =
+					externalReferenceCodeStructuredContents.get(
+						structuredContent.getExternalReferenceCode());
 
-					StructuredContent siteStructuredContent =
-						externalReferenceCodeStructuredContents.get(
-							structuredContent.getExternalReferenceCode());
-
+				if (siteStructuredContent != null) {
 					importedStructuredContentIds.add(
 						siteStructuredContent.getId());
 
@@ -416,15 +414,13 @@ public class Main {
 					updatedStructuredContentCount++;
 				}
 				else {
-					if (friendlyUrlPathStructuredContents.containsKey(
-							structuredContent.getFriendlyUrlPath())) {
+					StructuredContent friendlyUrlPathSiteStructuredContent =
+						friendlyUrlPathStructuredContents.get(
+							structuredContent.getFriendlyUrlPath());
 
-						StructuredContent siteStructuredContent =
-							friendlyUrlPathStructuredContents.get(
-								structuredContent.getFriendlyUrlPath());
-
+					if (friendlyUrlPathSiteStructuredContent != null) {
 						importedStructuredContentIds.add(
-							siteStructuredContent.getId());
+							friendlyUrlPathSiteStructuredContent.getId());
 
 						String relativeFileName = StringUtil.removeSubstring(
 							fileName, _baseDirName);
@@ -447,7 +443,7 @@ public class Main {
 						_deleteRAGDocument(structuredContent.getId());
 
 						_structuredContentResource.deleteStructuredContent(
-							siteStructuredContent.getId());
+							friendlyUrlPathSiteStructuredContent.getId());
 					}
 
 					String relativeFileName = StringUtil.removeSubstring(

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-cron/src/main/java/com/liferay/marketplace/MarketplaceCommandLineRunner.java
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-cron/src/main/java/com/liferay/marketplace/MarketplaceCommandLineRunner.java
@@ -845,16 +845,14 @@ public class MarketplaceCommandLineRunner
 
 				String key = jsonObject.getString("key");
 
-				if (!projectsUsingMarketplace.containsKey(key)) {
-					projectsUsingMarketplace.put(
-						key,
-						new JSONObject(
-						).put(
-							"accountName", jsonObject.getString("name")
-						).put(
-							"orders", new JSONArray()
-						));
-				}
+				projectsUsingMarketplace.putIfAbsent(
+					key,
+					new JSONObject(
+					).put(
+						"accountName", jsonObject.getString("name")
+					).put(
+						"orders", new JSONArray()
+					));
 
 				projectsUsingMarketplace.get(
 					key

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/BaseEngineClient.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/BaseEngineClient.java
@@ -428,8 +428,10 @@ public abstract class BaseEngineClient {
 	protected String getTemplatedURL(FaroProject faroProject, String type) {
 		String engineURL = getEngineURL(faroProject);
 
-		if (_urlPaths.containsKey(type)) {
-			return engineURL + _urlPaths.get(type);
+		String urlPath = _urlPaths.get(type);
+
+		if (urlPath != null) {
+			return engineURL + urlPath;
 		}
 
 		RestTemplate restTemplate = getRestTemplate(faroProject);


### PR DESCRIPTION
[LPD-98666](https://liferay.atlassian.net/browse/LPD-98666)

## What Is Being Fixed

Across the codebase a Map or Set is probed with `containsKey`/`contains` and, in the very next statement, the same key or element is read, removed, put, or added. The guard hashes the key twice, adds a line of noise, and in the put/add case races concurrent writers.

## How It Is Being Fixed

Each site is combined with its operation using the right primitive — `getOrDefault`, `putIfAbsent`, `computeIfAbsent`, branching on the operation result, or a new `MapUtil.getEntry` kernel helper (returns `null` for absent, a `SimpleImmutableEntry` otherwise) where absent-versus-present-null-versus-value must stay distinguishable. Every surviving corner was hand-reviewed for the present-null / three-way-absent semantics a naive rewrite would silently change.

This is the product-code half of the initiative. The SourceFormatter rule that enforces the pattern (`JavaRedundantContainsCheck`), together with the redundant-check fixes inside the source-formatter and build-tooling modules that the rule flags in its own codebase, ships separately to `ling-alan-huang` (who owns SourceFormatter checks). See the cross-reference comment below. That rule intentionally carries no whitelist, so this cleanup must land first.

## PR Check

**PASS** — tested SHA `c30c845f8d5a5e2e7b02fb828c32806d018ae85d`

Validated locally on this branch, and by CI on the identical 53-commit superset (`ci:test:sf` PASS, `ci:test:stable` 12/12 PASS):

| Validation | Result |
| --- | --- |
| Source Format | PASS — `format-source-current-branch`, 0 changes |
| Service Builder / REST Builder | PASS — no `service.xml`, `rest-openapi.yaml`, or `@Generated` files touched, so no regeneration drift |
| Baseline | PASS — no `packageinfo`/`bnd.bnd`/`.gradle` changed; the added `MapUtil.getEntry` rides within the package's existing `99.0.0` |
| Core Compile | PASS — `ant compile install-portal-snapshots` |
| Module / Integration / Cross-Module Compile, Java Unit | PASS on the identical superset via CI (`ci:test:stable` 12/12) |

<!-- pr-check {"result":"success","sha":"c30c845f8d5a5e2e7b02fb828c32806d018ae85d"} -->
