### PR TITLE
LPD-99881 Upload real image bytes so Adaptive Media can scale the attachments

### DIFF
--- a/modules/apps/document-library/document-library-test-util/bnd.bnd
+++ b/modules/apps/document-library/document-library-test-util/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Document Library Test Utilities
 Bundle-SymbolicName: com.liferay.document.library.test.util
-Bundle-Version: 5.1.2
+Bundle-Version: 5.2.0
 Export-Package:\
 	com.liferay.document.library.test.util,\
 	com.liferay.document.library.test.util.search

--- a/modules/apps/document-library/document-library-test-util/src/main/java/com/liferay/document/library/test/util/DLTestUtil.java
+++ b/modules/apps/document-library/document-library-test-util/src/main/java/com/liferay/document/library/test/util/DLTestUtil.java
@@ -24,7 +24,13 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.StringUtil;
 
+import java.awt.image.BufferedImage;
+
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import javax.imageio.ImageIO;
 
 /**
  * @author Adolfo Pérez
@@ -95,6 +101,18 @@ public class DLTestUtil {
 		throws PortalException {
 
 		return addDLFolder(groupId, true, serviceContext);
+	}
+
+	public static byte[] imageFileBytes(String formatName) throws IOException {
+		BufferedImage bufferedImage = new BufferedImage(
+			1, 1, BufferedImage.TYPE_INT_RGB);
+
+		ByteArrayOutputStream byteArrayOutputStream =
+			new ByteArrayOutputStream();
+
+		ImageIO.write(bufferedImage, formatName, byteArrayOutputStream);
+
+		return byteArrayOutputStream.toByteArray();
 	}
 
 	public static byte[] randomTextFileBytes() {

--- a/modules/apps/document-library/document-library-test-util/src/main/resources/com/liferay/document/library/test/util/packageinfo
+++ b/modules/apps/document-library/document-library-test-util/src/main/resources/com/liferay/document/library/test/util/packageinfo
@@ -1,1 +1,1 @@
-version 2.1.0
+version 2.2.0

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceSearchObjectEntriesTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceSearchObjectEntriesTest.java
@@ -512,7 +512,7 @@ public class ObjectEntryLocalServiceSearchObjectEntriesTest {
 			_objectDefinition.getPortletId(),
 			TempFileEntryUtil.getTempFileName(
 				RandomTestUtil.randomString() + ".jpg"),
-			FileUtil.createTempFile(DLTestUtil.randomTextFileBytes()),
+			FileUtil.createTempFile(DLTestUtil.imageFileBytes("jpg")),
 			ContentTypes.IMAGE_JPEG);
 
 		_addObjectEntry(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/info/item/provider/test/ObjectEntryInfoItemFieldValuesProviderTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/info/item/provider/test/ObjectEntryInfoItemFieldValuesProviderTest.java
@@ -8,6 +8,7 @@ package com.liferay.object.web.internal.info.item.provider.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
+import com.liferay.document.library.test.util.DLTestUtil;
 import com.liferay.document.library.util.DLURLHelper;
 import com.liferay.info.field.InfoFieldValue;
 import com.liferay.info.item.ClassPKInfoItemIdentifier;
@@ -212,8 +213,8 @@ public class ObjectEntryInfoItemFieldValuesProviderTest {
 		FileEntry fileEntry = _dlAppLocalService.addFileEntry(
 			null, TestPropsValues.getUserId(), _group.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, "test.png",
-			ContentTypes.IMAGE_PNG, RandomTestUtil.randomBytes(), null, null,
-			null,
+			ContentTypes.IMAGE_PNG, DLTestUtil.imageFileBytes("png"), null,
+			null, null,
 			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 
 		LocalDateTime localDateTime = LocalDateTime.of(2026, 1, 1, 23, 30);
@@ -319,8 +320,8 @@ public class ObjectEntryInfoItemFieldValuesProviderTest {
 		FileEntry fileEntry = _dlAppLocalService.addFileEntry(
 			null, TestPropsValues.getUserId(), _group.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, "test.png",
-			ContentTypes.IMAGE_PNG, RandomTestUtil.randomBytes(), null, null,
-			null,
+			ContentTypes.IMAGE_PNG, DLTestUtil.imageFileBytes("png"), null,
+			null, null,
 			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 
 		ObjectField objectField = _objectFieldLocalService.fetchObjectField(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99881

These tests uploaded files named .png and .jpg whose contents were random
bytes, so Adaptive Media could not decode them and logged "Unable to scale
file entry" warnings while trying to build previews.

Generate a real one-pixel image with ImageIO for the image-typed uploads so
Adaptive Media can scale them without warning. The tests still exercise the
attachment field paths they always did.

Root cause: this was born broken in two tests, each introducing an image-typed
upload backed by undecodable bytes.
f7f35e6c80aaf7ee2f3f23147752555acc26f414 ("LPD-82676 Update tests") switched
ObjectEntryInfoItemFieldValuesProviderTest's upload to test.png and
ContentTypes.IMAGE_PNG to exercise the image preview path but left the content
as random bytes, and 46fd6901807a0eae8e1be94a9db3d4fd8e833d03 ("LPD-78933 add
tests for extension keyword search") added testSearchByFileExtension uploading
random text under a .jpg name and ContentTypes.IMAGE_JPEG. Both emitted the
"Unable to scale file entry" warning from their first run, so neither is a
later regression.

## PR Check

**pr-check: PASS** — tested on `d5d5dbcc524f1e640c8c1b9975decaff5ee43109`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |

Validated locally on the object stabilization branch against upstream/master 96b538d; the branch content is identical to the reviewed commit.

<!-- pr-check {"result": "success", "sha": "d5d5dbcc524f1e640c8c1b9975decaff5ee43109"} -->
