### PR TITLE
LPD-99231 Move the segment criteria to General Attributes

### DIFF
--- a/modules/apps/audiences/audiences-service/src/main/java/com/liferay/audiences/internal/criteria/AudiencesCriteriaProviderImpl.java
+++ b/modules/apps/audiences/audiences-service/src/main/java/com/liferay/audiences/internal/criteria/AudiencesCriteriaProviderImpl.java
@@ -52,9 +52,9 @@ public class AudiencesCriteriaProviderImpl
 		List<AudiencesCriteriaType> audiencesCriteriaTypes = new ArrayList<>();
 
 		audiencesCriteriaTypes.add(
-			_getBrowserAttributesAudiencesCriteriaType(companyId, locale));
+			_getBrowserAttributesAudiencesCriteriaType(locale));
 		audiencesCriteriaTypes.add(
-			_getGeneralAttributesAudiencesCriteriaType(locale));
+			_getGeneralAttributesAudiencesCriteriaType(companyId, locale));
 
 		AudiencesCriteriaType customAudiencesCriteriaType =
 			_getCustomAudiencesCriteriaType(companyId, locale);
@@ -67,7 +67,7 @@ public class AudiencesCriteriaProviderImpl
 	}
 
 	private AudiencesCriteriaType _getBrowserAttributesAudiencesCriteriaType(
-		long companyId, Locale locale) {
+		Locale locale) {
 
 		List<AudiencesCriteria> audiencesCriterias = new ArrayList<>(
 			Arrays.asList(
@@ -197,32 +197,6 @@ public class AudiencesCriteriaProviderImpl
 					AudiencesCriteria.Type.SET
 				).build()));
 
-		List<AudiencesCriteria.Option> segmentsOptions =
-			TransformUtil.transform(
-				_segmentsEntryLocalService.getSegmentsEntriesBySource(
-					companyId, SegmentsEntryConstants.SOURCE_ASAH_FARO_BACKEND,
-					QueryUtil.ALL_POS, QueryUtil.ALL_POS, null),
-				segmentsEntry -> new AudiencesCriteria.Option(
-					segmentsEntry.getName(locale),
-					segmentsEntry.getExternalReferenceCode()));
-
-		if (!segmentsOptions.isEmpty()) {
-			audiencesCriterias.add(
-				AudiencesCriteriaBuilder.setIcon(
-					"users"
-				).setInputType(
-					AudiencesCriteria.InputType.SELECT
-				).setKey(
-					AudiencesCriteriaKeys.SEGMENT
-				).setLabel(
-					_language.get(locale, "segments")
-				).setOptions(
-					segmentsOptions
-				).setType(
-					AudiencesCriteria.Type.STRING
-				).build());
-		}
-
 		Collections.addAll(
 			audiencesCriterias,
 			AudiencesCriteriaBuilder.setIcon(
@@ -328,9 +302,9 @@ public class AudiencesCriteriaProviderImpl
 	}
 
 	private AudiencesCriteriaType _getGeneralAttributesAudiencesCriteriaType(
-		Locale locale) {
+		long companyId, Locale locale) {
 
-		return new AudiencesCriteriaType(
+		List<AudiencesCriteria> audiencesCriterias = new ArrayList<>(
 			Arrays.asList(
 				AudiencesCriteriaBuilder.setIcon(
 					"check"
@@ -355,8 +329,36 @@ public class AudiencesCriteriaProviderImpl
 					_getLanguageOptions(locale)
 				).setType(
 					AudiencesCriteria.Type.STRING
-				).build()),
-			AudiencesCriteriaTypeKeys.GENERAL,
+				).build()));
+
+		List<AudiencesCriteria.Option> segmentsOptions =
+			TransformUtil.transform(
+				_segmentsEntryLocalService.getSegmentsEntriesBySource(
+					companyId, SegmentsEntryConstants.SOURCE_ASAH_FARO_BACKEND,
+					QueryUtil.ALL_POS, QueryUtil.ALL_POS, null),
+				segmentsEntry -> new AudiencesCriteria.Option(
+					segmentsEntry.getName(locale),
+					segmentsEntry.getExternalReferenceCode()));
+
+		if (!segmentsOptions.isEmpty()) {
+			audiencesCriterias.add(
+				AudiencesCriteriaBuilder.setIcon(
+					"users"
+				).setInputType(
+					AudiencesCriteria.InputType.SELECT
+				).setKey(
+					AudiencesCriteriaKeys.SEGMENT
+				).setLabel(
+					_language.get(locale, "segments")
+				).setOptions(
+					segmentsOptions
+				).setType(
+					AudiencesCriteria.Type.STRING
+				).build());
+		}
+
+		return new AudiencesCriteriaType(
+			audiencesCriterias, AudiencesCriteriaTypeKeys.GENERAL,
 			_language.get(locale, AudiencesCriteriaTypeKeys.GENERAL));
 	}
 

