### PR TITLE
LPD-99910 Stop re-sanitizing a localized field's default locale value

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -3846,6 +3846,24 @@ public class DefaultObjectEntryManagerImpl
 					properties);
 			}
 
+			if (objectField.isLocalized()) {
+				ObjectFieldBusinessType objectFieldBusinessType =
+					_objectFieldBusinessTypeRegistry.getObjectFieldBusinessType(
+						objectField.getBusinessType());
+
+				Map<String, Object> localizedValues =
+					objectFieldBusinessType.getLocalizedValues(
+						objectField, serviceContext.getUserId(), properties);
+
+				if (localizedValues != null) {
+					values.put(
+						objectField.getI18nObjectFieldName(),
+						(Serializable)localizedValues);
+
+					continue;
+				}
+			}
+
 			Object value = ObjectEntryValuesUtil.getValue(
 				getGroupId(objectDefinition, scopeKey),
 				_objectDefinitionLocalService, objectEntryLocalService,
@@ -3865,20 +3883,7 @@ public class DefaultObjectEntryManagerImpl
 			}
 
 			if (objectField.isLocalized()) {
-				ObjectFieldBusinessType objectFieldBusinessType =
-					_objectFieldBusinessTypeRegistry.getObjectFieldBusinessType(
-						objectField.getBusinessType());
-
-				Map<String, Object> localizedValues =
-					objectFieldBusinessType.getLocalizedValues(
-						objectField, serviceContext.getUserId(), properties);
-
-				if (localizedValues != null) {
-					values.put(
-						objectField.getI18nObjectFieldName(),
-						(Serializable)localizedValues);
-				}
-				else if (value != null) {
+				if (value != null) {
 					String defaultLanguageId =
 						objectEntry.getDefaultLanguageId();
 

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -220,6 +220,7 @@ import com.liferay.portal.search.searcher.Searcher;
 import com.liferay.portal.security.script.management.test.rule.ScriptManagementConfigurationTestRule;
 import com.liferay.portal.service.PersistedModelLocalServiceRegistryUtil;
 import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
 import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.FeatureFlags;
@@ -2739,23 +2740,45 @@ public class DefaultObjectEntryManagerImplTest
 	public void testAddObjectEntryWithLocalizedRichTextObjectField()
 		throws Exception {
 
-		ObjectEntry objectEntry = _defaultObjectEntryManager.addObjectEntry(
-			_simpleDTOConverterContext, _objectDefinition2,
-			new ObjectEntry() {
-				{
-					properties = HashMapBuilder.<String, Object>put(
-						"localizedRichTextObjectFieldName_i18n",
-						HashMapBuilder.<String, Object>put(
-							"en_US",
-							"en_US <script>console.log('XSS');</script>"
-						).put(
-							"pt_BR",
-							"pt_BR <script>console.log('XSS');</script>"
-						).build()
-					).build();
-				}
-			},
-			null);
+		ObjectEntry objectEntry = null;
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.portal.security.antisamy.internal." +
+					"AntiSamySanitizerImpl",
+				LoggerTestUtil.WARN)) {
+
+			objectEntry = _defaultObjectEntryManager.addObjectEntry(
+				_simpleDTOConverterContext, _objectDefinition2,
+				new ObjectEntry() {
+					{
+						properties = HashMapBuilder.<String, Object>put(
+							"localizedRichTextObjectFieldName_i18n",
+							HashMapBuilder.<String, Object>put(
+								"en_US",
+								"en_US <script>console.log('XSS');</script>"
+							).put(
+								"pt_BR",
+								"pt_BR <script>console.log('XSS');</script>"
+							).build()
+						).build();
+					}
+				},
+				null);
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertEquals(logEntries.toString(), 2, logEntries.size());
+
+			for (LogEntry logEntry : logEntries) {
+				Assert.assertEquals(
+					LoggerTestUtil.WARN, logEntry.getPriority());
+				Assert.assertEquals(
+					"The script tag is not allowed for security reasons. " +
+						"This tag should not affect the display of the input. ",
+					logEntry.getMessage());
+				Assert.assertNull(logEntry.getThrowable());
+			}
+		}
 
 		Assert.assertEquals(
 			"en_US",


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99910

## What Is Being Fixed

`DefaultObjectEntryManagerImpl._toObjectValues` resolved the scalar value through `ObjectEntryValuesUtil.getValue` for every object field before handling localized values. For a localized rich text field, the scalar path runs the `TEXT_HTML` sanitizer on the default locale value, and `getLocalizedValues` then sanitizes every locale — so the default locale value was sanitized twice, and the discarded scalar result also logged a duplicate AntiSamy warning.

Root cause: born broken in `1f99ce880f099` ("LPD-43552 Add a new method to maintain consistency in handling localized values"), which switched the localized branch from a plain `objectEntry.getPropertyValue` read (no sanitization) to `objectFieldBusinessType.getLocalizedValues` (which runs the sanitizer per locale) while leaving the earlier scalar `getValue` call — which already sanitizes the default locale value — running for localized fields.

## How It Is Being Fixed

Resolve the localized values first and `continue` when they are present, so the scalar value is only resolved for non-localized fields and each localized value is sanitized exactly once. The rich text field test captures the AntiSamy warning and asserts its exact count and content.

## PR Check

**pr-check: PASS** — tested on `ef65767a8463ba3f6651c1066a7e903d0b5e976d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "ef65767a8463ba3f6651c1066a7e903d0b5e976d"} -->
