### PR TITLE
LPD-98752 Consolidate CMS and CMP site initialization

### DIFF
--- a/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/feature/flag/CMPFeatureFlagListener.java
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/feature/flag/CMPFeatureFlagListener.java
@@ -45,10 +45,8 @@ public class CMPFeatureFlagListener implements FeatureFlagListener {
 
 			_groupLocalService.checkSystemGroups(companyId);
 
-			com.liferay.site.cms.site.initializer.util.SiteInitializerUtil.
-				initialize(companyId, _cmsSiteInitializer);
-
-			SiteInitializerUtil.initialize(companyId, _cmpSiteInitializer);
+			SiteInitializerUtil.initialize(
+				_cmpSiteInitializer, _cmsSiteInitializer, companyId);
 		}
 		catch (PortalException portalException) {
 			_log.error(portalException);

--- a/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/instance/lifecycle/AddDefaultLayoutInitialRequestPortalInstanceLifecycleListener.java
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/instance/lifecycle/AddDefaultLayoutInitialRequestPortalInstanceLifecycleListener.java
@@ -5,12 +5,8 @@
 
 package com.liferay.site.cmp.site.initializer.internal.instance.lifecycle;
 
-import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.instance.lifecycle.InitialRequestPortalInstanceLifecycleListener;
 import com.liferay.portal.instance.lifecycle.PortalInstanceLifecycleListener;
-import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
-import com.liferay.portal.kernel.license.util.App;
-import com.liferay.portal.kernel.license.util.LicenseManagerUtil;
 import com.liferay.site.cmp.site.initializer.internal.util.SiteInitializerUtil;
 import com.liferay.site.initializer.SiteInitializer;
 
@@ -34,18 +30,8 @@ public class AddDefaultLayoutInitialRequestPortalInstanceLifecycleListener
 
 	@Override
 	protected void doPortalInstanceRegistered(long companyId) throws Exception {
-		if (!LicenseManagerUtil.isAppEnabled(App.CMP)) {
-			return;
-		}
-
-		try (SafeCloseable safeCloseable =
-				CTCollectionThreadLocal.setProductionModeWithSafeCloseable()) {
-
-			com.liferay.site.cms.site.initializer.util.SiteInitializerUtil.
-				initialize(companyId, _cmsSiteInitializer);
-
-			SiteInitializerUtil.initialize(companyId, _cmpSiteInitializer);
-		}
+		SiteInitializerUtil.initialize(
+			_cmpSiteInitializer, _cmsSiteInitializer, companyId);
 	}
 
 	@Reference(

--- a/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/util/SiteInitializerUtil.java
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/util/SiteInitializerUtil.java
@@ -11,6 +11,8 @@ import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.license.util.App;
+import com.liferay.portal.kernel.license.util.LicenseManagerUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Layout;
@@ -41,10 +43,6 @@ public class SiteInitializerUtil {
 	public static void initialize(
 			long companyId, SiteInitializer siteInitializer)
 		throws PortalException {
-
-		if (!FeatureFlagManagerUtil.isEnabled(companyId, "LPD-58677")) {
-			return;
-		}
 
 		Group group = GroupLocalServiceUtil.getGroup(
 			companyId, GroupConstants.CMS);
@@ -100,6 +98,23 @@ public class SiteInitializerUtil {
 
 			ServiceContextThreadLocal.popServiceContext();
 		}
+	}
+
+	public static void initialize(
+			SiteInitializer cmpSiteInitializer,
+			SiteInitializer cmsSiteInitializer, long companyId)
+		throws PortalException {
+
+		if (!FeatureFlagManagerUtil.isEnabled(companyId, "LPD-58677") ||
+			!LicenseManagerUtil.isAppEnabled(App.CMP)) {
+
+			return;
+		}
+
+		com.liferay.site.cms.site.initializer.util.SiteInitializerUtil.
+			initialize(companyId, cmsSiteInitializer);
+
+		initialize(companyId, cmpSiteInitializer);
 	}
 
 	private static User _getUser(long companyId) throws PortalException {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98752

## What Is Being Fixed

The original LPD-98752 change had both callers that trigger CMP site initialization — the feature flag listener and the initial-request lifecycle listener — each initialize the CMS site before the CMP site, duplicating the feature flag check, the CMP license check, and the CMS-then-CMP ordering across the two entry points. Review feedback asked that this duplicated logic be consolidated.

## How It Is Being Fixed

This is a follow-up to the original LPD-98752 pull request, as requested in review. A single `SiteInitializerUtil.initialize(cmpSiteInitializer, cmsSiteInitializer, companyId)` method now owns the guard (feature flag plus CMP license) and the CMS-then-CMP ordering. Both `CMPFeatureFlagListener` and the initial-request lifecycle listener delegate to it, so neither repeats the guard or the ordering.

## Why Are There No Tests?

The consolidation is behavior preserving and is already exercised by the existing `AddDefaultLayoutInitialRequestPortalInstanceLifecycleListenerTest` integration test that landed with the original LPD-98752 work, which verifies the CMS site is initialized before the CMP site.

## PR Check

**pr-check: PASS** — tested on `f96160a6a9cc730611b368fa4152b248daac987b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Cross-Module Compile | PASS |

<!-- pr-check {"result": "success", "sha": "f96160a6a9cc730611b368fa4152b248daac987b"} -->
