### PR TITLE
LPD-99354 Fix Design Library depot creation when LPD-57283 is off

### DIFF
--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/security/permission/wrapper/DepotPermissionCheckerWrapper.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/security/permission/wrapper/DepotPermissionCheckerWrapper.java
@@ -225,8 +225,14 @@ public class DepotPermissionCheckerWrapper extends PermissionCheckerWrapper {
 
 			Group group = _groupLocalService.fetchGroup(groupId);
 
+			if (group == null) {
+				return false;
+			}
+
 			return _isOrAddToPermissionCache(
-				group, DepotRoleNameUtil.getOwnerRoleName(_getSubtype(group)),
+				group,
+				DepotRoleNameUtil.getOwnerRoleName(
+					group.getCompanyId(), _getSubtype(group)),
 				this::_isGroupOwner);
 		}
 		catch (Exception exception) {
@@ -448,7 +454,9 @@ public class DepotPermissionCheckerWrapper extends PermissionCheckerWrapper {
 				DepotRoleNameUtil.getAdministratorRoleName(subtype), true) ||
 			_userGroupRoleLocalService.hasUserGroupRole(
 				getUserId(), liveGroup.getGroupId(),
-				DepotRoleNameUtil.getOwnerRoleName(subtype), true)) {
+				DepotRoleNameUtil.getOwnerRoleName(
+					liveGroup.getCompanyId(), subtype),
+				true)) {
 
 			return true;
 		}
@@ -501,7 +509,9 @@ public class DepotPermissionCheckerWrapper extends PermissionCheckerWrapper {
 
 		return _userGroupRoleLocalService.hasUserGroupRole(
 			getUserId(), liveGroup.getGroupId(),
-			DepotRoleNameUtil.getOwnerRoleName(_getSubtype(liveGroup)), true);
+			DepotRoleNameUtil.getOwnerRoleName(
+				liveGroup.getCompanyId(), _getSubtype(liveGroup)),
+			true);
 	}
 
 	private boolean _isOrAddToPermissionCache(

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/security/permission/wrapper/DepotPermissionCheckerWrapper.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/security/permission/wrapper/DepotPermissionCheckerWrapper.java
@@ -153,7 +153,7 @@ public class DepotPermissionCheckerWrapper extends PermissionCheckerWrapper {
 			return _isOrAddToPermissionCache(
 				group,
 				DepotRoleNameUtil.getContentReviewerRoleName(
-					_getSubtype(group)),
+					companyId, _getSubtype(group)),
 				this::_isContentReviewer);
 		}
 		catch (Exception exception) {
@@ -176,13 +176,18 @@ public class DepotPermissionCheckerWrapper extends PermissionCheckerWrapper {
 
 			Group group = _groupLocalService.fetchGroup(groupId);
 
+			if (group == null) {
+				return false;
+			}
+
 			if (_isCMSAdministrator(group)) {
 				return true;
 			}
 
 			return _isOrAddToPermissionCache(
 				group,
-				DepotRoleNameUtil.getAdministratorRoleName(_getSubtype(group)),
+				DepotRoleNameUtil.getAdministratorRoleName(
+					group.getCompanyId(), _getSubtype(group)),
 				this::_isGroupAdmin);
 		}
 		catch (Exception exception) {
@@ -323,7 +328,7 @@ public class DepotPermissionCheckerWrapper extends PermissionCheckerWrapper {
 								subtype, DepotRolesConstants.SUBTYPE_PROJECT) &&
 							Objects.equals(
 								DepotRoleNameUtil.getAdministratorRoleName(
-									subtype),
+									getCompanyId(), subtype),
 								role.getName())) {
 
 							return null;
@@ -396,7 +401,7 @@ public class DepotPermissionCheckerWrapper extends PermissionCheckerWrapper {
 		return _userGroupRoleLocalService.hasUserGroupRole(
 			getUserId(), liveGroup.getGroupId(),
 			DepotRoleNameUtil.getContentReviewerRoleName(
-				_getSubtype(liveGroup)),
+				liveGroup.getCompanyId(), _getSubtype(liveGroup)),
 			true);
 	}
 
