### PR TITLE
LPD-99059 Fix OutOfMemoryError exporting a site with object entries

### DIFF
--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineExportTaskExecutorImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineExportTaskExecutorImpl.java
@@ -35,12 +35,8 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.module.configuration.ConfigurationException;
-import com.liferay.portal.kernel.search.BooleanClauseOccur;
-import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Sort;
-import com.liferay.portal.kernel.search.filter.BooleanFilter;
 import com.liferay.portal.kernel.search.filter.Filter;
-import com.liferay.portal.kernel.search.filter.RangeTermFilter;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
@@ -64,8 +60,6 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
-
-import java.lang.reflect.Method;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -231,24 +225,6 @@ public class BatchEngineExportTaskExecutorImpl
 		LastSessionRecorderHelperUtil.syncLastSessionState();
 	}
 
-	private Filter _createCursorFilter(
-		long lastEntryClassPK, Filter originalFilter) {
-
-		BooleanFilter booleanFilter = new BooleanFilter();
-
-		if (originalFilter != null) {
-			booleanFilter.add(originalFilter, BooleanClauseOccur.MUST);
-		}
-
-		booleanFilter.add(
-			new RangeTermFilter(
-				Field.ENTRY_CLASS_PK, false, false,
-				String.valueOf(lastEntryClassPK), null),
-			BooleanClauseOccur.MUST);
-
-		return booleanFilter;
-	}
-
 	private InputStream _exportItems(
 			BatchEngineExportTask batchEngineExportTask, Settings settings)
 		throws Exception {
@@ -315,8 +291,6 @@ public class BatchEngineExportTaskExecutorImpl
 			Sort[] sorts = _getSorts(
 				batchEngineTaskItemDelegate, parameters, user);
 
-			boolean cursorPaginationActive = _isCursorPaginationEnabled(sorts);
-
 			Page<?> page = batchEngineTaskItemDelegate.read(
 				filter, Pagination.of(1, exportBatchSize), sorts,
 				filteredParameters, (String)parameters.get("search"));
@@ -381,27 +355,10 @@ public class BatchEngineExportTaskExecutorImpl
 					break;
 				}
 
-				Long lastItemId = null;
-
-				if (cursorPaginationActive) {
-					lastItemId = _getLastItemId(items);
-
-					if (lastItemId == null) {
-						cursorPaginationActive = false;
-					}
-				}
-
-				Filter readFilter = filter;
-				Pagination pagination = Pagination.of(
-					(int)page.getPage() + 1, exportBatchSize);
-
-				if (cursorPaginationActive) {
-					readFilter = _createCursorFilter(lastItemId, filter);
-					pagination = Pagination.of(1, exportBatchSize);
-				}
-
 				page = batchEngineTaskItemDelegate.read(
-					readFilter, pagination, sorts, filteredParameters,
+					filter,
+					Pagination.of((int)page.getPage() + 1, exportBatchSize),
+					sorts, filteredParameters,
 					(String)parameters.get("search"));
 
 				items = page.getItems();
@@ -546,47 +503,6 @@ public class BatchEngineExportTaskExecutorImpl
 		return filteredParameters;
 	}
 
