### PR TITLE
LPD-99339 Stabilize ObjectEntryResourceTest cross-company, taxonomy, and CMS attachment failures

### DIFF
--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -18849,8 +18849,7 @@ public class ObjectEntryResourceTest {
 			fileEntry -> JSONUtil.put(
 				_OBJECT_FIELD_NAME_ATTACHMENT_CMS_BASIC_DOCUMENT_SOURCE,
 				_getFileEntryJSONObject(
-					_getDLFolder(depotEntry.getGroupId(), objectDefinition),
-					fileEntry, objectDefinition,
+					null, fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_CMS_BASIC_DOCUMENT_SOURCE)),
 			_toFileEntry(
 				Base64::encode, DLTestUtil.randomTextFileBytes(),
@@ -19820,8 +19819,7 @@ public class ObjectEntryResourceTest {
 			fileEntry -> JSONUtil.put(
 				_OBJECT_FIELD_NAME_ATTACHMENT_CMS_BASIC_DOCUMENT_SOURCE,
 				_getFileEntryJSONObject(
-					_getDLFolder(depotEntry.getGroupId(), objectDefinition),
-					fileEntry, objectDefinition,
+					null, fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_CMS_BASIC_DOCUMENT_SOURCE)),
 			_toFileEntry(
 				Base64::encode, DLTestUtil.randomTextFileBytes(),

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -7173,12 +7173,23 @@ public class ObjectEntryResourceTest {
 	public void testGetObjectEntryFilteredByTaxonomyCategories()
 		throws Exception {
 
+		Company company = _companyLocalService.getCompany(
+			TestPropsValues.getCompanyId());
+
+		AssetVocabulary assetVocabulary =
+			_assetVocabularyLocalService.addVocabulary(
+				TestPropsValues.getUserId(), company.getGroupId(),
+				RandomTestUtil.randomString(), new ServiceContext());
+
 		TaxonomyCategory taxonomyCategory1 =
-			_postTaxonomyVocabularyTaxonomyCategory();
+			_postTaxonomyVocabularyTaxonomyCategory(
+				company.getGroupId(), assetVocabulary.getVocabularyId());
 		TaxonomyCategory taxonomyCategory2 =
-			_postTaxonomyVocabularyTaxonomyCategory();
+			_postTaxonomyVocabularyTaxonomyCategory(
+				company.getGroupId(), assetVocabulary.getVocabularyId());
 		TaxonomyCategory taxonomyCategory3 =
-			_postTaxonomyVocabularyTaxonomyCategory();
+			_postTaxonomyVocabularyTaxonomyCategory(
+				company.getGroupId(), assetVocabulary.getVocabularyId());
 
 		_postObjectEntryWithTaxonomyCategories();
 		_postObjectEntryWithTaxonomyCategories(taxonomyCategory1);

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -10167,7 +10167,7 @@ public class ObjectEntryResourceTest {
 						Http.Method.POST);
 
 					Assert.assertEquals(
-						"BAD_REQUEST", jsonObject.getString("status"));
+						"FORBIDDEN", jsonObject.getString("status"));
 				}
 			);
 		}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99339

## What Is Being Fixed

Three `ObjectEntryResourceTest` scenarios fail on the object integration test batch. The bundle was rebuilt to the current master, booted on a fresh PostgreSQL 16 database with the CMS feature flag (LPD-17564) enabled to match the CI object batch, and each failure was traced back to the commit that changed the product behavior.

## How It Is Being Fixed

Three self-contained commits, each recording its own root cause:

- `testPostCustomObjectEntryWithAttachmentObjectFieldInDifferentCompany` expects `FORBIDDEN` instead of `BAD_REQUEST`. LPD-97411 switched referenced-file resolution to the permission-checked `DLAppService`, so a cross-company file reference is now rejected with 403.
- `testGetObjectEntryFilteredByTaxonomyCategories` creates its taxonomy categories in the company group. LPD-74644 added POST-time scope validation that rejects categories outside the company-scoped entry's scope; its companion test fix (`96acf225`) migrated the sibling tests but left this one behind.
- The CMS basic document attachment scenarios (`testPost`/`testPatchPut`/`...ByExternalReferenceCode...WithAttachmentObjectField`) expect the file in the depot group's default document library rather than the object definitions portlet repository. LPD-80967 routed CMS basic document attachments to the default library, and the companion test update kept the stale portlet-repository expectation.

Each fix was verified locally against a PostgreSQL 16 bundle with the CMS flag on.

## PR Check

**pr-check: PASS** — tested on `6c4b35026d545fcbb8763f125acea94b85645ebd`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |

<!-- pr-check {"result": "success", "sha": "6c4b35026d545fcbb8763f125acea94b85645ebd"} -->
