### PR TITLE
LPD-61142 Convert getTrigger to getTriggerConfiguration in super calls

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/UpgradeJavaSchedulerEntryImplConstructorCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/UpgradeJavaSchedulerEntryImplConstructorCheck.java
@@ -108,6 +108,12 @@ public class UpgradeJavaSchedulerEntryImplConstructorCheck
 			}
 		}
 
+		if (constructorContent.contains(".getTrigger()")) {
+			return StringUtil.replace(
+				constructorContent, ".getTrigger()",
+				".getTriggerConfiguration()");
+		}
+
 		return constructorContent;
 	}
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/UpgradeJavaSchedulerEntryImplConstructorCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/UpgradeJavaSchedulerEntryImplConstructorCheck.java
@@ -108,13 +108,8 @@ public class UpgradeJavaSchedulerEntryImplConstructorCheck
 			}
 		}
 
-		if (constructorContent.contains(".getTrigger()")) {
-			return StringUtil.replace(
-				constructorContent, ".getTrigger()",
-				".getTriggerConfiguration()");
-		}
-
-		return constructorContent;
+		return StringUtil.replace(
+			constructorContent, ".getTrigger()", ".getTriggerConfiguration()");
 	}
 
 	private String _replaceSuper(JavaConstructor javaConstructor) {

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/UpgradeJavaSchedulerEntryImplConstructorCheck.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/UpgradeJavaSchedulerEntryImplConstructorCheck.testjava
@@ -19,9 +19,15 @@ public class UpgradeJavaSchedulerEntryImplConstructorCheck
 	}
 
 	public UpgradeJavaSchedulerEntryImplConstructorCheck(
-			SchedulerEntryImpl schedulerEntry) {
+			SchedulerEntryImpl schedulerEntryImpl) {
 
-		super(schedulerEntry.getEventListenerClass(), schedulerEntry.getTriggerConfiguration(), schedulerEntry.getDescription());
+		super(schedulerEntryImpl.getEventListenerClass(), schedulerEntryImpl.getTriggerConfiguration(), schedulerEntryImpl.getDescription());
+	}
+
+	public UpgradeJavaSchedulerEntryImplConstructorCheck(
+			SchedulerEntryImpl schedulerEntryImpl, StorageType storageType) {
+
+		super(schedulerEntryImpl.getEventListenerClass(), schedulerEntryImpl.getTriggerConfiguration(), schedulerEntryImpl.getDescription());
 	}
 
 	public UpgradeJavaSchedulerEntryImplConstructorCheck(

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/UpgradeJavaSchedulerEntryImplConstructorCheck.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/UpgradeJavaSchedulerEntryImplConstructorCheck.testjava
@@ -17,9 +17,15 @@ public class UpgradeJavaSchedulerEntryImplConstructorCheck
 	}
 
 	public UpgradeJavaSchedulerEntryImplConstructorCheck(
-			SchedulerEntryImpl schedulerEntry) {
+			SchedulerEntryImpl schedulerEntryImpl) {
 
 		super();
+	}
+
+	public UpgradeJavaSchedulerEntryImplConstructorCheck(
+			SchedulerEntryImpl schedulerEntryImpl, StorageType storageType) {
+
+		super(schedulerEntryImpl.getEventListenerClass(), schedulerEntryImpl.getTrigger(), schedulerEntryImpl.getDescription());
 	}
 
 	public UpgradeJavaSchedulerEntryImplConstructorCheck(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-61142

## What Is Being Fixed

The `UpgradeJavaSchedulerEntryImplConstructorCheck` source-formatter upgrade check rewrites legacy `SchedulerEntryImpl` constructors, but it left `SchedulerEntryImpl.getTrigger()` calls inside the generated `super(...)` call untouched. The automated upgrade therefore produced code that still referenced the removed `getTrigger()` API instead of `getTriggerConfiguration()`.

## How It Is Being Fixed

The check's constructor-content builder now runs a final `StringUtil.replace` that swaps `.getTrigger()` for `.getTriggerConfiguration()` in the `super(...)` content it emits, so the upgraded constructor calls the current API. A new test case in `UpgradeJavaSchedulerEntryImplConstructorCheck.testjava` and its expected counterpart cover a `super(...)` passing `schedulerEntryImpl.getTrigger()`, asserting it is converted to `getTriggerConfiguration()`.

## PR Check

**pr-check: PASS** — tested on `fe01af79069cd492186e839ef9d5039ce0e46445`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS (NO-SOURCE) |
| Java Unit Tests | NOT RUN (environment) |

Java Unit Tests could not execute locally — the source-formatter test runtime resolves a thin, locally-built kernel snapshot that omits embedded libraries (`com.liferay.petra.concurrent.DCLSingleton`, `org.jabsorb.JSONSerializer`); every source-formatter test class fails identically at class init regardless of the branch. CI runs against the full kernel and will cover it. All other validations pass.

<!-- pr-check {"result": "success", "sha": "fe01af79069cd492186e839ef9d5039ce0e46445"} -->
