### PR TITLE
LPD-99259 Hide Products and Commerce Classic Navigation fragments

### DIFF
--- a/modules/apps/commerce/commerce-order-content-web/src/main/java/com/liferay/commerce/order/content/web/internal/fragment/renderer/CommerceClassicNavigationFragmentRenderer.java
+++ b/modules/apps/commerce/commerce-order-content-web/src/main/java/com/liferay/commerce/order/content/web/internal/fragment/renderer/CommerceClassicNavigationFragmentRenderer.java
@@ -45,6 +45,11 @@ public class CommerceClassicNavigationFragmentRenderer
 	}
 
 	@Override
+	public boolean isSelectable(HttpServletRequest httpServletRequest) {
+		return false;
+	}
+
+	@Override
 	public void render(
 		FragmentRendererContext fragmentRendererContext,
 		HttpServletRequest httpServletRequest,

--- a/modules/apps/site/site-pim-site-initializer/src/main/java/com/liferay/site/pim/site/initializer/internal/fragment/renderer/ProductsSectionFragmentRenderer.java
+++ b/modules/apps/site/site-pim-site-initializer/src/main/java/com/liferay/site/pim/site/initializer/internal/fragment/renderer/ProductsSectionFragmentRenderer.java
@@ -39,6 +39,11 @@ public class ProductsSectionFragmentRenderer implements FragmentRenderer {
 	}
 
 	@Override
+	public boolean isSelectable(HttpServletRequest httpServletRequest) {
+		return false;
+	}
+
+	@Override
 	public void render(
 		FragmentRendererContext fragmentRendererContext,
 		HttpServletRequest httpServletRequest,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99259

## What Is Being Fixed

The Products and Commerce Classic Navigation fragments were offered in the page editor's fragment selection panel, but they are internal fragments that only work in the context of the sites that register them. Page authors could select them and drop them onto arbitrary pages where they do not belong.

## How It Is Being Fixed

Both fragment renderers now override `isSelectable` to return `false`, which hides them from the fragment selection panel while keeping them rendering on the pages that already use them.

## Why Are There No Tests?

The change is two `isSelectable` overrides that return a constant `false`, with no logic to exercise.

## PR Check

**pr-check: PASS** — tested on `ce93f05df1c04b03075b53406f344eace91d3525`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "ce93f05df1c04b03075b53406f344eace91d3525"} -->
