### PR TITLE
LPD-97811 Link CMS assets to CMP projects and tasks

### DIFF
--- a/modules/apps/headless/headless-cmp/headless-cmp-impl/src/main/java/com/liferay/headless/cmp/internal/resource/v1_0/TaskStatisticsResourceImpl.java
+++ b/modules/apps/headless/headless-cmp/headless-cmp-impl/src/main/java/com/liferay/headless/cmp/internal/resource/v1_0/TaskStatisticsResourceImpl.java
@@ -75,51 +75,52 @@ public class TaskStatisticsResourceImpl extends BaseTaskStatisticsResourceImpl {
 	}
 
 	private long _getCount(
-			String filterString, ObjectEntry projectObjectEntry,
-			ObjectDefinition taskObjectDefinition)
+			ObjectEntry cmpProjectObjectEntry,
+			ObjectDefinition cmpTaskObjectDefinition, String filterString)
 		throws Exception {
 
 		List<Long> groupIds = new ArrayList<>();
 
-		if (projectObjectEntry == null) {
+		if (cmpProjectObjectEntry == null) {
 			groupIds = transform(
 				_depotEntryLocalService.getDepotEntries(
 					contextCompany.getCompanyId(), DepotConstants.TYPE_PROJECT),
 				DepotEntryModel::getGroupId);
 		}
 		else {
-			groupIds.add(projectObjectEntry.getGroupId());
+			groupIds.add(cmpProjectObjectEntry.getGroupId());
 		}
 
 		return _objectEntryLocalService.getValuesListCount(
 			groupIds.toArray(new Long[0]), 0, 0,
-			taskObjectDefinition.getObjectDefinitionId(),
-			_filterFactory.create(filterString, taskObjectDefinition), true,
+			cmpTaskObjectDefinition.getObjectDefinitionId(),
+			_filterFactory.create(filterString, cmpTaskObjectDefinition), true,
 			null);
 	}
 
 	private TaskStatistics _toTaskStatistics(
-		ObjectEntry projectObjectEntry, ObjectDefinition taskObjectDefinition) {
+		ObjectEntry cmpProjectObjectEntry,
+		ObjectDefinition cmpTaskObjectDefinition) {
 
 		return new TaskStatistics() {
 			{
 				setBlockedCount(
 					() -> _getCount(
-						"state eq 'blocked'", projectObjectEntry,
-						taskObjectDefinition));
+						cmpProjectObjectEntry, cmpTaskObjectDefinition,
+						"state eq 'blocked'"));
 				setInProgressCount(
 					() -> _getCount(
-						"state eq 'inProgress'", projectObjectEntry,
-						taskObjectDefinition));
+						cmpProjectObjectEntry, cmpTaskObjectDefinition,
+						"state eq 'inProgress'"));
 				setOverdueCount(
 					() -> _getCount(
+						cmpProjectObjectEntry, cmpTaskObjectDefinition,
 						"dueDate lt " + LocalDate.now() +
-							" and state ne 'done'",
-						projectObjectEntry, taskObjectDefinition));
+							" and state ne 'done'"));
 				setTotalCount(
 					() -> _getCount(
-						StringPool.BLANK, projectObjectEntry,
-						taskObjectDefinition));
+						cmpProjectObjectEntry, cmpTaskObjectDefinition,
+						StringPool.BLANK));
 			}
 		};
 	}

--- a/modules/apps/headless/headless-cmp/headless-cmp-test/src/testIntegration/java/com/liferay/headless/cmp/resource/v1_0/test/ContentCoverageResourceTest.java
+++ b/modules/apps/headless/headless-cmp/headless-cmp-test/src/testIntegration/java/com/liferay/headless/cmp/resource/v1_0/test/ContentCoverageResourceTest.java
@@ -117,6 +117,20 @@ public class ContentCoverageResourceTest
 	public void testGraphQLGetProjectContentCoverageNotFound() {
 	}
 
+	private ObjectEntry _addCMPProjectObjectEntry(
+			long[] assetCategoryIds, String assetTagName)
+		throws Exception {
+
+		ObjectEntry objectEntry = CMPTestUtil.addCMPProjectObjectEntry();
+
+		_partialUpdateObjectEntry(assetCategoryIds, new String[0], objectEntry);
+		_partialUpdateObjectEntry(
+			new long[0], new String[] {assetTagName},
+			CMPTestUtil.addCMPTaskObjectEntry(objectEntry));
+
+		return objectEntry;
+	}
+
 	private ObjectEntry _addContentObjectEntry(
 			long[] assetCategoryIds, String[] assetTagNames)
 		throws Exception {
@@ -158,20 +172,6 @@ public class ContentCoverageResourceTest
 		_objectEntryLocalService.updateStatus(
 			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(), status,
 			ServiceContextTestUtil.getServiceContext(_depotEntry.getGroupId()));
-	}
-
-	private ObjectEntry _addProjectObjectEntry(
-			long[] assetCategoryIds, String assetTagName)
-		throws Exception {
-
-		ObjectEntry objectEntry = CMPTestUtil.addProjectObjectEntry();
-
-		_partialUpdateObjectEntry(assetCategoryIds, new String[0], objectEntry);
-		_partialUpdateObjectEntry(
-			new long[0], new String[] {assetTagName},
-			CMPTestUtil.addTaskObjectEntry(objectEntry));
-
-		return objectEntry;
 	}
 
 	private void _assertContentCoverage(
@@ -218,7 +218,7 @@ public class ContentCoverageResourceTest
 
 		String assetTagName = "L_CMP_TASK_" + RandomTestUtil.randomString(10);
 
-		ObjectEntry objectEntry = _addProjectObjectEntry(
+		ObjectEntry objectEntry = _addCMPProjectObjectEntry(
 			new long[] {awarenessAssetCategory.getCategoryId()}, assetTagName);
 
 		_addContentObjectEntry(new long[0], new String[] {assetTagName});
@@ -256,7 +256,7 @@ public class ContentCoverageResourceTest
 
 		String assetTagName = "L_CMP_TASK_" + RandomTestUtil.randomString(10);
 
-		ObjectEntry projectObjectEntry = _addProjectObjectEntry(
+		ObjectEntry cmpProjectObjectEntry = _addCMPProjectObjectEntry(
 			new long[] {
 				awarenessAssetCategory.getCategoryId(),
 				championAssetCategory.getCategoryId(),
@@ -331,7 +331,7 @@ public class ContentCoverageResourceTest
 				new AssetCategory[] {
 					championAssetCategory, decisionMakerAssetCategory
 				}),
-			projectObjectEntry);
+			cmpProjectObjectEntry);
 	}
 
 	private void _testGetProjectContentCoverageWithInvalidProjectId()
@@ -348,7 +348,7 @@ public class ContentCoverageResourceTest
 
 		String assetTagName = "L_CMP_TASK_" + RandomTestUtil.randomString(10);
 
-		ObjectEntry objectEntry = _addProjectObjectEntry(
+		ObjectEntry objectEntry = _addCMPProjectObjectEntry(
 			new long[0], assetTagName);
 
 		AssetCategory decisionMakerAssetCategory = _getAssetCategory(
@@ -373,7 +373,7 @@ public class ContentCoverageResourceTest
 
 		String assetTagName = "L_CMP_TASK_" + RandomTestUtil.randomString(10);
 
-		ObjectEntry objectEntry = _addProjectObjectEntry(
+		ObjectEntry objectEntry = _addCMPProjectObjectEntry(
 			new long[] {
 				awarenessAssetCategory.getCategoryId(),
 				championAssetCategory.getCategoryId()

--- a/modules/apps/headless/headless-cmp/headless-cmp-test/src/testIntegration/java/com/liferay/headless/cmp/resource/v1_0/test/TaskStatisticsResourceTest.java
+++ b/modules/apps/headless/headless-cmp/headless-cmp-test/src/testIntegration/java/com/liferay/headless/cmp/resource/v1_0/test/TaskStatisticsResourceTest.java
@@ -53,19 +53,21 @@ public class TaskStatisticsResourceTest
 
 		CMPTestUtil.getOrAddGroup(TaskStatisticsResourceTest.class);
 
-		_projectObjectEntry1 = CMPTestUtil.addProjectObjectEntry();
+		_cmpProjectObjectEntry1 = CMPTestUtil.addCMPProjectObjectEntry();
 
 		_partialUpdateObjectEntry(
-			null, CMPTestUtil.addTaskObjectEntry(_projectObjectEntry1),
+			null, CMPTestUtil.addCMPTaskObjectEntry(_cmpProjectObjectEntry1),
 			"blocked");
 		_partialUpdateObjectEntry(
-			"3000-01-31", CMPTestUtil.addTaskObjectEntry(_projectObjectEntry1),
+			"3000-01-31",
+			CMPTestUtil.addCMPTaskObjectEntry(_cmpProjectObjectEntry1),
 			"inProgress");
 
-		_projectObjectEntry2 = CMPTestUtil.addProjectObjectEntry();
+		_cmpProjectObjectEntry2 = CMPTestUtil.addCMPProjectObjectEntry();
 
 		_partialUpdateObjectEntry(
-			"2025-01-31", CMPTestUtil.addTaskObjectEntry(_projectObjectEntry2),
+			"2025-01-31",
+			CMPTestUtil.addCMPTaskObjectEntry(_cmpProjectObjectEntry2),
 			"inProgress");
 	}
 
@@ -73,8 +75,8 @@ public class TaskStatisticsResourceTest
 	public void tearDown() throws Exception {
 		super.tearDown();
 
-		_objectEntryLocalService.deleteObjectEntry(_projectObjectEntry1);
-		_objectEntryLocalService.deleteObjectEntry(_projectObjectEntry2);
+		_objectEntryLocalService.deleteObjectEntry(_cmpProjectObjectEntry1);
+		_objectEntryLocalService.deleteObjectEntry(_cmpProjectObjectEntry2);
 	}
 
 	@Override
@@ -82,7 +84,7 @@ public class TaskStatisticsResourceTest
 	public void testGetProjectTaskStatistics() throws Exception {
 		TaskStatistics taskStatistics1 =
 			taskStatisticsResource.getProjectTaskStatistics(
-				_projectObjectEntry1.getObjectEntryId(), null);
+				_cmpProjectObjectEntry1.getObjectEntryId(), null);
 
 		Assert.assertEquals(
 			1, GetterUtil.getLong(taskStatistics1.getBlockedCount()));
@@ -95,7 +97,7 @@ public class TaskStatisticsResourceTest
 
 		TaskStatistics taskStatistics2 =
 			taskStatisticsResource.getProjectTaskStatistics(
-				_projectObjectEntry2.getObjectEntryId(), null);
+				_cmpProjectObjectEntry2.getObjectEntryId(), null);
 
 		Assert.assertEquals(
 			0, GetterUtil.getLong(taskStatistics2.getBlockedCount()));
@@ -148,10 +150,10 @@ public class TaskStatisticsResourceTest
 			ServiceContextTestUtil.getServiceContext());
 	}
 
+	private ObjectEntry _cmpProjectObjectEntry1;
+	private ObjectEntry _cmpProjectObjectEntry2;
+
 	@Inject
 	private ObjectEntryLocalService _objectEntryLocalService;
-
-	private ObjectEntry _projectObjectEntry1;
-	private ObjectEntry _projectObjectEntry2;
 
 }

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/util/ObjectDefinitionUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/util/ObjectDefinitionUtil.java
@@ -217,7 +217,11 @@ public class ObjectDefinitionUtil {
 		).put(
 			"CMPProject", "/cmp/projects"
 		).put(
+			"CMPProjectLink", "/cmp/project-links"
+		).put(
 			"CMPTask", "/cmp/tasks"
+		).put(
+			"CMPTaskLink", "/cmp/task-links"
 		).put(
 			"CMSBasicDocument", "/cms/basic-documents"
 		).put(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectValidationRuleLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectValidationRuleLocalServiceImpl.java
@@ -939,7 +939,10 @@ public class ObjectValidationRuleLocalServiceImpl
 			ObjectField objectField = _objectFieldPersistence.fetchByPrimaryKey(
 				GetterUtil.getLong(objectValidationRuleSetting.getValue()));
 
-			if ((objectField == null) || objectField.isSystem() ||
+			if ((objectField == null) ||
+				(!objectDefinition.isModifiableAndSystem() &&
+				 objectField.isSystem()) ||
+				objectField.isMetadata() ||
 				(objectValidationRuleSetting.compareName(
 					ObjectValidationRuleSettingConstants.
 						NAME_COMPOSITE_KEY_OBJECT_FIELD_ID) &&

--- a/modules/apps/site-initializer/site-initializer-cmp/src/main/resources/com/liferay/site/initializer/cmp/internal/batch/03-object-definition.batch-engine-data.json
+++ b/modules/apps/site-initializer/site-initializer-cmp/src/main/resources/com/liferay/site/initializer/cmp/internal/batch/03-object-definition.batch-engine-data.json
@@ -272,6 +272,51 @@
 				{
 					"deletionType": "cascade",
 					"edge": false,
+					"externalReferenceCode": "L_CMP_PROJECT_TO_L_CMP_PROJECT_LINKS",
+					"label": {
+						"en_US": "CMP Project to CMP Project Links"
+					},
+					"name": "cmpProjectToCMPProjectLinks",
+					"objectDefinitionExternalReferenceCode1": "L_CMP_PROJECT",
+					"objectDefinitionExternalReferenceCode2": "L_CMP_PROJECT_LINK",
+					"objectDefinitionModifiable2": true,
+					"objectDefinitionName2": "CMPProjectLink",
+					"objectDefinitionScope2": "depot",
+					"objectDefinitionSystem2": true,
+					"objectField": {
+						"DBType": "Long",
+						"businessType": "Relationship",
+						"externalReferenceCode": "CMP_PROJECT_TO_CMP_PROJECT_LINKS",
+						"indexed": true,
+						"indexedAsKeyword": false,
+						"label": {
+							"en_US": "CMP Project to CMP Project Links"
+						},
+						"name": "r_cmpProjectToCMPProjectLinks_c_cmpProjectId",
+						"objectFieldSettings": [
+							{
+								"name": "objectDefinition1ShortName",
+								"value": "CMPProject"
+							},
+							{
+								"name": "objectRelationshipERCObjectFieldName",
+								"value": "r_cmpProjectToCMPProjectLinks_c_cmpProjectERC"
+							}
+						],
+						"relationshipType": "oneToMany",
+						"required": true,
+						"system": true,
+						"type": "Long"
+					},
+					"parameterObjectFieldId": 0,
+					"parameterObjectFieldName": "",
+					"reverse": false,
+					"system": true,
+					"type": "oneToMany"
+				},
+				{
+					"deletionType": "cascade",
+					"edge": false,
 					"externalReferenceCode": "L_CMP_PROJECT_TO_L_CMP_TASKS",
 					"label": {
 						"en_US": "CMP Project to CMP Tasks"
@@ -325,6 +370,120 @@
 			},
 			"system": true,
 			"titleObjectFieldName": "title"
+		},
+		{
+			"className": "com.liferay.object.model.ObjectDefinition#P4A1",
+			"enableCategorization": false,
+			"enableComments": false,
+			"enableFriendlyURLCustomization": false,
+			"enableIndexSearch": true,
+			"enableLocalization": false,
+			"enableObjectEntryDraft": false,
+			"enableObjectEntryHistory": false,
+			"enableObjectEntrySchedule": false,
+			"enableObjectEntrySubscription": false,
+			"externalReferenceCode": "L_CMP_PROJECT_LINK",
+			"label": {
+				"en_US": "Project Link"
+			},
+			"modifiable": true,
+			"name": "CMPProjectLink",
+			"objectDefinitionSettings": [
+				{
+					"name": "acceptAllGroups",
+					"value": "true"
+				},
+				{
+					"name": "domain",
+					"value": "project"
+				},
+				{
+					"name": "visible",
+					"value": "false"
+				}
+			],
+			"objectFields": [
+				{
+					"DBType": "String",
+					"businessType": "Text",
+					"externalReferenceCode": "CLASS_EXTERNAL_REFERENCE_CODE",
+					"indexed": true,
+					"indexedAsKeyword": true,
+					"label": {
+						"en_US": "Class External Reference Code"
+					},
+					"name": "classExternalReferenceCode",
+					"required": true,
+					"system": true
+				},
+				{
+					"DBType": "String",
+					"businessType": "Text",
+					"externalReferenceCode": "CLASS_NAME",
+					"indexed": true,
+					"indexedAsKeyword": true,
+					"label": {
+						"en_US": "Class Name"
+					},
+					"name": "className",
+					"required": true,
+					"system": true
+				},
+				{
+					"DBType": "String",
+					"businessType": "Text",
+					"externalReferenceCode": "GROUP_EXTERNAL_REFERENCE_CODE",
+					"indexed": true,
+					"indexedAsKeyword": true,
+					"label": {
+						"en_US": "Group External Reference Code"
+					},
+					"name": "groupExternalReferenceCode",
+					"required": true,
+					"system": true
+				}
+			],
+			"objectFolderExternalReferenceCode": "L_CMP_PROJECT_MANAGEMENT_DEFINITIONS",
+			"objectValidationRules": [
+				{
+					"active": true,
+					"engine": "compositeKey",
+					"errorLabel": {
+						"en_US": "This asset is already linked to this project."
+					},
+					"externalReferenceCode": "L_CMP_PROJECT_LINK_UNIQUE",
+					"name": {
+						"en_US": "Project Link Unique"
+					},
+					"objectDefinitionExternalReferenceCode": "L_CMP_PROJECT_LINK",
+					"objectValidationRuleSettings": [
+						{
+							"name": "compositeKeyObjectFieldExternalReferenceCode",
+							"value": "CLASS_EXTERNAL_REFERENCE_CODE"
+						},
+						{
+							"name": "compositeKeyObjectFieldExternalReferenceCode",
+							"value": "CLASS_NAME"
+						},
+						{
+							"name": "compositeKeyObjectFieldExternalReferenceCode",
+							"value": "GROUP_EXTERNAL_REFERENCE_CODE"
+						}
+					],
+					"outputType": "fullValidation",
+					"system": true
+				}
+			],
+			"panelCategoryKey": "",
+			"pluralLabel": {
+				"en_US": "Project Links"
+			},
+			"scope": "depot",
+			"status": {
+				"code": 0
+			},
+			"system": true,
+			"titleObjectFieldName": "classExternalReferenceCode"
 		},
 		{
 			"className": "com.liferay.object.model.ObjectDefinition#C1N3",
@@ -578,6 +737,53 @@
 				}
 			],
 			"objectFolderExternalReferenceCode": "L_CMP_PROJECT_MANAGEMENT_DEFINITIONS",
+			"objectRelationships": [
+				{
+					"deletionType": "cascade",
+					"edge": false,
+					"externalReferenceCode": "L_CMP_TASK_TO_L_CMP_TASK_LINKS",
+					"label": {
+						"en_US": "CMP Task to CMP Task Links"
+					},
+					"name": "cmpTaskToCMPTaskLinks",
+					"objectDefinitionExternalReferenceCode1": "L_CMP_TASK",
+					"objectDefinitionExternalReferenceCode2": "L_CMP_TASK_LINK",
+					"objectDefinitionModifiable2": true,
+					"objectDefinitionName2": "CMPTaskLink",
+					"objectDefinitionScope2": "depot",
+					"objectDefinitionSystem2": true,
+					"objectField": {
+						"DBType": "Long",
+						"businessType": "Relationship",
+						"externalReferenceCode": "CMP_TASK_TO_CMP_TASK_LINKS",
+						"indexed": true,
+						"indexedAsKeyword": false,
+						"label": {
+							"en_US": "CMP Task to CMP Task Links"
+						},
+						"name": "r_cmpTaskToCMPTaskLinks_c_cmpTaskId",
+						"objectFieldSettings": [
+							{
+								"name": "objectDefinition1ShortName",
+								"value": "CMPTask"
+							},
+							{
+								"name": "objectRelationshipERCObjectFieldName",
+								"value": "r_cmpTaskToCMPTaskLinks_c_cmpTaskERC"
+							}
+						],
+						"relationshipType": "oneToMany",
+						"required": true,
+						"system": true,
+						"type": "Long"
+					},
+					"parameterObjectFieldId": 0,
+					"parameterObjectFieldName": "",
+					"reverse": false,
+					"system": true,
+					"type": "oneToMany"
+				}
+			],
 			"panelCategoryKey": "",
 			"parameterRequired": false,
 			"pluralLabel": {
@@ -590,6 +796,124 @@
 			},
 			"system": true,
 			"titleObjectFieldName": "title"
+		},
+		{
+			"className": "com.liferay.object.model.ObjectDefinition#T7R2",
+			"enableCategorization": false,
+			"enableComments": false,
+			"enableFriendlyURLCustomization": false,
+			"enableIndexSearch": true,
+			"enableLocalization": false,
+			"enableObjectEntryDraft": false,
+			"enableObjectEntryHistory": false,
+			"enableObjectEntrySchedule": false,
+			"enableObjectEntrySubscription": false,
+			"externalReferenceCode": "L_CMP_TASK_LINK",
+			"label": {
+				"en_US": "Task Link"
+			},
+			"modifiable": true,
+			"name": "CMPTaskLink",
+			"objectDefinitionSettings": [
+				{
+					"name": "acceptAllGroups",
+					"value": "true"
+				},
+				{
+					"name": "domain",
+					"value": "project"
+				},
+				{
+					"name": "visible",
+					"value": "false"
+				}
+			],
+			"objectFields": [
+				{
+					"DBType": "String",
+					"businessType": "Text",
+					"externalReferenceCode": "CLASS_EXTERNAL_REFERENCE_CODE",
+					"indexed": true,
+					"indexedAsKeyword": true,
+					"label": {
+						"en_US": "Class External Reference Code"
+					},
+					"name": "classExternalReferenceCode",
+					"required": true,
+					"system": true
+				},
+				{
+					"DBType": "String",
+					"businessType": "Text",
+					"externalReferenceCode": "CLASS_NAME",
+					"indexed": true,
+					"indexedAsKeyword": true,
+					"label": {
+						"en_US": "Class Name"
+					},
+					"name": "className",
+					"required": true,
+					"system": true
+				},
+				{
+					"DBType": "String",
+					"businessType": "Text",
+					"externalReferenceCode": "GROUP_EXTERNAL_REFERENCE_CODE",
+					"indexed": true,
+					"indexedAsKeyword": true,
+					"label": {
+						"en_US": "Group External Reference Code"
+					},
+					"name": "groupExternalReferenceCode",
+					"required": true,
+					"system": true
+				}
+			],
+			"objectFolderExternalReferenceCode": "L_CMP_PROJECT_MANAGEMENT_DEFINITIONS",
+			"objectValidationRules": [
+				{
+					"active": true,
+					"engine": "compositeKey",
+					"errorLabel": {
+						"en_US": "This asset is already linked to this task."
+					},
+					"externalReferenceCode": "L_CMP_TASK_LINK_UNIQUE",
+					"name": {
+						"en_US": "Task Link Unique"
+					},
+					"objectDefinitionExternalReferenceCode": "L_CMP_TASK_LINK",
+					"objectValidationRuleSettings": [
+						{
+							"name": "compositeKeyObjectFieldExternalReferenceCode",
+							"value": "CLASS_EXTERNAL_REFERENCE_CODE"
+						},
+						{
+							"name": "compositeKeyObjectFieldExternalReferenceCode",
+							"value": "CLASS_NAME"
+						},
+						{
+							"name": "compositeKeyObjectFieldExternalReferenceCode",
+							"value": "CMP_TASK_TO_CMP_TASK_LINKS"
+						},
+						{
+							"name": "compositeKeyObjectFieldExternalReferenceCode",
+							"value": "GROUP_EXTERNAL_REFERENCE_CODE"
+						}
+					],
+					"outputType": "fullValidation",
+					"system": true
+				}
+			],
+			"panelCategoryKey": "",
+			"pluralLabel": {
+				"en_US": "Task Links"
+			},
+			"scope": "depot",
+			"status": {
+				"code": 0
+			},
+			"system": true,
+			"titleObjectFieldName": "classExternalReferenceCode"
 		}
 	]
 }

--- a/modules/apps/site/site-cmp-site-initializer-rest-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/site/site-cmp-site-initializer-rest-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -10,9 +10,13 @@ import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.HTTPTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -25,6 +29,10 @@ import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.site.cmp.site.initializer.test.util.CMPTestUtil;
+
+import java.io.Serializable;
+
+import java.util.Collections;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -53,10 +61,32 @@ public class ObjectEntryResourceTest {
 	public void setUp() throws Exception {
 		CMPTestUtil.getOrAddGroup(ObjectEntryResourceTest.class);
 
+		ObjectDefinition basicWebContentObjectDefinition =
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_CMS_BASIC_WEB_CONTENT", TestPropsValues.getCompanyId());
+		DepotEntry depotEntry = _addDepotEntry(DepotConstants.TYPE_SPACE);
+
+		_basicWebContentObjectEntry = _objectEntryLocalService.addObjectEntry(
+			depotEntry.getGroupId(), TestPropsValues.getUserId(),
+			basicWebContentObjectDefinition.getObjectDefinitionId(), 0, null,
+			Collections.singletonMap(
+				"title_i18n",
+				(Serializable)RandomTestUtil.randomLanguageIdStringMap()),
+			ServiceContextTestUtil.getServiceContext());
+
+		_projectLinkObjectDefinition =
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_CMP_PROJECT_LINK", TestPropsValues.getCompanyId());
 		_projectObjectDefinition =
 			_objectDefinitionLocalService.
 				getObjectDefinitionByExternalReferenceCode(
 					"L_CMP_PROJECT", TestPropsValues.getCompanyId());
+		_taskLinkObjectDefinition =
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_CMP_TASK_LINK", TestPropsValues.getCompanyId());
 		_taskObjectDefinition =
 			_objectDefinitionLocalService.
 				getObjectDefinitionByExternalReferenceCode(
@@ -64,82 +94,247 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
-	public void testPostObjectEntry() throws Exception {
-		DepotEntry depotEntry1 = _depotEntryLocalService.addDepotEntry(
-			RandomTestUtil.randomLocaleStringMap(),
-			RandomTestUtil.randomLocaleStringMap(), DepotConstants.TYPE_PROJECT,
-			ServiceContextTestUtil.getServiceContext());
+	public void testPostProjectLinkObjectEntry() throws Exception {
+
+		// Link basic web content in a project
+
+		_testPostProjectLinkObjectEntry();
+
+		// Link the same basic web content in a different project
+
+		_testPostProjectLinkObjectEntry();
+	}
+
+	@Test
+	public void testPostProjectObjectEntry() throws Exception {
+		DepotEntry depotEntry = _addDepotEntry(DepotConstants.TYPE_PROJECT);
 
 		Assert.assertEquals(
 			409,
 			HTTPTestUtil.invokeToHttpCode(
 				null,
 				_projectObjectDefinition.getRESTContextPath() + "/scopes/" +
-					depotEntry1.getGroupId(),
+					depotEntry.getGroupId(),
 				Http.Method.POST));
 
-		JSONObject projectJSONObject = HTTPTestUtil.invokeToJSONObject(
-			JSONUtil.put(
-				"title", RandomTestUtil.randomString()
-			).toString(),
-			_projectObjectDefinition.getRESTContextPath(), Http.Method.POST);
+		JSONObject projectObjectEntryJSONObject = _postProjectObjectEntry();
 
-		DepotEntry depotEntry2 = _depotEntryLocalService.fetchGroupDepotEntry(
-			projectJSONObject.getLong("scopeId"));
+		depotEntry = _depotEntryLocalService.fetchGroupDepotEntry(
+			projectObjectEntryJSONObject.getLong("scopeId"));
 
-		Assert.assertEquals(DepotConstants.TYPE_PROJECT, depotEntry2.getType());
+		Assert.assertEquals(DepotConstants.TYPE_PROJECT, depotEntry.getType());
+	}
+
+	@Test
+	public void testPostTaskLinkObjectEntry() throws Exception {
+
+		// Link basic web content in a task
+
+		_testPostTaskLinkObjectEntry();
+
+		// Link the same basic web content in a different task
+
+		_testPostTaskLinkObjectEntry();
+	}
+
+	@Test
+	public void testPostTaskObjectEntry() throws Exception {
+		DepotEntry depotEntry = _addDepotEntry(DepotConstants.TYPE_PROJECT);
+		JSONObject projectObjectEntryJSONObject = _postProjectObjectEntry();
 
 		Assert.assertEquals(
 			400,
 			HTTPTestUtil.invokeToHttpCode(
 				JSONUtil.put(
 					"r_cmpProjectToCMPTasks_c_cmpProjectId",
-					projectJSONObject.getLong("id")
+					projectObjectEntryJSONObject.getLong("id")
 				).put(
 					"title", RandomTestUtil.randomString()
 				).toString(),
 				_taskObjectDefinition.getRESTContextPath() + "/scopes/" +
-					depotEntry1.getGroupId(),
+					depotEntry.getGroupId(),
 				Http.Method.POST));
 		Assert.assertEquals(
 			404,
 			HTTPTestUtil.invokeToHttpCode(
 				JSONUtil.put(
 					"r_cmpProjectToCMPTasks_c_cmpProjectERC",
-					projectJSONObject.getString("externalReferenceCode")
+					projectObjectEntryJSONObject.getString(
+						"externalReferenceCode")
 				).put(
 					"title", RandomTestUtil.randomString()
 				).toString(),
 				_taskObjectDefinition.getRESTContextPath() + "/scopes/" +
-					depotEntry1.getGroupId(),
+					depotEntry.getGroupId(),
 				Http.Method.POST));
 
-		JSONObject taskJSONObject = HTTPTestUtil.invokeToJSONObject(
+		JSONObject taskObjectEntryJSONObject = HTTPTestUtil.invokeToJSONObject(
 			JSONUtil.put(
 				"r_cmpProjectToCMPTasks_c_cmpProjectERC",
-				projectJSONObject.getString("externalReferenceCode")
+				projectObjectEntryJSONObject.getString("externalReferenceCode")
 			).put(
 				"title", RandomTestUtil.randomString()
 			).toString(),
 			_taskObjectDefinition.getRESTContextPath() + "/scopes/" +
-				depotEntry2.getGroupId(),
+				projectObjectEntryJSONObject.getLong("scopeId"),
 			Http.Method.POST);
 
 		Assert.assertEquals(
-			projectJSONObject.getLong("id"),
-			taskJSONObject.getLong("r_cmpProjectToCMPTasks_c_cmpProjectId"));
+			projectObjectEntryJSONObject.getLong("id"),
+			taskObjectEntryJSONObject.getLong(
+				"r_cmpProjectToCMPTasks_c_cmpProjectId"));
 		Assert.assertEquals(
-			projectJSONObject.getLong("scopeId"),
-			taskJSONObject.getLong("scopeId"));
+			projectObjectEntryJSONObject.getLong("scopeId"),
+			taskObjectEntryJSONObject.getLong("scopeId"));
 	}
+
+	private DepotEntry _addDepotEntry(int type) throws Exception {
+		return _depotEntryLocalService.addDepotEntry(
+			RandomTestUtil.randomLocaleStringMap(),
+			RandomTestUtil.randomLocaleStringMap(), type,
+			ServiceContextTestUtil.getServiceContext());
+	}
+
+	private JSONObject _getBasicWebContentObjectEntryJSONObject() {
+		return JSONUtil.put(
+			"classExternalReferenceCode",
+			_basicWebContentObjectEntry.getExternalReferenceCode()
+		).put(
+			"className", _basicWebContentObjectEntry.getModelClassName()
+		).put(
+			"groupExternalReferenceCode",
+			() -> {
+				Group group = _groupLocalService.getGroup(
+					_basicWebContentObjectEntry.getGroupId());
+
+				return group.getExternalReferenceCode();
+			}
+		);
+	}
+
+	private JSONObject _postProjectObjectEntry() throws Exception {
+		return HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				"title", RandomTestUtil.randomString()
+			).toString(),
+			_projectObjectDefinition.getRESTContextPath(), Http.Method.POST);
+	}
+
+	private JSONObject _postTaskObjectEntry() throws Exception {
+		JSONObject projectObjectEntryJSONObject = _postProjectObjectEntry();
+
+		return HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				"r_cmpProjectToCMPTasks_c_cmpProjectERC",
+				projectObjectEntryJSONObject.getString("externalReferenceCode")
+			).put(
+				"title", RandomTestUtil.randomString()
+			).toString(),
+			_taskObjectDefinition.getRESTContextPath() + "/scopes/" +
+				projectObjectEntryJSONObject.getLong("scopeId"),
+			Http.Method.POST);
+	}
+
+	private void _testPostProjectLinkObjectEntry() throws Exception {
+		JSONObject bodyJSONObject = _getBasicWebContentObjectEntryJSONObject();
+
+		JSONObject projectObjectEntryJSONObject = _postProjectObjectEntry();
+
+		bodyJSONObject.put(
+			"r_cmpProjectToCMPProjectLinks_c_cmpProjectId",
+			projectObjectEntryJSONObject.getLong("id"));
+
+		JSONObject projectLinkObjectEntryJSONObject =
+			HTTPTestUtil.invokeToJSONObject(
+				bodyJSONObject.toString(),
+				_projectLinkObjectDefinition.getRESTContextPath() + "/scopes/" +
+					projectObjectEntryJSONObject.getLong("scopeId"),
+				Http.Method.POST);
+
+		Assert.assertEquals(
+			bodyJSONObject.getString("classExternalReferenceCode"),
+			projectLinkObjectEntryJSONObject.getString(
+				"classExternalReferenceCode"));
+		Assert.assertEquals(
+			bodyJSONObject.getString("className"),
+			projectLinkObjectEntryJSONObject.getString("className"));
+		Assert.assertEquals(
+			bodyJSONObject.getString("groupExternalReferenceCode"),
+			projectLinkObjectEntryJSONObject.getString(
+				"groupExternalReferenceCode"));
+		Assert.assertEquals(
+			bodyJSONObject.getLong(
+				"r_cmpProjectToCMPProjectLinks_c_cmpProjectId"),
+			projectLinkObjectEntryJSONObject.getLong(
+				"r_cmpProjectToCMPProjectLinks_c_cmpProjectId"));
+
+		Assert.assertEquals(
+			400,
+			HTTPTestUtil.invokeToHttpCode(
+				bodyJSONObject.toString(),
+				_projectLinkObjectDefinition.getRESTContextPath() + "/scopes/" +
+					projectObjectEntryJSONObject.getLong("scopeId"),
+				Http.Method.POST));
+	}
+
+	private void _testPostTaskLinkObjectEntry() throws Exception {
+		JSONObject bodyJSONObject = _getBasicWebContentObjectEntryJSONObject();
+
+		JSONObject taskObjectEntryJSONObject = _postTaskObjectEntry();
+
+		bodyJSONObject.put(
+			"r_cmpTaskToCMPTaskLinks_c_cmpTaskId",
+			taskObjectEntryJSONObject.getLong("id"));
+
+		JSONObject taskLinkObjectEntryJSONObject =
+			HTTPTestUtil.invokeToJSONObject(
+				bodyJSONObject.toString(),
+				_taskLinkObjectDefinition.getRESTContextPath() + "/scopes/" +
+					taskObjectEntryJSONObject.getLong("scopeId"),
+				Http.Method.POST);
+
+		Assert.assertEquals(
+			bodyJSONObject.getString("classExternalReferenceCode"),
+			taskLinkObjectEntryJSONObject.getString(
+				"classExternalReferenceCode"));
+		Assert.assertEquals(
+			bodyJSONObject.getString("className"),
+			taskLinkObjectEntryJSONObject.getString("className"));
+		Assert.assertEquals(
+			bodyJSONObject.getString("groupExternalReferenceCode"),
+			taskLinkObjectEntryJSONObject.getString(
+				"groupExternalReferenceCode"));
+		Assert.assertEquals(
+			bodyJSONObject.getLong("r_cmpTaskToCMPTaskLinks_c_cmpTaskId"),
+			taskLinkObjectEntryJSONObject.getLong(
+				"r_cmpTaskToCMPTaskLinks_c_cmpTaskId"));
+
+		Assert.assertEquals(
+			400,
+			HTTPTestUtil.invokeToHttpCode(
+				bodyJSONObject.toString(),
+				_taskLinkObjectDefinition.getRESTContextPath() + "/scopes/" +
+					taskObjectEntryJSONObject.getLong("scopeId"),
+				Http.Method.POST));
+	}
+
+	private ObjectEntry _basicWebContentObjectEntry;
 
 	@Inject
 	private DepotEntryLocalService _depotEntryLocalService;
 
 	@Inject
