### PR TITLE
LPD-98672 Do not commit the shared transaction in the object copy listener

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/instance/lifecycle/CompanyObjectDefinitionPortalInstanceLifecycleListener.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/instance/lifecycle/CompanyObjectDefinitionPortalInstanceLifecycleListener.java
@@ -90,19 +90,14 @@ public class CompanyObjectDefinitionPortalInstanceLifecycleListener
 				continue;
 			}
 
-			try (AutoCloseable autoCloseable = _disableAutoCommit(connection)) {
-				_executeUpdates(
-					_classNameColumnNamesMap, company.getCompanyId(),
-					connection, objectDefinition.getClassName(), className);
-				_executeUpdates(
-					_portletIdColumnNamesMap, company.getCompanyId(),
-					connection,
-					ObjectDefinitionUtil.getPortletId(
-						objectDefinition.getClassName()),
-					ObjectDefinitionUtil.getPortletId(className));
-
-				connection.commit();
-			}
+			_executeUpdates(
+				_classNameColumnNamesMap, company.getCompanyId(), connection,
+				objectDefinition.getClassName(), className);
+			_executeUpdates(
+				_portletIdColumnNamesMap, company.getCompanyId(), connection,
+				ObjectDefinitionUtil.getPortletId(
+					objectDefinition.getClassName()),
+				ObjectDefinitionUtil.getPortletId(className));
 
 			_ploEntryLocalService.deletePLOEntries(
 				company.getCompanyId(), "model.resource." + className);
@@ -173,16 +168,6 @@ public class CompanyObjectDefinitionPortalInstanceLifecycleListener
 					objectDefinition);
 			}
 		}
-	}
-
-	private AutoCloseable _disableAutoCommit(Connection connection)
-		throws Exception {
-
-		boolean autoCommit = connection.getAutoCommit();
-
-		connection.setAutoCommit(false);
-
-		return () -> connection.setAutoCommit(autoCommit);
 	}
 
 	private void _executeUpdates(


### PR DESCRIPTION
[LPD-98672](https://liferay.atlassian.net/browse/LPD-98672)

Follow-up to LPD-98668. A codebase-wide audit of explicit JDBC `Connection` commit/rollback/setAutoCommit surfaced one more instance of the same borrowed-connection commit hazard.

## What Is Being Fixed

During a database partition company copy, `CompanyObjectDefinitionPortalInstanceLifecycleListener` rewrites object definition class name references across ~15 tables. It borrowed the connection via `CurrentConnection` and called `commit()` on it. That connection belongs to `PortalInstanceLifecycleListenerManagerImpl.preregisterCompany`, which is `@Transactional(REQUIRED)` and runs every lifecycle listener in one transaction — so the `commit()` flushed that shared transaction (other listeners' work and the copy orchestration's pending writes).

## How It Is Being Fixed

A strict partial revert of `6abc0172a9b807cdf94e98f19b913934dcf2da80` (LPD-73197), which added the rewrite. The rewrite is kept; only the `commit()` and the no-op `_disableAutoCommit` wrapper are removed.

Unlike the DDL in LPD-98668 (which PostgreSQL only makes visible to later transactions once the connection is explicitly committed), this listener runs plain **DML**. `preregisterCompany` runs inside the `REQUIRES_NEW` transaction opened in `copyDBPartitionCompany`, which commits at its boundary, and the deploy that reads the rewrite runs afterward in `registerCompany` — a separate transaction. So the rewrite is durable and visible without the explicit commit, which only flushed the caller mid-flight. The rewrite now participates in the enclosing transaction, committing atomically with the rest of the preregister phase. An owned connection was not used (as in LPD-98668) because the loop interleaves service calls on the transaction connection with the raw rewrite SQL.

## PR Check

**PASS** — tested SHA `c9640b814a6130624505a9e67943f9fd9c2503f8`

| Validation | Result |
| --- | --- |
| Source Format | PASS — `format-source-current-branch`, 0 changes |
| Baseline | PASS — single Java file, no `packageinfo`/`bnd.bnd`/`.gradle`; change is inside a private method body (no API change) |
| Per-Module Compile | PASS — `:apps:object:object-service:compileJava` |

**Regression verification.** LPD-73197 shipped no dedicated test, but `CompanyLocalServiceDBPartitionTest.testCopyDBPartitionCompany` is a strong acceptance test: it publishes an object definition, copies the company, and asserts the copied references resolve under the **new** class name (would fail if the rewrite regressed). Ran A/B — master (with the commit) vs this fix (without) — against a live partition-enabled portal on **both MySQL and PostgreSQL**, all four cases PASS, plus both copy failure-path variants. On CI (shuyangzhou#12379) the `modules-integration-db-partition` batch that runs this test passed on MySQL and PostgreSQL; `ci:test:sf` and `ci:test:stable` passed; remaining `db-partition` failures are the pre-existing `DatabasePartitioning` Poshi tests unrelated to database connections.

<!-- pr-check {"result":"success","sha":"c9640b814a6130624505a9e67943f9fd9c2503f8"} -->
