### PR TITLE
LPD-98968 Skip the object definition settings read without any edge

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -45,6 +45,7 @@ import com.liferay.object.internal.uad.exporter.ObjectEntryUADExporter;
 import com.liferay.object.internal.workflow.ObjectEntryWorkflowHandler;
 import com.liferay.object.model.ObjectAction;
 import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectDefinitionSetting;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.ObjectLayout;
@@ -220,12 +221,28 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 		Map<String, List<ServiceRegistration<?>>> serviceRegistrationsMap =
 			new ConcurrentHashMap<>();
 
+		Map<Long, List<ObjectRelationship>> objectRelationshipsMap =
+			_objectRelationshipLocalService.getObjectRelationshipsMap(
+				companyId);
+
+		// A root object definition IDs setting only holds a value while an edge
+		// object relationship exists, so skip the setting table read and pass
+		// an empty map when the company has no edge
+
+		Map<Long, ObjectDefinitionSetting> objectDefinitionSettingsMap =
+			Collections.emptyMap();
+
+		if (_hasEdgeObjectRelationship(objectRelationshipsMap)) {
+			objectDefinitionSettingsMap =
+				_objectDefinitionSettingLocalService.
+					getObjectDefinitionSettingsMap(
+						companyId,
+						ObjectDefinitionSettingConstants.
+							NAME_ROOT_OBJECT_DEFINITION_IDS);
+		}
+
 		ObjectDefinitionTreeUtil.populateRootObjectDefinitionIds(
-			objectDefinitions,
-			_objectDefinitionSettingLocalService.getObjectDefinitionSettingsMap(
-				companyId,
-				ObjectDefinitionSettingConstants.
-					NAME_ROOT_OBJECT_DEFINITION_IDS));
+			objectDefinitions, objectDefinitionSettingsMap);
 
 		Map<Long, List<ObjectAction>> objectActionsMap =
 			_objectActionLocalService.getObjectActionsMap(
@@ -234,9 +251,6 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 			_objectFieldLocalService.getObjectFieldsMap(companyId);
 		Map<Long, List<ObjectLayout>> objectLayoutsMap =
 			_objectLayoutLocalService.getObjectLayoutsMap(companyId);
-		Map<Long, List<ObjectRelationship>> objectRelationshipsMap =
-			_objectRelationshipLocalService.getObjectRelationshipsMap(
-				companyId);
 
 		for (ObjectDefinition objectDefinition : objectDefinitions) {
 			long objectDefinitionId = objectDefinition.getObjectDefinitionId();
@@ -576,6 +590,22 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 		return StringBundler.concat(
 			serviceRegistrationKey, StringPool.POUND,
 			objectRelationship.getObjectRelationshipId());
+	}
+
+	private boolean _hasEdgeObjectRelationship(
+		Map<Long, List<ObjectRelationship>> objectRelationshipsMap) {
+
+		for (List<ObjectRelationship> objectRelationships :
+				objectRelationshipsMap.values()) {
+
+			for (ObjectRelationship objectRelationship : objectRelationships) {
+				if (objectRelationship.isEdge()) {
+					return true;
+				}
+			}
+		}
+
+		return false;
 	}
 
 	private void _registerObjectRelationshipsRelatedInfoCollectionProviders(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98968

## What Is Being Fixed

`ObjectDefinitionDeployerImpl.deploy` read every root object definition IDs setting for the company on each deploy, through `ObjectDefinitionSettingLocalService.getObjectDefinitionSettingsMap`. That `ObjectDefinitionSetting` table query ran on every startup and portal instance deploy, even for companies with no object definition tree. After LPD-95465 removed the LPD-34594 feature flag, the read became unconditional.

## How It Is Being Fixed

A root object definition IDs setting only holds a value while an edge object relationship exists: that value is written exclusively through `ObjectDefinitionTreeUtil`'s bind and unbind paths, both gated on an edge relationship, and an unbind leaves the setting row empty rather than deleting it. So when a company has no edge relationship, every such setting is empty and parses to an empty array.

The deploy path now reuses the object relationships map it already loads, checks whether any relationship is an edge, and skips the setting table read entirely when none is, passing an empty map to `populateRootObjectDefinitionIds`. The method then caches an empty array per object definition, identical to the result the empty setting rows would have produced. No new query is added; the existing object relationships map fetch is only moved earlier in the method.

## PR Check

**pr-check: PASS** — tested on `69b376c6ccd907f73933754741bfb16188e5da1c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "69b376c6ccd907f73933754741bfb16188e5da1c"} -->
