### PR TITLE
LPD-99501 Create the CMS test group as the guest user to match production

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-test-util/src/main/java/com/liferay/site/cms/site/initializer/test/util/CMSTestUtil.java
+++ b/modules/apps/site/site-cms-site-initializer-test-util/src/main/java/com/liferay/site/cms/site/initializer/test/util/CMSTestUtil.java
@@ -17,6 +17,7 @@ import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUti
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -30,15 +31,23 @@ import com.liferay.site.initializer.SiteInitializerRegistry;
 public class CMSTestUtil {
 
 	public static Group getOrAddGroup(Class<?> clazz) throws Exception {
+		long companyId = TestPropsValues.getCompanyId();
+
 		Group group = GroupLocalServiceUtil.fetchGroup(
-			TestPropsValues.getCompanyId(), GroupConstants.CMS);
+			companyId, GroupConstants.CMS);
 
 		if (group != null) {
 			return group;
 		}
 
+		// Create the group with the guest user as the creator, exactly as the
+		// production GroupLocalServiceImpl.checkSystemGroups path provisions
+		// the CMS system group. A non-guest creator would be added as the
+		// site owner and a group member, which production never does, and
+		// that membership would dangle once the group is removed.
+
 		group = GroupTestUtil.addGroup(
-			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(), 0,
+			companyId, UserLocalServiceUtil.getGuestUserId(companyId), 0,
 			GroupConstants.CMS);
 
 		PermissionChecker originalPermissionChecker =


### PR DESCRIPTION
[LPD-99501](https://liferay.atlassian.net/browse/LPD-99501) / [LPD-99502](https://liferay.atlassian.net/browse/LPD-99502)

## What Is Being Fixed

`CMSTestUtil.getOrAddGroup` created the CMS system group with the shared test admin as the creator, which added the admin to `Users_Groups` as the site owner. Because `CMS` is a reserved system group, DataGuard cannot delete the test-created group through `deleteGroup` (it throws `MustNotDeleteSystemGroup`) and falls back to a raw session delete that drops the `Group_` row without clearing the `Users_Groups` mappings. The admin membership is left dangling, and any later test that serializes that admin fails in `UserAccount.getSiteBriefs` with `NoSuchGroupException` — breaking `ObjectEntryRelatedObjectsResourceTest` and other tests across every module that uses this fixture (~46 callers). Production never creates this membership: `CMSFeatureFlagListener` provisions the CMS group via `checkSystemGroups` with the guest user.

## How It Is Being Fixed

Create the CMS group with the guest user as the creator in `CMSTestUtil.getOrAddGroup`, exactly as production's `checkSystemGroups`. The guest creator skips the creator-membership branch (`!user.isGuestUser()`), so the group has no owner and no member and nothing dangles after DataGuard cleanup.

## PR Check

**pr-check: PASS** — tested on `0c878a21aea7a2ac8b5963e166346425fe095cb7`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Baseline | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

CI validation (self-PR shuyangzhou#12390, byte-identical content): `ci:test:stable` PASSED; `ci:test:relevant` no regression.

<!-- pr-check {"result": "success", "sha": "0c878a21aea7a2ac8b5963e166346425fe095cb7"} -->
