### PR TITLE
LPD-98939 Hide Design Library Admin menu options from Design Library Members

### DIFF
--- a/modules/apps/design-library/design-library-web/src/main/java/com/liferay/design/library/web/internal/display/context/DesignLibraryResourcesDisplayContext.java
+++ b/modules/apps/design-library/design-library-web/src/main/java/com/liferay/design/library/web/internal/display/context/DesignLibraryResourcesDisplayContext.java
@@ -28,6 +28,7 @@ import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.LiferayPortletURL;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.resource.PortletResourcePermission;
 import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -288,22 +289,34 @@ public class DesignLibraryResourcesDisplayContext {
 			Group group, long designLibraryEntryId)
 		throws PortalException {
 
-		return JSONUtil.putAll(
-			JSONUtil.put(
-				"href",
-				PortletURLBuilder.createActionURL(
-					_liferayPortletResponse
-				).setMVCRenderCommandName(
-					"/design_library/design_library_settings"
-				).setParameter(
-					DesignLibraryConstants.DESIGN_LIBRARY_ENTRY_ID_KEY,
-					designLibraryEntryId
-				).buildString()
-			).put(
-				"label", LanguageUtil.get(_httpServletRequest, "settings")
-			).put(
-				"symbolLeft", "cog"
-			),
+		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
+
+		boolean hasAssignMembersPermission = GroupPermissionUtil.contains(
+			_themeDisplay.getPermissionChecker(), group.getGroupId(),
+			ActionKeys.ASSIGN_MEMBERS);
+
+		boolean hasUpdatePermission = _hasPermission(group, ActionKeys.UPDATE);
+
+		if (hasUpdatePermission) {
+			jsonArray.put(
+				JSONUtil.put(
+					"href",
+					PortletURLBuilder.createActionURL(
+						_liferayPortletResponse
+					).setMVCRenderCommandName(
+						"/design_library/design_library_settings"
+					).setParameter(
+						DesignLibraryConstants.DESIGN_LIBRARY_ENTRY_ID_KEY,
+						designLibraryEntryId
+					).buildString()
+				).put(
+					"label", LanguageUtil.get(_httpServletRequest, "settings")
+				).put(
+					"symbolLeft", "cog"
+				));
+		}
+
+		jsonArray.put(
 			JSONUtil.put(
 				"externalReferenceCode", group.getExternalReferenceCode()
 			).put(
@@ -315,61 +328,76 @@ public class DesignLibraryResourcesDisplayContext {
 				"symbolLeft", "globe"
 			).put(
 				"target", "connected-sites"
-			),
+			)
+		).put(
 			JSONUtil.put(
 				"externalReferenceCode", group.getExternalReferenceCode()
 			).put(
-				"hasAssignMembersPermission",
-				GroupPermissionUtil.contains(
-					_themeDisplay.getPermissionChecker(), group.getGroupId(),
-					ActionKeys.ASSIGN_MEMBERS)
+				"hasAssignMembersPermission", hasAssignMembersPermission
 			).put(
 				"href", "#manage-members"
 			).put(
-				"label", LanguageUtil.get(_httpServletRequest, "manage-members")
+				"label",
+				LanguageUtil.get(
+					_httpServletRequest,
+					hasAssignMembersPermission ? "manage-members" :
+						"view-members")
 			).put(
 				"ownerId", String.valueOf(group.getCreatorUserId())
 			).put(
 				"symbolLeft", "users"
 			).put(
 				"target", "manage-members"
-			),
-			JSONUtil.put(
-				"href",
-				_getExportImportPortletURL(
-					group, ExportImportPortletKeys.EXPORT)
+			)
+		);
+
+		if (hasUpdatePermission) {
+			jsonArray.put(
+				JSONUtil.put(
+					"href",
+					_getExportImportPortletURL(
+						group, ExportImportPortletKeys.EXPORT)
+				).put(
+					"label", LanguageUtil.get(_httpServletRequest, "export")
+				).put(
+					"symbolLeft", "export"
+				)
 			).put(
-				"label", LanguageUtil.get(_httpServletRequest, "export")
-			).put(
-				"symbolLeft", "export"
-			),
-			JSONUtil.put(
-				"href",
-				_getExportImportPortletURL(
-					group, ExportImportPortletKeys.IMPORT)
-			).put(
-				"label", LanguageUtil.get(_httpServletRequest, "import")
-			).put(
-				"symbolLeft", "import"
-			),
-			JSONUtil.put(
-				"descriptiveName", group.getDescriptiveName()
-			).put(
-				"href",
-				"/o/headless-asset-library/v1.0/asset-libraries/" +
-					group.getExternalReferenceCode()
-			).put(
-				"label", LanguageUtil.get(_httpServletRequest, "delete")
-			).put(
-				"redirect",
-				PortletURLBuilder.createActionURL(
-					_liferayPortletResponse
-				).buildString()
-			).put(
-				"symbolLeft", "trash"
-			).put(
-				"target", "delete"
-			));
+				JSONUtil.put(
+					"href",
+					_getExportImportPortletURL(
+						group, ExportImportPortletKeys.IMPORT)
+				).put(
+					"label", LanguageUtil.get(_httpServletRequest, "import")
+				).put(
+					"symbolLeft", "import"
+				)
+			);
+		}
+
+		if (_hasPermission(group, ActionKeys.DELETE)) {
+			jsonArray.put(
+				JSONUtil.put(
+					"descriptiveName", group.getDescriptiveName()
+				).put(
+					"href",
+					"/o/headless-asset-library/v1.0/asset-libraries/" +
+						group.getExternalReferenceCode()
+				).put(
+					"label", LanguageUtil.get(_httpServletRequest, "delete")
+				).put(
+					"redirect",
+					PortletURLBuilder.createActionURL(
+						_liferayPortletResponse
+					).buildString()
+				).put(
+					"symbolLeft", "trash"
+				).put(
+					"target", "delete"
+				));
+		}
+
+		return jsonArray;
 	}
 
 	private String _getAddFragmentCollectionURL(Group depotGroup) {
@@ -504,6 +532,14 @@ public class DesignLibraryResourcesDisplayContext {
 		return portletResourcePermission.contains(
 			_themeDisplay.getPermissionChecker(), groupId,
 			StyleBookActionKeys.MANAGE_STYLE_BOOK_ENTRIES);
+	}
+
+	private boolean _hasPermission(Group group, String actionId) {
+		PermissionChecker permissionChecker =
+			_themeDisplay.getPermissionChecker();
+
+		return permissionChecker.hasPermission(
+			group, DepotEntry.class.getName(), group.getClassPK(), actionId);
 	}
 
 	private static final Snapshot<FragmentCollectionLocalService>

--- a/modules/apps/design-library/design-library-web/src/main/resources/META-INF/resources/js/DesignLibraryBreadcrumb.tsx
+++ b/modules/apps/design-library/design-library-web/src/main/resources/META-INF/resources/js/DesignLibraryBreadcrumb.tsx
@@ -38,7 +38,7 @@ function ActionDropdownItem({
 	externalReferenceCode = '',
 	hasAssignMembersPermission = false,
 	href = '',
-	label,
+	label = '',
 	ownerId = '',
 	redirect,
 	target,
@@ -58,6 +58,7 @@ function ActionDropdownItem({
 				openManageMembersModal({
 					externalReferenceCode,
 					hasAssignMembersPermission,
+					headerTitle: label,
 					ownerId,
 				});
 			},

--- a/modules/apps/design-library/design-library-web/src/main/resources/META-INF/resources/js/actions/breadcrumbActions.ts
+++ b/modules/apps/design-library/design-library-web/src/main/resources/META-INF/resources/js/actions/breadcrumbActions.ts
@@ -55,10 +55,12 @@ export function openConnectedSitesModal({
 export function openManageMembersModal({
 	externalReferenceCode,
 	hasAssignMembersPermission,
+	headerTitle,
 	ownerId,
 }: {
 	externalReferenceCode: string;
 	hasAssignMembersPermission: boolean;
+	headerTitle: string;
 	ownerId: string;
 }) {
 	openModal({
@@ -66,6 +68,7 @@ export function openManageMembersModal({
 			DesignLibraryManageMembersModal({
 				externalReferenceCode,
 				hasAssignMembersPermission,
+				headerTitle,
 				ownerId,
 			}),
 		size: 'md',

--- a/modules/apps/design-library/design-library-web/src/main/resources/META-INF/resources/js/modal/DesignLibraryManageMembersModal.tsx
+++ b/modules/apps/design-library/design-library-web/src/main/resources/META-INF/resources/js/modal/DesignLibraryManageMembersModal.tsx
@@ -10,7 +10,14 @@ import AddMembersInput from '../components/members/AddMembersInput';
 
 const CONFIG: MembersConfig = {
 	defaultRoleExternalReferenceCode: 'L_DESIGN_LIBRARY_MEMBER',
-	excludedRoleExternalReferenceCodes: ['L_DESIGN_LIBRARY_OWNER'],
+	excludedRoleExternalReferenceCodes: [
+		'L_ASSET_LIBRARY_ADMINISTRATOR',
+		'L_ASSET_LIBRARY_CONNECTED_SITE_MEMBER',
+		'L_ASSET_LIBRARY_CONTENT_REVIEWER',
+		'L_ASSET_LIBRARY_MEMBER',
+		'L_ASSET_LIBRARY_OWNER',
+		'L_DESIGN_LIBRARY_OWNER',
+	],
 	messages: {
 		addGroupError: Liferay.Language.get(
 			'failed-to-add-group-x-to-design-library'

--- a/modules/apps/design-library/design-library-web/src/main/resources/META-INF/resources/js/modal/DesignLibraryManageMembersModal.tsx
+++ b/modules/apps/design-library/design-library-web/src/main/resources/META-INF/resources/js/modal/DesignLibraryManageMembersModal.tsx
@@ -58,10 +58,12 @@ const CONFIG: MembersConfig = {
 export default function DesignLibraryManageMembersModal({
 	externalReferenceCode,
 	hasAssignMembersPermission,
+	headerTitle,
 	ownerId,
 }: {
 	externalReferenceCode: string;
 	hasAssignMembersPermission: boolean;
+	headerTitle: string;
 	ownerId: string;
 }) {
 	return (
@@ -72,7 +74,7 @@ export default function DesignLibraryManageMembersModal({
 			)}
 			externalReferenceCode={externalReferenceCode}
 			hasAssignMembersPermission={hasAssignMembersPermission}
-			headerTitle={Liferay.Language.get('manage-members')}
+			headerTitle={headerTitle}
 			ownerId={ownerId}
 			renderAddMembersInput={(api) => <AddMembersInput {...api} />}
 		/>

--- a/modules/apps/design-library/design-library-web/src/test/java/com/liferay/design/library/web/internal/display/context/DesignLibraryResourcesDisplayContextTest.java
+++ b/modules/apps/design-library/design-library-web/src/test/java/com/liferay/design/library/web/internal/display/context/DesignLibraryResourcesDisplayContextTest.java
@@ -13,13 +13,20 @@ import com.liferay.fragment.model.FragmentCollection;
 import com.liferay.fragment.service.FragmentCollectionLocalService;
 import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.json.JSONFactoryImpl;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.module.service.Snapshot;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.LiferayPortletURL;
+import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.resource.PortletResourcePermission;
+import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -30,7 +37,11 @@ import com.liferay.portal.test.rule.LiferayUnitTestRule;
 import com.liferay.style.book.constants.StyleBookPortletKeys;
 import com.liferay.style.book.model.StyleBookEntry;
 
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.junit.After;
@@ -46,6 +57,7 @@ import org.mockito.Mockito;
 import org.springframework.mock.web.MockHttpServletRequest;
 
 /**
+ * @author Gabriel Prates
  * @author Lourdes Fernández Besada
  */
 public class DesignLibraryResourcesDisplayContextTest {
@@ -58,6 +70,7 @@ public class DesignLibraryResourcesDisplayContextTest {
 	@Before
 	public void setUp() {
 		_setUpDesignLibraryResourcesDisplayContext();
+		_setUpJSONFactoryUtil();
 		_setUpHttpServletRequest();
 	}
 
@@ -84,6 +97,77 @@ public class DesignLibraryResourcesDisplayContextTest {
 					"entryClassNames=", FragmentCollection.class.getName(), ",",
 					StyleBookEntry.class.getName(), "&filter=groupIds/any(g:g ",
 					"eq ", depotEntry.getGroupId(), ")")));
+	}
+
+	@Test
+	public void testGetBreadcrumbPropsActionItemsWithAssignMembersPermission()
+		throws Exception {
+
+		List<String> labels = _getBreadcrumbPropsActionItemsLabels(
+			false, false, true);
+
+		Assert.assertFalse(labels.toString(), labels.contains("view-members"));
+		Assert.assertTrue(labels.toString(), labels.contains("manage-members"));
+	}
+
+	@Test
+	public void testGetBreadcrumbPropsActionItemsWithDeletePermission()
+		throws Exception {
+
+		List<String> labels = _getBreadcrumbPropsActionItemsLabels(
+			false, true, false);
+
+		Assert.assertFalse(labels.toString(), labels.contains("export"));
+		Assert.assertFalse(labels.toString(), labels.contains("import"));
+		Assert.assertFalse(labels.toString(), labels.contains("settings"));
+		Assert.assertTrue(labels.toString(), labels.contains("delete"));
+	}
+
+	@Test
+	public void testGetBreadcrumbPropsActionItemsWithNoPermissions()
+		throws Exception {
+
+		List<String> labels = _getBreadcrumbPropsActionItemsLabels(
+			false, false, false);
+
+		Assert.assertFalse(labels.toString(), labels.contains("delete"));
+		Assert.assertFalse(labels.toString(), labels.contains("export"));
+		Assert.assertFalse(labels.toString(), labels.contains("import"));
+		Assert.assertFalse(
+			labels.toString(), labels.contains("manage-members"));
+		Assert.assertFalse(labels.toString(), labels.contains("settings"));
+		Assert.assertTrue(
+			labels.toString(), labels.contains("connected-sites"));
+		Assert.assertTrue(labels.toString(), labels.contains("view-members"));
+	}
+
+	@Test
+	public void testGetBreadcrumbPropsActionItemsWithUpdateAndDeletePermission()
+		throws Exception {
+
+		List<String> labels = _getBreadcrumbPropsActionItemsLabels(
+			true, true, true);
+
+		Assert.assertTrue(
+			labels.toString(), labels.contains("connected-sites"));
+		Assert.assertTrue(labels.toString(), labels.contains("delete"));
+		Assert.assertTrue(labels.toString(), labels.contains("export"));
+		Assert.assertTrue(labels.toString(), labels.contains("import"));
+		Assert.assertTrue(labels.toString(), labels.contains("manage-members"));
+		Assert.assertTrue(labels.toString(), labels.contains("settings"));
+	}
+
+	@Test
+	public void testGetBreadcrumbPropsActionItemsWithUpdatePermission()
+		throws Exception {
+
+		List<String> labels = _getBreadcrumbPropsActionItemsLabels(
+			true, false, false);
+
+		Assert.assertFalse(labels.toString(), labels.contains("delete"));
+		Assert.assertTrue(labels.toString(), labels.contains("export"));
+		Assert.assertTrue(labels.toString(), labels.contains("import"));
+		Assert.assertTrue(labels.toString(), labels.contains("settings"));
 	}
 
 	@Test
@@ -194,6 +278,140 @@ public class DesignLibraryResourcesDisplayContextTest {
 		}
 	}
 
+	private List<String> _getBreadcrumbPropsActionItemsLabels(
+			boolean hasUpdatePermission, boolean hasDeletePermission,
+			boolean hasAssignMembersPermission)
+		throws Exception {
+
+		try (MockedStatic<GroupPermissionUtil> groupPermissionUtilMockedStatic =
+				Mockito.mockStatic(GroupPermissionUtil.class);
+			MockedStatic<PortletURLBuilder> portletURLBuilderMockedStatic =
+				Mockito.mockStatic(PortletURLBuilder.class)) {
+
+			groupPermissionUtilMockedStatic.when(
+				() -> GroupPermissionUtil.contains(
+					Mockito.any(PermissionChecker.class), Mockito.anyLong(),
+					Mockito.eq(ActionKeys.ASSIGN_MEMBERS))
+			).thenReturn(
+				hasAssignMembersPermission
+			);
+
+			PortletURLBuilder.PortletURLStep portletURLStep = Mockito.mock(
+				PortletURLBuilder.PortletURLStep.class, Mockito.RETURNS_SELF);
+
+			portletURLBuilderMockedStatic.when(
+				() -> PortletURLBuilder.createActionURL(
+					Mockito.any(LiferayPortletResponse.class))
+			).thenReturn(
+				portletURLStep
+			);
+
+			portletURLBuilderMockedStatic.when(
+				() -> PortletURLBuilder.create(Mockito.any())
+			).thenReturn(
+				portletURLStep
+			);
+
+			PermissionChecker permissionChecker = Mockito.mock(
+				PermissionChecker.class);
+
+			Mockito.when(
+				permissionChecker.hasPermission(
+					Mockito.any(Group.class),
+					Mockito.eq(DepotEntry.class.getName()), Mockito.anyLong(),
+					Mockito.eq(ActionKeys.UPDATE))
+			).thenReturn(
+				hasUpdatePermission
+			);
+
+			Mockito.when(
+				permissionChecker.hasPermission(
+					Mockito.any(Group.class),
+					Mockito.eq(DepotEntry.class.getName()), Mockito.anyLong(),
+					Mockito.eq(ActionKeys.DELETE))
+			).thenReturn(
+				hasDeletePermission
+			);
+
+			Group group = Mockito.mock(Group.class);
+
+			Mockito.when(
+				group.getClassPK()
+			).thenReturn(
+				_DEPOT_ENTRY_ID
+			);
+
+			Mockito.when(
+				group.getName(Mockito.any(Locale.class))
+			).thenReturn(
+				"design-library-name"
+			);
+
+			DepotEntry depotEntry = Mockito.mock(DepotEntry.class);
+
+			Mockito.when(
+				depotEntry.getGroup()
+			).thenReturn(
+				group
+			);
+
+			_depotEntryLocalServiceUtilMockedStatic.when(
+				() -> DepotEntryLocalServiceUtil.getDepotEntry(
+					Mockito.anyLong())
+			).thenReturn(
+				depotEntry
+			);
+
+			_languageUtilMockedStatic.when(
+				() -> LanguageUtil.get(
+					Mockito.any(HttpServletRequest.class), Mockito.anyString())
+			).thenAnswer(
+				invocation -> invocation.getArgument(1)
+			);
+
+			ThemeDisplay themeDisplay = new ThemeDisplay();
+
+			themeDisplay.setPermissionChecker(permissionChecker);
+
+			HttpServletRequest httpServletRequest = Mockito.mock(
+				HttpServletRequest.class);
+
+			Mockito.when(
+				httpServletRequest.getAttribute(WebKeys.THEME_DISPLAY)
+			).thenReturn(
+				themeDisplay
+			);
+
+			Mockito.when(
+				httpServletRequest.getLocale()
+			).thenReturn(
+				LocaleUtil.US
+			);
+
+			DesignLibraryResourcesDisplayContext
+				designLibraryResourcesDisplayContext =
+					new DesignLibraryResourcesDisplayContext(
+						httpServletRequest,
+						Mockito.mock(LiferayPortletResponse.class));
+
+			List<String> labels = new ArrayList<>();
+
+			Map<String, Object> breadcrumbProps =
+				designLibraryResourcesDisplayContext.getBreadcrumbProps(
+					group.getClassPK());
+
+			JSONArray jsonArray = (JSONArray)breadcrumbProps.get("actionItems");
+
+			for (int i = 0; i < jsonArray.length(); i++) {
+				JSONObject jsonObject = jsonArray.getJSONObject(i);
+
+				labels.add(jsonObject.getString("label"));
+			}
+
+			return labels;
+		}
+	}
+
 	private DepotEntry _mockDepotEntry(long designLibraryEntryId)
 		throws Exception {
 
@@ -293,6 +511,12 @@ public class DesignLibraryResourcesDisplayContextTest {
 			WebKeys.THEME_DISPLAY, _themeDisplay);
 	}
 
+	private void _setUpJSONFactoryUtil() {
+		JSONFactoryUtil jsonFactoryUtil = new JSONFactoryUtil();
+
+		jsonFactoryUtil.setJSONFactory(new JSONFactoryImpl());
+	}
+
 	private void _setUpPortletURLMocks() {
 		Mockito.when(
 			_liferayPortletResponse.createRenderURL()
@@ -322,6 +546,8 @@ public class DesignLibraryResourcesDisplayContextTest {
 			RandomTestUtil.randomString()
 		);
 	}
+
+	private static final long _DEPOT_ENTRY_ID = 12345;
 
 	private final MockedStatic<DepotEntryLocalServiceUtil>
 		_depotEntryLocalServiceUtilMockedStatic = Mockito.mockStatic(

--- a/modules/apps/design-library/design-library-web/src/test/java/com/liferay/design/library/web/internal/display/context/DesignLibraryResourcesDisplayContextTest.java
+++ b/modules/apps/design-library/design-library-web/src/test/java/com/liferay/design/library/web/internal/display/context/DesignLibraryResourcesDisplayContextTest.java
@@ -69,9 +69,10 @@ public class DesignLibraryResourcesDisplayContextTest {
 
 	@Before
 	public void setUp() {
-		_setUpDesignLibraryResourcesDisplayContext();
 		_setUpJSONFactoryUtil();
 		_setUpHttpServletRequest();
+
+		_setUpDesignLibraryResourcesDisplayContext();
 	}
 
 	@After

--- a/modules/apps/design-library/design-library-web/src/test/java/com/liferay/design/library/web/internal/display/context/DesignLibraryResourcesDisplayContextTest.java
+++ b/modules/apps/design-library/design-library-web/src/test/java/com/liferay/design/library/web/internal/display/context/DesignLibraryResourcesDisplayContextTest.java
@@ -104,7 +104,7 @@ public class DesignLibraryResourcesDisplayContextTest {
 		throws Exception {
 
 		List<String> labels = _getBreadcrumbPropsActionItemsLabels(
-			false, false, true);
+			true, false, false);
 
 		Assert.assertFalse(labels.toString(), labels.contains("view-members"));
 		Assert.assertTrue(labels.toString(), labels.contains("manage-members"));
@@ -162,7 +162,7 @@ public class DesignLibraryResourcesDisplayContextTest {
 		throws Exception {
 
 		List<String> labels = _getBreadcrumbPropsActionItemsLabels(
-			true, false, false);
+			false, false, true);
 
 		Assert.assertFalse(labels.toString(), labels.contains("delete"));
 		Assert.assertTrue(labels.toString(), labels.contains("export"));
@@ -279,8 +279,8 @@ public class DesignLibraryResourcesDisplayContextTest {
 	}
 
 	private List<String> _getBreadcrumbPropsActionItemsLabels(
-			boolean hasUpdatePermission, boolean hasDeletePermission,
-			boolean hasAssignMembersPermission)
+			boolean hasAssignMembersPermission, boolean hasDeletePermission,
+			boolean hasUpdatePermission)
 		throws Exception {
 
 		try (MockedStatic<GroupPermissionUtil> groupPermissionUtilMockedStatic =
@@ -319,18 +319,18 @@ public class DesignLibraryResourcesDisplayContextTest {
 				permissionChecker.hasPermission(
 					Mockito.any(Group.class),
 					Mockito.eq(DepotEntry.class.getName()), Mockito.anyLong(),
-					Mockito.eq(ActionKeys.UPDATE))
+					Mockito.eq(ActionKeys.DELETE))
 			).thenReturn(
-				hasUpdatePermission
+				hasDeletePermission
 			);
 
 			Mockito.when(
 				permissionChecker.hasPermission(
 					Mockito.any(Group.class),
 					Mockito.eq(DepotEntry.class.getName()), Mockito.anyLong(),
-					Mockito.eq(ActionKeys.DELETE))
+					Mockito.eq(ActionKeys.UPDATE))
 			).thenReturn(
-				hasDeletePermission
+				hasUpdatePermission
 			);
 
 			Group group = Mockito.mock(Group.class);
@@ -369,12 +369,12 @@ public class DesignLibraryResourcesDisplayContextTest {
 				invocation -> invocation.getArgument(1)
 			);
 
+			HttpServletRequest httpServletRequest = Mockito.mock(
+				HttpServletRequest.class);
+
 			ThemeDisplay themeDisplay = new ThemeDisplay();
 
 			themeDisplay.setPermissionChecker(permissionChecker);
-
-			HttpServletRequest httpServletRequest = Mockito.mock(
-				HttpServletRequest.class);
 
 			Mockito.when(
 				httpServletRequest.getAttribute(WebKeys.THEME_DISPLAY)


### PR DESCRIPTION
Rebased and resend from https://github.com/brianchandotcom/liferay-portal/pull/178922

Forwarded from: https://github.com/liferay-platform-experience/liferay-portal/pull/2150 (Took 1 `ci:forward` attempt in 11 minutes)
[Console](https://test-1-42.liferay.com/job/test-portal-source-format/4148//consoleFull)

@gabsprates
@liferay-platform-experience

Original pull request comment:
https://liferay.atlassian.net/browse/LPD-98939

## What Is Being Fixed

Members of a design library saw admin-only actions in the breadcrumb menu — Settings, Export, Import, and Delete — even though they lacked permission to use them. The members action also always read "Manage Members," implying edit capability regardless of the member's role.

## How It Is Being Fixed

The breadcrumb action items are now built conditionally from the current user's permissions on the design library. Settings, Export, and Import appear only with UPDATE permission, and Delete appears only with DELETE permission. The members action label switches between "Manage Members" and "View Members" based on the ASSIGN_MEMBERS permission, and the members modal takes that label as its header title so the heading matches the action. The members modal also excludes the asset library roles from the assignable role list. A unit test covers the permission-driven action set.

## PR Check

**pr-check: PASS** — tested on `2ccea6a1ba7b008c45b13fdbe1f7d07acf8b63c2`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "2ccea6a1ba7b008c45b13fdbe1f7d07acf8b63c2"} -->
