### PR TITLE
LPD-99878 Capture the expected error log in ObjectActionExecutorRegistryImplTest

### DIFF
--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/action/executor/test/ObjectActionExecutorRegistryImplTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/action/executor/test/ObjectActionExecutorRegistryImplTest.java
@@ -14,6 +14,9 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
+import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -73,8 +76,31 @@ public class ObjectActionExecutorRegistryImplTest {
 			new TestObjectActionExecutor(1, Collections.emptyList(), true);
 
 		ServiceRegistration<ObjectActionExecutor>
+			objectActionExecutorServiceRegistration1 = null;
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.object.internal.action.executor." +
+					"ObjectActionExecutorRegistryImpl",
+				LoggerTestUtil.ERROR)) {
+
 			objectActionExecutorServiceRegistration1 = _register(
 				testObjectActionExecutor1);
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
+
+			LogEntry logEntry = logEntries.get(0);
+
+			Assert.assertEquals(
+				"Unable to get object action executor service",
+				logEntry.getMessage());
+			Assert.assertEquals(LoggerTestUtil.ERROR, logEntry.getPriority());
+
+			Throwable throwable = logEntry.getThrowable();
+
+			Assert.assertSame(RuntimeException.class, throwable.getClass());
+		}
 
 		TestObjectActionExecutor testObjectActionExecutor2 =
 			new TestObjectActionExecutor(1, Collections.emptyList(), false);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99878

testActivateWithException registers a TestObjectActionExecutor whose getKey
throws, exercising the registry's handling of an executor that fails during
activation. That path logs an expected "Unable to get object action executor
service" error, so capture it around the registration and assert it.

Root cause: this was born broken in
497c195e1ba7feca3f8b7605a4601204b2c3b287 ("LPD-64551 protect against bad object
action executor services"), which in one change added both the
ObjectActionExecutorRegistryImpl.activate() catch that logs the error at ERROR
when an executor's getKey throws and the failing-executor test scenario that
triggers it, but wrote the test without a LogCapture so the expected ERROR and
its stack trace leaked into the run. 291ae736a949bf1a421180c0e1b5a363f05af25b
("LPD-64551 SF") later only renamed the test to testActivateWithException and
preserved the noise, so this is an own goal implemented incompletely rather than
a later regression.

## PR Check

**pr-check: PASS** — tested on `456cefacc0ea3d26675ef4a5f28d4dabdd68fec2`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |

Validated locally on the object stabilization branch against upstream/master 96b538d; the branch content is identical to the reviewed commit.

<!-- pr-check {"result": "success", "sha": "456cefacc0ea3d26675ef4a5f28d4dabdd68fec2"} -->
