### PR TITLE
LPD-99914 Expect the DSR Seller regular role in the email notification roles test

### DIFF
--- a/modules/apps/notification/notification-test/build.gradle
+++ b/modules/apps/notification/notification-test/build.gradle
@@ -18,6 +18,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-test-util")
 	testIntegrationImplementation project(":apps:portal-vulcan:portal-vulcan-api")
 	testIntegrationImplementation project(":apps:portal:portal-upgrade-test-util")
+	testIntegrationImplementation project(":apps:site:site-dsr-site-initializer-api")
 	testIntegrationImplementation project(":apps:static:portal:portal-upgrade-api")
 	testIntegrationImplementation project(":apps:subscription:subscription-api")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")

--- a/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/web/internal/portlet/action/test/GetEmailNotificationRolesMVCResourceCommandTest.java
+++ b/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/web/internal/portlet/action/test/GetEmailNotificationRolesMVCResourceCommandTest.java
@@ -36,6 +36,7 @@ import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.site.dsr.site.initializer.constants.DSRRoleConstants;
 
 import java.io.ByteArrayOutputStream;
 
@@ -171,6 +172,7 @@ public class GetEmailNotificationRolesMVCResourceCommandTest {
 						AccountRoleConstants.ROLE_NAME_ORDER_ADMINISTRATOR),
 					JSONUtil.put(
 						"name", AccountRoleConstants.ROLE_NAME_SUPPLIER),
+					JSONUtil.put("name", DSRRoleConstants.NAME_DSR_SELLER),
 					JSONUtil.put("name", RoleConstants.ADMINISTRATOR),
 					JSONUtil.put("name", RoleConstants.ANALYTICS_ADMINISTRATOR),
 					JSONUtil.put("name", RoleConstants.OWNER),


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99914

## What Is Being Fixed

`GetEmailNotificationRolesMVCResourceCommandTest` hardcodes the regular roles the email notification roles endpoint returns for a company and asserted 15, but every company now has 16: the DSR site initializer provisions a `DSR Seller` regular role per company through `ObjectDefinitionDeployerImpl`. The test failed with `regularRoles[]: Expected 15 values but got 16`.

Root cause: got broken later by LPD-97613. Before `4d0719bb3df41` ("LPD-97613 Remove FF", 2026-07-24) the DSR site initializer was behind a feature flag and did not run for a default company, so the endpoint returned 15 regular roles. That change removed the flag and made DSR provision per company by default, creating the `DSR Seller` regular role everywhere, but it did not update this test's hardcoded expectation.

## How It Is Being Fixed

Add `DSRRoleConstants.NAME_DSR_SELLER` to the expected `regularRoles` (referenced as a compile-safe constant like the other roles) and a `testIntegration` dependency on `site-dsr-site-initializer-api`. Verified locally on a fresh environment: the test passes (16 expected = 16 actual).

## PR Check

**pr-check: PASS** — tested on `bc0393f7afcc14626b5571325188276860a2541c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "bc0393f7afcc14626b5571325188276860a2541c"} -->
