### PR TITLE
LPD-98268 Use TransactionCallbackUtil instead of the deprecated util

### DIFF
--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/src/main/java/com/liferay/headless/batch/engine/internal/resource/v1_0/ExportTaskResourceImpl.java
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/src/main/java/com/liferay/headless/batch/engine/internal/resource/v1_0/ExportTaskResourceImpl.java
@@ -15,7 +15,7 @@ import com.liferay.headless.batch.engine.internal.resource.v1_0.util.ParametersU
 import com.liferay.headless.batch.engine.resource.v1_0.ExportTaskResource;
 import com.liferay.petra.executor.PortalExecutorManager;
 import com.liferay.petra.io.StreamUtil;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -115,7 +115,7 @@ public class ExportTaskResourceImpl extends BaseExportTaskResourceImpl {
 		// transaction commits so the processing thread reads a fully
 		// persisted batch engine export task
 
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> executorService.submit(
 				() -> _batchEngineExportTaskExecutor.execute(
 					batchEngineExportTask)));

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/src/main/java/com/liferay/headless/batch/engine/internal/resource/v1_0/ImportTaskResourceImpl.java
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/src/main/java/com/liferay/headless/batch/engine/internal/resource/v1_0/ImportTaskResourceImpl.java
@@ -27,7 +27,7 @@ import com.liferay.petra.io.StreamUtil;
 import com.liferay.petra.io.unsync.UnsyncByteArrayInputStream;
 import com.liferay.petra.io.unsync.UnsyncByteArrayOutputStream;
 import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.util.File;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PropsUtil;
@@ -531,7 +531,7 @@ public class ImportTaskResourceImpl extends BaseImportTaskResourceImpl {
 		// transaction commits so the processing thread reads a fully
 		// persisted batch engine import task
 
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> executorService.submit(
 				() -> _batchEngineImportTaskExecutor.execute(
 					batchEngineImportTask)));


### PR DESCRIPTION
[LPD-98268](https://liferay.atlassian.net/browse/LPD-98268)

## What Is Being Fixed

Commit `1cb8431` (LPD-98268) introduced two calls to `TransactionCommitCallbackUtil.registerCallback(...)` in the batch engine REST resources. That class is `@Deprecated` (as of Cavanaugh / 7.4.x) and merely forwards to `TransactionCallbackUtil`.

## How It Is Being Fixed

Both call sites — and their imports — are switched to the non-deprecated `TransactionCallbackUtil.registerCommitCallback(...)`, which is exactly what the deprecated method delegates to, so the behavior is unchanged.

- `ExportTaskResourceImpl.java`
- `ImportTaskResourceImpl.java`

## PR Check

### Results Summary

| Validation | Result |
| --- | --- |
| Source Format | ✅ Pass |
| Per-Module Compile (`headless-batch-engine-impl`) | ✅ Pass |
| Baseline | N/A — internal packages only, no exported-API or `packageinfo` change |
| Integration / Unit | N/A — no test files in the diff |

Tested SHA: `bad957f95a9564c8c5edee7110e1b92c9c8d42e5`

<!-- pr-check {"result": "success", "sha": "bad957f95a9564c8c5edee7110e1b92c9c8d42e5"} -->
