### PR TITLE
LPD-99432 Clean up the workflow handler test tree in tearDown

### DIFF
--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/workflow/test/ObjectEntryWorkflowHandlerTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/workflow/test/ObjectEntryWorkflowHandlerTest.java
@@ -51,6 +51,7 @@ import java.io.Serializable;
 import java.util.Collections;
 import java.util.List;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -84,6 +85,14 @@ public class ObjectEntryWorkflowHandlerTest {
 			_group.getGroupId(), TestPropsValues.getUserId());
 
 		_serviceContext.setWorkflowAction(WorkflowConstants.ACTION_PUBLISH);
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		TreeTestUtil.deleteObjectDefinitionHierarchy(
+			_objectDefinitionLocalService,
+			new String[] {"C_A", "C_AA", "C_AB", "C_AAA", "C_AAB"},
+			_objectEntryLocalService, _objectRelationshipLocalService);
 	}
 
 	@Test
@@ -191,11 +200,6 @@ public class ObjectEntryWorkflowHandlerTest {
 			workflowHandler.getEntryClassPK(
 				TestPropsValues.getCompanyId(), mockHttpServletRequest,
 				workflowTask));
-
-		TreeTestUtil.deleteObjectDefinitionHierarchy(
-			_objectDefinitionLocalService,
-			new String[] {"C_A", "C_AA", "C_AB", "C_AAA", "C_AAB"},
-			_objectEntryLocalService, _objectRelationshipLocalService);
 	}
 
 	@Test


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99432

## What Is Being Fixed

`ObjectEntryWorkflowHandlerTest.testGetEntryClassPK` builds a fixed-name object definition tree (`C_A`, `C_AA`, `C_AB`, `C_AAA`, `C_AAB`) and deleted it **inline** at the end of the method. When the method fails before reaching that inline cleanup, the data guard rule removes the definition rows but their backing DDL tables (`o_<companyId>_<shortName>`, e.g. `o_<companyId>_a`) are left behind. Later object test classes that build the same fixed-name tree then fail their `CREATE TABLE` with `relation o_<companyId>_a already exists`, cascading into ~20 downstream failures (`ObjectEntryServiceTest`, `ObjectEntryLocalServiceTest`, `TreeTest`, `ObjectDefinitionLocalServiceTest`) when the whole suite runs in one JVM.

## How It Is Being Fixed

The leaker was pinned by instrumenting `ObjectDefinitionLocalServiceImpl.runSQL` to log a stack trace on every create/drop of the `o_<companyId>_a` table and running the full object-test suite — the log showed matched create/drop pairs until `testGetEntryClassPK` created the table with no following drop, after which every later tree test collided on it.

The fix moves the `deleteObjectDefinitionHierarchy` call from the end of `testGetEntryClassPK` to an `@After tearDown`, so the tree and its tables are removed even when the test body fails. This mirrors the sibling `ObjectEntryModelListenerTest`, which already cleans up in `@After`. Running the full object-test suite went from 33 failures to 10 (the entire orphan-table cascade cleared).

## PR Check

**pr-check: PASS** — tested on `2d16403f0db73561548c7c4cf3ea92c888217729`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |

<!-- pr-check {"result": "success", "sha": "2d16403f0db73561548c7c4cf3ea92c888217729"} -->
