### PR TITLE
LPD-99539 Associate the DDM masked field label with its input

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Password/Password.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Password/Password.es.js
@@ -7,6 +7,7 @@ import {ReactFieldBase as FieldBase} from 'dynamic-data-mapping-form-field-type/
 import React, {useState} from 'react';
 
 const Password = ({
+	id,
 	name,
 	onBlur,
 	onChange,
@@ -22,11 +23,11 @@ const Password = ({
 	);
 
 	return (
-		<FieldBase {...otherProps} name={name} readOnly={disabled}>
+		<FieldBase {...otherProps} id={id} name={name} readOnly={disabled}>
 			<input
 				className="ddm-field-text form-control"
 				disabled={disabled}
-				id={name}
+				id={id ?? name}
 				name={name}
 				onBlur={onBlur}
 				onFocus={onFocus}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/api/FieldBase/ReactFieldBase.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/api/FieldBase/ReactFieldBase.js
@@ -295,6 +295,7 @@ export default function FieldBase({
 		type === 'image' ||
 		type === 'localizable_text' ||
 		type === 'numeric' ||
+		type === 'password' ||
 		type === 'phone-number' ||
 		type === 'rich_text' ||
 		type === 'search_location' ||


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99539

## What Is Being Fixed

Any System Settings field declared as a password renders as the DDM `password` field, whose label is not bound to its input. The label carries no `for` attribute and is a sibling rather than a parent of the input, and `Password.es.js` supplies no `aria-label` or `aria-labelledby` to compensate, so the input has no accessible name at all: screen readers cannot announce it and clicking the label does not focus it. 72 fields across 55 configuration classes are affected, including the SAML keystore and private key passwords, the Akismet API key, the SharePoint and OneDrive client secrets, and the Commerce payment method secret and transaction keys.

The cause is that `password` is missing from the `showFor` whitelist in `ReactFieldBase`, which decides whether the rendered label gets `htmlFor`.

## How It Is Being Fixed

`password` is added to `showFor`, so the label renders `htmlFor` resolved from `id ?? name` the same way every other text-like field does. `Password.es.js` is aligned with `Text.es.js`: it destructures `id`, forwards it to `FieldBase`, and sets the input's `id` to `id ?? name`, so label and input agree on the identifier in both the plain and repeatable cases.

## How This Surfaced

`02fa1c2bd6195` ("LPD-88886 Mask credential fields in translator configurations") flagged `serviceAccountPrivateKey` as a password, making it the first such field exercised by a test. This Playwright test has failed on `[master] ci:test:page-management` since `6962c13` (2026-07-23), last passing on `e44d5b5` (2026-07-22):

`layout-content-page-editor-web/form-container/localizationSelectFragment.spec.ts > Can apply auto translation for a language`

## Why Are There No Tests?

The regression is already covered by the Playwright test above, which fails before this change and passes after it. Victor explicitly asked for no new test.

## PR Check

**pr-check: PASS** — tested on `35e7f3a2e8166`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "35e7f3a2e8166b0ec35c6587e22253b107194e77"} -->
