### PR TITLE
LPD-98534 Convert not-found-exception catches to null-tolerant fetch siblings

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-image-service/src/main/java/com/liferay/adaptive/media/image/internal/exportimport/content/processor/AMImageHTMLExportImportContentProcessor.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-service/src/main/java/com/liferay/adaptive/media/image/internal/exportimport/content/processor/AMImageHTMLExportImportContentProcessor.java
@@ -100,17 +100,8 @@ public class AMImageHTMLExportImportContentProcessor
 		}
 	}
 
-	private FileEntry _getFileEntry(long fileEntryId) {
-		try {
-			return _dlAppLocalService.getFileEntry(fileEntryId);
-		}
-		catch (PortalException portalException) {
-			if (_log.isWarnEnabled()) {
-				_log.warn(portalException);
-			}
-
-			return null;
-		}
+	private FileEntry _getFileEntry(long fileEntryId) throws Exception {
+		return _dlAppLocalService.fetchFileEntry(fileEntryId);
 	}
 
 	private Document _parseDocument(String html) {

--- a/modules/apps/adaptive-media/adaptive-media-image-service/src/main/java/com/liferay/adaptive/media/image/internal/exportimport/content/processor/AMImageHTMLExportImportContentProcessor.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-service/src/main/java/com/liferay/adaptive/media/image/internal/exportimport/content/processor/AMImageHTMLExportImportContentProcessor.java
@@ -100,10 +100,6 @@ public class AMImageHTMLExportImportContentProcessor
 		}
 	}
 
