### PR TITLE
LPD-47005 Add upgrade rule replacing removed Optional getters

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -4564,6 +4564,22 @@
 	},
 	{
 		"classNames": [
+			"PortletSharedSearchResponse"
+		],
+		"from": "getKeywordsOptional",
+		"issueKey": "LPD-47005",
+		"to": "getKeywords"
+	},
+	{
+		"classNames": [
+			"PortletSharedSearchResponse"
+		],
+		"from": "getSpellCheckSuggestionOptional",
+		"issueKey": "LPD-47005",
+		"to": "getSpellCheckSuggestion"
+	},
+	{
+		"classNames": [
 			"SiteNavigationMenuLocalService",
 			"SiteNavigationMenuLocalServiceUtil"
 		],

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_47005.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_47005.testjava
@@ -1,0 +1,23 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class LPD_47005 {
+
+	public void method() {
+		_portletSharedSearchResponse.getKeywords();
+		_portletSharedSearchResponse.getSpellCheckSuggestion();
+	}
+
+	@Reference
+	private PortletSharedSearchResponse _portletSharedSearchResponse;
+
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_47005.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_47005.testjava
@@ -1,0 +1,23 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class LPD_47005 {
+
+	public void method() {
+		_portletSharedSearchResponse.getKeywordsOptional();
+		_portletSharedSearchResponse.getSpellCheckSuggestionOptional();
+	}
+
+	@Reference
+	private PortletSharedSearchResponse _portletSharedSearchResponse;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-47005

## What Is Being Fixed

The `getKeywordsOptional()` and `getSpellCheckSuggestionOptional()` methods on
`PortletSharedSearchResponse` were removed in favor of the non-Optional
`getKeywords()` and `getSpellCheckSuggestion()`. Callers that still use the
removed methods have no automated migration path.

## How It Is Being Fixed

Two entries are added to the source formatter's `replacements.json`
upgrade-catch-all check, mapping `getKeywordsOptional` to `getKeywords` and
`getSpellCheckSuggestionOptional` to `getSpellCheckSuggestion` on
`PortletSharedSearchResponse`. When the upgrade formatter runs, calls to the
removed methods are rewritten automatically. Test fixtures under
`upgrade-catch-all-check` cover both replacements.

## PR Check

**pr-check: PASS** — tested on `07f56835558d3ad0c534d6df595ccc80e7a19a8c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "07f56835558d3ad0c534d6df595ccc80e7a19a8c"} -->
