### PR TITLE
LPD-85995 Add source formatter rule for removed SitesUtil method

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -6000,6 +6000,15 @@
 		]
 	},
 	{
+		"from": "SitesUtil.updateLayoutSetPrototypesLinks",
+		"issueKey": "LPD-85995",
+		"newImports": [
+			"com.liferay.sites.kernel.util.Sites"
+		],
+		"newReference": "Sites _sites",
+		"to": "_sites.updateLayoutSetPrototypesLinks"
+	},
+	{
 		"from": "regex:MultiVMPoolUtil\\s*.\\s*getPortalCache\\(\\s*(?<prefixMethodName>[\\s\\S]*?)\\)",
 		"issueKey": "LPS-153962",
 		"newImports": [

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_85995.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_85995.testjava
@@ -1,0 +1,32 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+import com.liferay.sites.kernel.util.Sites;
+
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class LPD_85995 {
+
+	public void method(
+		Group group, long publicLayoutSetPrototypeId,
+		long privateLayoutSetPrototypeId,
+		boolean publicLayoutSetPrototypeLinkEnabled,
+		boolean privateLayoutSetPrototypeLinkEnabled) {
+
+		_sites.updateLayoutSetPrototypesLinks(
+			group, publicLayoutSetPrototypeId, privateLayoutSetPrototypeId,
+			publicLayoutSetPrototypeLinkEnabled,
+			privateLayoutSetPrototypeLinkEnabled);
+	}
+
+	@Reference
+	private Sites _sites;
+
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_85995.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_85995.testjava
@@ -1,0 +1,25 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class LPD_85995 {
+
+	public void method(
+		Group group, long publicLayoutSetPrototypeId,
+		long privateLayoutSetPrototypeId,
+		boolean publicLayoutSetPrototypeLinkEnabled,
+		boolean privateLayoutSetPrototypeLinkEnabled) {
+
+		SitesUtil.updateLayoutSetPrototypesLinks(
+			group, publicLayoutSetPrototypeId, privateLayoutSetPrototypeId,
+			publicLayoutSetPrototypeLinkEnabled,
+			privateLayoutSetPrototypeLinkEnabled);
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-85995

## What Is Being Fixed

The static method `SitesUtil.updateLayoutSetPrototypesLinks` was removed. Callers that still use the static invocation no longer compile, and there was no automated way to migrate them to the new instance-based API.

## How It Is Being Fixed

A replacement rule is added to the source formatter's `replacements.json`, so the upgrade catch-all check automatically rewrites `SitesUtil.updateLayoutSetPrototypesLinks(...)` into `_sites.updateLayoutSetPrototypesLinks(...)`, injecting a `Sites` field via `@Reference` along with its import. Input and expected fixtures are added under the `upgrade-catch-all-check` test resources to verify the transformation.

## PR Check

**pr-check: PASS** — tested on `89909046ad5fb27e4e534067c4738041b64390e4`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "89909046ad5fb27e4e534067c4738041b64390e4"} -->