+	private GroupLocalService _groupLocalService;
+
+	@Inject
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;
 
+	@Inject
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	private ObjectDefinition _projectLinkObjectDefinition;
 	private ObjectDefinition _projectObjectDefinition;
+	private ObjectDefinition _taskLinkObjectDefinition;
 	private ObjectDefinition _taskObjectDefinition;
 
 }

--- a/modules/apps/site/site-cmp-site-initializer-rest-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/site/site-cmp-site-initializer-rest-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -61,97 +61,101 @@ public class ObjectEntryResourceTest {
 	public void setUp() throws Exception {
 		CMPTestUtil.getOrAddGroup(ObjectEntryResourceTest.class);
 
-		ObjectDefinition basicWebContentObjectDefinition =
+		ObjectDefinition cmsBasicWebContentObjectDefinition =
 			_objectDefinitionLocalService.
 				getObjectDefinitionByExternalReferenceCode(
 					"L_CMS_BASIC_WEB_CONTENT", TestPropsValues.getCompanyId());
 		DepotEntry depotEntry = _addDepotEntry(DepotConstants.TYPE_SPACE);
 
-		_basicWebContentObjectEntry = _objectEntryLocalService.addObjectEntry(
-			depotEntry.getGroupId(), TestPropsValues.getUserId(),
-			basicWebContentObjectDefinition.getObjectDefinitionId(), 0, null,
-			Collections.singletonMap(
-				"title_i18n",
-				(Serializable)RandomTestUtil.randomLanguageIdStringMap()),
-			ServiceContextTestUtil.getServiceContext());
+		_cmsBasicWebContentObjectEntry =
+			_objectEntryLocalService.addObjectEntry(
+				depotEntry.getGroupId(), TestPropsValues.getUserId(),
+				cmsBasicWebContentObjectDefinition.getObjectDefinitionId(), 0,
+				null,
+				Collections.singletonMap(
+					"title_i18n",
+					(Serializable)RandomTestUtil.randomLanguageIdStringMap()),
+				ServiceContextTestUtil.getServiceContext());
 
-		_projectLinkObjectDefinition =
+		_cmpProjectLinkObjectDefinition =
 			_objectDefinitionLocalService.
 				getObjectDefinitionByExternalReferenceCode(
 					"L_CMP_PROJECT_LINK", TestPropsValues.getCompanyId());
-		_projectObjectDefinition =
+		_cmpProjectObjectDefinition =
 			_objectDefinitionLocalService.
 				getObjectDefinitionByExternalReferenceCode(
 					"L_CMP_PROJECT", TestPropsValues.getCompanyId());
-		_taskLinkObjectDefinition =
+		_cmpTaskLinkObjectDefinition =
 			_objectDefinitionLocalService.
 				getObjectDefinitionByExternalReferenceCode(
 					"L_CMP_TASK_LINK", TestPropsValues.getCompanyId());
-		_taskObjectDefinition =
+		_cmpTaskObjectDefinition =
 			_objectDefinitionLocalService.
 				getObjectDefinitionByExternalReferenceCode(
 					"L_CMP_TASK", TestPropsValues.getCompanyId());
 	}
 
 	@Test
-	public void testPostProjectLinkObjectEntry() throws Exception {
+	public void testPostCMPProjectLinkObjectEntry() throws Exception {
 
 		// Link basic web content in a project
 
-		_testPostProjectLinkObjectEntry();
+		_testPostCMPProjectLinkObjectEntry();
 
 		// Link the same basic web content in a different project
 
-		_testPostProjectLinkObjectEntry();
+		_testPostCMPProjectLinkObjectEntry();
 	}
 
 	@Test
-	public void testPostProjectObjectEntry() throws Exception {
+	public void testPostCMPProjectObjectEntry() throws Exception {
 		DepotEntry depotEntry = _addDepotEntry(DepotConstants.TYPE_PROJECT);
 
 		Assert.assertEquals(
 			409,
 			HTTPTestUtil.invokeToHttpCode(
 				null,
-				_projectObjectDefinition.getRESTContextPath() + "/scopes/" +
+				_cmpProjectObjectDefinition.getRESTContextPath() + "/scopes/" +
 					depotEntry.getGroupId(),
 				Http.Method.POST));
 
-		JSONObject projectObjectEntryJSONObject = _postProjectObjectEntry();
+		JSONObject cmpProjectObjectEntryJSONObject =
+			_postCMPProjectObjectEntry();
 
 		depotEntry = _depotEntryLocalService.fetchGroupDepotEntry(
-			projectObjectEntryJSONObject.getLong("scopeId"));
+			cmpProjectObjectEntryJSONObject.getLong("scopeId"));
 
 		Assert.assertEquals(DepotConstants.TYPE_PROJECT, depotEntry.getType());
 	}
 
 	@Test
-	public void testPostTaskLinkObjectEntry() throws Exception {
+	public void testPostCMPTaskLinkObjectEntry() throws Exception {
 
 		// Link basic web content in a task
 
-		_testPostTaskLinkObjectEntry();
+		_testPostCMPTaskLinkObjectEntry();
 
 		// Link the same basic web content in a different task
 
-		_testPostTaskLinkObjectEntry();
+		_testPostCMPTaskLinkObjectEntry();
 	}
 
 	@Test
-	public void testPostTaskObjectEntry() throws Exception {
+	public void testPostCMPTaskObjectEntry() throws Exception {
+		JSONObject cmpProjectObjectEntryJSONObject =
+			_postCMPProjectObjectEntry();
 		DepotEntry depotEntry = _addDepotEntry(DepotConstants.TYPE_PROJECT);
-		JSONObject projectObjectEntryJSONObject = _postProjectObjectEntry();
 
 		Assert.assertEquals(
 			400,
 			HTTPTestUtil.invokeToHttpCode(
 				JSONUtil.put(
 					"r_cmpProjectToCMPTasks_c_cmpProjectId",
-					projectObjectEntryJSONObject.getLong("id")
+					cmpProjectObjectEntryJSONObject.getLong("id")
 				).put(
 					"title", RandomTestUtil.randomString()
 				).toString(),
-				_taskObjectDefinition.getRESTContextPath() + "/scopes/" +
+				_cmpTaskObjectDefinition.getRESTContextPath() + "/scopes/" +
 					depotEntry.getGroupId(),
 				Http.Method.POST));
 		Assert.assertEquals(
@@ -159,33 +163,35 @@ public class ObjectEntryResourceTest {
 			HTTPTestUtil.invokeToHttpCode(
 				JSONUtil.put(
 					"r_cmpProjectToCMPTasks_c_cmpProjectERC",
-					projectObjectEntryJSONObject.getString(
+					cmpProjectObjectEntryJSONObject.getString(
 						"externalReferenceCode")
 				).put(
 					"title", RandomTestUtil.randomString()
 				).toString(),
-				_taskObjectDefinition.getRESTContextPath() + "/scopes/" +
+				_cmpTaskObjectDefinition.getRESTContextPath() + "/scopes/" +
 					depotEntry.getGroupId(),
 				Http.Method.POST));
 
-		JSONObject taskObjectEntryJSONObject = HTTPTestUtil.invokeToJSONObject(
-			JSONUtil.put(
-				"r_cmpProjectToCMPTasks_c_cmpProjectERC",
-				projectObjectEntryJSONObject.getString("externalReferenceCode")
-			).put(
-				"title", RandomTestUtil.randomString()
-			).toString(),
-			_taskObjectDefinition.getRESTContextPath() + "/scopes/" +
-				projectObjectEntryJSONObject.getLong("scopeId"),
-			Http.Method.POST);
+		JSONObject cmpTaskObjectEntryJSONObject =
+			HTTPTestUtil.invokeToJSONObject(
+				JSONUtil.put(
+					"r_cmpProjectToCMPTasks_c_cmpProjectERC",
+					cmpProjectObjectEntryJSONObject.getString(
+						"externalReferenceCode")
+				).put(
+					"title", RandomTestUtil.randomString()
+				).toString(),
+				_cmpTaskObjectDefinition.getRESTContextPath() + "/scopes/" +
+					cmpProjectObjectEntryJSONObject.getLong("scopeId"),
+				Http.Method.POST);
 
 		Assert.assertEquals(
-			projectObjectEntryJSONObject.getLong("id"),
-			taskObjectEntryJSONObject.getLong(
+			cmpProjectObjectEntryJSONObject.getLong("id"),
+			cmpTaskObjectEntryJSONObject.getLong(
 				"r_cmpProjectToCMPTasks_c_cmpProjectId"));
 		Assert.assertEquals(
-			projectObjectEntryJSONObject.getLong("scopeId"),
-			taskObjectEntryJSONObject.getLong("scopeId"));
+			cmpProjectObjectEntryJSONObject.getLong("scopeId"),
+			cmpTaskObjectEntryJSONObject.getLong("scopeId"));
 	}
 
 	private DepotEntry _addDepotEntry(int type) throws Exception {
@@ -195,130 +201,141 @@ public class ObjectEntryResourceTest {
 			ServiceContextTestUtil.getServiceContext());
 	}
 
-	private JSONObject _getBasicWebContentObjectEntryJSONObject() {
+	private JSONObject _getCMSBasicWebContentObjectEntryJSONObject() {
 		return JSONUtil.put(
 			"classExternalReferenceCode",
-			_basicWebContentObjectEntry.getExternalReferenceCode()
+			_cmsBasicWebContentObjectEntry.getExternalReferenceCode()
 		).put(
-			"className", _basicWebContentObjectEntry.getModelClassName()
+			"className", _cmsBasicWebContentObjectEntry.getModelClassName()
 		).put(
 			"groupExternalReferenceCode",
 			() -> {
 				Group group = _groupLocalService.getGroup(
-					_basicWebContentObjectEntry.getGroupId());
+					_cmsBasicWebContentObjectEntry.getGroupId());
 
 				return group.getExternalReferenceCode();
 			}
 		);
 	}
 
-	private JSONObject _postProjectObjectEntry() throws Exception {
+	private JSONObject _postCMPProjectObjectEntry() throws Exception {
 		return HTTPTestUtil.invokeToJSONObject(
 			JSONUtil.put(
 				"title", RandomTestUtil.randomString()
 			).toString(),
-			_projectObjectDefinition.getRESTContextPath(), Http.Method.POST);
+			_cmpProjectObjectDefinition.getRESTContextPath(), Http.Method.POST);
 	}
 
-	private JSONObject _postTaskObjectEntry() throws Exception {
-		JSONObject projectObjectEntryJSONObject = _postProjectObjectEntry();
+	private JSONObject _postCMPTaskObjectEntry() throws Exception {
+		JSONObject cmpProjectObjectEntryJSONObject =
+			_postCMPProjectObjectEntry();
 
 		return HTTPTestUtil.invokeToJSONObject(
 			JSONUtil.put(
 				"r_cmpProjectToCMPTasks_c_cmpProjectERC",
-				projectObjectEntryJSONObject.getString("externalReferenceCode")
+				cmpProjectObjectEntryJSONObject.getString(
+					"externalReferenceCode")
 			).put(
 				"title", RandomTestUtil.randomString()
 			).toString(),
-			_taskObjectDefinition.getRESTContextPath() + "/scopes/" +
-				projectObjectEntryJSONObject.getLong("scopeId"),
+			_cmpTaskObjectDefinition.getRESTContextPath() + "/scopes/" +
+				cmpProjectObjectEntryJSONObject.getLong("scopeId"),
 			Http.Method.POST);
 	}
 
-	private void _testPostProjectLinkObjectEntry() throws Exception {
-		JSONObject bodyJSONObject = _getBasicWebContentObjectEntryJSONObject();
+	private void _testPostCMPProjectLinkObjectEntry() throws Exception {
+		JSONObject bodyJSONObject =
+			_getCMSBasicWebContentObjectEntryJSONObject();
 
-		JSONObject projectObjectEntryJSONObject = _postProjectObjectEntry();
+		JSONObject cmpProjectObjectEntryJSONObject =
+			_postCMPProjectObjectEntry();
 
 		bodyJSONObject.put(
 			"r_cmpProjectToCMPProjectLinks_c_cmpProjectId",
-			projectObjectEntryJSONObject.getLong("id"));
+			cmpProjectObjectEntryJSONObject.getLong("id"));
 
-		JSONObject projectLinkObjectEntryJSONObject =
+		JSONObject cmpProjectLinkObjectEntryJSONObject =
 			HTTPTestUtil.invokeToJSONObject(
 				bodyJSONObject.toString(),
-				_projectLinkObjectDefinition.getRESTContextPath() + "/scopes/" +
-					projectObjectEntryJSONObject.getLong("scopeId"),
+				_cmpProjectLinkObjectDefinition.getRESTContextPath() +
+					"/scopes/" +
+						cmpProjectObjectEntryJSONObject.getLong("scopeId"),
 				Http.Method.POST);
 
 		Assert.assertEquals(
 			bodyJSONObject.getString("classExternalReferenceCode"),
-			projectLinkObjectEntryJSONObject.getString(
+			cmpProjectLinkObjectEntryJSONObject.getString(
 				"classExternalReferenceCode"));
 		Assert.assertEquals(
 			bodyJSONObject.getString("className"),
-			projectLinkObjectEntryJSONObject.getString("className"));
+			cmpProjectLinkObjectEntryJSONObject.getString("className"));
 		Assert.assertEquals(
 			bodyJSONObject.getString("groupExternalReferenceCode"),
-			projectLinkObjectEntryJSONObject.getString(
+			cmpProjectLinkObjectEntryJSONObject.getString(
 				"groupExternalReferenceCode"));
 		Assert.assertEquals(
 			bodyJSONObject.getLong(
 				"r_cmpProjectToCMPProjectLinks_c_cmpProjectId"),
-			projectLinkObjectEntryJSONObject.getLong(
+			cmpProjectLinkObjectEntryJSONObject.getLong(
 				"r_cmpProjectToCMPProjectLinks_c_cmpProjectId"));
 
 		Assert.assertEquals(
 			400,
 			HTTPTestUtil.invokeToHttpCode(
 				bodyJSONObject.toString(),
-				_projectLinkObjectDefinition.getRESTContextPath() + "/scopes/" +
-					projectObjectEntryJSONObject.getLong("scopeId"),
+				_cmpProjectLinkObjectDefinition.getRESTContextPath() +
+					"/scopes/" +
+						cmpProjectObjectEntryJSONObject.getLong("scopeId"),
 				Http.Method.POST));
 	}
 
-	private void _testPostTaskLinkObjectEntry() throws Exception {
-		JSONObject bodyJSONObject = _getBasicWebContentObjectEntryJSONObject();
+	private void _testPostCMPTaskLinkObjectEntry() throws Exception {
+		JSONObject bodyJSONObject =
+			_getCMSBasicWebContentObjectEntryJSONObject();
 
-		JSONObject taskObjectEntryJSONObject = _postTaskObjectEntry();
+		JSONObject cmpTaskObjectEntryJSONObject = _postCMPTaskObjectEntry();
 
 		bodyJSONObject.put(
 			"r_cmpTaskToCMPTaskLinks_c_cmpTaskId",
-			taskObjectEntryJSONObject.getLong("id"));
+			cmpTaskObjectEntryJSONObject.getLong("id"));
 
-		JSONObject taskLinkObjectEntryJSONObject =
+		JSONObject cmpTaskLinkObjectEntryJSONObject =
 			HTTPTestUtil.invokeToJSONObject(
 				bodyJSONObject.toString(),
-				_taskLinkObjectDefinition.getRESTContextPath() + "/scopes/" +
-					taskObjectEntryJSONObject.getLong("scopeId"),
+				_cmpTaskLinkObjectDefinition.getRESTContextPath() + "/scopes/" +
+					cmpTaskObjectEntryJSONObject.getLong("scopeId"),
 				Http.Method.POST);
 
 		Assert.assertEquals(
 			bodyJSONObject.getString("classExternalReferenceCode"),
-			taskLinkObjectEntryJSONObject.getString(
+			cmpTaskLinkObjectEntryJSONObject.getString(
 				"classExternalReferenceCode"));
 		Assert.assertEquals(
 			bodyJSONObject.getString("className"),
-			taskLinkObjectEntryJSONObject.getString("className"));
+			cmpTaskLinkObjectEntryJSONObject.getString("className"));
 		Assert.assertEquals(
 			bodyJSONObject.getString("groupExternalReferenceCode"),
-			taskLinkObjectEntryJSONObject.getString(
+			cmpTaskLinkObjectEntryJSONObject.getString(
 				"groupExternalReferenceCode"));
 		Assert.assertEquals(
 			bodyJSONObject.getLong("r_cmpTaskToCMPTaskLinks_c_cmpTaskId"),
-			taskLinkObjectEntryJSONObject.getLong(
+			cmpTaskLinkObjectEntryJSONObject.getLong(
 				"r_cmpTaskToCMPTaskLinks_c_cmpTaskId"));
 
 		Assert.assertEquals(
 			400,
 			HTTPTestUtil.invokeToHttpCode(
 				bodyJSONObject.toString(),
-				_taskLinkObjectDefinition.getRESTContextPath() + "/scopes/" +
-					taskObjectEntryJSONObject.getLong("scopeId"),
+				_cmpTaskLinkObjectDefinition.getRESTContextPath() + "/scopes/" +
+					cmpTaskObjectEntryJSONObject.getLong("scopeId"),
 				Http.Method.POST));
 	}
 
-	private ObjectEntry _basicWebContentObjectEntry;
+	private ObjectDefinition _cmpProjectLinkObjectDefinition;
+	private ObjectDefinition _cmpProjectObjectDefinition;
+	private ObjectDefinition _cmpTaskLinkObjectDefinition;
+	private ObjectDefinition _cmpTaskObjectDefinition;
+	private ObjectEntry _cmsBasicWebContentObjectEntry;
 
 	@Inject
 	private DepotEntryLocalService _depotEntryLocalService;
@@ -331,10 +348,5 @@ public class ObjectEntryResourceTest {
 
 	@Inject
 	private ObjectEntryLocalService _objectEntryLocalService;
-
-	private ObjectDefinition _projectLinkObjectDefinition;
-	private ObjectDefinition _projectObjectDefinition;
-	private ObjectDefinition _taskLinkObjectDefinition;
-	private ObjectDefinition _taskObjectDefinition;
 
 }

--- a/modules/apps/site/site-cmp-site-initializer-test-util/src/main/java/com/liferay/site/cmp/site/initializer/test/util/CMPTestUtil.java
+++ b/modules/apps/site/site-cmp-site-initializer-test-util/src/main/java/com/liferay/site/cmp/site/initializer/test/util/CMPTestUtil.java
@@ -42,7 +42,9 @@ import java.util.Collections;
  */
 public class CMPTestUtil {
 
-	public static ObjectEntry addProjectObjectEntry() throws PortalException {
+	public static ObjectEntry addCMPProjectObjectEntry()
+		throws PortalException {
+
 		DepotEntry depotEntry = DepotEntryLocalServiceUtil.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
@@ -70,14 +72,15 @@ public class CMPTestUtil {
 			serviceContext);
 	}
 
-	public static ObjectEntry addTaskObjectEntry() throws PortalException {
-		return addTaskObjectEntry(addProjectObjectEntry());
+	public static ObjectEntry addCMPTaskObjectEntry() throws PortalException {
+		return addCMPTaskObjectEntry(addCMPProjectObjectEntry());
 	}
 
-	public static ObjectEntry addTaskObjectEntry(ObjectEntry projectObjectEntry)
+	public static ObjectEntry addCMPTaskObjectEntry(
+			ObjectEntry cmpProjectObjectEntry)
 		throws PortalException {
 
-		ObjectDefinition taskObjectDefinition =
+		ObjectDefinition cmpTaskObjectDefinition =
 			ObjectDefinitionLocalServiceUtil.
 				getObjectDefinitionByExternalReferenceCode(
 					"L_CMP_TASK", TestPropsValues.getCompanyId());
@@ -88,11 +91,12 @@ public class CMPTestUtil {
 		serviceContext.setWorkflowAction(WorkflowConstants.ACTION_SAVE_DRAFT);
 
 		return ObjectEntryLocalServiceUtil.addObjectEntry(
-			projectObjectEntry.getGroupId(), projectObjectEntry.getUserId(),
-			taskObjectDefinition.getObjectDefinitionId(), 0, null,
+			cmpProjectObjectEntry.getGroupId(),
+			cmpProjectObjectEntry.getUserId(),
+			cmpTaskObjectDefinition.getObjectDefinitionId(), 0, null,
 			HashMapBuilder.<String, Serializable>put(
 				"r_cmpProjectToCMPTasks_c_cmpProjectId",
-				projectObjectEntry.getObjectEntryId()
+				cmpProjectObjectEntry.getObjectEntryId()
 			).put(
 				"title", RandomTestUtil.randomString()
 			).build(),

--- a/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/display/context/test/BaseAssigneeSectionDisplayContextTestCase.java
+++ b/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/display/context/test/BaseAssigneeSectionDisplayContextTestCase.java
@@ -48,10 +48,10 @@ public abstract class BaseAssigneeSectionDisplayContextTestCase {
 
 		httpServletRequest = new MockHttpServletRequest();
 
-		projectObjectEntry = CMPTestUtil.addProjectObjectEntry();
+		cmpProjectObjectEntry = CMPTestUtil.addCMPProjectObjectEntry();
 
 		httpServletRequest.setAttribute(
-			InfoDisplayWebKeys.INFO_ITEM, projectObjectEntry);
+			InfoDisplayWebKeys.INFO_ITEM, cmpProjectObjectEntry);
 
 		themeDisplay = new ThemeDisplay() {
 			{
@@ -106,12 +106,12 @@ public abstract class BaseAssigneeSectionDisplayContextTestCase {
 			HttpServletRequest httpServletRequest)
 		throws Exception;
 
+	protected ObjectEntry cmpProjectObjectEntry;
 	protected HttpServletRequest httpServletRequest;
 
 	@Inject
 	protected ObjectEntryLocalService objectEntryLocalService;
 
-	protected ObjectEntry projectObjectEntry;
 	protected ThemeDisplay themeDisplay;
 
 	@Inject

--- a/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/display/context/test/BaseInfoSummarySectionDisplayContextTestCase.java
+++ b/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/display/context/test/BaseInfoSummarySectionDisplayContextTestCase.java
@@ -35,7 +35,7 @@ public abstract class BaseInfoSummarySectionDisplayContextTestCase {
 		CMPTestUtil.getOrAddGroup(
 			BaseInfoSummarySectionDisplayContextTestCase.class);
 
-		projectObjectEntry = CMPTestUtil.addProjectObjectEntry();
+		cmpProjectObjectEntry = CMPTestUtil.addCMPProjectObjectEntry();
 	}
 
 	protected abstract FragmentRenderer getFragmentRenderer();
@@ -73,7 +73,7 @@ public abstract class BaseInfoSummarySectionDisplayContextTestCase {
 			HttpServletRequest httpServletRequest)
 		throws Exception;
 
-	protected ObjectEntry projectObjectEntry;
+	protected ObjectEntry cmpProjectObjectEntry;
 	protected ThemeDisplay themeDisplay;
 
 }

--- a/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/display/context/test/BaseTasksSectionDisplayContextTestCase.java
+++ b/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/display/context/test/BaseTasksSectionDisplayContextTestCase.java
@@ -68,41 +68,44 @@ public abstract class BaseTasksSectionDisplayContextTestCase
 	public void setUp() throws Exception {
 		super.setUp();
 
-		projectObjectDefinition =
+		cmpProjectObjectDefinition =
 			objectDefinitionLocalService.
 				getObjectDefinitionByExternalReferenceCode(
 					"L_CMP_PROJECT", TestPropsValues.getCompanyId());
 
-		ObjectEntry projectObjectEntry = CMPTestUtil.addProjectObjectEntry();
+		ObjectEntry cmpProjectObjectEntry =
+			CMPTestUtil.addCMPProjectObjectEntry();
 
-		projectObjectEntry = _objectEntryLocalService.updateObjectEntry(
-			TestPropsValues.getUserId(), projectObjectEntry.getObjectEntryId(),
-			projectObjectEntry.getObjectEntryFolderId(),
-			projectObjectEntry.getValues(),
+		cmpProjectObjectEntry = _objectEntryLocalService.updateObjectEntry(
+			TestPropsValues.getUserId(),
+			cmpProjectObjectEntry.getObjectEntryId(),
+			cmpProjectObjectEntry.getObjectEntryFolderId(),
+			cmpProjectObjectEntry.getValues(),
 			ServiceContextTestUtil.getServiceContext());
 
 		assetEntry = _assetEntryLocalService.getEntry(
-			projectObjectDefinition.getClassName(),
-			projectObjectEntry.getObjectEntryId());
+			cmpProjectObjectDefinition.getClassName(),
+			cmpProjectObjectEntry.getObjectEntryId());
 	}
 
 	@Test
 	public void testGetAdditionalProps() throws Exception {
 		Map<String, Object> additionalProps = getAdditionalProps(null);
 
-		Assert.assertNull(additionalProps.get("projectId"));
 		Assert.assertEquals(
-			projectObjectDefinition.getObjectDefinitionId(),
-			additionalProps.get("projectObjectDefinitionId"));
+			cmpProjectObjectDefinition.getObjectDefinitionId(),
+			additionalProps.get("cmpProjectObjectDefinitionId"));
+		Assert.assertNull(additionalProps.get("cmpProjectObjectEntryId"));
 		Assert.assertNotNull(additionalProps.get("states"));
 
 		additionalProps = getAdditionalProps(assetEntry);
 
 		Assert.assertEquals(
-			assetEntry.getClassPK(), additionalProps.get("projectId"));
+			cmpProjectObjectDefinition.getObjectDefinitionId(),
+			additionalProps.get("cmpProjectObjectDefinitionId"));
 		Assert.assertEquals(
-			projectObjectDefinition.getObjectDefinitionId(),
-			additionalProps.get("projectObjectDefinitionId"));
+			assetEntry.getClassPK(),
+			additionalProps.get("cmpProjectObjectEntryId"));
 		Assert.assertNotNull(additionalProps.get("states"));
 	}
 
@@ -140,7 +143,7 @@ public abstract class BaseTasksSectionDisplayContextTestCase
 				themeDisplay.getPortalURL(), themeDisplay.getPathMain(),
 				GroupConstants.CMS_FRIENDLY_URL,
 				"/add_project?objectDefinitionId=",
-				projectObjectDefinition.getObjectDefinitionId(), "&plid=",
+				cmpProjectObjectDefinition.getObjectDefinitionId(), "&plid=",
 				themeDisplay.getPlid(), "&redirect=",
 				themeDisplay.getURLCurrent(),
 				"&action=createProjectGlobalTask"),
@@ -155,13 +158,13 @@ public abstract class BaseTasksSectionDisplayContextTestCase
 				"&redirect=", themeDisplay.getURLCurrent(),
 				"&action=createGlobalTask"),
 			getValue(dropdownItem, "addTaskURL"));
+		Assert.assertEquals(
+			String.valueOf(cmpProjectObjectDefinition.getObjectDefinitionId()),
+			getValue(dropdownItem, "cmpProjectObjectDefinitionId"));
 		Assert.assertEquals("New Task", dropdownItem.get("label"));
 		Assert.assertEquals(
 			String.valueOf(objectDefinition.getObjectDefinitionId()),
 			getValue(dropdownItem, "objectDefinitionId"));
-		Assert.assertEquals(
-			String.valueOf(projectObjectDefinition.getObjectDefinitionId()),
-			getValue(dropdownItem, "projectObjectDefinitionId"));
 		Assert.assertEquals(
 			StringBundler.concat(
 				themeDisplay.getPortalURL(), themeDisplay.getPathMain(),
@@ -244,7 +247,7 @@ public abstract class BaseTasksSectionDisplayContextTestCase
 		"com.liferay.portal.workflow.kaleo.model.KaleoTaskInstanceToken";
 
 	protected AssetEntry assetEntry;
-	protected ObjectDefinition projectObjectDefinition;
+	protected ObjectDefinition cmpProjectObjectDefinition;
 
 	private DropdownItem _getDropdownItem(CreationMenu creationMenu) {
 		List<DropdownItem> dropdownItems = (List<DropdownItem>)creationMenu.get(

--- a/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/display/context/test/ViewAllTasksSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/display/context/test/ViewAllTasksSectionDisplayContextTest.java
@@ -117,15 +117,20 @@ public class ViewAllTasksSectionDisplayContextTest
 				"entryClassName", objectDefinition.getClassName()),
 			fdsActionDropdownItems.get(4));
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
-			"trash", "delete", "Delete", null,
+			"date-time", "update-due-date", "Update Due Date", "get",
 			Collections.singletonMap(
 				"entryClassName", objectDefinition.getClassName()),
 			fdsActionDropdownItems.get(5));
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
+			"trash", "delete", "Delete", null,
+			Collections.singletonMap(
+				"entryClassName", objectDefinition.getClassName()),
+			fdsActionDropdownItems.get(6));
+		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
 			"view", "actionLinkWorkflowTask", "View", null,
 			Collections.singletonMap(
 				"entryClassName", CLASS_NAME_KALEO_TASK_INSTANCE_TOKEN),
-			fdsActionDropdownItems.get(6));
+			fdsActionDropdownItems.get(7));
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
 			null, "assignToMeWorkflowTask", "Assign to Me", null,
 			HashMapBuilder.<String, Object>put(
@@ -135,7 +140,7 @@ public class ViewAllTasksSectionDisplayContextTest
 			).put(
 				"entryClassName", CLASS_NAME_KALEO_TASK_INSTANCE_TOKEN
 			).build(),
-			fdsActionDropdownItems.get(7));
+			fdsActionDropdownItems.get(8));
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
 			null, "assignToWorkflowTask", "Assign to...", null,
 			HashMapBuilder.<String, Object>put(
@@ -143,7 +148,7 @@ public class ViewAllTasksSectionDisplayContextTest
 			).put(
 				"entryClassName", CLASS_NAME_KALEO_TASK_INSTANCE_TOKEN
 			).build(),
-			fdsActionDropdownItems.get(8));
+			fdsActionDropdownItems.get(9));
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
 			"date-time", "updateDueDateWorkflowTask", "Update Due Date", null,
 			HashMapBuilder.<String, Object>put(
@@ -151,9 +156,9 @@ public class ViewAllTasksSectionDisplayContextTest
 			).put(
 				"entryClassName", CLASS_NAME_KALEO_TASK_INSTANCE_TOKEN
 			).build(),
-			fdsActionDropdownItems.get(9));
+			fdsActionDropdownItems.get(10));
 		Assert.assertEquals(
-			fdsActionDropdownItems.toString(), 10,
+			fdsActionDropdownItems.toString(), 11,
 			fdsActionDropdownItems.size());
 	}
 

--- a/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/display/context/test/ViewAssigneeSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/display/context/test/ViewAssigneeSectionDisplayContextTest.java
@@ -69,7 +69,7 @@ public class ViewAssigneeSectionDisplayContextTest
 	public void setUp() throws Exception {
 		super.setUp();
 
-		ObjectDefinition taskObjectDefinition =
+		ObjectDefinition cmpTaskObjectDefinition =
 			_objectDefinitionLocalService.
 				getObjectDefinitionByExternalReferenceCode(
 					"L_CMP_TASK", TestPropsValues.getCompanyId());
@@ -79,19 +79,20 @@ public class ViewAssigneeSectionDisplayContextTest
 
 		serviceContext.setWorkflowAction(WorkflowConstants.ACTION_SAVE_DRAFT);
 
-		_taskObjectEntry = objectEntryLocalService.addObjectEntry(
-			projectObjectEntry.getGroupId(), projectObjectEntry.getUserId(),
-			taskObjectDefinition.getObjectDefinitionId(), 0, null,
+		_cmpTaskObjectEntry = objectEntryLocalService.addObjectEntry(
+			cmpProjectObjectEntry.getGroupId(),
+			cmpProjectObjectEntry.getUserId(),
+			cmpTaskObjectDefinition.getObjectDefinitionId(), 0, null,
 			HashMapBuilder.<String, Serializable>put(
 				"r_cmpProjectToCMPTasks_c_cmpProjectId",
-				projectObjectEntry.getObjectEntryId()
+				cmpProjectObjectEntry.getObjectEntryId()
 			).put(
 				"title", RandomTestUtil.randomString()
 			).build(),
 			serviceContext);
 
 		httpServletRequest.setAttribute(
-			InfoDisplayWebKeys.INFO_ITEM, _taskObjectEntry);
+			InfoDisplayWebKeys.INFO_ITEM, _cmpTaskObjectEntry);
 	}
 
 	@Test
@@ -119,7 +120,7 @@ public class ViewAssigneeSectionDisplayContextTest
 			).put(
 				"type", Assignee.Type.ROLE.toString()
 			).build(),
-			_taskObjectEntry,
+			_cmpTaskObjectEntry,
 			HashMapBuilder.<String, Serializable>put(
 				"assignTo",
 				HashMapBuilder.put(
@@ -142,7 +143,7 @@ public class ViewAssigneeSectionDisplayContextTest
 			).put(
 				"type", Assignee.Type.USER.toString()
 			).build(),
-			_taskObjectEntry,
+			_cmpTaskObjectEntry,
 			HashMapBuilder.<String, Serializable>put(
 				"assignTo",
 				HashMapBuilder.put(
@@ -169,6 +170,8 @@ public class ViewAssigneeSectionDisplayContextTest
 	@Inject
 	private ClassNameLocalService _classNameLocalService;
 
+	private ObjectEntry _cmpTaskObjectEntry;
+
 	@Inject(
 		filter = "component.name=com.liferay.site.cmp.site.initializer.internal.fragment.renderer.ViewAssigneeJSPSectionFragmentRenderer"
 	)
@@ -179,7 +182,5 @@ public class ViewAssigneeSectionDisplayContextTest
 
 	@Inject
 	private RoleLocalService _roleLocalService;
-
-	private ObjectEntry _taskObjectEntry;
 
 }

--- a/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/display/context/test/ViewProjectInfoSummarySectionDisplayContextTest.java
+++ b/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/display/context/test/ViewProjectInfoSummarySectionDisplayContextTest.java
@@ -70,27 +70,31 @@ public class ViewProjectInfoSummarySectionDisplayContextTest
 		User user1 = UserTestUtil.addUser();
 		User user2 = UserTestUtil.addUser();
 
-		projectObjectEntry = _objectEntryLocalService.partialUpdateObjectEntry(
-			projectObjectEntry.getUserId(),
-			projectObjectEntry.getObjectEntryId(),
-			projectObjectEntry.getObjectEntryFolderId(),
-			HashMapBuilder.<String, Serializable>put(
-				"dueDate", "2026-01-31"
-			).put(
-				"r_userToCMPProjectManager_userId", user1.getUserId()
-			).put(
-				"r_userToCMPProjectSponsor_userId", user2.getUserId()
-			).put(
-				"state", "inProgress"
-			).put(
-				"title", title
-			).build(),
-			serviceContext);
+		cmpProjectObjectEntry =
+			_objectEntryLocalService.partialUpdateObjectEntry(
+				cmpProjectObjectEntry.getUserId(),
+				cmpProjectObjectEntry.getObjectEntryId(),
+				cmpProjectObjectEntry.getObjectEntryFolderId(),
+				HashMapBuilder.<String, Serializable>put(
+					"dueDate", "2026-01-31"
+				).put(
+					"r_userToCMPProjectManager_userId", user1.getUserId()
+				).put(
+					"r_userToCMPProjectSponsor_userId", user2.getUserId()
+				).put(
+					"state", "inProgress"
+				).put(
+					"title", title
+				).build(),
+				serviceContext);
 
-		Map<String, Object> properties = getProperties(projectObjectEntry);
+		Map<String, Object> properties = getProperties(cmpProjectObjectEntry);
 
 		JSONAssert.assertEquals(
 			JSONUtil.put(
+				"cmpProjectObjectEntryId",
+				cmpProjectObjectEntry.getObjectEntryId()
+			).put(
 				"dueDate", "2026-01-31"
 			).put(
 				"funnelStages", new String[0]
@@ -107,8 +111,6 @@ public class ViewProjectInfoSummarySectionDisplayContextTest
 				)
 			).put(
 				"personas", new String[0]
-			).put(
-				"projectId", projectObjectEntry.getObjectEntryId()
 			).put(
 				"sponsor",
 				JSONUtil.put(

--- a/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/display/context/test/ViewProjectManagerAssigneeSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/display/context/test/ViewProjectManagerAssigneeSectionDisplayContextTest.java
@@ -78,7 +78,7 @@ public class ViewProjectManagerAssigneeSectionDisplayContextTest
 			).put(
 				"type", Assignee.Type.USER.toString()
 			).build(),
-			projectObjectEntry,
+			cmpProjectObjectEntry,
 			HashMapBuilder.<String, Serializable>put(
 				"r_userToCMPProjectManager_userId", user.getUserId()
 			).build());

--- a/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/display/context/test/ViewProjectSponsorAssigneeSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/display/context/test/ViewProjectSponsorAssigneeSectionDisplayContextTest.java
@@ -78,7 +78,7 @@ public class ViewProjectSponsorAssigneeSectionDisplayContextTest
 			).put(
 				"type", Assignee.Type.USER.toString()
 			).build(),
-			projectObjectEntry,
+			cmpProjectObjectEntry,
 			HashMapBuilder.<String, Serializable>put(
 				"r_userToCMPProjectSponsor_userId", user.getUserId()
 			).build());

--- a/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/display/context/test/ViewProjectTasksSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/display/context/test/ViewProjectTasksSectionDisplayContextTest.java
@@ -78,7 +78,7 @@ public class ViewProjectTasksSectionDisplayContextTest
 			getFDSActionDropdownItems(assetEntry);
 
 		Assert.assertEquals(
-			fdsActionDropdownItems.toString(), 6,
+			fdsActionDropdownItems.toString(), 7,
 			fdsActionDropdownItems.size());
 
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
@@ -103,10 +103,15 @@ public class ViewProjectTasksSectionDisplayContextTest
 				"entryClassName", objectDefinition.getClassName()),
 			fdsActionDropdownItems.get(4));
 		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