@@ -451,7 +456,9 @@ public class DepotPermissionCheckerWrapper extends PermissionCheckerWrapper {
 
 		if (_userGroupRoleLocalService.hasUserGroupRole(
 				getUserId(), liveGroup.getGroupId(),
-				DepotRoleNameUtil.getAdministratorRoleName(subtype), true) ||
+				DepotRoleNameUtil.getAdministratorRoleName(
+					liveGroup.getCompanyId(), subtype),
+				true) ||
 			_userGroupRoleLocalService.hasUserGroupRole(
 				getUserId(), liveGroup.getGroupId(),
 				DepotRoleNameUtil.getOwnerRoleName(
@@ -492,7 +499,8 @@ public class DepotPermissionCheckerWrapper extends PermissionCheckerWrapper {
 				DepotRolesConstants.ASSET_LIBRARY_CONNECTED_SITE_MEMBER) ||
 			_hasRole(
 				liveGroup.getCompanyId(), roleIds,
-				DepotRoleNameUtil.getMemberRoleName(_getSubtype(liveGroup)))) {
+				DepotRoleNameUtil.getMemberRoleName(
+					liveGroup.getCompanyId(), _getSubtype(liveGroup)))) {
 
 			return true;
 		}

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/util/DepotRoleNameUtil.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/util/DepotRoleNameUtil.java
@@ -6,6 +6,7 @@
 package com.liferay.depot.internal.util;
 
 import com.liferay.depot.constants.DepotRolesConstants;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 
 import java.util.Objects;
 
@@ -50,9 +51,10 @@ public class DepotRoleNameUtil {
 		return DepotRolesConstants.ASSET_LIBRARY_MEMBER;
 	}
 
-	public static String getOwnerRoleName(String subtype) {
+	public static String getOwnerRoleName(long companyId, String subtype) {
 		if (Objects.equals(
-				subtype, DepotRolesConstants.SUBTYPE_DESIGN_LIBRARY)) {
+				subtype, DepotRolesConstants.SUBTYPE_DESIGN_LIBRARY) &&
+			FeatureFlagManagerUtil.isEnabled(companyId, "LPD-57283")) {
 
 			return DepotRolesConstants.DESIGN_LIBRARY_OWNER;
 		}

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/util/DepotRoleNameUtil.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/util/DepotRoleNameUtil.java
@@ -15,9 +15,12 @@ import java.util.Objects;
  */
 public class DepotRoleNameUtil {
 
-	public static String getAdministratorRoleName(String subtype) {
+	public static String getAdministratorRoleName(
+		long companyId, String subtype) {
+
 		if (Objects.equals(
-				subtype, DepotRolesConstants.SUBTYPE_DESIGN_LIBRARY)) {
+				subtype, DepotRolesConstants.SUBTYPE_DESIGN_LIBRARY) &&
+			FeatureFlagManagerUtil.isEnabled(companyId, "LPD-57283")) {
 
 			return DepotRolesConstants.DESIGN_LIBRARY_ADMINISTRATOR;
 		}
@@ -28,9 +31,12 @@ public class DepotRoleNameUtil {
 		return DepotRolesConstants.ASSET_LIBRARY_ADMINISTRATOR;
 	}
 
-	public static String getContentReviewerRoleName(String subtype) {
+	public static String getContentReviewerRoleName(
+		long companyId, String subtype) {
+
 		if (Objects.equals(
-				subtype, DepotRolesConstants.SUBTYPE_DESIGN_LIBRARY)) {
+				subtype, DepotRolesConstants.SUBTYPE_DESIGN_LIBRARY) &&
+			FeatureFlagManagerUtil.isEnabled(companyId, "LPD-57283")) {
 
 			return DepotRolesConstants.DESIGN_LIBRARY_CONTENT_REVIEWER;
 		}
@@ -38,9 +44,10 @@ public class DepotRoleNameUtil {
 		return DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER;
 	}
 
-	public static String getMemberRoleName(String subtype) {
+	public static String getMemberRoleName(long companyId, String subtype) {
 		if (Objects.equals(
-				subtype, DepotRolesConstants.SUBTYPE_DESIGN_LIBRARY)) {
+				subtype, DepotRolesConstants.SUBTYPE_DESIGN_LIBRARY) &&
+			FeatureFlagManagerUtil.isEnabled(companyId, "LPD-57283")) {
 
 			return DepotRolesConstants.DESIGN_LIBRARY_MEMBER;
 		}

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/impl/DepotEntryLocalServiceImpl.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/impl/DepotEntryLocalServiceImpl.java
@@ -147,6 +147,7 @@ public class DepotEntryLocalServiceImpl extends DepotEntryLocalServiceBaseImpl {
 			Role role = _roleLocalService.getRole(
 				group.getCompanyId(),
 				DepotRoleNameUtil.getOwnerRoleName(
+					group.getCompanyId(),
 					DepotRolesConstants.getSubtype(type)));
 
 			_userGroupRoleLocalService.addUserGroupRoles(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99354

## What Is Being Fixed

Creating a Design Library depot (`DepotConstants.TYPE_DESIGN_LIBRARY`) throws `NoSuchRoleException: No Role exists with the key {..., name=design library owner}` whenever the `LPD-57283` feature flag is disabled. This is a regression from `LPD-98812`, which changed `DepotEntryLocalServiceImpl.addDepotEntry` to resolve the owner role from the depot subtype and look up the `Design Library Owner` role. That role is only created when `LPD-57283` is enabled (by the portal instance lifecycle listener at startup, or the feature flag listener when the flag is toggled on), so with the flag off the lookup fails and depot creation aborts. Before `LPD-98812`, `addDepotEntry` always used the always-present `Asset Library Owner` role.

## How It Is Being Fixed

`DepotRoleNameUtil.getOwnerRoleName` now takes the company id and returns `DESIGN_LIBRARY_OWNER` only when the subtype is design-library and `LPD-57283` is enabled, falling back to `ASSET_LIBRARY_OWNER` otherwise. This restores the pre-`LPD-98812` behavior when the feature is off and preserves it when on. `DepotEntryLocalServiceImpl` and the three owner-role lookups in `DepotPermissionCheckerWrapper` pass the company id so depot creation and owner permission checks resolve the role the same way. `isGroupOwner` gains an explicit null-group guard so the company-id lookup is safe (a null group already resolved to `false` before).

## Why Are There No Tests?

The regression is already covered by the existing integration test `AddFragmentEntryLinksMVCActionCommandTest#testAddFragmentEntryLinks`, which creates a Design Library depot and failed with this `NoSuchRoleException` before the fix and passes after it.

## PR Check

**pr-check: PASS** — tested on `e8e81cefb2357b13773894cb0d7ccc720dc1e302`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Cross-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "e8e81cefb2357b13773894cb0d7ccc720dc1e302"} -->

