### PR TITLE
LPD-99716 Skip CMS site initialization when the CMS group is absent

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-api/src/main/java/com/liferay/site/cms/site/initializer/util/SiteInitializerUtil.java
+++ b/modules/apps/site/site-cms-site-initializer-api/src/main/java/com/liferay/site/cms/site/initializer/util/SiteInitializerUtil.java
@@ -45,8 +45,12 @@ public class SiteInitializerUtil {
 			return;
 		}
 
-		Group group = GroupLocalServiceUtil.getGroup(
+		Group group = GroupLocalServiceUtil.fetchGroup(
 			companyId, GroupConstants.CMS);
+
+		if (group == null) {
+			return;
+		}
 
 		String friendlyURL = FriendlyURLNormalizerUtil.normalizeWithEncoding(
 			"/dashboard");


### PR DESCRIPTION
[LPD-99716](https://liferay.atlassian.net/browse/LPD-99716)

Follow-up to LPD-99716 (already merged): fixes a regression that merged change introduced.

## What Is Being Fixed

LPD-99716's `CMSFeatureFlagListener` deprovisions the CMS system group when LPD-17564 is disabled, evicting it from `GroupLocalServiceImpl`'s JVM-global `_systemGroupsMap` — the only code anywhere that evicts that map. `SiteInitializerUtil.initialize` reads the LPD-17564 flag and then calls the throwing `GroupLocalServiceUtil.getGroup(companyId, CMS)`. Once the group is deprovisioned, that lookup throws `NoSuchGroupException` on the asynchronous portal instance lifecycle path (for example when a configuration event reactivates the CMS listener). The error is logged and, under LogAssertion, fails unrelated tests such as `ObjectEntryResourceTest.testGetObjectEntryActionsWithSystemSharingDisabled`.

## How It Is Being Fixed

Use the nullable `fetchGroup` and return early when the CMS group is absent. The flag can legitimately read enabled while the group is mid-provision or already deprovisioned, and with no CMS group there is nothing to initialize.

Verified on object-rest-test: this eliminates the four `InitialRequestSyncUtil` `NoSuchGroupException` errors and fixes `testGetObjectEntryActionsWithSystemSharingDisabled` (0 errors, test passing).

## PR Check

**pr-check: PASS** — tested on `96f3126097772d1477bc2edf88ae25a688c76734`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |

<!-- pr-check {"result": "success", "sha": "96f3126097772d1477bc2edf88ae25a688c76734"} -->
