### PR TITLE
LPD-99341 Scope the object entry audit events nested field to the requested entry

### DIFF
--- a/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/service/impl/AuditEventLocalServiceImpl.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/service/impl/AuditEventLocalServiceImpl.java
@@ -158,7 +158,7 @@ public class AuditEventLocalServiceImpl extends AuditEventLocalServiceBaseImpl {
 		if (ArrayUtil.isNotEmpty(accountEntryIds)) {
 			junction.add(accountEntryIdProperty.in(accountEntryIds));
 		}
-		else {
+		else if (andSearch) {
 			junction.add(accountEntryIdProperty.eq(0L));
 		}
 
@@ -224,7 +224,7 @@ public class AuditEventLocalServiceImpl extends AuditEventLocalServiceBaseImpl {
 		if (Validator.isNotNull(contextName)) {
 			junction.add(contextNameProperty.eq(contextName));
 		}
-		else {
+		else if (andSearch) {
 			junction.add(contextNameProperty.isNull());
 		}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99341

## What Is Being Fixed

The object entry `auditEvents` nested REST field returned **every** audit event in the database instead of the requested entry's own. `testGetObjectEntryWithAuditEvents` expected 2 events (one add, one update) and received the whole audit table. This is also a cross-company disclosure: any user with object entry history permission on a single entry received all audit events across all companies.

## How It Is Being Fixed

`ObjectEntryDTOConverter` queries `AuditEventLocalService.getAuditEvents` in **disjunction** mode (`andSearch=false`) with only the object entry primary key set. `AuditEventLocalServiceImpl._buildDynamicQuery` unconditionally added `accountEntryId = 0` and `contextName IS NULL` as further disjuncts. The common `AuditMessage` constructor hardcodes `accountEntryId=0` and `contextName=null`, so essentially every audit row matches those two disjuncts (verified: 17656 of 17656 rows), and in an OR query each one alone matched the whole table — with `companyId=0` giving no company scope either.

The fix guards both default clauses with `else if (andSearch)`. In conjunction mode (`andSearch=true`) — used by the audit REST resource and the audit web UI — the default filter is preserved. In disjunction mode — used only by the object entry converter — the query reduces to the entry primary key clause, restoring the pre-LPD-91075 behavior.

Root cause: **LPD-91075** (`904341206caf894fb232ee9b4181dc26c1e989eb`) introduced the two unconditional `else` branches when adding the `accountEntryIds` and `contextName` search parameters.

## PR Check

**pr-check: PASS** — tested on `6583143fae64ea528b63700700fc285c7bb0f1a3`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Baseline | PASS |

Verified locally on a PostgreSQL 16 bundle: `testGetObjectEntryWithAuditEvents` passes (entry-scoped, 2 events) and `AuditEventServiceTest.testGetAuditEvents` passes (the conjunction-mode default filter used by the REST resource and UI is unchanged).

<!-- pr-check {"result": "success", "sha": "6583143fae64ea528b63700700fc285c7bb0f1a3"} -->
