### PR TITLE
LPD-98578 LPD-98577 Fix Templates checkbox locator collision

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/PagesConfiguration.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/PagesConfiguration.path
@@ -37,7 +37,7 @@
 </tr>
 <tr>
 	<td>CONTENT_CHOOSE_CONTENT_CONTENT_CHECKBOX</td>
-	<td>//label[contains(.,'${key_contentName}')]//following-sibling::span | //label[contains(.,'${key_contentName}')]//following-sibling::span/../input</td>
+	<td>//label[.//strong[normalize-space()='${key_contentName}']]//following-sibling::span | //label[.//strong[normalize-space()='${key_contentName}']]//following-sibling::span/../input</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
## Failing Test

`LocalFile.StagingUpgrade#ViewStagingDefaultSettingAfterUpgrade{704,713,721,730,70106,71103,72101,73101,621021}` (9 archive-version variants) — Task LPD-98577 / Technical Task LPD-98578.

## Root Cause

LPD-95672 (commit 83bcf3394778813a2dc65dbfa7dbf4fade1dc331) changed `getPortletId()` on 5 headless REST resources under `headless-admin-site` from `LayoutAdminPortletKeys.GROUP_PAGES` to `LayoutPageTemplateAdminPortletKeys.LAYOUT_PAGE_TEMPLATES`. Since these resources are `ExportImportVulcanBatchEngineTaskItemDelegate`s, `BatchEnginePortletDataHandlerRegistrar` dynamically registers a `BatchEnginePortletDataHandler` OSGi service under whatever portlet ID they report. Before the commit that dynamic handler folded into the existing "Pages" entry; after it, it creates a brand new entry for the Page Templates portlet, which the classic Staging Configuration screen (`staging_configuration_staged_portlets.jspf`) now renders as its own "Page Templates" checkbox — sorted alphabetically ahead of the pre-existing "Templates" (Web Content Templates) checkbox, and checked by default (`BatchEnginePortletDataHandler.isStaged()` hardcodes `true`).

The Poshi locator for the "Templates" checkbox (`PagesConfiguration#CONTENT_CHOOSE_CONTENT_CONTENT_CHECKBOX`) matched with `contains(., '${key_contentName}')` against the whole label text. Since "Page Templates" contains the substring "Templates", the XPath now matches both checkboxes, and because the new one is checked and sorts first in document order, `assertNotChecked("Templates")` ends up asserting against the wrong, checked checkbox instead of the real one further down the list.

Confirmed via Liferay's RCA tool: a clean pass at the parent commit (6c58897d), a failure at 83bcf33 with this exact locator string in the stack trace, and a screenshot showing "Page Templates" checked while "Templates" itself is unchecked.

## Fix

Match the checkbox's `<strong>` label text exactly (`normalize-space()`) instead of a `contains()` substring, so the two checkboxes no longer collide. Checked every other caller of the same locator (`ContentConfiguration.macro`, `RemoteStaging.testcase`, `Staging.macro`, and the classic Export wizard via `LAR.macro`) — all pass full, exact content-type names, so the tighter match is safe there too (and arguably fixes a latent click-target bug in the classic Export wizard).

## Test plan

- [x] Verified via the RCA tool: `LocalFile.StagingUpgrade#ViewStagingDefaultSettingAfterUpgrade704` passes with the fix, confirmed with a screenshot showing "Templates" correctly located and unchecked
- [x] Confirmed the same shared locator/macro is used by all 9 archive-version variants

**pr-check: PASS** — tested on `2f2e6678570cafd5c5512092415169ade63812cb`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | PASS |
| Poshi Syntax | PASS |

<!-- pr-check {"result": "success", "sha": "2f2e6678570cafd5c5512092415169ade63812cb"} -->