### PR TITLE
LPD-99314 Stabilize failing and flaky Objects tests

### DIFF
--- a/modules/apps/object/object-rest-api/src/test/java/com/liferay/object/rest/dto/v1_0/ObjectEntryTest.java
+++ b/modules/apps/object/object-rest-api/src/test/java/com/liferay/object/rest/dto/v1_0/ObjectEntryTest.java
@@ -16,7 +16,6 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Assert;
@@ -80,8 +79,6 @@ public class ObjectEntryTest {
 					executorService.submit(
 						() -> new HashMap<>(objectEntry.getProperties())));
 			}
-
-			executorService.awaitTermination(10, TimeUnit.SECONDS);
 
 			for (Future<?> future : futures) {
 				Map<String, Object> properties =

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/trash/test/ObjectEntryFolderTrashHandlerTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/trash/test/ObjectEntryFolderTrashHandlerTest.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.Time;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -35,6 +36,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Alicia García
  */
+@FeatureFlag("LPD-17564")
 @RunWith(Arquillian.class)
 public class ObjectEntryFolderTrashHandlerTest {
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/upgrade/v10_0_0/test/ObjectDefinitionUpgradeProcessTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/upgrade/v10_0_0/test/ObjectDefinitionUpgradeProcessTest.java
@@ -62,6 +62,7 @@ public class ObjectDefinitionUpgradeProcessTest {
 
 		_assertObjectDefinitionPKObjectFieldPrefix(objectDefinition2, "c_");
 
+		String name = "Test" + RandomTestUtil.randomString();
 		String pkObjectFieldDBColumnName = StringUtil.randomId();
 		String pkObjectFieldName = StringUtil.randomId();
 
@@ -69,7 +70,7 @@ public class ObjectDefinitionUpgradeProcessTest {
 			ObjectDefinitionTestUtil.addModifiableSystemObjectDefinition(
 				TestPropsValues.getUserId(), null,
 				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
-				"FDSEntry", pkObjectFieldDBColumnName, pkObjectFieldName,
+				name, pkObjectFieldDBColumnName, pkObjectFieldName,
 				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
 				ObjectDefinitionConstants.SCOPE_COMPANY, null, 1,
 				List.of(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -151,8 +151,6 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.audit.AuditMessage;
 import com.liferay.portal.kernel.audit.AuditRouter;
 import com.liferay.portal.kernel.comment.CommentManagerUtil;
-import com.liferay.portal.kernel.dao.db.DBManagerUtil;
-import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.dao.orm.FinderCacheUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
@@ -3119,40 +3117,25 @@ public class ObjectEntryLocalServiceTest {
 					).build()),
 				false);
 
-		_objectEntryLocalService.addObjectEntry(
+		String multiselectPicklistObjectFieldValue =
+			_getMultiselectPicklistObjectFieldValue(prefixKey, 100);
+
+		ObjectEntry objectEntry = _objectEntryLocalService.addObjectEntry(
 			0, TestPropsValues.getUserId(),
 			objectDefinition.getObjectDefinitionId(),
 			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
 			null,
 			HashMapBuilder.<String, Serializable>put(
 				"multiselectPicklistObjectField",
-				_getMultiselectPicklistObjectFieldValue(prefixKey, 10)
+				multiselectPicklistObjectFieldValue
 			).build(),
 			new ServiceContext());
 
-		int expectedMaxLength = 5000;
+		Map<String, Serializable> values = objectEntry.getValues();
 
-		if (DBManagerUtil.getDBType() == DBType.SQLSERVER) {
-			expectedMaxLength = 4000;
-		}
-
-		AssertUtils.assertFailure(
-			ObjectEntryValuesException.ExceedsTextMaxLength.class,
-			StringBundler.concat(
-				"Object entry value exceeds the maximum length of ",
-				expectedMaxLength, " characters for object field ",
-				"\"multiselectPicklistObjectField\""),
-			() -> _objectEntryLocalService.addObjectEntry(
-				0, TestPropsValues.getUserId(),
-				objectDefinition.getObjectDefinitionId(),
-				ObjectEntryFolderConstants.
-					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
-				null,
-				HashMapBuilder.<String, Serializable>put(
-					"multiselectPicklistObjectField",
-					_getMultiselectPicklistObjectFieldValue(prefixKey, 100)
-				).build(),
-				new ServiceContext()));
+		Assert.assertEquals(
+			multiselectPicklistObjectFieldValue,
+			values.get("multiselectPicklistObjectField"));
 	}
 
 	@FeatureFlag("LPD-17564")
@@ -5031,8 +5014,7 @@ public class ObjectEntryLocalServiceTest {
 				"listTypeEntryKeyRequired", "listTypeEntryKey1"
 			).build());
 
-		objectEntry1.setExternalReferenceCode(
-			RandomTestUtil.randomString(500));
+		objectEntry1.setExternalReferenceCode(RandomTestUtil.randomString(500));
 
 		objectEntry1 = _objectEntryLocalService.updateObjectEntry(objectEntry1);
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -5032,7 +5032,7 @@ public class ObjectEntryLocalServiceTest {
 			).build());
 
 		objectEntry1.setExternalReferenceCode(
-			RandomTestUtil.randomString(1000));
+			RandomTestUtil.randomString(500));
 
 		objectEntry1 = _objectEntryLocalService.updateObjectEntry(objectEntry1);
 

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/collection/provider/ObjectEntrySingleFormVariationInfoCollectionProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/collection/provider/ObjectEntrySingleFormVariationInfoCollectionProvider.java
@@ -72,7 +72,6 @@ import com.liferay.portal.kernel.search.NestedQuery;
 import com.liferay.portal.kernel.search.QueryConfig;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.Sort;
-import com.liferay.portal.kernel.search.SortFactoryUtil;
 import com.liferay.portal.kernel.search.TermQuery;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.GroupLocalService;
@@ -327,9 +326,7 @@ public class ObjectEntrySingleFormVariationInfoCollectionProvider
 		com.liferay.info.sort.Sort sort = collectionQuery.getSort();
 
 		if (sort == null) {
-			searchContext.setSorts(
-				SortFactoryUtil.create(
-					Field.CREATE_DATE, Sort.LONG_TYPE, false));
+			searchContext.setSorts(_DEFAULT_INDEXED_SORTS);
 		}
 
 		searchContext.setStart(pagination.getStart());
@@ -444,7 +441,7 @@ public class ObjectEntrySingleFormVariationInfoCollectionProvider
 					collectionQuery.getPagination()),
 				ObjectEntryInfoCollectionProviderUtil.getSearch(
 					collectionQuery),
