### PR TITLE
LPD-99880 Capture the expected sharing error logs in ObjectEntryFolderSharingTest

### DIFF
--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/sharing/test/ObjectEntryFolderSharingTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/sharing/test/ObjectEntryFolderSharingTest.java
@@ -9,10 +9,12 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectEntryFolderLocalService;
+import com.liferay.portal.kernel.exception.NoSuchResourceActionException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.module.service.Snapshot;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
@@ -21,10 +23,16 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.security.permission.contributor.PermissionSQLContributor;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
+import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.sharing.security.permission.SharingPermissionChecker;
 import com.liferay.sharing.test.util.BaseSharingTestCase;
 
+import java.util.List;
+
+import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -42,10 +50,159 @@ public class ObjectEntryFolderSharingTest
 	public void testAdminCanShareWithAddDiscussion() throws Exception {
 	}
 
+	@Override
+	@Test
+	public void testInlinePermissions() throws Exception {
+		try (LogCapture logCapture1 = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.sharing.web.internal.interpreter." +
+					"AssetRendererSharingEntryInterpreter",
+				LoggerTestUtil.ERROR);
+			LogCapture logCapture2 = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.sharing.notifications.internal.service." +
+					"NotificationsSharingEntryLocalServiceWrapper",
+				LoggerTestUtil.ERROR)) {
+
+			super.testInlinePermissions();
+
+			List<LogEntry> logEntries1 = logCapture1.getLogEntries();
+
+			Assert.assertEquals(logEntries1.toString(), 3, logEntries1.size());
+
+			for (LogEntry logEntry : logEntries1) {
+				Assert.assertEquals(
+					LoggerTestUtil.ERROR, logEntry.getPriority());
+
+				String message = logEntry.getMessage();
+
+				Assert.assertTrue(
+					message,
+					message.contains(
+						"must have VIEW permission for " +
+							"com.liferay.object.model.ObjectEntryFolder"));
+
+				Throwable throwable = logEntry.getThrowable();
+
+				Assert.assertEquals(
+					PrincipalException.MustHavePermission.class,
+					throwable.getClass());
+			}
+
+			List<LogEntry> logEntries2 = logCapture2.getLogEntries();
+
+			Assert.assertEquals(logEntries2.toString(), 1, logEntries2.size());
+
+			LogEntry logEntry = logEntries2.get(0);
+
+			Assert.assertEquals(LoggerTestUtil.ERROR, logEntry.getPriority());
+
+			String message = logEntry.getMessage();
+
+			Assert.assertTrue(
+				message,
+				message.contains(
+					"Unable to send notification for sharing entry: "));
+
+			Throwable throwable = logEntry.getThrowable();
+
+			Assert.assertEquals(
+				PrincipalException.MustHavePermission.class,
+				throwable.getClass());
+		}
+	}
+
 	@Ignore
 	@Override
 	@Test
 	public void testMovingToRecycleBinSharedModelDoesNotDeleteSharingEntries() {
+	}
+
+	@Override
+	@Test
+	public void testUserWithAddDiscussionAndViewSharingEntryActionCanAddDiscussionPrivateModel()
+		throws Exception {
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.portal.security.permission." +
+					"AdvancedPermissionChecker",
+				LoggerTestUtil.ERROR)) {
+
+			super.
+				testUserWithAddDiscussionAndViewSharingEntryActionCanAddDiscussionPrivateModel();
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
+
+			LogEntry logEntry = logEntries.get(0);
+
+			Assert.assertEquals(LoggerTestUtil.ERROR, logEntry.getPriority());
+			Assert.assertEquals(
+				"com.liferay.object.model.ObjectEntryFolder#ADD_DISCUSSION",
+				logEntry.getMessage());
+
+			Throwable throwable = logEntry.getThrowable();
+
+			Assert.assertEquals(
+				NoSuchResourceActionException.class, throwable.getClass());
+		}
+	}
+
+	@Override
+	@Test
+	public void testUserWithAddDiscussionPermissionCannotShareWithUpdate()
+		throws Exception {
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.sharing.test.util.BaseSharingTestCase",
+				LoggerTestUtil.ERROR)) {
+
+			super.testUserWithAddDiscussionPermissionCannotShareWithUpdate();
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
+
+			LogEntry logEntry = logEntries.get(0);
+
+			Assert.assertEquals(LoggerTestUtil.ERROR, logEntry.getPriority());
+			Assert.assertEquals(
+				"com.liferay.object.model.ObjectEntryFolder#ADD_DISCUSSION",
+				logEntry.getMessage());
+
+			Throwable throwable = logEntry.getThrowable();
+
+			Assert.assertEquals(
+				NoSuchResourceActionException.class, throwable.getClass());
+		}
+	}
+
+	@Override
+	@Test
+	public void testUserWithAddDiscussionPermissionCannotShareWithView()
+		throws Exception {
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.sharing.test.util.BaseSharingTestCase",
+				LoggerTestUtil.ERROR)) {
+
+			super.testUserWithAddDiscussionPermissionCannotShareWithView();
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
+
+			LogEntry logEntry = logEntries.get(0);
+
+			Assert.assertEquals(LoggerTestUtil.ERROR, logEntry.getPriority());
+			Assert.assertEquals(
+				"com.liferay.object.model.ObjectEntryFolder#ADD_DISCUSSION",
+				logEntry.getMessage());
+
+			Throwable throwable = logEntry.getThrowable();
+
+			Assert.assertEquals(
+				NoSuchResourceActionException.class, throwable.getClass());
+		}
 	}
 
 	@Ignore
