### PR TITLE
LPD-99499 Deindex object fields when deleting an object definition

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldLocalServiceImpl.java
@@ -91,6 +91,8 @@ import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.module.service.Snapshot;
 import com.liferay.portal.kernel.search.Indexable;
 import com.liferay.portal.kernel.search.IndexableType;
+import com.liferay.portal.kernel.search.Indexer;
+import com.liferay.portal.kernel.search.IndexerRegistryUtil;
 import com.liferay.portal.kernel.security.permission.ResourceActions;
 import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
@@ -365,6 +367,9 @@ public class ObjectFieldLocalServiceImpl
 		ObjectDefinition objectDefinition =
 			_objectDefinitionPersistence.findByPrimaryKey(objectDefinitionId);
 
+		Indexer<ObjectField> indexer = IndexerRegistryUtil.nullSafeGetIndexer(
+			ObjectField.class);
+
 		for (ObjectField objectField :
 				objectFieldPersistence.findByObjectDefinitionId(
 					objectDefinitionId)) {
@@ -374,6 +379,8 @@ public class ObjectFieldLocalServiceImpl
 			}
 
 			objectFieldPersistence.remove(objectField);
+
+			indexer.delete(objectField);
 
 			if (FeatureFlagManagerUtil.isEnabled(
 					objectField.getCompanyId(), "LPD-17564") &&


### PR DESCRIPTION
[LPD-99499](https://liferay.atlassian.net/browse/LPD-99499)

## What Is Being Fixed

Deleting an object definition orphans its object fields' search documents. `ObjectFieldLocalServiceImpl.deleteObjectFieldByObjectDefinitionId` removes each field via a raw `objectFieldPersistence.remove`, which bypasses the `@Indexable(DELETE)` advice on the service delete methods. Object fields have been a searchable model since LPS-136480, so they are indexed on creation but never deindexed on definition deletion — the orphaned `ObjectField` documents accumulate unbounded in the shared search index while the database stays clean. A single `DefaultObjectEntryManagerImplTest` run (~1000 definitions) leaves ~14,000 orphaned documents.

Root cause: `66a7006ce2d89dcd7c3877cf9e633c818c60d434` (LPS-148810, "Avoid attempt to delete relationship field twice") introduced `deleteObjectFieldByObjectDefinitionId` with the raw remove and never gained the matching deindex.

## How It Is Being Fixed

Delete each object field's document directly through its `Indexer` (`IndexerRegistryUtil.nullSafeGetIndexer(ObjectField.class).delete(objectField)`) inside `deleteObjectFieldByObjectDefinitionId`. The AOP delete cannot be reused here: `@Indexable` defers the search delete until after the surrounding transaction commits, by which point the object definition is already deleted and `ObjectEntryModelDocumentContributor` throws a `NullPointerException` resolving the now null definition. The direct indexer delete runs while the definition still exists.

## PR Check

**pr-check: PASS** — tested on `594718373b220546e9a67eed06b7560799d65f85`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result":"success","sha":"594718373b220546e9a67eed06b7560799d65f85"} -->
