### PR TITLE
LPD-99038 Always send external reference code and source

### DIFF
--- a/modules/test/playwright/helpers/json-web-services/JSONWebServicesSegmentsEntryApiHelper.ts
+++ b/modules/test/playwright/helpers/json-web-services/JSONWebServicesSegmentsEntryApiHelper.ts
@@ -18,11 +18,13 @@ export class JSONWebServicesSegmentsEntryApiHelper {
 
 	async addSegmentsEntry({
 		criteria,
+		externalReferenceCode,
 		groupId,
 		name,
 		source,
 	}: {
 		criteria: Segment;
+		externalReferenceCode?: string;
 		groupId: string;
 		name: string;
 		source?: string;
@@ -40,16 +42,17 @@ export class JSONWebServicesSegmentsEntryApiHelper {
 			'descriptionMap',
 			JSON.stringify({en_US: getRandomString()})
 		);
+		urlSearchParams.append(
+			'externalReferenceCode',
+			externalReferenceCode ?? ''
+		);
 		urlSearchParams.append('nameMap', JSON.stringify({en_US: name}));
 		urlSearchParams.append('segmentsEntryKey', '');
 		urlSearchParams.append(
 			'serviceContext',
 			JSON.stringify({scopeGroupId: groupId, userId: user.userId})
 		);
-
-		if (source) {
-			urlSearchParams.append('source', source);
-		}
+		urlSearchParams.append('source', source ?? 'DEFAULT');
 
 		return await this.apiHelpers.post(
 			`${liferayConfig.environment.baseUrl}${this.basePath}/add-segments-entry`,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99038

## What Is Being Fixed

The Playwright test "simulationMenu.spec.ts > Page content › Preview content in a widget page by segment" failed with an HTTP 404 when its JSON web services helper called `addSegmentsEntry`. LPD-98771 collapsed `SegmentsEntryService.addSegmentsEntry` into a single signature that requires an external reference code and a source, so the helper's previous parameter set no longer matched any remote method.

## How It Is Being Fixed

The `JSONWebServicesSegmentsEntryApiHelper.addSegmentsEntry` helper now always sends `externalReferenceCode` and `source`. Both are exposed as optional inputs with safe defaults: an empty external reference code (auto-generated by the service, whose entity is `external-reference-code="group"`) and a `DEFAULT` source, mirroring `SegmentsTestUtil`. JSON web services resolves methods by parameter name, so sending both makes the request match the surviving signature.

## Why Are There No Tests?

This change is entirely within test infrastructure — a Playwright JSON web services helper. It repairs an existing Playwright test (which is its own coverage) after an intentional API contract change; no new test is warranted.

## PR Check

**pr-check: PASS** — tested on `1626411ab3170605e45927695eafcbfb6a0e1862`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "1626411ab3170605e45927695eafcbfb6a0e1862"} -->
