### PR TITLE
LPD-99882 Silence the ANTLR console error listeners in DDMExpressionImpl

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-expression/src/main/java/com/liferay/dynamic/data/mapping/expression/internal/DDMExpressionImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-expression/src/main/java/com/liferay/dynamic/data/mapping/expression/internal/DDMExpressionImpl.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import org.antlr.v4.runtime.ANTLRInputStream;
 import org.antlr.v4.runtime.BailErrorStrategy;
 import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.ConsoleErrorListener;
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
 
 /**
@@ -99,9 +100,15 @@ public class DDMExpressionImpl<T> implements DDMExpression<T> {
 			throw new IllegalArgumentException();
 		}
 
+		DDMExpressionLexer ddmExpressionLexer = new DDMExpressionLexer(
+			new ANTLRInputStream(expression));
+
+		ddmExpressionLexer.removeErrorListener(ConsoleErrorListener.INSTANCE);
+
 		DDMExpressionParser ddmExpressionParser = new DDMExpressionParser(
-			new CommonTokenStream(
-				new DDMExpressionLexer(new ANTLRInputStream(expression))));
+			new CommonTokenStream(ddmExpressionLexer));
+
+		ddmExpressionParser.removeErrorListener(ConsoleErrorListener.INSTANCE);
 
 		ddmExpressionParser.setErrorHandler(new BailErrorStrategy());
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99882

BailErrorStrategy governs only the parser's error recovery, so it does not stop
ANTLR's default ConsoleErrorListener from printing lexer token recognition
errors straight to System.err. When an object definition batch import feeds a
JSON fallback such as {"name":...} into createExpression, the lexer prints
"line 1:0 token recognition error at: '{'" even though the resulting
DDMExpressionException is already caught and handled by every caller.

Remove the default ConsoleErrorListener from both the lexer and the parser so
those messages stop leaking to the console. The BailErrorStrategy contract is
unchanged: invalid syntax still surfaces as DDMExpressionException.InvalidSyntax.

Root cause: this was born broken in
36580849005cffd3ac422126bb3e8631a3f0c83d ("LPS-66755 Update implementation") in
2016, which rewrote DDMExpressionImpl to parse with ANTLR and catch failures as
DDMExpressionException.InvalidSyntax but never detached ANTLR's default
ConsoleErrorListener. Invalid input has therefore printed token recognition and
syntax errors to System.err ever since; later callers such as the object
definition batch importer feeding JSON into createExpression merely made the
latent noise visible, so this completes the original design rather than fixing a
regression.

## PR Check

**pr-check: PASS** — tested on `98f98eb7a6c32ed48a835bb684c5169c9af98837`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |

Validated locally on the object stabilization branch against upstream/master 96b538d; the branch content is identical to the reviewed commit.

<!-- pr-check {"result": "success", "sha": "98f98eb7a6c32ed48a835bb684c5169c9af98837"} -->
