### PR TITLE
LPD-99506 Create the CMS test group as the guest user through a shared fixture

### DIFF
--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/KeywordResourceTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/KeywordResourceTest.java
@@ -38,7 +38,6 @@ import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
-import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -400,9 +399,8 @@ public class KeywordResourceTest extends BaseKeywordResourceTestCase {
 
 		testGroup = CMSTestUtil.getOrAddGroup(KeywordResourceTest.class);
 
-		irrelevantGroup = GroupTestUtil.addGroup(
-			testDepotEntryGroup.getCompanyId(), TestPropsValues.getUserId(),
-			GroupConstants.DEFAULT_PARENT_GROUP_ID, GroupConstants.CMS);
+		irrelevantGroup = GroupTestUtil.getOrAddCMSGroup(
+			testDepotEntryGroup.getCompanyId());
 
 		super.testGetSiteKeywordsPage();
 

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyCategoryResourceTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyCategoryResourceTest.java
@@ -41,7 +41,6 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.lazy.referencing.LazyReferencingThreadLocal;
 import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
@@ -947,12 +946,10 @@ public class TaxonomyCategoryResourceTest
 				RoleConstants.TYPE_REGULAR, null, null);
 		}
 
-		irrelevantGroup = GroupTestUtil.addGroup(
-			testDepotEntryGroup.getCompanyId(), TestPropsValues.getUserId(),
-			GroupConstants.DEFAULT_PARENT_GROUP_ID, GroupConstants.CMS);
-		testGroup = GroupTestUtil.addGroup(
-			testDepotEntryGroup.getCompanyId(), TestPropsValues.getUserId(),
-			GroupConstants.DEFAULT_PARENT_GROUP_ID, GroupConstants.CMS);
+		irrelevantGroup = GroupTestUtil.getOrAddCMSGroup(
+			testDepotEntryGroup.getCompanyId());
+
+		testGroup = irrelevantGroup;
 	}
 
 	private TaxonomyCategory _addSystemTaxonomyCategory() throws Exception {

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyVocabularyResourceTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyVocabularyResourceTest.java
@@ -472,12 +472,10 @@ public class TaxonomyVocabularyResourceTest
 				RoleConstants.TYPE_REGULAR, null, null);
 		}
 
