### PR TITLE
LPD-98994 Add Playwright tests for element variations

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationsList.tsx
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationsList.tsx
@@ -139,7 +139,7 @@ export default function ElementVariationsList({
 													{elementVariation.active ? null : (
 														<ClayLabel displayType="danger">
 															{Liferay.Language.get(
-																'inactive'
+																'disabled'
 															)}
 														</ClayLabel>
 													)}

--- a/modules/test/playwright/fixtures/audiencesPagesTest.ts
+++ b/modules/test/playwright/fixtures/audiencesPagesTest.ts
@@ -3,15 +3,14 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {test} from '@playwright/test';
-
 import {AudiencesPage} from '../pages/audiences-web/AudiencesPage';
+import {dataApiHelpersTest} from './dataApiHelpersTest';
 
-const audiencesPagesTest = test.extend<{
+const audiencesPagesTest = dataApiHelpersTest.extend<{
 	audiencesPage: AudiencesPage;
 }>({
-	audiencesPage: async ({page}, use) => {
-		await use(new AudiencesPage(page));
+	audiencesPage: async ({apiHelpers, page}, use) => {
+		await use(new AudiencesPage(page, apiHelpers));
 	},
 });
 

--- a/modules/test/playwright/helpers/ApiHelpers.ts
+++ b/modules/test/playwright/helpers/ApiHelpers.ts
@@ -55,6 +55,7 @@ import {SearchExperiencesApiHelper} from './SearchExperiencesApiHelper';
 import {JSONWebServicesAnnouncementsEntryApiHelper} from './json-web-services/JSONWebServicesAnnouncementsEntryApiHelper';
 import {JSONWebServicesAssetDisplayPageEntryApiHelper} from './json-web-services/JSONWebServicesAssetDisplayPageEntryApiHelper';
 import {JSONWebServicesAssetListEntryApiHelper} from './json-web-services/JSONWebServicesAssetListEntryApiHelper';
+import {JSONWebServicesAudiencesEntryApiHelper} from './json-web-services/JSONWebServicesAudiencesEntryApiHelper';
 import {JSONWebServicesCalendarApiHelper} from './json-web-services/JSONWebServicesCalendarApiHelper';
 import {JSONWebServicesCalendarResourceApiHelper} from './json-web-services/JSONWebServicesCalendarResourceApiHelper';
 import {JSONWebServicesClassNameApiHelper} from './json-web-services/JSONWebServicesClassNameApiHelper';
@@ -157,6 +158,7 @@ export class ApiHelpers {
 	readonly jsonWebServicesAnnouncementsEntryApiHelper: JSONWebServicesAnnouncementsEntryApiHelper;
 	readonly jsonWebServicesAssetDisplayPageEntry: JSONWebServicesAssetDisplayPageEntryApiHelper;
 	readonly jsonWebServicesAssetListEntry: JSONWebServicesAssetListEntryApiHelper;
+	readonly jsonWebServicesAudiencesEntry: JSONWebServicesAudiencesEntryApiHelper;
 	readonly jsonWebServicesCalendar: JSONWebServicesCalendarApiHelper;
 	readonly jsonWebServicesCalendarResource: JSONWebServicesCalendarResourceApiHelper;
 	readonly jsonWebServicesClassName: JSONWebServicesClassNameApiHelper;
@@ -255,6 +257,8 @@ export class ApiHelpers {
 			new JSONWebServicesAssetDisplayPageEntryApiHelper(this);
 		this.jsonWebServicesAssetListEntry =
 			new JSONWebServicesAssetListEntryApiHelper(this);
+		this.jsonWebServicesAudiencesEntry =
+			new JSONWebServicesAudiencesEntryApiHelper(this);
 		this.jsonWebServicesCalendar = new JSONWebServicesCalendarApiHelper(
 			this
 		);
@@ -507,6 +511,11 @@ export class DataApiHelpers extends ApiHelpers {
 			}
 			else if (item.type === 'assetLibrary') {
 				await this.headlessAssetLibrary.deleteAssetLibrary(item.id);
+			}
+			else if (item.type === 'audiencesEntry') {
+				await this.jsonWebServicesAudiencesEntry.deleteAudiencesEntry(
+					item.id
+				);
 			}
 			else if (item.type === 'catalog') {
 				await this.headlessCommerceAdminCatalog.deleteCatalog(item.id);

--- a/modules/test/playwright/helpers/json-web-services/JSONWebServicesAudiencesEntryApiHelper.ts
+++ b/modules/test/playwright/helpers/json-web-services/JSONWebServicesAudiencesEntryApiHelper.ts
@@ -1,0 +1,32 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {liferayConfig} from '../../liferay.config';
+import {ApiHelpers, DataApiHelpers} from '../ApiHelpers';
+
+export class JSONWebServicesAudiencesEntryApiHelper {
+	readonly apiHelpers: ApiHelpers | DataApiHelpers;
+	readonly basePath: string;
+
+	constructor(apiHelpers: ApiHelpers | DataApiHelpers) {
+		this.apiHelpers = apiHelpers;
+		this.basePath = '/api/jsonws/audiences.audiencesentry';
+	}
+
+	async deleteAudiencesEntry(audiencesEntryId: number) {
+		const urlSearchParams = new URLSearchParams();
+
+		urlSearchParams.append('audiencesEntryId', String(audiencesEntryId));
+
+		return this.apiHelpers.post(
+			`${liferayConfig.environment.baseUrl}${this.basePath}/delete-audiences-entry`,
+			{
+				data: urlSearchParams.toString(),
+				failOnStatusCode: true,
+				headers: await this.apiHelpers.getJSONWebServicesHeaders(),
+			}
+		);
+	}
+}

--- a/modules/test/playwright/pages/audiences-web/AudiencesPage.ts
+++ b/modules/test/playwright/pages/audiences-web/AudiencesPage.ts
@@ -5,11 +5,13 @@
 
 import {Locator, Page, expect} from '@playwright/test';
 
+import {DataApiHelpers} from '../../helpers/ApiHelpers';
 import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
 import {PORTLET_URLS} from '../../utils/portletUrls';
 import {waitForAlert} from '../../utils/waitForAlert';
 
 export class AudiencesPage {
+	readonly apiHelpers: DataApiHelpers;
 	readonly nameInput: Locator;
 	readonly newAudienceButton: Locator;
 	readonly page: Page;
@@ -17,7 +19,8 @@ export class AudiencesPage {
 	readonly saveButton: Locator;
 	readonly valueInput: Locator;
 
-	constructor(page: Page) {
+	constructor(page: Page, apiHelpers: DataApiHelpers) {
+		this.apiHelpers = apiHelpers;
 		this.nameInput = page.getByPlaceholder('New Audience');
 		this.newAudienceButton = page.getByLabel('New', {exact: true});
 		this.page = page;
@@ -107,6 +110,27 @@ export class AudiencesPage {
 		await this.saveButton.click();
 
 		await waitForAlert(this.page);
+
+		// Register the audience so the data fixture deletes it on teardown,
+		// even when the test fails before reaching any manual cleanup
+
+		const editItem = this.page.getByRole('menuitem', {name: 'Edit'});
+
+		await clickAndExpectToBeVisible({
+			target: editItem,
+			trigger: this.page
+				.locator('tr', {hasText: name})
+				.locator('button.dropdown-toggle'),
+		});
+
+		const editHref = await editItem.getAttribute('href');
+
+		await this.page.keyboard.press('Escape');
+
+		this.apiHelpers.data.push({
+			id: Number(editHref?.match(/audiencesEntryId=(\d+)/)?.[1]),
+			type: 'audiencesEntry',
+		});
 	}
 
 	async deleteAudience(name: string) {

--- a/modules/test/playwright/pages/layout-content-page-editor-web/ElementVariationsPage.ts
+++ b/modules/test/playwright/pages/layout-content-page-editor-web/ElementVariationsPage.ts
@@ -6,6 +6,7 @@
 import {Locator, Page} from '@playwright/test';
 
 import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
+import {hoverAndExpectToBeVisible} from '../../utils/hoverAndExpectToBeVisible';
 
 export class ElementVariationsPage {
 	readonly audienceInput: Locator;
@@ -71,18 +72,9 @@ export class ElementVariationsPage {
 
 		await this.nameInput.fill(name);
 
-		await clickAndExpectToBeVisible({
-			autoClick: true,
-			target: this.page.getByRole('option', {name: pageElementLabel}),
-			trigger: this.pageElementPicker,
-		});
+		await this.selectPageElement(pageElementLabel);
 
-		await this.audienceInput.fill(audienceName);
-
-		await this.page
-			.locator('.dropdown-menu')
-			.getByText(audienceName)
-			.click();
+		await this.selectAudience(audienceName);
 
 		if (hide) {
 			await this.hideToggle.click();
@@ -111,6 +103,72 @@ export class ElementVariationsPage {
 		await this.saveButton.click();
 
 		await this.sidebar.getByText(name).waitFor();
+	}
+
+	async deleteElementVariation(name: string) {
+		await this.openVariationActions(name);
+
+		await this.page
+			.locator('.dropdown-menu')
+			.getByText('Delete', {exact: true})
+			.click();
+
+		await this.getVariationListItem(name).waitFor({state: 'hidden'});
+	}
+
+	async editElementVariation({
+		hide,
+		html,
+		javaScript,
+		name,
+		newName,
+	}: {
+		hide?: boolean;
+		html?: string;
+		javaScript?: string;
+		name: string;
+		newName?: string;
+	}) {
+		await this.openVariationActions(name);
+
+		await this.page
+			.locator('.dropdown-menu')
+			.getByText('Edit', {exact: true})
+			.click();
+
+		if (newName) {
+			await this.nameInput.fill(newName);
+		}
+
+		if (hide) {
+			await this.hideToggle.click();
+		}
+
+		if (html) {
+			await this.htmlInput.fill(html);
+		}
+
+		if (javaScript) {
+			await this.javaScriptInput.fill(javaScript);
+		}
+
+		await this.saveButton.click();
+
+		await this.sidebar.getByText(newName ?? name).waitFor();
+	}
+
+	getVariationListItem(name: string): Locator {
+		return this.sidebar.getByRole('listitem').filter({hasText: name});
+	}
+
+	async openVariationActions(name: string) {
+		const item = this.getVariationListItem(name);
+
+		await hoverAndExpectToBeVisible({
+			autoClick: true,
+			target: item.getByRole('button', {name: 'Actions'}),
+			trigger: item,
+		});
 	}
 
 	async prioritizeAudience(audienceName: string) {
@@ -159,11 +217,47 @@ export class ElementVariationsPage {
 		await this.audiencesPriorityModal.waitFor({state: 'hidden'});
 	}
 
+	async setVariationActive(name: string, active: boolean) {
+		await this.openVariationActions(name);
+
+		const responsePromise = this.page.waitForResponse((response) =>
+			response
+				.url()
+				.includes(
+					'update_layout_page_template_structure_rel_element_variation'
+				)
+		);
+
+		await this.page
+			.locator('.dropdown-menu')
+			.getByText(active ? 'Enable' : 'Disable', {exact: true})
+			.click();
+
+		await responsePromise;
+	}
+
+	async selectAudience(audienceName: string) {
+		await this.audienceInput.fill(audienceName);
+
+		await this.page
+			.locator('.dropdown-menu')
+			.getByText(audienceName)
+			.click();
+	}
+
 	async selectLanguage(languageId: string) {
 		await this.languageSelector.click();
 
 		await this.page
 			.getByRole('option', {name: `${languageId} Language`})
 			.click();
+	}
+
+	async selectPageElement(pageElementLabel: string) {
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: this.page.getByRole('option', {name: pageElementLabel}),
+			trigger: this.pageElementPicker,
+		});
 	}
 }

--- a/modules/test/playwright/tests/layout-content-page-editor-web/main/elementVariations.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/main/elementVariations.spec.ts
@@ -422,7 +422,7 @@ test(
 );
 
 test(
-	'Excludes an inactive variation from the page and applies it again once re-enabled',
+	'Excludes a disabled variation from the page and applies it again once re-enabled',
 	{tag: '@LPD-95644'},
 	async ({
 		apiHelpers,
@@ -480,7 +480,7 @@ test(
 		await elementVariationsPage.setVariationActive(variationName, false);
 
 		await expect(
-			elementVariationsPage.sidebar.getByText('Inactive', {exact: true})
+			elementVariationsPage.sidebar.getByText('Disabled', {exact: true})
 		).toBeVisible();
 
 		// Publish the page
@@ -489,7 +489,7 @@ test(
 
 		await pageEditorPage.publishPage();
 
-		// The inactive variation is excluded from the runtime bundle
+		// The disabled variation is excluded from the runtime bundle
 
 		await page.goto(`/web${site.friendlyUrlPath}${layout.friendlyUrlPath}`);
 
@@ -506,7 +506,7 @@ test(
 		await elementVariationsPage.setVariationActive(variationName, true);
 
 		await expect(
-			elementVariationsPage.sidebar.getByText('Inactive', {exact: true})
+			elementVariationsPage.sidebar.getByText('Disabled', {exact: true})
 		).not.toBeVisible();
 
 		// Publish the page again

--- a/modules/test/playwright/tests/layout-content-page-editor-web/main/elementVariations.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/main/elementVariations.spec.ts
@@ -14,6 +14,7 @@ import {loginTest} from '../../../fixtures/loginTest';
 import {pageEditorPagesTest} from '../../../fixtures/pageEditorPagesTest';
 import getRandomString from '../../../utils/getRandomString';
 import {performLoginViaApi} from '../../../utils/performLogin';
+import {waitForSPAToBeLoaded} from '../../../utils/waitForSPAToBeLoaded';
 import getFragmentDefinition from './utils/getFragmentDefinition';
 import getPageDefinition from './utils/getPageDefinition';
 
@@ -140,13 +141,6 @@ test(
 		).not.toBeVisible();
 
 		await nonMatchingContext.close();
-
-		// Delete the audience, which is company scoped and does not go away
-		// with the site
-
-		await audiencesPage.goto();
-
-		await audiencesPage.deleteAudience(audienceName);
 	}
 );
 
@@ -245,13 +239,6 @@ test(
 		await page.goto(
 			`/en/web${site.friendlyUrlPath}${layout.friendlyUrlPath}`
 		);
-
-		// Delete the audience, which is company scoped and does not go away
-		// with the site
-
-		await audiencesPage.goto();
-
-		await audiencesPage.deleteAudience(audienceName);
 	}
 );
 
@@ -340,15 +327,6 @@ test(
 		await expect(page.getByText(firstVariationText)).toBeVisible();
 
 		await expect(page.getByText(secondVariationText)).not.toBeVisible();
-
-		// Delete the audiences, which are company scoped and do not go away with
-		// the site
-
-		await audiencesPage.goto();
-
-		await audiencesPage.deleteAudience(firstAudienceName);
-
-		await audiencesPage.deleteAudience(secondAudienceName);
 	}
 );
 
@@ -440,14 +418,459 @@ test(
 		await expect(page.getByText(secondVariationText)).toBeVisible();
 
 		await expect(page.getByText(firstVariationText)).not.toBeVisible();
+	}
+);
 
-		// Delete the audiences, which are company scoped and do not go away with
-		// the site
+test(
+	'Excludes an inactive variation from the page and applies it again once re-enabled',
+	{tag: '@LPD-95644'},
+	async ({
+		apiHelpers,
+		audiencesPage,
+		elementVariationsPage,
+		page,
+		pageEditorPage,
+		site,
+	}) => {
+
+		// Create an audience matching the browser language
+
+		const audienceName = 'Audience ' + getRandomString();
 
 		await audiencesPage.goto();
 
-		await audiencesPage.deleteAudience(firstAudienceName);
+		await audiencesPage.createAudience({
+			attributeName: 'Language',
+			name: audienceName,
+			value: 'English (United States)',
+			valueType: 'select',
+		});
 
-		await audiencesPage.deleteAudience(secondAudienceName);
+		// Create a page with a Heading fragment
+
+		const layout = await apiHelpers.headlessDelivery.createSitePage({
+			pageDefinition: getPageDefinition([
+				getFragmentDefinition({
+					id: getRandomString(),
+					key: 'BASIC_COMPONENT-heading',
+				}),
+			]),
+			siteId: site.id,
+			title: getRandomString(),
+		});
+
+		// Create a variation replacing the heading HTML
+
+		await pageEditorPage.goto(layout, site.friendlyUrlPath);
+
+		await pageEditorPage.goToElementVariations();
+
+		const variationName = 'Toggle heading';
+		const variationText = 'Variation ' + getRandomString();
+
+		await elementVariationsPage.createElementVariation({
+			audienceName,
+			html: `<span>${variationText}</span>`,
+			name: variationName,
+			pageElementLabel: 'Heading (element-text)',
+		});
+
+		// Disable the variation from the actions menu
+
+		await elementVariationsPage.setVariationActive(variationName, false);
+
+		await expect(
+			elementVariationsPage.sidebar.getByText('Inactive', {exact: true})
+		).toBeVisible();
+
+		// Publish the page
+
+		await pageEditorPage.goto(layout, site.friendlyUrlPath);
+
+		await pageEditorPage.publishPage();
+
+		// The inactive variation is excluded from the runtime bundle
+
+		await page.goto(`/web${site.friendlyUrlPath}${layout.friendlyUrlPath}`);
+
+		await expect(page.getByText('Heading Example')).toBeVisible();
+
+		await expect(page.getByText(variationText)).not.toBeVisible();
+
+		// Re-enable the variation from the actions menu
+
+		await pageEditorPage.goto(layout, site.friendlyUrlPath);
+
+		await pageEditorPage.goToElementVariations();
+
+		await elementVariationsPage.setVariationActive(variationName, true);
+
+		await expect(
+			elementVariationsPage.sidebar.getByText('Inactive', {exact: true})
+		).not.toBeVisible();
+
+		// Publish the page again
+
+		await pageEditorPage.goto(layout, site.friendlyUrlPath);
+
+		await pageEditorPage.publishPage();
+
+		// The re-enabled variation is applied in view mode
+
+		await page.goto(`/web${site.friendlyUrlPath}${layout.friendlyUrlPath}`);
+
+		await expect(page.getByText(variationText)).toBeVisible();
+
+		await expect(page.getByText('Heading Example')).not.toBeVisible();
+	}
+);
+
+test(
+	'Applies a variation only after the page is published',
+	{tag: '@LPD-93951'},
+	async ({
+		apiHelpers,
+		audiencesPage,
+		elementVariationsPage,
+		page,
+		pageEditorPage,
+		site,
+	}) => {
+
+		// Create an audience matching the browser language
+
+		const audienceName = 'Audience ' + getRandomString();
+
+		await audiencesPage.goto();
+
+		await audiencesPage.createAudience({
+			attributeName: 'Language',
+			name: audienceName,
+			value: 'English (United States)',
+			valueType: 'select',
+		});
+
+		// Create a page with a Heading fragment
+
+		const layout = await apiHelpers.headlessDelivery.createSitePage({
+			pageDefinition: getPageDefinition([
+				getFragmentDefinition({
+					id: getRandomString(),
+					key: 'BASIC_COMPONENT-heading',
+				}),
+			]),
+			siteId: site.id,
+			title: getRandomString(),
+		});
+
+		// Create a variation replacing the heading HTML on the draft
+
+		await pageEditorPage.goto(layout, site.friendlyUrlPath);
+
+		await pageEditorPage.goToElementVariations();
+
+		const variationText = 'Variation ' + getRandomString();
+
+		await elementVariationsPage.createElementVariation({
+			audienceName,
+			html: `<span>${variationText}</span>`,
+			name: 'Draft heading',
+			pageElementLabel: 'Heading (element-text)',
+		});
+
+		// The unpublished variation is not applied in view mode
+
+		await page.goto(`/web${site.friendlyUrlPath}${layout.friendlyUrlPath}`);
+
+		await expect(page.getByText('Heading Example')).toBeVisible();
+
+		await expect(page.getByText(variationText)).not.toBeVisible();
+
+		// Publish the page
+
+		await pageEditorPage.goto(layout, site.friendlyUrlPath);
+
+		await pageEditorPage.publishPage();
+
+		// The variation is applied once the page is published
+
+		await page.goto(`/web${site.friendlyUrlPath}${layout.friendlyUrlPath}`);
+
+		await expect(page.getByText(variationText)).toBeVisible();
+
+		await expect(page.getByText('Heading Example')).not.toBeVisible();
+	}
+);
+
+test(
+	'Edits an existing variation and applies the updated payload',
+	{tag: '@LPD-93951'},
+	async ({
+		apiHelpers,
+		audiencesPage,
+		elementVariationsPage,
+		page,
+		pageEditorPage,
+		site,
+	}) => {
+
+		// Create an audience matching the browser language
+
+		const audienceName = 'Audience ' + getRandomString();
+
+		await audiencesPage.goto();
+
+		await audiencesPage.createAudience({
+			attributeName: 'Language',
+			name: audienceName,
+			value: 'English (United States)',
+			valueType: 'select',
+		});
+
+		// Create a page with a Heading fragment
+
+		const layout = await apiHelpers.headlessDelivery.createSitePage({
+			pageDefinition: getPageDefinition([
+				getFragmentDefinition({
+					id: getRandomString(),
+					key: 'BASIC_COMPONENT-heading',
+				}),
+			]),
+			siteId: site.id,
+			title: getRandomString(),
+		});
+
+		// Create a variation replacing the heading HTML
+
+		await pageEditorPage.goto(layout, site.friendlyUrlPath);
+
+		await pageEditorPage.goToElementVariations();
+
+		const variationName = 'Editable heading';
+		const originalText = 'Original ' + getRandomString();
+
+		await elementVariationsPage.createElementVariation({
+			audienceName,
+			html: `<span>${originalText}</span>`,
+			name: variationName,
+			pageElementLabel: 'Heading (element-text)',
+		});
+
+		// Edit the variation payload
+
+		const updatedText = 'Updated ' + getRandomString();
+
+		await elementVariationsPage.editElementVariation({
+			html: `<span>${updatedText}</span>`,
+			name: variationName,
+		});
+
+		// Publish the page
+
+		await pageEditorPage.goto(layout, site.friendlyUrlPath);
+
+		await pageEditorPage.publishPage();
+
+		// The updated payload is applied in view mode
+
+		await page.goto(`/web${site.friendlyUrlPath}${layout.friendlyUrlPath}`);
+
+		await expect(page.getByText(updatedText)).toBeVisible();
+
+		await expect(page.getByText(originalText)).not.toBeVisible();
+	}
+);
+
+test(
+	'Deletes a variation from the actions menu',
+	{tag: '@LPD-93951'},
+	async ({
+		apiHelpers,
+		audiencesPage,
+		elementVariationsPage,
+		pageEditorPage,
+		site,
+	}) => {
+
+		// Create an audience matching the browser language
+
+		const audienceName = 'Audience ' + getRandomString();
+
+		await audiencesPage.goto();
+
+		await audiencesPage.createAudience({
+			attributeName: 'Language',
+			name: audienceName,
+			value: 'English (United States)',
+			valueType: 'select',
+		});
+
+		// Create a page with a Heading fragment
+
+		const layout = await apiHelpers.headlessDelivery.createSitePage({
+			pageDefinition: getPageDefinition([
+				getFragmentDefinition({
+					id: getRandomString(),
+					key: 'BASIC_COMPONENT-heading',
+				}),
+			]),
+			siteId: site.id,
+			title: getRandomString(),
+		});
+
+		// Create a variation on the heading element
+
+		await pageEditorPage.goto(layout, site.friendlyUrlPath);
+
+		await pageEditorPage.goToElementVariations();
+
+		const variationName = 'Removable heading';
+
+		await elementVariationsPage.createElementVariation({
+			audienceName,
+			html: `<span>${getRandomString()}</span>`,
+			name: variationName,
+			pageElementLabel: 'Heading (element-text)',
+		});
+
+		await expect(
+			elementVariationsPage.getVariationListItem(variationName)
+		).toBeVisible();
+
+		// Delete the variation from the actions menu
+
+		await elementVariationsPage.deleteElementVariation(variationName);
+
+		// The variation is no longer listed
+
+		await expect(
+			elementVariationsPage.sidebar.getByText(variationName)
+		).not.toBeVisible();
+	}
+);
+
+test(
+	'Loads each page own variations when navigating between pages',
+	{tag: '@LPD-93951'},
+	async ({
+		apiHelpers,
+		audiencesPage,
+		elementVariationsPage,
+		page,
+		pageEditorPage,
+		site,
+	}) => {
+
+		// Create an audience matching the browser language
+
+		const audienceName = 'Audience ' + getRandomString();
+
+		await audiencesPage.goto();
+
+		await audiencesPage.createAudience({
+			attributeName: 'Language',
+			name: audienceName,
+			value: 'English (United States)',
+			valueType: 'select',
+		});
+
+		// Create two pages, each with a Heading fragment
+
+		const firstLayout = await apiHelpers.headlessDelivery.createSitePage({
+			pageDefinition: getPageDefinition([
+				getFragmentDefinition({
+					id: getRandomString(),
+					key: 'BASIC_COMPONENT-heading',
+				}),
+			]),
+			siteId: site.id,
+			title: getRandomString(),
+		});
+
+		const secondLayout = await apiHelpers.headlessDelivery.createSitePage({
+			pageDefinition: getPageDefinition([
+				getFragmentDefinition({
+					id: getRandomString(),
+					key: 'BASIC_COMPONENT-heading',
+				}),
+			]),
+			siteId: site.id,
+			title: getRandomString(),
+		});
+
+		// Replace the heading on the first page and publish
+
+		await pageEditorPage.goto(firstLayout, site.friendlyUrlPath);
+
+		await pageEditorPage.goToElementVariations();
+
+		const firstVariationText = 'First ' + getRandomString();
+
+		await elementVariationsPage.createElementVariation({
+			audienceName,
+			html: `<span>${firstVariationText}</span>`,
+			name: 'First page heading',
+			pageElementLabel: 'Heading (element-text)',
+		});
+
+		await pageEditorPage.goto(firstLayout, site.friendlyUrlPath);
+
+		await pageEditorPage.publishPage();
+
+		// Replace the heading on the second page and publish
+
+		await pageEditorPage.goto(secondLayout, site.friendlyUrlPath);
+
+		await pageEditorPage.goToElementVariations();
+
+		const secondVariationText = 'Second ' + getRandomString();
+
+		await elementVariationsPage.createElementVariation({
+			audienceName,
+			html: `<span>${secondVariationText}</span>`,
+			name: 'Second page heading',
+			pageElementLabel: 'Heading (element-text)',
+		});
+
+		await pageEditorPage.goto(secondLayout, site.friendlyUrlPath);
+
+		await pageEditorPage.publishPage();
+
+		// The first page applies its own variation
+
+		await page.goto(
+			`/web${site.friendlyUrlPath}${firstLayout.friendlyUrlPath}`
+		);
+
+		await expect(page.getByText(firstVariationText)).toBeVisible();
+
+		await expect(page.getByText(secondVariationText)).not.toBeVisible();
+
+		// A client-side navigation to the second page reapplies detection and
+		// loads the second page variation
+
+		await page
+			.locator(`a[href*="${secondLayout.friendlyUrlPath}"]`)
+			.first()
+			.click();
+
+		await waitForSPAToBeLoaded(page);
+
+		await expect(page.getByText(secondVariationText)).toBeVisible();
+
+		await expect(page.getByText(firstVariationText)).not.toBeVisible();
+
+		// Navigating back loads the first page variation again
+
+		await page
+			.locator(`a[href*="${firstLayout.friendlyUrlPath}"]`)
+			.first()
+			.click();
+
+		await waitForSPAToBeLoaded(page);
+
+		await expect(page.getByText(firstVariationText)).toBeVisible();
+
+		await expect(page.getByText(secondVariationText)).not.toBeVisible();
 	}
 );


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98994

## What Is Being Fixed

The element variation feature had Playwright coverage only for happy-path application, priority ordering, and translated payloads. The inactive toggle, publish-only application, editing and deleting a variation from the editor, and re-application across client-side page navigation were untested. Audiences created by these tests were deleted manually, so a failing test left company-scoped audiences behind.

## How It Is Being Fixed

Add five Playwright tests covering the inactive-variation toggle, publish-only application, editing a variation, deleting a variation, and cross-page navigation that reapplies each page's own variations, together with the element variation page object actions they drive. Audiences created through the audiences page object now register for deletion through the data API helpers and a new audiences JSON web service, capturing the audience id from the list row so teardown removes it even when a test fails.

## PR Check

**pr-check: PASS** — tested on `09d272fcf473775b79c95e24cfedfeed054ec33f`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "09d272fcf473775b79c95e24cfedfeed054ec33f"} -->
