### PR TITLE
LPD-99660 Remove AOP proxy hops from the DLApp fetch methods

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppLocalServiceImpl.java
@@ -604,7 +604,7 @@ public class DLAppLocalServiceImpl extends DLAppLocalServiceBaseImpl {
 		throws PortalException {
 
 		try {
-			return dlAppLocalService.getFileEntry(groupId, folderId, title);
+			return getFileEntry(groupId, folderId, title);
 		}
 		catch (NoSuchFileEntryException noSuchFileEntryException) {
 			if (_log.isDebugEnabled()) {
@@ -641,8 +641,7 @@ public class DLAppLocalServiceImpl extends DLAppLocalServiceBaseImpl {
 		throws PortalException {
 
 		try {
-			return dlAppLocalService.getFileEntryByFileName(
-				groupId, folderId, fileName);
+			return getFileEntryByFileName(groupId, folderId, fileName);
 		}
 		catch (NoSuchFileEntryException noSuchFileEntryException) {
 			if (_log.isDebugEnabled()) {

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppServiceImpl.java
@@ -1046,7 +1046,7 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 	@Override
 	public FileEntry fetchFileEntry(long fileEntryId) throws PortalException {
 		try {
-			return dlAppService.getFileEntry(fileEntryId);
+			return getFileEntry(fileEntryId);
 		}
 		catch (NoSuchFileEntryException noSuchFileEntryException) {
 			if (_log.isDebugEnabled()) {
@@ -1062,7 +1062,7 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 		throws PortalException {
 
 		try {
-			return dlAppService.getFileEntry(groupId, folderId, title);
+			return getFileEntry(groupId, folderId, title);
 		}
 		catch (NoSuchFileEntryException noSuchFileEntryException) {
 			if (_log.isDebugEnabled()) {
@@ -1079,7 +1079,7 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 		throws PortalException {
 
 		try {
-			return dlAppService.getFileEntryByExternalReferenceCode(
+			return getFileEntryByExternalReferenceCode(
 				externalReferenceCode, groupId);
 		}
 		catch (NoSuchFileEntryException noSuchFileEntryException) {
@@ -1097,8 +1097,7 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 		throws PortalException {
 
 		try {
-			return dlAppService.getFileEntryByFileName(
-				groupId, folderId, fileName);
+			return getFileEntryByFileName(groupId, folderId, fileName);
 		}
 		catch (NoSuchFileEntryException noSuchFileEntryException) {
 			if (_log.isDebugEnabled()) {
@@ -1114,7 +1113,7 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 		throws PortalException {
 
 		try {
-			return dlAppService.getFileEntryByUuidAndGroupId(uuid, groupId);
+			return getFileEntryByUuidAndGroupId(uuid, groupId);
 		}
 		catch (NoSuchFileEntryException noSuchFileEntryException) {
 			if (_log.isDebugEnabled()) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99660

https://liferay.atlassian.net/browse/LPD-99661

## What Is Being Fixed

Source Formatter is failing on master. `FetchContractCatchCheck` reports two violations in `DLAppLocalServiceImpl`:

```
1: Do not catch "NoSuchFileEntryException" around the lookup "dlAppLocalService.getFileEntry" to signal a missing entity, call the null-tolerant fetch sibling and check for null instead: ./portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppLocalServiceImpl.java 609 (Checkstyle:FetchContractCatchCheck)
2: Do not catch "NoSuchFileEntryException" around the lookup "dlAppLocalService.getFileEntryByFileName" to signal a missing entity, call the null-tolerant fetch sibling and check for null instead: ./portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppLocalServiceImpl.java 647 (Checkstyle:FetchContractCatchCheck)
```

Behind those two sits a wider defect. Seven `fetch*` methods across `DLAppLocalServiceImpl` and `DLAppServiceImpl` reach their own service's `get*` sibling through the injected AOP proxy reference instead of calling it directly, re-entering the AOP advice chain for a call that never leaves the class.

Only two of the seven surface as Source Formatter violations. `FetchContractCatchCheck` gates on a lookup qualifier ending in `LocalService`, `LocalServiceUtil` or `Persistence`, so it matches the two `dlAppLocalService` calls and silently ignores the five `dlAppService` calls in `DLAppServiceImpl`.

**Root cause:** created wrong in 51c1780680034422512fbb175de94ef2540cfe93 (`LPD-98311 Add fetch methods and remove exception based flow control`, 2026-07-15), which added all seven methods in their proxy-hopping form. `FetchContractCatchCheck` only became active on master on 2026-07-23, when Source Formatter 1.0.1604 was pinned, so the two visible violations sat unreported for eight days.

## How It Is Being Fixed

All seven proxy hops become direct self-calls — two in `DLAppLocalServiceImpl`, five in `DLAppServiceImpl` — reverting the regression at every site the offending commit introduced rather than only the two the current checks happen to see.

Dropping the qualifier also clears both Source Formatter violations, so the suppression proposed in liferay-core-infra/liferay-portal#10153 is unnecessary and that pull request is closed.

The exception based flow control inside these `fetch*` methods is deliberately left unchanged here. The violations clear because the lookup is no longer a qualified service call; converting the catch blocks to a null-tolerant repository path is a separate concern and is tracked separately.

## Notes

@adolfopa — this reverts the seven proxy hops added by 51c1780680034422512fbb175de94ef2540cfe93. No behavior change is intended; the `get*` targets are the same methods on the same class.

@ling-alan-huang — this is the class of regression `JavaServiceHopCheck` (ling-alan-huang#4313) is written to catch. Nothing flagged any of the seven sites because that check has not merged yet.

## PR Check

**pr-check: PASS** — tested on `876f98985558ca5c2b089cd6c0763fac1432fecf`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Transaction Usage | PASS |
| Full Portal Build | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "876f98985558ca5c2b089cd6c0763fac1432fecf"} -->