-			"trash", "delete", "Delete", null,
+			"date-time", "update-due-date", "Update Due Date", "get",
 			Collections.singletonMap(
 				"entryClassName", objectDefinition.getClassName()),
 			fdsActionDropdownItems.get(5));
+		FrontendDataSetTestUtil.assertFDSActionDropdownItem(
+			"trash", "delete", "Delete", null,
+			Collections.singletonMap(
+				"entryClassName", objectDefinition.getClassName()),
+			fdsActionDropdownItems.get(6));
 	}
 
 	@Test

--- a/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/display/context/test/ViewProjectTasksSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/display/context/test/ViewProjectTasksSectionDisplayContextTest.java
@@ -125,7 +125,7 @@ public class ViewProjectTasksSectionDisplayContextTest
 
 		Assert.assertEquals(
 			assetEntry.getClassPK(),
-			tasksQuickFiltersProperties.get("projectId"));
+			tasksQuickFiltersProperties.get("cmpProjectObjectEntryId"));
 	}
 
 	@Override

--- a/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/display/context/test/ViewTaskInfoSummarySectionDisplayContextTest.java
+++ b/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/display/context/test/ViewTaskInfoSummarySectionDisplayContextTest.java
@@ -67,7 +67,8 @@ public class ViewTaskInfoSummarySectionDisplayContextTest
 	public void setUp() throws Exception {
 		super.setUp();
 
-		_taskObjectEntry = CMPTestUtil.addTaskObjectEntry(projectObjectEntry);
+		_cmpTaskObjectEntry = CMPTestUtil.addCMPTaskObjectEntry(
+			cmpProjectObjectEntry);
 	}
 
 	@Test
@@ -84,9 +85,10 @@ public class ViewTaskInfoSummarySectionDisplayContextTest
 
 		String title = RandomTestUtil.randomString();
 
-		_taskObjectEntry = _objectEntryLocalService.partialUpdateObjectEntry(
-			_taskObjectEntry.getUserId(), _taskObjectEntry.getObjectEntryId(),
-			_taskObjectEntry.getObjectEntryFolderId(),
+		_cmpTaskObjectEntry = _objectEntryLocalService.partialUpdateObjectEntry(
+			_cmpTaskObjectEntry.getUserId(),
+			_cmpTaskObjectEntry.getObjectEntryId(),
+			_cmpTaskObjectEntry.getObjectEntryFolderId(),
 			HashMapBuilder.<String, Serializable>put(
 				"assignTo",
 				HashMapBuilder.put(
@@ -104,7 +106,7 @@ public class ViewTaskInfoSummarySectionDisplayContextTest
 			).build(),
 			serviceContext);
 
-		Map<String, Object> properties = getProperties(_taskObjectEntry);
+		Map<String, Object> properties = getProperties(_cmpTaskObjectEntry);
 
 		JSONAssert.assertEquals(
 			JSONUtil.put(
@@ -116,6 +118,8 @@ public class ViewTaskInfoSummarySectionDisplayContextTest
 				).put(
 					"type", Assignee.Type.ROLE.toString()
 				)
+			).put(
+				"cmpTaskObjectEntryId", _cmpTaskObjectEntry.getObjectEntryId()
 			).put(
 				"dueDate", "2026-01-31"
 			).put(
@@ -156,8 +160,6 @@ public class ViewTaskInfoSummarySectionDisplayContextTest
 			).put(
 				"tags", assetTagNames
 			).put(
-				"taskId", _taskObjectEntry.getObjectEntryId()
-			).put(
 				"title", title
 			).toString(),
 			_jsonFactory.looseSerializeDeep(properties), true);
@@ -180,6 +182,8 @@ public class ViewTaskInfoSummarySectionDisplayContextTest
 	@Inject
 	private ClassNameLocalService _classNameLocalService;
 
+	private ObjectEntry _cmpTaskObjectEntry;
+
 	@Inject(
 		filter = "component.name=com.liferay.site.cmp.site.initializer.internal.fragment.renderer.ViewTaskInfoSummaryJSPSectionFragmentRenderer"
 	)
@@ -193,7 +197,5 @@ public class ViewTaskInfoSummarySectionDisplayContextTest
 
 	@Inject
 	private RoleLocalService _roleLocalService;
-
-	private ObjectEntry _taskObjectEntry;
 
 }

--- a/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/fragment/renderer/test/BaseComponentSectionFragmentRendererTestCase.java
+++ b/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/fragment/renderer/test/BaseComponentSectionFragmentRendererTestCase.java
@@ -44,22 +44,23 @@ public abstract class BaseComponentSectionFragmentRendererTestCase {
 		CMPTestUtil.getOrAddGroup(
 			BaseComponentSectionFragmentRendererTestCase.class);
 
-		projectObjectDefinition =
+		cmpProjectObjectDefinition =
 			objectDefinitionLocalService.
 				getObjectDefinitionByExternalReferenceCode(
 					"L_CMP_PROJECT", TestPropsValues.getCompanyId());
 
-		projectObjectEntry = CMPTestUtil.addProjectObjectEntry();
+		cmpProjectObjectEntry = CMPTestUtil.addCMPProjectObjectEntry();
 
-		projectTitle = MapUtil.getString(
-			projectObjectEntry.getValues(), "title");
+		cmpProjectObjectEntryTitle = MapUtil.getString(
+			cmpProjectObjectEntry.getValues(), "title");
 
-		taskObjectDefinition =
+		cmpTaskObjectDefinition =
 			objectDefinitionLocalService.
 				getObjectDefinitionByExternalReferenceCode(
 					"L_CMP_TASK", TestPropsValues.getCompanyId());
 
-		taskObjectEntry = CMPTestUtil.addTaskObjectEntry(projectObjectEntry);
+		cmpTaskObjectEntry = CMPTestUtil.addCMPTaskObjectEntry(
+			cmpProjectObjectEntry);
 
 		themeDisplay = new ThemeDisplay() {
 			{
@@ -77,7 +78,7 @@ public abstract class BaseComponentSectionFragmentRendererTestCase {
 		};
 
 		mockHttpServletRequest = getMockHttpServletRequest(
-			projectObjectDefinition, projectObjectEntry);
+			cmpProjectObjectDefinition, cmpProjectObjectEntry);
 	}
 
 	protected abstract FragmentRenderer getFragmentRenderer();
@@ -122,16 +123,16 @@ public abstract class BaseComponentSectionFragmentRendererTestCase {
 			null, mockHttpServletRequest);
 	}
 
+	protected ObjectDefinition cmpProjectObjectDefinition;
+	protected ObjectEntry cmpProjectObjectEntry;
+	protected String cmpProjectObjectEntryTitle;
+	protected ObjectDefinition cmpTaskObjectDefinition;
+	protected ObjectEntry cmpTaskObjectEntry;
 	protected MockHttpServletRequest mockHttpServletRequest;
 
 	@Inject
 	protected ObjectDefinitionLocalService objectDefinitionLocalService;
 
-	protected ObjectDefinition projectObjectDefinition;
-	protected ObjectEntry projectObjectEntry;
-	protected String projectTitle;
-	protected ObjectDefinition taskObjectDefinition;
-	protected ObjectEntry taskObjectEntry;
 	protected ThemeDisplay themeDisplay;
 
 	@Inject

--- a/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/fragment/renderer/test/CommentsComponentSectionFragmentRendererTest.java
+++ b/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/fragment/renderer/test/CommentsComponentSectionFragmentRendererTest.java
@@ -67,8 +67,8 @@ public class CommentsComponentSectionFragmentRendererTest
 			themeDisplay.getPortalURL(), themeDisplay.getPathMain(),
 			GroupConstants.CMS_FRIENDLY_URL, actionId, "?p_l_id=",
 			themeDisplay.getPlid(), "&classNameId=",
-			_portal.getClassNameId(projectObjectDefinition.getClassName()),
-			"&classPK=", projectObjectEntry.getObjectEntryId());
+			_portal.getClassNameId(cmpProjectObjectDefinition.getClassName()),
+			"&classPK=", cmpProjectObjectEntry.getObjectEntryId());
 	}
 
 	@Inject(

--- a/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/fragment/renderer/test/EditorToolbarComponentSectionFragmentRendererTest.java
+++ b/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/fragment/renderer/test/EditorToolbarComponentSectionFragmentRendererTest.java
@@ -56,8 +56,8 @@ public class EditorToolbarComponentSectionFragmentRendererTest
 				themeDisplay.getPathFriendlyURLPublic(),
 				GroupConstants.CMS_FRIENDLY_URL, "/e/project/",
 				PortalUtil.getClassNameId(
-					projectObjectDefinition.getClassName()),
-				StringPool.SLASH, projectObjectEntry.getObjectEntryId()),
+					cmpProjectObjectDefinition.getClassName()),
+				StringPool.SLASH, cmpProjectObjectEntry.getObjectEntryId()),
 			MapUtil.getString(getProps(), "formSubmitURL"));
 		Assert.assertEquals(
 			"New Project", MapUtil.getString(getProps(), "title"));
@@ -72,24 +72,24 @@ public class EditorToolbarComponentSectionFragmentRendererTest
 				themeDisplay.getPortalURL(), themeDisplay.getPathMain(),
 				GroupConstants.CMS_FRIENDLY_URL,
 				"/add_task?objectDefinitionId=",
-				taskObjectDefinition.getObjectDefinitionId(), "&plid=",
+				cmpTaskObjectDefinition.getObjectDefinitionId(), "&plid=",
 				themeDisplay.getPlid(), "&projectGroupId=",