@@ -53,6 +210,68 @@ public class ObjectEntryFolderSharingTest
 	@Test
 	public void testUserWithAddDiscussionPermissionCanShareWithAddDiscussion()
 		throws Exception {
+	}
+
+	@Override
+	@Test
+	public void testUserWithoutAddDiscussionSharingEntryActionCannotAddDiscussionPrivateModel()
+		throws Exception {
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.portal.security.permission." +
+					"AdvancedPermissionChecker",
+				LoggerTestUtil.ERROR)) {
+
+			super.
+				testUserWithoutAddDiscussionSharingEntryActionCannotAddDiscussionPrivateModel();
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
+
+			LogEntry logEntry = logEntries.get(0);
+
+			Assert.assertEquals(LoggerTestUtil.ERROR, logEntry.getPriority());
+			Assert.assertEquals(
+				"com.liferay.object.model.ObjectEntryFolder#ADD_DISCUSSION",
+				logEntry.getMessage());
+
+			Throwable throwable = logEntry.getThrowable();
+
+			Assert.assertEquals(
+				NoSuchResourceActionException.class, throwable.getClass());
+		}
+	}
+
+	@Override
+	@Test
+	public void testUserWithUpdateAndViewSharingEntryActionCannotAddDiscussionPrivateModel()
+		throws Exception {
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.portal.security.permission." +
+					"AdvancedPermissionChecker",
+				LoggerTestUtil.ERROR)) {
+
+			super.
+				testUserWithUpdateAndViewSharingEntryActionCannotAddDiscussionPrivateModel();
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
+
+			LogEntry logEntry = logEntries.get(0);
+
+			Assert.assertEquals(LoggerTestUtil.ERROR, logEntry.getPriority());
+			Assert.assertEquals(
+				"com.liferay.object.model.ObjectEntryFolder#ADD_DISCUSSION",
+				logEntry.getMessage());
+
+			Throwable throwable = logEntry.getThrowable();
+
+			Assert.assertEquals(
+				NoSuchResourceActionException.class, throwable.getClass());
+		}
 	}
 
 	@Ignore


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99880

ObjectEntryFolder has no ADD_DISCUSSION resource action and no sharing-aware
asset renderer, so the sharing scenarios inherited from BaseSharingTestCase
deliberately provoke permission-denied and notification errors. The
LogAssertionAppender rethrows those expected errors and fails the run.

Capture the four loggers that emit them for the lifetime of the test, matching
how other tests silence expected error output, so the inherited scenarios can
run without polluting the log.

Root cause: this was born broken in
191bf545c0da5f1187df98f9849648ee4291c3f9 ("LPD-65945 Integration tests"), which
created ObjectEntryFolderSharingTest as a BaseSharingTestCase subclass. At that
point ObjectEntryFolder already lacked an ADD_DISCUSSION resource action and a
sharing-aware asset renderer, so the inherited scenarios emitted the expected
errors from the first run; the creating commit ignored four unrelated scenarios
but neither ignored nor captured the error-emitting ones. The file was untouched
until this fix, so there is no intervening regression.

## PR Check

**pr-check: PASS** — tested on `d7394e9c7b99c9d9b49755b64c81d758d469360b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |

Validated locally on the object stabilization branch against upstream/master 96b538d; the branch content is identical to the reviewed commit.

<!-- pr-check {"result": "success", "sha": "d7394e9c7b99c9d9b49755b64c81d758d469360b"} -->
