### PR TITLE
LPD-99879 Copy the object definition label maps without double-localizing

### DIFF
--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
@@ -3061,13 +3061,10 @@ public class ObjectDefinitionLocalServiceTest {
 				_objectDefinitionLocalService.addCustomObjectDefinition(
 					null, user.getUserId(), 0, objectDefinition1.getClassName(),
 					true, false, true, false, true, false, false, false, false,
-					null,
-					LocalizedMapUtil.getLocalizedMap(
-						objectDefinition1.getLabel()),
+					null, objectDefinition1.getLabelMap(),
 					objectDefinition1.getShortName(), null, null,
-					LocalizedMapUtil.getLocalizedMap(
-						objectDefinition1.getPluralLabel()),
-					true, ObjectDefinitionConstants.SCOPE_COMPANY,
+					objectDefinition1.getPluralLabelMap(), true,
+					ObjectDefinitionConstants.SCOPE_COMPANY,
 					ObjectDefinitionConstants.STORAGE_TYPE_DEFAULT,
 					Collections.emptyList(),
 					Arrays.asList(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99879

testGetClassName built the second object definition's label from
objectDefinition1.getLabel() and getPluralLabel(), which return the raw
localization XML of the label column, and wrapped that XML in another
LocalizedMapUtil.getLocalizedMap call. The result was a doubly serialized
label whose en_US value was itself a full localization XML string.

When the object definition is created, addOrUpdateObjectDefinitionPLOEntries
stores objectDefinition.getLabel(locale) as the value of a PLOEntry. Because
the label was double-localized, getLabel(locale) returned the inner XML rather
than a plain string, so the PLOEntry value was localization XML. PLOEntry
persistence sanitizes the value as TEXT_HTML, and AntiSamy filtered the XML
tags, logging fifty-two "root/label/pluralLabel tag has been filtered"
warnings across the run.

Reuse objectDefinition1.getLabelMap() and getPluralLabelMap() so the copied
label is a plain localized map, matching how every production caller supplies
labels. The PLOEntry values become plain strings and AntiSamy no longer has
anything to filter.

Root cause: this was born broken in
8c708d431821ce2256432f65866e27c8654e5d89 ("LPD-55379 Test if objects on
different companies can have the same className"), which added testGetClassName
and, from its first version, wrapped the no-arg getLabel and getPluralLabel
column getters, which return the stored localization XML, in a second
LocalizedMapUtil.getLocalizedMap call. The PLOEntry persistence that turns that
XML into TEXT_HTML AntiSamy warnings had existed since
577dc2be5f018c2bf0afe5333438961d392a35b0 ("LPD-34176") well before the test, so
the warnings appeared from the test's first run and no later change is involved.

## PR Check

**pr-check: PASS** — tested on `1d96d826c6ee7b9c72d6c3c0e04f3e876caeff37`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |

Validated locally on the object stabilization branch against upstream/master 96b538d; the branch content is identical to the reviewed commit.

<!-- pr-check {"result": "success", "sha": "1d96d826c6ee7b9c72d6c3c0e04f3e876caeff37"} -->