-				projectObjectEntry.getGroupId(), "&projectId=",
-				projectObjectEntry.getObjectEntryId(), "&redirect=/redirect-",
-				"url&action=createGlobalTask"),
+				cmpProjectObjectEntry.getGroupId(), "&projectId=",
+				cmpProjectObjectEntry.getObjectEntryId(),
+				"&redirect=/redirect-url&action=createGlobalTask"),
 			MapUtil.getString(getProps(), "formSubmitURL"));
 		Assert.assertEquals(
 			"New Project", MapUtil.getString(getProps(), "title"));
 
 		mockHttpServletRequest = getMockHttpServletRequest(
-			projectObjectDefinition,
-			_partialUpdateObjectEntry(projectObjectEntry));
+			cmpProjectObjectDefinition,
+			_partialUpdateObjectEntry(cmpProjectObjectEntry));
 
 		Assert.assertEquals(
 			"Edit Project", MapUtil.getString(getProps(), "title"));
 
 		mockHttpServletRequest = getMockHttpServletRequest(
-			taskObjectDefinition, taskObjectEntry);
+			cmpTaskObjectDefinition, cmpTaskObjectEntry);
 
 		Assert.assertEquals(
 			"/redirect-url", MapUtil.getString(getProps(), "backURL"));
@@ -105,7 +105,8 @@ public class EditorToolbarComponentSectionFragmentRendererTest
 		Assert.assertEquals("New Task", MapUtil.getString(getProps(), "title"));
 
 		mockHttpServletRequest = getMockHttpServletRequest(
-			taskObjectDefinition, _partialUpdateObjectEntry(taskObjectEntry));
+			cmpTaskObjectDefinition,
+			_partialUpdateObjectEntry(cmpTaskObjectEntry));
 
 		Assert.assertEquals(
 			"Edit Task", MapUtil.getString(getProps(), "title"));

--- a/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/fragment/renderer/test/HistoryComponentSectionFragmentRendererTest.java
+++ b/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/fragment/renderer/test/HistoryComponentSectionFragmentRendererTest.java
@@ -48,7 +48,7 @@ public class HistoryComponentSectionFragmentRendererTest
 		Assert.assertEquals("ProjectHistory", _getComponentName());
 
 		mockHttpServletRequest = getMockHttpServletRequest(
-			taskObjectDefinition, taskObjectEntry);
+			cmpTaskObjectDefinition, cmpTaskObjectEntry);
 
 		Assert.assertEquals("TaskHistory", _getComponentName());
 	}
@@ -57,18 +57,18 @@ public class HistoryComponentSectionFragmentRendererTest
 	public void testGetProps() throws Exception {
 		Assert.assertEquals(
 			StringBundler.concat(
-				"/o", projectObjectDefinition.getRESTContextPath(),
-				StringPool.SLASH, projectObjectEntry.getObjectEntryId(),
+				"/o", cmpProjectObjectDefinition.getRESTContextPath(),
+				StringPool.SLASH, cmpProjectObjectEntry.getObjectEntryId(),
 				"?fields=auditEvents&nestedFields=auditEvents"),
 			MapUtil.getString(getProps(), "apiURL"));
 
 		mockHttpServletRequest = getMockHttpServletRequest(
-			taskObjectDefinition, taskObjectEntry);
+			cmpTaskObjectDefinition, cmpTaskObjectEntry);
 
 		Assert.assertEquals(
 			StringBundler.concat(
-				"/o", taskObjectDefinition.getRESTContextPath(),
-				StringPool.SLASH, taskObjectEntry.getObjectEntryId(),
+				"/o", cmpTaskObjectDefinition.getRESTContextPath(),
+				StringPool.SLASH, cmpTaskObjectEntry.getObjectEntryId(),
 				"?fields=auditEvents&nestedFields=auditEvents"),
 			MapUtil.getString(getProps(), "apiURL"));
 	}

--- a/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/fragment/renderer/test/ProjectBreadcrumbComponentSectionFragmentRendererTest.java
+++ b/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/fragment/renderer/test/ProjectBreadcrumbComponentSectionFragmentRendererTest.java
@@ -66,8 +66,8 @@ public class ProjectBreadcrumbComponentSectionFragmentRendererTest
 					themeDisplay.getPathFriendlyURLPublic(),
 					GroupConstants.CMS_FRIENDLY_URL, "/e/edit-project/",
 					_portal.getClassNameId(
-						projectObjectDefinition.getClassName()),
-					StringPool.SLASH, projectObjectEntry.getObjectEntryId(),
+						cmpProjectObjectDefinition.getClassName()),
+					StringPool.SLASH, cmpProjectObjectEntry.getObjectEntryId(),
 					"?redirect=", themeDisplay.getURLCurrent())
 			).put(
 				"label", "Edit"
@@ -82,10 +82,11 @@ public class ProjectBreadcrumbComponentSectionFragmentRendererTest
 			JSONUtil.put(
 				"href",
 				StringBundler.concat(
-					"/o", projectObjectDefinition.getRESTContextPath(),
-					"/scopes/", projectObjectEntry.getGroupId(),
+					"/o", cmpProjectObjectDefinition.getRESTContextPath(),
+					"/scopes/", cmpProjectObjectEntry.getGroupId(),
 					"/by-external-reference-code/",
-					projectObjectEntry.getExternalReferenceCode(), "/subscribe")
+					cmpProjectObjectEntry.getExternalReferenceCode(),
+					"/subscribe")
 			).put(
 				"label", "Watch Project"
 			).put(
@@ -94,13 +95,14 @@ public class ProjectBreadcrumbComponentSectionFragmentRendererTest
 					themeDisplay.getPathFriendlyURLPublic(),
 					GroupConstants.CMS_FRIENDLY_URL, "/e/project/",
 					PortalUtil.getClassNameId(
-						projectObjectDefinition.getClassName()),
-					StringPool.SLASH, projectObjectEntry.getObjectEntryId())
+						cmpProjectObjectDefinition.getClassName()),
+					StringPool.SLASH, cmpProjectObjectEntry.getObjectEntryId())
 			).put(
 				"successMessage",
 				_language.format(
 					mockHttpServletRequest, "you-are-successfully-watching-x",
-					StringBundler.concat("<strong>", projectTitle, "</strong>"))
+					StringBundler.concat(
+						"<strong>", cmpProjectObjectEntryTitle, "</strong>"))
 			).put(
 				"symbolLeft", "bell-on"
 			).put(
@@ -117,17 +119,17 @@ public class ProjectBreadcrumbComponentSectionFragmentRendererTest
 				"confirmationMessage",
 				_language.format(
 					mockHttpServletRequest, "delete-project-confirmation-body",
-					projectTitle)
+					cmpProjectObjectEntryTitle)
 			).put(
 				"confirmationTitle",
 				_language.format(
 					mockHttpServletRequest, "delete-asset-confirmation-title",
-					projectTitle)
+					cmpProjectObjectEntryTitle)
 			).put(
 				"href",
 				StringBundler.concat(
-					"/o", projectObjectDefinition.getRESTContextPath(),
-					StringPool.SLASH, projectObjectEntry.getObjectEntryId())
+					"/o", cmpProjectObjectDefinition.getRESTContextPath(),
+					StringPool.SLASH, cmpProjectObjectEntry.getObjectEntryId())
 			).put(
 				"label", "Delete"
 			).put(
@@ -139,7 +141,8 @@ public class ProjectBreadcrumbComponentSectionFragmentRendererTest
 				"successMessage",
 				_language.format(
 					mockHttpServletRequest, "x-was-successfully-deleted",
-					StringBundler.concat("<strong>", projectTitle, "</strong>"))
+					StringBundler.concat(
+						"<strong>", cmpProjectObjectEntryTitle, "</strong>"))
 			).put(
 				"symbolLeft", "trash"
 			).put(
@@ -172,7 +175,7 @@ public class ProjectBreadcrumbComponentSectionFragmentRendererTest
 			).put(
 				"href", StringPool.BLANK
 			).put(
-				"label", projectTitle
+				"label", cmpProjectObjectEntryTitle
 			).toString(),
 			jsonObject.toString(), true);
 

--- a/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/fragment/renderer/test/ProjectSelectorComponentSectionFragmentRendererTest.java
+++ b/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/fragment/renderer/test/ProjectSelectorComponentSectionFragmentRendererTest.java
@@ -50,7 +50,7 @@ public class ProjectSelectorComponentSectionFragmentRendererTest
 		super.setUp();
 
 		mockHttpServletRequest = getMockHttpServletRequest(
-			taskObjectDefinition, taskObjectEntry);
+			cmpTaskObjectDefinition, cmpTaskObjectEntry);
 	}
 
 	@Test
@@ -62,9 +62,10 @@ public class ProjectSelectorComponentSectionFragmentRendererTest
 		JSONAssert.assertEquals(
 			JSONUtil.put(
 				"label",
-				MapUtil.getString(projectObjectEntry.getValues(), "title")
+				MapUtil.getString(cmpProjectObjectEntry.getValues(), "title")
 			).put(
-				"value", String.valueOf(projectObjectEntry.getObjectEntryId())
+				"value",
+				String.valueOf(cmpProjectObjectEntry.getObjectEntryId())
 			).toString(),
 			String.valueOf(jsonArray.getJSONObject(0)), true);
 	}

--- a/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/fragment/renderer/test/StateSelectorComponentSectionFragmentRendererTest.java
+++ b/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/fragment/renderer/test/StateSelectorComponentSectionFragmentRendererTest.java
@@ -85,19 +85,20 @@ public class StateSelectorComponentSectionFragmentRendererTest
 			).toString(),
 			MapUtil.getString(getProps(), "states"), true);
 
-		projectObjectEntry = _objectEntryLocalService.partialUpdateObjectEntry(
-			projectObjectEntry.getUserId(),
-			projectObjectEntry.getObjectEntryId(),
-			projectObjectEntry.getObjectEntryFolderId(),
-			HashMapBuilder.<String, Serializable>put(
-				"state", "inProgress"
-			).put(
-				"title", RandomTestUtil.randomString()
-			).build(),
-			ServiceContextTestUtil.getServiceContext());
+		cmpProjectObjectEntry =
+			_objectEntryLocalService.partialUpdateObjectEntry(
+				cmpProjectObjectEntry.getUserId(),
+				cmpProjectObjectEntry.getObjectEntryId(),
+				cmpProjectObjectEntry.getObjectEntryFolderId(),
+				HashMapBuilder.<String, Serializable>put(
+					"state", "inProgress"
+				).put(
+					"title", RandomTestUtil.randomString()
+				).build(),
+				ServiceContextTestUtil.getServiceContext());
 
 		mockHttpServletRequest.setAttribute(
-			InfoDisplayWebKeys.INFO_ITEM, projectObjectEntry);
+			InfoDisplayWebKeys.INFO_ITEM, cmpProjectObjectEntry);
 
 		Assert.assertEquals(
 			"inProgress", MapUtil.getString(getProps(), "initialSelectedKey"));

--- a/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/fragment/renderer/test/TagsComponentSectionFragmentRendererTest.java
+++ b/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/fragment/renderer/test/TagsComponentSectionFragmentRendererTest.java
@@ -56,11 +56,12 @@ public class TagsComponentSectionFragmentRendererTest
 
 		serviceContext.setAssetTagNames(new String[] {keyword1, keyword2});
 
-		projectObjectEntry = _objectEntryLocalService.partialUpdateObjectEntry(
-			projectObjectEntry.getUserId(),
-			projectObjectEntry.getObjectEntryId(),
-			projectObjectEntry.getObjectEntryFolderId(), Collections.emptyMap(),
-			serviceContext);
+		cmpProjectObjectEntry =
+			_objectEntryLocalService.partialUpdateObjectEntry(
+				cmpProjectObjectEntry.getUserId(),
+				cmpProjectObjectEntry.getObjectEntryId(),
+				cmpProjectObjectEntry.getObjectEntryFolderId(),
+				Collections.emptyMap(), serviceContext);
 
 		themeDisplay.setPermissionChecker(
 			PermissionThreadLocal.getPermissionChecker());

--- a/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/fragment/renderer/test/TaskBreadcrumbComponentSectionFragmentRendererTest.java
+++ b/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/fragment/renderer/test/TaskBreadcrumbComponentSectionFragmentRendererTest.java
@@ -68,7 +68,7 @@ public class TaskBreadcrumbComponentSectionFragmentRendererTest
 	public void setUp() throws Exception {
 		super.setUp();
 
-		_taskObjectDefinition =
+		_cmpTaskObjectDefinition =
 			objectDefinitionLocalService.
 				getObjectDefinitionByExternalReferenceCode(
 					"L_CMP_TASK", TestPropsValues.getCompanyId());
@@ -78,19 +78,21 @@ public class TaskBreadcrumbComponentSectionFragmentRendererTest
 
 		serviceContext.setWorkflowAction(WorkflowConstants.ACTION_SAVE_DRAFT);
 
-		_taskObjectEntry = _objectEntryLocalService.addObjectEntry(
-			projectObjectEntry.getGroupId(), projectObjectEntry.getUserId(),
-			_taskObjectDefinition.getObjectDefinitionId(), 0, null,
+		_cmpTaskObjectEntry = _objectEntryLocalService.addObjectEntry(
+			cmpProjectObjectEntry.getGroupId(),
+			cmpProjectObjectEntry.getUserId(),
+			_cmpTaskObjectDefinition.getObjectDefinitionId(), 0, null,
 			HashMapBuilder.<String, Serializable>put(
 				"r_cmpProjectToCMPTasks_c_cmpProjectId",
-				projectObjectEntry.getObjectEntryId()
+				cmpProjectObjectEntry.getObjectEntryId()
 			).build(),
 			serviceContext);
 
-		_taskTitle = MapUtil.getString(_taskObjectEntry.getValues(), "title");
+		_cmpTaskObjectEntryTitle = MapUtil.getString(
+			_cmpTaskObjectEntry.getValues(), "title");
 
 		mockHttpServletRequest = getMockHttpServletRequest(
-			_taskObjectDefinition, _taskObjectEntry);
+			_cmpTaskObjectDefinition, _cmpTaskObjectEntry);
 	}
 
 	@Test
@@ -108,8 +110,8 @@ public class TaskBreadcrumbComponentSectionFragmentRendererTest
 					themeDisplay.getPathFriendlyURLPublic(),
 					GroupConstants.CMS_FRIENDLY_URL, "/e/edit-task/",
 					_portal.getClassNameId(
-						_taskObjectDefinition.getClassName()),
-					StringPool.SLASH, _taskObjectEntry.getObjectEntryId(),
+						_cmpTaskObjectDefinition.getClassName()),
+					StringPool.SLASH, _cmpTaskObjectEntry.getObjectEntryId(),
 					"?redirect=", themeDisplay.getURLCurrent())
 			).put(
 				"label", "Edit"
@@ -124,10 +126,11 @@ public class TaskBreadcrumbComponentSectionFragmentRendererTest
 			JSONUtil.put(
 				"href",
 				StringBundler.concat(
-					"/o", _taskObjectDefinition.getRESTContextPath(),
-					"/scopes/", _taskObjectEntry.getGroupId(),
+					"/o", _cmpTaskObjectDefinition.getRESTContextPath(),
+					"/scopes/", _cmpTaskObjectEntry.getGroupId(),
 					"/by-external-reference-code/",
-					_taskObjectEntry.getExternalReferenceCode(), "/subscribe")
+					_cmpTaskObjectEntry.getExternalReferenceCode(),
+					"/subscribe")
 			).put(
 				"label", "Watch Task"
 			).put(
@@ -136,8 +139,8 @@ public class TaskBreadcrumbComponentSectionFragmentRendererTest
 					themeDisplay.getPathFriendlyURLPublic(),
 					GroupConstants.CMS_FRIENDLY_URL, "/e/task/",
 					PortalUtil.getClassNameId(
-						_taskObjectDefinition.getClassName()),
-					StringPool.SLASH, _taskObjectEntry.getObjectEntryId())
+						_cmpTaskObjectDefinition.getClassName()),
+					StringPool.SLASH, _cmpTaskObjectEntry.getObjectEntryId())
 			).put(
 				"successMessage",
 				LanguageUtil.format(
@@ -145,7 +148,7 @@ public class TaskBreadcrumbComponentSectionFragmentRendererTest
 					StringBundler.concat(
 						"<strong>",
 						MapUtil.getString(
-							_taskObjectEntry.getValues(), "title"),
+							_cmpTaskObjectEntry.getValues(), "title"),
 						"</strong>"))
 			).put(
 				"symbolLeft", "bell-on"
@@ -163,17 +166,17 @@ public class TaskBreadcrumbComponentSectionFragmentRendererTest
 				"confirmationMessage",
 				_language.format(
 					mockHttpServletRequest, "delete-task-confirmation-body",
-					_taskTitle)
+					_cmpTaskObjectEntryTitle)
 			).put(
 				"confirmationTitle",
 				_language.format(
 					mockHttpServletRequest, "delete-asset-confirmation-title",
-					_taskTitle)
+					_cmpTaskObjectEntryTitle)
 			).put(
 				"href",
 				StringBundler.concat(
-					"/o", _taskObjectDefinition.getRESTContextPath(),
-					StringPool.SLASH, _taskObjectEntry.getObjectEntryId())
+					"/o", _cmpTaskObjectDefinition.getRESTContextPath(),
+					StringPool.SLASH, _cmpTaskObjectEntry.getObjectEntryId())
 			).put(
 				"label", "Delete"
 			).put(
@@ -185,7 +188,8 @@ public class TaskBreadcrumbComponentSectionFragmentRendererTest
 				"successMessage",
 				_language.format(
 					mockHttpServletRequest, "x-was-successfully-deleted",
-					StringBundler.concat("<strong>", _taskTitle, "</strong>"))
+					StringBundler.concat(
+						"<strong>", _cmpTaskObjectEntryTitle, "</strong>"))
 			).put(
 				"symbolLeft", "trash"
 			).put(
@@ -221,10 +225,10 @@ public class TaskBreadcrumbComponentSectionFragmentRendererTest
 					themeDisplay.getPathFriendlyURLPublic(),
 					GroupConstants.CMS_FRIENDLY_URL, "/e/project/",
 					PortalUtil.getClassNameId(
-						projectObjectDefinition.getClassName()),
-					StringPool.SLASH, projectObjectEntry.getObjectEntryId())
+						cmpProjectObjectDefinition.getClassName()),
+					StringPool.SLASH, cmpProjectObjectEntry.getObjectEntryId())
 			).put(
-				"label", projectTitle
+				"label", cmpProjectObjectEntryTitle
 			).toString(),
 			jsonObject.toString(), true);
 
@@ -236,7 +240,7 @@ public class TaskBreadcrumbComponentSectionFragmentRendererTest
 			).put(
 				"href", StringPool.BLANK
 			).put(
-				"label", _taskTitle
+				"label", _cmpTaskObjectEntryTitle
 			).toString(),
 			jsonObject.toString(), true);
 
@@ -248,6 +252,10 @@ public class TaskBreadcrumbComponentSectionFragmentRendererTest
 	protected FragmentRenderer getFragmentRenderer() {
 		return _fragmentRenderer;
 	}
+
+	private ObjectDefinition _cmpTaskObjectDefinition;
+	private ObjectEntry _cmpTaskObjectEntry;
+	private String _cmpTaskObjectEntryTitle;
 
 	@Inject(
 		filter = "component.name=com.liferay.site.cmp.site.initializer.internal.fragment.renderer.TaskBreadcrumbComponentSectionFragmentRenderer"
@@ -262,9 +270,5 @@ public class TaskBreadcrumbComponentSectionFragmentRendererTest
 
 	@Inject
 	private Portal _portal;
-
-	private ObjectDefinition _taskObjectDefinition;
-	private ObjectEntry _taskObjectEntry;
-	private String _taskTitle;
 
 }

--- a/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/frontend/data/set/view/table/test/TaskSectionTableFDSViewTest.java
+++ b/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/frontend/data/set/view/table/test/TaskSectionTableFDSViewTest.java
@@ -71,7 +71,7 @@ public class TaskSectionTableFDSViewTest
 		assertFDSTableSchemaField(
 			null, "projectTitleTableCellRenderer", "project", "projectTitle");
 		assertFDSTableSchemaField(
-			null, "stateTableCellRenderer", "state-status", "state");
+			null, "stateTableCellRenderer", "state", "state");
 		assertFDSTableSchemaField(
 			"actionLink", "simpleActionLinkTableCellRenderer", "title",
 			"title");

--- a/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/model/listener/test/BaseModelListenerTestCase.java
+++ b/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/model/listener/test/BaseModelListenerTestCase.java
@@ -55,7 +55,7 @@ public abstract class BaseModelListenerTestCase {
 
 		CMPTestUtil.getOrAddGroup(BaseModelListenerTestCase.class);
 
-		projectObjectEntry = CMPTestUtil.addProjectObjectEntry();
+		cmpProjectObjectEntry = CMPTestUtil.addCMPProjectObjectEntry();
 	}
 
 	@After
@@ -63,17 +63,17 @@ public abstract class BaseModelListenerTestCase {
 		ReflectionTestUtil.setFieldValue(
 			getModelListener(), "auditRouter", _auditRouter);
 
-		_objectEntryLocalService.deleteObjectEntry(projectObjectEntry);
+		_objectEntryLocalService.deleteObjectEntry(cmpProjectObjectEntry);
 	}
 
 	protected void assertAuditMessage(String expectedEventType) {
 		AuditMessage auditMessage = _auditMessages.poll();
 
 		Assert.assertEquals(
-			projectObjectEntry.getModelClassName(),
+			cmpProjectObjectEntry.getModelClassName(),
 			auditMessage.getClassName());
 		Assert.assertEquals(
-			projectObjectEntry.getObjectEntryId(),
+			cmpProjectObjectEntry.getObjectEntryId(),
 			GetterUtil.getLong(auditMessage.getClassPK()));
 		Assert.assertEquals(expectedEventType, auditMessage.getEventType());
 
@@ -82,7 +82,7 @@ public abstract class BaseModelListenerTestCase {
 
 	protected abstract ModelListener<?> getModelListener();
 
-	protected ObjectEntry projectObjectEntry;
+	protected ObjectEntry cmpProjectObjectEntry;
 
 	private final Queue<AuditMessage> _auditMessages = new LinkedList<>();
 	private AuditRouter _auditRouter;

--- a/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/model/listener/test/MBMessageModelListenerTest.java
+++ b/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/model/listener/test/MBMessageModelListenerTest.java
@@ -92,15 +92,17 @@ public class MBMessageModelListenerTest {
 
 	@Test
 	public void testOnAfterCreate() throws Exception {
-		ObjectEntry projectObjectEntry = CMPTestUtil.addProjectObjectEntry();
+		ObjectEntry cmpProjectObjectEntry =
+			CMPTestUtil.addCMPProjectObjectEntry();
 
 		_objectEntryLocalService.subscribeObjectEntry(
-			TestPropsValues.getUserId(), projectObjectEntry.getGroupId(),
-			projectObjectEntry.getObjectEntryId());
+			TestPropsValues.getUserId(), cmpProjectObjectEntry.getGroupId(),
+			cmpProjectObjectEntry.getObjectEntryId());
 
-		projectObjectEntry = _objectEntryLocalService.updateObjectEntry(
-			TestPropsValues.getUserId(), projectObjectEntry.getObjectEntryId(),
-			projectObjectEntry.getObjectEntryFolderId(),
+		cmpProjectObjectEntry = _objectEntryLocalService.updateObjectEntry(
+			TestPropsValues.getUserId(),
+			cmpProjectObjectEntry.getObjectEntryId(),
+			cmpProjectObjectEntry.getObjectEntryFolderId(),
 			HashMapBuilder.<String, Serializable>put(
 				"title", RandomTestUtil.randomString()
 			).build(),
@@ -109,9 +111,10 @@ public class MBMessageModelListenerTest {
 		User user = TestPropsValues.getUser();
 
 		_commentManager.addComment(
-			null, TestPropsValues.getUserId(), projectObjectEntry.getGroupId(),
-			projectObjectEntry.getModelClassName(),
-			projectObjectEntry.getObjectEntryId(), user.getFullName(), null,
+			null, TestPropsValues.getUserId(),
+			cmpProjectObjectEntry.getGroupId(),
+			cmpProjectObjectEntry.getModelClassName(),
+			cmpProjectObjectEntry.getObjectEntryId(), user.getFullName(), null,
 			RandomTestUtil.randomString(),
 			new IdentityServiceContextFunction(
 				ServiceContextTestUtil.getServiceContext()));
@@ -119,14 +122,14 @@ public class MBMessageModelListenerTest {
 		Assert.assertTrue(
 			MailServiceTestUtil.lastMailMessageContains(
 				"There is a new comment on the project " +
-					projectObjectEntry.getTitleValue()));
+					cmpProjectObjectEntry.getTitleValue()));
 		Assert.assertTrue(
 			MailServiceTestUtil.lastMailMessageContains(
 				StringBundler.concat(
 					GroupConstants.CMS_FRIENDLY_URL, "/e/project/",
 					_portal.getClassNameId(
-						projectObjectEntry.getModelClassName()),
-					"/", projectObjectEntry.getObjectEntryId())));
+						cmpProjectObjectEntry.getModelClassName()),
+					"/", cmpProjectObjectEntry.getObjectEntryId())));
 	}
 
 	@Inject