-	private Long _getItemId(Object item) {
-		Class<?> clazz = item.getClass();
-
-		try {
-			Method method = clazz.getMethod("getId");
-
-			Object id = method.invoke(item);
-
-			if (id instanceof Long) {
-				return (Long)id;
-			}
-
-			if (id instanceof Number) {
-				Number number = (Number)id;
-
-				return number.longValue();
-			}
-		}
-		catch (Exception exception) {
-			if (_log.isDebugEnabled()) {
-				_log.debug("Unable to extract ID from " + clazz, exception);
-			}
-		}
-
-		return null;
-	}
-
-	private Long _getLastItemId(Collection<?> items) {
-		if (items.isEmpty()) {
-			return null;
-		}
-
-		Object lastItem = null;
-
-		for (Object item : items) {
-			lastItem = item;
-		}
-
-		return _getItemId(lastItem);
-	}
-
 	private Map<String, Serializable> _getParameters(
 		BatchEngineExportTask batchEngineExportTask) {
 
@@ -658,14 +574,6 @@ public class BatchEngineExportTaskExecutorImpl
 		zipOutputStream.putNextEntry(zipEntry);
 
 		return zipOutputStream;
-	}
-
-	private boolean _isCursorPaginationEnabled(Sort[] sorts) {
-		if (sorts == null) {
-			return true;
-		}
-
-		return false;
 	}
 
 	private Map<String, List<String>> _toMultivaluedMap(

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
@@ -1746,6 +1746,52 @@ public class BatchEnginePortletDataHandlerTest {
 	}
 
 	@Test
+	@TestInfo("LPD-99059")
+	public void testExportSiteObjectEntriesExceedingExportBatchSize()
+		throws Exception {
+
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				ObjectDefinitionTestUtil.getRandomName(),
+				Collections.singletonList(
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+						ObjectFieldConstants.DB_TYPE_STRING, true, true, null,
+						RandomTestUtil.randomString(), "textField", false)),
+				ObjectDefinitionConstants.SCOPE_SITE);
+
+		Group group = GroupTestUtil.addGroup();
+
+		int objectEntriesCount = 150;
+
+		for (int i = 0; i < objectEntriesCount; i++) {
+			_objectEntryLocalService.addObjectEntry(
+				group.getGroupId(), TestPropsValues.getUserId(),
+				objectDefinition.getObjectDefinitionId(),
+				ObjectEntryFolderConstants.
+					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+				null,
+				HashMapBuilder.<String, Serializable>put(
+					"textField", RandomTestUtil.randomString()
+				).build(),
+				ServiceContextTestUtil.getServiceContext());
+		}
+
+		File larFile = new ExportImportExecutor(
+		).withGroupId(
+			group.getGroupId()
+		).withObjectEntries(
+			objectDefinition
+		).executeExport();
+
+		JSONArray jsonArray = _getExportedObjectEntriesJSONArray(
+			objectDefinition.getExternalReferenceCode(), larFile,
+			group.getGroupId());
+
+		Assert.assertEquals(objectEntriesCount, jsonArray.length());
+	}
+
+	@Test
 	public void testGetDescriptionAndTagWithObjectDefinitionHierarchy()
 		throws Exception {
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99059

## What Is Being Fixed

Exporting a site that contains a site-scoped object definition with more entries than one export batch never terminates and eventually throws java.lang.OutOfMemoryError: Java heap space.

The batch engine export enabled cursor pagination for every export without a sort (LPD-81551, finalized in LPD-85155). Cursor pagination freezes pagination at the first page and advances by passing a RangeTermFilter on ENTRY_CLASS_PK to the delegate's read method. This only works for delegates that apply that filter and return items ordered by ascending ENTRY_CLASS_PK. Delegates that cannot — object entries, and the relationship-scoped read paths of several headless resources — page through the database and ignore the filter, so the cursor never advanced: the export re-read the same page into an in-memory buffer until the JVM ran out of heap. A progress guard that would have caught this was removed in LPD-85155.

## How It Is Being Fixed

Cursor pagination is removed from the batch engine export, which now uses offset pagination for every delegate. Offset pagination walks all pages correctly regardless of whether a delegate honors the filter, so it eliminates the entire class of failure at once — the object-entry OOM, the parameter-driven database-offset branches of other delegates, and any future delegate that cannot support the cursor contract — without a fragile per-delegate opt-in or a runtime fallback guard. A regression integration test exports a site-scoped object definition with more entries than the export batch size and asserts every entry is present in the LAR.

The read-time degradation that originally motivated cursor pagination (LPD-76657) can be addressed later without sacrificing correctness.

## PR Check

**pr-check: PASS** — tested on `9138148eb3c7c134eeb0a06b03a699bbc92a16c3`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "9138148eb3c7c134eeb0a06b03a699bbc92a16c3"} -->