-	private FileEntry _getFileEntry(long fileEntryId) throws Exception {
-		return _dlAppLocalService.fetchFileEntry(fileEntryId);
-	}
-
 	private Document _parseDocument(String html) {
 		Document document = Jsoup.parseBodyFragment(html);
 
@@ -143,7 +139,8 @@ public class AMImageHTMLExportImportContentProcessor
 
 			long fileEntryId = amEmbeddedReferenceSet.importReference(path);
 
-			FileEntry fileEntry = _getFileEntry(fileEntryId);
+			FileEntry fileEntry = _dlAppLocalService.fetchFileEntry(
+				fileEntryId);
 
 			if (fileEntry == null) {
 				continue;

--- a/modules/apps/commerce/commerce-media-impl/src/main/java/com/liferay/commerce/media/internal/servlet/CommerceMediaServlet.java
+++ b/modules/apps/commerce/commerce-media-impl/src/main/java/com/liferay/commerce/media/internal/servlet/CommerceMediaServlet.java
@@ -156,17 +156,8 @@ public class CommerceMediaServlet extends HttpServlet {
 		return _getFileEntry(cpAttachmentFileEntry.getFileEntryId());
 	}
 
-	private FileEntry _getFileEntry(long fileEntryId) {
-		try {
-			return _dlAppLocalService.getFileEntry(fileEntryId);
-		}
-		catch (PortalException portalException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(portalException);
-			}
-
-			return null;
-		}
+	private FileEntry _getFileEntry(long fileEntryId) throws PortalException {
+		return _dlAppLocalService.fetchFileEntry(fileEntryId);
 	}
 
 	private long _getGroupId(

--- a/modules/apps/commerce/commerce-media-impl/src/main/java/com/liferay/commerce/media/internal/servlet/CommerceMediaServlet.java
+++ b/modules/apps/commerce/commerce-media-impl/src/main/java/com/liferay/commerce/media/internal/servlet/CommerceMediaServlet.java
@@ -153,11 +153,8 @@ public class CommerceMediaServlet extends HttpServlet {
 			_cpAttachmentFileEntryLocalService.getCPAttachmentFileEntry(
 				GetterUtil.getLongStrict(cpAttachmentFileEntryIdParam));
 
-		return _getFileEntry(cpAttachmentFileEntry.getFileEntryId());
-	}
-
-	private FileEntry _getFileEntry(long fileEntryId) throws PortalException {
-		return _dlAppLocalService.fetchFileEntry(fileEntryId);
+		return _dlAppLocalService.fetchFileEntry(
+			cpAttachmentFileEntry.getFileEntryId());
 	}
 
 	private long _getGroupId(
@@ -328,7 +325,8 @@ public class CommerceMediaServlet extends HttpServlet {
 					return;
 				}
 
-				FileEntry fileEntry = _getFileEntry(fileEntryId);
+				FileEntry fileEntry = _dlAppLocalService.fetchFileEntry(
+					fileEntryId);
 
 				if (fileEntry == null) {
 					_sendError(
@@ -620,7 +618,7 @@ public class CommerceMediaServlet extends HttpServlet {
 					return;
 				}
 
-				fileEntry = _getFileEntry(fileEntryId);
+				fileEntry = _dlAppLocalService.fetchFileEntry(fileEntryId);
 			}
 
 			ServletResponseUtil.sendFile(

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/FileEntryStagedModelDataHandler.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/FileEntryStagedModelDataHandler.java
@@ -153,7 +153,7 @@ public class FileEntryStagedModelDataHandler
 		String uuid, long groupId) {
 
 		try {
-			return _dlAppLocalService.getFileEntryByUuidAndGroupId(
+			return _dlAppLocalService.fetchFileEntryByUuidAndGroupId(
 				uuid, groupId);
 		}
 		catch (PortalException portalException) {

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/FileShortcutStagedModelDataHandler.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/FileShortcutStagedModelDataHandler.java
@@ -259,7 +259,7 @@ public class FileShortcutStagedModelDataHandler
 
 	private FileEntry _fetchFileEntry(long fileEntryId) {
 		try {
-			return _dlAppLocalService.getFileEntry(fileEntryId);
+			return _dlAppLocalService.fetchFileEntry(fileEntryId);
 		}
 		catch (PortalException portalException) {
 			if (_log.isWarnEnabled()) {

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/PublishFolderMVCActionCommand.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/PublishFolderMVCActionCommand.java
@@ -70,7 +70,7 @@ public class PublishFolderMVCActionCommand extends BaseMVCActionCommand {
 
 	private Folder _getFolder(long folderId) {
 		try {
-			return _dlAppLocalService.getFolder(folderId);
+			return _dlAppLocalService.fetchFolder(folderId);
 		}
 		catch (PortalException portalException) {
 			if (_log.isWarnEnabled()) {

--- a/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/input/template/parser/FragmentEntryInputTemplateNodeContextHelperImpl.java
+++ b/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/input/template/parser/FragmentEntryInputTemplateNodeContextHelperImpl.java
@@ -822,7 +822,7 @@ public class FragmentEntryInputTemplateNodeContextHelperImpl
 
 	private FileEntry _fetchFileEntry(long fileEntryId) {
 		try {
-			return _dlAppLocalService.getFileEntry(fileEntryId);
+			return _dlAppLocalService.fetchFileEntry(fileEntryId);
 		}
 		catch (PortalException portalException) {
 			if (_log.isWarnEnabled()) {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/converter/SharedAssetDTOConverter.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/converter/SharedAssetDTOConverter.java
@@ -301,7 +301,9 @@ public class SharedAssetDTOConverter
 		return fileEntry;
 	}
 
-	private String _getMimeType(SharingEntry sharingEntry) {
+	private String _getMimeType(SharingEntry sharingEntry)
+		throws PortalException {
+
 		if (StringUtil.equals(
 				ObjectEntryFolder.class.getName(),
 				sharingEntry.getClassName())) {
@@ -357,16 +359,10 @@ public class SharedAssetDTOConverter
 			return null;
 		}
 
-		com.liferay.portal.kernel.repository.model.FileEntry fileEntry = null;
+		com.liferay.portal.kernel.repository.model.FileEntry fileEntry =
+			_dlAppLocalService.fetchFileEntry(file);
 
-		try {
-			fileEntry = _dlAppLocalService.getFileEntry(file);
-		}
-		catch (PortalException portalException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(portalException);
-			}
-
+		if (fileEntry == null) {
 			return null;
 		}
 

--- a/modules/apps/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/bulk/selection/MultipleUserNotificationEventBulkSelection.java
+++ b/modules/apps/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/bulk/selection/MultipleUserNotificationEventBulkSelection.java
@@ -10,11 +10,6 @@ import com.liferay.bulk.selection.BaseMultipleEntryBulkSelection;
 import com.liferay.bulk.selection.BulkSelection;
 import com.liferay.bulk.selection.BulkSelectionFactory;
 import com.liferay.bulk.selection.EmptyBulkSelection;
-import com.liferay.petra.reflect.ReflectionUtil;
-import com.liferay.portal.kernel.exception.NoSuchUserNotificationEventException;
-import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.UserNotificationEvent;
 import com.liferay.portal.kernel.service.UserNotificationEventLocalService;
 
@@ -49,26 +44,9 @@ public class MultipleUserNotificationEventBulkSelection
 
 	@Override
 	protected UserNotificationEvent fetchEntry(long entryId) {
-		try {
-			return _userNotificationEventLocalService.getUserNotificationEvent(
-				entryId);
-		}
-		catch (NoSuchUserNotificationEventException
-					noSuchUserNotificationEventException) {
-
-			if (_log.isWarnEnabled()) {
-				_log.warn(noSuchUserNotificationEventException);
-			}
-
-			return null;
-		}
-		catch (PortalException portalException) {
-			return ReflectionUtil.throwException(portalException);
-		}
+		return _userNotificationEventLocalService.fetchUserNotificationEvent(
+			entryId);
 	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		MultipleUserNotificationEventBulkSelection.class);
 
 	private final UserNotificationEventLocalService
 		_userNotificationEventLocalService;

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/BaseModelRetrieverImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/BaseModelRetrieverImpl.java
@@ -5,8 +5,6 @@
 
 package com.liferay.portal.search.internal.indexer;
 
-import com.liferay.petra.string.StringBundler;
-import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -47,19 +45,7 @@ public class BaseModelRetrieverImpl implements BaseModelRetriever {
 		PersistedModelLocalService persistedModelLocalService =
 			_getPersistedModelLocalService(className);
 
-		try {
-			return persistedModelLocalService.getPersistedModel(classPK);
-		}
-		catch (PortalException portalException) {
-			if (_log.isWarnEnabled()) {
-				_log.warn(
-					StringBundler.concat(
-						"No ", className, " found for class PK ", classPK),
-					portalException);
-			}
-
-			return null;
-		}
+		return persistedModelLocalService.fetchPersistedModel(classPK);
 	}
 
 	private PersistedModelLocalService _getPersistedModelLocalService(

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/impl/KaleoInstanceLocalServiceImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/impl/KaleoInstanceLocalServiceImpl.java
@@ -35,7 +35,6 @@ import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.workflow.kaleo.exception.NoSuchInstanceException;
 import com.liferay.portal.workflow.kaleo.internal.search.KaleoInstanceTokenField;
 import com.liferay.portal.workflow.kaleo.model.KaleoInstance;
 import com.liferay.portal.workflow.kaleo.runtime.util.WorkflowContextUtil;
@@ -201,18 +200,14 @@ public class KaleoInstanceLocalServiceImpl
 	public KaleoInstance deleteKaleoInstance(long kaleoInstanceId)
 		throws PortalException {
 
-		KaleoInstance kaleoInstance = null;
+		KaleoInstance kaleoInstance =
+			kaleoInstancePersistence.fetchByPrimaryKey(kaleoInstanceId);
 
-		try {
-			kaleoInstance = kaleoInstancePersistence.remove(kaleoInstanceId);
-		}
-		catch (NoSuchInstanceException noSuchInstanceException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(noSuchInstanceException);
-			}
-
+		if (kaleoInstance == null) {
 			return null;
 		}
+
+		kaleoInstancePersistence.remove(kaleoInstance);
 
 		// Kaleo instance tokens
 

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/odata/entity/EntityModelFieldMapper.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/odata/entity/EntityModelFieldMapper.java
@@ -10,10 +10,7 @@ import com.liferay.expando.kernel.model.ExpandoColumnConstants;
 import com.liferay.expando.kernel.service.ExpandoColumnLocalService;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.CamelCaseUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
@@ -61,18 +58,8 @@ public class EntityModelFieldMapper {
 	}
 
 	public ExpandoColumn getExpandoColumn(String entityFieldName) {
-		long expandoColumnId = getExpandoColumnId(entityFieldName);
-
-		try {
-			return _expandoColumnLocalService.getColumn(expandoColumnId);
-		}
-		catch (PortalException portalException) {
-			_log.error(
-				"Unable to find Expando Column with id " + expandoColumnId,
-				portalException);
-
-			return null;
-		}
+		return _expandoColumnLocalService.fetchExpandoColumn(
+			getExpandoColumnId(entityFieldName));
 	}
 
 	public String getExpandoColumnEntityFieldName(ExpandoColumn expandoColumn) {
@@ -310,9 +297,6 @@ public class EntityModelFieldMapper {
 
 		return "string";
 	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		EntityModelFieldMapper.class);
 
 	@Reference
 	private ExpandoColumnLocalService _expandoColumnLocalService;

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/upload/test/TestFileEntry.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/upload/test/TestFileEntry.java
@@ -154,7 +154,7 @@ public class TestFileEntry implements FileEntry {
 	@Override
 	public Folder getFolder() {
 		try {
-			return DLAppLocalServiceUtil.getFolder(_folderId);
+			return DLAppLocalServiceUtil.fetchFolder(_folderId);
 		}
 		catch (PortalException portalException) {
 			if (_log.isDebugEnabled()) {

--- a/modules/apps/wiki/wiki-api/bnd.bnd
+++ b/modules/apps/wiki/wiki-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Wiki API
 Bundle-SymbolicName: com.liferay.wiki.api
-Bundle-Version: 22.0.2
+Bundle-Version: 22.1.0
 Export-Package:\
 	com.liferay.wiki.configuration,\
 	com.liferay.wiki.configuration.definition,\

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiPageLocalService.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiPageLocalService.java
@@ -336,6 +336,9 @@ public interface WikiPageLocalService
 	public WikiPage fetchPage(long resourcePrimKey);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public WikiPage fetchPage(long resourcePrimKey, Boolean head);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public WikiPage fetchPage(long nodeId, String title);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
@@ -801,4 +804,4 @@ public interface WikiPageLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1265994469
+// LIFERAY-SERVICE-BUILDER-HASH:-1469070703

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiPageLocalServiceUtil.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiPageLocalServiceUtil.java
@@ -413,6 +413,10 @@ public class WikiPageLocalServiceUtil {
 		return getService().fetchPage(resourcePrimKey);
 	}
 
+	public static WikiPage fetchPage(long resourcePrimKey, Boolean head) {
+		return getService().fetchPage(resourcePrimKey, head);
+	}
+
 	public static WikiPage fetchPage(long nodeId, String title) {
 		return getService().fetchPage(nodeId, title);
 	}
@@ -1105,4 +1109,4 @@ public class WikiPageLocalServiceUtil {
 			WikiPageLocalServiceUtil.class, WikiPageLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2131732958
+// LIFERAY-SERVICE-BUILDER-HASH:-1715222725

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiPageLocalServiceWrapper.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiPageLocalServiceWrapper.java
@@ -460,6 +460,11 @@ public class WikiPageLocalServiceWrapper
 	}
 
 	@Override
+	public WikiPage fetchPage(long resourcePrimKey, Boolean head) {
+		return _wikiPageLocalService.fetchPage(resourcePrimKey, head);
+	}
+
+	@Override
 	public WikiPage fetchPage(long nodeId, String title) {
 		return _wikiPageLocalService.fetchPage(nodeId, title);
 	}
@@ -1287,4 +1292,4 @@ public class WikiPageLocalServiceWrapper
 	private WikiPageLocalService _wikiPageLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1924662821
+// LIFERAY-SERVICE-BUILDER-HASH:1709699507

--- a/modules/apps/wiki/wiki-api/src/main/resources/com/liferay/wiki/service/packageinfo
+++ b/modules/apps/wiki/wiki-api/src/main/resources/com/liferay/wiki/service/packageinfo
@@ -1,1 +1,1 @@
-version 6.0.0
+version 6.1.0

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/asset/validator/FrontPageAssetEntryValidatorExclusionRule.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/asset/validator/FrontPageAssetEntryValidatorExclusionRule.java
@@ -7,9 +7,6 @@ package com.liferay.wiki.internal.asset.validator;
 
 import com.liferay.asset.kernel.validator.AssetEntryValidatorExclusionRule;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
-import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.wiki.configuration.WikiGroupServiceConfiguration;
 import com.liferay.wiki.constants.WikiPageConstants;
@@ -46,16 +43,11 @@ public class FrontPageAssetEntryValidatorExclusionRule
 		}
 
 		if (wikiPage == null) {
-			try {
-				wikiPage = _wikiPageLocalService.getPage(classPK, false);
-			}
-			catch (PortalException portalException) {
-				if (_log.isWarnEnabled()) {
-					_log.warn(portalException);
-				}
+			wikiPage = _wikiPageLocalService.fetchPage(classPK, false);
+		}
 
-				return false;
-			}
+		if (wikiPage == null) {
+			return false;
 		}
 
 		if (StringUtil.equals(
@@ -75,9 +67,6 @@ public class FrontPageAssetEntryValidatorExclusionRule
 		_wikiGroupServiceConfiguration = ConfigurableUtil.createConfigurable(
 			WikiGroupServiceConfiguration.class, properties);
 	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		FrontPageAssetEntryValidatorExclusionRule.class);
 
 	private volatile WikiGroupServiceConfiguration
 		_wikiGroupServiceConfiguration;

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiPageLocalServiceImpl.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiPageLocalServiceImpl.java
@@ -918,6 +918,24 @@ public class WikiPageLocalServiceImpl extends WikiPageLocalServiceBaseImpl {
 	}
 
 	@Override
+	public WikiPage fetchPage(long resourcePrimKey, Boolean head) {
+		WikiPageResource pageResource =
+			_wikiPageResourcePersistence.fetchByPrimaryKey(resourcePrimKey);
+
+		if (pageResource == null) {
+			return null;
+		}
+
+		if (head == null) {
+			return wikiPagePersistence.fetchByN_T_First(
+				pageResource.getNodeId(), pageResource.getTitle(), null);
+		}
+
+		return wikiPagePersistence.fetchByN_T_H_First(
+			pageResource.getNodeId(), pageResource.getTitle(), head, null);
+	}
+
+	@Override
 	public WikiPage fetchPage(long nodeId, String title) {
 		return wikiPagePersistence.fetchByN_T_H_First(
 			nodeId, title, true, null);

--- a/modules/dxp/apps/commerce/commerce-machine-learning-forecast-alert-web/src/main/java/com/liferay/commerce/machine/learning/forecast/alert/web/internal/display/context/CommerceMLForecastAlertEntryListDisplayContext.java
+++ b/modules/dxp/apps/commerce/commerce-machine-learning-forecast-alert-web/src/main/java/com/liferay/commerce/machine/learning/forecast/alert/web/internal/display/context/CommerceMLForecastAlertEntryListDisplayContext.java
@@ -5,8 +5,6 @@
 
 package com.liferay.commerce.machine.learning.forecast.alert.web.internal.display.context;
 
-import com.liferay.account.model.AccountEntry;
-import com.liferay.account.service.AccountEntryLocalService;
 import com.liferay.commerce.machine.learning.forecast.alert.constants.CommerceMLForecastAlertActionKeys;
 import com.liferay.commerce.machine.learning.forecast.alert.constants.CommerceMLForecastAlertConstants;
 import com.liferay.commerce.machine.learning.forecast.alert.model.CommerceMLForecastAlertEntry;
@@ -27,22 +25,16 @@ import jakarta.portlet.RenderRequest;
 public class CommerceMLForecastAlertEntryListDisplayContext {
 
 	public CommerceMLForecastAlertEntryListDisplayContext(
-		AccountEntryLocalService accountEntryLocalService,
 		CommerceMLForecastAlertEntryService commerceMLForecastAlertEntryService,
 		PortletResourcePermission portletResourcePermission,
 		RenderRequest renderRequest) {
 
-		_accountEntryLocalService = accountEntryLocalService;
 		_commerceMLForecastAlertEntryService =
 			commerceMLForecastAlertEntryService;
 		_portletResourcePermission = portletResourcePermission;
 
 		_commerceMLForecastAlertEntryRequestHelper =
 			new CommerceMLForecastAlertEntryRequestHelper(renderRequest);
-	}
-
-	public AccountEntry getAccountEntry(long accountEntryId) {
-		return _accountEntryLocalService.fetchAccountEntry(accountEntryId);
 	}
 
 	public PortletURL getPortletURL() {
@@ -98,7 +90,6 @@ public class CommerceMLForecastAlertEntryListDisplayContext {
 			CommerceMLForecastAlertActionKeys.VIEW_ALERTS);
 	}
 
-	private final AccountEntryLocalService _accountEntryLocalService;
 	private final CommerceMLForecastAlertEntryRequestHelper
 		_commerceMLForecastAlertEntryRequestHelper;
 	private final CommerceMLForecastAlertEntryService

--- a/modules/dxp/apps/commerce/commerce-machine-learning-forecast-alert-web/src/main/java/com/liferay/commerce/machine/learning/forecast/alert/web/internal/display/context/CommerceMLForecastAlertEntryListDisplayContext.java
+++ b/modules/dxp/apps/commerce/commerce-machine-learning-forecast-alert-web/src/main/java/com/liferay/commerce/machine/learning/forecast/alert/web/internal/display/context/CommerceMLForecastAlertEntryListDisplayContext.java
@@ -14,8 +14,6 @@ import com.liferay.commerce.machine.learning.forecast.alert.service.CommerceMLFo
 import com.liferay.commerce.machine.learning.forecast.alert.web.internal.display.context.helper.CommerceMLForecastAlertEntryRequestHelper;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.security.permission.resource.PortletResourcePermission;
@@ -44,14 +42,7 @@ public class CommerceMLForecastAlertEntryListDisplayContext {
 	}
 
 	public AccountEntry getAccountEntry(long accountEntryId) {
-		try {
-			return _accountEntryLocalService.getAccountEntry(accountEntryId);
-		}
-		catch (PortalException portalException) {
-			_log.error(portalException);
-
-			return null;
-		}
+		return _accountEntryLocalService.fetchAccountEntry(accountEntryId);
 	}
 
 	public PortletURL getPortletURL() {
@@ -106,9 +97,6 @@ public class CommerceMLForecastAlertEntryListDisplayContext {
 			GroupConstants.DEFAULT_LIVE_GROUP_ID,
 			CommerceMLForecastAlertActionKeys.VIEW_ALERTS);
 	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		CommerceMLForecastAlertEntryListDisplayContext.class);
 
 	private final AccountEntryLocalService _accountEntryLocalService;
 	private final CommerceMLForecastAlertEntryRequestHelper

--- a/modules/dxp/apps/commerce/commerce-machine-learning-forecast-alert-web/src/main/java/com/liferay/commerce/machine/learning/forecast/alert/web/internal/portlet/CommerceMLForecastAlertPortlet.java
+++ b/modules/dxp/apps/commerce/commerce-machine-learning-forecast-alert-web/src/main/java/com/liferay/commerce/machine/learning/forecast/alert/web/internal/portlet/CommerceMLForecastAlertPortlet.java
@@ -5,7 +5,6 @@
 
 package com.liferay.commerce.machine.learning.forecast.alert.web.internal.portlet;
 
-import com.liferay.account.service.AccountEntryLocalService;
 import com.liferay.commerce.machine.learning.forecast.alert.constants.CommerceMLForecastAlertConstants;
 import com.liferay.commerce.machine.learning.forecast.alert.constants.CommerceMLForecastAlertPortletKeys;
 import com.liferay.commerce.machine.learning.forecast.alert.service.CommerceMLForecastAlertEntryService;
@@ -63,7 +62,6 @@ public class CommerceMLForecastAlertPortlet extends MVCPortlet {
 			CommerceMLForecastAlertEntryListDisplayContext
 				commerceMLForecastAlertEntryListDisplayContext =
 					new CommerceMLForecastAlertEntryListDisplayContext(
-						_accountEntryLocalService,
 						_commerceMLForecastAlertEntryService,
 						_portletResourcePermission, renderRequest);
 
@@ -81,9 +79,6 @@ public class CommerceMLForecastAlertPortlet extends MVCPortlet {
 
 		super.render(renderRequest, renderResponse);
 	}
-
-	@Reference
-	private AccountEntryLocalService _accountEntryLocalService;
 
 	@Reference
 	private CommerceMLForecastAlertEntryService

--- a/modules/dxp/apps/commerce/commerce-machine-learning-forecast-alert-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/dxp/apps/commerce/commerce-machine-learning-forecast-alert-web/src/main/resources/META-INF/resources/init.jsp
@@ -14,6 +14,7 @@ taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
 <%@ page import="com.liferay.account.model.AccountEntry" %><%@
+page import="com.liferay.account.service.AccountEntryLocalServiceUtil" %><%@
 page import="com.liferay.commerce.machine.learning.forecast.alert.constants.CommerceMLForecastAlertActionKeys" %><%@
 page import="com.liferay.commerce.machine.learning.forecast.alert.constants.CommerceMLForecastAlertConstants" %><%@
 page import="com.liferay.commerce.machine.learning.forecast.alert.model.CommerceMLForecastAlertEntry" %><%@

--- a/modules/dxp/apps/commerce/commerce-machine-learning-forecast-alert-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/dxp/apps/commerce/commerce-machine-learning-forecast-alert-web/src/main/resources/META-INF/resources/view.jsp
@@ -28,7 +28,7 @@ CommerceMLForecastAlertEntryListDisplayContext commerceMLForecastAlertEntryListD
 				>
 
 					<%
-					AccountEntry accountEntry = commerceMLForecastAlertEntryListDisplayContext.getAccountEntry(commerceMLForecastAlertEntry.getCommerceAccountId());
+					AccountEntry accountEntry = AccountEntryLocalServiceUtil.fetchAccountEntry(commerceMLForecastAlertEntry.getCommerceAccountId());
 
 					long logoId = accountEntry.getLogoId();
 					%>

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppLocalServiceImpl.java
@@ -619,6 +619,52 @@ public class DLAppLocalServiceImpl extends DLAppLocalServiceBaseImpl {
 	}
 
 	@Override
+	public FileEntry fetchFileEntryByUuidAndGroupId(String uuid, long groupId)
+		throws PortalException {
+
+		try {
+			LocalRepository localRepository = getLocalRepository(groupId);
+
+			return localRepository.getFileEntryByUuid(uuid);
+		}
+		catch (NoSuchFileEntryException noSuchFileEntryException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(noSuchFileEntryException);
+			}
+		}
+
+		List<Repository> repositories = _repositoryPersistence.findByGroupId(
+			groupId);
+
+		for (Repository repository : repositories) {
+			if (Objects.equals(
+					repository.getClassName(),
+					TemporaryFileEntryRepository.class.getName())) {
+
+				if (_log.isDebugEnabled()) {
+					_log.debug("Skipping temporary file entry repository");
+				}
+
+				continue;
+			}
+
+			try {
+				LocalRepository localRepository = getLocalRepository(
+					repository.getRepositoryId());
+
+				return localRepository.getFileEntryByUuid(uuid);
+			}
+			catch (NoSuchFileEntryException noSuchFileEntryException) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(noSuchFileEntryException);
+				}
+			}
+		}
+
+		return null;
+	}
+
+	@Override
 	public FileShortcut fetchFileShortcut(long fileShortcutId)
 		throws PortalException {
 
@@ -758,49 +804,16 @@ public class DLAppLocalServiceImpl extends DLAppLocalServiceBaseImpl {
 	public FileEntry getFileEntryByUuidAndGroupId(String uuid, long groupId)
 		throws PortalException {
 
-		try {
-			LocalRepository localRepository = getLocalRepository(groupId);
+		FileEntry fileEntry = fetchFileEntryByUuidAndGroupId(uuid, groupId);
 
-			return localRepository.getFileEntryByUuid(uuid);
-		}
-		catch (NoSuchFileEntryException noSuchFileEntryException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(noSuchFileEntryException);
-			}
+		if (fileEntry == null) {
+			throw new NoSuchFileEntryException(
+				StringBundler.concat(
+					"No DLFileEntry exists with the key {uuid=", uuid,
+					", groupId=", groupId, StringPool.CLOSE_CURLY_BRACE));
 		}
 
-		List<Repository> repositories = _repositoryPersistence.findByGroupId(
-			groupId);
-
-		for (Repository repository : repositories) {
-			if (Objects.equals(
-					repository.getClassName(),
-					TemporaryFileEntryRepository.class.getName())) {
-
-				if (_log.isDebugEnabled()) {
-					_log.debug("Skipping temporary file entry repository");
-				}
-
-				continue;
-			}
-
-			try {
-				LocalRepository localRepository = getLocalRepository(
-					repository.getRepositoryId());
-
-				return localRepository.getFileEntryByUuid(uuid);
-			}
-			catch (NoSuchFileEntryException noSuchFileEntryException) {
-				if (_log.isDebugEnabled()) {
-					_log.debug(noSuchFileEntryException);
-				}
-			}
-		}
-
-		throw new NoSuchFileEntryException(
-			StringBundler.concat(
-				"No DLFileEntry exists with the key {uuid=", uuid, ", groupId=",
-				groupId, StringPool.CLOSE_CURLY_BRACE));
+		return fileEntry;
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppLocalServiceImpl.java
@@ -6,6 +6,7 @@
 package com.liferay.portlet.documentlibrary.service.impl;
 
 import com.liferay.document.library.kernel.exception.NoSuchFileEntryException;
+import com.liferay.document.library.kernel.exception.NoSuchFolderException;
 import com.liferay.document.library.kernel.model.DLFolder;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.model.DLVersionNumberIncrease;
@@ -684,6 +685,23 @@ public class DLAppLocalServiceImpl extends DLAppLocalServiceBaseImpl {
 
 		return localRepository.fetchFileShortcutByExternalReferenceCode(
 			externalReferenceCode);
+	}
+
+	@Override
+	public Folder fetchFolder(long folderId) throws PortalException {
+		try {
+			LocalRepository localRepository =
+				RepositoryProviderUtil.getFolderLocalRepository(folderId);
+
+			return localRepository.getFolder(folderId);
+		}
+		catch (NoSuchFolderException noSuchFolderException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(noSuchFolderException);
+			}
+
+			return null;
+		}
 	}
 
 	@Override

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppLocalService.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppLocalService.java
@@ -363,6 +363,10 @@ public interface DLAppLocalService extends BaseLocalService {
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public FileEntry fetchFileEntryByUuidAndGroupId(String uuid, long groupId)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public FileShortcut fetchFileShortcut(long fileShortcutId)
 		throws PortalException;
 
@@ -815,4 +819,4 @@ public interface DLAppLocalService extends BaseLocalService {
 		throws PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1235902289
+// LIFERAY-SERVICE-BUILDER-HASH:-1008036570

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppLocalService.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppLocalService.java
@@ -376,6 +376,9 @@ public interface DLAppLocalService extends BaseLocalService {
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public Folder fetchFolder(long folderId) throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public Folder fetchFolderByExternalReferenceCode(
 			String externalReferenceCode, long groupId)
 		throws PortalException;
@@ -819,4 +822,4 @@ public interface DLAppLocalService extends BaseLocalService {
 		throws PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1008036570
+// LIFERAY-SERVICE-BUILDER-HASH:929140234

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppLocalServiceUtil.java
@@ -457,6 +457,13 @@ public class DLAppLocalServiceUtil {
 			externalReferenceCode, groupId);
 	}
 
+	public static com.liferay.portal.kernel.repository.model.Folder fetchFolder(
+			long folderId)
+		throws PortalException {
+
+		return getService().fetchFolder(folderId);
+	}
+
 	public static com.liferay.portal.kernel.repository.model.Folder
 			fetchFolderByExternalReferenceCode(
 				String externalReferenceCode, long groupId)
@@ -1039,4 +1046,4 @@ public class DLAppLocalServiceUtil {
 	private static volatile DLAppLocalService _service;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1621021125
+// LIFERAY-SERVICE-BUILDER-HASH:-1180157448

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppLocalServiceUtil.java
@@ -434,6 +434,13 @@ public class DLAppLocalServiceUtil {
 			groupId, externalReferenceCode);
 	}
 
+	public static com.liferay.portal.kernel.repository.model.FileEntry
+			fetchFileEntryByUuidAndGroupId(String uuid, long groupId)
+		throws PortalException {
+
+		return getService().fetchFileEntryByUuidAndGroupId(uuid, groupId);
+	}
+
 	public static com.liferay.portal.kernel.repository.model.FileShortcut
 			fetchFileShortcut(long fileShortcutId)
 		throws PortalException {
@@ -1032,4 +1039,4 @@ public class DLAppLocalServiceUtil {
 	private static volatile DLAppLocalService _service;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1812234655
+// LIFERAY-SERVICE-BUILDER-HASH:1621021125

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppLocalServiceWrapper.java
@@ -474,6 +474,14 @@ public class DLAppLocalServiceWrapper
 	}
 
 	@Override
+	public com.liferay.portal.kernel.repository.model.Folder fetchFolder(
+			long folderId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _dlAppLocalService.fetchFolder(folderId);
+	}
+
+	@Override
 	public com.liferay.portal.kernel.repository.model.Folder
 			fetchFolderByExternalReferenceCode(
 				String externalReferenceCode, long groupId)
@@ -1083,4 +1091,4 @@ public class DLAppLocalServiceWrapper
 	private DLAppLocalService _dlAppLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-543347863
+// LIFERAY-SERVICE-BUILDER-HASH:150245717

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppLocalServiceWrapper.java
@@ -448,6 +448,14 @@ public class DLAppLocalServiceWrapper
 	}
 
 	@Override
+	public com.liferay.portal.kernel.repository.model.FileEntry
+			fetchFileEntryByUuidAndGroupId(String uuid, long groupId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _dlAppLocalService.fetchFileEntryByUuidAndGroupId(uuid, groupId);
+	}
+
+	@Override
 	public com.liferay.portal.kernel.repository.model.FileShortcut
 			fetchFileShortcut(long fileShortcutId)
 		throws com.liferay.portal.kernel.exception.PortalException {
@@ -1075,4 +1083,4 @@ public class DLAppLocalServiceWrapper
 	private DLAppLocalService _dlAppLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1650995868
+// LIFERAY-SERVICE-BUILDER-HASH:-543347863

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/packageinfo
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/packageinfo
@@ -1,1 +1,1 @@
-version 21.6.2
+version 21.7.0


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98534

## What Is Being Fixed

Methods that promise null on absence frequently resolve an entity through a throwing get or find lookup and catch `PortalException` or a `NoSuch*Exception` only to return the null or false absence sentinel — using a not-found exception as control flow.

## How It Is Being Fixed

Convert every such occurrence to the null-tolerant fetch sibling with a null check, keeping the catch where it still guards genuine repository failures, and inline the helpers that became one-line passthroughs. Add the three missing siblings the conversions needed: `DLAppLocalService.fetchFileEntryByUuidAndGroupId`, `DLAppLocalService.fetchFolder`, and `WikiPageLocalService.fetchPage(resourcePrimKey, head)` (with their minor package version bumps and Service Builder regeneration).

This is the product-code half of the initiative. The SourceFormatter rule that enforces the contract (`JavaFetchContractCatchCheck`) ships separately to `ling-alan-huang`, who owns SourceFormatter checks; see the cross-reference comment. That rule carries no whitelist, so this cleanup must land first.

## PR Check

**PASS** — tested SHA `78dda0e93bc758ac32e672f880e5ba0883b9ad2e`

Validated locally on this branch; the per-module/integration compile set was validated in the original combined PR's pr-check (this branch is that change minus the check commit, rebased cleanly onto current master with no conflict on any API, regeneration, or `packageinfo` file):

| Validation | Result |
| --- | --- |
| Source Format | PASS — `format-source-current-branch`, 0 changes |
| Baseline | PASS — minor bumps for the added `fetch*` methods: wiki-api `6.0.0`→`6.1.0` (bundle `22.1.0`), document-library kernel service `21.6.2`→`21.7.0`; master's base versions unchanged |
| Service Builder | PASS — no `service.xml` change; the committed regeneration is preserved intact by the clean rebase |
| Core Compile | PASS — `ant compile install-portal-snapshots` (portal-kernel with the new `DLAppLocalService` methods) |
| Per-Module / Integration Test Compile | PASS in the original combined PR's pr-check (15 changed modules + portal-osgi-web-portlet-container-test); code unchanged by the split + clean rebase |

<!-- pr-check {"result":"success","sha":"78dda0e93bc758ac32e672f880e5ba0883b9ad2e"} -->