--- a/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/model/listener/test/ObjectEntryAuditModelListenerTest.java
+++ b/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/model/listener/test/ObjectEntryAuditModelListenerTest.java
@@ -83,7 +83,7 @@ public class ObjectEntryAuditModelListenerTest {
 
 		CMPTestUtil.getOrAddGroup(ObjectEntryAuditModelListenerTest.class);
 
-		_cmpTaskObjectEntry = CMPTestUtil.addTaskObjectEntry();
+		_cmpTaskObjectEntry = CMPTestUtil.addCMPTaskObjectEntry();
 
 		_cmpTaskObjectEntry = _objectEntryLocalService.partialUpdateObjectEntry(
 			_cmpTaskObjectEntry.getUserId(),

--- a/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/model/listener/test/ObjectEntryModelListenerTest.java
+++ b/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/model/listener/test/ObjectEntryModelListenerTest.java
@@ -73,89 +73,93 @@ public class ObjectEntryModelListenerTest {
 
 	@Test
 	public void testOnAfterCreate() throws Exception {
-		ObjectEntry projectObjectEntry = CMPTestUtil.addProjectObjectEntry();
+		ObjectEntry cmpProjectObjectEntry =
+			CMPTestUtil.addCMPProjectObjectEntry();
 
 		Group group = _groupLocalService.getGroup(
-			projectObjectEntry.getGroupId());
+			cmpProjectObjectEntry.getGroupId());
 
 		Assert.assertEquals(
 			group.getName(LocaleUtil.getDefault()),
-			MapUtil.getString(projectObjectEntry.getValues(), "title"));
+			MapUtil.getString(cmpProjectObjectEntry.getValues(), "title"));
 
 		Role role = RoleUtil.getOrAddCMSAdministratorRole(
 			TestPropsValues.getCompanyId(), TestPropsValues.getUserId());
 
 		_assertResourceActions(
-			projectObjectEntry, role.getName(), ActionKeys.ADD_DISCUSSION,
+			cmpProjectObjectEntry, role.getName(), ActionKeys.ADD_DISCUSSION,
 			ActionKeys.DELETE, ActionKeys.DELETE_DISCUSSION,
 			ActionKeys.PERMISSIONS, ActionKeys.SUBSCRIBE, ActionKeys.UPDATE,
 			ActionKeys.UPDATE_DISCUSSION, ActionKeys.VIEW,
 			ObjectActionKeys.OBJECT_ENTRY_HISTORY);
 
 		_assertResourceActions(
-			projectObjectEntry, DepotRolesConstants.PROJECT_CONTRIBUTOR,
+			cmpProjectObjectEntry, DepotRolesConstants.PROJECT_CONTRIBUTOR,
 			ActionKeys.ADD_DISCUSSION, ActionKeys.VIEW);
 		_assertResourceActions(
-			projectObjectEntry, DepotRolesConstants.PROJECT_MANAGER,
+			cmpProjectObjectEntry, DepotRolesConstants.PROJECT_MANAGER,
 			ActionKeys.ADD_DISCUSSION, ActionKeys.DELETE,
 			ActionKeys.DELETE_DISCUSSION, ActionKeys.PERMISSIONS,
 			ActionKeys.SUBSCRIBE, ActionKeys.UPDATE,
 			ActionKeys.UPDATE_DISCUSSION, ActionKeys.VIEW,
 			ObjectActionKeys.OBJECT_ENTRY_HISTORY);
 		_assertResourceActions(
-			projectObjectEntry, DepotRolesConstants.PROJECT_MEMBER,
+			cmpProjectObjectEntry, DepotRolesConstants.PROJECT_MEMBER,
 			ActionKeys.ADD_DISCUSSION, ActionKeys.VIEW);
 
-		ObjectEntry taskObjectEntry = CMPTestUtil.addTaskObjectEntry(
-			projectObjectEntry);
+		ObjectEntry cmpTaskObjectEntry = CMPTestUtil.addCMPTaskObjectEntry(
+			cmpProjectObjectEntry);
 
 		_assertResourceActions(
-			taskObjectEntry, role.getName(), ActionKeys.ADD_DISCUSSION,
+			cmpTaskObjectEntry, role.getName(), ActionKeys.ADD_DISCUSSION,
 			ActionKeys.DELETE, ActionKeys.DELETE_DISCUSSION,
 			ActionKeys.PERMISSIONS, ActionKeys.SUBSCRIBE, ActionKeys.UPDATE,
 			ActionKeys.UPDATE_DISCUSSION, ActionKeys.VIEW,
 			ObjectActionKeys.OBJECT_ENTRY_HISTORY);
 
 		_assertResourceActions(
-			taskObjectEntry, DepotRolesConstants.PROJECT_CONTRIBUTOR,
+			cmpTaskObjectEntry, DepotRolesConstants.PROJECT_CONTRIBUTOR,
 			ActionKeys.ADD_DISCUSSION, ActionKeys.UPDATE, ActionKeys.VIEW);
 		_assertResourceActions(
-			taskObjectEntry, DepotRolesConstants.PROJECT_MANAGER,
+			cmpTaskObjectEntry, DepotRolesConstants.PROJECT_MANAGER,
 			ActionKeys.ADD_DISCUSSION, ActionKeys.DELETE,
 			ActionKeys.DELETE_DISCUSSION, ActionKeys.PERMISSIONS,
 			ActionKeys.SUBSCRIBE, ActionKeys.UPDATE,
 			ActionKeys.UPDATE_DISCUSSION, ActionKeys.VIEW,
 			ObjectActionKeys.OBJECT_ENTRY_HISTORY);
 		_assertResourceActions(
-			taskObjectEntry, DepotRolesConstants.PROJECT_MEMBER,
+			cmpTaskObjectEntry, DepotRolesConstants.PROJECT_MEMBER,
 			ActionKeys.ADD_DISCUSSION, ActionKeys.VIEW);
 	}
 
 	@Test
 	public void testOnAfterUpdate() throws Exception {
-		ObjectEntry projectObjectEntry = CMPTestUtil.addProjectObjectEntry();
+		ObjectEntry cmpProjectObjectEntry =
+			CMPTestUtil.addCMPProjectObjectEntry();
 
-		User user1 = UserTestUtil.addUser(projectObjectEntry.getGroupId());
-		User user2 = UserTestUtil.addUser(projectObjectEntry.getGroupId());
+		User user1 = UserTestUtil.addUser(cmpProjectObjectEntry.getGroupId());
+		User user2 = UserTestUtil.addUser(cmpProjectObjectEntry.getGroupId());
 
-		Map<String, Serializable> values = projectObjectEntry.getValues();
+		Map<String, Serializable> values = cmpProjectObjectEntry.getValues();
 
 		values.put("r_userToCMPProjectManager_userId", user1.getUserId());
 		values.put("r_userToCMPProjectSponsor_userId", user2.getUserId());
 
-		projectObjectEntry.setValues(values);
+		cmpProjectObjectEntry.setValues(values);
 
-		projectObjectEntry = _objectEntryLocalService.partialUpdateObjectEntry(
-			TestPropsValues.getUserId(), projectObjectEntry.getObjectEntryId(),
-			projectObjectEntry.getObjectEntryFolderId(), values,
-			ServiceContextTestUtil.getServiceContext());
+		cmpProjectObjectEntry =
+			_objectEntryLocalService.partialUpdateObjectEntry(
+				TestPropsValues.getUserId(),
+				cmpProjectObjectEntry.getObjectEntryId(),
+				cmpProjectObjectEntry.getObjectEntryFolderId(), values,
+				ServiceContextTestUtil.getServiceContext());
 
 		_assertUserGroupRoles(
 			1, Collections.singletonList(DepotRolesConstants.PROJECT_MANAGER),
-			projectObjectEntry.getGroupId(), user1.getUserId());
+			cmpProjectObjectEntry.getGroupId(), user1.getUserId());
 		_assertUserGroupRoles(
 			1, Collections.singletonList(DepotRolesConstants.PROJECT_MEMBER),
-			projectObjectEntry.getGroupId(), user2.getUserId());
+			cmpProjectObjectEntry.getGroupId(), user2.getUserId());
 	}
 
 	private void _assertResourceActions(

--- a/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/model/listener/test/UserGroupModelListenerTest.java
+++ b/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/model/listener/test/UserGroupModelListenerTest.java
@@ -37,7 +37,7 @@ public class UserGroupModelListenerTest extends BaseModelListenerTestCase {
 	@Test
 	public void testOnAfterAddAssociation() throws Exception {
 		_userGroupLocalService.setGroupUserGroups(
-			projectObjectEntry.getGroupId(),
+			cmpProjectObjectEntry.getGroupId(),
 			new long[] {_userGroup.getUserGroupId()});
 
 		assertAuditMessage("CMP_ADD_MEMBER");
@@ -46,13 +46,13 @@ public class UserGroupModelListenerTest extends BaseModelListenerTestCase {
 	@Test
 	public void testOnAfterRemoveAssociation() throws Exception {
 		_userGroupLocalService.setGroupUserGroups(
-			projectObjectEntry.getGroupId(),
+			cmpProjectObjectEntry.getGroupId(),
 			new long[] {_userGroup.getUserGroupId()});
 
 		assertAuditMessage("CMP_ADD_MEMBER");
 
 		_userGroupLocalService.unsetGroupUserGroups(
-			projectObjectEntry.getGroupId(),
+			cmpProjectObjectEntry.getGroupId(),
 			new long[] {_userGroup.getUserGroupId()});
 
 		assertAuditMessage("CMP_REMOVE_MEMBER");

--- a/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/model/listener/test/UserModelListenerTest.java
+++ b/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/model/listener/test/UserModelListenerTest.java
@@ -42,14 +42,14 @@ public class UserModelListenerTest extends BaseModelListenerTestCase {
 
 	@Test
 	public void testOnAfterAddAssociation() throws Exception {
-		_updateUser(new long[] {projectObjectEntry.getGroupId()});
+		_updateUser(new long[] {cmpProjectObjectEntry.getGroupId()});
 
 		assertAuditMessage("CMP_ADD_MEMBER");
 	}
 
 	@Test
 	public void testOnAfterRemoveAssociation() throws Exception {
-		_updateUser(new long[] {projectObjectEntry.getGroupId()});
+		_updateUser(new long[] {cmpProjectObjectEntry.getGroupId()});
 
 		assertAuditMessage("CMP_ADD_MEMBER");
 

--- a/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/service/test/ObjectEntryLocalServiceTest.java
@@ -52,24 +52,27 @@ public class ObjectEntryLocalServiceTest {
 	public void setUp() throws Exception {
 		CMPTestUtil.getOrAddGroup(ObjectEntryLocalServiceTest.class);
 
-		_projectLinkObjectDefinition =
+		_cmpProjectLinkObjectDefinition =
 			_objectDefinitionLocalService.
 				getObjectDefinitionByExternalReferenceCode(
 					"L_CMP_PROJECT_LINK", TestPropsValues.getCompanyId());
-		_taskLinkObjectDefinition =
+		_cmpTaskLinkObjectDefinition =
 			_objectDefinitionLocalService.
 				getObjectDefinitionByExternalReferenceCode(
 					"L_CMP_TASK_LINK", TestPropsValues.getCompanyId());
 	}
 
 	@Test
-	public void testDeleteProjectObjectEntry() throws Exception {
-		ObjectEntry projectObjectEntry = CMPTestUtil.addProjectObjectEntry();
+	public void testDeleteCMPProjectObjectEntry() throws Exception {
+		ObjectEntry cmpProjectObjectEntry =
+			CMPTestUtil.addCMPProjectObjectEntry();
 
-		ObjectEntry projectLinkObjectEntry =
+		ObjectEntry cmpProjectLinkObjectEntry =
 			_objectEntryLocalService.addObjectEntry(
-				projectObjectEntry.getGroupId(), projectObjectEntry.getUserId(),
-				_projectLinkObjectDefinition.getObjectDefinitionId(), 0, null,
+				cmpProjectObjectEntry.getGroupId(),
+				cmpProjectObjectEntry.getUserId(),
+				_cmpProjectLinkObjectDefinition.getObjectDefinitionId(), 0,
+				null,
 				HashMapBuilder.<String, Serializable>put(
 					"classExternalReferenceCode", RandomTestUtil.randomString()
 				).put(
@@ -78,26 +81,26 @@ public class ObjectEntryLocalServiceTest {
 					"groupExternalReferenceCode", RandomTestUtil.randomString()
 				).put(
 					"r_cmpProjectToCMPProjectLinks_c_cmpProjectId",
-					projectObjectEntry.getObjectEntryId()
+					cmpProjectObjectEntry.getObjectEntryId()
 				).build(),
 				ServiceContextTestUtil.getServiceContext());
 
 		_objectEntryLocalService.deleteObjectEntry(
-			projectObjectEntry.getObjectEntryId());
+			cmpProjectObjectEntry.getObjectEntryId());
 
 		Assert.assertNull(
 			_objectEntryLocalService.fetchObjectEntry(
-				projectLinkObjectEntry.getObjectEntryId()));
+				cmpProjectLinkObjectEntry.getObjectEntryId()));
 	}
 
 	@Test
-	public void testDeleteTaskObjectEntry() throws Exception {
-		ObjectEntry taskObjectEntry = CMPTestUtil.addTaskObjectEntry();
+	public void testDeleteCMPTaskObjectEntry() throws Exception {
+		ObjectEntry cmpTaskObjectEntry = CMPTestUtil.addCMPTaskObjectEntry();
 
-		ObjectEntry taskLinkObjectEntry =
+		ObjectEntry cmpTaskLinkObjectEntry =
 			_objectEntryLocalService.addObjectEntry(
-				taskObjectEntry.getGroupId(), taskObjectEntry.getUserId(),
-				_taskLinkObjectDefinition.getObjectDefinitionId(), 0, null,
+				cmpTaskObjectEntry.getGroupId(), cmpTaskObjectEntry.getUserId(),
+				_cmpTaskLinkObjectDefinition.getObjectDefinitionId(), 0, null,
 				HashMapBuilder.<String, Serializable>put(
 					"classExternalReferenceCode", RandomTestUtil.randomString()
 				).put(
@@ -106,17 +109,20 @@ public class ObjectEntryLocalServiceTest {
 					"groupExternalReferenceCode", RandomTestUtil.randomString()
 				).put(
 					"r_cmpTaskToCMPTaskLinks_c_cmpTaskId",
-					taskObjectEntry.getObjectEntryId()
+					cmpTaskObjectEntry.getObjectEntryId()
 				).build(),
 				ServiceContextTestUtil.getServiceContext());
 
 		_objectEntryLocalService.deleteObjectEntry(
-			taskObjectEntry.getObjectEntryId());
+			cmpTaskObjectEntry.getObjectEntryId());
 
 		Assert.assertNull(
 			_objectEntryLocalService.fetchObjectEntry(
-				taskLinkObjectEntry.getObjectEntryId()));
+				cmpTaskLinkObjectEntry.getObjectEntryId()));
 	}
+
+	private ObjectDefinition _cmpProjectLinkObjectDefinition;
+	private ObjectDefinition _cmpTaskLinkObjectDefinition;
 
 	@Inject
 	private DepotEntryLocalService _depotEntryLocalService;
@@ -126,8 +132,5 @@ public class ObjectEntryLocalServiceTest {
 
 	@Inject
 	private ObjectEntryLocalService _objectEntryLocalService;
-
-	private ObjectDefinition _projectLinkObjectDefinition;
-	private ObjectDefinition _taskLinkObjectDefinition;
 
 }

--- a/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/service/test/ObjectEntryLocalServiceTest.java
@@ -1,0 +1,133 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cmp.site.initializer.internal.service.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.site.cmp.site.initializer.test.util.CMPTestUtil;
+
+import java.io.Serializable;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Guilherme Camacho
+ */
+@FeatureFlags(
+	featureFlags = {@FeatureFlag("LPD-17564"), @FeatureFlag("LPD-58677")}
+)
+@RunWith(Arquillian.class)
+public class ObjectEntryLocalServiceTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		CMPTestUtil.getOrAddGroup(ObjectEntryLocalServiceTest.class);
+
+		_projectLinkObjectDefinition =
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_CMP_PROJECT_LINK", TestPropsValues.getCompanyId());
+		_taskLinkObjectDefinition =
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_CMP_TASK_LINK", TestPropsValues.getCompanyId());
+	}
+
+	@Test
+	public void testDeleteProjectObjectEntry() throws Exception {
+		ObjectEntry projectObjectEntry = CMPTestUtil.addProjectObjectEntry();
+
+		ObjectEntry projectLinkObjectEntry =
+			_objectEntryLocalService.addObjectEntry(
+				projectObjectEntry.getGroupId(), projectObjectEntry.getUserId(),
+				_projectLinkObjectDefinition.getObjectDefinitionId(), 0, null,
+				HashMapBuilder.<String, Serializable>put(
+					"classExternalReferenceCode", RandomTestUtil.randomString()
+				).put(
+					"className", RandomTestUtil.randomString()
+				).put(
+					"groupExternalReferenceCode", RandomTestUtil.randomString()
+				).put(
+					"r_cmpProjectToCMPProjectLinks_c_cmpProjectId",
+					projectObjectEntry.getObjectEntryId()
+				).build(),
+				ServiceContextTestUtil.getServiceContext());
+
+		_objectEntryLocalService.deleteObjectEntry(
+			projectObjectEntry.getObjectEntryId());
+
+		Assert.assertNull(
+			_objectEntryLocalService.fetchObjectEntry(
+				projectLinkObjectEntry.getObjectEntryId()));
+	}
+
+	@Test
+	public void testDeleteTaskObjectEntry() throws Exception {
+		ObjectEntry taskObjectEntry = CMPTestUtil.addTaskObjectEntry();
+
+		ObjectEntry taskLinkObjectEntry =
+			_objectEntryLocalService.addObjectEntry(
+				taskObjectEntry.getGroupId(), taskObjectEntry.getUserId(),
+				_taskLinkObjectDefinition.getObjectDefinitionId(), 0, null,
+				HashMapBuilder.<String, Serializable>put(
+					"classExternalReferenceCode", RandomTestUtil.randomString()
+				).put(
+					"className", RandomTestUtil.randomString()
+				).put(
+					"groupExternalReferenceCode", RandomTestUtil.randomString()
+				).put(
+					"r_cmpTaskToCMPTaskLinks_c_cmpTaskId",
+					taskObjectEntry.getObjectEntryId()
+				).build(),
+				ServiceContextTestUtil.getServiceContext());
+
+		_objectEntryLocalService.deleteObjectEntry(
+			taskObjectEntry.getObjectEntryId());
+
+		Assert.assertNull(
+			_objectEntryLocalService.fetchObjectEntry(
+				taskLinkObjectEntry.getObjectEntryId()));
+	}
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Inject
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	private ObjectDefinition _projectLinkObjectDefinition;
+	private ObjectDefinition _taskLinkObjectDefinition;
+
+}

--- a/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/struts/test/AddTaskStrutsActionTest.java
+++ b/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/struts/test/AddTaskStrutsActionTest.java
@@ -62,8 +62,8 @@ public class AddTaskStrutsActionTest {
 	public void setUp() throws Exception {
 		CMPTestUtil.getOrAddGroup(AddTaskStrutsActionTest.class);
 
-		_projectObjectEntry = CMPTestUtil.addProjectObjectEntry();
-		_taskObjectDefinition =
+		_cmpProjectObjectEntry = CMPTestUtil.addCMPProjectObjectEntry();
+		_cmpTaskObjectDefinition =
 			_objectDefinitionLocalService.
 				getObjectDefinitionByExternalReferenceCode(
 					"L_CMP_TASK", TestPropsValues.getCompanyId());
@@ -86,12 +86,13 @@ public class AddTaskStrutsActionTest {
 
 		mockHttpServletRequest.setParameter(
 			"objectDefinitionId",
-			String.valueOf(_taskObjectDefinition.getObjectDefinitionId()));
+			String.valueOf(_cmpTaskObjectDefinition.getObjectDefinitionId()));
 		mockHttpServletRequest.setParameter(
-			"projectGroupId", String.valueOf(_projectObjectEntry.getGroupId()));
+			"projectGroupId",
+			String.valueOf(_cmpProjectObjectEntry.getGroupId()));
 		mockHttpServletRequest.setParameter(
 			"projectId",
-			String.valueOf(_projectObjectEntry.getObjectEntryId()));
+			String.valueOf(_cmpProjectObjectEntry.getObjectEntryId()));
 
 		MockHttpServletResponse mockHttpServletResponse =
 			new MockHttpServletResponse();
@@ -104,32 +105,35 @@ public class AddTaskStrutsActionTest {
 			StringBundler.concat(
 				themeDisplay.getPathFriendlyURLPublic(),
 				GroupConstants.CMS_FRIENDLY_URL, "/e/edit-task/",
-				_portal.getClassNameId(_taskObjectDefinition.getClassName()),
+				_portal.getClassNameId(_cmpTaskObjectDefinition.getClassName()),
 				StringPool.SLASH));
 
-		ObjectEntry taskObjectEntry = _objectEntryLocalService.fetchObjectEntry(
-			GetterUtil.getLong(objectEntryId));
+		ObjectEntry cmpTaskObjectEntry =
+			_objectEntryLocalService.fetchObjectEntry(
+				GetterUtil.getLong(objectEntryId));
 
 		Assert.assertEquals(
-			_projectObjectEntry.getGroupId(), taskObjectEntry.getGroupId());
+			_cmpProjectObjectEntry.getGroupId(),
+			cmpTaskObjectEntry.getGroupId());
 		Assert.assertEquals(
-			_taskObjectDefinition.getObjectDefinitionId(),
-			taskObjectEntry.getObjectDefinitionId());
+			_cmpTaskObjectDefinition.getObjectDefinitionId(),
+			cmpTaskObjectEntry.getObjectDefinitionId());
 		Assert.assertEquals(
-			WorkflowConstants.STATUS_DRAFT, taskObjectEntry.getStatus());
+			WorkflowConstants.STATUS_DRAFT, cmpTaskObjectEntry.getStatus());
 		Assert.assertEquals(
-			_projectObjectEntry.getObjectEntryId(),
+			_cmpProjectObjectEntry.getObjectEntryId(),
 			MapUtil.getLong(
-				taskObjectEntry.getValues(),
+				cmpTaskObjectEntry.getValues(),
 				"r_cmpProjectToCMPTasks_c_cmpProjectId"));
 
 		String[] tagNames = _assetTagLocalService.getTagNames(
-			_taskObjectDefinition.getClassName(),
-			taskObjectEntry.getObjectEntryId());
+			_cmpTaskObjectDefinition.getClassName(),
+			cmpTaskObjectEntry.getObjectEntryId());
 
 		Assert.assertTrue(
 			StringUtil.startsWith(
-				tagNames[0], _taskObjectDefinition.getExternalReferenceCode()));
+				tagNames[0],
+				_cmpTaskObjectDefinition.getExternalReferenceCode()));
 	}
 
 	@Inject(filter = "path=/cms/add_task")
@@ -137,6 +141,9 @@ public class AddTaskStrutsActionTest {
 
 	@Inject
 	private AssetTagLocalService _assetTagLocalService;
+
+	private ObjectEntry _cmpProjectObjectEntry;
+	private ObjectDefinition _cmpTaskObjectDefinition;
 
 	@Inject
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;
@@ -146,8 +153,5 @@ public class AddTaskStrutsActionTest {
 
 	@Inject
 	private Portal _portal;
-
-	private ObjectEntry _projectObjectEntry;
-	private ObjectDefinition _taskObjectDefinition;
 
 }

--- a/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/display/context/BaseTasksSectionDisplayContext.java
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/display/context/BaseTasksSectionDisplayContext.java
@@ -63,6 +63,8 @@ public abstract class BaseTasksSectionDisplayContext
 	public BaseTasksSectionDisplayContext(
 		AssetTagLocalService assetTagLocalService,
 		ClassNameLocalService classNameLocalService,
+		ObjectDefinition cmpProjectObjectDefinition,
+		ObjectDefinition cmpTaskObjectDefinition,
 		DepotEntryLocalService depotEntryLocalService,
 		HttpServletRequest httpServletRequest,
 		ListTypeEntryLocalService listTypeEntryLocalService,
@@ -70,27 +72,27 @@ public abstract class BaseTasksSectionDisplayContext
 		ObjectFieldLocalService objectFieldLocalService,
 		ObjectStateFlowLocalService objectStateFlowLocalService,
 		ObjectStateLocalService objectStateLocalService,
-		ObjectDefinition projectObjectDefinition, RoleService roleService,
-		ObjectDefinition taskObjectDefinition) {
+		RoleService roleService) {
 
-		super(httpServletRequest, taskObjectDefinition, objectEntryService);
+		super(httpServletRequest, cmpTaskObjectDefinition, objectEntryService);
 
 		this.assetTagLocalService = assetTagLocalService;
 		this.classNameLocalService = classNameLocalService;
+		this.cmpProjectObjectDefinition = cmpProjectObjectDefinition;
 		this.depotEntryLocalService = depotEntryLocalService;
 		this.listTypeEntryLocalService = listTypeEntryLocalService;
 		this.objectFieldLocalService = objectFieldLocalService;
 		this.objectStateFlowLocalService = objectStateFlowLocalService;
 		this.objectStateLocalService = objectStateLocalService;
-		this.projectObjectDefinition = projectObjectDefinition;
 		this.roleService = roleService;
 	}
 
 	public Map<String, Object> getAdditionalProps() throws Exception {
 		return HashMapBuilder.<String, Object>put(
-			"hasAddTaskPermission", hasAddObjectEntryPortletResourcePermission()
+			"cmpProjectObjectDefinitionId",
+			cmpProjectObjectDefinition.getObjectDefinitionId()
 		).put(
-			"projectId",
+			"cmpProjectObjectEntryId",
 			() -> {
 				if (assetEntry == null) {
 					return null;
@@ -99,8 +101,7 @@ public abstract class BaseTasksSectionDisplayContext
 				return assetEntry.getClassPK();
 			}
 		).put(
-			"projectObjectDefinitionId",
-			projectObjectDefinition.getObjectDefinitionId()
+			"hasAddTaskPermission", hasAddObjectEntryPortletResourcePermission()
 		).put(
 			"states",
 			() -> {
@@ -200,7 +201,7 @@ public abstract class BaseTasksSectionDisplayContext
 					"addProjectURL",
 					StringBundler.concat(
 						ActionUtil.getAddProjectURL(
-							projectObjectDefinition, themeDisplay),
+							cmpProjectObjectDefinition, themeDisplay),
 						"&action=",
 						CMPActionConstants.CREATE_PROJECT_GLOBAL_TASK));
 				dropdownItem.putData(
@@ -210,12 +211,12 @@ public abstract class BaseTasksSectionDisplayContext
 							0, objectDefinition, 0, themeDisplay),
 						"&action=", CMPActionConstants.CREATE_GLOBAL_TASK));
 				dropdownItem.putData(
+					"cmpProjectObjectDefinitionId",
+					String.valueOf(
+						cmpProjectObjectDefinition.getObjectDefinitionId()));
+				dropdownItem.putData(
 					"objectDefinitionId",
 					String.valueOf(objectDefinition.getObjectDefinitionId()));
-				dropdownItem.putData(
-					"projectObjectDefinitionId",
-					String.valueOf(
-						projectObjectDefinition.getObjectDefinitionId()));
 
 				if (assetEntry != null) {
 					dropdownItem.putData(
@@ -255,21 +256,21 @@ public abstract class BaseTasksSectionDisplayContext
 
 		fdsFilters.add(
 			new AssigneeSelectionFDSFilter(
-				classNameLocalService, projectObjectDefinition.getCompanyId(),
-				roleService));
+				classNameLocalService,
+				cmpProjectObjectDefinition.getCompanyId(), roleService));
 		fdsFilters.add(new CreateDateFDSFilter());
 		fdsFilters.add(new DueDateRangeFDSFilter());
 
 		if (assetEntry == null) {
 			fdsFilters.add(
-				new ProjectSelectionFDSFilter(projectObjectDefinition));
+				new ProjectSelectionFDSFilter(cmpProjectObjectDefinition));
 		}
 
 		fdsFilters.add(new StateSelectionFDSFilter());
 		fdsFilters.add(
 			new TagSelectionFDSFilter(
-				assetTagLocalService, depotEntryLocalService, assetEntry,
-				projectObjectDefinition));
+				assetTagLocalService, cmpProjectObjectDefinition,
+				depotEntryLocalService, assetEntry));
 
 		return fdsFilters;
 	}
@@ -489,12 +490,12 @@ public abstract class BaseTasksSectionDisplayContext
 
 	protected final AssetTagLocalService assetTagLocalService;
 	protected final ClassNameLocalService classNameLocalService;
+	protected final ObjectDefinition cmpProjectObjectDefinition;
 	protected final DepotEntryLocalService depotEntryLocalService;
 	protected final ListTypeEntryLocalService listTypeEntryLocalService;
 	protected final ObjectFieldLocalService objectFieldLocalService;
 	protected final ObjectStateFlowLocalService objectStateFlowLocalService;
 	protected final ObjectStateLocalService objectStateLocalService;
-	protected final ObjectDefinition projectObjectDefinition;
 	protected final RoleService roleService;
 
 	private JSONArray _getNextStatesJSONArray(

--- a/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/display/context/ViewAllTasksSectionDisplayContext.java
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/display/context/ViewAllTasksSectionDisplayContext.java
@@ -39,6 +39,8 @@ public class ViewAllTasksSectionDisplayContext
 	public ViewAllTasksSectionDisplayContext(
 		AssetTagLocalService assetTagLocalService,
 		ClassNameLocalService classNameLocalService,
+		ObjectDefinition cmpProjectObjectDefinition,
+		ObjectDefinition cmpTaskObjectDefinition,
 		DepotEntryLocalService depotEntryLocalService,
 		HttpServletRequest httpServletRequest,
 		ListTypeEntryLocalService listTypeEntryLocalService,
@@ -46,15 +48,15 @@ public class ViewAllTasksSectionDisplayContext
 		ObjectFieldLocalService objectFieldLocalService,
 		ObjectStateFlowLocalService objectStateFlowLocalService,
 		ObjectStateLocalService objectStateLocalService,
-		ObjectDefinition projectObjectDefinition, RoleService roleService,
-		ObjectDefinition taskObjectDefinition) {
+		RoleService roleService) {
 
 		super(
-			assetTagLocalService, classNameLocalService, depotEntryLocalService,
-			httpServletRequest, listTypeEntryLocalService, objectEntryService,
+			assetTagLocalService, classNameLocalService,
+			cmpProjectObjectDefinition, cmpTaskObjectDefinition,
+			depotEntryLocalService, httpServletRequest,
+			listTypeEntryLocalService, objectEntryService,
 			objectFieldLocalService, objectStateFlowLocalService,
-			objectStateLocalService, projectObjectDefinition, roleService,
-			taskObjectDefinition);
+			objectStateLocalService, roleService);
 	}
 
 	@Override