--- a/modules/apps/audiences/audiences-test/src/testIntegration/java/com/liferay/audiences/criteria/test/AudiencesCriteriaProviderTest.java
+++ b/modules/apps/audiences/audiences-test/src/testIntegration/java/com/liferay/audiences/criteria/test/AudiencesCriteriaProviderTest.java
@@ -72,35 +72,6 @@ public class AudiencesCriteriaProviderTest {
 
 		Assert.assertEquals(
 			AudiencesCriteria.Type.STRING, urlAudiencesCriteria.getType());
-
-		SegmentsEntry segmentsEntry = _addSegmentsEntry();
-
-		audiencesCriteriaTypes =
-			_audiencesCriteriaProvider.getAudiencesCriteriaTypes(
-				TestPropsValues.getCompanyId(), LocaleUtil.getDefault());
-
-		audiencesCriteriaType = audiencesCriteriaTypes.get(0);
-
-		audiencesCriterias = audiencesCriteriaType.getAudiencesCriterias();
-
-		Assert.assertEquals(
-			audiencesCriterias.toString(), 15, audiencesCriterias.size());
-
-		AudiencesCriteria segmentAudiencesCriteria = _getAudiencesCriteria(
-			audiencesCriterias, "segment");
-
-		Assert.assertEquals(
-			AudiencesCriteria.InputType.SELECT,
-			segmentAudiencesCriteria.getInputType());
-		Assert.assertEquals(
-			AudiencesCriteria.Type.STRING, segmentAudiencesCriteria.getType());
-
-		AudiencesCriteria.Option option = _getOption(
-			segmentAudiencesCriteria.getOptions(),
-			segmentsEntry.getExternalReferenceCode());
-
-		Assert.assertEquals(
-			segmentsEntry.getName(LocaleUtil.getDefault()), option.getLabel());
 	}
 
 	@Test
@@ -152,6 +123,7 @@ public class AudiencesCriteriaProviderTest {
 
 		Assert.assertEquals(
 			audiencesCriterias.toString(), 2, audiencesCriterias.size());
+		Assert.assertNull(_getAudiencesCriteria(audiencesCriterias, "segment"));
 
 		AudiencesCriteria authenticationAudiencesCriteria =
 			_getAudiencesCriteria(
@@ -174,6 +146,35 @@ public class AudiencesCriteriaProviderTest {
 			languageAudiencesCriteria.getOptions();
 
 		Assert.assertFalse(options.toString(), options.isEmpty());
+
+		SegmentsEntry segmentsEntry = _addSegmentsEntry();
+
+		audiencesCriteriaTypes =
+			_audiencesCriteriaProvider.getAudiencesCriteriaTypes(
+				TestPropsValues.getCompanyId(), LocaleUtil.getDefault());
+
+		audiencesCriteriaType = audiencesCriteriaTypes.get(1);
+
+		audiencesCriterias = audiencesCriteriaType.getAudiencesCriterias();
+
+		Assert.assertEquals(
+			audiencesCriterias.toString(), 3, audiencesCriterias.size());
+
+		AudiencesCriteria segmentAudiencesCriteria = _getAudiencesCriteria(
+			audiencesCriterias, "segment");
+
+		Assert.assertEquals(
+			AudiencesCriteria.InputType.SELECT,
+			segmentAudiencesCriteria.getInputType());
+		Assert.assertEquals(
+			AudiencesCriteria.Type.STRING, segmentAudiencesCriteria.getType());
+
+		AudiencesCriteria.Option option = _getOption(
+			segmentAudiencesCriteria.getOptions(),
+			segmentsEntry.getExternalReferenceCode());
+
+		Assert.assertEquals(
+			segmentsEntry.getName(LocaleUtil.getDefault()), option.getLabel());
 	}
 
 	private void _addClientExtensionEntry(String name, String symbol)


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99231

## What Is Being Fixed

The segment audiences criteria (segments entries sourced from the ASAH Faro backend) was listed under the Browser Attributes criteria type in the Audience Builder sidebar, where it does not belong. It should appear under the General Attributes criteria type.

## How It Is Being Fixed

The segment criteria block, which builds a SELECT option list from the company's ASAH Faro backend segments entries, is moved out of the Browser Attributes criteria type and into the General Attributes criteria type. The two private builder methods swap the companyId parameter accordingly: General Attributes now receives the companyId it needs to query segments entries, while Browser Attributes no longer takes it. The integration test is updated to assert the segment criteria is absent from Browser Attributes and present under General Attributes, with the expected option counts adjusted.

## PR Check

**pr-check: PASS** — tested on `868419663ba508682d1a7865814f1c5abcbd965e`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "868419663ba508682d1a7865814f1c5abcbd965e"} -->
