### PR TITLE
LPD-99884 Capture the expected error log in ObjectEntryManagerRegistryImplTest

### DIFF
--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/ObjectEntryManagerRegistryImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/ObjectEntryManagerRegistryImplTest.java
@@ -14,6 +14,9 @@ import com.liferay.object.scope.CompanyScoped;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
+import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.vulcan.aggregation.Aggregation;
@@ -74,8 +77,30 @@ public class ObjectEntryManagerRegistryImplTest {
 			new TestObjectEntryManager(1, true);
 
 		ServiceRegistration<ObjectEntryManager>
+			objectEntryManagerServiceRegistration1 = null;
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.object.rest.internal.manager.v1_0." +
+					"ObjectEntryManagerRegistryImpl",
+				LoggerTestUtil.ERROR)) {
+
 			objectEntryManagerServiceRegistration1 = _register(
 				testObjectEntryManager1);
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
+
+			LogEntry logEntry = logEntries.get(0);
+
+			Assert.assertEquals(LoggerTestUtil.ERROR, logEntry.getPriority());
+			Assert.assertEquals(
+				"Unable to get object entry manager", logEntry.getMessage());
+
+			Throwable throwable = logEntry.getThrowable();
+
+			Assert.assertEquals(RuntimeException.class, throwable.getClass());
+		}
 
 		TestObjectEntryManager testObjectEntryManager2 =
 			new TestObjectEntryManager(1, false);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99884

testActivateWithException registers a TestObjectEntryManager whose getStorageType
throws, exercising the registry's handling of a manager that fails during
activation. That path logs an expected "Unable to get object entry manager"
error, so capture it around the registration and assert it.

Root cause: this was born broken as an incomplete LPD-70461.
32175c5d89eab924993c0fefe0bfeae24ec11e7d ("LPD-70461 Add test") added
testActivateWithException to exercise the activation-failure path, and twelve
minutes later 0b77d8ca93d96927b1e7b1810e5c729dd5b0167a ("LPD-70461 Add support
for logs") wrapped ObjectEntryManagerRegistryImpl.activate()'s emitter in a
catch that logs the error at ERROR on that path. From then on the test drove an
intentional ERROR but never captured it, leaking it on every run, so this is an
incomplete implementation rather than a later regression.

## PR Check

**pr-check: PASS** — tested on `2682e0b8e95f718ea06fb549ffcda27b52339e04`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |

Validated locally on the object stabilization branch against upstream/master 96b538d; the branch content is identical to the reviewed commit.

<!-- pr-check {"result": "success", "sha": "2682e0b8e95f718ea06fb549ffcda27b52339e04"} -->
