### PR TITLE
LPD-99883 Avoid nested paragraph AntiSamy warnings in the comment tests

### DIFF
--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -17665,18 +17665,14 @@ public class ObjectEntryResourceTest {
 			JSONUtil.put(
 				"externalReferenceCode", externalReferenceCode
 			).put(
-				"text",
-				StringBundler.concat(
-					"<p>", RandomTestUtil.randomString(), "</p>")
+				"text", RandomTestUtil.randomString()
 			),
 			JSONUtil.put(
 				"externalReferenceCode", RandomTestUtil.randomString()
 			).put(
 				"parentCommentExternalReferenceCode", externalReferenceCode
 			).put(
-				"text",
-				StringBundler.concat(
-					"<p>", RandomTestUtil.randomString(), "</p>")
+				"text", RandomTestUtil.randomString()
 			));
 
 		String endpoint = _getEndpoint(objectDefinition, groupId);
@@ -17919,32 +17915,28 @@ public class ObjectEntryResourceTest {
 			JSONUtil.put(
 				"externalReferenceCode", externalReferenceCode
 			).put(
-				"text",
-				StringBundler.concat(
-					"<p>", RandomTestUtil.randomString(), "</p>")
+				"text", RandomTestUtil.randomString()
 			),
 			JSONUtil.put(
 				"externalReferenceCode", RandomTestUtil.randomString()
 			).put(
 				"parentCommentExternalReferenceCode", externalReferenceCode
 			).put(
-				"text",
-				StringBundler.concat(
-					"<p>", RandomTestUtil.randomString(), "</p>")
+				"text", RandomTestUtil.randomString()
 			),
 			JSONUtil.put(
 				"externalReferenceCode", RandomTestUtil.randomString()
 			).put(
-				"text",
-				StringBundler.concat(
-					"<p>", RandomTestUtil.randomString(), "</p>")
+				"text", RandomTestUtil.randomString()
 			));
 
 		_postObjectEntryWithComments(
 			commentsJSONArray, groupId, false, objectDefinition);
 
 		JSONAssert.assertEquals(
-			commentsJSONArray.toString(),
+			_toExpectedCommentsJSONArray(
+				commentsJSONArray
+			).toString(),
 			_getCommentsJSONArray(
 				groupId, objectDefinition
 			).toString(),
@@ -19627,22 +19619,20 @@ public class ObjectEntryResourceTest {
 			JSONUtil.put(
 				"externalReferenceCode", externalReferenceCode
 			).put(
-				"text",
-				StringBundler.concat(
-					"<p>", RandomTestUtil.randomString(), "</p>")
+				"text", RandomTestUtil.randomString()
 			),
 			JSONUtil.put(
 				"externalReferenceCode", RandomTestUtil.randomString()
 			).put(
 				"parentCommentExternalReferenceCode", externalReferenceCode
 			).put(
-				"text",
-				StringBundler.concat(
-					"<p>", RandomTestUtil.randomString(), "</p>")
+				"text", RandomTestUtil.randomString()
 			));
 
 		JSONAssert.assertEquals(
-			commentsJSONArray.toString(),
+			_toExpectedCommentsJSONArray(
+				commentsJSONArray
+			).toString(),
 			_patchPutObjectEntryWithComments(
 				commentsJSONArray, groupId, httpMethod, objectDefinition,
 				objectEntryJSONObject
@@ -19653,29 +19643,25 @@ public class ObjectEntryResourceTest {
 			JSONUtil.put(
 				"externalReferenceCode", externalReferenceCode
 			).put(
-				"text",
-				StringBundler.concat(
-					"<p>", RandomTestUtil.randomString(), "</p>")
+				"text", RandomTestUtil.randomString()
 			),
 			JSONUtil.put(
 				"externalReferenceCode", RandomTestUtil.randomString()
 			).put(
 				"parentCommentExternalReferenceCode", externalReferenceCode
 			).put(
-				"text",
-				StringBundler.concat(
-					"<p>", RandomTestUtil.randomString(), "</p>")
+				"text", RandomTestUtil.randomString()
 			),
 			JSONUtil.put(
 				"externalReferenceCode", RandomTestUtil.randomString()
 			).put(
-				"text",
-				StringBundler.concat(
-					"<p>", RandomTestUtil.randomString(), "</p>")
+				"text", RandomTestUtil.randomString()
 			));
 
 		JSONAssert.assertEquals(
-			commentsJSONArray.toString(),
+			_toExpectedCommentsJSONArray(
+				commentsJSONArray
+			).toString(),
 			_patchPutObjectEntryWithComments(
 				commentsJSONArray, groupId, httpMethod, objectDefinition,
 				objectEntryJSONObject
@@ -20812,9 +20798,7 @@ public class ObjectEntryResourceTest {
 			JSONUtil.put(
 				"externalReferenceCode", RandomTestUtil.randomString()
 			).put(
-				"text",
-				StringBundler.concat(
-					"<p>", RandomTestUtil.randomString(), "</p>")
+				"text", RandomTestUtil.randomString()
 			));
 
 		Assert.assertEquals(
@@ -20826,7 +20810,9 @@ public class ObjectEntryResourceTest {
 		_enableComments(objectDefinition);
 
 		JSONAssert.assertEquals(
-			commentsJSONArray.toString(),
+			_toExpectedCommentsJSONArray(
+				commentsJSONArray
+			).toString(),
 			_postObjectEntryWithComments(
 				commentsJSONArray, groupId, true, objectDefinition
 			).toString(),
@@ -20838,22 +20824,20 @@ public class ObjectEntryResourceTest {
 			JSONUtil.put(
 				"externalReferenceCode", externalReferenceCode
 			).put(
-				"text",
-				StringBundler.concat(
-					"<p>", RandomTestUtil.randomString(), "</p>")
+				"text", RandomTestUtil.randomString()
 			),
 			JSONUtil.put(
 				"externalReferenceCode", RandomTestUtil.randomString()
 			).put(
 				"parentCommentExternalReferenceCode", externalReferenceCode
 			).put(
-				"text",
-				StringBundler.concat(
-					"<p>", RandomTestUtil.randomString(), "</p>")
+				"text", RandomTestUtil.randomString()
 			));
 
 		JSONAssert.assertEquals(
-			commentsJSONArray.toString(),
+			_toExpectedCommentsJSONArray(
+				commentsJSONArray
+			).toString(),
 			_postObjectEntryWithComments(
 				commentsJSONArray, groupId, true, objectDefinition
 			).toString(),
@@ -22254,6 +22238,27 @@ public class ObjectEntryResourceTest {
 
 		return JSONFactoryUtil.createJSONObject(
 			embeddedTaxonomyCategory.toString());
+	}
+
+	private JSONArray _toExpectedCommentsJSONArray(JSONArray commentsJSONArray)
+		throws Exception {
+
+		JSONArray expectedCommentsJSONArray = JSONFactoryUtil.createJSONArray();
+
+		for (int i = 0; i < commentsJSONArray.length(); i++) {
+			JSONObject commentJSONObject = commentsJSONArray.getJSONObject(i);
+
+			expectedCommentsJSONArray.put(
+				JSONFactoryUtil.createJSONObject(
+					commentJSONObject.toString()
+				).put(
+					"text",
+					StringBundler.concat(
+						"<p>", commentJSONObject.getString("text"), "</p>")
+				));
+		}
+
+		return expectedCommentsJSONArray;
 	}
 
 	private com.liferay.object.rest.dto.v1_0.FileEntry _toFileEntry(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99883

The object REST comment tests submitted comment text already wrapped in a
paragraph tag, and ObjectEntryComment wraps the text in a paragraph tag again, so
the value that reached the TEXT_HTML sanitizer was a paragraph nested in a
paragraph. AntiSamy stripped the empty outer paragraph and logged a warning on
every comment.

Submit plain comment text instead and assert the paragraph-wrapped value the API
returns, so the tests still verify the comment round trip without provoking the
sanitizer.

Root cause: this was born broken under LPD-74365.
473987527809b46c4312f17611f0c77e67945031 ("LPD-74365 wrap text with tags") made
the ObjectEntryComment constructor store the text wrapped in a paragraph tag,
and hours later 6e57ab3b150fe034d398abe7b10c34c748ec515b ("LPD-74365 Add tests")
submitted comment text that was itself already paragraph-wrapped. Production
wrapped it a second time, so every comment reached the TEXT_HTML sanitizer
nested and AntiSamy stripped the empty outer paragraph, warning once per comment
from the first run. The assertion still matched because the sanitizer collapsed
the nesting back to the submitted value, which is why the noise went unnoticed.

## PR Check

**pr-check: PASS** — tested on `de48712ce78a8b5d27404a87ebc5e4ff08e8ea97`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |

Validated locally on the object stabilization branch against upstream/master 96b538d; the branch content is identical to the reviewed commit.

<!-- pr-check {"result": "success", "sha": "de48712ce78a8b5d27404a87ebc5e4ff08e8ea97"} -->
