### PR TITLE
LPD-99915 Delete the object definitions leaked by the get tests

### DIFF
--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionResourceTest.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionResourceTest.java
@@ -2836,6 +2836,9 @@ public class ObjectDefinitionResourceTest
 		Assert.assertEquals(
 			"/o/c/" + objectDefinitionPluralName,
 			objectDefinition.getRestContextPath());
+
+		objectDefinitionResource.deleteObjectDefinition(
+			objectDefinition.getId());
 	}
 
 	private void _testGetObjectDefinitionsPage(
@@ -2925,6 +2928,13 @@ public class ObjectDefinitionResourceTest
 		Assert.assertTrue(
 			ArrayUtil.isEmpty(
 				objectDefinitionAA.getObjectDefinitionSettings()));
+
+		objectDefinitionResource.deleteObjectDefinition(
+			objectDefinitionA.getId());
+		objectDefinitionResource.deleteObjectDefinition(
+			objectDefinitionAA.getId());
+		objectDefinitionResource.deleteObjectDefinition(
+			objectDefinitionB.getId());
 	}
 
 	@TestInfo("LPD-63538")


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99915

## What Is Being Fixed

`testGetObjectDefinitionsPage` and `testGetObjectDefinitionsPageWithSortString` fail in the full `ObjectDefinitionResourceTest` run (but pass in isolation). They inspect only the first page (`Pagination.of(1, 10)`) and assert the two definitions they create are contained in it. Earlier get tests leak object definitions that inflate the total, pushing those two definitions off the first page → `assertContains` fails. This is a within-class, order-dependent pollution.

Root cause: `_testGetObjectDefinition` and `_testGetObjectDefinitionWithRootObjectDefinitionExternalReferenceCodes` create four object definitions via `objectDefinitionResource.postObjectDefinition` and never delete them; unlike `_addObjectDefinition` definitions they are not `@DeleteAfterTestRun` tracked. Born in `eaf759c25b998` (LPD-62594, 2025-08-19) and `18604813da918` (LPD-66180, 2025-09-29); latent until the shared object-definition count grew (Testray last pass 2026-06-09).

## How It Is Being Fixed

Delete the four leaked object definitions so each get test cleans up after itself. Verified on a fresh environment: the whole class now runs with only the separate `testPostObjectDefinition` (a 400-vs-200 `allowStandaloneObjectEntry` issue) failing.

## PR Check

**pr-check: PASS** — tested on `128a812cb9ff6c4afbb83670162265d40910e93f`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "128a812cb9ff6c4afbb83670162265d40910e93f"} -->
