### PR TITLE
LPD-98852 Extend timeout for the fragment configuration comparison test

### DIFF
--- a/modules/test/playwright/tests/layout-admin-web/main/exportImport.spec.ts
+++ b/modules/test/playwright/tests/layout-admin-web/main/exportImport.spec.ts
@@ -302,6 +302,8 @@ test(
 		pageEditorPage,
 		site: siteA,
 	}) => {
+		test.slow();
+
 		const getFragmentConfigurationScreenshots = async ({screenshots}) => {
 			const configurationPanel = page.getByLabel('Configuration Panel', {
 				exact: true,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98852

## Failing Test

`layout-admin-web/main/exportImport.spec.ts > Compare fragment configurations when exporting/importing a site`

`modules/test/playwright/tests/layout-admin-web/main/exportImport.spec.ts`

```
› layout-admin-web/main/exportImport.spec.ts:295:1 › Compare fragment configurations when exporting/importing a site @LPD-74680
Test timeout of 90000ms exceeded.
Error: locator.click: Test timeout of 90000ms exceeded.
Call log:
  - waiting for getByRole('tab', { name: 'General', exact: true }).filter({ visible: true }).last()
    at ../pages/layout-content-page-editor-web/PageEditorPage.ts:1398
```

## Root Cause

The failure is a flaky CI timeout, not a regression. The Testray history for this case alternates pass/fail across builds, and the test passes reliably locally in around 30 seconds. The test captures a screenshot for every configuration tab (General, Styles, Advanced, plus Mapping/Link for text elements) of every fragment in the page-structure tree, iterating in a loop. Under CI load this cumulative UI work occasionally overruns the default 90 second Playwright test budget, timing out while clicking the General configuration tab.

## Fix

Add `test.slow()`, which triples the test timeout to 270 seconds. This matches the sibling `LPS-96391` test in the same file, which already does this for a comparably heavy export/import flow. No product code changes.

- `modules/test/playwright/tests/layout-admin-web/main/exportImport.spec.ts`