-				null);
+				_DEFAULT_OBJECT_ENTRY_SORTS);
 
 		return InfoPage.of(
 			TransformUtil.transform(
@@ -504,7 +501,7 @@ public class ObjectEntrySingleFormVariationInfoCollectionProvider
 					collectionQuery.getPagination()),
 				ObjectEntryInfoCollectionProviderUtil.getSearch(
 					collectionQuery),
-				null);
+				_DEFAULT_OBJECT_ENTRY_SORTS);
 
 		return InfoPage.of(
 			TransformUtil.transform(
@@ -798,6 +795,16 @@ public class ObjectEntrySingleFormVariationInfoCollectionProvider
 
 		return false;
 	}
+
+	private static final Sort[] _DEFAULT_INDEXED_SORTS = {
+		new Sort(Field.CREATE_DATE, Sort.LONG_TYPE, false),
+		new Sort(Field.ENTRY_CLASS_PK, Sort.LONG_TYPE, false)
+	};
+
+	private static final Sort[] _DEFAULT_OBJECT_ENTRY_SORTS = {
+		new Sort(Field.CREATE_DATE, Sort.LONG_TYPE, false),
+		new Sort("id", Sort.LONG_TYPE, false)
+	};
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		ObjectEntrySingleFormVariationInfoCollectionProvider.class);

--- a/modules/test/playwright/utils/performLogin.ts
+++ b/modules/test/playwright/utils/performLogin.ts
@@ -172,19 +172,9 @@ export async function performAnalyticsCloudLoginViaApi(
 }
 
 export async function performLogout(page: Page) {
-	await page.goto('/');
+	await page.goto('/c/portal/logout');
 
-	await expect(async () => {
-		await page.getByTitle('User Profile Menu').click({timeout: 1000});
-
-		await page
-			.getByRole('menuitem', {name: 'Sign Out'})
-			.click({timeout: 1000});
-
-		await expect(page.getByRole('button', {name: 'Sign In'})).toBeVisible({
-			timeout: 3000,
-		});
-	}).toPass();
+	await page.waitForURL((url) => !url.pathname.endsWith('/c/portal/logout'));
 }
 
 export async function performUserSwitch(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99314

## What Is Being Fixed

Several tests in the Objects suite fail or flake in `ci:test:object`, unrelated to any single feature. Running the full suite locally on a clean master separated genuine failures from cross-module pollution and environment noise, and each genuine failure was traced back to its root-cause commit.

## How It Is Being Fixed

Seven self-contained commits:

- Remove a dead 10-second `awaitTermination` wait from `ObjectEntryTest` (present since it was created in `5c6183dc`).
- Fit the long external-reference-code test to the `varchar(500)` column (LPD-89588 shrank it from 1000).
- Replace the retired `FDSEntry` name in `ObjectDefinitionUpgradeProcessTest` (LPD-56706 retired it as a modifiable system object name).
- Enable the LPD-17564 feature flag on `ObjectEntryFolderTrashHandlerTest` (created without it in `12f3c65`).
- Route `performLogout` through `/c/portal/logout` with an element-free completion check, replacing a UI-menu click that depended on the client-hydrated React user menu (flaky since its creation in LPD-25858, a hard hang since LPD-77487).
- Give `ObjectEntrySingleFormVariationInfoCollectionProvider` a deterministic default sort (`createDate` then primary key) across all three fetch paths; the indexer path already sorted but `getApprovedObjectEntries`/`getObjectEntries` passed `null` (incomplete since LPD-56443).
- Update the multiselect picklist test for the CLOB column type (LPD-86826 changed the storage to CLOB).

Each commit records its own root cause. Every fix was verified locally against a PostgreSQL 16 bundle, and `ci:test:object` shows the same job pass count as a no-op baseline with no new unique failures.

## PR Check

**pr-check: PASS** — tested on `29afffc6476948997ebc5f139b2046e476617d11`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Baseline | PASS |
| Cross-Module Compile | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

REST Builder and JavaScript Unit matched by path but were verified inapplicable (a hand-written test under `dto/v1_0/` is not generated output; `performLogin.ts` is a Playwright util with no jest suite) and were not run.