-		irrelevantGroup = GroupTestUtil.addGroup(
-			testDepotEntryGroup.getCompanyId(), TestPropsValues.getUserId(),
-			GroupConstants.DEFAULT_PARENT_GROUP_ID, GroupConstants.CMS);
-		testGroup = GroupTestUtil.addGroup(
-			testDepotEntryGroup.getCompanyId(), TestPropsValues.getUserId(),
-			GroupConstants.DEFAULT_PARENT_GROUP_ID, GroupConstants.CMS);
+		irrelevantGroup = GroupTestUtil.getOrAddCMSGroup(
+			testDepotEntryGroup.getCompanyId());
+
+		testGroup = irrelevantGroup;
 	}
 
 	private <T> void _assertSingletonArrayEquals(

--- a/modules/apps/layout/layout-seo-test/src/testIntegration/java/com/liferay/layout/seo/test/LayoutSEOLinkManagerPageTitleTest.java
+++ b/modules/apps/layout/layout-seo-test/src/testIntegration/java/com/liferay/layout/seo/test/LayoutSEOLinkManagerPageTitleTest.java
@@ -15,7 +15,6 @@ import com.liferay.portal.kernel.exception.NoSuchLayoutException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutPrototype;
 import com.liferay.portal.kernel.model.Portlet;
@@ -74,14 +73,7 @@ public class LayoutSEOLinkManagerPageTitleTest {
 		if (FeatureFlagManagerUtil.isEnabled(
 				_group.getCompanyId(), "LPD-17564")) {
 
-			_cmsGroup = _groupLocalService.fetchGroup(
-				_group.getCompanyId(), GroupConstants.CMS);
-
-			if (_cmsGroup == null) {
-				_cmsGroup = GroupTestUtil.addGroup(
-					_group.getCompanyId(), TestPropsValues.getUserId(),
-					GroupConstants.DEFAULT_PARENT_GROUP_ID, GroupConstants.CMS);
-			}
+			_cmsGroup = GroupTestUtil.getOrAddCMSGroup(_group.getCompanyId());
 		}
 
 		_layout.setGroupId(_group.getGroupId());

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/info/field/converter/test/ObjectFieldInfoFieldConverterTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/info/field/converter/test/ObjectFieldInfoFieldConverterTest.java
@@ -40,8 +40,6 @@ import com.liferay.object.test.util.ObjectDefinitionTestUtil;
 import com.liferay.object.test.util.ObjectRelationshipTestUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.model.GroupConstants;
-import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -155,14 +153,8 @@ public class ObjectFieldInfoFieldConverterTest {
 				_portal.getPortalURL(new MockHttpServletRequest()) +
 					_portal.getPathContext()));
 
-		Group cmsGroup = GroupLocalServiceUtil.fetchGroup(
-			TestPropsValues.getCompanyId(), GroupConstants.CMS);
-
-		if (cmsGroup == null) {
-			cmsGroup = GroupTestUtil.addGroup(
-				TestPropsValues.getCompanyId(), TestPropsValues.getUserId(), 0,
-				GroupConstants.CMS);
-		}
+		Group cmsGroup = GroupTestUtil.getOrAddCMSGroup(
+			TestPropsValues.getCompanyId());
 
 		RESTContextPathResolver restContextPathResolver =
 			_restContextPathResolverRegistry.getRESTContextPathResolver(

--- a/modules/apps/roles/roles-admin-test/src/testIntegration/java/com/liferay/roles/admin/internal/security/permission/contributor/test/SiteRoleContributorTest.java
+++ b/modules/apps/roles/roles-admin-test/src/testIntegration/java/com/liferay/roles/admin/internal/security/permission/contributor/test/SiteRoleContributorTest.java
@@ -10,7 +10,6 @@ import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.UserGroup;
@@ -61,9 +60,7 @@ public class SiteRoleContributorTest {
 
 	@Before
 	public void setUp() throws Exception {
-		_group = GroupTestUtil.addGroup(
-			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-			GroupConstants.DEFAULT_PARENT_GROUP_ID, GroupConstants.CMS);
+		_group = GroupTestUtil.getOrAddCMSGroup(TestPropsValues.getCompanyId());
 
 		_user = UserTestUtil.addUser();
 

--- a/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/manager/test/RecentGroupManagerTest.java
+++ b/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/manager/test/RecentGroupManagerTest.java
@@ -93,8 +93,8 @@ public class RecentGroupManagerTest {
 		// Until the feature flag LPD-17564 is removed, we need an explicit CMS
 		// group creation.
 
-		Group group = _groupLocalService.fetchGroup(
-			TestPropsValues.getCompanyId(), GroupConstants.CMS);
+		Group group = GroupTestUtil.getOrAddCMSGroup(
+			TestPropsValues.getCompanyId());
 
 		if (group != null) {
 			return;
@@ -109,10 +109,6 @@ public class RecentGroupManagerTest {
 				RoleConstants.SITE_MEMBER, null, null,
 				RoleConstants.TYPE_REGULAR, null, null);
 		}
-
-		GroupTestUtil.addGroup(
-			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-			GroupConstants.DEFAULT_PARENT_GROUP_ID, GroupConstants.CMS);
 	}
 
 	private MockHttpServletRequest _getMockHttpServletRequest()

--- a/portal-test/src/com/liferay/portal/kernel/test/util/GroupTestUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/GroupTestUtil.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.GroupServiceUtil;
 import com.liferay.portal.kernel.service.LayoutSetLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.test.randomizerbumpers.NumericStringRandomizerBumper;
 import com.liferay.portal.kernel.test.randomizerbumpers.UniqueStringRandomizerBumper;
 import com.liferay.portal.kernel.util.FriendlyURLNormalizerUtil;
@@ -324,6 +325,19 @@ public class GroupTestUtil {
 
 		StagingLocalServiceUtil.enableLocalStaging(
 			userId, group, false, false, serviceContext);
+	}
+
+	public static Group getOrAddCMSGroup(long companyId) throws Exception {
+		Group cmsGroup = GroupLocalServiceUtil.fetchGroup(
+			companyId, GroupConstants.CMS);
+
+		if (cmsGroup == null) {
+			cmsGroup = addGroup(
+				companyId, UserLocalServiceUtil.getGuestUserId(companyId), 0,
+				GroupConstants.CMS);
+		}
+
+		return cmsGroup;
 	}
 
 	public static Group updateDisplaySettings(


### PR DESCRIPTION
[LPD-99506](https://liferay.atlassian.net/browse/LPD-99506)

## What Is Being Fixed

Integration tests provision the reserved CMS system group (`GroupConstants.CMS`) with the shared test admin as the creator through `GroupTestUtil.addGroup`. Because the creator is not the guest user, `GroupLocalServiceImpl.addGroup` runs its creator-membership branch and adds the admin to `Users_Groups` as the site owner, which production never does. When DataGuard removes the system group it refuses with `MustNotDeleteSystemGroup` and falls back to a raw session delete that drops the `Group_` row without clearing the `Users_Groups` mappings, so the admin membership dangles and later tests that serialize that admin fail in `UserAccount.getSiteBriefs` with `NoSuchGroupException`.

## How It Is Being Fixed

Add `GroupTestUtil.getOrAddCMSGroup`, which fetches the CMS group and, when absent, creates it with the guest user exactly as production's `checkSystemGroups` path does, so no owner membership is ever added and nothing dangles after cleanup. Every caller is migrated to it, one file per commit, each pinning the born-broken commit. A whole-codebase scan confirmed no other reserved system group (a `GroupConstants.SYSTEM_GROUPS` key) is created with a non-guest creator.

## Related

A Source Formatter check enforcing this rule (so the anti-pattern cannot return) is submitted separately to the source-formatter maintainer: https://github.com/ling-alan-huang/liferay-portal/pull/4323 (LPD-99507).

## PR Check

Validated on PR #12392's `ci:test:object` run (build 502802274, git hash `eec17ed`, byte-identical content):
- Source Format: PASS (`format-source-current-branch` clean)
- Baseline: PASS (no version bump required; the added `GroupTestUtil.getOrAddCMSGroup` is covered by the existing package version 10.8.0 — CI does not flag `portal-test` semantic-versioning while it does flag other test-util additions)
- Per-Module and Integration Test Compile: PASS
- No regression: the object-area failures in that run are the chronic `ObjectEntryResourceTest` setUp race and pre-existing Playwright/Poshi/semantic-versioning noise, none of which touch this change

