### PR TITLE
LPD-99716 Deprovision the CMS system group when LPD-17564 is disabled

### DIFF
--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/feature/flag/test/AttachmentObjectFieldDownloadActionFeatureFlagListenerTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/feature/flag/test/AttachmentObjectFieldDownloadActionFeatureFlagListenerTest.java
@@ -21,6 +21,7 @@ import com.liferay.object.model.ObjectField;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.feature.flag.constants.FeatureFlagConstants;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.Role;
@@ -122,6 +123,9 @@ public class AttachmentObjectFieldDownloadActionFeatureFlagListenerTest {
 			String.valueOf(objectEntry.getObjectEntryId()),
 			powerUserRole.getRoleId(), new String[] {ActionKeys.VIEW});
 
+		boolean lpd17564Enabled = FeatureFlagManagerUtil.isEnabled(
+			objectDefinition.getCompanyId(), "LPD-17564");
+
 		try (PropsTemporarySwapper propsTemporarySwapper =
 				new PropsTemporarySwapper(
 					FeatureFlagConstants.getKey("LPD-17564"),
@@ -178,6 +182,13 @@ public class AttachmentObjectFieldDownloadActionFeatureFlagListenerTest {
 					ResourceConstants.SCOPE_INDIVIDUAL,
 					String.valueOf(objectEntry.getObjectEntryId()),
 					userRole.getRoleId(), attachmentDownloadActionKey));
+		}
+		finally {
+			if (!lpd17564Enabled) {
+				FeatureFlagTestUtil.invokeFeatureFlagListeners(
+					objectDefinition.getCompanyId(), lpd17564Enabled,
+					"LPD-17564");
+			}
 		}
 	}
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/feature/flag/CMSFeatureFlagListener.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/feature/flag/CMSFeatureFlagListener.java
@@ -6,6 +6,7 @@
 package com.liferay.site.cms.site.initializer.internal.feature.flag;
 
 import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagListener;
@@ -14,9 +15,19 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ServiceWrapper;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.ProxyUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.spring.aop.AopInvocationHandler;
 import com.liferay.site.cms.site.initializer.util.SiteInitializerUtil;
 import com.liferay.site.initializer.SiteInitializer;
 
+import java.lang.reflect.Field;
+
+import java.util.Map;
 import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
@@ -34,10 +45,14 @@ public class CMSFeatureFlagListener implements FeatureFlagListener {
 	public void onValue(
 		long companyId, String featureFlagKey, boolean enabled) {
 
-		if (enabled && Objects.equals(featureFlagKey, "LPD-17564")) {
-			Group group = _groupLocalService.fetchGroup(
-				companyId, GroupConstants.CMS);
+		if (!Objects.equals(featureFlagKey, "LPD-17564")) {
+			return;
+		}
 
+		Group group = _groupLocalService.fetchGroup(
+			companyId, GroupConstants.CMS);
+
+		if (enabled) {
 			if (group != null) {
 				return;
 			}
@@ -53,7 +68,78 @@ public class CMSFeatureFlagListener implements FeatureFlagListener {
 			catch (PortalException portalException) {
 				_log.error(portalException);
 			}
+
+			return;
 		}
+
+		// Cover the disabling side: undo what enabling provisioned so the
+		// feature flag change leaves no state behind.
+
+		if (group == null) {
+			return;
+		}
+
+		try (SafeCloseable safeCloseable =
+				CTCollectionThreadLocal.setProductionModeWithSafeCloseable()) {
+
+			_deleteCMSSystemGroup(group);
+		}
+		catch (Exception exception) {
+			_log.error(exception);
+		}
+	}
+
+	private void _deleteCMSSystemGroup(Group group) throws Exception {
+
+		// The CMS group is a system group, so GroupLocalServiceImpl#deleteGroup
+		// refuses to delete it. LPD-17564 is a temporary feature flag, so
+		// temporarily lift CMS out of the sorted system group array to allow
+		// the delete, then restore it.
+
+		Portal portal = PortalUtil.getPortal();
+
+		Field sortedSystemGroupsField = ReflectionUtil.getDeclaredField(
+			portal.getClass(), "_sortedSystemGroups");
+
+		String[] sortedSystemGroups = (String[])sortedSystemGroupsField.get(
+			portal);
+
+		sortedSystemGroupsField.set(
+			portal, ArrayUtil.remove(sortedSystemGroups, GroupConstants.CMS));
+
+		try {
+			_groupLocalService.deleteGroup(group);
+		}
+		finally {
+			sortedSystemGroupsField.set(portal, sortedSystemGroups);
+		}
+
+		// GroupLocalServiceImpl#_systemGroupsMap caches system groups and is
+		// never invalidated on delete, so fetchGroup would keep returning the
+		// deleted CMS group as a phantom for the JVM's life.
+
+		_evictCachedSystemGroup(group);
+	}
+
+	private void _evictCachedSystemGroup(Group group) throws Exception {
+		AopInvocationHandler aopInvocationHandler =
+			ProxyUtil.fetchInvocationHandler(
+				_groupLocalService, AopInvocationHandler.class);
+
+		Object target = aopInvocationHandler.getTarget();
+
+		while (target instanceof ServiceWrapper<?> serviceWrapper) {
+			target = serviceWrapper.getWrappedService();
+		}
+
+		Field field = ReflectionUtil.getDeclaredField(
+			target.getClass(), "_systemGroupsMap");
+
+		Map<String, Group> systemGroupsMap = (Map<String, Group>)field.get(
+			target);
+
+		systemGroupsMap.remove(
+			StringUtil.toHexString(group.getCompanyId()) + group.getGroupKey());
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99716

## What Is Being Fixed

The Objects integration test suite had a cluster of cross-test pollution failures where tests that resolve the CMS system group failed with `NoSuchRoleException {name=cms administrator}`. `CMSFeatureFlagListener` provisioned the CMS system group when `LPD-17564` was enabled but never deprovisioned it when disabled, and `GroupLocalServiceImpl` caches system groups in a JVM-global map that `fetchGroup` consults before the persistence layer and that is never invalidated on delete. Once a test enabled the flag and DataGuard later removed the group's row, the map kept returning it as a phantom for the life of the JVM, breaking every later test that resolves the CMS group.

## How It Is Being Fixed

`CMSFeatureFlagListener` is made symmetric: when `LPD-17564` is disabled it deletes the CMS system group (temporarily lifting `CMS` out of `PortalImpl`'s sorted system group array) and evicts it from `GroupLocalServiceImpl`'s system group map (reached through the AOP proxy). The test `AttachmentObjectFieldDownloadActionFeatureFlagListenerTest` now captures the flag's initial state and, only when it turned the flag on, restores it — triggering the deprovisioning. Both are acceptable because `LPD-17564` is a temporary feature flag.

## PR Check

**pr-check: PASS** — tested on `fc1df4f7421341372fab92e6ed68c5a29ad712b4`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "fc1df4f7421341372fab92e6ed68c5a29ad712b4"} -->
