### PR TITLE
LPD-99062 Enforce the get/fetch service method contract

### DIFF
--- a/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/display/AddressDisplay.java
+++ b/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/display/AddressDisplay.java
@@ -93,9 +93,18 @@ public class AddressDisplay {
 	private AddressDisplay() {
 		_addressId = 0;
 		_city = StringPool.BLANK;
-		_listTypeId = ListTypeLocalServiceUtil.getListTypeId(
+
+		ListType listType = ListTypeLocalServiceUtil.fetchListType(
 			CompanyThreadLocal.getCompanyId(), "billing-and-shipping",
 			AccountEntry.class.getName() + ListTypeConstants.ADDRESS);
+
+		if (listType == null) {
+			_listTypeId = 0;
+		}
+		else {
+			_listTypeId = listType.getListTypeId();
+		}
+
 		_listTypeName = StringPool.BLANK;
 		_name = StringPool.BLANK;
 		_region = null;

--- a/modules/apps/account/account-api/src/main/java/com/liferay/account/service/AccountGroupLocalService.java
+++ b/modules/apps/account/account-api/src/main/java/com/liferay/account/service/AccountGroupLocalService.java
@@ -310,7 +310,8 @@ public interface AccountGroupLocalService
 	public ActionableDynamicQuery getActionableDynamicQuery();
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public AccountGroup getDefaultAccountGroup(long companyId);
+	public AccountGroup getDefaultAccountGroup(long companyId)
+		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public ExportActionableDynamicQuery getExportActionableDynamicQuery(
@@ -384,4 +385,4 @@ public interface AccountGroupLocalService
 		throws PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-298338204
+// LIFERAY-SERVICE-BUILDER-HASH:170682256

--- a/modules/apps/account/account-api/src/main/java/com/liferay/account/service/AccountGroupLocalServiceUtil.java
+++ b/modules/apps/account/account-api/src/main/java/com/liferay/account/service/AccountGroupLocalServiceUtil.java
@@ -355,7 +355,9 @@ public class AccountGroupLocalServiceUtil {
 		return getService().getActionableDynamicQuery();
 	}
 
-	public static AccountGroup getDefaultAccountGroup(long companyId) {
+	public static AccountGroup getDefaultAccountGroup(long companyId)
+		throws PortalException {
+
 		return getService().getDefaultAccountGroup(companyId);
 	}
 
@@ -474,4 +476,4 @@ public class AccountGroupLocalServiceUtil {
 			AccountGroupLocalServiceUtil.class, AccountGroupLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1968204458
+// LIFERAY-SERVICE-BUILDER-HASH:-565231272

--- a/modules/apps/account/account-api/src/main/java/com/liferay/account/service/AccountGroupLocalServiceWrapper.java
+++ b/modules/apps/account/account-api/src/main/java/com/liferay/account/service/AccountGroupLocalServiceWrapper.java
@@ -411,7 +411,8 @@ public class AccountGroupLocalServiceWrapper
 
 	@Override
 	public com.liferay.account.model.AccountGroup getDefaultAccountGroup(
-		long companyId) {
+			long companyId)
+		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _accountGroupLocalService.getDefaultAccountGroup(companyId);
 	}
@@ -560,4 +561,4 @@ public class AccountGroupLocalServiceWrapper
 	private AccountGroupLocalService _accountGroupLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:573676555
+// LIFERAY-SERVICE-BUILDER-HASH:82523321

--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/instance/lifecycle/AddAccountEntryAddressListTypesPortalInstanceLifecycleListener.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/instance/lifecycle/AddAccountEntryAddressListTypesPortalInstanceLifecycleListener.java
@@ -72,7 +72,7 @@ public class AddAccountEntryAddressListTypesPortalInstanceLifecycleListener
 	}
 
 	private boolean _hasListType(long companyId, String name, String type) {
-		ListType listType = _listTypeLocalService.getListType(
+		ListType listType = _listTypeLocalService.fetchListType(
 			companyId, name, type);
 
 		if (listType != null) {

--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/instance/lifecycle/AddAccountEntryContactListTypesPortalInstanceLifecycleListener.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/instance/lifecycle/AddAccountEntryContactListTypesPortalInstanceLifecycleListener.java
@@ -42,7 +42,7 @@ public class AddAccountEntryContactListTypesPortalInstanceLifecycleListener
 	}
 
 	private boolean _hasListType(long companyId, String name, String type) {
-		ListType listType = _listTypeLocalService.getListType(
+		ListType listType = _listTypeLocalService.fetchListType(
 			companyId, name, type);
 
 		if (listType != null) {

--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountGroupLocalServiceImpl.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountGroupLocalServiceImpl.java
@@ -264,8 +264,10 @@ public class AccountGroupLocalServiceImpl
 	}
 
 	@Override
-	public AccountGroup getDefaultAccountGroup(long companyId) {
-		return accountGroupPersistence.fetchByC_D_First(companyId, true, null);
+	public AccountGroup getDefaultAccountGroup(long companyId)
+		throws PortalException {
+
+		return accountGroupPersistence.findByC_D_First(companyId, true, null);
 	}
 
 	@Indexable(type = IndexableType.REINDEX)

--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountGroupLocalServiceImpl.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountGroupLocalServiceImpl.java
@@ -351,7 +351,7 @@ public class AccountGroupLocalServiceImpl
 
 		_validateName(name);
 
-		AccountGroup accountGroup = accountGroupPersistence.fetchByPrimaryKey(
+		AccountGroup accountGroup = accountGroupPersistence.findByPrimaryKey(
 			accountGroupId);
 
 		accountGroup.setExternalReferenceCode(externalReferenceCode);

--- a/modules/apps/address/address-impl/src/main/java/com/liferay/address/internal/search/spi/model/query/contributor/AddressModelPreFilterContributor.java
+++ b/modules/apps/address/address-impl/src/main/java/com/liferay/address/internal/search/spi/model/query/contributor/AddressModelPreFilterContributor.java
@@ -121,7 +121,7 @@ public class AddressModelPreFilterContributor
 			String listTypeType =
 				className.getClassName() + ListTypeConstants.ADDRESS;
 
-			ListType listType = _listTypeLocalService.getListType(
+			ListType listType = _listTypeLocalService.fetchListType(
 				searchContext.getCompanyId(), typeNames[i], listTypeType);
 
 			if (listType == null) {

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceAddressLocalService.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceAddressLocalService.java
@@ -90,7 +90,8 @@ public interface CommerceAddressLocalService extends BaseLocalService {
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<CommerceAddress> getBillingAndShippingCommerceAddresses(
-		long companyId, String className, long classPK);
+			long companyId, String className, long classPK)
+		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<CommerceAddress> getBillingCommerceAddresses(
@@ -99,7 +100,8 @@ public interface CommerceAddressLocalService extends BaseLocalService {
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<CommerceAddress> getBillingCommerceAddresses(
-		long channelId, String className, long classPK, int start, int end);
+			long channelId, String className, long classPK, int start, int end)
+		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<CommerceAddress> getBillingCommerceAddresses(
@@ -110,7 +112,8 @@ public interface CommerceAddressLocalService extends BaseLocalService {
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getBillingCommerceAddressesCount(
-		long channelId, String className, long classPK, int start, int end);
+			long channelId, String className, long classPK, int start, int end)
+		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getBillingCommerceAddressesCount(
@@ -182,7 +185,8 @@ public interface CommerceAddressLocalService extends BaseLocalService {
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<CommerceAddress> getShippingCommerceAddresses(
-		long channelId, String className, long classPK, int start, int end);
+			long channelId, String className, long classPK, int start, int end)
+		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<CommerceAddress> getShippingCommerceAddresses(
@@ -223,4 +227,4 @@ public interface CommerceAddressLocalService extends BaseLocalService {
 		throws PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1521900522
+// LIFERAY-SERVICE-BUILDER-HASH:913212826

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceAddressLocalServiceUtil.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceAddressLocalServiceUtil.java
@@ -106,7 +106,8 @@ public class CommerceAddressLocalServiceUtil {
 	}
 
 	public static List<CommerceAddress> getBillingAndShippingCommerceAddresses(
-		long companyId, String className, long classPK) {
+			long companyId, String className, long classPK)
+		throws PortalException {
 
 		return getService().getBillingAndShippingCommerceAddresses(
 			companyId, className, classPK);
@@ -121,7 +122,8 @@ public class CommerceAddressLocalServiceUtil {
 	}
 
 	public static List<CommerceAddress> getBillingCommerceAddresses(
-		long channelId, String className, long classPK, int start, int end) {
+			long channelId, String className, long classPK, int start, int end)
+		throws PortalException {
 
 		return getService().getBillingCommerceAddresses(
 			channelId, className, classPK, start, end);
@@ -139,7 +141,8 @@ public class CommerceAddressLocalServiceUtil {
 	}
 
 	public static int getBillingCommerceAddressesCount(
-		long channelId, String className, long classPK, int start, int end) {
+			long channelId, String className, long classPK, int start, int end)
+		throws PortalException {
 
 		return getService().getBillingCommerceAddressesCount(
 			channelId, className, classPK, start, end);
@@ -247,7 +250,8 @@ public class CommerceAddressLocalServiceUtil {
 	}
 
 	public static List<CommerceAddress> getShippingCommerceAddresses(
-		long channelId, String className, long classPK, int start, int end) {
+			long channelId, String className, long classPK, int start, int end)
+		throws PortalException {
 
 		return getService().getShippingCommerceAddresses(
 			channelId, className, classPK, start, end);
@@ -322,4 +326,4 @@ public class CommerceAddressLocalServiceUtil {
 			CommerceAddressLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1116480905
+// LIFERAY-SERVICE-BUILDER-HASH:-947118601

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceAddressLocalServiceWrapper.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceAddressLocalServiceWrapper.java
@@ -123,8 +123,9 @@ public class CommerceAddressLocalServiceWrapper
 
 	@Override
 	public java.util.List<com.liferay.commerce.model.CommerceAddress>
-		getBillingAndShippingCommerceAddresses(
-			long companyId, String className, long classPK) {
+			getBillingAndShippingCommerceAddresses(
+				long companyId, String className, long classPK)
+		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _commerceAddressLocalService.
 			getBillingAndShippingCommerceAddresses(
@@ -143,9 +144,10 @@ public class CommerceAddressLocalServiceWrapper
 
 	@Override
 	public java.util.List<com.liferay.commerce.model.CommerceAddress>
-		getBillingCommerceAddresses(
-			long channelId, String className, long classPK, int start,
-			int end) {
+			getBillingCommerceAddresses(
+				long channelId, String className, long classPK, int start,
+				int end)
+		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _commerceAddressLocalService.getBillingCommerceAddresses(
 			channelId, className, classPK, start, end);
@@ -166,7 +168,8 @@ public class CommerceAddressLocalServiceWrapper
 
 	@Override
 	public int getBillingCommerceAddressesCount(
-		long channelId, String className, long classPK, int start, int end) {
+			long channelId, String className, long classPK, int start, int end)
+		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _commerceAddressLocalService.getBillingCommerceAddressesCount(
 			channelId, className, classPK, start, end);
@@ -300,9 +303,10 @@ public class CommerceAddressLocalServiceWrapper
 
 	@Override
 	public java.util.List<com.liferay.commerce.model.CommerceAddress>
-		getShippingCommerceAddresses(
-			long channelId, String className, long classPK, int start,
-			int end) {
+			getShippingCommerceAddresses(
+				long channelId, String className, long classPK, int start,
+				int end)
+		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _commerceAddressLocalService.getShippingCommerceAddresses(
 			channelId, className, classPK, start, end);
@@ -388,4 +392,4 @@ public class CommerceAddressLocalServiceWrapper
 	private CommerceAddressLocalService _commerceAddressLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:786935859
+// LIFERAY-SERVICE-BUILDER-HASH:664406615

--- a/modules/apps/commerce/commerce-product-type-virtual-api/src/main/java/com/liferay/commerce/product/type/virtual/service/CPDefinitionVirtualSettingLocalService.java
+++ b/modules/apps/commerce/commerce-product-type-virtual-api/src/main/java/com/liferay/commerce/product/type/virtual/service/CPDefinitionVirtualSettingLocalService.java
@@ -251,7 +251,8 @@ public interface CPDefinitionVirtualSettingLocalService
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public CPDefinitionVirtualSetting getCPDefinitionVirtualSetting(
-		String className, long classPK);
+			String className, long classPK)
+		throws PortalException;
 
 	/**
 	 * Returns the cp definition virtual setting matching the UUID and group.
@@ -375,4 +376,4 @@ public interface CPDefinitionVirtualSettingLocalService
 		throws PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1593314084
+// LIFERAY-SERVICE-BUILDER-HASH:960374904

--- a/modules/apps/commerce/commerce-product-type-virtual-api/src/main/java/com/liferay/commerce/product/type/virtual/service/CPDefinitionVirtualSettingLocalServiceUtil.java
+++ b/modules/apps/commerce/commerce-product-type-virtual-api/src/main/java/com/liferay/commerce/product/type/virtual/service/CPDefinitionVirtualSettingLocalServiceUtil.java
@@ -291,7 +291,8 @@ public class CPDefinitionVirtualSettingLocalServiceUtil {
 	}
 
 	public static CPDefinitionVirtualSetting getCPDefinitionVirtualSetting(
-		String className, long classPK) {
+			String className, long classPK)
+		throws PortalException {
 
 		return getService().getCPDefinitionVirtualSetting(className, classPK);
 	}
@@ -467,4 +468,4 @@ public class CPDefinitionVirtualSettingLocalServiceUtil {
 			CPDefinitionVirtualSettingLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2073070156
+// LIFERAY-SERVICE-BUILDER-HASH:644056326

--- a/modules/apps/commerce/commerce-product-type-virtual-api/src/main/java/com/liferay/commerce/product/type/virtual/service/CPDefinitionVirtualSettingLocalServiceWrapper.java
+++ b/modules/apps/commerce/commerce-product-type-virtual-api/src/main/java/com/liferay/commerce/product/type/virtual/service/CPDefinitionVirtualSettingLocalServiceWrapper.java
@@ -352,7 +352,8 @@ public class CPDefinitionVirtualSettingLocalServiceWrapper
 	public
 		com.liferay.commerce.product.type.virtual.model.
 			CPDefinitionVirtualSetting getCPDefinitionVirtualSetting(
-				String className, long classPK) {
+					String className, long classPK)
+				throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _cpDefinitionVirtualSettingLocalService.
 			getCPDefinitionVirtualSetting(className, classPK);
@@ -587,4 +588,4 @@ public class CPDefinitionVirtualSettingLocalServiceWrapper
 		_cpDefinitionVirtualSettingLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-723309112
+// LIFERAY-SERVICE-BUILDER-HASH:1829592922

--- a/modules/apps/commerce/commerce-product-type-virtual-order-service/src/main/java/com/liferay/commerce/product/type/virtual/order/service/impl/CommerceVirtualOrderItemLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-type-virtual-order-service/src/main/java/com/liferay/commerce/product/type/virtual/order/service/impl/CommerceVirtualOrderItemLocalServiceImpl.java
@@ -142,7 +142,7 @@ public class CommerceVirtualOrderItemLocalServiceImpl
 
 			cpDefinitionVirtualSetting =
 				_cpDefinitionVirtualSettingLocalService.
-					getCPDefinitionVirtualSetting(
+					fetchCPDefinitionVirtualSetting(
 						CPDefinition.class.getName(),
 						commerceOrderItem.getCPDefinitionId());
 		}

--- a/modules/apps/commerce/commerce-product-type-virtual-service/src/main/java/com/liferay/commerce/product/type/virtual/service/impl/CPDefinitionVirtualSettingLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-type-virtual-service/src/main/java/com/liferay/commerce/product/type/virtual/service/impl/CPDefinitionVirtualSettingLocalServiceImpl.java
@@ -303,9 +303,10 @@ public class CPDefinitionVirtualSettingLocalServiceImpl
 
 	@Override
 	public CPDefinitionVirtualSetting getCPDefinitionVirtualSetting(
-		String className, long classPK) {
+			String className, long classPK)
+		throws PortalException {
 
-		return cpDefinitionVirtualSettingPersistence.fetchByC_C(
+		return cpDefinitionVirtualSettingPersistence.findByC_C(
 			_classNameLocalService.getClassNameId(className), classPK);
 	}
 

--- a/modules/apps/commerce/commerce-qualifier-service/src/main/java/com/liferay/commerce/qualifier/internal/metadata/CommerceBillingAddressCommerceQualifierMetadata.java
+++ b/modules/apps/commerce/commerce-qualifier-service/src/main/java/com/liferay/commerce/qualifier/internal/metadata/CommerceBillingAddressCommerceQualifierMetadata.java
@@ -15,12 +15,15 @@ import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.petra.sql.dsl.query.sort.OrderByExpression;
 import com.liferay.portal.kernel.model.Address;
 import com.liferay.portal.kernel.model.AddressTable;
+import com.liferay.portal.kernel.model.ListType;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.AddressLocalService;
 import com.liferay.portal.kernel.service.ListTypeLocalService;
 import com.liferay.portal.kernel.service.PersistedModelLocalService;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
@@ -44,17 +47,10 @@ public class CommerceBillingAddressCommerceQualifierMetadata
 	@Override
 	public Predicate getFilterPredicate() {
 		return AddressTable.INSTANCE.listTypeId.in(
-			new Long[] {
-				_listTypeLocalService.getListTypeId(
-					CompanyThreadLocal.getCompanyId(),
-					AccountListTypeConstants.
-						ACCOUNT_ENTRY_ADDRESS_TYPE_BILLING_AND_SHIPPING,
-					AccountListTypeConstants.ACCOUNT_ENTRY_ADDRESS),
-				_listTypeLocalService.getListTypeId(
-					CompanyThreadLocal.getCompanyId(),
-					AccountListTypeConstants.ACCOUNT_ENTRY_ADDRESS_TYPE_BILLING,
-					AccountListTypeConstants.ACCOUNT_ENTRY_ADDRESS)
-			});
+			_getListTypeIds(
+				AccountListTypeConstants.
+					ACCOUNT_ENTRY_ADDRESS_TYPE_BILLING_AND_SHIPPING,
+				AccountListTypeConstants.ACCOUNT_ENTRY_ADDRESS_TYPE_BILLING));
 	}
 
 	@Override
@@ -104,6 +100,22 @@ public class CommerceBillingAddressCommerceQualifierMetadata
 		return new OrderByExpression[] {
 			AddressTable.INSTANCE.addressId.descending()
 		};
+	}
+
+	private Long[] _getListTypeIds(String... names) {
+		List<Long> listTypeIds = new ArrayList<>();
+
+		for (String name : names) {
+			ListType listType = _listTypeLocalService.fetchListType(
+				CompanyThreadLocal.getCompanyId(), name,
+				AccountListTypeConstants.ACCOUNT_ENTRY_ADDRESS);
+
+			if (listType != null) {
+				listTypeIds.add(listType.getListTypeId());
+			}
+		}
+
+		return listTypeIds.toArray(new Long[0]);
 	}
 
 	@Reference

--- a/modules/apps/commerce/commerce-qualifier-service/src/main/java/com/liferay/commerce/qualifier/internal/metadata/CommerceShippingAddressCommerceQualifierMetadata.java
+++ b/modules/apps/commerce/commerce-qualifier-service/src/main/java/com/liferay/commerce/qualifier/internal/metadata/CommerceShippingAddressCommerceQualifierMetadata.java
@@ -15,12 +15,15 @@ import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.petra.sql.dsl.query.sort.OrderByExpression;
 import com.liferay.portal.kernel.model.Address;
 import com.liferay.portal.kernel.model.AddressTable;
+import com.liferay.portal.kernel.model.ListType;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.AddressLocalService;
 import com.liferay.portal.kernel.service.ListTypeLocalService;
 import com.liferay.portal.kernel.service.PersistedModelLocalService;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
@@ -44,18 +47,10 @@ public class CommerceShippingAddressCommerceQualifierMetadata
 	@Override
 	public Predicate getFilterPredicate() {
 		return AddressTable.INSTANCE.listTypeId.in(
-			new Long[] {
-				_listTypeLocalService.getListTypeId(
-					CompanyThreadLocal.getCompanyId(),
-					AccountListTypeConstants.
-						ACCOUNT_ENTRY_ADDRESS_TYPE_BILLING_AND_SHIPPING,
-					AccountListTypeConstants.ACCOUNT_ENTRY_ADDRESS),
-				_listTypeLocalService.getListTypeId(
-					CompanyThreadLocal.getCompanyId(),
-					AccountListTypeConstants.
-						ACCOUNT_ENTRY_ADDRESS_TYPE_SHIPPING,
-					AccountListTypeConstants.ACCOUNT_ENTRY_ADDRESS)
-			});
+			_getListTypeIds(
+				AccountListTypeConstants.
+					ACCOUNT_ENTRY_ADDRESS_TYPE_BILLING_AND_SHIPPING,
+				AccountListTypeConstants.ACCOUNT_ENTRY_ADDRESS_TYPE_SHIPPING));
 	}
 
 	@Override
@@ -105,6 +100,22 @@ public class CommerceShippingAddressCommerceQualifierMetadata
 		return new OrderByExpression[] {
 			AddressTable.INSTANCE.addressId.descending()
 		};
+	}
+
+	private Long[] _getListTypeIds(String... names) {
+		List<Long> listTypeIds = new ArrayList<>();
+
+		for (String name : names) {
+			ListType listType = _listTypeLocalService.fetchListType(
+				CompanyThreadLocal.getCompanyId(), name,
+				AccountListTypeConstants.ACCOUNT_ENTRY_ADDRESS);
+
+			if (listType != null) {
+				listTypeIds.add(listType.getListTypeId());
+			}
+		}
+
+		return listTypeIds.toArray(new Long[0]);
 	}
 
 	@Reference

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/upgrade/v7_0_0/CommerceAddressUpgradeProcess.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/upgrade/v7_0_0/CommerceAddressUpgradeProcess.java
@@ -173,14 +173,18 @@ public class CommerceAddressUpgradeProcess extends UpgradeProcess {
 		};
 	}
 
-	private long _getAddressListTypeId(long companyId, String name) {
+	private long _getAddressListTypeId(long companyId, String name)
+		throws PortalException {
+
 		ListType listType = _listTypeLocalService.getListType(
 			companyId, name, AccountListTypeConstants.ACCOUNT_ENTRY_ADDRESS);
 
 		return listType.getListTypeId();
 	}
 
-	private long _getListTypeId(int commerceAddressType, long companyId) {
+	private long _getListTypeId(int commerceAddressType, long companyId)
+		throws PortalException {
+
 		String name = null;
 
 		if (CommerceAddressConstants.ADDRESS_TYPE_BILLING ==
@@ -203,7 +207,7 @@ public class CommerceAddressUpgradeProcess extends UpgradeProcess {
 	}
 
 	private void _setAddressListType(long companyId, String name) {
-		ListType listType = _listTypeLocalService.getListType(
+		ListType listType = _listTypeLocalService.fetchListType(
 			companyId, name, AccountListTypeConstants.ACCOUNT_ENTRY_ADDRESS);
 
 		if (listType == null) {

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/upgrade/v8_5_0/CommerceAddressTypeUpgradeProcess.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/upgrade/v8_5_0/CommerceAddressTypeUpgradeProcess.java
@@ -54,7 +54,7 @@ public class CommerceAddressTypeUpgradeProcess extends UpgradeProcess {
 	}
 
 	private long _getListTypeId(long companyId, String name) {
-		ListType listType = _listTypeLocalService.getListType(
+		ListType listType = _listTypeLocalService.fetchListType(
 			companyId, name, AccountListTypeConstants.ACCOUNT_ENTRY_ADDRESS);
 
 		if (listType == null) {

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/model/impl/CommerceAddressImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/model/impl/CommerceAddressImpl.java
@@ -93,7 +93,9 @@ public class CommerceAddressImpl extends CommerceAddressBaseImpl {
 			AccountEntry.class.getName(), address.getClassName());
 	}
 
-	public static long toAddressTypeId(int commerceAddressType) {
+	public static long toAddressTypeId(int commerceAddressType)
+		throws PortalException {
+
 		if (CommerceAddressConstants.ADDRESS_TYPE_BILLING ==
 				commerceAddressType) {
 
@@ -272,7 +274,7 @@ public class CommerceAddressImpl extends CommerceAddressBaseImpl {
 		return false;
 	}
 
-	private static long _getAddressTypeId(String name) {
+	private static long _getAddressTypeId(String name) throws PortalException {
 		ListType listType = ListTypeLocalServiceUtil.getListType(
 			CompanyThreadLocal.getCompanyId(), name,
 			AccountListTypeConstants.ACCOUNT_ENTRY_ADDRESS);

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceAddressLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceAddressLocalServiceImpl.java
@@ -206,7 +206,8 @@ public class CommerceAddressLocalServiceImpl
 
 	@Override
 	public List<CommerceAddress> getBillingAndShippingCommerceAddresses(
-		long companyId, String className, long classPK) {
+			long companyId, String className, long classPK)
+		throws PortalException {
 
 		return TransformUtil.transform(
 			_addressLocalService.getListTypeAddresses(
@@ -231,7 +232,8 @@ public class CommerceAddressLocalServiceImpl
 
 	@Override
 	public List<CommerceAddress> getBillingCommerceAddresses(
-		long channelId, String className, long classPK, int start, int end) {
+			long channelId, String className, long classPK, int start, int end)
+		throws PortalException {
 
 		return TransformUtil.transform(
 			_addressLocalService.dslQuery(
@@ -284,7 +286,8 @@ public class CommerceAddressLocalServiceImpl
 
 	@Override
 	public int getBillingCommerceAddressesCount(
-		long channelId, String className, long classPK, int start, int end) {
+			long channelId, String className, long classPK, int start, int end)
+		throws PortalException {
 
 		return _addressLocalService.dslQueryCount(
 			_getGroupByStep(
@@ -452,7 +455,8 @@ public class CommerceAddressLocalServiceImpl
 
 	@Override
 	public List<CommerceAddress> getShippingCommerceAddresses(
-		long channelId, String className, long classPK, int start, int end) {
+			long channelId, String className, long classPK, int start, int end)
+		throws PortalException {
 
 		return TransformUtil.transform(
 			_addressLocalService.dslQuery(

--- a/modules/apps/commerce/commerce-wish-list-api/bnd.bnd
+++ b/modules/apps/commerce/commerce-wish-list-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Commerce Wish List API
 Bundle-SymbolicName: com.liferay.commerce.wish.list.api
-Bundle-Version: 16.0.1
+Bundle-Version: 16.1.0
 Export-Package:\
 	com.liferay.commerce.wish.list.constants,\
 	com.liferay.commerce.wish.list.exception,\

--- a/modules/apps/commerce/commerce-wish-list-api/src/main/java/com/liferay/commerce/wish/list/service/CommerceWishListLocalService.java
+++ b/modules/apps/commerce/commerce-wish-list-api/src/main/java/com/liferay/commerce/wish/list/service/CommerceWishListLocalService.java
@@ -329,6 +329,7 @@ public interface CommerceWishListLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getCommerceWishListsCount(long userId, long groupId);
 
+	@ThreadLocalCachable
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public CommerceWishList getDefaultCommerceWishList(
 			long userId, long groupId, String guestUuid)
@@ -375,4 +376,4 @@ public interface CommerceWishListLocalService
 		throws PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-829143369
+// LIFERAY-SERVICE-BUILDER-HASH:-1647897195

--- a/modules/apps/commerce/commerce-wish-list-api/src/main/java/com/liferay/commerce/wish/list/service/CommerceWishListLocalService.java
+++ b/modules/apps/commerce/commerce-wish-list-api/src/main/java/com/liferay/commerce/wish/list/service/CommerceWishListLocalService.java
@@ -228,6 +228,12 @@ public interface CommerceWishListLocalService
 	public CommerceWishList fetchCommerceWishListByUuidAndGroupId(
 		String uuid, long groupId);
 
+	@ThreadLocalCachable
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public CommerceWishList fetchDefaultCommerceWishList(
+			long userId, long groupId, String guestUuid)
+		throws PortalException;
+
 	@SystemEvent(type = SystemEventConstants.TYPE_DELETE)
 	public CommerceWishList forceDeleteCommerceWishList(
 		CommerceWishList commerceWishList);
@@ -323,7 +329,6 @@ public interface CommerceWishListLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getCommerceWishListsCount(long userId, long groupId);
 
-	@ThreadLocalCachable
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public CommerceWishList getDefaultCommerceWishList(
 			long userId, long groupId, String guestUuid)
@@ -370,4 +375,4 @@ public interface CommerceWishListLocalService
 		throws PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1123211494
+// LIFERAY-SERVICE-BUILDER-HASH:-829143369

--- a/modules/apps/commerce/commerce-wish-list-api/src/main/java/com/liferay/commerce/wish/list/service/CommerceWishListLocalServiceUtil.java
+++ b/modules/apps/commerce/commerce-wish-list-api/src/main/java/com/liferay/commerce/wish/list/service/CommerceWishListLocalServiceUtil.java
@@ -256,6 +256,14 @@ public class CommerceWishListLocalServiceUtil {
 			uuid, groupId);
 	}
 
+	public static CommerceWishList fetchDefaultCommerceWishList(
+			long userId, long groupId, String guestUuid)
+		throws PortalException {
+
+		return getService().fetchDefaultCommerceWishList(
+			userId, groupId, guestUuid);
+	}
+
 	public static CommerceWishList forceDeleteCommerceWishList(
 		CommerceWishList commerceWishList) {
 
@@ -453,4 +461,4 @@ public class CommerceWishListLocalServiceUtil {
 			CommerceWishListLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1197351635
+// LIFERAY-SERVICE-BUILDER-HASH:-1579568768

--- a/modules/apps/commerce/commerce-wish-list-api/src/main/java/com/liferay/commerce/wish/list/service/CommerceWishListLocalServiceWrapper.java
+++ b/modules/apps/commerce/commerce-wish-list-api/src/main/java/com/liferay/commerce/wish/list/service/CommerceWishListLocalServiceWrapper.java
@@ -294,6 +294,16 @@ public class CommerceWishListLocalServiceWrapper
 
 	@Override
 	public com.liferay.commerce.wish.list.model.CommerceWishList
+			fetchDefaultCommerceWishList(
+				long userId, long groupId, String guestUuid)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _commerceWishListLocalService.fetchDefaultCommerceWishList(
+			userId, groupId, guestUuid);
+	}
+
+	@Override
+	public com.liferay.commerce.wish.list.model.CommerceWishList
 		forceDeleteCommerceWishList(
 			com.liferay.commerce.wish.list.model.CommerceWishList
 				commerceWishList) {
@@ -542,4 +552,4 @@ public class CommerceWishListLocalServiceWrapper
 	private CommerceWishListLocalService _commerceWishListLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:645334971
+// LIFERAY-SERVICE-BUILDER-HASH:-1580409396

--- a/modules/apps/commerce/commerce-wish-list-api/src/main/resources/com/liferay/commerce/wish/list/service/packageinfo
+++ b/modules/apps/commerce/commerce-wish-list-api/src/main/resources/com/liferay/commerce/wish/list/service/packageinfo
@@ -1,1 +1,1 @@
-version 4.0.0
+version 4.1.0

--- a/modules/apps/commerce/commerce-wish-list-service/src/main/java/com/liferay/commerce/wish/list/internal/helper/CommerceWishListHttpHelperImpl.java
+++ b/modules/apps/commerce/commerce-wish-list-service/src/main/java/com/liferay/commerce/wish/list/internal/helper/CommerceWishListHttpHelperImpl.java
@@ -85,7 +85,7 @@ public class CommerceWishListHttpHelperImpl
 			cookieName, httpServletRequest);
 
 		CommerceWishList commerceWishList =
-			_commerceWishListLocalService.getDefaultCommerceWishList(
+			_commerceWishListLocalService.fetchDefaultCommerceWishList(
 				user.getUserId(), groupId, guestUuid);
 
 		if (commerceWishList == null) {

--- a/modules/apps/commerce/commerce-wish-list-service/src/main/java/com/liferay/commerce/wish/list/service/impl/CommerceWishListLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-wish-list-service/src/main/java/com/liferay/commerce/wish/list/service/impl/CommerceWishListLocalServiceImpl.java
@@ -183,7 +183,7 @@ public class CommerceWishListLocalServiceImpl
 			}
 		}
 
-		if (guestCommerceWishList != null) {
+		if ((guestCommerceWishList != null) && (commerceWishList != null)) {
 			_mergeCommerceWishList(
 				guestCommerceWishList.getCommerceWishListId(),
 				commerceWishList.getCommerceWishListId());

--- a/modules/apps/commerce/commerce-wish-list-service/src/main/java/com/liferay/commerce/wish/list/service/impl/CommerceWishListLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-wish-list-service/src/main/java/com/liferay/commerce/wish/list/service/impl/CommerceWishListLocalServiceImpl.java
@@ -7,6 +7,7 @@ package com.liferay.commerce.wish.list.service.impl;
 
 import com.liferay.commerce.wish.list.exception.CommerceWishListNameException;
 import com.liferay.commerce.wish.list.exception.GuestWishListMaxAllowedException;
+import com.liferay.commerce.wish.list.exception.NoSuchWishListException;
 import com.liferay.commerce.wish.list.exception.RequiredCommerceWishListException;
 import com.liferay.commerce.wish.list.internal.configuration.CommerceWishListConfiguration;
 import com.liferay.commerce.wish.list.model.CommerceWishList;
@@ -141,6 +142,57 @@ public class CommerceWishListLocalServiceImpl
 	}
 
 	@Override
+	@ThreadLocalCachable
+	public CommerceWishList fetchDefaultCommerceWishList(
+			long userId, long groupId, String guestUuid)
+		throws PortalException {
+
+		User user = _userLocalService.fetchUser(userId);
+
+		CommerceWishList guestCommerceWishList = null;
+
+		if (Validator.isNotNull(guestUuid)) {
+			guestCommerceWishList =
+				commerceWishListLocalService.
+					fetchCommerceWishListByUuidAndGroupId(guestUuid, groupId);
+
+			if ((guestCommerceWishList != null) &&
+				!guestCommerceWishList.isGuestWishList()) {
+
+				guestCommerceWishList = null;
+			}
+		}
+
+		if ((user == null) || user.isGuestUser()) {
+			return guestCommerceWishList;
+		}
+
+		CommerceWishList commerceWishList =
+			commerceWishListPersistence.fetchByG_U_D_First(
+				groupId, userId, true, null);
+
+		if (commerceWishList == null) {
+			commerceWishList = commerceWishListPersistence.fetchByG_U_D_First(
+				groupId, userId, false, null);
+
+			if (commerceWishList != null) {
+				commerceWishList.setDefaultWishList(true);
+
+				commerceWishList = commerceWishListPersistence.update(
+					commerceWishList);
+			}
+		}
+
+		if (guestCommerceWishList != null) {
+			_mergeCommerceWishList(
+				guestCommerceWishList.getCommerceWishListId(),
+				commerceWishList.getCommerceWishListId());
+		}
+
+		return commerceWishList;
+	}
+
+	@Override
 	@SystemEvent(type = SystemEventConstants.TYPE_DELETE)
 	public CommerceWishList forceDeleteCommerceWishList(
 		CommerceWishList commerceWishList) {
@@ -187,46 +239,12 @@ public class CommerceWishListLocalServiceImpl
 			long userId, long groupId, String guestUuid)
 		throws PortalException {
 
-		User user = _userLocalService.getUser(userId);
-
-		CommerceWishList guestCommerceWishList = null;
-
-		if (Validator.isNotNull(guestUuid)) {
-			guestCommerceWishList =
-				commerceWishListLocalService.
-					fetchCommerceWishListByUuidAndGroupId(guestUuid, groupId);
-
-			if ((guestCommerceWishList != null) &&
-				!guestCommerceWishList.isGuestWishList()) {
-
-				guestCommerceWishList = null;
-			}
-		}
-
-		if (user.isGuestUser()) {
-			return guestCommerceWishList;
-		}
-
-		CommerceWishList commerceWishList =
-			commerceWishListPersistence.fetchByG_U_D_First(
-				groupId, userId, true, null);
+		CommerceWishList commerceWishList = fetchDefaultCommerceWishList(
+			userId, groupId, guestUuid);
 
 		if (commerceWishList == null) {
-			commerceWishList = commerceWishListPersistence.fetchByG_U_D_First(
-				groupId, userId, false, null);
-
-			if (commerceWishList != null) {
-				commerceWishList.setDefaultWishList(true);
-
-				commerceWishList = commerceWishListPersistence.update(
-					commerceWishList);
-			}
-		}
-
-		if (guestCommerceWishList != null) {
-			_mergeCommerceWishList(
-				guestCommerceWishList.getCommerceWishListId(),
-				commerceWishList.getCommerceWishListId());
+			throw new NoSuchWishListException(
+				"No default commerce wish list exists for user " + userId);
 		}
 
 		return commerceWishList;

--- a/modules/apps/commerce/commerce-wish-list-service/src/main/java/com/liferay/commerce/wish/list/service/impl/CommerceWishListServiceImpl.java
+++ b/modules/apps/commerce/commerce-wish-list-service/src/main/java/com/liferay/commerce/wish/list/service/impl/CommerceWishListServiceImpl.java
@@ -109,7 +109,7 @@ public class CommerceWishListServiceImpl
 		throws PortalException {
 
 		CommerceWishList commerceWishList =
-			commerceWishListLocalService.getDefaultCommerceWishList(
+			commerceWishListLocalService.fetchDefaultCommerceWishList(
 				getUserId(), groupId, null);
 
 		if (commerceWishList != null) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/OrderRuleAccountGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/OrderRuleAccountGroupResourceImpl.java
@@ -151,7 +151,7 @@ public class OrderRuleAccountGroupResourceImpl
 		}
 		else {
 			accountGroup =
-				_accountGroupService.fetchAccountGroupByExternalReferenceCode(
+				_accountGroupService.getAccountGroupByExternalReferenceCode(
 					orderRuleAccountGroup.
 						getAccountGroupExternalReferenceCode(),
 					contextCompany.getCompanyId());

--- a/modules/apps/cookies/cookies-api/src/main/java/com/liferay/cookies/service/CookiesConsentPreferenceLocalService.java
+++ b/modules/apps/cookies/cookies-api/src/main/java/com/liferay/cookies/service/CookiesConsentPreferenceLocalService.java
@@ -227,7 +227,8 @@ public interface CookiesConsentPreferenceLocalService
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public CookiesConsentPreference getCookiesConsentPreference(
-		long userId, String domain, String name);
+			long userId, String domain, String name)
+		throws PortalException;
 
 	/**
 	 * Returns a range of all the cookies consent preferences.
@@ -289,4 +290,4 @@ public interface CookiesConsentPreferenceLocalService
 		CookiesConsentPreference cookiesConsentPreference);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:2105518075
+// LIFERAY-SERVICE-BUILDER-HASH:-1885118937

--- a/modules/apps/cookies/cookies-api/src/main/java/com/liferay/cookies/service/CookiesConsentPreferenceLocalServiceUtil.java
+++ b/modules/apps/cookies/cookies-api/src/main/java/com/liferay/cookies/service/CookiesConsentPreferenceLocalServiceUtil.java
@@ -263,7 +263,8 @@ public class CookiesConsentPreferenceLocalServiceUtil {
 	}
 
 	public static CookiesConsentPreference getCookiesConsentPreference(
-		long userId, String domain, String name) {
+			long userId, String domain, String name)
+		throws PortalException {
 
 		return getService().getCookiesConsentPreference(userId, domain, name);
 	}
@@ -352,4 +353,4 @@ public class CookiesConsentPreferenceLocalServiceUtil {
 			CookiesConsentPreferenceLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1672528352
+// LIFERAY-SERVICE-BUILDER-HASH:-1988590670

--- a/modules/apps/cookies/cookies-api/src/main/java/com/liferay/cookies/service/CookiesConsentPreferenceLocalServiceWrapper.java
+++ b/modules/apps/cookies/cookies-api/src/main/java/com/liferay/cookies/service/CookiesConsentPreferenceLocalServiceWrapper.java
@@ -300,7 +300,8 @@ public class CookiesConsentPreferenceLocalServiceWrapper
 
 	@Override
 	public com.liferay.cookies.model.CookiesConsentPreference
-		getCookiesConsentPreference(long userId, String domain, String name) {
+			getCookiesConsentPreference(long userId, String domain, String name)
+		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _cookiesConsentPreferenceLocalService.
 			getCookiesConsentPreference(userId, domain, name);
@@ -417,4 +418,4 @@ public class CookiesConsentPreferenceLocalServiceWrapper
 		_cookiesConsentPreferenceLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:492301751
+// LIFERAY-SERVICE-BUILDER-HASH:-2076735159

--- a/modules/apps/cookies/cookies-rest-impl/src/main/java/com/liferay/cookies/rest/internal/resource/v1_0/CookiesConsentPreferenceResourceImpl.java
+++ b/modules/apps/cookies/cookies-rest-impl/src/main/java/com/liferay/cookies/rest/internal/resource/v1_0/CookiesConsentPreferenceResourceImpl.java
@@ -49,9 +49,8 @@ public class CookiesConsentPreferenceResourceImpl
 
 		com.liferay.cookies.model.CookiesConsentPreference
 			serviceBuilderCookiesConsentPreference =
-				_cookiesConsentPreferenceLocalService.
-					getCookiesConsentPreference(
-						contextUser.getUserId(), _getDomain(), name);
+				_cookiesConsentPreferencePersistence.fetchByU_D_N(
+					contextUser.getUserId(), _getDomain(), name);
 
 		if (serviceBuilderCookiesConsentPreference == null) {
 			return null;

--- a/modules/apps/cookies/cookies-service/src/main/java/com/liferay/cookies/service/impl/CookiesConsentPreferenceLocalServiceImpl.java
+++ b/modules/apps/cookies/cookies-service/src/main/java/com/liferay/cookies/service/impl/CookiesConsentPreferenceLocalServiceImpl.java
@@ -69,9 +69,10 @@ public class CookiesConsentPreferenceLocalServiceImpl
 	}
 
 	public CookiesConsentPreference getCookiesConsentPreference(
-		long userId, String domain, String name) {
+			long userId, String domain, String name)
+		throws PortalException {
 
-		return cookiesConsentPreferencePersistence.fetchByU_D_N(
+		return cookiesConsentPreferencePersistence.findByU_D_N(
 			userId, domain, name);
 	}
 

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/impl/DepotEntryPinLocalServiceImpl.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/impl/DepotEntryPinLocalServiceImpl.java
@@ -97,7 +97,7 @@ public class DepotEntryPinLocalServiceImpl
 	public DepotEntryPin getDepotEntryPin(long userId, long depotEntryId)
 		throws PortalException {
 
-		return depotEntryPinPersistence.fetchByU_D(userId, depotEntryId);
+		return depotEntryPinPersistence.findByU_D(userId, depotEntryId);
 	}
 
 	@Override

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/FileEntryStagedModelDataHandler.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/FileEntryStagedModelDataHandler.java
@@ -557,7 +557,7 @@ public class FileEntryStagedModelDataHandler
 						if (updateFileEntry) {
 							DLFileVersion alreadyExistingFileVersion =
 								_dlFileVersionLocalService.
-									getFileVersionByUuidAndGroupId(
+									fetchDLFileVersionByUuidAndGroupId(
 										fileVersionUuid,
 										existingFileEntry.getGroupId());
 

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLinkLocalService.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLinkLocalService.java
@@ -303,7 +303,8 @@ public interface FragmentEntryLinkLocalService
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public FragmentEntryLink getFragmentEntryLink(
-		long groupId, String originalFragmentEntryLinkERC, long plid);
+			long groupId, String originalFragmentEntryLinkERC, long plid)
+		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public FragmentEntryLink getFragmentEntryLinkByExternalReferenceCode(
@@ -533,4 +534,4 @@ public interface FragmentEntryLinkLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1570191875
+// LIFERAY-SERVICE-BUILDER-HASH:-268484777

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLinkLocalService.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLinkLocalService.java
@@ -249,6 +249,10 @@ public interface FragmentEntryLinkLocalService
 	public FragmentEntryLink fetchFragmentEntryLink(long fragmentEntryLinkId);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public FragmentEntryLink fetchFragmentEntryLink(
+		long groupId, String originalFragmentEntryLinkERC, long plid);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public FragmentEntryLink fetchFragmentEntryLinkByExternalReferenceCode(
 		String externalReferenceCode, long groupId);
 
@@ -534,4 +538,4 @@ public interface FragmentEntryLinkLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-268484777
+// LIFERAY-SERVICE-BUILDER-HASH:1523302530

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLinkLocalServiceUtil.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLinkLocalServiceUtil.java
@@ -372,7 +372,8 @@ public class FragmentEntryLinkLocalServiceUtil {
 	}
 
 	public static FragmentEntryLink getFragmentEntryLink(
-		long groupId, String originalFragmentEntryLinkERC, long plid) {
+			long groupId, String originalFragmentEntryLinkERC, long plid)
+		throws PortalException {
 
 		return getService().getFragmentEntryLink(
 			groupId, originalFragmentEntryLinkERC, plid);
@@ -720,4 +721,4 @@ public class FragmentEntryLinkLocalServiceUtil {
 			FragmentEntryLinkLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1703836549
+// LIFERAY-SERVICE-BUILDER-HASH:-1856823383

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLinkLocalServiceUtil.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLinkLocalServiceUtil.java
@@ -290,6 +290,13 @@ public class FragmentEntryLinkLocalServiceUtil {
 		return getService().fetchFragmentEntryLink(fragmentEntryLinkId);
 	}
 
+	public static FragmentEntryLink fetchFragmentEntryLink(
+		long groupId, String originalFragmentEntryLinkERC, long plid) {
+
+		return getService().fetchFragmentEntryLink(
+			groupId, originalFragmentEntryLinkERC, plid);
+	}
+
 	public static FragmentEntryLink
 		fetchFragmentEntryLinkByExternalReferenceCode(
 			String externalReferenceCode, long groupId) {
@@ -721,4 +728,4 @@ public class FragmentEntryLinkLocalServiceUtil {
 			FragmentEntryLinkLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1856823383
+// LIFERAY-SERVICE-BUILDER-HASH:-1331238008

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLinkLocalServiceWrapper.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLinkLocalServiceWrapper.java
@@ -326,6 +326,14 @@ public class FragmentEntryLinkLocalServiceWrapper
 	}
 
 	@Override
+	public FragmentEntryLink fetchFragmentEntryLink(
+		long groupId, String originalFragmentEntryLinkERC, long plid) {
+
+		return _fragmentEntryLinkLocalService.fetchFragmentEntryLink(
+			groupId, originalFragmentEntryLinkERC, plid);
+	}
+
+	@Override
 	public FragmentEntryLink fetchFragmentEntryLinkByExternalReferenceCode(
 		String externalReferenceCode, long groupId) {
 
@@ -855,4 +863,4 @@ public class FragmentEntryLinkLocalServiceWrapper
 	private FragmentEntryLinkLocalService _fragmentEntryLinkLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-84086422
+// LIFERAY-SERVICE-BUILDER-HASH:564296629

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLinkLocalServiceWrapper.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLinkLocalServiceWrapper.java
@@ -420,7 +420,8 @@ public class FragmentEntryLinkLocalServiceWrapper
 
 	@Override
 	public FragmentEntryLink getFragmentEntryLink(
-		long groupId, String originalFragmentEntryLinkERC, long plid) {
+			long groupId, String originalFragmentEntryLinkERC, long plid)
+		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _fragmentEntryLinkLocalService.getFragmentEntryLink(
 			groupId, originalFragmentEntryLinkERC, plid);
@@ -854,4 +855,4 @@ public class FragmentEntryLinkLocalServiceWrapper
 	private FragmentEntryLinkLocalService _fragmentEntryLinkLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-15895300
+// LIFERAY-SERVICE-BUILDER-HASH:-84086422

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
@@ -383,9 +383,10 @@ public class FragmentEntryLinkLocalServiceImpl
 
 	@Override
 	public FragmentEntryLink getFragmentEntryLink(
-		long groupId, String originalFragmentEntryLinkERC, long plid) {
+			long groupId, String originalFragmentEntryLinkERC, long plid)
+		throws PortalException {
 
-		return fragmentEntryLinkPersistence.fetchByG_OFELERC_P_First(
+		return fragmentEntryLinkPersistence.findByG_OFELERC_P_First(
 			groupId, originalFragmentEntryLinkERC, plid, null);
 	}
 

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
@@ -326,6 +326,14 @@ public class FragmentEntryLinkLocalServiceImpl
 	}
 
 	@Override
+	public FragmentEntryLink fetchFragmentEntryLink(
+		long groupId, String originalFragmentEntryLinkERC, long plid) {
+
+		return fragmentEntryLinkPersistence.fetchByG_OFELERC_P_First(
+			groupId, originalFragmentEntryLinkERC, plid, null);
+	}
+
+	@Override
 	public List<FragmentEntryLink> getAllFragmentEntryLinksByFragmentEntry(
 			FragmentEntry fragmentEntry, int start, int end,
 			OrderByComparator<FragmentEntryLink> orderByComparator)

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
@@ -618,8 +618,8 @@ public class FragmentEntryLinkLocalServiceImpl
 			boolean updateClassedModel)
 		throws PortalException {
 
-		FragmentEntryLink fragmentEntryLink = fetchFragmentEntryLink(
-			fragmentEntryLinkId);
+		FragmentEntryLink fragmentEntryLink =
+			fragmentEntryLinkPersistence.findByPrimaryKey(fragmentEntryLinkId);
 
 		_checkUnlockedLayout(fragmentEntryLink.getPlid(), userId);
 
@@ -646,8 +646,8 @@ public class FragmentEntryLinkLocalServiceImpl
 
 		_checkUnlockedLayout(plid, userId);
 
-		FragmentEntryLink fragmentEntryLink = fetchFragmentEntryLink(
-			fragmentEntryLinkId);
+		FragmentEntryLink fragmentEntryLink =
+			fragmentEntryLinkPersistence.findByPrimaryKey(fragmentEntryLinkId);
 
 		fragmentEntryLink.setUserId(user.getUserId());
 		fragmentEntryLink.setUserName(user.getFullName());

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/util/ServiceBuilderListTypeUtil.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/util/ServiceBuilderListTypeUtil.java
@@ -42,11 +42,11 @@ public class ServiceBuilderListTypeUtil {
 	public static long toServiceBuilderListTypeId(
 		long companyId, String defaultName, String name, String type) {
 
-		ListType listType = ListTypeLocalServiceUtil.getListType(
+		ListType listType = ListTypeLocalServiceUtil.fetchListType(
 			companyId, name, type);
 
 		if (listType == null) {
-			listType = ListTypeLocalServiceUtil.getListType(
+			listType = ListTypeLocalServiceUtil.fetchListType(
 				companyId, defaultName, type);
 		}
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/EmailAddressResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/EmailAddressResourceImpl.java
@@ -203,7 +203,7 @@ public class EmailAddressResourceImpl extends BaseEmailAddressResourceImpl {
 	}
 
 	private Long _getListTypeId(String className, String name) {
-		ListType listType = _listTypeService.getListType(
+		ListType listType = _listTypeService.fetchListType(
 			contextCompany.getCompanyId(), name,
 			className + ListTypeConstants.EMAIL_ADDRESS);
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/PhoneResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/PhoneResourceImpl.java
@@ -218,7 +218,7 @@ public class PhoneResourceImpl extends BasePhoneResourceImpl {
 	}
 
 	private Long _getListTypeId(String className, String name) {
-		ListType listType = _listTypeService.getListType(
+		ListType listType = _listTypeService.fetchListType(
 			contextCompany.getCompanyId(), name,
 			className + ListTypeConstants.PHONE);
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/PostalAddressResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/PostalAddressResourceImpl.java
@@ -412,7 +412,7 @@ public class PostalAddressResourceImpl extends BasePostalAddressResourceImpl {
 			type = className.getClassName() + ListTypeConstants.ADDRESS;
 		}
 
-		ListType listType = _listTypeLocalService.getListType(
+		ListType listType = _listTypeLocalService.fetchListType(
 			contextCompany.getCompanyId(), postalAddress.getAddressType(),
 			type);
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/WebUrlResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/WebUrlResourceImpl.java
@@ -225,7 +225,7 @@ public class WebUrlResourceImpl extends BaseWebUrlResourceImpl {
 	}
 
 	private Long _getListTypeId(String className, String name) {
-		ListType listType = _listTypeService.getListType(
+		ListType listType = _listTypeService.fetchListType(
 			contextCompany.getCompanyId(), name,
 			className + ListTypeConstants.WEBSITE);
 

--- a/modules/apps/info/info-impl/src/main/java/com/liferay/info/internal/request/struts/EditInfoItemStrutsAction.java
+++ b/modules/apps/info/info-impl/src/main/java/com/liferay/info/internal/request/struts/EditInfoItemStrutsAction.java
@@ -524,7 +524,9 @@ public class EditInfoItemStrutsAction implements StrutsAction {
 				_fragmentEntryLinkLocalService.fetchFragmentEntryLink(
 					fragmentEntryLinkId);
 
-			if (!fragmentEntryLink.isTypeInput()) {
+			if ((fragmentEntryLink == null) ||
+				!fragmentEntryLink.isTypeInput()) {
+
 				continue;
 			}
 

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_1_0/ImageTypeContentUpgradeProcess.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_1_0/ImageTypeContentUpgradeProcess.java
@@ -102,7 +102,7 @@ public class ImageTypeContentUpgradeProcess extends UpgradeProcess {
 					long userId = (Long)values[3];
 
 					try {
-						Image image = _imageLocalService.getImage(
+						Image image = _imageLocalService.fetchImage(
 							articleImageId);
 
 						if (image == null) {

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/helper/JournalRSSHelper.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/helper/JournalRSSHelper.java
@@ -281,7 +281,7 @@ public class JournalRSSHelper {
 					imageId = GetterUtil.getLong(imageIdStrings[0]);
 				}
 
-				image = _imageLocalService.getImage(imageId);
+				image = _imageLocalService.fetchImage(imageId);
 			}
 			catch (Exception exception) {
 				if (_log.isWarnEnabled()) {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/util/layout/structure/LayoutStructureUtil.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/util/layout/structure/LayoutStructureUtil.java
@@ -175,6 +175,10 @@ public class LayoutStructureUtil {
 				FragmentEntryLinkLocalServiceUtil.fetchFragmentEntryLink(
 					fragmentStyledLayoutStructureItem.getFragmentEntryLinkId());
 
+			if (fragmentEntryLink == null) {
+				return true;
+			}
+
 			FragmentEntry fragmentEntry = getFragmentEntry(fragmentEntryLink);
 
 			if (fragmentEntry != null) {

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/exportimport/data/handler/StagedLayoutSetStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/exportimport/data/handler/StagedLayoutSetStagedModelDataHandler.java
@@ -440,31 +440,10 @@ public class StagedLayoutSetStagedModelDataHandler
 		Image image = null;
 
 		if (layoutSetBranch != null) {
-			try {
-				image = _imageLocalService.getImage(
-					layoutSetBranch.getLogoId());
-			}
-			catch (PortalException portalException) {
-				if (_log.isWarnEnabled()) {
-					_log.warn(
-						"Unable to get logo for layout set branch " +
-							layoutSetBranch.getLayoutSetBranchId(),
-						portalException);
-				}
-			}
+			image = _imageLocalService.fetchImage(layoutSetBranch.getLogoId());
 		}
 		else {
-			try {
-				image = _imageLocalService.getImage(layoutSet.getLogoId());
-			}
-			catch (PortalException portalException) {
-				if (_log.isWarnEnabled()) {
-					_log.warn(
-						"Unable to get logo for layout set " +
-							layoutSet.getLayoutSetId(),
-						portalException);
-				}
-			}
+			image = _imageLocalService.fetchImage(layoutSet.getLogoId());
 		}
 
 		if ((image != null) && (image.getTextObj() != null)) {

--- a/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/service/LayoutLocalServiceWrapper.java
+++ b/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/service/LayoutLocalServiceWrapper.java
@@ -871,7 +871,7 @@ public class LayoutLocalServiceWrapper
 
 			if (fragmentEntryLink.isDeleted()) {
 				FragmentEntryLink targetLayoutFragmentEntryLink =
-					_fragmentEntryLinkLocalService.getFragmentEntryLink(
+					_fragmentEntryLinkLocalService.fetchFragmentEntryLink(
 						targetLayout.getGroupId(),
 						fragmentEntryLink.getExternalReferenceCode(),
 						targetLayout.getPlid());

--- a/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/service/LayoutLocalServiceWrapper.java
+++ b/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/service/LayoutLocalServiceWrapper.java
@@ -1227,7 +1227,7 @@ public class LayoutLocalServiceWrapper
 					fragmentStyledLayoutStructureItem.getFragmentEntryLinkId());
 
 			FragmentEntryLink targetLayoutFragmentEntryLink =
-				_fragmentEntryLinkLocalService.getFragmentEntryLink(
+				_fragmentEntryLinkLocalService.fetchFragmentEntryLink(
 					targetLayout.getGroupId(),
 					originalFragmentEntryLink.getExternalReferenceCode(),
 					targetLayout.getPlid());

--- a/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/service/LayoutLocalServiceWrapper.java
+++ b/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/service/LayoutLocalServiceWrapper.java
@@ -1557,7 +1557,7 @@ public class LayoutLocalServiceWrapper
 			_copyLayoutClientExtensions(
 				_sourceLayout, _targetLayout, _user.getUserId());
 
-			Image image = _imageLocalService.getImage(
+			Image image = _imageLocalService.fetchImage(
 				_sourceLayout.getIconImageId());
 
 			byte[] imageBytes = null;

--- a/modules/apps/marketplace/marketplace-store-web/src/main/java/com/liferay/marketplace/store/web/internal/oauth/util/OAuthManager.java
+++ b/modules/apps/marketplace/marketplace-store-web/src/main/java/com/liferay/marketplace/store/web/internal/oauth/util/OAuthManager.java
@@ -46,10 +46,10 @@ public class OAuthManager {
 	}
 
 	public Token getAccessToken(User user) throws PortalException {
-		ExpandoValue secretExpandoValue = _expandoValueLocalService.getValue(
+		ExpandoValue secretExpandoValue = _expandoValueLocalService.fetchValue(
 			user.getCompanyId(), User.class.getName(), "MP", "accessSecret",
 			user.getUserId());
-		ExpandoValue tokenExpandoValue = _expandoValueLocalService.getValue(
+		ExpandoValue tokenExpandoValue = _expandoValueLocalService.fetchValue(
 			user.getCompanyId(), User.class.getName(), "MP", "accessToken",
 			user.getUserId());
 
@@ -74,10 +74,10 @@ public class OAuthManager {
 	}
 
 	public Token getRequestToken(User user) throws PortalException {
-		ExpandoValue secretExpandoValue = _expandoValueLocalService.getValue(
+		ExpandoValue secretExpandoValue = _expandoValueLocalService.fetchValue(
 			user.getCompanyId(), User.class.getName(), "MP", "requestSecret",
 			user.getUserId());
-		ExpandoValue tokenExpandoValue = _expandoValueLocalService.getValue(
+		ExpandoValue tokenExpandoValue = _expandoValueLocalService.fetchValue(
 			user.getCompanyId(), User.class.getName(), "MP", "requestToken",
 			user.getUserId());
 

--- a/modules/apps/message-boards/message-boards-api/bnd.bnd
+++ b/modules/apps/message-boards/message-boards-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Message Boards API
 Bundle-SymbolicName: com.liferay.message.boards.api
-Bundle-Version: 30.0.2
+Bundle-Version: 30.1.0
 Export-Package:\
 	com.liferay.message.boards.configuration,\
 	com.liferay.message.boards.constants,\

--- a/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/MBThreadFlagLocalService.java
+++ b/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/MBThreadFlagLocalService.java
@@ -229,6 +229,9 @@ public interface MBThreadFlagLocalService
 		String uuid, long groupId);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public MBThreadFlag fetchThreadFlag(long userId, MBThread thread);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public ActionableDynamicQuery getActionableDynamicQuery();
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
@@ -362,4 +365,4 @@ public interface MBThreadFlagLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1569622709
+// LIFERAY-SERVICE-BUILDER-HASH:1722500708

--- a/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/MBThreadFlagLocalServiceUtil.java
+++ b/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/MBThreadFlagLocalServiceUtil.java
@@ -240,6 +240,12 @@ public class MBThreadFlagLocalServiceUtil {
 		return getService().fetchMBThreadFlagByUuidAndGroupId(uuid, groupId);
 	}
 
+	public static MBThreadFlag fetchThreadFlag(
+		long userId, com.liferay.message.boards.model.MBThread thread) {
+
+		return getService().fetchThreadFlag(userId, thread);
+	}
+
 	public static com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery
 		getActionableDynamicQuery() {
 
@@ -399,4 +405,4 @@ public class MBThreadFlagLocalServiceUtil {
 			MBThreadFlagLocalServiceUtil.class, MBThreadFlagLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:2070684054
+// LIFERAY-SERVICE-BUILDER-HASH:1748871968

--- a/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/MBThreadFlagLocalServiceWrapper.java
+++ b/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/MBThreadFlagLocalServiceWrapper.java
@@ -268,6 +268,13 @@ public class MBThreadFlagLocalServiceWrapper
 	}
 
 	@Override
+	public MBThreadFlag fetchThreadFlag(
+		long userId, com.liferay.message.boards.model.MBThread thread) {
+
+		return _mbThreadFlagLocalService.fetchThreadFlag(userId, thread);
+	}
+
+	@Override
 	public com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery
 		getActionableDynamicQuery() {
 
@@ -475,4 +482,4 @@ public class MBThreadFlagLocalServiceWrapper
 	private MBThreadFlagLocalService _mbThreadFlagLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1137522955
+// LIFERAY-SERVICE-BUILDER-HASH:1602459440

--- a/modules/apps/message-boards/message-boards-api/src/main/resources/com/liferay/message/boards/service/packageinfo
+++ b/modules/apps/message-boards/message-boards-api/src/main/resources/com/liferay/message/boards/service/packageinfo
@@ -1,1 +1,1 @@
-version 11.1.0
+version 11.2.0

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBThreadFlagLocalServiceImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBThreadFlagLocalServiceImpl.java
@@ -115,16 +115,21 @@ public class MBThreadFlagLocalServiceImpl
 	}
 
 	@Override
-	public MBThreadFlag getThreadFlag(long userId, MBThread thread)
-		throws PortalException {
+	public MBThreadFlag fetchThreadFlag(long userId, MBThread thread) {
+		User user = _userLocalService.fetchUser(userId);
 
-		User user = _userLocalService.getUser(userId);
-
-		if (user.isGuestUser()) {
+		if ((user == null) || user.isGuestUser()) {
 			return null;
 		}
 
 		return mbThreadFlagPersistence.fetchByU_T(userId, thread.getThreadId());
+	}
+
+	@Override
+	public MBThreadFlag getThreadFlag(long userId, MBThread thread)
+		throws PortalException {
+
+		return mbThreadFlagPersistence.findByU_T(userId, thread.getThreadId());
 	}
 
 	@Override

--- a/modules/apps/notification/notification-api/bnd.bnd
+++ b/modules/apps/notification/notification-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Notification API
 Bundle-SymbolicName: com.liferay.notification.api
-Bundle-Version: 21.0.2
+Bundle-Version: 21.1.0
 Export-Package:\
 	com.liferay.notification.constants,\
 	com.liferay.notification.context,\

--- a/modules/apps/notification/notification-api/src/main/java/com/liferay/notification/service/NotificationRecipientLocalService.java
+++ b/modules/apps/notification/notification-api/src/main/java/com/liferay/notification/service/NotificationRecipientLocalService.java
@@ -202,6 +202,10 @@ public interface NotificationRecipientLocalService
 	public NotificationRecipient fetchNotificationRecipient(
 		long notificationRecipientId);
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public NotificationRecipient fetchNotificationRecipientByClassPK(
+		long classPK);
+
 	/**
 	 * Returns the notification recipient with the matching UUID and company.
 	 *
@@ -236,8 +240,8 @@ public interface NotificationRecipientLocalService
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public NotificationRecipient getNotificationRecipientByClassPK(
-		long classPK);
+	public NotificationRecipient getNotificationRecipientByClassPK(long classPK)
+		throws PortalException;
 
 	/**
 	 * Returns the notification recipient with the matching UUID and company.
@@ -305,4 +309,4 @@ public interface NotificationRecipientLocalService
 		NotificationRecipient notificationRecipient);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1278996706
+// LIFERAY-SERVICE-BUILDER-HASH:445054226

--- a/modules/apps/notification/notification-api/src/main/java/com/liferay/notification/service/NotificationRecipientLocalServiceUtil.java
+++ b/modules/apps/notification/notification-api/src/main/java/com/liferay/notification/service/NotificationRecipientLocalServiceUtil.java
@@ -219,6 +219,12 @@ public class NotificationRecipientLocalServiceUtil {
 		return getService().fetchNotificationRecipient(notificationRecipientId);
 	}
 
+	public static NotificationRecipient fetchNotificationRecipientByClassPK(
+		long classPK) {
+
+		return getService().fetchNotificationRecipientByClassPK(classPK);
+	}
+
 	/**
 	 * Returns the notification recipient with the matching UUID and company.
 	 *
@@ -270,7 +276,8 @@ public class NotificationRecipientLocalServiceUtil {
 	}
 
 	public static NotificationRecipient getNotificationRecipientByClassPK(
-		long classPK) {
+			long classPK)
+		throws PortalException {
 
 		return getService().getNotificationRecipientByClassPK(classPK);
 	}
@@ -362,4 +369,4 @@ public class NotificationRecipientLocalServiceUtil {
 			NotificationRecipientLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-136507293
+// LIFERAY-SERVICE-BUILDER-HASH:-1561036574

--- a/modules/apps/notification/notification-api/src/main/java/com/liferay/notification/service/NotificationRecipientLocalServiceWrapper.java
+++ b/modules/apps/notification/notification-api/src/main/java/com/liferay/notification/service/NotificationRecipientLocalServiceWrapper.java
@@ -249,6 +249,14 @@ public class NotificationRecipientLocalServiceWrapper
 			notificationRecipientId);
 	}
 
+	@Override
+	public com.liferay.notification.model.NotificationRecipient
+		fetchNotificationRecipientByClassPK(long classPK) {
+
+		return _notificationRecipientLocalService.
+			fetchNotificationRecipientByClassPK(classPK);
+	}
+
 	/**
 	 * Returns the notification recipient with the matching UUID and company.
 	 *
@@ -308,7 +316,8 @@ public class NotificationRecipientLocalServiceWrapper
 
 	@Override
 	public com.liferay.notification.model.NotificationRecipient
-		getNotificationRecipientByClassPK(long classPK) {
+			getNotificationRecipientByClassPK(long classPK)
+		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _notificationRecipientLocalService.
 			getNotificationRecipientByClassPK(classPK);
@@ -425,4 +434,4 @@ public class NotificationRecipientLocalServiceWrapper
 		_notificationRecipientLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2009132914
+// LIFERAY-SERVICE-BUILDER-HASH:2348665

--- a/modules/apps/notification/notification-api/src/main/resources/com/liferay/notification/service/packageinfo
+++ b/modules/apps/notification/notification-api/src/main/resources/com/liferay/notification/service/packageinfo
@@ -1,1 +1,1 @@
-version 10.2.0
+version 10.3.0

--- a/modules/apps/notification/notification-rest-api/src/main/java/com/liferay/notification/rest/dto/v1_0/util/NotificationUtil.java
+++ b/modules/apps/notification/notification-rest-api/src/main/java/com/liferay/notification/rest/dto/v1_0/util/NotificationUtil.java
@@ -86,7 +86,7 @@ public class NotificationUtil {
 
 		NotificationRecipient notificationRecipient =
 			NotificationRecipientLocalServiceUtil.
-				getNotificationRecipientByClassPK(classPK);
+				fetchNotificationRecipientByClassPK(classPK);
 
 		if (notificationRecipient != null) {
 			return notificationRecipient;

--- a/modules/apps/notification/notification-service/src/main/java/com/liferay/notification/model/impl/NotificationQueueEntryImpl.java
+++ b/modules/apps/notification/notification-service/src/main/java/com/liferay/notification/model/impl/NotificationQueueEntryImpl.java
@@ -33,7 +33,7 @@ public class NotificationQueueEntryImpl extends NotificationQueueEntryBaseImpl {
 	@Override
 	public NotificationRecipient getNotificationRecipient() {
 		return NotificationRecipientLocalServiceUtil.
-			getNotificationRecipientByClassPK(getNotificationQueueEntryId());
+			fetchNotificationRecipientByClassPK(getNotificationQueueEntryId());
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/notification/notification-service/src/main/java/com/liferay/notification/model/impl/NotificationTemplateImpl.java
+++ b/modules/apps/notification/notification-service/src/main/java/com/liferay/notification/model/impl/NotificationTemplateImpl.java
@@ -16,7 +16,7 @@ public class NotificationTemplateImpl extends NotificationTemplateBaseImpl {
 	@Override
 	public NotificationRecipient getNotificationRecipient() {
 		return NotificationRecipientLocalServiceUtil.
-			getNotificationRecipientByClassPK(getNotificationTemplateId());
+			fetchNotificationRecipientByClassPK(getNotificationTemplateId());
 	}
 
 }

--- a/modules/apps/notification/notification-service/src/main/java/com/liferay/notification/service/impl/NotificationRecipientLocalServiceImpl.java
+++ b/modules/apps/notification/notification-service/src/main/java/com/liferay/notification/service/impl/NotificationRecipientLocalServiceImpl.java
@@ -50,10 +50,17 @@ public class NotificationRecipientLocalServiceImpl
 	}
 
 	@Override
-	public NotificationRecipient getNotificationRecipientByClassPK(
+	public NotificationRecipient fetchNotificationRecipientByClassPK(
 		long classPK) {
 
 		return notificationRecipientPersistence.fetchByClassPK(classPK);
+	}
+
+	@Override
+	public NotificationRecipient getNotificationRecipientByClassPK(long classPK)
+		throws PortalException {
+
+		return notificationRecipientPersistence.findByClassPK(classPK);
 	}
 
 	@Reference

--- a/modules/apps/password-policy/password-policy-test/src/testIntegration/java/com/liferay/password/policy/service/test/PasswordPolicyLocalServiceTest.java
+++ b/modules/apps/password-policy/password-policy-test/src/testIntegration/java/com/liferay/password/policy/service/test/PasswordPolicyLocalServiceTest.java
@@ -39,6 +39,88 @@ public class PasswordPolicyLocalServiceTest {
 			PermissionCheckerMethodTestRule.INSTANCE);
 
 	@Test
+	public void testFetchPasswordPolicyByUserIdWithLDAPPasswordPolicy()
+		throws Exception {
+
+		try (LDAPAuthConfigurationProviderTemporarySwapper
+				ldapAuthConfigurationProviderTemporarySwapper =
+					new LDAPAuthConfigurationProviderTemporarySwapper(
+						TestPropsValues.getCompanyId(), true)) {
+
+			User user = _addUser(true);
+
+			Assert.assertNull(
+				_passwordPolicyLocalService.fetchPasswordPolicyByUserId(
+					user.getUserId()));
+
+			user = _addUser(false);
+
+			Assert.assertNotNull(
+				_passwordPolicyLocalService.fetchPasswordPolicyByUserId(
+					user.getUserId()));
+		}
+	}
+
+	@Test
+	public void testFetchPasswordPolicyByUserIdWithoutLDAPPasswordPolicy()
+		throws Exception {
+
+		try (LDAPAuthConfigurationProviderTemporarySwapper
+				ldapAuthConfigurationProviderTemporarySwapper =
+					new LDAPAuthConfigurationProviderTemporarySwapper(
+						TestPropsValues.getCompanyId(), false)) {
+
+			User user = _addUser(true);
+
+			Assert.assertNotNull(
+				_passwordPolicyLocalService.fetchPasswordPolicyByUserId(
+					user.getUserId()));
+
+			user = _addUser(false);
+
+			Assert.assertNotNull(
+				_passwordPolicyLocalService.fetchPasswordPolicyByUserId(
+					user.getUserId()));
+		}
+	}
+
+	@Test
+	public void testFetchPasswordPolicyByUserWithLDAPPasswordPolicy()
+		throws Exception {
+
+		try (LDAPAuthConfigurationProviderTemporarySwapper
+				ldapAuthConfigurationProviderTemporarySwapper =
+					new LDAPAuthConfigurationProviderTemporarySwapper(
+						TestPropsValues.getCompanyId(), true)) {
+
+			Assert.assertNull(
+				_passwordPolicyLocalService.fetchPasswordPolicyByUser(
+					_addUser(true)));
+			Assert.assertNotNull(
+				_passwordPolicyLocalService.fetchPasswordPolicyByUser(
+					_addUser(false)));
+		}
+	}
+
+	@Test
+	public void testFetchPasswordPolicyByUserWithoutLDAPPasswordPolicy()
+		throws Exception {
+
+		try (LDAPAuthConfigurationProviderTemporarySwapper
+				ldapAuthConfigurationProviderTemporarySwapper =
+					new LDAPAuthConfigurationProviderTemporarySwapper(
+						TestPropsValues.getCompanyId(), false)) {
+
+			Assert.assertNotNull(
+				_passwordPolicyLocalService.fetchPasswordPolicyByUser(
+					_addUser(true)));
+			Assert.assertNotNull(
+				_passwordPolicyLocalService.fetchPasswordPolicyByUser(
+					_addUser(false)));
+		}
+	}
+
+	@Test
 	public void testGetDefaultPasswordPolicyWithLDAPPasswordPolicy()
 		throws Exception {
 
@@ -50,88 +132,6 @@ public class PasswordPolicyLocalServiceTest {
 			Assert.assertNotNull(
 				_passwordPolicyLocalService.getDefaultPasswordPolicy(
 					TestPropsValues.getCompanyId()));
-		}
-	}
-
-	@Test
-	public void testGetPasswordPolicyByUserIdWithLDAPPasswordPolicy()
-		throws Exception {
-
-		try (LDAPAuthConfigurationProviderTemporarySwapper
-				ldapAuthConfigurationProviderTemporarySwapper =
-					new LDAPAuthConfigurationProviderTemporarySwapper(
-						TestPropsValues.getCompanyId(), true)) {
-
-			User user = _addUser(true);
-
-			Assert.assertNull(
-				_passwordPolicyLocalService.getPasswordPolicyByUserId(
-					user.getUserId()));
-
-			user = _addUser(false);
-
-			Assert.assertNotNull(
-				_passwordPolicyLocalService.getPasswordPolicyByUserId(
-					user.getUserId()));
-		}
-	}
-
-	@Test
-	public void testGetPasswordPolicyByUserIdWithoutLDAPPasswordPolicy()
-		throws Exception {
-
-		try (LDAPAuthConfigurationProviderTemporarySwapper
-				ldapAuthConfigurationProviderTemporarySwapper =
-					new LDAPAuthConfigurationProviderTemporarySwapper(
-						TestPropsValues.getCompanyId(), false)) {
-
-			User user = _addUser(true);
-
-			Assert.assertNotNull(
-				_passwordPolicyLocalService.getPasswordPolicyByUserId(
-					user.getUserId()));
-
-			user = _addUser(false);
-
-			Assert.assertNotNull(
-				_passwordPolicyLocalService.getPasswordPolicyByUserId(
-					user.getUserId()));
-		}
-	}
-
-	@Test
-	public void testGetPasswordPolicyByUserWithLDAPPasswordPolicy()
-		throws Exception {
-
-		try (LDAPAuthConfigurationProviderTemporarySwapper
-				ldapAuthConfigurationProviderTemporarySwapper =
-					new LDAPAuthConfigurationProviderTemporarySwapper(
-						TestPropsValues.getCompanyId(), true)) {
-
-			Assert.assertNull(
-				_passwordPolicyLocalService.getPasswordPolicyByUser(
-					_addUser(true)));
-			Assert.assertNotNull(
-				_passwordPolicyLocalService.getPasswordPolicyByUser(
-					_addUser(false)));
-		}
-	}
-
-	@Test
-	public void testGetPasswordPolicyByUserWithoutLDAPPasswordPolicy()
-		throws Exception {
-
-		try (LDAPAuthConfigurationProviderTemporarySwapper
-				ldapAuthConfigurationProviderTemporarySwapper =
-					new LDAPAuthConfigurationProviderTemporarySwapper(
-						TestPropsValues.getCompanyId(), false)) {
-
-			Assert.assertNotNull(
-				_passwordPolicyLocalService.getPasswordPolicyByUser(
-					_addUser(true)));
-			Assert.assertNotNull(
-				_passwordPolicyLocalService.getPasswordPolicyByUser(
-					_addUser(false)));
 		}
 	}
 

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/OIDCUserInfoProcessor.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/OIDCUserInfoProcessor.java
@@ -171,7 +171,7 @@ public class OIDCUserInfoProcessor {
 			}
 		}
 
-		ListType listType = _listTypeLocalService.getListType(
+		ListType listType = _listTypeLocalService.fetchListType(
 			user.getCompanyId(),
 			_getClaimString(
 				"addressType", addressMapperJSONObject, userInfoJSONObject),
@@ -420,7 +420,7 @@ public class OIDCUserInfoProcessor {
 			return;
 		}
 
-		ListType listType = _listTypeLocalService.getListType(
+		ListType listType = _listTypeLocalService.fetchListType(
 			user.getCompanyId(),
 			_getClaimString(
 				"phoneType", phoneMapperJSONObject, userInfoJSONObject),

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/OIDCUserInfoProcessor.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/OIDCUserInfoProcessor.java
@@ -753,7 +753,7 @@ public class OIDCUserInfoProcessor {
 				continue;
 			}
 
-			ExpandoValue expandoValue = _expandoValueLocalService.getValue(
+			ExpandoValue expandoValue = _expandoValueLocalService.fetchValue(
 				expandoColumn.getTableId(), expandoColumn.getColumnId(),
 				userGroup.getUserGroupId());
 

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/DefaultPortalToLDAPConverter.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/DefaultPortalToLDAPConverter.java
@@ -633,7 +633,7 @@ public class DefaultPortalToLDAPConverter implements PortalToLDAPConverter {
 		Image image = null;
 
 		try {
-			image = _imageLocalService.getImage(user.getPortraitId());
+			image = _imageLocalService.fetchImage(user.getPortraitId());
 
 			if (image != null) {
 				bytes = image.getTextObj();

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
@@ -1670,7 +1670,7 @@ public class LDAPUserImporterImpl implements LDAPUserImporter {
 					(value != null)) {
 
 					ExpandoValue existingValue =
-						_expandoValueLocalService.getValue(
+						_expandoValueLocalService.fetchValue(
 							expandoBridge.getCompanyId(),
 							expandoBridge.getClassName(),
 							ExpandoTableConstants.DEFAULT_TABLE_NAME, name,
@@ -2037,7 +2037,7 @@ public class LDAPUserImporterImpl implements LDAPUserImporter {
 						userGroup.getCompanyId());
 
 					ExpandoValue expandoValue =
-						_expandoValueLocalService.getValue(
+						_expandoValueLocalService.fetchValue(
 							expandoColumn.getTableId(),
 							expandoColumn.getColumnId(), userGroupId);
 

--- a/modules/apps/portal/portal-list-type-test/src/testIntegration/java/com/liferay/portal/list/type/test/ListTypeLocalServiceTest.java
+++ b/modules/apps/portal/portal-list-type-test/src/testIntegration/java/com/liferay/portal/list/type/test/ListTypeLocalServiceTest.java
@@ -78,7 +78,7 @@ public class ListTypeLocalServiceTest {
 				JSONObject listTypeJSONObject =
 					listTypesJSONArray.getJSONObject(i);
 
-				ListType listType = _listTypeLocalService.getListType(
+				ListType listType = _listTypeLocalService.fetchListType(
 					_company.getCompanyId(),
 					listTypeJSONObject.getString("name"),
 					listTypeJSONObject.getString("type"));
@@ -102,7 +102,7 @@ public class ListTypeLocalServiceTest {
 				_company.getCompanyId(), _LIST_TYPE_NAME, _LIST_TYPE_TYPE);
 
 			Assert.assertNotNull(
-				_listTypeLocalService.getListType(
+				_listTypeLocalService.fetchListType(
 					_company.getCompanyId(), _LIST_TYPE_NAME, _LIST_TYPE_TYPE));
 
 			try (SafeCloseable safeCloseable2 =
@@ -110,7 +110,7 @@ public class ListTypeLocalServiceTest {
 						PortalUtil.getDefaultCompanyId())) {
 
 				Assert.assertNull(
-					_listTypeLocalService.getListType(
+					_listTypeLocalService.fetchListType(
 						PortalUtil.getDefaultCompanyId(), _LIST_TYPE_NAME,
 						_LIST_TYPE_TYPE));
 			}

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/UpgradeListTypeAuditFieldsTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/UpgradeListTypeAuditFieldsTest.java
@@ -10,7 +10,6 @@ import com.liferay.portal.kernel.model.ListType;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.ListTypeLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
-import com.liferay.portal.kernel.upgrade.UpgradeException;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -35,7 +34,7 @@ public class UpgradeListTypeAuditFieldsTest {
 		new LiferayIntegrationTestRule();
 
 	@Before
-	public void setUp() {
+	public void setUp() throws Exception {
 		ListType listType = _listTypeLocalService.getListType(
 			CompanyThreadLocal.getCompanyId(), _LIST_TYPE_NAME,
 			_LIST_TYPE_TYPE);
@@ -46,7 +45,7 @@ public class UpgradeListTypeAuditFieldsTest {
 	}
 
 	@Test
-	public void testUpgrade() throws UpgradeException {
+	public void testUpgrade() throws Exception {
 		UpgradeProcess upgradeProcess = new UpgradeListTypeAuditFields();
 
 		upgradeProcess.upgrade();

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/UpgradeListTypeTypeTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/UpgradeListTypeTypeTest.java
@@ -59,13 +59,13 @@ public class UpgradeListTypeTypeTest {
 			FinderCacheUtil.clearCache();
 
 			for (String listTypeName : _listTypeNames) {
-				ListType oldListType = _listTypeLocalService.getListType(
+				ListType oldListType = _listTypeLocalService.fetchListType(
 					CompanyThreadLocal.getCompanyId(), listTypeName,
 					_OLD_LIST_TYPE_TYPE);
 
 				Assert.assertNull(oldListType);
 
-				ListType newListType = _listTypeLocalService.getListType(
+				ListType newListType = _listTypeLocalService.fetchListType(
 					CompanyThreadLocal.getCompanyId(), listTypeName,
 					_NEW_LIST_TYPE_TYPE);
 
@@ -82,7 +82,7 @@ public class UpgradeListTypeTypeTest {
 	}
 
 	private ListType _deleteListType(String listTypeName, String listTypeType) {
-		ListType listType = _listTypeLocalService.getListType(
+		ListType listType = _listTypeLocalService.fetchListType(
 			CompanyThreadLocal.getCompanyId(), listTypeName, listTypeType);
 
 		if (listType != null) {

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/provider/BaseSegmentsEntryProvider.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/provider/BaseSegmentsEntryProvider.java
@@ -424,7 +424,7 @@ public abstract class BaseSegmentsEntryProvider
 				expandoColumnLocalService.getColumns(expandoTable.getTableId());
 
 			for (ExpandoColumn expandoColumn : expandoColumns) {
-				ExpandoValue expandoValue = expandoValueLocalService.getValue(
+				ExpandoValue expandoValue = expandoValueLocalService.fetchValue(
 					expandoTable.getTableId(), expandoColumn.getColumnId(),
 					user.getUserId());
 

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/anonymizer/UADAnonymousUserProviderImpl.java
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/anonymizer/UADAnonymousUserProviderImpl.java
@@ -80,7 +80,7 @@ public class UADAnonymousUserProviderImpl implements UADAnonymousUserProvider {
 			_counterLocalService.increment());
 
 		PasswordPolicy passwordPolicy =
-			_passwordPolicyLocalService.getDefaultPasswordPolicy(companyId);
+			_passwordPolicyLocalService.fetchDefaultPasswordPolicy(companyId);
 
 		String randomString = PwdToolkitUtil.generate(passwordPolicy);
 

--- a/modules/apps/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/exportimport/data/handler/ListTypeStagedModelDataHandler.java
+++ b/modules/apps/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/exportimport/data/handler/ListTypeStagedModelDataHandler.java
@@ -84,7 +84,7 @@ public class ListTypeStagedModelDataHandler
 			PortletDataContext portletDataContext, ListType listType)
 		throws Exception {
 
-		ListType existingListType = _listTypeLocalService.getListType(
+		ListType existingListType = _listTypeLocalService.fetchListType(
 			portletDataContext.getCompanyId(), listType.getName(),
 			listType.getType());
 

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/field/expression/handler/ExpandoUserFieldExpressionHandler.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/field/expression/handler/ExpandoUserFieldExpressionHandler.java
@@ -284,7 +284,7 @@ public class ExpandoUserFieldExpressionHandler
 		ExpandoValue expandoValue = null;
 
 		if (!user.isNew()) {
-			expandoValue = _expandoValueLocalService.getValue(
+			expandoValue = _expandoValueLocalService.fetchValue(
 				user.getCompanyId(), User.class.getName(),
 				ExpandoTableConstants.DEFAULT_TABLE_NAME,
 				validUserFieldExpression, user.getUserId());

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/field/expression/handler/MembershipsUserFieldExpressionHandler.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/field/expression/handler/MembershipsUserFieldExpressionHandler.java
@@ -192,9 +192,10 @@ public class MembershipsUserFieldExpressionHandler
 					continue;
 				}
 
-				ExpandoValue expandoValue = _expandoValueLocalService.getValue(
-					expandoColumn.getTableId(), expandoColumn.getColumnId(),
-					userGroup.getUserGroupId());
+				ExpandoValue expandoValue =
+					_expandoValueLocalService.fetchValue(
+						expandoColumn.getTableId(), expandoColumn.getColumnId(),
+						userGroup.getUserGroupId());
 
 				if ((expandoValue != null) &&
 					samlIdpEntityId.equals(expandoValue.getString())) {

--- a/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/manager/UserManagerImpl.java
+++ b/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/manager/UserManagerImpl.java
@@ -1097,7 +1097,7 @@ public class UserManagerImpl implements UserManager {
 			return StringPool.BLANK;
 		}
 
-		ExpandoValue expandoValue = _expandoValueLocalService.getValue(
+		ExpandoValue expandoValue = _expandoValueLocalService.fetchValue(
 			expandoTable.getTableId(), expandoColumn.getColumnId(), classPK);
 
 		if (expandoValue == null) {

--- a/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/util/ScimUtil.java
+++ b/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/util/ScimUtil.java
@@ -801,7 +801,7 @@ public class ScimUtil {
 	private static long _getListTypeId(
 		long companyId, String name, String type) {
 
-		ListType listType = ListTypeLocalServiceUtil.getListType(
+		ListType listType = ListTypeLocalServiceUtil.fetchListType(
 			companyId, StringUtil.toLowerCase(name), type);
 
 		if (listType == null) {

--- a/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/util/ScimUtil.java
+++ b/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/util/ScimUtil.java
@@ -767,7 +767,7 @@ public class ScimUtil {
 			return null;
 		}
 
-		ExpandoValue expandoValue = ExpandoValueLocalServiceUtil.getValue(
+		ExpandoValue expandoValue = ExpandoValueLocalServiceUtil.fetchValue(
 			expandoTableId, expandoColumn.getColumnId(),
 			GetterUtil.getLong(userIdString));
 

--- a/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/util/ScimUtil.java
+++ b/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/util/ScimUtil.java
@@ -812,7 +812,7 @@ public class ScimUtil {
 	}
 
 	private static String _getProfileURL(Contact contact) {
-		long listTypeId = ListTypeLocalServiceUtil.getListTypeId(
+		long listTypeId = _getListTypeId(
 			contact.getCompanyId(), "personal",
 			Contact.class.getName() + ".website");
 

--- a/portal-impl/src/com/liferay/portal/model/impl/UserImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/UserImpl.java
@@ -606,7 +606,7 @@ public class UserImpl extends UserBaseImpl {
 	public PasswordPolicy getPasswordPolicy() throws PortalException {
 		if (_passwordPolicy == null) {
 			_passwordPolicy =
-				PasswordPolicyLocalServiceUtil.getPasswordPolicyByUser(this);
+				PasswordPolicyLocalServiceUtil.fetchPasswordPolicyByUser(this);
 		}
 
 		return _passwordPolicy;

--- a/portal-impl/src/com/liferay/portal/service/http/ListTypeServiceHttp.java
+++ b/portal-impl/src/com/liferay/portal/service/http/ListTypeServiceHttp.java
@@ -41,6 +41,38 @@ import com.liferay.portal.kernel.util.MethodKey;
  */
 public class ListTypeServiceHttp {
 
+	public static com.liferay.portal.kernel.model.ListType fetchListType(
+		HttpPrincipal httpPrincipal, long companyId, String name, String type) {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				ListTypeServiceUtil.class, "fetchListType",
+				_fetchListTypeParameterTypes0);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, companyId, name, type);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.portal.kernel.model.ListType)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
 	public static com.liferay.portal.kernel.model.ListType getListType(
 			HttpPrincipal httpPrincipal, long listTypeId)
 		throws com.liferay.portal.kernel.exception.PortalException {
@@ -48,7 +80,7 @@ public class ListTypeServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ListTypeServiceUtil.class, "getListType",
-				_getListTypeParameterTypes0);
+				_getListTypeParameterTypes1);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, listTypeId);
@@ -66,38 +98,6 @@ public class ListTypeServiceHttp {
 						exception;
 				}
 
-				throw new com.liferay.portal.kernel.exception.SystemException(
-					exception);
-			}
-
-			return (com.liferay.portal.kernel.model.ListType)returnObj;
-		}
-		catch (com.liferay.portal.kernel.exception.SystemException
-					systemException) {
-
-			_log.error(systemException, systemException);
-
-			throw systemException;
-		}
-	}
-
-	public static com.liferay.portal.kernel.model.ListType fetchListType(
-		HttpPrincipal httpPrincipal, long companyId, String name, String type) {
-
-		try {
-			MethodKey methodKey = new MethodKey(
-				ListTypeServiceUtil.class, "fetchListType",
-				_fetchListTypeParameterTypes1);
-
-			MethodHandler methodHandler = new MethodHandler(
-				methodKey, companyId, name, type);
-
-			Object returnObj = null;
-
-			try {
-				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
-			}
-			catch (Exception exception) {
 				throw new com.liferay.portal.kernel.exception.SystemException(
 					exception);
 			}
@@ -294,11 +294,11 @@ public class ListTypeServiceHttp {
 
 	private static Log _log = LogFactoryUtil.getLog(ListTypeServiceHttp.class);
 
-	private static final Class<?>[] _getListTypeParameterTypes0 = new Class[] {
+	private static final Class<?>[] _fetchListTypeParameterTypes0 =
+		new Class[] {long.class, String.class, String.class};
+	private static final Class<?>[] _getListTypeParameterTypes1 = new Class[] {
 		long.class
 	};
-	private static final Class<?>[] _fetchListTypeParameterTypes1 =
-		new Class[] {long.class, String.class, String.class};
 	private static final Class<?>[] _getListTypeParameterTypes2 = new Class[] {
 		long.class, String.class, String.class
 	};
@@ -315,4 +315,4 @@ public class ListTypeServiceHttp {
 	};
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:614428720
+// LIFERAY-SERVICE-BUILDER-HASH:1960186770

--- a/portal-impl/src/com/liferay/portal/service/http/ListTypeServiceHttp.java
+++ b/portal-impl/src/com/liferay/portal/service/http/ListTypeServiceHttp.java
@@ -155,7 +155,9 @@ public class ListTypeServiceHttp {
 	}
 
 	public static long getListTypeId(
-		HttpPrincipal httpPrincipal, long companyId, String name, String type) {
+			HttpPrincipal httpPrincipal, long companyId, String name,
+			String type)
+		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
 			MethodKey methodKey = new MethodKey(
@@ -171,6 +173,13 @@ public class ListTypeServiceHttp {
 				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
 			}
 			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
 				throw new com.liferay.portal.kernel.exception.SystemException(
 					exception);
 			}
@@ -315,4 +324,4 @@ public class ListTypeServiceHttp {
 	};
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1960186770
+// LIFERAY-SERVICE-BUILDER-HASH:901028312

--- a/portal-impl/src/com/liferay/portal/service/http/ListTypeServiceHttp.java
+++ b/portal-impl/src/com/liferay/portal/service/http/ListTypeServiceHttp.java
@@ -81,13 +81,13 @@ public class ListTypeServiceHttp {
 		}
 	}
 
-	public static com.liferay.portal.kernel.model.ListType getListType(
+	public static com.liferay.portal.kernel.model.ListType fetchListType(
 		HttpPrincipal httpPrincipal, long companyId, String name, String type) {
 
 		try {
 			MethodKey methodKey = new MethodKey(
-				ListTypeServiceUtil.class, "getListType",
-				_getListTypeParameterTypes1);
+				ListTypeServiceUtil.class, "fetchListType",
+				_fetchListTypeParameterTypes1);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, name, type);
@@ -113,13 +113,54 @@ public class ListTypeServiceHttp {
 		}
 	}
 
+	public static com.liferay.portal.kernel.model.ListType getListType(
+			HttpPrincipal httpPrincipal, long companyId, String name,
+			String type)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				ListTypeServiceUtil.class, "getListType",
+				_getListTypeParameterTypes2);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, companyId, name, type);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.portal.kernel.model.ListType)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
 	public static long getListTypeId(
 		HttpPrincipal httpPrincipal, long companyId, String name, String type) {
 
 		try {
 			MethodKey methodKey = new MethodKey(
 				ListTypeServiceUtil.class, "getListTypeId",
-				_getListTypeIdParameterTypes2);
+				_getListTypeIdParameterTypes3);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, name, type);
@@ -151,7 +192,7 @@ public class ListTypeServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ListTypeServiceUtil.class, "getListTypes",
-				_getListTypesParameterTypes3);
+				_getListTypesParameterTypes4);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, type);
@@ -186,7 +227,7 @@ public class ListTypeServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ListTypeServiceUtil.class, "validate",
-				_validateParameterTypes4);
+				_validateParameterTypes5);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, listTypeId, classNameId, type);
@@ -222,7 +263,7 @@ public class ListTypeServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ListTypeServiceUtil.class, "validate",
-				_validateParameterTypes5);
+				_validateParameterTypes6);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, listTypeId, type);
@@ -256,20 +297,22 @@ public class ListTypeServiceHttp {
 	private static final Class<?>[] _getListTypeParameterTypes0 = new Class[] {
 		long.class
 	};
-	private static final Class<?>[] _getListTypeParameterTypes1 = new Class[] {
+	private static final Class<?>[] _fetchListTypeParameterTypes1 =
+		new Class[] {long.class, String.class, String.class};
+	private static final Class<?>[] _getListTypeParameterTypes2 = new Class[] {
 		long.class, String.class, String.class
 	};
-	private static final Class<?>[] _getListTypeIdParameterTypes2 =
+	private static final Class<?>[] _getListTypeIdParameterTypes3 =
 		new Class[] {long.class, String.class, String.class};
-	private static final Class<?>[] _getListTypesParameterTypes3 = new Class[] {
+	private static final Class<?>[] _getListTypesParameterTypes4 = new Class[] {
 		long.class, String.class
 	};
-	private static final Class<?>[] _validateParameterTypes4 = new Class[] {
+	private static final Class<?>[] _validateParameterTypes5 = new Class[] {
 		long.class, long.class, String.class
 	};
-	private static final Class<?>[] _validateParameterTypes5 = new Class[] {
+	private static final Class<?>[] _validateParameterTypes6 = new Class[] {
 		long.class, String.class
 	};
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:859136583
+// LIFERAY-SERVICE-BUILDER-HASH:614428720

--- a/portal-impl/src/com/liferay/portal/service/impl/ImageLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ImageLocalServiceImpl.java
@@ -8,7 +8,6 @@ package com.liferay.portal.service.impl;
 import com.liferay.document.library.kernel.store.Store;
 import com.liferay.document.library.kernel.util.DLValidatorUtil;
 import com.liferay.petra.io.unsync.UnsyncByteArrayInputStream;
-import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.image.ImageToolUtil;
 import com.liferay.portal.kernel.exception.ImageTypeException;
@@ -44,7 +43,7 @@ public class ImageLocalServiceImpl extends ImageLocalServiceBaseImpl {
 			return null;
 		}
 
-		Image image = getImage(imageId);
+		Image image = fetchImage(imageId);
 
 		if (image == null) {
 			return null;
@@ -64,34 +63,13 @@ public class ImageLocalServiceImpl extends ImageLocalServiceBaseImpl {
 
 	@Override
 	public Image getCompanyLogo(long imageId) {
-		Image image = getImage(imageId);
+		Image image = fetchImage(imageId);
 
 		if (image != null) {
 			return image;
 		}
 
 		return ImageToolUtil.getDefaultCompanyLogo();
-	}
-
-	@Override
-	public Image getImage(long imageId) {
-		try {
-			if (imageId <= 0) {
-				return null;
-			}
-
-			return imagePersistence.fetchByPrimaryKey(imageId);
-		}
-		catch (Exception exception) {
-			if (_log.isWarnEnabled()) {
-				_log.warn(
-					StringBundler.concat(
-						"Unable to get image ", imageId, ": ",
-						exception.getMessage()));
-			}
-
-			return null;
-		}
 	}
 
 	@Override
@@ -120,7 +98,7 @@ public class ImageLocalServiceImpl extends ImageLocalServiceBaseImpl {
 
 	@Override
 	public Image getImageOrDefault(long imageId) {
-		Image image = getImage(imageId);
+		Image image = fetchImage(imageId);
 
 		if (image != null) {
 			return image;
@@ -298,7 +276,7 @@ public class ImageLocalServiceImpl extends ImageLocalServiceBaseImpl {
 	}
 
 	private long _getImageCompanyId(long imageId) {
-		Image image = getImage(imageId);
+		Image image = fetchImage(imageId);
 
 		if (image == null) {
 			if (_log.isWarnEnabled()) {

--- a/portal-impl/src/com/liferay/portal/service/impl/ListTypeLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ListTypeLocalServiceImpl.java
@@ -54,13 +54,20 @@ public class ListTypeLocalServiceImpl extends ListTypeLocalServiceBaseImpl {
 	}
 
 	@Override
-	public ListType getListType(long companyId, String name, String type) {
+	public ListType fetchListType(long companyId, String name, String type) {
 		return listTypePersistence.fetchByC_N_T(companyId, name, type);
 	}
 
 	@Override
+	public ListType getListType(long companyId, String name, String type)
+		throws PortalException {
+
+		return listTypePersistence.findByC_N_T(companyId, name, type);
+	}
+
+	@Override
 	public long getListTypeId(long companyId, String name, String type) {
-		ListType listType = getListType(companyId, name, type);
+		ListType listType = fetchListType(companyId, name, type);
 
 		return listType.getListTypeId();
 	}

--- a/portal-impl/src/com/liferay/portal/service/impl/ListTypeLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ListTypeLocalServiceImpl.java
@@ -66,8 +66,10 @@ public class ListTypeLocalServiceImpl extends ListTypeLocalServiceBaseImpl {
 	}
 
 	@Override
-	public long getListTypeId(long companyId, String name, String type) {
-		ListType listType = fetchListType(companyId, name, type);
+	public long getListTypeId(long companyId, String name, String type)
+		throws PortalException {
+
+		ListType listType = getListType(companyId, name, type);
 
 		return listType.getListTypeId();
 	}

--- a/portal-impl/src/com/liferay/portal/service/impl/ListTypeServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ListTypeServiceImpl.java
@@ -17,13 +17,20 @@ import java.util.List;
 public class ListTypeServiceImpl extends ListTypeServiceBaseImpl {
 
 	@Override
+	public ListType fetchListType(long companyId, String name, String type) {
+		return listTypePersistence.fetchByC_N_T(companyId, name, type);
+	}
+
+	@Override
 	public ListType getListType(long listTypeId) throws PortalException {
 		return listTypePersistence.findByPrimaryKey(listTypeId);
 	}
 
 	@Override
-	public ListType getListType(long companyId, String name, String type) {
-		return listTypePersistence.fetchByC_N_T(companyId, name, type);
+	public ListType getListType(long companyId, String name, String type)
+		throws PortalException {
+
+		return listTypePersistence.findByC_N_T(companyId, name, type);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/service/impl/ListTypeServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ListTypeServiceImpl.java
@@ -34,7 +34,9 @@ public class ListTypeServiceImpl extends ListTypeServiceBaseImpl {
 	}
 
 	@Override
-	public long getListTypeId(long companyId, String name, String type) {
+	public long getListTypeId(long companyId, String name, String type)
+		throws PortalException {
+
 		return listTypeLocalService.getListTypeId(companyId, name, type);
 	}
 

--- a/portal-impl/src/com/liferay/portal/service/impl/PasswordPolicyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PasswordPolicyLocalServiceImpl.java
@@ -216,6 +216,12 @@ public class PasswordPolicyLocalServiceImpl
 	}
 
 	@Override
+	public PasswordPolicy fetchDefaultPasswordPolicy(long companyId) {
+		return passwordPolicyPersistence.fetchByC_N(
+			companyId, PropsValues.PASSWORDS_DEFAULT_POLICY_NAME);
+	}
+
+	@Override
 	public PasswordPolicy fetchPasswordPolicy(long companyId, String name) {
 		return passwordPolicyPersistence.fetchByC_N(companyId, name);
 	}
@@ -224,7 +230,7 @@ public class PasswordPolicyLocalServiceImpl
 	public PasswordPolicy getDefaultPasswordPolicy(long companyId)
 		throws PortalException {
 
-		return passwordPolicyPersistence.fetchByC_N(
+		return passwordPolicyPersistence.findByC_N(
 			companyId, PropsValues.PASSWORDS_DEFAULT_POLICY_NAME);
 	}
 

--- a/portal-impl/src/com/liferay/portal/service/impl/PasswordPolicyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PasswordPolicyLocalServiceImpl.java
@@ -9,6 +9,7 @@ import com.liferay.petra.string.CharPool;
 import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.cache.thread.local.ThreadLocalCachable;
 import com.liferay.portal.kernel.exception.DuplicatePasswordPolicyException;
+import com.liferay.portal.kernel.exception.NoSuchPasswordPolicyException;
 import com.liferay.portal.kernel.exception.PasswordPolicyNameException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.RequiredPasswordPolicyException;
@@ -227,6 +228,58 @@ public class PasswordPolicyLocalServiceImpl
 	}
 
 	@Override
+	public PasswordPolicy fetchPasswordPolicyByUser(User user)
+		throws PortalException {
+
+		if (LDAPSettingsUtil.isPasswordPolicyEnabled(
+				user.getLdapServerId(), user.getCompanyId())) {
+
+			return null;
+		}
+
+		long count = passwordPolicyPersistence.countByCompanyId(
+			user.getCompanyId());
+
+		if (count == 1) {
+			return passwordPolicyPersistence.fetchByC_N(
+				user.getCompanyId(), PropsValues.PASSWORDS_DEFAULT_POLICY_NAME);
+		}
+
+		PasswordPolicyRel passwordPolicyRel =
+			_passwordPolicyRelPersistence.fetchByC_C(
+				_classNameLocalService.getClassNameId(User.class.getName()),
+				user.getUserId());
+
+		if (passwordPolicyRel != null) {
+			return getPasswordPolicy(passwordPolicyRel.getPasswordPolicyId());
+		}
+
+		long[] organizationIds = _userPersistence.getOrganizationPrimaryKeys(
+			user.getUserId());
+
+		if (organizationIds.length == 0) {
+			return passwordPolicyPersistence.fetchByC_N(
+				user.getCompanyId(), PropsValues.PASSWORDS_DEFAULT_POLICY_NAME);
+		}
+
+		return getPasswordPolicy(user.getCompanyId(), organizationIds);
+	}
+
+	@Override
+	@ThreadLocalCachable
+	public PasswordPolicy fetchPasswordPolicyByUserId(long userId)
+		throws PortalException {
+
+		User user = _userPersistence.fetchByPrimaryKey(userId);
+
+		if (user == null) {
+			return null;
+		}
+
+		return fetchPasswordPolicyByUser(user);
+	}
+
+	@Override
 	public PasswordPolicy getDefaultPasswordPolicy(long companyId)
 		throws PortalException {
 
@@ -265,38 +318,14 @@ public class PasswordPolicyLocalServiceImpl
 	public PasswordPolicy getPasswordPolicyByUser(User user)
 		throws PortalException {
 
-		if (LDAPSettingsUtil.isPasswordPolicyEnabled(
-				user.getLdapServerId(), user.getCompanyId())) {
+		PasswordPolicy passwordPolicy = fetchPasswordPolicyByUser(user);
 
-			return null;
+		if (passwordPolicy == null) {
+			throw new NoSuchPasswordPolicyException(
+				"No password policy exists for user " + user.getUserId());
 		}
 
-		long count = passwordPolicyPersistence.countByCompanyId(
-			user.getCompanyId());
-
-		if (count == 1) {
-			return passwordPolicyPersistence.fetchByC_N(
-				user.getCompanyId(), PropsValues.PASSWORDS_DEFAULT_POLICY_NAME);
-		}
-
-		PasswordPolicyRel passwordPolicyRel =
-			_passwordPolicyRelPersistence.fetchByC_C(
-				_classNameLocalService.getClassNameId(User.class.getName()),
-				user.getUserId());
-
-		if (passwordPolicyRel != null) {
-			return getPasswordPolicy(passwordPolicyRel.getPasswordPolicyId());
-		}
-
-		long[] organizationIds = _userPersistence.getOrganizationPrimaryKeys(
-			user.getUserId());
-
-		if (organizationIds.length == 0) {
-			return passwordPolicyPersistence.fetchByC_N(
-				user.getCompanyId(), PropsValues.PASSWORDS_DEFAULT_POLICY_NAME);
-		}
-
-		return getPasswordPolicy(user.getCompanyId(), organizationIds);
+		return passwordPolicy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/service/impl/PasswordTrackerLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PasswordTrackerLocalServiceImpl.java
@@ -53,7 +53,7 @@ public class PasswordTrackerLocalServiceImpl
 		throws PortalException {
 
 		PasswordPolicy passwordPolicy =
-			_passwordPolicyLocalService.getPasswordPolicyByUserId(userId);
+			_passwordPolicyLocalService.fetchPasswordPolicyByUserId(userId);
 
 		if ((passwordPolicy == null) || !passwordPolicy.isHistory()) {
 			return true;
@@ -91,7 +91,7 @@ public class PasswordTrackerLocalServiceImpl
 		throws PortalException {
 
 		PasswordPolicy passwordPolicy =
-			_passwordPolicyLocalService.getPasswordPolicyByUserId(userId);
+			_passwordPolicyLocalService.fetchPasswordPolicyByUserId(userId);
 
 		if ((passwordPolicy != null) && passwordPolicy.isHistory()) {
 			long passwordTrackerId = counterLocalService.increment();

--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -7219,7 +7219,7 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		}
 
 		PasswordPolicy passwordPolicy =
-			_passwordPolicyLocalService.getPasswordPolicyByUserId(userId);
+			_passwordPolicyLocalService.fetchPasswordPolicyByUserId(userId);
 
 		PwdToolkitUtil.validate(userId, password1, password2, passwordPolicy);
 	}

--- a/portal-impl/src/com/liferay/portal/setup/SetupWizardUtil.java
+++ b/portal-impl/src/com/liferay/portal/setup/SetupWizardUtil.java
@@ -341,21 +341,14 @@ public class SetupWizardUtil {
 
 		boolean passwordReset = false;
 
-		try {
-			PasswordPolicy passwordPolicy =
-				PasswordPolicyLocalServiceUtil.getDefaultPasswordPolicy(
-					company.getCompanyId());
+		PasswordPolicy passwordPolicy =
+			PasswordPolicyLocalServiceUtil.fetchDefaultPasswordPolicy(
+				company.getCompanyId());
 
-			if ((passwordPolicy != null) && passwordPolicy.isChangeable() &&
-				passwordPolicy.isChangeRequired()) {
+		if ((passwordPolicy != null) && passwordPolicy.isChangeable() &&
+			passwordPolicy.isChangeRequired()) {
 
-				passwordReset = true;
-			}
-		}
-		catch (PortalException portalException) {
-			if (_log.isWarnEnabled()) {
-				_log.warn(portalException);
-			}
+			passwordReset = true;
 		}
 
 		User user = SetupWizardSampleDataUtil.updateAdminUser(

--- a/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
+++ b/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
@@ -71,7 +71,6 @@ import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermi
 import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.ImageLocalServiceUtil;
-import com.liferay.portal.kernel.service.ImageServiceUtil;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.service.LayoutSetLocalServiceUtil;
 import com.liferay.portal.kernel.service.OrganizationLocalServiceUtil;
@@ -514,7 +513,7 @@ public class WebServerServlet extends HttpServlet {
 		long imageId = getImageId(httpServletRequest);
 
 		if (imageId > 0) {
-			image = ImageServiceUtil.getImage(imageId);
+			image = ImageLocalServiceUtil.fetchImage(imageId);
 
 			String path = GetterUtil.getString(
 				httpServletRequest.getPathInfo());
@@ -818,7 +817,7 @@ public class WebServerServlet extends HttpServlet {
 			UserLocalServiceUtil.updatePortrait(
 				user.getUserId(), image.getTextObj());
 
-			return ImageLocalServiceUtil.getImage(imageId);
+			return ImageLocalServiceUtil.fetchImage(imageId);
 		}
 
 		return image;

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileVersionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileVersionLocalServiceImpl.java
@@ -93,9 +93,10 @@ public class DLFileVersionLocalServiceImpl
 
 	@Override
 	public DLFileVersion getFileVersionByUuidAndGroupId(
-		String uuid, long groupId) {
+			String uuid, long groupId)
+		throws PortalException {
 
-		return dlFileVersionPersistence.fetchByUUID_G(uuid, groupId);
+		return dlFileVersionPersistence.findByUUID_G(uuid, groupId);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/expando/service/impl/ExpandoRowLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/expando/service/impl/ExpandoRowLocalServiceImpl.java
@@ -166,21 +166,19 @@ public class ExpandoRowLocalServiceImpl extends ExpandoRowLocalServiceBaseImpl {
 
 	@Override
 	public ExpandoRow getRow(
-		long companyId, long classNameId, String tableName, long classPK) {
+			long companyId, long classNameId, String tableName, long classPK)
+		throws PortalException {
 
-		ExpandoTable table = _expandoTablePersistence.fetchByC_C_N(
+		ExpandoTable table = _expandoTablePersistence.findByC_C_N(
 			companyId, classNameId, tableName);
 
-		if (table == null) {
-			return null;
-		}
-
-		return expandoRowPersistence.fetchByT_C(table.getTableId(), classPK);
+		return expandoRowPersistence.findByT_C(table.getTableId(), classPK);
 	}
 
 	@Override
 	public ExpandoRow getRow(
-		long companyId, String className, String tableName, long classPK) {
+			long companyId, String className, String tableName, long classPK)
+		throws PortalException {
 
 		return expandoRowLocalService.getRow(
 			companyId, _classNameLocalService.getClassNameId(className),

--- a/portal-impl/src/com/liferay/portlet/expando/service/impl/ExpandoValueLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/expando/service/impl/ExpandoValueLocalServiceImpl.java
@@ -1240,7 +1240,7 @@ public class ExpandoValueLocalServiceImpl
 			String columnName, long classPK, boolean defaultData)
 		throws PortalException {
 
-		ExpandoValue value = expandoValueLocalService.getValue(
+		ExpandoValue value = expandoValueLocalService.fetchValue(
 			companyId, className, tableName, columnName, classPK);
 
 		if (value == null) {
@@ -1256,7 +1256,7 @@ public class ExpandoValueLocalServiceImpl
 			String columnName, long classPK, boolean[] defaultData)
 		throws PortalException {
 
-		ExpandoValue value = expandoValueLocalService.getValue(
+		ExpandoValue value = expandoValueLocalService.fetchValue(
 			companyId, className, tableName, columnName, classPK);
 
 		if (value == null) {
@@ -1272,7 +1272,7 @@ public class ExpandoValueLocalServiceImpl
 			String columnName, long classPK, Date defaultData)
 		throws PortalException {
 
-		ExpandoValue value = expandoValueLocalService.getValue(
+		ExpandoValue value = expandoValueLocalService.fetchValue(
 			companyId, className, tableName, columnName, classPK);
 
 		if (value == null) {
@@ -1288,7 +1288,7 @@ public class ExpandoValueLocalServiceImpl
 			String columnName, long classPK, Date[] defaultData)
 		throws PortalException {
 
-		ExpandoValue value = expandoValueLocalService.getValue(
+		ExpandoValue value = expandoValueLocalService.fetchValue(
 			companyId, className, tableName, columnName, classPK);
 
 		if (value == null) {
@@ -1304,7 +1304,7 @@ public class ExpandoValueLocalServiceImpl
 			String columnName, long classPK, double defaultData)
 		throws PortalException {
 
-		ExpandoValue value = expandoValueLocalService.getValue(
+		ExpandoValue value = expandoValueLocalService.fetchValue(
 			companyId, className, tableName, columnName, classPK);
 
 		if (value == null) {
@@ -1320,7 +1320,7 @@ public class ExpandoValueLocalServiceImpl
 			String columnName, long classPK, double[] defaultData)
 		throws PortalException {
 
-		ExpandoValue value = expandoValueLocalService.getValue(
+		ExpandoValue value = expandoValueLocalService.fetchValue(
 			companyId, className, tableName, columnName, classPK);
 
 		if (value == null) {
@@ -1336,7 +1336,7 @@ public class ExpandoValueLocalServiceImpl
 			String columnName, long classPK, float defaultData)
 		throws PortalException {
 
-		ExpandoValue value = expandoValueLocalService.getValue(
+		ExpandoValue value = expandoValueLocalService.fetchValue(
 			companyId, className, tableName, columnName, classPK);
 
 		if (value == null) {
@@ -1352,7 +1352,7 @@ public class ExpandoValueLocalServiceImpl
 			String columnName, long classPK, float[] defaultData)
 		throws PortalException {
 
-		ExpandoValue value = expandoValueLocalService.getValue(
+		ExpandoValue value = expandoValueLocalService.fetchValue(
 			companyId, className, tableName, columnName, classPK);
 
 		if (value == null) {
@@ -1368,7 +1368,7 @@ public class ExpandoValueLocalServiceImpl
 			String columnName, long classPK, int defaultData)
 		throws PortalException {
 
-		ExpandoValue value = expandoValueLocalService.getValue(
+		ExpandoValue value = expandoValueLocalService.fetchValue(
 			companyId, className, tableName, columnName, classPK);
 
 		if (value == null) {
@@ -1384,7 +1384,7 @@ public class ExpandoValueLocalServiceImpl
 			String columnName, long classPK, int[] defaultData)
 		throws PortalException {
 
-		ExpandoValue value = expandoValueLocalService.getValue(
+		ExpandoValue value = expandoValueLocalService.fetchValue(
 			companyId, className, tableName, columnName, classPK);
 
 		if (value == null) {
@@ -1400,7 +1400,7 @@ public class ExpandoValueLocalServiceImpl
 			String columnName, long classPK, JSONObject defaultDataJSONObject)
 		throws PortalException {
 
-		ExpandoValue value = expandoValueLocalService.getValue(
+		ExpandoValue value = expandoValueLocalService.fetchValue(
 			companyId, className, tableName, columnName, classPK);
 
 		if (value == null) {
@@ -1416,7 +1416,7 @@ public class ExpandoValueLocalServiceImpl
 			String columnName, long classPK, long defaultData)
 		throws PortalException {
 
-		ExpandoValue value = expandoValueLocalService.getValue(
+		ExpandoValue value = expandoValueLocalService.fetchValue(
 			companyId, className, tableName, columnName, classPK);
 
 		if (value == null) {
@@ -1432,7 +1432,7 @@ public class ExpandoValueLocalServiceImpl
 			String columnName, long classPK, long[] defaultData)
 		throws PortalException {
 
-		ExpandoValue value = expandoValueLocalService.getValue(
+		ExpandoValue value = expandoValueLocalService.fetchValue(
 			companyId, className, tableName, columnName, classPK);
 
 		if (value == null) {
@@ -1448,7 +1448,7 @@ public class ExpandoValueLocalServiceImpl
 			String columnName, long classPK, Map<?, ?> defaultData)
 		throws PortalException {
 
-		ExpandoValue value = expandoValueLocalService.getValue(
+		ExpandoValue value = expandoValueLocalService.fetchValue(
 			companyId, className, tableName, columnName, classPK);
 
 		if (value == null) {
@@ -1472,7 +1472,7 @@ public class ExpandoValueLocalServiceImpl
 			String columnName, long classPK, Number defaultData)
 		throws PortalException {
 
-		ExpandoValue value = expandoValueLocalService.getValue(
+		ExpandoValue value = expandoValueLocalService.fetchValue(
 			companyId, className, tableName, columnName, classPK);
 
 		if (value == null) {
@@ -1488,7 +1488,7 @@ public class ExpandoValueLocalServiceImpl
 			String columnName, long classPK, Number[] defaultData)
 		throws PortalException {
 
-		ExpandoValue value = expandoValueLocalService.getValue(
+		ExpandoValue value = expandoValueLocalService.fetchValue(
 			companyId, className, tableName, columnName, classPK);
 
 		if (value == null) {
@@ -1504,7 +1504,7 @@ public class ExpandoValueLocalServiceImpl
 			String columnName, long classPK, short defaultData)
 		throws PortalException {
 
-		ExpandoValue value = expandoValueLocalService.getValue(
+		ExpandoValue value = expandoValueLocalService.fetchValue(
 			companyId, className, tableName, columnName, classPK);
 
 		if (value == null) {
@@ -1520,7 +1520,7 @@ public class ExpandoValueLocalServiceImpl
 			String columnName, long classPK, short[] defaultData)
 		throws PortalException {
 
-		ExpandoValue value = expandoValueLocalService.getValue(
+		ExpandoValue value = expandoValueLocalService.fetchValue(
 			companyId, className, tableName, columnName, classPK);
 
 		if (value == null) {
@@ -1536,7 +1536,7 @@ public class ExpandoValueLocalServiceImpl
 			String columnName, long classPK, String defaultData)
 		throws PortalException {
 
-		ExpandoValue value = expandoValueLocalService.getValue(
+		ExpandoValue value = expandoValueLocalService.fetchValue(
 			companyId, className, tableName, columnName, classPK);
 
 		if (value == null) {
@@ -1552,7 +1552,7 @@ public class ExpandoValueLocalServiceImpl
 			String columnName, long classPK, String[] defaultData)
 		throws PortalException {
 
-		ExpandoValue value = expandoValueLocalService.getValue(
+		ExpandoValue value = expandoValueLocalService.fetchValue(
 			companyId, className, tableName, columnName, classPK);
 
 		if (value == null) {

--- a/portal-impl/src/com/liferay/portlet/expando/service/impl/ExpandoValueLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/expando/service/impl/ExpandoValueLocalServiceImpl.java
@@ -1006,6 +1006,44 @@ public class ExpandoValueLocalServiceImpl
 	}
 
 	@Override
+	public ExpandoValue fetchValue(long tableId, long columnId, long classPK) {
+		return expandoValuePersistence.fetchByT_C_C(tableId, columnId, classPK);
+	}
+
+	@Override
+	public ExpandoValue fetchValue(
+		long companyId, long classNameId, String tableName, String columnName,
+		long classPK) {
+
+		ExpandoTable table = _expandoTablePersistence.fetchByC_C_N(
+			companyId, classNameId, tableName);
+
+		if (table == null) {
+			return null;
+		}
+
+		ExpandoColumn column = _expandoColumnPersistence.fetchByT_N(
+			table.getTableId(), columnName);
+
+		if (column == null) {
+			return null;
+		}
+
+		return expandoValuePersistence.fetchByT_C_C(
+			table.getTableId(), column.getColumnId(), classPK);
+	}
+
+	@Override
+	public ExpandoValue fetchValue(
+		long companyId, String className, String tableName, String columnName,
+		long classPK) {
+
+		return expandoValueLocalService.fetchValue(
+			companyId, _classNameLocalService.getClassNameId(className),
+			tableName, columnName, classPK);
+	}
+
+	@Override
 	public List<ExpandoValue> getColumnValues(
 		long columnId, int start, int end) {
 
@@ -1640,37 +1678,33 @@ public class ExpandoValueLocalServiceImpl
 	}
 
 	@Override
-	public ExpandoValue getValue(long tableId, long columnId, long classPK) {
-		return expandoValuePersistence.fetchByT_C_C(tableId, columnId, classPK);
+	public ExpandoValue getValue(long tableId, long columnId, long classPK)
+		throws PortalException {
+
+		return expandoValuePersistence.findByT_C_C(tableId, columnId, classPK);
 	}
 
 	@Override
 	public ExpandoValue getValue(
-		long companyId, long classNameId, String tableName, String columnName,
-		long classPK) {
+			long companyId, long classNameId, String tableName,
+			String columnName, long classPK)
+		throws PortalException {
 
-		ExpandoTable table = _expandoTablePersistence.fetchByC_C_N(
+		ExpandoTable table = _expandoTablePersistence.findByC_C_N(
 			companyId, classNameId, tableName);
 
-		if (table == null) {
-			return null;
-		}
-
-		ExpandoColumn column = _expandoColumnPersistence.fetchByT_N(
+		ExpandoColumn column = _expandoColumnPersistence.findByT_N(
 			table.getTableId(), columnName);
 
-		if (column == null) {
-			return null;
-		}
-
-		return expandoValuePersistence.fetchByT_C_C(
+		return expandoValuePersistence.findByT_C_C(
 			table.getTableId(), column.getColumnId(), classPK);
 	}
 
 	@Override
 	public ExpandoValue getValue(
-		long companyId, String className, String tableName, String columnName,
-		long classPK) {
+			long companyId, String className, String tableName,
+			String columnName, long classPK)
+		throws PortalException {
 
 		return expandoValueLocalService.getValue(
 			companyId, _classNameLocalService.getClassNameId(className),

--- a/portal-impl/src/com/liferay/portlet/social/service/impl/SocialActivitySetLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/social/service/impl/SocialActivitySetLocalServiceImpl.java
@@ -96,18 +96,20 @@ public class SocialActivitySetLocalServiceImpl
 
 	@Override
 	public SocialActivitySet getClassActivitySet(
-		long classNameId, long classPK, int type) {
+			long classNameId, long classPK, int type)
+		throws PortalException {
 
-		return socialActivitySetPersistence.fetchByC_C_T_First(
+		return socialActivitySetPersistence.findByC_C_T_First(
 			classNameId, classPK, type,
 			SocialActivitySetModifiedDateComparator.getInstance(false));
 	}
 
 	@Override
 	public SocialActivitySet getClassActivitySet(
-		long userId, long classNameId, long classPK, int type) {
+			long userId, long classNameId, long classPK, int type)
+		throws PortalException {
 
-		return socialActivitySetPersistence.fetchByU_C_C_T_First(
+		return socialActivitySetPersistence.findByU_C_C_T_First(
 			userId, classNameId, classPK, type,
 			SocialActivitySetModifiedDateComparator.getInstance(false));
 	}
@@ -166,18 +168,20 @@ public class SocialActivitySetLocalServiceImpl
 
 	@Override
 	public SocialActivitySet getUserActivitySet(
-		long groupId, long userId, int type) {
+			long groupId, long userId, int type)
+		throws PortalException {
 
-		return socialActivitySetPersistence.fetchByG_U_T_First(
+		return socialActivitySetPersistence.findByG_U_T_First(
 			groupId, userId, type,
 			SocialActivitySetModifiedDateComparator.getInstance(false));
 	}
 
 	@Override
 	public SocialActivitySet getUserActivitySet(
-		long groupId, long userId, long classNameId, int type) {
+			long groupId, long userId, long classNameId, int type)
+		throws PortalException {
 
-		return socialActivitySetPersistence.fetchByG_U_C_T_First(
+		return socialActivitySetPersistence.findByG_U_C_T_First(
 			groupId, userId, classNameId, type,
 			SocialActivitySetModifiedDateComparator.getInstance(false));
 	}

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileVersionLocalService.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileVersionLocalService.java
@@ -313,7 +313,8 @@ public interface DLFileVersionLocalService
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public DLFileVersion getFileVersionByUuidAndGroupId(
-		String uuid, long groupId);
+			String uuid, long groupId)
+		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<DLFileVersion> getFileVersions(long fileEntryId, int status);
@@ -389,4 +390,4 @@ public interface DLFileVersionLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1922430040
+// LIFERAY-SERVICE-BUILDER-HASH:-1635321172

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileVersionLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileVersionLocalServiceUtil.java
@@ -340,7 +340,8 @@ public class DLFileVersionLocalServiceUtil {
 	}
 
 	public static DLFileVersion getFileVersionByUuidAndGroupId(
-		String uuid, long groupId) {
+			String uuid, long groupId)
+		throws PortalException {
 
 		return getService().getFileVersionByUuidAndGroupId(uuid, groupId);
 	}
@@ -442,4 +443,4 @@ public class DLFileVersionLocalServiceUtil {
 	private static volatile DLFileVersionLocalService _service;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1220833315
+// LIFERAY-SERVICE-BUILDER-HASH:1156495179

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileVersionLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileVersionLocalServiceWrapper.java
@@ -377,7 +377,8 @@ public class DLFileVersionLocalServiceWrapper
 
 	@Override
 	public DLFileVersion getFileVersionByUuidAndGroupId(
-		String uuid, long groupId) {
+			String uuid, long groupId)
+		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _dlFileVersionLocalService.getFileVersionByUuidAndGroupId(
 			uuid, groupId);
@@ -524,4 +525,4 @@ public class DLFileVersionLocalServiceWrapper
 	private DLFileVersionLocalService _dlFileVersionLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-336277103
+// LIFERAY-SERVICE-BUILDER-HASH:1398958783

--- a/portal-kernel/src/com/liferay/expando/kernel/service/ExpandoRowLocalService.java
+++ b/portal-kernel/src/com/liferay/expando/kernel/service/ExpandoRowLocalService.java
@@ -298,11 +298,13 @@ public interface ExpandoRowLocalService
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public ExpandoRow getRow(
-		long companyId, long classNameId, String tableName, long classPK);
+			long companyId, long classNameId, String tableName, long classPK)
+		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public ExpandoRow getRow(
-		long companyId, String className, String tableName, long classPK);
+			long companyId, String className, String tableName, long classPK)
+		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<ExpandoRow> getRows(long tableId, int start, int end);
@@ -353,4 +355,4 @@ public interface ExpandoRowLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1460711818
+// LIFERAY-SERVICE-BUILDER-HASH:1790962166

--- a/portal-kernel/src/com/liferay/expando/kernel/service/ExpandoRowLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/expando/kernel/service/ExpandoRowLocalServiceUtil.java
@@ -351,13 +351,15 @@ public class ExpandoRowLocalServiceUtil {
 	}
 
 	public static ExpandoRow getRow(
-		long companyId, long classNameId, String tableName, long classPK) {
+			long companyId, long classNameId, String tableName, long classPK)
+		throws PortalException {
 
 		return getService().getRow(companyId, classNameId, tableName, classPK);
 	}
 
 	public static ExpandoRow getRow(
-		long companyId, String className, String tableName, long classPK) {
+			long companyId, String className, String tableName, long classPK)
+		throws PortalException {
 
 		return getService().getRow(companyId, className, tableName, classPK);
 	}
@@ -423,4 +425,4 @@ public class ExpandoRowLocalServiceUtil {
 	private static volatile ExpandoRowLocalService _service;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-440061931
+// LIFERAY-SERVICE-BUILDER-HASH:-156443079

--- a/portal-kernel/src/com/liferay/expando/kernel/service/ExpandoRowLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/expando/kernel/service/ExpandoRowLocalServiceWrapper.java
@@ -397,7 +397,8 @@ public class ExpandoRowLocalServiceWrapper
 
 	@Override
 	public ExpandoRow getRow(
-		long companyId, long classNameId, String tableName, long classPK) {
+			long companyId, long classNameId, String tableName, long classPK)
+		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _expandoRowLocalService.getRow(
 			companyId, classNameId, tableName, classPK);
@@ -405,7 +406,8 @@ public class ExpandoRowLocalServiceWrapper
 
 	@Override
 	public ExpandoRow getRow(
-		long companyId, String className, String tableName, long classPK) {
+			long companyId, String className, String tableName, long classPK)
+		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _expandoRowLocalService.getRow(
 			companyId, className, tableName, classPK);
@@ -512,4 +514,4 @@ public class ExpandoRowLocalServiceWrapper
 	private ExpandoRowLocalService _expandoRowLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-246128185
+// LIFERAY-SERVICE-BUILDER-HASH:-1252422941

--- a/portal-kernel/src/com/liferay/expando/kernel/service/ExpandoValueLocalService.java
+++ b/portal-kernel/src/com/liferay/expando/kernel/service/ExpandoValueLocalService.java
@@ -361,6 +361,19 @@ public interface ExpandoValueLocalService
 	public ExpandoValue fetchExpandoValue(long valueId);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public ExpandoValue fetchValue(long tableId, long columnId, long classPK);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public ExpandoValue fetchValue(
+		long companyId, long classNameId, String tableName, String columnName,
+		long classPK);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public ExpandoValue fetchValue(
+		long companyId, String className, String tableName, String columnName,
+		long classPK);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public ActionableDynamicQuery getActionableDynamicQuery();
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
@@ -643,17 +656,20 @@ public interface ExpandoValueLocalService
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public ExpandoValue getValue(long tableId, long columnId, long classPK);
+	public ExpandoValue getValue(long tableId, long columnId, long classPK)
+		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public ExpandoValue getValue(
-		long companyId, long classNameId, String tableName, String columnName,
-		long classPK);
+			long companyId, long classNameId, String tableName,
+			String columnName, long classPK)
+		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public ExpandoValue getValue(
-		long companyId, String className, String tableName, String columnName,
-		long classPK);
+			long companyId, String className, String tableName,
+			String columnName, long classPK)
+		throws PortalException;
 
 	/**
 	 * Updates the expando value in the database or adds it if it does not yet exist. Also notifies the appropriate model listeners.
@@ -684,4 +700,4 @@ public interface ExpandoValueLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1802350331
+// LIFERAY-SERVICE-BUILDER-HASH:1195626595

--- a/portal-kernel/src/com/liferay/expando/kernel/service/ExpandoValueLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/expando/kernel/service/ExpandoValueLocalServiceUtil.java
@@ -482,6 +482,28 @@ public class ExpandoValueLocalServiceUtil {
 		return getService().fetchExpandoValue(valueId);
 	}
 
+	public static ExpandoValue fetchValue(
+		long tableId, long columnId, long classPK) {
+
+		return getService().fetchValue(tableId, columnId, classPK);
+	}
+
+	public static ExpandoValue fetchValue(
+		long companyId, long classNameId, String tableName, String columnName,
+		long classPK) {
+
+		return getService().fetchValue(
+			companyId, classNameId, tableName, columnName, classPK);
+	}
+
+	public static ExpandoValue fetchValue(
+		long companyId, String className, String tableName, String columnName,
+		long classPK) {
+
+		return getService().fetchValue(
+			companyId, className, tableName, columnName, classPK);
+	}
+
 	public static com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery
 		getActionableDynamicQuery() {
 
@@ -907,22 +929,25 @@ public class ExpandoValueLocalServiceUtil {
 	}
 
 	public static ExpandoValue getValue(
-		long tableId, long columnId, long classPK) {
+			long tableId, long columnId, long classPK)
+		throws PortalException {
 
 		return getService().getValue(tableId, columnId, classPK);
 	}
 
 	public static ExpandoValue getValue(
-		long companyId, long classNameId, String tableName, String columnName,
-		long classPK) {
+			long companyId, long classNameId, String tableName,
+			String columnName, long classPK)
+		throws PortalException {
 
 		return getService().getValue(
 			companyId, classNameId, tableName, columnName, classPK);
 	}
 
 	public static ExpandoValue getValue(
-		long companyId, String className, String tableName, String columnName,
-		long classPK) {
+			long companyId, String className, String tableName,
+			String columnName, long classPK)
+		throws PortalException {
 
 		return getService().getValue(
 			companyId, className, tableName, columnName, classPK);
@@ -953,4 +978,4 @@ public class ExpandoValueLocalServiceUtil {
 	private static volatile ExpandoValueLocalService _service;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:850244069
+// LIFERAY-SERVICE-BUILDER-HASH:-1643081554

--- a/portal-kernel/src/com/liferay/expando/kernel/service/ExpandoValueLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/expando/kernel/service/ExpandoValueLocalServiceWrapper.java
@@ -542,6 +542,29 @@ public class ExpandoValueLocalServiceWrapper
 	}
 
 	@Override
+	public ExpandoValue fetchValue(long tableId, long columnId, long classPK) {
+		return _expandoValueLocalService.fetchValue(tableId, columnId, classPK);
+	}
+
+	@Override
+	public ExpandoValue fetchValue(
+		long companyId, long classNameId, String tableName, String columnName,
+		long classPK) {
+
+		return _expandoValueLocalService.fetchValue(
+			companyId, classNameId, tableName, columnName, classPK);
+	}
+
+	@Override
+	public ExpandoValue fetchValue(
+		long companyId, String className, String tableName, String columnName,
+		long classPK) {
+
+		return _expandoValueLocalService.fetchValue(
+			companyId, className, tableName, columnName, classPK);
+	}
+
+	@Override
 	public com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery
 		getActionableDynamicQuery() {
 
@@ -1020,14 +1043,17 @@ public class ExpandoValueLocalServiceWrapper
 	}
 
 	@Override
-	public ExpandoValue getValue(long tableId, long columnId, long classPK) {
+	public ExpandoValue getValue(long tableId, long columnId, long classPK)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
 		return _expandoValueLocalService.getValue(tableId, columnId, classPK);
 	}
 
 	@Override
 	public ExpandoValue getValue(
-		long companyId, long classNameId, String tableName, String columnName,
-		long classPK) {
+			long companyId, long classNameId, String tableName,
+			String columnName, long classPK)
+		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _expandoValueLocalService.getValue(
 			companyId, classNameId, tableName, columnName, classPK);
@@ -1035,8 +1061,9 @@ public class ExpandoValueLocalServiceWrapper
 
 	@Override
 	public ExpandoValue getValue(
-		long companyId, String className, String tableName, String columnName,
-		long classPK) {
+			long companyId, String className, String tableName,
+			String columnName, long classPK)
+		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _expandoValueLocalService.getValue(
 			companyId, className, tableName, columnName, classPK);
@@ -1097,4 +1124,4 @@ public class ExpandoValueLocalServiceWrapper
 	private ExpandoValueLocalService _expandoValueLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1003331169
+// LIFERAY-SERVICE-BUILDER-HASH:-1705224228

--- a/portal-kernel/src/com/liferay/expando/kernel/service/packageinfo
+++ b/portal-kernel/src/com/liferay/expando/kernel/service/packageinfo
@@ -1,1 +1,1 @@
-version 1.14.1
+version 1.15.0

--- a/portal-kernel/src/com/liferay/portal/kernel/service/ListTypeLocalService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/ListTypeLocalService.java
@@ -250,7 +250,8 @@ public interface ListTypeLocalService
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public long getListTypeId(long companyId, String name, String type);
+	public long getListTypeId(long companyId, String name, String type)
+		throws PortalException;
 
 	/**
 	 * Returns a range of all the list types.
@@ -313,4 +314,4 @@ public interface ListTypeLocalService
 	public void validate(long listTypeId, String type) throws PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1510231488
+// LIFERAY-SERVICE-BUILDER-HASH:200992620

--- a/portal-kernel/src/com/liferay/portal/kernel/service/ListTypeLocalService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/ListTypeLocalService.java
@@ -199,6 +199,9 @@ public interface ListTypeLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public ListType fetchListType(long listTypeId);
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public ListType fetchListType(long companyId, String name, String type);
+
 	/**
 	 * Returns the list type with the matching UUID and company.
 	 *
@@ -231,7 +234,8 @@ public interface ListTypeLocalService
 	public ListType getListType(long listTypeId) throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public ListType getListType(long companyId, String name, String type);
+	public ListType getListType(long companyId, String name, String type)
+		throws PortalException;
 
 	/**
 	 * Returns the list type with the matching UUID and company.
@@ -309,4 +313,4 @@ public interface ListTypeLocalService
 	public void validate(long listTypeId, String type) throws PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1797287438
+// LIFERAY-SERVICE-BUILDER-HASH:-1510231488

--- a/portal-kernel/src/com/liferay/portal/kernel/service/ListTypeLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/ListTypeLocalServiceUtil.java
@@ -210,6 +210,12 @@ public class ListTypeLocalServiceUtil {
 		return getService().fetchListType(listTypeId);
 	}
 
+	public static ListType fetchListType(
+		long companyId, String name, String type) {
+
+		return getService().fetchListType(companyId, name, type);
+	}
+
 	/**
 	 * Returns the list type with the matching UUID and company.
 	 *
@@ -255,8 +261,8 @@ public class ListTypeLocalServiceUtil {
 		return getService().getListType(listTypeId);
 	}
 
-	public static ListType getListType(
-		long companyId, String name, String type) {
+	public static ListType getListType(long companyId, String name, String type)
+		throws PortalException {
 
 		return getService().getListType(companyId, name, type);
 	}
@@ -363,4 +369,4 @@ public class ListTypeLocalServiceUtil {
 	private static volatile ListTypeLocalService _service;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-75455825
+// LIFERAY-SERVICE-BUILDER-HASH:-1662070774

--- a/portal-kernel/src/com/liferay/portal/kernel/service/ListTypeLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/ListTypeLocalServiceUtil.java
@@ -282,7 +282,9 @@ public class ListTypeLocalServiceUtil {
 		return getService().getListTypeByUuidAndCompanyId(uuid, companyId);
 	}
 
-	public static long getListTypeId(long companyId, String name, String type) {
+	public static long getListTypeId(long companyId, String name, String type)
+		throws PortalException {
+
 		return getService().getListTypeId(companyId, name, type);
 	}
 
@@ -369,4 +371,4 @@ public class ListTypeLocalServiceUtil {
 	private static volatile ListTypeLocalService _service;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1662070774
+// LIFERAY-SERVICE-BUILDER-HASH:567064924

--- a/portal-kernel/src/com/liferay/portal/kernel/service/ListTypeLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/ListTypeLocalServiceWrapper.java
@@ -322,7 +322,9 @@ public class ListTypeLocalServiceWrapper
 	}
 
 	@Override
-	public long getListTypeId(long companyId, String name, String type) {
+	public long getListTypeId(long companyId, String name, String type)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
 		return _listTypeLocalService.getListTypeId(companyId, name, type);
 	}
 
@@ -431,4 +433,4 @@ public class ListTypeLocalServiceWrapper
 	private ListTypeLocalService _listTypeLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-139184102
+// LIFERAY-SERVICE-BUILDER-HASH:-912638968

--- a/portal-kernel/src/com/liferay/portal/kernel/service/ListTypeLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/ListTypeLocalServiceWrapper.java
@@ -236,6 +236,13 @@ public class ListTypeLocalServiceWrapper
 		return _listTypeLocalService.fetchListType(listTypeId);
 	}
 
+	@Override
+	public com.liferay.portal.kernel.model.ListType fetchListType(
+		long companyId, String name, String type) {
+
+		return _listTypeLocalService.fetchListType(companyId, name, type);
+	}
+
 	/**
 	 * Returns the list type with the matching UUID and company.
 	 *
@@ -291,7 +298,8 @@ public class ListTypeLocalServiceWrapper
 
 	@Override
 	public com.liferay.portal.kernel.model.ListType getListType(
-		long companyId, String name, String type) {
+			long companyId, String name, String type)
+		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _listTypeLocalService.getListType(companyId, name, type);
 	}
@@ -423,4 +431,4 @@ public class ListTypeLocalServiceWrapper
 	private ListTypeLocalService _listTypeLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-214153983
+// LIFERAY-SERVICE-BUILDER-HASH:-139184102

--- a/portal-kernel/src/com/liferay/portal/kernel/service/ListTypeService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/ListTypeService.java
@@ -52,7 +52,8 @@ public interface ListTypeService extends BaseService {
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public long getListTypeId(long companyId, String name, String type);
+	public long getListTypeId(long companyId, String name, String type)
+		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<ListType> getListTypes(long companyId, String type);
@@ -70,4 +71,4 @@ public interface ListTypeService extends BaseService {
 	public void validate(long listTypeId, String type) throws PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2120261031
+// LIFERAY-SERVICE-BUILDER-HASH:-321237371

--- a/portal-kernel/src/com/liferay/portal/kernel/service/ListTypeService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/ListTypeService.java
@@ -42,10 +42,14 @@ public interface ListTypeService extends BaseService {
 	 * Never modify this interface directly. Add custom service methods to <code>com.liferay.portal.service.impl.ListTypeServiceImpl</code> and rerun ServiceBuilder to automatically copy the method declarations to this interface. Consume the list type remote service via injection or a <code>org.osgi.util.tracker.ServiceTracker</code>. Use {@link ListTypeServiceUtil} if injection and service tracking are not available.
 	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public ListType fetchListType(long companyId, String name, String type);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public ListType getListType(long listTypeId) throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public ListType getListType(long companyId, String name, String type);
+	public ListType getListType(long companyId, String name, String type)
+		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public long getListTypeId(long companyId, String name, String type);
@@ -66,4 +70,4 @@ public interface ListTypeService extends BaseService {
 	public void validate(long listTypeId, String type) throws PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1115632999
+// LIFERAY-SERVICE-BUILDER-HASH:-2120261031

--- a/portal-kernel/src/com/liferay/portal/kernel/service/ListTypeServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/ListTypeServiceUtil.java
@@ -45,7 +45,9 @@ public class ListTypeServiceUtil {
 		return getService().getListType(companyId, name, type);
 	}
 
-	public static long getListTypeId(long companyId, String name, String type) {
+	public static long getListTypeId(long companyId, String name, String type)
+		throws PortalException {
+
 		return getService().getListTypeId(companyId, name, type);
 	}
 
@@ -85,4 +87,4 @@ public class ListTypeServiceUtil {
 	private static volatile ListTypeService _service;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1762656099
+// LIFERAY-SERVICE-BUILDER-HASH:1815735563

--- a/portal-kernel/src/com/liferay/portal/kernel/service/ListTypeServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/ListTypeServiceUtil.java
@@ -29,12 +29,18 @@ public class ListTypeServiceUtil {
 	 *
 	 * Never modify this class directly. Add custom service methods to <code>com.liferay.portal.service.impl.ListTypeServiceImpl</code> and rerun ServiceBuilder to regenerate this class.
 	 */
+	public static ListType fetchListType(
+		long companyId, String name, String type) {
+
+		return getService().fetchListType(companyId, name, type);
+	}
+
 	public static ListType getListType(long listTypeId) throws PortalException {
 		return getService().getListType(listTypeId);
 	}
 
-	public static ListType getListType(
-		long companyId, String name, String type) {
+	public static ListType getListType(long companyId, String name, String type)
+		throws PortalException {
 
 		return getService().getListType(companyId, name, type);
 	}
@@ -79,4 +85,4 @@ public class ListTypeServiceUtil {
 	private static volatile ListTypeService _service;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1001508198
+// LIFERAY-SERVICE-BUILDER-HASH:-1762656099

--- a/portal-kernel/src/com/liferay/portal/kernel/service/ListTypeServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/ListTypeServiceWrapper.java
@@ -24,6 +24,13 @@ public class ListTypeServiceWrapper
 	}
 
 	@Override
+	public com.liferay.portal.kernel.model.ListType fetchListType(
+		long companyId, java.lang.String name, java.lang.String type) {
+
+		return _listTypeService.fetchListType(companyId, name, type);
+	}
+
+	@Override
 	public com.liferay.portal.kernel.model.ListType getListType(long listTypeId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
@@ -32,7 +39,8 @@ public class ListTypeServiceWrapper
 
 	@Override
 	public com.liferay.portal.kernel.model.ListType getListType(
-		long companyId, java.lang.String name, java.lang.String type) {
+			long companyId, java.lang.String name, java.lang.String type)
+		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _listTypeService.getListType(companyId, name, type);
 	}
@@ -89,4 +97,4 @@ public class ListTypeServiceWrapper
 	private ListTypeService _listTypeService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1315426182
+// LIFERAY-SERVICE-BUILDER-HASH:558814426

--- a/portal-kernel/src/com/liferay/portal/kernel/service/ListTypeServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/ListTypeServiceWrapper.java
@@ -47,7 +47,8 @@ public class ListTypeServiceWrapper
 
 	@Override
 	public long getListTypeId(
-		long companyId, java.lang.String name, java.lang.String type) {
+			long companyId, java.lang.String name, java.lang.String type)
+		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _listTypeService.getListTypeId(companyId, name, type);
 	}
@@ -97,4 +98,4 @@ public class ListTypeServiceWrapper
 	private ListTypeService _listTypeService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:558814426
+// LIFERAY-SERVICE-BUILDER-HASH:-729478996

--- a/portal-kernel/src/com/liferay/portal/kernel/service/PasswordPolicyLocalService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/PasswordPolicyLocalService.java
@@ -230,6 +230,15 @@ public interface PasswordPolicyLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public PasswordPolicy fetchPasswordPolicy(long companyId, String name);
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public PasswordPolicy fetchPasswordPolicyByUser(User user)
+		throws PortalException;
+
+	@ThreadLocalCachable
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public PasswordPolicy fetchPasswordPolicyByUserId(long userId)
+		throws PortalException;
+
 	/**
 	 * Returns the password policy with the matching UUID and company.
 	 *
@@ -304,7 +313,6 @@ public interface PasswordPolicyLocalService
 	public PasswordPolicy getPasswordPolicyByUser(User user)
 		throws PortalException;
 
-	@ThreadLocalCachable
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public PasswordPolicy getPasswordPolicyByUserId(long userId)
 		throws PortalException;
@@ -364,4 +372,4 @@ public interface PasswordPolicyLocalService
 	public PasswordPolicy updatePasswordPolicy(PasswordPolicy passwordPolicy);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:2042806418
+// LIFERAY-SERVICE-BUILDER-HASH:1147952912

--- a/portal-kernel/src/com/liferay/portal/kernel/service/PasswordPolicyLocalService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/PasswordPolicyLocalService.java
@@ -313,6 +313,7 @@ public interface PasswordPolicyLocalService
 	public PasswordPolicy getPasswordPolicyByUser(User user)
 		throws PortalException;
 
+	@ThreadLocalCachable
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public PasswordPolicy getPasswordPolicyByUserId(long userId)
 		throws PortalException;
@@ -372,4 +373,4 @@ public interface PasswordPolicyLocalService
 	public PasswordPolicy updatePasswordPolicy(PasswordPolicy passwordPolicy);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1147952912
+// LIFERAY-SERVICE-BUILDER-HASH:-2089236586

--- a/portal-kernel/src/com/liferay/portal/kernel/service/PasswordPolicyLocalService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/PasswordPolicyLocalService.java
@@ -222,6 +222,9 @@ public interface PasswordPolicyLocalService
 		DynamicQuery dynamicQuery, Projection projection);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public PasswordPolicy fetchDefaultPasswordPolicy(long companyId);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public PasswordPolicy fetchPasswordPolicy(long passwordPolicyId);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
@@ -361,4 +364,4 @@ public interface PasswordPolicyLocalService
 	public PasswordPolicy updatePasswordPolicy(PasswordPolicy passwordPolicy);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:554307998
+// LIFERAY-SERVICE-BUILDER-HASH:2042806418

--- a/portal-kernel/src/com/liferay/portal/kernel/service/PasswordPolicyLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/PasswordPolicyLocalServiceUtil.java
@@ -248,6 +248,19 @@ public class PasswordPolicyLocalServiceUtil {
 		return getService().fetchPasswordPolicy(companyId, name);
 	}
 
+	public static PasswordPolicy fetchPasswordPolicyByUser(
+			com.liferay.portal.kernel.model.User user)
+		throws PortalException {
+
+		return getService().fetchPasswordPolicyByUser(user);
+	}
+
+	public static PasswordPolicy fetchPasswordPolicyByUserId(long userId)
+		throws PortalException {
+
+		return getService().fetchPasswordPolicyByUserId(userId);
+	}
+
 	/**
 	 * Returns the password policy with the matching UUID and company.
 	 *
@@ -440,4 +453,4 @@ public class PasswordPolicyLocalServiceUtil {
 	private static volatile PasswordPolicyLocalService _service;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:2122577674
+// LIFERAY-SERVICE-BUILDER-HASH:1524807190

--- a/portal-kernel/src/com/liferay/portal/kernel/service/PasswordPolicyLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/PasswordPolicyLocalServiceUtil.java
@@ -234,6 +234,10 @@ public class PasswordPolicyLocalServiceUtil {
 		return getService().dynamicQueryCount(dynamicQuery, projection);
 	}
 
+	public static PasswordPolicy fetchDefaultPasswordPolicy(long companyId) {
+		return getService().fetchDefaultPasswordPolicy(companyId);
+	}
+
 	public static PasswordPolicy fetchPasswordPolicy(long passwordPolicyId) {
 		return getService().fetchPasswordPolicy(passwordPolicyId);
 	}
@@ -436,4 +440,4 @@ public class PasswordPolicyLocalServiceUtil {
 	private static volatile PasswordPolicyLocalService _service;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1635504886
+// LIFERAY-SERVICE-BUILDER-HASH:2122577674

--- a/portal-kernel/src/com/liferay/portal/kernel/service/PasswordPolicyLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/PasswordPolicyLocalServiceWrapper.java
@@ -260,6 +260,14 @@ public class PasswordPolicyLocalServiceWrapper
 	}
 
 	@Override
+	public com.liferay.portal.kernel.model.PasswordPolicy
+		fetchDefaultPasswordPolicy(long companyId) {
+
+		return _passwordPolicyLocalService.fetchDefaultPasswordPolicy(
+			companyId);
+	}
+
+	@Override
 	public com.liferay.portal.kernel.model.PasswordPolicy fetchPasswordPolicy(
 		long passwordPolicyId) {
 
@@ -503,4 +511,4 @@ public class PasswordPolicyLocalServiceWrapper
 	private PasswordPolicyLocalService _passwordPolicyLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-920056944
+// LIFERAY-SERVICE-BUILDER-HASH:-51622873

--- a/portal-kernel/src/com/liferay/portal/kernel/service/PasswordPolicyLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/PasswordPolicyLocalServiceWrapper.java
@@ -282,6 +282,22 @@ public class PasswordPolicyLocalServiceWrapper
 		return _passwordPolicyLocalService.fetchPasswordPolicy(companyId, name);
 	}
 
+	@Override
+	public com.liferay.portal.kernel.model.PasswordPolicy
+			fetchPasswordPolicyByUser(com.liferay.portal.kernel.model.User user)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _passwordPolicyLocalService.fetchPasswordPolicyByUser(user);
+	}
+
+	@Override
+	public com.liferay.portal.kernel.model.PasswordPolicy
+			fetchPasswordPolicyByUserId(long userId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _passwordPolicyLocalService.fetchPasswordPolicyByUserId(userId);
+	}
+
 	/**
 	 * Returns the password policy with the matching UUID and company.
 	 *
@@ -511,4 +527,4 @@ public class PasswordPolicyLocalServiceWrapper
 	private PasswordPolicyLocalService _passwordPolicyLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-51622873
+// LIFERAY-SERVICE-BUILDER-HASH:282024609

--- a/portal-kernel/src/com/liferay/social/kernel/service/SocialActivitySetLocalService.java
+++ b/portal-kernel/src/com/liferay/social/kernel/service/SocialActivitySetLocalService.java
@@ -218,11 +218,13 @@ public interface SocialActivitySetLocalService
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public SocialActivitySet getClassActivitySet(
-		long classNameId, long classPK, int type);
+			long classNameId, long classPK, int type)
+		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public SocialActivitySet getClassActivitySet(
-		long userId, long classNameId, long classPK, int type);
+			long userId, long classNameId, long classPK, int type)
+		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<SocialActivitySet> getGroupActivitySets(
@@ -305,11 +307,13 @@ public interface SocialActivitySetLocalService
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public SocialActivitySet getUserActivitySet(
-		long groupId, long userId, int type);
+			long groupId, long userId, int type)
+		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public SocialActivitySet getUserActivitySet(
-		long groupId, long userId, long classNameId, int type);
+			long groupId, long userId, long classNameId, int type)
+		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<SocialActivitySet> getUserActivitySets(
@@ -365,4 +369,4 @@ public interface SocialActivitySetLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1159412119
+// LIFERAY-SERVICE-BUILDER-HASH:-950438591

--- a/portal-kernel/src/com/liferay/social/kernel/service/SocialActivitySetLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/social/kernel/service/SocialActivitySetLocalServiceUtil.java
@@ -230,13 +230,15 @@ public class SocialActivitySetLocalServiceUtil {
 	}
 
 	public static SocialActivitySet getClassActivitySet(
-		long classNameId, long classPK, int type) {
+			long classNameId, long classPK, int type)
+		throws PortalException {
 
 		return getService().getClassActivitySet(classNameId, classPK, type);
 	}
 
 	public static SocialActivitySet getClassActivitySet(
-		long userId, long classNameId, long classPK, int type) {
+			long userId, long classNameId, long classPK, int type)
+		throws PortalException {
 
 		return getService().getClassActivitySet(
 			userId, classNameId, classPK, type);
@@ -348,13 +350,15 @@ public class SocialActivitySetLocalServiceUtil {
 	}
 
 	public static SocialActivitySet getUserActivitySet(
-		long groupId, long userId, int type) {
+			long groupId, long userId, int type)
+		throws PortalException {
 
 		return getService().getUserActivitySet(groupId, userId, type);
 	}
 
 	public static SocialActivitySet getUserActivitySet(
-		long groupId, long userId, long classNameId, int type) {
+			long groupId, long userId, long classNameId, int type)
+		throws PortalException {
 
 		return getService().getUserActivitySet(
 			groupId, userId, classNameId, type);
@@ -424,4 +428,4 @@ public class SocialActivitySetLocalServiceUtil {
 	private static volatile SocialActivitySetLocalService _service;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-318516587
+// LIFERAY-SERVICE-BUILDER-HASH:-205466759

--- a/portal-kernel/src/com/liferay/social/kernel/service/SocialActivitySetLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/social/kernel/service/SocialActivitySetLocalServiceWrapper.java
@@ -263,7 +263,8 @@ public class SocialActivitySetLocalServiceWrapper
 
 	@Override
 	public SocialActivitySet getClassActivitySet(
-		long classNameId, long classPK, int type) {
+			long classNameId, long classPK, int type)
+		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _socialActivitySetLocalService.getClassActivitySet(
 			classNameId, classPK, type);
@@ -271,7 +272,8 @@ public class SocialActivitySetLocalServiceWrapper
 
 	@Override
 	public SocialActivitySet getClassActivitySet(
-		long userId, long classNameId, long classPK, int type) {
+			long userId, long classNameId, long classPK, int type)
+		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _socialActivitySetLocalService.getClassActivitySet(
 			userId, classNameId, classPK, type);
@@ -407,7 +409,8 @@ public class SocialActivitySetLocalServiceWrapper
 
 	@Override
 	public SocialActivitySet getUserActivitySet(
-		long groupId, long userId, int type) {
+			long groupId, long userId, int type)
+		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _socialActivitySetLocalService.getUserActivitySet(
 			groupId, userId, type);
@@ -415,7 +418,8 @@ public class SocialActivitySetLocalServiceWrapper
 
 	@Override
 	public SocialActivitySet getUserActivitySet(
-		long groupId, long userId, long classNameId, int type) {
+			long groupId, long userId, long classNameId, int type)
+		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _socialActivitySetLocalService.getUserActivitySet(
 			groupId, userId, classNameId, type);
@@ -528,4 +532,4 @@ public class SocialActivitySetLocalServiceWrapper
 	private SocialActivitySetLocalService _socialActivitySetLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-65778887
+// LIFERAY-SERVICE-BUILDER-HASH:595185053


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99062

## What Is Being Fixed

Liferay's service naming contract is: `get*` throws on a missing entity, `fetch*` returns `null`. Several `*LocalServiceImpl`/`*ServiceImpl` `get*` methods violated this by internally delegating to `fetch*`-style logic — silently returning `null`, or dereferencing the `null` (e.g. `ListTypeLocalServiceImpl.getListTypeId`) and throwing a meaningless `NullPointerException` instead of a `PortalException`. Callers could not rely on the contract, and null-tolerant call sites were indistinguishable from mandatory ones.

## How It Is Being Fixed

For each offender: add the missing `fetch*` sibling method, make the `get*` method throw on a missing entity, and repoint every null-tolerant caller to the `fetch*` form (mandatory callers keep `get*` and propagate). Exported packages get minor version bumps, carried in the pure `Regenerate` commits. A companion source formatter check (`JavaServiceGetFetchCheck`) that flags this pattern ships separately for the Source Formatter team's review; this cleanup PR is intended to land first.

## PR Check

**pr-check: PASS** — tested on `31944087cfd63aacb4de2b11042cd62bae50fd31`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Service Builder | PASS |
| Full Portal Build | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |

CI on the pre-split validation branch (identical product content): `ci:test:sf` PASS, `ci:test:stable` PASS (15/15); the `ci:test:relevant` report was fully triaged — 0 of 177 failures caused by this change (each reproducible failure was locally A/B-verified to fail identically on clean master).

<!-- pr-check {"result": "success", "sha": "31944087cfd63aacb4de2b11042cd62bae50fd31"} -->
