### PR TITLE
LPD-95007 Break the DS cycle that blocked upgrade registration

### DIFF
--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/impl/SegmentsExperienceLocalServiceImpl.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/impl/SegmentsExperienceLocalServiceImpl.java
@@ -16,6 +16,7 @@ import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.module.service.Snapshot;
 import com.liferay.portal.kernel.security.auth.GuestOrUserUtil;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.ResourceLocalService;
@@ -800,8 +801,16 @@ public class SegmentsExperienceLocalServiceImpl
 			layoutPageTemplateEntryPlid = layout.getClassPK();
 		}
 
+		LayoutPageTemplateEntryLocalService
+			layoutPageTemplateEntryLocalService =
+				_layoutPageTemplateEntryLocalServiceSnapshot.get();
+
+		if (layoutPageTemplateEntryLocalService == null) {
+			return;
+		}
+
 		LayoutPageTemplateEntry layoutPageTemplateEntry =
-			_layoutPageTemplateEntryLocalService.
+			layoutPageTemplateEntryLocalService.
 				fetchLayoutPageTemplateEntryByPlid(layoutPageTemplateEntryPlid);
 
 		if (layoutPageTemplateEntry != null) {
@@ -849,15 +858,16 @@ public class SegmentsExperienceLocalServiceImpl
 		}
 	}
 
+	private static final Snapshot<LayoutPageTemplateEntryLocalService>
+		_layoutPageTemplateEntryLocalServiceSnapshot = new Snapshot<>(
+			SegmentsExperienceLocalServiceImpl.class,
+			LayoutPageTemplateEntryLocalService.class);
+
 	@Reference
 	private Language _language;
 
 	@Reference
 	private LayoutLocalService _layoutLocalService;
-
-	@Reference
-	private LayoutPageTemplateEntryLocalService
-		_layoutPageTemplateEntryLocalService;
 
 	@Reference
 	private ResourceLocalService _resourceLocalService;


### PR DESCRIPTION
The hard @Reference from SegmentsExperienceLocalServiceImpl to LayoutPageTemplateEntryLocalService closed a circular dependency with layout-page-template-service, which already references SegmentsExperienceLocalService from its upgrade step registrator. At upgrade time the cycle could not activate, so the upgrade processes were never registered and ci:test:upgrade finished unresolved. A lazy Snapshot resolves the service at call time without declaring a DS dependency, breaking the cycle while keeping the page template validation.
