### PR TITLE
LPD-99413 List manyToMany relationships in the object entry form

### DIFF
--- a/modules/apps/object/object-info-api/src/main/java/com/liferay/object/info/item/provider/util/ObjectEntryInfoItemFormProviderUtil.java
+++ b/modules/apps/object/object-info-api/src/main/java/com/liferay/object/info/item/provider/util/ObjectEntryInfoItemFormProviderUtil.java
@@ -42,9 +42,11 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.template.info.item.provider.TemplateInfoItemFieldSetProvider;
 
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * @author Carolina Barbosa
@@ -375,11 +377,30 @@ public class ObjectEntryInfoItemFormProviderUtil {
 							name, namespace));
 				}
 
+				Set<ObjectRelationship> objectRelationships =
+					new LinkedHashSet<>(
+						ObjectRelationshipLocalServiceUtil.
+							getObjectRelationships(
+								objectDefinition.getObjectDefinitionId(),
+								true));
+
 				for (ObjectRelationship objectRelationship :
 						ObjectRelationshipLocalServiceUtil.
 							getObjectRelationships(
 								objectDefinition.getObjectDefinitionId(),
-								true)) {
+								ObjectRelationshipConstants.
+									DELETION_TYPE_DISASSOCIATE,
+								false)) {
+
+					if (objectRelationship.compareType(
+							ObjectRelationshipConstants.TYPE_MANY_TO_MANY)) {
+
+						objectRelationships.add(objectRelationship);
+					}
+				}
+
+				for (ObjectRelationship objectRelationship :
+						objectRelationships) {
 
 					unsafeConsumer.accept(
 						objectFieldInfoFieldConverter.

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/info/item/provider/test/ObjectEntryInfoItemFormProviderTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/info/item/provider/test/ObjectEntryInfoItemFormProviderTest.java
@@ -9,6 +9,7 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.info.field.InfoField;
 import com.liferay.info.field.InfoFieldSet;
 import com.liferay.info.field.type.OptionInfoFieldType;
+import com.liferay.info.field.type.RelationshipInfoFieldType;
 import com.liferay.info.field.type.SelectInfoFieldType;
 import com.liferay.info.form.InfoForm;
 import com.liferay.info.item.InfoItemReference;
@@ -27,6 +28,7 @@ import com.liferay.object.constants.ObjectActionExecutorConstants;
 import com.liferay.object.constants.ObjectActionTriggerConstants;
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectFieldSettingConstants;
+import com.liferay.object.constants.ObjectRelationshipConstants;
 import com.liferay.object.field.builder.AttachmentObjectFieldBuilder;
 import com.liferay.object.field.builder.PicklistObjectFieldBuilder;
 import com.liferay.object.field.builder.TextObjectFieldBuilder;
@@ -68,6 +70,7 @@ import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.props.test.util.PropsTemporarySwapper;
 import com.liferay.portal.test.rule.FeatureFlag;
@@ -253,6 +256,7 @@ public class ObjectEntryInfoItemFormProviderTest {
 		_testGetInfoFormWithAttachmentObjectField();
 		_testGetInfoFormWithEdgeObjectRelationship();
 		_testGetInfoFormWithEnableObjectEntrySchedule();
+		_testGetInfoFormWithManyToManyObjectRelationship();
 		_testGetInfoFormWithObjectAction();
 		_testGetInfoFormWithObjectRelationship();
 		_testGetInfoFormWithPicklistObjectField();
@@ -429,6 +433,31 @@ public class ObjectEntryInfoItemFormProviderTest {
 		_assertInfoField(true, "displayDate", _childInfoForm);
 		_assertInfoField(true, "expirationDate", _childInfoForm);
 		_assertInfoField(true, "reviewDate", _childInfoForm);
+	}
+
+	private void _testGetInfoFormWithManyToManyObjectRelationship()
+		throws Exception {
+
+		ObjectRelationship objectRelationship =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				_objectRelationshipLocalService, _parentObjectDefinition,
+				_childObjectDefinition,
+				ObjectRelationshipConstants.DELETION_TYPE_DISASSOCIATE,
+				StringUtil.randomId(),
+				ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
+		InfoForm infoForm = _getInfoForm(_parentObjectDefinition);
+
+		InfoField infoField = infoForm.getInfoField(
+			ObjectRelationshipConstants.OBJECT_RELATIONSHIP_FIELD_NAME_PREFIX +
+				objectRelationship.getName());
+
+		Assert.assertNotNull(infoField);
+		Assert.assertEquals(
+			RelationshipInfoFieldType.INSTANCE, infoField.getInfoFieldType());
+		Assert.assertTrue(
+			(boolean)infoField.getAttribute(
+				RelationshipInfoFieldType.MULTIPLE));
 	}
 
 	private void _testGetInfoFormWithObjectAction() throws Exception {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99413

## What Is Being Fixed

A CMS Content Structure with a "Select Related Content" field set to multiselection could not be used to create content. The field was missing from the content editor, and saving failed with "An error occurred while sending the form information."

## How It Is Being Fixed

The multiselection "Select Related Content" field is stored as a manyToMany object relationship (deletion type disassociate, no edge flag). Commit LPD-84614 changed the object entry form provider to list only edge relationships as relationship fields, which dropped these manyToMany relationships from the form. The save path still processed them, so it read a field value that was never submitted and failed with a generic InfoFormException. The form provider now lists edge relationships together with the manyToMany disassociate relationships the save path expects, restoring consistency between form rendering and saving.

## PR Check

**pr-check: PASS** — tested on `20e31c4d15b00ac8b63121001f570fe26e9498af`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "20e31c4d15b00ac8b63121001f570fe26e9498af"} -->