--- a/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/display/context/ViewProjectInfoSummarySectionDisplayContext.java
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/display/context/ViewProjectInfoSummarySectionDisplayContext.java
@@ -40,6 +40,8 @@ public class ViewProjectInfoSummarySectionDisplayContext
 
 	public Map<String, Object> getProperties() throws Exception {
 		return HashMapBuilder.<String, Object>put(
+			"cmpProjectObjectEntryId", objectEntry.getObjectEntryId()
+		).put(
 			"funnelStages", _getAssetCategoryTitles("L_CMP_FUNNEL_STAGE")
 		).put(
 			"manager",
@@ -48,8 +50,6 @@ public class ViewProjectInfoSummarySectionDisplayContext
 					getFieldValue("r_userToCMPProjectManager_userId")))
 		).put(
 			"personas", _getAssetCategoryTitles("L_CMP_PERSONAS")
-		).put(
-			"projectId", objectEntry.getObjectEntryId()
 		).put(
 			"sponsor",
 			_getUserInfoMap(

--- a/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/display/context/ViewProjectTasksSectionDisplayContext.java
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/display/context/ViewProjectTasksSectionDisplayContext.java
@@ -33,6 +33,8 @@ public class ViewProjectTasksSectionDisplayContext
 	public ViewProjectTasksSectionDisplayContext(
 		AssetTagLocalService assetTagLocalService,
 		ClassNameLocalService classNameLocalService,
+		ObjectDefinition cmpProjectObjectDefinition,
+		ObjectDefinition cmpTaskObjectDefinition,
 		DepotEntryLocalService depotEntryLocalService,
 		HttpServletRequest httpServletRequest,
 		ListTypeEntryLocalService listTypeEntryLocalService,
@@ -40,15 +42,15 @@ public class ViewProjectTasksSectionDisplayContext
 		ObjectFieldLocalService objectFieldLocalService,
 		ObjectStateFlowLocalService objectStateFlowLocalService,
 		ObjectStateLocalService objectStateLocalService,
-		ObjectDefinition projectObjectDefinition, RoleService roleService,
-		ObjectDefinition taskObjectDefinition) {
+		RoleService roleService) {
 
 		super(
-			assetTagLocalService, classNameLocalService, depotEntryLocalService,
-			httpServletRequest, listTypeEntryLocalService, objectEntryService,
+			assetTagLocalService, classNameLocalService,
+			cmpProjectObjectDefinition, cmpTaskObjectDefinition,
+			depotEntryLocalService, httpServletRequest,
+			listTypeEntryLocalService, objectEntryService,
 			objectFieldLocalService, objectStateFlowLocalService,
-			objectStateLocalService, projectObjectDefinition, roleService,
-			taskObjectDefinition);
+			objectStateLocalService, roleService);
 	}
 
 	@Override
@@ -77,7 +79,7 @@ public class ViewProjectTasksSectionDisplayContext
 
 	public Map<String, Object> getTasksQuickFiltersProperties() {
 		return HashMapBuilder.<String, Object>put(
-			"projectId",
+			"cmpProjectObjectEntryId",
 			() -> {
 				if (assetEntry == null) {
 					return null;

--- a/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/display/context/ViewProjectsSectionDisplayContext.java
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/display/context/ViewProjectsSectionDisplayContext.java
@@ -155,9 +155,9 @@ public class ViewProjectsSectionDisplayContext
 			new ProjectSponsorSelectionFDSFilter(),
 			new StateSelectionFDSFilter(),
 			new TagSelectionFDSFilter(
-				_assetTagLocalService, _depotEntryLocalService,
-				ObjectEntryUtil.getObjectEntry(httpServletRequest),
-				objectDefinition));
+				_assetTagLocalService, objectDefinition,
+				_depotEntryLocalService,
+				ObjectEntryUtil.getObjectEntry(httpServletRequest)));
 	}
 
 	private final AssetTagLocalService _assetTagLocalService;

--- a/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/display/context/ViewTaskInfoSummarySectionDisplayContext.java
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/display/context/ViewTaskInfoSummarySectionDisplayContext.java
@@ -49,7 +49,7 @@ public class ViewTaskInfoSummarySectionDisplayContext
 				return JSONFactoryUtil.createJSONObject(assignee.toString());
 			}
 		).put(
-			"taskId", objectEntry.getObjectEntryId()
+			"cmpTaskObjectEntryId", objectEntry.getObjectEntryId()
 		).putAll(
 			super.getProperties()
 		).build();

--- a/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/display/context/ViewWorkflowTasksSectionDisplayContext.java
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/display/context/ViewWorkflowTasksSectionDisplayContext.java
@@ -43,6 +43,8 @@ public class ViewWorkflowTasksSectionDisplayContext
 	public ViewWorkflowTasksSectionDisplayContext(
 		AssetTagLocalService assetTagLocalService,
 		ClassNameLocalService classNameLocalService,
+		ObjectDefinition cmpProjectObjectDefinition,
+		ObjectDefinition cmpTaskObjectDefinition,
 		DepotEntryLocalService depotEntryLocalService,
 		HttpServletRequest httpServletRequest,
 		ListTypeEntryLocalService listTypeEntryLocalService,
@@ -50,15 +52,15 @@ public class ViewWorkflowTasksSectionDisplayContext
 		ObjectFieldLocalService objectFieldLocalService,
 		ObjectStateFlowLocalService objectStateFlowLocalService,
 		ObjectStateLocalService objectStateLocalService,
-		ObjectDefinition projectObjectDefinition, RoleService roleService,
-		ObjectDefinition taskObjectDefinition) {
+		RoleService roleService) {
 
 		super(
-			assetTagLocalService, classNameLocalService, depotEntryLocalService,
-			httpServletRequest, listTypeEntryLocalService, objectEntryService,
+			assetTagLocalService, classNameLocalService,
+			cmpProjectObjectDefinition, cmpTaskObjectDefinition,
+			depotEntryLocalService, httpServletRequest,
+			listTypeEntryLocalService, objectEntryService,
 			objectFieldLocalService, objectStateFlowLocalService,
-			objectStateLocalService, projectObjectDefinition, roleService,
-			taskObjectDefinition);
+			objectStateLocalService, roleService);
 	}
 
 	@Override
@@ -134,8 +136,8 @@ public class ViewWorkflowTasksSectionDisplayContext
 	public List<FDSFilter> getFDSFilters() {
 		return ListUtil.fromArray(
 			new AssigneeSelectionFDSFilter(
-				classNameLocalService, projectObjectDefinition.getCompanyId(),
-				roleService),
+				classNameLocalService,
+				cmpProjectObjectDefinition.getCompanyId(), roleService),
 			new WorkflowTaskDueDateRangeFDSFilter(),
 			new WorkflowTaskStatusSelectionFDSFilter());
 	}

--- a/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/fragment/renderer/ContentCoverageMatrixComponentSectionFragmentRenderer.java
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/fragment/renderer/ContentCoverageMatrixComponentSectionFragmentRenderer.java
@@ -87,6 +87,11 @@ public class ContentCoverageMatrixComponentSectionFragmentRenderer
 			"assetFDSId",
 			"com.liferay.site.cms.site.initializer-allRelatedAssetsSection"
 		).put(
+			"cmpProjectObjectEntryId", objectEntry.getObjectEntryId()
+		).put(
+			"cmpProjectObjectEntryTitle",
+			MapUtil.getString(objectEntry.getValues(), "title")
+		).put(
 			"editProjectURL",
 			() -> {
 				ModelResourcePermission<ObjectEntry> modelResourcePermission =
@@ -140,10 +145,6 @@ public class ContentCoverageMatrixComponentSectionFragmentRenderer
 
 				return false;
 			}
-		).put(
-			"projectId", objectEntry.getObjectEntryId()
-		).put(
-			"projectTitle", MapUtil.getString(objectEntry.getValues(), "title")
 		).build();
 	}
 

--- a/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/fragment/renderer/ProjectSelectorComponentSectionFragmentRenderer.java
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/fragment/renderer/ProjectSelectorComponentSectionFragmentRenderer.java
@@ -61,13 +61,13 @@ public class ProjectSelectorComponentSectionFragmentRenderer
 			return Collections.emptyMap();
 		}
 
-		ObjectEntry projectObjectEntry =
+		ObjectEntry cmpProjectObjectEntry =
 			_objectEntryLocalService.fetchObjectEntry(
 				MapUtil.getLong(
 					objectEntry.getValues(),
 					"r_cmpProjectToCMPTasks_c_cmpProjectId"));
 
-		if (projectObjectEntry == null) {
+		if (cmpProjectObjectEntry == null) {
 			return Collections.emptyMap();
 		}
 
@@ -76,10 +76,11 @@ public class ProjectSelectorComponentSectionFragmentRenderer
 			() -> JSONUtil.putAll(
 				JSONUtil.put(
 					"label",
-					MapUtil.getString(projectObjectEntry.getValues(), "title")
+					MapUtil.getString(
+						cmpProjectObjectEntry.getValues(), "title")
 				).put(
 					"value",
-					String.valueOf(projectObjectEntry.getObjectEntryId())
+					String.valueOf(cmpProjectObjectEntry.getObjectEntryId())
 				))
 		).build();
 	}

--- a/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/fragment/renderer/TasksOverviewComponentSectionFragmentRenderer.java
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/fragment/renderer/TasksOverviewComponentSectionFragmentRenderer.java
@@ -57,10 +57,10 @@ public class TasksOverviewComponentSectionFragmentRenderer
 		FragmentRendererContext fragmentRendererContext,
 		HttpServletRequest httpServletRequest) {
 
-		ObjectEntry projectObjectEntry = ObjectEntryUtil.getObjectEntry(
+		ObjectEntry cmpProjectObjectEntry = ObjectEntryUtil.getObjectEntry(
 			httpServletRequest);
 
-		if (projectObjectEntry == null) {
+		if (cmpProjectObjectEntry == null) {
 			return null;
 		}
 
@@ -68,24 +68,24 @@ public class TasksOverviewComponentSectionFragmentRenderer
 			(ThemeDisplay)httpServletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
 
-		ObjectDefinition taskObjectDefinition =
+		ObjectDefinition cmpTaskObjectDefinition =
 			_objectDefinitionLocalService.
 				fetchObjectDefinitionByExternalReferenceCode(
 					"L_CMP_TASK", themeDisplay.getCompanyId());
 
 		return HashMapBuilder.<String, Object>put(
+			"cmpProjectObjectEntryId", cmpProjectObjectEntry.getObjectEntryId()
+		).put(
 			"hasAddTaskPermission",
 			() -> _objectEntryService.hasPortletResourcePermission(
-				projectObjectEntry.getGroupId(),
-				taskObjectDefinition.getObjectDefinitionId(),
+				cmpProjectObjectEntry.getGroupId(),
+				cmpTaskObjectDefinition.getObjectDefinitionId(),
 				ObjectActionKeys.ADD_OBJECT_ENTRY)
-		).put(
-			"projectId", projectObjectEntry.getObjectEntryId()
 		).put(
 			"redirect",
 			ActionUtil.getAddTaskURL(
-				projectObjectEntry.getGroupId(), taskObjectDefinition,
-				projectObjectEntry.getObjectEntryId(), themeDisplay)
+				cmpProjectObjectEntry.getGroupId(), cmpTaskObjectDefinition,
+				cmpProjectObjectEntry.getObjectEntryId(), themeDisplay)
 		).build();
 	}
 

--- a/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/fragment/renderer/ViewAllTasksJSPSectionFragmentRenderer.java
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/fragment/renderer/ViewAllTasksJSPSectionFragmentRenderer.java
@@ -52,17 +52,16 @@ public class ViewAllTasksJSPSectionFragmentRenderer
 
 		return new ViewAllTasksSectionDisplayContext(
 			_assetTagLocalService, _classNameLocalService,
-			_depotEntryLocalService, httpServletRequest,
-			_listTypeEntryLocalService, _objectEntryService,
-			_objectFieldLocalService, _objectStateFlowLocalService,
-			_objectStateLocalService,
 			_objectDefinitionLocalService.
 				fetchObjectDefinitionByExternalReferenceCode(
 					"L_CMP_PROJECT", themeDisplay.getCompanyId()),
-			_roleService,
 			_objectDefinitionLocalService.
 				fetchObjectDefinitionByExternalReferenceCode(
-					"L_CMP_TASK", themeDisplay.getCompanyId()));
+					"L_CMP_TASK", themeDisplay.getCompanyId()),
+			_depotEntryLocalService, httpServletRequest,
+			_listTypeEntryLocalService, _objectEntryService,
+			_objectFieldLocalService, _objectStateFlowLocalService,
+			_objectStateLocalService, _roleService);
 	}
 
 	@Override

--- a/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/fragment/renderer/ViewProjectTasksJSPSectionFragmentRenderer.java
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/fragment/renderer/ViewProjectTasksJSPSectionFragmentRenderer.java
@@ -53,17 +53,16 @@ public class ViewProjectTasksJSPSectionFragmentRenderer
 
 		return new ViewProjectTasksSectionDisplayContext(
 			_assetTagLocalService, _classNameLocalService,
-			_depotEntryLocalService, httpServletRequest,
-			_listTypeEntryLocalService, _objectEntryService,
-			_objectFieldLocalService, _objectStateFlowLocalService,
-			_objectStateLocalService,
 			_objectDefinitionLocalService.
 				fetchObjectDefinitionByExternalReferenceCode(
 					"L_CMP_PROJECT", themeDisplay.getCompanyId()),
-			_roleService,
 			_objectDefinitionLocalService.
 				fetchObjectDefinitionByExternalReferenceCode(
-					"L_CMP_TASK", themeDisplay.getCompanyId()));
+					"L_CMP_TASK", themeDisplay.getCompanyId()),
+			_depotEntryLocalService, httpServletRequest,
+			_listTypeEntryLocalService, _objectEntryService,
+			_objectFieldLocalService, _objectStateFlowLocalService,
+			_objectStateLocalService, _roleService);
 	}
 
 	@Override

--- a/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/fragment/renderer/ViewWorkflowTasksJSPSectionFragmentRenderer.java
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/fragment/renderer/ViewWorkflowTasksJSPSectionFragmentRenderer.java
@@ -53,17 +53,16 @@ public class ViewWorkflowTasksJSPSectionFragmentRenderer
 
 		return new ViewWorkflowTasksSectionDisplayContext(
 			_assetTagLocalService, _classNameLocalService,
-			_depotEntryLocalService, httpServletRequest,
-			_listTypeEntryLocalService, _objectEntryService,
-			_objectFieldLocalService, _objectStateFlowLocalService,
-			_objectStateLocalService,
 			_objectDefinitionLocalService.
 				fetchObjectDefinitionByExternalReferenceCode(
 					"L_CMP_PROJECT", themeDisplay.getCompanyId()),
-			_roleService,
 			_objectDefinitionLocalService.
 				fetchObjectDefinitionByExternalReferenceCode(
-					"L_CMP_TASK", themeDisplay.getCompanyId()));
+					"L_CMP_TASK", themeDisplay.getCompanyId()),
+			_depotEntryLocalService, httpServletRequest,
+			_listTypeEntryLocalService, _objectEntryService,
+			_objectFieldLocalService, _objectStateFlowLocalService,
+			_objectStateLocalService, _roleService);
 	}
 
 	@Override

