### PR TITLE
LPD-93954 Add the shared AI Assistant suggestion variables

### DIFF
--- a/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/_variables.scss
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-js-components-web/src/main/resources/META-INF/resources/js/_variables.scss
@@ -1,0 +1,11 @@
+@import 'cadmin-variables';
+
+$ai-loading-gradient: linear-gradient(
+	135.99deg,
+	$cadmin-purple 4.37%,
+	$cadmin-primary 98.53%
+);
+
+$categorization-new-label-background-color: #f3effd;
+$categorization-new-label-border-color: #e3d9fb;
+$categorization-new-label-color: #6e3ad6;


### PR DESCRIPTION
## What Is Being Fixed

The `ai-hub-cell-js-components-web` module does not build on master. Both `js/Categorization/categorization.scss` and `js/AIAssistantChat/chat.scss` do `@import '../variables'`, but the `js/_variables.scss` partial they import is missing. The sass compilation fails, so the module's `packageRunBuild` (and any `ant all` deploy) fails.

## How It Is Being Fixed

Adds the missing `js/_variables.scss` partial. It imports `cadmin-variables` and defines the shared `$ai-loading-gradient` plus the categorization "new" label colors that both stylesheets reference. With the partial present, both compile and the module builds again. Standalone so it can merge ahead of the rest of the AI Assistant work and un-break master immediately.