### PR TITLE
LPD-98690 Match lowercased design library in warning assertion

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/AddFragmentEntryLinksMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/AddFragmentEntryLinksMVCActionCommandTest.java
@@ -253,7 +253,7 @@ public class AddFragmentEntryLinksMVCActionCommandTest {
 
 			_testAddFragmentEntryLinks(
 				Collections.singletonList(
-					"was ignored because its Design Library is not connected " +
+					"was ignored because its design library is not connected " +
 						"to this site."),
 				fragmentComposition.getFragmentCompositionKey(),
 				_group.getGroupId());


### PR DESCRIPTION
Follow-up to #178985 to align the integration test with the lowercased "design library" from d316b0d87310151c1f45b24c5b8f4f04d4facfcf (LPD-98690 SF/Wordsmith). The assertion in testAddFragmentEntryLinks still expects the previous casing and fails after the merge.