--- a/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/frontend/data/set/filter/TagSelectionFDSFilter.java
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/frontend/data/set/filter/TagSelectionFDSFilter.java
@@ -28,13 +28,14 @@ public class TagSelectionFDSFilter extends BaseSelectionFDSFilter {
 
 	public TagSelectionFDSFilter(
 		AssetTagLocalService assetTagLocalService,
+		ObjectDefinition cmpProjectObjectDefinition,
 		DepotEntryLocalService depotEntryLocalService,
-		GroupedModel groupedModel, ObjectDefinition projectObjectDefinition) {
+		GroupedModel groupedModel) {
 
 		_assetTagLocalService = assetTagLocalService;
+		_cmpProjectObjectDefinition = cmpProjectObjectDefinition;
 		_depotEntryLocalService = depotEntryLocalService;
 		_groupedModel = groupedModel;
-		_projectObjectDefinition = projectObjectDefinition;
 	}
 
 	@Override
@@ -64,7 +65,7 @@ public class TagSelectionFDSFilter extends BaseSelectionFDSFilter {
 		else {
 			groupIds = TransformUtil.transformToLongArray(
 				_depotEntryLocalService.getDepotEntries(
-					_projectObjectDefinition.getCompanyId(),
+					_cmpProjectObjectDefinition.getCompanyId(),
 					DepotConstants.TYPE_PROJECT),
 				DepotEntryModel::getGroupId);
 		}
@@ -89,8 +90,8 @@ public class TagSelectionFDSFilter extends BaseSelectionFDSFilter {
 	}
 
 	private final AssetTagLocalService _assetTagLocalService;
+	private final ObjectDefinition _cmpProjectObjectDefinition;
 	private final DepotEntryLocalService _depotEntryLocalService;
 	private final GroupedModel _groupedModel;
-	private final ObjectDefinition _projectObjectDefinition;
 
 }

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/content_gap_matrix/ContentGapMatrixCard.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/content_gap_matrix/ContentGapMatrixCard.tsx
@@ -20,22 +20,22 @@ import './ContentGapMatrix.scss';
 
 interface ContentGapMatrixCardProps {
 	assetFDSId: string;
+	cmpProjectObjectEntryId: string;
+	cmpProjectObjectEntryTitle: string;
 	editProjectURL?: string;
 	groupId: number;
 	hasFunnelStagesOrPersonas: boolean;
-	projectId: string;
-	projectTitle: string;
 }
 
 const contentCoverageService = ContentCoverageServiceImpl;
 
 export default function ContentGapMatrixCard({
 	assetFDSId,
+	cmpProjectObjectEntryId,
+	cmpProjectObjectEntryTitle,
 	editProjectURL,
 	groupId,
 	hasFunnelStagesOrPersonas,
-	projectId,
-	projectTitle,
 }: ContentGapMatrixCardProps) {
 	const [data, setData] = useState<MatrixData | null>(null);
 	const [error, setError] = useState(false);
@@ -46,7 +46,9 @@ export default function ContentGapMatrixCard({
 		setLoading(true);
 
 		try {
-			setData(await contentCoverageService.getMatrix(projectId));
+			setData(
+				await contentCoverageService.getMatrix(cmpProjectObjectEntryId)
+			);
 		}
 		catch {
 			setError(true);
@@ -54,7 +56,7 @@ export default function ContentGapMatrixCard({
 		finally {
 			setLoading(false);
 		}
-	}, [projectId]);
+	}, [cmpProjectObjectEntryId]);
 
 	useEffect(() => {
 		if (hasFunnelStagesOrPersonas) {
@@ -78,9 +80,9 @@ export default function ContentGapMatrixCard({
 		return (
 			<div className="lfr-cmp__content-gap-matrix-card">
 				<ContentGapMatrixHeader
+					cmpProjectObjectEntryId={cmpProjectObjectEntryId}
+					cmpProjectObjectEntryTitle={cmpProjectObjectEntryTitle}
 					groupId={groupId}
-					projectId={projectId}
-					projectTitle={projectTitle}
 				/>
 
 				<div className="lfr-cmp__content-gap-matrix-container">
@@ -130,9 +132,9 @@ export default function ContentGapMatrixCard({
 		return (
 			<div className="lfr-cmp__content-gap-matrix-card">
 				<ContentGapMatrixHeader
+					cmpProjectObjectEntryId={cmpProjectObjectEntryId}
+					cmpProjectObjectEntryTitle={cmpProjectObjectEntryTitle}
 					groupId={groupId}
-					projectId={projectId}
-					projectTitle={projectTitle}
 				/>
 
 				<div className="lfr-cmp__content-gap-matrix-container">
@@ -149,10 +151,10 @@ export default function ContentGapMatrixCard({
 	return (
 		<div className="lfr-cmp__content-gap-matrix-card">
 			<ContentGapMatrixHeader
+				cmpProjectObjectEntryId={cmpProjectObjectEntryId}
+				cmpProjectObjectEntryTitle={cmpProjectObjectEntryTitle}
 				data={data}
 				groupId={groupId}
-				projectId={projectId}
-				projectTitle={projectTitle}
 			/>
 
 			<div className="lfr-cmp__content-gap-matrix-container">

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/content_gap_matrix/ContentGapMatrixHeader.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/content_gap_matrix/ContentGapMatrixHeader.tsx
@@ -13,15 +13,15 @@ import {MatrixData} from './types';
 import {computeCoveragePercentage, countCriticalGaps} from './utils';
 
 export default function ContentGapMatrixHeader({
+	cmpProjectObjectEntryId,
+	cmpProjectObjectEntryTitle,
 	data,
 	groupId,
-	projectId,
-	projectTitle,
 }: {
+	cmpProjectObjectEntryId?: string;
+	cmpProjectObjectEntryTitle?: string;
 	data?: MatrixData;
 	groupId?: number;
-	projectId?: string;
-	projectTitle?: string;
 }) {
 	const coveragePercentage = data ? computeCoveragePercentage(data) : 0;
 	const coverageDisplayType =
@@ -72,13 +72,13 @@ export default function ContentGapMatrixHeader({
 					context={{
 						cmsGroupId: groupId,
 						focusScope: 'full-matrix',
-						projectId,
+						projectId: cmpProjectObjectEntryId,
 					}}
 					initialMessage={sub(
 						Liferay.Language.get(
 							'get-ai-insights-for-the-x-content-coverage-matrix'
 						),
-						projectTitle
+						cmpProjectObjectEntryTitle
 					)}
 					instructionDefinitionScope="cms"
 					triggerLabel={Liferay.Language.get('get-ai-insights')}

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/content_gap_matrix/services/ContentCoverageService.ts
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/content_gap_matrix/services/ContentCoverageService.ts
@@ -8,7 +8,7 @@ import {fetch} from 'frontend-js-web';
 import {MatrixData, NO_FUNNEL_STAGE, NO_PERSONA, TaxonomyTerm} from '../types';
 
 export interface ContentCoverageService {
-	getMatrix(projectId: string): Promise<MatrixData>;
+	getMatrix(cmpProjectObjectEntryId: string): Promise<MatrixData>;
 }
 
 interface ContentCoverageTermResponse {
@@ -73,14 +73,14 @@ export function toMatrixData(response: ContentCoverageResponse): MatrixData {
  * (LPD-96935).
  */
 export const ContentCoverageServiceImpl: ContentCoverageService = {
-	async getMatrix(projectId: string): Promise<MatrixData> {
+	async getMatrix(cmpProjectObjectEntryId: string): Promise<MatrixData> {
 		const response = await fetch(
-			`/o/headless-cmp/v1.0/projects/${projectId}/content-coverage`
+			`/o/headless-cmp/v1.0/projects/${cmpProjectObjectEntryId}/content-coverage`
 		);
 
 		if (!response.ok) {
 			throw new Error(
-				`Unable to load content coverage for project ${projectId}`
+				`Unable to load content coverage for project ${cmpProjectObjectEntryId}`
 			);
 		}
 

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/content_gap_matrix/services/ContentCoverageServiceMock.ts
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/content_gap_matrix/services/ContentCoverageServiceMock.ts
@@ -26,7 +26,9 @@ const SCENARIOS: Record<string, MatrixData> = {
 };
 
 export const ContentCoverageServiceMock: ContentCoverageService = {
-	getMatrix(projectId: string): Promise<MatrixData> {
-		return Promise.resolve(SCENARIOS[projectId] ?? PARTIAL_COVERAGE_MATRIX);
+	getMatrix(cmpProjectObjectEntryId: string): Promise<MatrixData> {
+		return Promise.resolve(
+			SCENARIOS[cmpProjectObjectEntryId] ?? PARTIAL_COVERAGE_MATRIX
+		);
 	},
 };

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/modal/CreateTaskModal.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/modal/CreateTaskModal.tsx
@@ -29,21 +29,21 @@ import './../AssigneeTrigger.scss';
 
 type CreateTaskModalProps = {
 	closeModal: () => void;
+	cmpProjectObjectDefinitionId: number;
+	cmpProjectObjectEntryId?: string;
 	dueDate?: string;
 	loadData: Function;
 	onItemsChange?: Function;
-	projectId?: string;
-	projectObjectDefinitionId: number;
 	state: string;
 };
 
 export default function CreateTaskModal({
 	closeModal,
+	cmpProjectObjectDefinitionId,
+	cmpProjectObjectEntryId,
 	dueDate = '',
 	loadData,
 	onItemsChange,
-	projectId,
-	projectObjectDefinitionId,
 	state,
 }: CreateTaskModalProps) {
 	const [states, setStates] = useState([]);
@@ -68,7 +68,8 @@ export default function CreateTaskModal({
 		initialValues: {
 			assignTo: {},
 			dueDate,
-			r_cmpProjectToCMPTasks_c_cmpProjectId: Number(projectId) ?? 0,
+			r_cmpProjectToCMPTasks_c_cmpProjectId:
+				Number(cmpProjectObjectEntryId) ?? 0,
 			state,
 			title: '',
 		},
@@ -125,7 +126,7 @@ export default function CreateTaskModal({
 
 			const {
 				data: {items},
-			} = (await getAllProjects(projectObjectDefinitionId)) as {
+			} = (await getAllProjects(cmpProjectObjectDefinitionId)) as {
 				data: {
 					items: {
 						embedded: IProjectObjectEntry;
@@ -143,9 +144,9 @@ export default function CreateTaskModal({
 				})
 			);
 
-			if (projectId) {
+			if (cmpProjectObjectEntryId) {
 				const scopeKey = items.find(
-					({embedded: {id}}) => String(id) === projectId
+					({embedded: {id}}) => String(id) === cmpProjectObjectEntryId
 				)?.embedded.scopeKey;
 
 				if (scopeKey) {
@@ -155,7 +156,7 @@ export default function CreateTaskModal({
 		};
 
 		makeFetch();
-	}, [projectId, projectObjectDefinitionId]);
+	}, [cmpProjectObjectEntryId, cmpProjectObjectDefinitionId]);
 
 	return (
 		<ClayForm
@@ -181,7 +182,7 @@ export default function CreateTaskModal({
 				/>
 
 				<FieldPicker
-					disabled={!!projectId}
+					disabled={!!cmpProjectObjectEntryId}
 					errorMessage={
 						touched.r_cmpProjectToCMPTasks_c_cmpProjectId
 							? errors.r_cmpProjectToCMPTasks_c_cmpProjectId

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/modal/EditAssigneeModalContent.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/modal/EditAssigneeModalContent.tsx
@@ -17,17 +17,17 @@ import './../AssigneeTrigger.scss';
 
 type Props = {
 	closeModal: () => void;
+	cmpTaskObjectEntryId: string;
+	cmpTaskObjectEntryTitle: string;
 	loadData: Function;
-	taskId: string;
-	taskTitle: string;
 	value: AssigneeValue | {} | null;
 };
 
 export default function EditAssigneeModalContent({
 	closeModal,
+	cmpTaskObjectEntryId,
+	cmpTaskObjectEntryTitle,
 	loadData,
-	taskId,
-	taskTitle,
 	value: initialValue,
 }: Props) {
 	const [value, setValue] = useState<AssigneeValue | null | {}>(initialValue);
@@ -37,7 +37,7 @@ export default function EditAssigneeModalContent({
 
 		const {error} = await patchTaskById({
 			body: {assignTo: value},
-			taskId,
+			taskId: cmpTaskObjectEntryId,
 		});
 
 		if (!error) {
@@ -45,7 +45,10 @@ export default function EditAssigneeModalContent({
 
 			loadData();
 
-			displayAssignSuccessToast(taskTitle, (value as AssigneeValue).name);
+			displayAssignSuccessToast(
+				cmpTaskObjectEntryTitle,
+				(value as AssigneeValue).name
+			);
 		}
 		else {
 			displayErrorToast(error);

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/modal/SelectProjectModalContent.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/modal/SelectProjectModalContent.tsx
@@ -14,7 +14,7 @@ import React, {useState} from 'react';
 
 import './SelectProjectModalContent.scss';
 
-export interface Project {
+export interface CMPProject {
 	embedded: {
 		id: number;
 		scopeId: number;
@@ -26,21 +26,21 @@ export default function SelectProjectModalContent({
 	addProjectURL,
 	addTaskURL,
 	closeModal,
-	projectObjectDefinitionId,
+	cmpProjectObjectDefinitionId,
 }: {
 	addProjectURL: string;
 	addTaskURL: string;
 	closeModal: () => void;
-	projectObjectDefinitionId: number;
+	cmpProjectObjectDefinitionId: number;
 }) {
 	const [errorMessage, setErrorMessage] = useState<string>('');
-	const [selectedProject, setSelectedProject] = useState<Project | null>();
+	const [selectedProject, setSelectedProject] = useState<CMPProject | null>();
 
 	const {
 		resource,
 	}: {
 		resource: {
-			items: Project[];
+			items: CMPProject[];
 		};
 	} = useResource({
 		fetchOptions: {
@@ -49,10 +49,10 @@ export default function SelectProjectModalContent({
 			method: 'GET',
 		},
 		fetchPolicy: FetchPolicy.CacheFirst,
-		link: `${Liferay.ThemeDisplay.getPortalURL()}/o/search/v1.0/search?emptySearch=true&filter=objectDefinitionId eq ${projectObjectDefinitionId}&nestedFields=embedded`,
+		link: `${Liferay.ThemeDisplay.getPortalURL()}/o/search/v1.0/search?emptySearch=true&filter=objectDefinitionId eq ${cmpProjectObjectDefinitionId}&nestedFields=embedded`,
 	});
 
-	const projects: Project[] = resource?.items?.length
+	const projects: CMPProject[] = resource?.items?.length
 		? resource.items
 		: [
 				{
@@ -95,7 +95,7 @@ export default function SelectProjectModalContent({
 					label={Liferay.Language.get('project')}
 					required
 				>
-					<Picker<Project>
+					<Picker<CMPProject>
 						aria-label={Liferay.Language.get('project')}
 						items={projects}
 						messages={{

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/modal/UpdateDueDateModalContent.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/modal/UpdateDueDateModalContent.tsx
@@ -15,18 +15,18 @@ import DateField, {dateConfig} from '../DateField';
 
 type Props = {
 	closeModal: () => void;
+	cmpTaskObjectEntryId: string;
+	cmpTaskObjectEntryTitle: string;
 	dueDate?: string;
 	loadData: Function;
-	taskId: string;
-	taskTitle: string;
 };
 
 export default function UpdateDueDateModalContent({
 	closeModal,
+	cmpTaskObjectEntryId,
+	cmpTaskObjectEntryTitle,
 	dueDate: initialDueDate,
 	loadData,
-	taskId,
-	taskTitle,
 }: Props) {
 	const initialValue = initialDueDate
 		? moment(initialDueDate.slice(0, 10)).format(dateConfig.momentFormat)
@@ -45,7 +45,7 @@ export default function UpdateDueDateModalContent({
 						)
 					: '',
 			},
-			taskId,
+			taskId: cmpTaskObjectEntryId,
 		});
 
 		if (!error) {
@@ -53,7 +53,7 @@ export default function UpdateDueDateModalContent({
 
 			loadData();
 
-			displayDueDateSuccessToast(taskTitle);
+			displayDueDateSuccessToast(cmpTaskObjectEntryTitle);
 		}
 		else {
 			displayErrorToast(error);

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/project/ProjectInfoSummary.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/project/ProjectInfoSummary.tsx
@@ -16,26 +16,26 @@ import StateSelector, {State} from '../StateSelector';
 import User, {UserProps} from './User';
 
 interface ProjectInfoSummaryProps {
+	cmpProjectObjectEntryId: string;
 	dueDate: string;
 	funnelStages: string[];
 	hasUpdatePermission: boolean;
 	initialState: string;
 	manager: UserProps;
 	personas: string[];
-	projectId: string;
 	sponsor: UserProps;
 	states: State[];
 	tags: string[];
 }
 
 export default function ProjectInfoSummary({
+	cmpProjectObjectEntryId,
 	dueDate,
 	funnelStages,
 	hasUpdatePermission,
 	initialState,
 	manager,
 	personas,
-	projectId,
 	sponsor,
 	states,
 	tags,
@@ -59,7 +59,7 @@ export default function ProjectInfoSummary({
 
 								const {error} = await patchProjectById({
 									body: {state: key},
-									projectId,
+									projectId: cmpProjectObjectEntryId,
 								});
 
 								if (!error) {

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/AllTasksFDSPropsTransformer.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/AllTasksFDSPropsTransformer.tsx
@@ -279,9 +279,9 @@ export default function AllTasksFDSPropsTransformer({
 					}) => (
 						<EditAssigneeModalContent
 							closeModal={closeModal}
+							cmpTaskObjectEntryId={String(itemData.embedded.id)}
+							cmpTaskObjectEntryTitle={itemData.embedded.title}
 							loadData={loadData}
-							taskId={String(itemData.embedded.id)}
-							taskTitle={itemData.embedded.title}
 							value={itemData.embedded.assignTo}
 						/>
 					),

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/ProjectTasksFDSPropsTransformer.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/ProjectTasksFDSPropsTransformer.tsx
@@ -68,10 +68,11 @@ export default function ProjectTasksFDSPropsTransformer({
 		component: (props: any) =>
 			CalendarView({
 				...props,
+				cmpProjectObjectDefinitionId:
+					additionalProps.cmpProjectObjectDefinitionId,
+				cmpProjectObjectEntryId:
+					additionalProps.cmpProjectObjectEntryId,
 				hasAddTaskPermission: additionalProps.hasAddTaskPermission,
-				projectId: additionalProps.projectId,
-				projectObjectDefinitionId:
-					additionalProps.projectObjectDefinitionId,
 			}),
 		default: false,
 		initialPaginationDelta: FDS_PAGINATION_DELTA_ALL,
@@ -94,10 +95,11 @@ export default function ProjectTasksFDSPropsTransformer({
 		component: (props: any) =>
 			KanbanView({
 				...props,
+				cmpProjectObjectDefinitionId:
+					additionalProps.cmpProjectObjectDefinitionId,
+				cmpProjectObjectEntryId:
+					additionalProps.cmpProjectObjectEntryId,
 				hasAddTaskPermission: additionalProps.hasAddTaskPermission,
-				projectId: additionalProps.projectId,
-				projectObjectDefinitionId:
-					additionalProps.projectObjectDefinitionId,
 			}),
 		default: false,
 		initialPaginationDelta: FDS_PAGINATION_DELTA_ALL,
@@ -206,9 +208,9 @@ export default function ProjectTasksFDSPropsTransformer({
 					}) => (
 						<EditAssigneeModalContent
 							closeModal={closeModal}
+							cmpTaskObjectEntryId={String(itemData.embedded.id)}
+							cmpTaskObjectEntryTitle={itemData.embedded.title}
 							loadData={loadData}
-							taskId={String(itemData.embedded.id)}
-							taskTitle={itemData.embedded.title}
 							value={itemData.embedded.assignTo}
 						/>
 					),
@@ -225,10 +227,10 @@ export default function ProjectTasksFDSPropsTransformer({
 					}) => (
 						<UpdateDueDateModalContent
 							closeModal={closeModal}
+							cmpTaskObjectEntryId={String(itemData.embedded.id)}
+							cmpTaskObjectEntryTitle={itemData.embedded.title}
 							dueDate={itemData.embedded.dueDate}
 							loadData={loadData}
-							taskId={String(itemData.embedded.id)}
-							taskTitle={itemData.embedded.title}
 						/>
 					),
 					size: 'md',

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/actions/createTaskAction.ts
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/actions/createTaskAction.ts
@@ -12,12 +12,12 @@ import SelectProjectModalContent from '../../modal/SelectProjectModalContent';
 export default function createTaskAction({
 	addProjectURL,
 	addTaskURL,
-	projectObjectDefinitionId,
+	cmpProjectObjectDefinitionId,
 	redirect,
 }: {
 	addProjectURL: string;
 	addTaskURL: string;
-	projectObjectDefinitionId: number;
+	cmpProjectObjectDefinitionId: number;
 	redirect?: string;
 }) {
 	if (redirect) {
@@ -33,7 +33,7 @@ export default function createTaskAction({
 				addProjectURL,
 				addTaskURL,
 				closeModal,
-				projectObjectDefinitionId,
+				cmpProjectObjectDefinitionId,
 			}),
 		size: 'md',
 	});

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarView.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarView.tsx
@@ -42,11 +42,11 @@ import type {FirstDayOfWeekLocale} from 'frontend-js-web';
 const ADD_TASK_BUTTON_CLASS_NAME = 'lfr__calendar-view-add-task-button';
 
 interface CalendarViewProps {
+	cmpProjectObjectDefinitionId: number;
+	cmpProjectObjectEntryId?: string;
 	hasAddTaskPermission: boolean;
 	items: ITask[];
 	itemsActions: IItemsActions[];
-	projectId?: string;
-	projectObjectDefinitionId: number;
 }
 
 interface MoreLinkPopover {
@@ -56,11 +56,11 @@ interface MoreLinkPopover {
 }
 
 export default function CalendarView({
+	cmpProjectObjectDefinitionId,
+	cmpProjectObjectEntryId,
 	hasAddTaskPermission,
 	items,
 	itemsActions,
-	projectId,
-	projectObjectDefinitionId,
 }: CalendarViewProps) {
 	const {loadData, onItemsChange} = useContext(FrontendDataSetContext);
 
@@ -189,11 +189,11 @@ export default function CalendarView({
 			contentComponent: ({closeModal}: {closeModal: () => void}) => (
 				<CreateTaskModal
 					closeModal={closeModal}
+					cmpProjectObjectDefinitionId={cmpProjectObjectDefinitionId}
+					cmpProjectObjectEntryId={cmpProjectObjectEntryId}
 					dueDate={dueDate}
 					loadData={loadData}
 					onItemsChange={onItemsChange}
-					projectId={projectId}
-					projectObjectDefinitionId={projectObjectDefinitionId}
 					state={DEFAULT_TASK_STATE_KEY}
 				/>
 			),

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/kanban_view/KanbanView.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/kanban_view/KanbanView.tsx
@@ -17,11 +17,11 @@ import {KanbanViewContext} from './context';
 import {useOptimisticBoard} from './hooks/useOptimisticBoard';
 
 interface KanbanViewProps {
+	cmpProjectObjectDefinitionId: number;
+	cmpProjectObjectEntryId: string;
 	hasAddTaskPermission: boolean;
 	items: ITask[];
 	itemsActions: IItemsActions[];
-	projectId: string;
-	projectObjectDefinitionId: number;
 }
 
 function KanbanView(props: KanbanViewProps) {
@@ -62,11 +62,12 @@ function KanbanView(props: KanbanViewProps) {
 			value={{
 				boardData,
 				changeTaskStatus,
+				cmpProjectObjectDefinitionId:
+					props.cmpProjectObjectDefinitionId,
+				cmpProjectObjectEntryId: props.cmpProjectObjectEntryId,
 				hasAddTaskPermission: props.hasAddTaskPermission,
 				itemsActions: props.itemsActions,
 				loadData,
-				projectId: props.projectId,
-				projectObjectDefinitionId: props.projectObjectDefinitionId,
 			}}
 		>
 			<Board />

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/kanban_view/components/Column.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/kanban_view/components/Column.tsx
@@ -45,10 +45,10 @@ export function ColumnView({
 }: IColumnViewProps) {
 	const {
 		changeTaskStatus,
+		cmpProjectObjectDefinitionId,
+		cmpProjectObjectEntryId,
 		hasAddTaskPermission,
 		loadData,
-		projectId,
-		projectObjectDefinitionId,
 	} = useContext(KanbanViewContext);
 
 	const canTransition = (taskStateKey: string) => {
@@ -133,11 +133,13 @@ export function ColumnView({
 									}) => (
 										<CreateTaskModal
 											closeModal={closeModal}
-											loadData={loadData}
-											projectId={projectId}
-											projectObjectDefinitionId={
-												projectObjectDefinitionId
+											cmpProjectObjectDefinitionId={
+												cmpProjectObjectDefinitionId
 											}
+											cmpProjectObjectEntryId={
+												cmpProjectObjectEntryId
+											}
+											loadData={loadData}
 											state={key}
 										/>
 									),

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/kanban_view/components/Task.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/kanban_view/components/Task.tsx
@@ -24,7 +24,7 @@ import './Task.scss';
 const TaskCard = React.memo(
 	forwardRef<HTMLDivElement, {isDragging?: boolean; task: ITask}>(
 		({isDragging, task}, ref) => {
-			const {itemsActions, loadData, projectId} =
+			const {cmpProjectObjectEntryId, itemsActions, loadData} =
 				useContext(KanbanViewContext);
 
 			return (
@@ -69,7 +69,7 @@ const TaskCard = React.memo(
 									className="lfr__kaban-task-card-row-text-content"
 									displayType="subtitle"
 								>
-									{!projectId
+									{!cmpProjectObjectEntryId
 										? task.embedded.cmpProjectToCMPTasks
 												.title
 										: DateRenderer({

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/kanban_view/context.ts
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/kanban_view/context.ts
@@ -17,11 +17,11 @@ interface IKanbanContext {
 			name: string;
 		}
 	) => void;
+	cmpProjectObjectDefinitionId: number;
+	cmpProjectObjectEntryId: string;
 	hasAddTaskPermission: boolean;
 	itemsActions: IItemsActions[];
 	loadData: Function;
-	projectId: string;
-	projectObjectDefinitionId: number;
 }
 
 export const KanbanViewContext = React.createContext({} as IKanbanContext);

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/kanban_view/hooks/useOptimisticBoard.ts
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/kanban_view/hooks/useOptimisticBoard.ts
@@ -40,11 +40,11 @@ function mapByStateCode(items: ITask[]): {[key: string]: IColumn} {
 }
 
 interface PendingMove {
+	cmpTaskObjectEntryId: number | string;
 	newStatus: {
 		key: string;
 		name: string;
 	};
-	taskId: number | string;
 }
 
 export function useOptimisticBoard(
@@ -70,7 +70,8 @@ export function useOptimisticBoard(
 	const boardData = useMemo(() => {
 		const mergedItems = serverTasks.map((serverTask) => {
 			const pendingMove = pendingMoves.find(
-				(pendingMove) => pendingMove.taskId === serverTask.embedded.id
+				(pendingMove) =>
+					pendingMove.cmpTaskObjectEntryId === serverTask.embedded.id
 			);
 
 			if (pendingMove) {
@@ -95,8 +96,8 @@ export function useOptimisticBoard(
 	const moveTask = useCallback(
 		async (task: ITask, newStatus: {key: string; name: string}) => {
 			const pendingMoveOperation: PendingMove = {
+				cmpTaskObjectEntryId: task.embedded.id,
 				newStatus,
-				taskId: task.embedded.id,
 			};
 
 			setPendingMoves((prevPendingMoves) => [

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/task/TaskInfoSummary.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/task/TaskInfoSummary.tsx
@@ -23,23 +23,23 @@ import '../AssigneeTrigger.scss';
 
 interface TaskInfoSummaryProps {
 	assignTo: AssigneeValue;
+	cmpTaskObjectEntryId: string;
 	dueDate: string;
 	hasUpdatePermission: boolean;
 	initialState: string;
 	states: State[];
 	tags: string[];
-	taskId: string;
 	title: string;
 }
 
 export default function TaskInfoSummary({
 	assignTo,
+	cmpTaskObjectEntryId,
 	dueDate,
 	hasUpdatePermission,
 	initialState,
 	states,
 	tags,
-	taskId,
 	title,
 }: TaskInfoSummaryProps) {
 	const [selectedStateKey, setSelectedStateKey] = useState(initialState);
@@ -61,7 +61,7 @@ export default function TaskInfoSummary({
 
 								const {error} = await patchTaskById({
 									body: {state: key},
-									taskId,
+									taskId: cmpTaskObjectEntryId,
 								});
 
 								if (!error) {
@@ -90,7 +90,7 @@ export default function TaskInfoSummary({
 							onChange={async (value: AssigneeValue | {}) => {
 								const {error} = await patchTaskById({
 									body: {assignTo: value},
-									taskId,
+									taskId: cmpTaskObjectEntryId,
 								});
 
 								if (!error) {

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/task/TasksOverview.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/task/TasksOverview.tsx
@@ -65,12 +65,12 @@ function StatisticButton({
 }
 
 export default function TasksOverview({
+	cmpProjectObjectEntryId,
 	hasAddTaskPermission,
-	projectId,
 	redirect,
 }: {
+	cmpProjectObjectEntryId: string;
 	hasAddTaskPermission: boolean;
-	projectId: string;
 	redirect: string;
 }) {
 	const [blockedCount, setBlockedCount] = useState(0);
@@ -115,9 +115,9 @@ export default function TasksOverview({
 			fetch(url).then((response) => response.json());
 
 		const [projectData, taskStatisticsData] = await Promise.all([
-			fetchJSON(`/o/cmp/projects/${projectId}`),
+			fetchJSON(`/o/cmp/projects/${cmpProjectObjectEntryId}`),
 			fetchJSON(
-				`/o/headless-cmp/v1.0/projects/${projectId}/task-statistics/`
+				`/o/headless-cmp/v1.0/projects/${cmpProjectObjectEntryId}/task-statistics/`
 			),
 		]);
 
@@ -128,7 +128,7 @@ export default function TasksOverview({
 		setTotalCount(taskStatisticsData.totalCount);
 
 		setLoading(false);
-	}, [projectId]);
+	}, [cmpProjectObjectEntryId]);
 
 	useEffect(() => {
 		fetchCounts();

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/task/TasksQuickFilters.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/task/TasksQuickFilters.tsx
@@ -83,7 +83,11 @@ function QuickFilterButton({
 	);
 }
 
-export default function TasksQuickFilters({projectId}: {projectId?: string}) {
+export default function TasksQuickFilters({
+	cmpProjectObjectEntryId,
+}: {
+	cmpProjectObjectEntryId?: string;
+}) {
 	const [activeQuickFilter, setActiveQuickFilter] = useState<string | null>(
 		null
 	);
@@ -278,8 +282,8 @@ export default function TasksQuickFilters({projectId}: {projectId?: string}) {
 
 	const fetchCounts = useCallback(async () => {
 		fetch(
-			projectId
-				? `/o/headless-cmp/v1.0/projects/${projectId}/task-statistics/`
+			cmpProjectObjectEntryId
+				? `/o/headless-cmp/v1.0/projects/${cmpProjectObjectEntryId}/task-statistics/`
 				: '/o/headless-cmp/v1.0/task-statistics/',
 			{
 				method: 'GET',
@@ -292,7 +296,7 @@ export default function TasksQuickFilters({projectId}: {projectId?: string}) {
 			setOverdueCount(data.overdueCount);
 			setTotalCount(data.totalCount);
 		});
-	}, [projectId]);
+	}, [cmpProjectObjectEntryId]);
 
 	useEffect(() => {
 		fetchCounts();

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/utils/api.ts
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/utils/api.ts
@@ -34,9 +34,9 @@ export async function deleteTaskById({taskId}: {taskId: string}) {
 	return await ApiHelper.delete(`/o/cmp/tasks/${taskId}`);
 }
 
-export async function getAllProjects(projectObjectDefinitionId: number) {
+export async function getAllProjects(cmpProjectObjectDefinitionId: number) {
 	return await ApiHelper.get(
-		`/o/search/v1.0/search?emptySearch=true&filter=objectDefinitionId eq ${projectObjectDefinitionId}&nestedFields=embedded`
+		`/o/search/v1.0/search?emptySearch=true&filter=objectDefinitionId eq ${cmpProjectObjectDefinitionId}&nestedFields=embedded`
 	);
 }
 

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/utils/getTaskItemsActions.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/utils/getTaskItemsActions.tsx
@@ -163,9 +163,9 @@ export default function getTaskItemsActions(
 					}) => (
 						<EditAssigneeModalContent
 							closeModal={closeModal}
+							cmpTaskObjectEntryId={String(task.embedded.id)}
+							cmpTaskObjectEntryTitle={task.embedded.title}
 							loadData={loadData}
-							taskId={String(task.embedded.id)}
-							taskTitle={task.embedded.title}
 							value={task.embedded.assignTo}
 						/>
 					),
@@ -188,10 +188,10 @@ export default function getTaskItemsActions(
 					}) => (
 						<UpdateDueDateModalContent
 							closeModal={closeModal}
+							cmpTaskObjectEntryId={String(task.embedded.id)}
+							cmpTaskObjectEntryTitle={task.embedded.title}
 							dueDate={task.embedded.dueDate}
 							loadData={loadData}
-							taskId={String(task.embedded.id)}
-							taskTitle={task.embedded.title}
 						/>
 					),
 					size: 'md',

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/CalendarView.spec.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/CalendarView.spec.tsx
@@ -35,11 +35,11 @@ jest.mock('@fullcalendar/react', () => {
 const renderCalendarView = (hasAddTaskPermission: boolean) =>
 	render(
 		<CalendarView
+			cmpProjectObjectDefinitionId={456}
+			cmpProjectObjectEntryId="123"
 			hasAddTaskPermission={hasAddTaskPermission}
 			items={[]}
 			itemsActions={[]}
-			projectId="123"
-			projectObjectDefinitionId={456}
 		/>
 	);
 

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/ContentGapMatrixCard.spec.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/ContentGapMatrixCard.spec.tsx
@@ -15,6 +15,8 @@ describe('ContentGapMatrixCard', () => {
 			<ContentGapMatrixCard
 				assetFDSId="fdsId"
 				cmpProjectObjectEntryId="123"
+				cmpProjectObjectEntryTitle="Project"
+				groupId={123}
 				hasFunnelStagesOrPersonas={false}
 			/>
 		);
@@ -27,7 +29,9 @@ describe('ContentGapMatrixCard', () => {
 			<ContentGapMatrixCard
 				assetFDSId="fdsId"
 				cmpProjectObjectEntryId="123"
+				cmpProjectObjectEntryTitle="Project"
 				editProjectURL="/edit-project"
+				groupId={123}
 				hasFunnelStagesOrPersonas={false}
 			/>
 		);

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/ContentGapMatrixCard.spec.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/ContentGapMatrixCard.spec.tsx
@@ -14,8 +14,8 @@ describe('ContentGapMatrixCard', () => {
 		render(
 			<ContentGapMatrixCard
 				assetFDSId="fdsId"
+				cmpProjectObjectEntryId="123"
 				hasFunnelStagesOrPersonas={false}
-				projectId="123"
 			/>
 		);
 
@@ -26,9 +26,9 @@ describe('ContentGapMatrixCard', () => {
 		render(
 			<ContentGapMatrixCard
 				assetFDSId="fdsId"
+				cmpProjectObjectEntryId="123"
 				editProjectURL="/edit-project"
 				hasFunnelStagesOrPersonas={false}
-				projectId="123"
 			/>
 		);
 

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/CreateTaskModal.spec.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/CreateTaskModal.spec.tsx
@@ -131,15 +131,15 @@ describe('CreateTaskModal', () => {
 	});
 
 	const renderModal = (
-		projectId?: string,
+		cmpProjectObjectEntryId?: string,
 		props: Partial<React.ComponentProps<typeof CreateTaskModal>> = {}
 	) =>
 		render(
 			<CreateTaskModal
 				closeModal={() => {}}
+				cmpProjectObjectDefinitionId={123}
+				cmpProjectObjectEntryId={cmpProjectObjectEntryId}
 				loadData={() => {}}
-				projectId={projectId}
-				projectObjectDefinitionId={123}
 				state=""
 				{...props}
 			/>

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/EditAssigneeModalContent.spec.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/EditAssigneeModalContent.spec.tsx
@@ -30,9 +30,9 @@ describe('EditAssigneeModalContent', () => {
 		const {getByText} = render(
 			<EditAssigneeModalContent
 				closeModal={mockCloseModal}
+				cmpTaskObjectEntryId="123"
+				cmpTaskObjectEntryTitle="Task Title"
 				loadData={mockLoadData}
-				taskId="123"
-				taskTitle="Task Title"
 				value={{name: 'New Assignee'}}
 			/>
 		);

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/KanbanView.spec.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/KanbanView.spec.tsx
@@ -43,11 +43,11 @@ describe('KanbanView mapping and lifecycle', () => {
 
 		const {unmount} = render(
 			<KanbanView
+				cmpProjectObjectDefinitionId={123}
+				cmpProjectObjectEntryId=""
 				hasAddTaskPermission
 				items={items}
 				itemsActions={[]}
-				projectId=""
-				projectObjectDefinitionId={123}
 			/>
 		);
 

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/ProjectInfoSummary.spec.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/ProjectInfoSummary.spec.tsx
@@ -21,13 +21,13 @@ describe('ProjectInfoSummary', () => {
 	it('renders with props', () => {
 		const {getByText} = render(
 			<ProjectInfoSummary
+				cmpProjectObjectEntryId="123"
 				dueDate="2023-12-31"
 				funnelStages={[]}
 				hasUpdatePermission
 				initialState="notStarted"
 				manager={mockManager}
 				personas={[]}
-				projectId="123"
 				sponsor={mockSponsor}
 				states={mockStates}
 				tags={['tag1', 'tag2']}
@@ -46,13 +46,13 @@ describe('ProjectInfoSummary', () => {
 	it('renders personas and funnel stages as chips', () => {
 		const {getByText} = render(
 			<ProjectInfoSummary
+				cmpProjectObjectEntryId="123"
 				dueDate="2023-12-31"
 				funnelStages={['Awareness', 'Consideration']}
 				hasUpdatePermission
 				initialState="notStarted"
 				manager={mockManager}
 				personas={['Decision Maker', 'Champion']}
-				projectId="123"
 				sponsor={mockSponsor}
 				states={mockStates}
 				tags={[]}
@@ -68,13 +68,13 @@ describe('ProjectInfoSummary', () => {
 	it('renders empty personas and funnel stages without chips', () => {
 		const {queryByText} = render(
 			<ProjectInfoSummary
+				cmpProjectObjectEntryId="123"
 				dueDate="2023-12-31"
 				funnelStages={[]}
 				hasUpdatePermission
 				initialState="notStarted"
 				manager={mockManager}
 				personas={[]}
-				projectId="123"
 				sponsor={mockSponsor}
 				states={mockStates}
 				tags={[]}
@@ -88,13 +88,13 @@ describe('ProjectInfoSummary', () => {
 	it('disables the state selector when the user lacks update permission', () => {
 		render(
 			<ProjectInfoSummary
+				cmpProjectObjectEntryId="123"
 				dueDate="2023-12-31"
 				funnelStages={[]}
 				hasUpdatePermission={false}
 				initialState="notStarted"
 				manager={mockManager}
 				personas={[]}
-				projectId="123"
 				sponsor={mockSponsor}
 				states={mockStates}
 				tags={[]}

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/SelectProjectModalContent.spec.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/SelectProjectModalContent.spec.tsx
@@ -26,7 +26,7 @@ const defaultProps = {
 	addProjectURL: 'http://localhost/add-project',
 	addTaskURL: 'http://localhost/add-task',
 	closeModal: mockCloseModal,
-	projectObjectDefinitionId: 123,
+	cmpProjectObjectDefinitionId: 123,
 };
 
 describe('SelectProjectModalContent', () => {

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/Task.spec.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/Task.spec.tsx
@@ -105,17 +105,20 @@ describe('Kanban Task', () => {
 		},
 	} as any;
 
-	const renderTask = (itemsActions: any[] = [], projectId = '') =>
+	const renderTask = (
+		itemsActions: any[] = [],
+		cmpProjectObjectEntryId = ''
+	) =>
 		render(
 			<KanbanViewContext.Provider
 				value={{
 					boardData: {},
 					changeTaskStatus: jest.fn(),
+					cmpProjectObjectDefinitionId: 123,
+					cmpProjectObjectEntryId,
 					hasAddTaskPermission: true,
 					itemsActions,
 					loadData: mockLoadData,
-					projectId,
-					projectObjectDefinitionId: 123,
 				}}
 			>
 				<Task {...task} />
@@ -231,11 +234,11 @@ describe('Kanban Task', () => {
 				value={{
 					boardData: {},
 					changeTaskStatus: jest.fn(),
+					cmpProjectObjectDefinitionId: 123,
+					cmpProjectObjectEntryId: '123',
 					hasAddTaskPermission: true,
 					itemsActions: [],
 					loadData: mockLoadData,
-					projectId: '123',
-					projectObjectDefinitionId: 123,
 				}}
 			>
 				<Task {...taskWithDueDate} />
@@ -302,11 +305,11 @@ describe('Kanban Task', () => {
 					value={{
 						boardData: {},
 						changeTaskStatus: jest.fn(),
+						cmpProjectObjectDefinitionId: 123,
+						cmpProjectObjectEntryId: '',
 						hasAddTaskPermission: true,
 						itemsActions: [],
 						loadData: mockLoadData,
-						projectId: '',
-						projectObjectDefinitionId: 123,
 					}}
 				>
 					<Task {...taskWithSubscription} />
@@ -337,11 +340,11 @@ describe('Kanban Task', () => {
 					value={{
 						boardData: {},
 						changeTaskStatus: jest.fn(),
+						cmpProjectObjectDefinitionId: 123,
+						cmpProjectObjectEntryId: '',
 						hasAddTaskPermission: true,
 						itemsActions: [],
 						loadData: mockLoadData,
-						projectId: '',
-						projectObjectDefinitionId: 123,
 					}}
 				>
 					<Task {...taskWithSubscription} />

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/TaskInfoSummary.spec.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/TaskInfoSummary.spec.tsx
@@ -31,12 +31,12 @@ describe('TaskInfoSummary', () => {
 		const {container} = render(
 			<TaskInfoSummary
 				assignTo={mockAssignTo}
+				cmpTaskObjectEntryId="123"
 				dueDate="2023-12-31"
 				hasUpdatePermission
 				initialState="notStarted"
 				states={mockStates}
 				tags={['tag1', 'tag2']}
-				taskId="123"
 				title="Task"
 			/>
 		);
@@ -60,12 +60,12 @@ describe('TaskInfoSummary', () => {
 		render(
 			<TaskInfoSummary
 				assignTo={mockAssignTo}
+				cmpTaskObjectEntryId="123"
 				dueDate="2023-12-31"
 				hasUpdatePermission={false}
 				initialState="notStarted"
 				states={mockStates}
 				tags={['tag1', 'tag2']}
-				taskId="123"
 				title="Task"
 			/>
 		);

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/TasksOverview.spec.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/TasksOverview.spec.tsx
@@ -33,8 +33,8 @@ describe('TasksOverview', () => {
 		await act(async () => {
 			render(
 				<TasksOverview
+					cmpProjectObjectEntryId="123"
 					hasAddTaskPermission
-					projectId="123"
 					redirect="/redirect-url"
 				/>
 			);
@@ -72,8 +72,8 @@ describe('TasksOverview', () => {
 		await act(async () => {
 			render(
 				<TasksOverview
+					cmpProjectObjectEntryId="123"
 					hasAddTaskPermission
-					projectId="123"
 					redirect="/redirect-url"
 				/>
 			);
@@ -116,8 +116,8 @@ describe('TasksOverview', () => {
 		await act(async () => {
 			render(
 				<TasksOverview
+					cmpProjectObjectEntryId="123"
 					hasAddTaskPermission={false}
-					projectId="123"
 					redirect="/redirect-url"
 				/>
 			);

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/TasksQuickFilters.spec.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/TasksQuickFilters.spec.tsx
@@ -261,7 +261,7 @@ describe('TasksQuickFilters', () => {
 
 	it('renders the appropriate counts when a projectId is provided', async () => {
 		await act(async () => {
-			render(<TasksQuickFilters projectId="123" />);
+			render(<TasksQuickFilters cmpProjectObjectEntryId="123" />);
 		});
 
 		expect(fetch).toHaveBeenCalledWith(

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/UpdateDueDateModalContent.spec.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/UpdateDueDateModalContent.spec.tsx
@@ -60,10 +60,10 @@ const renderModal = (
 	render(
 		<UpdateDueDateModalContent
 			closeModal={mockCloseModal}
+			cmpTaskObjectEntryId="123"
+			cmpTaskObjectEntryTitle="Task Title"
 			dueDate="2026-07-15T00:00:00Z"
 			loadData={mockLoadData}
-			taskId="123"
-			taskTitle="Task Title"
 			{...props}
 		/>
 	);

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/createTaskAction.spec.ts
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/createTaskAction.spec.ts
@@ -27,7 +27,7 @@ describe('createTaskAction', () => {
 			createTaskAction({
 				addProjectURL: '/add-project',
 				addTaskURL: '/add-task',
-				projectObjectDefinitionId: 123,
+				cmpProjectObjectDefinitionId: 123,
 			});
 
 			expect(mockNavigate).not.toHaveBeenCalled();
@@ -41,7 +41,7 @@ describe('createTaskAction', () => {
 				addProjectURL: '/add-project',
 				addTaskURL: '/add-task',
 				closeModal: mockCloseModal,
-				projectObjectDefinitionId: 123,
+				cmpProjectObjectDefinitionId: 123,
 			});
 		});
 	});
@@ -55,7 +55,7 @@ describe('createTaskAction', () => {
 			createTaskAction({
 				addProjectURL: '/add-project',
 				addTaskURL: '/add-task',
-				projectObjectDefinitionId: 123,
+				cmpProjectObjectDefinitionId: 123,
 				redirect: 'http://localhost/redirect-url',
 			});
 
@@ -75,7 +75,7 @@ describe('createTaskAction', () => {
 			createTaskAction({
 				addProjectURL: '/add-project',
 				addTaskURL: '/add-task',
-				projectObjectDefinitionId: 123,
+				cmpProjectObjectDefinitionId: 123,
 				redirect:
 					'http://localhost/web/cms/add_task?projectId=42&redirect=http://localhost/web/cms/tasks',
 			});

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
@@ -15,10 +15,13 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.info.constants.InfoDisplayWebKeys;
 import com.liferay.info.localized.InfoLocalizedValue;
 import com.liferay.object.constants.ObjectFolderConstants;
+import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntryFolder;
+import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
 import com.liferay.object.service.ObjectDefinitionService;
 import com.liferay.object.service.ObjectEntryFolderLocalServiceUtil;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
@@ -97,6 +100,15 @@ public abstract class BaseSectionDisplayContext {
 	}
 
 	public Map<String, Object> getAdditionalProps() {
+		ObjectDefinition cmpProjectObjectDefinition =
+			ObjectDefinitionLocalServiceUtil.
+				fetchObjectDefinitionByExternalReferenceCode(
+					"L_CMP_PROJECT", themeDisplay.getCompanyId());
+		ObjectDefinition cmpTaskObjectDefinition =
+			ObjectDefinitionLocalServiceUtil.
+				fetchObjectDefinitionByExternalReferenceCode(
+					"L_CMP_TASK", themeDisplay.getCompanyId());
+
 		return HashMapBuilder.<String, Object>put(
 			"additionalAPIURLParameters",
 			() -> {
@@ -136,6 +148,70 @@ public abstract class BaseSectionDisplayContext {
 			SectionDisplayContextUtil.getDepotEntriesJSONArray(
 				httpServletRequest,
 				getRootObjectEntryFolderExternalReferenceCode())
+		).put(
+			"cmpProjectLinkObjectDefinitionId",
+			() -> {
+				ObjectDefinition cmpProjectLinkObjectDefinition =
+					ObjectDefinitionLocalServiceUtil.
+						fetchObjectDefinitionByExternalReferenceCode(
+							"L_CMP_PROJECT_LINK", themeDisplay.getCompanyId());
+
+				if (cmpProjectLinkObjectDefinition == null) {
+					return null;
+				}
+
+				return cmpProjectLinkObjectDefinition.getObjectDefinitionId();
+			}
+		).put(
+			"cmpProjectObjectDefinitionId",
+			() -> {
+				if (cmpProjectObjectDefinition == null) {
+					return null;
+				}
+
+				return cmpProjectObjectDefinition.getObjectDefinitionId();
+			}
+		).put(
+			"cmpProjectViewURL",
+			() -> {
+				if (cmpProjectObjectDefinition == null) {
+					return null;
+				}
+
+				return _getCMPViewURL(cmpProjectObjectDefinition, "project");
+			}
+		).put(
+			"cmpTaskLinkObjectDefinitionId",
+			() -> {
+				ObjectDefinition cmpTaskLinkObjectDefinition =
+					ObjectDefinitionLocalServiceUtil.
+						fetchObjectDefinitionByExternalReferenceCode(
+							"L_CMP_TASK_LINK", themeDisplay.getCompanyId());
+
+				if (cmpTaskLinkObjectDefinition == null) {
+					return null;
+				}
+
+				return cmpTaskLinkObjectDefinition.getObjectDefinitionId();
+			}
+		).put(
+			"cmpTaskObjectDefinitionId",
+			() -> {
+				if (cmpTaskObjectDefinition == null) {
+					return null;
+				}
+
+				return cmpTaskObjectDefinition.getObjectDefinitionId();
+			}
+		).put(
+			"cmpTaskViewURL",
+			() -> {
+				if (cmpTaskObjectDefinition == null) {
+					return null;
+				}
+
+				return _getCMPViewURL(cmpTaskObjectDefinition, "task");
+			}
 		).put(
 			"cmsGroupId",
 			() -> {
@@ -308,6 +384,15 @@ public abstract class BaseSectionDisplayContext {
 	protected final ObjectEntryFolder objectEntryFolder;
 	protected final Portal portal;
 	protected final ThemeDisplay themeDisplay;
+
+	private String _getCMPViewURL(
+		ObjectDefinition objectDefinition, String type) {
+
+		return StringBundler.concat(
+			themeDisplay.getPortalURL(), portal.getPathFriendlyURLPublic(),
+			"/cms/e/", type, "/",
+			portal.getClassNameId(objectDefinition.getClassName()));
+	}
 
 	private JSONObject _getExportFileFormatJSONObject(
 		TranslationInfoItemFieldValuesExporter

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ContentEditorSidePanelComponentSectionFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ContentEditorSidePanelComponentSectionFragmentRenderer.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.editor.configuration.EditorConfigurationFactory
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
@@ -34,6 +35,7 @@ import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.DateUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.site.cms.site.initializer.internal.util.CommentUtil;
@@ -126,6 +128,15 @@ public class ContentEditorSidePanelComponentSectionFragmentRenderer
 			(ThemeDisplay)httpServletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
 
+		ObjectDefinition cmpProjectObjectDefinition =
+			_objectDefinitionLocalService.
+				fetchObjectDefinitionByExternalReferenceCode(
+					"L_CMP_PROJECT", themeDisplay.getCompanyId());
+		ObjectDefinition cmpTaskObjectDefinition =
+			_objectDefinitionLocalService.
+				fetchObjectDefinitionByExternalReferenceCode(
+					"L_CMP_TASK", themeDisplay.getCompanyId());
+
 		return HashMapBuilder.<String, Object>put(
 			"addCommentURL",
 			() -> {
@@ -149,6 +160,72 @@ public class ContentEditorSidePanelComponentSectionFragmentRenderer
 			"assetLibraryId", objectEntry.getGroupId()
 		).put(
 			"assetType", classNameId
+		).put(
+			"cmpProjectLinkObjectDefinitionId",
+			() -> {
+				ObjectDefinition cmpProjectLinkObjectDefinition =
+					_objectDefinitionLocalService.
+						fetchObjectDefinitionByExternalReferenceCode(
+							"L_CMP_PROJECT_LINK", themeDisplay.getCompanyId());
+
+				if (cmpProjectLinkObjectDefinition == null) {
+					return null;
+				}
+
+				return cmpProjectLinkObjectDefinition.getObjectDefinitionId();
+			}
+		).put(
+			"cmpProjectObjectDefinitionId",
+			() -> {
+				if (cmpProjectObjectDefinition == null) {
+					return null;
+				}
+
+				return cmpProjectObjectDefinition.getObjectDefinitionId();
+			}
+		).put(
+			"cmpProjectViewURL",
+			() -> {
+				if (cmpProjectObjectDefinition == null) {
+					return null;
+				}
+
+				return _getCMPViewURL(
+					cmpProjectObjectDefinition, themeDisplay, "project");
+			}
+		).put(
+			"cmpTaskLinkObjectDefinitionId",
+			() -> {
+				ObjectDefinition cmpTaskLinkObjectDefinition =
+					_objectDefinitionLocalService.
+						fetchObjectDefinitionByExternalReferenceCode(
+							"L_CMP_TASK_LINK", themeDisplay.getCompanyId());
+
+				if (cmpTaskLinkObjectDefinition == null) {
+					return null;
+				}
+
+				return cmpTaskLinkObjectDefinition.getObjectDefinitionId();
+			}
+		).put(
+			"cmpTaskObjectDefinitionId",
+			() -> {
+				if (cmpTaskObjectDefinition == null) {
+					return null;
+				}
+
+				return cmpTaskObjectDefinition.getObjectDefinitionId();
+			}
+		).put(
+			"cmpTaskViewURL",
+			() -> {
+				if (cmpTaskObjectDefinition == null) {
+					return null;
+				}
+
+				return _getCMPViewURL(
+					cmpTaskObjectDefinition, themeDisplay, "task");
+			}
 		).put(
 			"cmsGroupId", themeDisplay.getScopeGroupId()
 		).put(
@@ -232,6 +309,22 @@ public class ContentEditorSidePanelComponentSectionFragmentRenderer
 				return data.get("editorConfig");
 			}
 		).put(
+			"entryClassName", objectEntry.getModelClassName()
+		).put(
+			"entryExternalReferenceCode", objectEntry.getExternalReferenceCode()
+		).put(
+			"entryGroupExternalReferenceCode",
+			() -> {
+				Group group = groupLocalService.fetchGroup(
+					objectEntry.getGroupId());
+
+				if (group == null) {
+					return null;
+				}
+
+				return group.getExternalReferenceCode();
+			}
+		).put(
 			"expirationDate",
 			() -> {
 				String restoredExpirationDate =
@@ -306,6 +399,17 @@ public class ContentEditorSidePanelComponentSectionFragmentRenderer
 		).build();
 	}
 
+	private String _getCMPViewURL(
+		ObjectDefinition objectDefinition, ThemeDisplay themeDisplay,
+		String type) {
+
+		return StringBundler.concat(
+			themeDisplay.getPortalURL(), _portal.getPathFriendlyURLPublic(),
+			"/cms/e/", type, "/",
+			_classNameLocalService.getClassNameId(
+				objectDefinition.getClassName()));
+	}
+
 	@Reference
 	private ClassNameLocalService _classNameLocalService;
 
@@ -323,6 +427,9 @@ public class ContentEditorSidePanelComponentSectionFragmentRenderer
 
 	@Reference
 	private ObjectEntryService _objectEntryService;
+
+	@Reference
+	private Portal _portal;
 
 	@Reference
 	private SubscriptionLocalService _subscriptionLocalService;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/model/listener/ObjectEntryModelListener.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/model/listener/ObjectEntryModelListener.java
@@ -233,8 +233,8 @@ public class ObjectEntryModelListener extends BaseModelListener<ObjectEntry> {
 	}
 
 	private void _route(
-			AssetTag assetTag, List<Attribute> attributes, String eventType,
-			ObjectDefinition taskObjectDefinition)
+			AssetTag assetTag, List<Attribute> attributes,
+			ObjectDefinition cmpTaskObjectDefinition, String eventType)
 		throws Exception {
 
 		for (long assetEntryId :
@@ -246,7 +246,7 @@ public class ObjectEntryModelListener extends BaseModelListener<ObjectEntry> {
 
 			if (!StringUtil.equals(
 					assetEntry.getClassName(),
-					taskObjectDefinition.getClassName())) {
+					cmpTaskObjectDefinition.getClassName())) {
 
 				continue;
 			}
@@ -272,12 +272,12 @@ public class ObjectEntryModelListener extends BaseModelListener<ObjectEntry> {
 			return;
 		}
 
-		ObjectDefinition taskObjectDefinition =
+		ObjectDefinition cmpTaskObjectDefinition =
 			_objectDefinitionLocalService.
 				fetchObjectDefinitionByExternalReferenceCode(
 					"L_CMP_TASK", objectEntry.getCompanyId());
 
-		if (taskObjectDefinition == null) {
+		if (cmpTaskObjectDefinition == null) {
 			return;
 		}
 
@@ -292,23 +292,23 @@ public class ObjectEntryModelListener extends BaseModelListener<ObjectEntry> {
 			SetUtil.asymmetricDifference(newAssetTagNames, oldAssetTagNames),
 			Collections.singletonList(
 				new Attribute(objectEntry.getTitleValue())),
-			"CMP_ADD_ASSET", taskObjectDefinition);
+			cmpTaskObjectDefinition, "CMP_ADD_ASSET");
 		_route(
 			SetUtil.asymmetricDifference(oldAssetTagNames, newAssetTagNames),
 			Collections.singletonList(
 				new Attribute(objectEntry.getTitleValue())),
-			"CMP_REMOVE_ASSET", taskObjectDefinition);
+			cmpTaskObjectDefinition, "CMP_REMOVE_ASSET");
 	}
 
 	private void _route(
 			Set<String> assetTagNames, List<Attribute> attributes,
-			String eventType, ObjectDefinition taskObjectDefinition)
+			ObjectDefinition cmpTaskObjectDefinition, String eventType)
 		throws Exception {
 
 		for (String assetTagName : assetTagNames) {
 			if (!StringUtil.startsWith(
 					assetTagName,
-					taskObjectDefinition.getExternalReferenceCode())) {
+					cmpTaskObjectDefinition.getExternalReferenceCode())) {
 
 				continue;
 			}
@@ -318,7 +318,8 @@ public class ObjectEntryModelListener extends BaseModelListener<ObjectEntry> {
 						new long[0], assetTagName, QueryUtil.ALL_POS,
 						QueryUtil.ALL_POS)) {
 
-				_route(assetTag, attributes, eventType, taskObjectDefinition);
+				_route(
+					assetTag, attributes, cmpTaskObjectDefinition, eventType);
 			}
 		}
 	}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/components/LinkedProjects.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/components/LinkedProjects.tsx
@@ -141,7 +141,7 @@ export default function LinkedProjects({
 		const joinedProjects: CMPProject[] = [];
 
 		links.forEach((link) => {
-			const project = projectsById.get(link.projectId);
+			const project = projectsById.get(link.cmpProjectObjectEntryId);
 
 			if (project) {
 				joinedProjects.push({...project, linkId: link.id});
@@ -152,13 +152,18 @@ export default function LinkedProjects({
 	}, [links, projects]);
 
 	const selectableProjects = useMemo(() => {
-		const linkedProjectIds = new Set(links.map(({projectId}) => projectId));
+		const linkedProjectIds = new Set(
+			links.map(({cmpProjectObjectEntryId}) => cmpProjectObjectEntryId)
+		);
 
 		return projects.filter(({id}) => !linkedProjectIds.has(id));
 	}, [links, projects]);
 
 	const linkProject = async (project: CMPProject) => {
-		setLinks((previous) => [...previous, {projectId: project.id}]);
+		setLinks((previous) => [
+			...previous,
+			{cmpProjectObjectEntryId: project.id},
+		]);
 
 		const {data, error} = await ProjectLinkService.linkProject({
 			entryClassName,
@@ -173,7 +178,10 @@ export default function LinkedProjects({
 
 		if (error || !data) {
 			setLinks((previous) =>
-				previous.filter(({projectId}) => projectId !== project.id)
+				previous.filter(
+					({cmpProjectObjectEntryId}) =>
+						cmpProjectObjectEntryId !== project.id
+				)
 			);
 
 			openToast({
@@ -188,7 +196,9 @@ export default function LinkedProjects({
 
 		setLinks((previous) =>
 			previous.map((link) =>
-				link.projectId === project.id ? {...link, id: data.id} : link
+				link.cmpProjectObjectEntryId === project.id
+					? {...link, id: data.id}
+					: link
 			)
 		);
 
@@ -208,7 +218,10 @@ export default function LinkedProjects({
 		const linkId = project.linkId;
 
 		setLinks((previous) =>
-			previous.filter(({projectId}) => projectId !== project.id)
+			previous.filter(
+				({cmpProjectObjectEntryId}) =>
+					cmpProjectObjectEntryId !== project.id
+			)
 		);
 
 		const {error} = await ProjectLinkService.unlinkProject({linkId});
@@ -220,7 +233,7 @@ export default function LinkedProjects({
 		if (error) {
 			setLinks((previous) => [
 				...previous,
-				{id: linkId, projectId: project.id},
+				{cmpProjectObjectEntryId: project.id, id: linkId},
 			]);
 
 			openToast({message: error, type: 'danger'});

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/services/ProjectLinkService.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/services/ProjectLinkService.ts
@@ -38,8 +38,8 @@ export type CMPTask = {
  * entry id (required to unlink) and the linked project id.
  */
 export type ProjectLink = {
+	cmpProjectObjectEntryId: number;
 	id?: number;
-	projectId: number;
 };
 
 type ProjectLinkSearchItem = {
@@ -165,17 +165,18 @@ async function getLinkedTasks({
 	const tasksByProjectId: {[projectId: number]: CMPTask[]} = {};
 
 	data.forEach(({embedded}) => {
-		const projectId = embedded.r_cmpProjectToCMPTasks_c_cmpProjectId;
+		const cmpProjectObjectEntryId =
+			embedded.r_cmpProjectToCMPTasks_c_cmpProjectId;
 
-		if (projectId === undefined) {
+		if (cmpProjectObjectEntryId === undefined) {
 			return;
 		}
 
-		if (!tasksByProjectId[projectId]) {
-			tasksByProjectId[projectId] = [];
+		if (!tasksByProjectId[cmpProjectObjectEntryId]) {
+			tasksByProjectId[cmpProjectObjectEntryId] = [];
 		}
 
-		tasksByProjectId[projectId].push({
+		tasksByProjectId[cmpProjectObjectEntryId].push({
 			id: embedded.id,
 			title: embedded.title,
 		});
@@ -228,8 +229,9 @@ async function getProjectLinks({
 		}
 
 		links.push({
+			cmpProjectObjectEntryId:
+				embedded.r_cmpProjectToCMPProjectLinks_c_cmpProjectId,
 			id: embedded.id,
-			projectId: embedded.r_cmpProjectToCMPProjectLinks_c_cmpProjectId,
 		});
 	});
 

--- a/modules/apps/site/site-cms-site-initializer/test/js/common/components/LinkedProjects.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/common/components/LinkedProjects.test.tsx
@@ -57,8 +57,8 @@ function mockService({
 	});
 	jest.spyOn(ProjectLinkService, 'getProjectLinks').mockResolvedValue({
 		data: linked.map((project) => ({
+			cmpProjectObjectEntryId: project.id,
 			id: project.linkId,
-			projectId: project.id,
 		})),
 		error: null,
 	});

--- a/modules/apps/site/site-cms-site-initializer/test/js/common/services/ProjectLinkService.test.ts
+++ b/modules/apps/site/site-cms-site-initializer/test/js/common/services/ProjectLinkService.test.ts
@@ -29,15 +29,15 @@ function mockSearchResponse(items: unknown[], lastPage: number = 1) {
 function relationshipItem({
 	classExternalReferenceCode = 'ASSET-1',
 	className = 'com.example.Content',
+	cmpProjectObjectEntryId = 1,
 	groupExternalReferenceCode = 'SPACE-1',
 	id = 11,
-	projectId = 1,
 }: {
 	classExternalReferenceCode?: string;
 	className?: string;
+	cmpProjectObjectEntryId?: number;
 	groupExternalReferenceCode?: string;
 	id?: number;
-	projectId?: number;
 }) {
 	return {
 		embedded: {
@@ -45,7 +45,8 @@ function relationshipItem({
 			className,
 			groupExternalReferenceCode,
 			id,
-			r_cmpProjectToCMPProjectLinks_c_cmpProjectId: projectId,
+			r_cmpProjectToCMPProjectLinks_c_cmpProjectId:
+				cmpProjectObjectEntryId,
 		},
 	};
 }
@@ -161,21 +162,21 @@ describe('ProjectLinkService', () => {
 	it('matches relationship entries against the asset identity', async () => {
 		mockFetch.mockResolvedValueOnce(
 			mockSearchResponse([
-				relationshipItem({id: 11, projectId: 1}),
+				relationshipItem({cmpProjectObjectEntryId: 1, id: 11}),
 				relationshipItem({
 					classExternalReferenceCode: 'OTHER-ASSET',
+					cmpProjectObjectEntryId: 2,
 					id: 12,
-					projectId: 2,
 				}),
 				relationshipItem({
+					cmpProjectObjectEntryId: 3,
 					groupExternalReferenceCode: 'OTHER-SPACE',
 					id: 13,
-					projectId: 3,
 				}),
 				relationshipItem({
 					className: 'com.example.Other',
+					cmpProjectObjectEntryId: 4,
 					id: 14,
-					projectId: 4,
 				}),
 			])
 		);
@@ -185,7 +186,7 @@ describe('ProjectLinkService', () => {
 			cmpProjectLinkObjectDefinitionId: 42,
 		});
 
-		expect(data).toEqual([{id: 11, projectId: 1}]);
+		expect(data).toEqual([{cmpProjectObjectEntryId: 1, id: 11}]);
 	});
 
 	it('returns empty results when the object definition id is missing', async () => {
@@ -211,11 +212,11 @@ describe('ProjectLinkService', () => {
 	it('skips the className check when the asset entry class name is unknown', async () => {
 		mockFetch.mockResolvedValueOnce(
 			mockSearchResponse([
-				relationshipItem({id: 11, projectId: 1}),
+				relationshipItem({cmpProjectObjectEntryId: 1, id: 11}),
 				relationshipItem({
 					className: 'com.example.Other',
+					cmpProjectObjectEntryId: 2,
 					id: 12,
-					projectId: 2,
 				}),
 			])
 		);
@@ -227,8 +228,8 @@ describe('ProjectLinkService', () => {
 		});
 
 		expect(data).toEqual([
-			{id: 11, projectId: 1},
-			{id: 12, projectId: 2},
+			{cmpProjectObjectEntryId: 1, id: 11},
+			{cmpProjectObjectEntryId: 2, id: 12},
 		]);
 	});
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97809
https://liferay.atlassian.net/browse/LPD-97811
https://liferay.atlassian.net/browse/LPD-98828

## What Is Being Fixed

Content editors had no way to associate CMS assets with CMP projects and tasks, and CMP entity naming was inconsistent: the same object appeared bare (projectObjectEntry) in some places and prefixed (cmpProjectObjectDefinition) in others. Brian flagged that split as super confusing when he denied the earlier PR #179094.

## How It Is Being Fixed

Adds the CMP project link and CMP task link object definitions and lets content editors link CMS assets to CMP projects and tasks, exposing the asset and CMP metadata the content editor and list need. The technical task LPD-98828 relaxes the object validation rule check so a modifiable system object may use its non-metadata system fields in a unique composite key, which the link entities require. Alongside the feature, every CMP entity variable, method, data key, and TypeScript type is standardized on the cmp or CMP prefix across the Java and frontend layers, and CMS entities carry the cms or CMS prefix the same way, matching the convention already merged in PR #179081; genuine wire, DOM, OpenAPI, and FDS column contracts are left bare on purpose. Two trailing commits are test-only catch-ups for pre-existing master failures surfaced during verification: LPD-98671 for the update due date action and LPD-93152 for the renamed state column.

## PR Check

**pr-check: PASS** — tested on `eec63122f644ec264ac8ea712213f424ecbe73dc`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "eec63122f644ec264ac8ea712213f424ecbe73dc"} -->
