### PR TITLE
LPD-99087 Deny design library access without the right permission

### DIFF
--- a/modules/apps/design-library/design-library-web/src/main/java/com/liferay/design/library/web/internal/constants/DesignLibraryConstants.java
+++ b/modules/apps/design-library/design-library-web/src/main/java/com/liferay/design/library/web/internal/constants/DesignLibraryConstants.java
@@ -10,6 +10,8 @@ package com.liferay.design.library.web.internal.constants;
  */
 public class DesignLibraryConstants {
 
+	public static final String DESIGN_LIBRARY_ENTRY = "designLibraryEntry";
+
 	public static final String DESIGN_LIBRARY_ENTRY_ID_KEY =
 		"designLibraryEntryId";
 

--- a/modules/apps/design-library/design-library-web/src/main/java/com/liferay/design/library/web/internal/constants/DesignLibraryWebKeys.java
+++ b/modules/apps/design-library/design-library-web/src/main/java/com/liferay/design/library/web/internal/constants/DesignLibraryWebKeys.java
@@ -7,6 +7,7 @@ package com.liferay.design.library.web.internal.constants;
 
 /**
  * @author Gabriel Prates
+ * @author Thiago Buarque
  */
 public class DesignLibraryWebKeys {
 

--- a/modules/apps/design-library/design-library-web/src/main/java/com/liferay/design/library/web/internal/constants/DesignLibraryWebKeys.java
+++ b/modules/apps/design-library/design-library-web/src/main/java/com/liferay/design/library/web/internal/constants/DesignLibraryWebKeys.java
@@ -12,7 +12,6 @@ public class DesignLibraryWebKeys {
 
 	public static final String DESIGN_LIBRARY_ENTRY = "designLibraryEntry";
 
-	public static final String DESIGN_LIBRARY_ENTRY_ID_KEY =
-		"designLibraryEntryId";
+	public static final String DESIGN_LIBRARY_ENTRY_ID = "designLibraryEntryId";
 
 }

--- a/modules/apps/design-library/design-library-web/src/main/java/com/liferay/design/library/web/internal/constants/DesignLibraryWebKeys.java
+++ b/modules/apps/design-library/design-library-web/src/main/java/com/liferay/design/library/web/internal/constants/DesignLibraryWebKeys.java
@@ -8,7 +8,7 @@ package com.liferay.design.library.web.internal.constants;
 /**
  * @author Gabriel Prates
  */
-public class DesignLibraryConstants {
+public class DesignLibraryWebKeys {
 
 	public static final String DESIGN_LIBRARY_ENTRY = "designLibraryEntry";
 

--- a/modules/apps/design-library/design-library-web/src/main/java/com/liferay/design/library/web/internal/display/context/DesignLibraryResourcesDisplayContext.java
+++ b/modules/apps/design-library/design-library-web/src/main/java/com/liferay/design/library/web/internal/display/context/DesignLibraryResourcesDisplayContext.java
@@ -6,7 +6,7 @@
 package com.liferay.design.library.web.internal.display.context;
 
 import com.liferay.depot.model.DepotEntry;
-import com.liferay.design.library.web.internal.constants.DesignLibraryConstants;
+import com.liferay.design.library.web.internal.constants.DesignLibraryWebKeys;
 import com.liferay.exportimport.constants.ExportImportPortletKeys;
 import com.liferay.fragment.constants.FragmentActionKeys;
 import com.liferay.fragment.constants.FragmentConstants;
@@ -288,7 +288,7 @@ public class DesignLibraryResourcesDisplayContext {
 					).setMVCRenderCommandName(
 						"/design_library/design_library_settings"
 					).setParameter(
-						DesignLibraryConstants.DESIGN_LIBRARY_ENTRY_ID_KEY,
+						DesignLibraryWebKeys.DESIGN_LIBRARY_ENTRY_ID_KEY,
 						_depotEntry.getDepotEntryId()
 					).buildString()
 				).put(
@@ -450,7 +450,7 @@ public class DesignLibraryResourcesDisplayContext {
 		).setMVCRenderCommandName(
 			"/design_library/design_library_resources"
 		).setParameter(
-			DesignLibraryConstants.DESIGN_LIBRARY_ENTRY_ID_KEY,
+			DesignLibraryWebKeys.DESIGN_LIBRARY_ENTRY_ID_KEY,
 			_depotEntry.getDepotEntryId()
 		).buildString();
 	}

--- a/modules/apps/design-library/design-library-web/src/main/java/com/liferay/design/library/web/internal/display/context/DesignLibraryResourcesDisplayContext.java
+++ b/modules/apps/design-library/design-library-web/src/main/java/com/liferay/design/library/web/internal/display/context/DesignLibraryResourcesDisplayContext.java
@@ -288,7 +288,7 @@ public class DesignLibraryResourcesDisplayContext {
 					).setMVCRenderCommandName(
 						"/design_library/design_library_settings"
 					).setParameter(
-						DesignLibraryWebKeys.DESIGN_LIBRARY_ENTRY_ID_KEY,
+						DesignLibraryWebKeys.DESIGN_LIBRARY_ENTRY_ID,
 						_depotEntry.getDepotEntryId()
 					).buildString()
 				).put(
@@ -450,7 +450,7 @@ public class DesignLibraryResourcesDisplayContext {
 		).setMVCRenderCommandName(
 			"/design_library/design_library_resources"
 		).setParameter(
-			DesignLibraryWebKeys.DESIGN_LIBRARY_ENTRY_ID_KEY,
+			DesignLibraryWebKeys.DESIGN_LIBRARY_ENTRY_ID,
 			_depotEntry.getDepotEntryId()
 		).buildString();
 	}

--- a/modules/apps/design-library/design-library-web/src/main/java/com/liferay/design/library/web/internal/display/context/DesignLibraryResourcesDisplayContext.java
+++ b/modules/apps/design-library/design-library-web/src/main/java/com/liferay/design/library/web/internal/display/context/DesignLibraryResourcesDisplayContext.java
@@ -6,7 +6,6 @@
 package com.liferay.design.library.web.internal.display.context;
 
 import com.liferay.depot.model.DepotEntry;
-import com.liferay.depot.service.DepotEntryLocalServiceUtil;
 import com.liferay.design.library.web.internal.constants.DesignLibraryConstants;
 import com.liferay.exportimport.constants.ExportImportPortletKeys;
 import com.liferay.fragment.constants.FragmentActionKeys;
@@ -51,13 +50,15 @@ import java.util.Map;
 
 /**
  * @author Gabriel Prates
+ * @author Thiago Buarque
  */
 public class DesignLibraryResourcesDisplayContext {
 
 	public DesignLibraryResourcesDisplayContext(
-		HttpServletRequest httpServletRequest,
+		DepotEntry depotEntry, HttpServletRequest httpServletRequest,
 		LiferayPortletResponse liferayPortletResponse) {
 
+		_depotEntry = depotEntry;
 		_httpServletRequest = httpServletRequest;
 		_liferayPortletResponse = liferayPortletResponse;
 
@@ -65,28 +66,20 @@ public class DesignLibraryResourcesDisplayContext {
 			WebKeys.THEME_DISPLAY);
 	}
 
-	public String getAPIURL(long designLibraryEntryId) throws PortalException {
-		DepotEntry depotEntry = DepotEntryLocalServiceUtil.getDepotEntry(
-			designLibraryEntryId);
-
+	public String getAPIURL() {
 		return StringBundler.concat(
 			"/o/search/v1.0/search?emptySearch=true",
 			"&entryClassNames=com.liferay.fragment.model.FragmentCollection",
 			",com.liferay.style.book.model.StyleBookEntry",
-			"&filter=groupIds/any(g:g eq ", depotEntry.getGroupId(), ")",
+			"&filter=groupIds/any(g:g eq ", _depotEntry.getGroupId(), ")",
 			"&nestedFields=embedded&page=1&pageSize=20");
 	}
 
-	public Map<String, Object> getBreadcrumbProps(long designLibraryEntryId)
-		throws PortalException {
-
-		DepotEntry depotEntry = DepotEntryLocalServiceUtil.getDepotEntry(
-			designLibraryEntryId);
-
-		Group group = depotEntry.getGroup();
+	public Map<String, Object> getBreadcrumbProps() throws PortalException {
+		Group group = _depotEntry.getGroup();
 
 		return HashMapBuilder.<String, Object>put(
-			"actionItems", _getActionItemsJSONArray(group, designLibraryEntryId)
+			"actionItems", _getActionItemsJSONArray(group)
 		).put(
 			"breadcrumbItems", _getBreadcrumbItemsJSONArray(group)
 		).build();
@@ -106,17 +99,12 @@ public class DesignLibraryResourcesDisplayContext {
 		).build();
 	}
 
-	public List<FDSActionDropdownItem> getFDSActionDropdownItems(
-			long designLibraryEntryId)
+	public List<FDSActionDropdownItem> getFDSActionDropdownItems()
 		throws PortalException {
 
-		DepotEntry depotEntry = DepotEntryLocalServiceUtil.getDepotEntry(
-			designLibraryEntryId);
+		Group depotGroup = _depotEntry.getGroup();
 
-		Group depotGroup = depotEntry.getGroup();
-
-		String designLibraryResourcesURL = _getDesignLibraryResourcesURL(
-			designLibraryEntryId);
+		String designLibraryResourcesURL = _getDesignLibraryResourcesURL();
 
 		String viewFragmentCollectionURL = PortletURLBuilder.create(
 			PortalUtil.getControlPanelPortletURL(
@@ -194,13 +182,8 @@ public class DesignLibraryResourcesDisplayContext {
 				).build()));
 	}
 
-	public Map<String, Object> getFDSAdditionalProps(long designLibraryEntryId)
-		throws PortalException {
-
-		DepotEntry depotEntry = DepotEntryLocalServiceUtil.getDepotEntry(
-			designLibraryEntryId);
-
-		Group depotGroup = depotEntry.getGroup();
+	public Map<String, Object> getFDSAdditionalProps() throws PortalException {
+		Group depotGroup = _depotEntry.getGroup();
 
 		boolean manageFragmentEntriesPermission =
 			_hasManageFragmentEntriesPermission(depotGroup.getGroupId());
@@ -223,8 +206,7 @@ public class DesignLibraryResourcesDisplayContext {
 					return null;
 				}
 
-				return _getAddFragmentEntryURL(
-					depotGroup, designLibraryEntryId);
+				return _getAddFragmentEntryURL(depotGroup);
 			}
 		).put(
 			"addStyleBookEntryURL",
@@ -233,8 +215,7 @@ public class DesignLibraryResourcesDisplayContext {
 					return null;
 				}
 
-				return _getAddStyleBookEntryURL(
-					depotGroup, designLibraryEntryId);
+				return _getAddStyleBookEntryURL(depotGroup);
 			}
 		).put(
 			"canAddStyleBook", manageStyleBookEntriesPermission
@@ -283,17 +264,11 @@ public class DesignLibraryResourcesDisplayContext {
 		).build();
 	}
 
-	public boolean hasContentAccess(long designLibraryEntryId)
-		throws PortalException {
-
-		DepotEntry depotEntry = DepotEntryLocalServiceUtil.getDepotEntry(
-			designLibraryEntryId);
-
-		return _hasManageStyleBookEntriesPermission(depotEntry.getGroupId());
+	public boolean hasContentAccess() {
+		return _hasManageStyleBookEntriesPermission(_depotEntry.getGroupId());
 	}
 
-	private JSONArray _getActionItemsJSONArray(
-			Group group, long designLibraryEntryId)
+	private JSONArray _getActionItemsJSONArray(Group group)
 		throws PortalException {
 
 		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
@@ -314,7 +289,7 @@ public class DesignLibraryResourcesDisplayContext {
 						"/design_library/design_library_settings"
 					).setParameter(
 						DesignLibraryConstants.DESIGN_LIBRARY_ENTRY_ID_KEY,
-						designLibraryEntryId
+						_depotEntry.getDepotEntryId()
 					).buildString()
 				).put(
 					"label", LanguageUtil.get(_httpServletRequest, "settings")
@@ -418,9 +393,7 @@ public class DesignLibraryResourcesDisplayContext {
 		return portletURL.toString();
 	}
 
-	private String _getAddFragmentEntryURL(
-		Group depotGroup, long designLibraryEntryId) {
-
+	private String _getAddFragmentEntryURL(Group depotGroup) {
 		return PortletURLBuilder.create(
 			PortalUtil.getControlPanelPortletURL(
 				_httpServletRequest, depotGroup, FragmentPortletKeys.FRAGMENT,
@@ -428,15 +401,13 @@ public class DesignLibraryResourcesDisplayContext {
 		).setActionName(
 			"/fragment/add_fragment_entry"
 		).setRedirect(
-			_getDesignLibraryResourcesURL(designLibraryEntryId)
+			_getDesignLibraryResourcesURL()
 		).setParameter(
 			"type", FragmentConstants.TYPE_COMPONENT
 		).buildString();
 	}
 
-	private String _getAddStyleBookEntryURL(
-		Group depotGroup, long designLibraryEntryId) {
-
+	private String _getAddStyleBookEntryURL(Group depotGroup) {
 		return PortletURLBuilder.create(
 			PortalUtil.getControlPanelPortletURL(
 				_httpServletRequest, depotGroup,
@@ -445,7 +416,7 @@ public class DesignLibraryResourcesDisplayContext {
 		).setActionName(
 			"/style_book/add_style_book_entry"
 		).setRedirect(
-			_getDesignLibraryResourcesURL(designLibraryEntryId)
+			_getDesignLibraryResourcesURL()
 		).setParameter(
 			"backURLTitle", depotGroup.getName(_themeDisplay.getLocale())
 		).buildString();
@@ -473,14 +444,14 @@ public class DesignLibraryResourcesDisplayContext {
 			));
 	}
 
-	private String _getDesignLibraryResourcesURL(long designLibraryEntryId) {
+	private String _getDesignLibraryResourcesURL() {
 		return PortletURLBuilder.createRenderURL(
 			_liferayPortletResponse
 		).setMVCRenderCommandName(
 			"/design_library/design_library_resources"
 		).setParameter(
 			DesignLibraryConstants.DESIGN_LIBRARY_ENTRY_ID_KEY,
-			designLibraryEntryId
+			_depotEntry.getDepotEntryId()
 		).buildString();
 	}
 
@@ -564,6 +535,7 @@ public class DesignLibraryResourcesDisplayContext {
 			PortletResourcePermission.class,
 			"(resource.name=" + StyleBookConstants.RESOURCE_NAME + ")");
 
+	private final DepotEntry _depotEntry;
 	private final HttpServletRequest _httpServletRequest;
 	private final LiferayPortletResponse _liferayPortletResponse;
 	private final ThemeDisplay _themeDisplay;

--- a/modules/apps/design-library/design-library-web/src/main/java/com/liferay/design/library/web/internal/display/context/DesignLibrarySettingsDisplayContext.java
+++ b/modules/apps/design-library/design-library-web/src/main/java/com/liferay/design/library/web/internal/display/context/DesignLibrarySettingsDisplayContext.java
@@ -6,7 +6,7 @@
 package com.liferay.design.library.web.internal.display.context;
 
 import com.liferay.depot.model.DepotEntry;
-import com.liferay.design.library.web.internal.constants.DesignLibraryConstants;
+import com.liferay.design.library.web.internal.constants.DesignLibraryWebKeys;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
@@ -73,7 +73,7 @@ public class DesignLibrarySettingsDisplayContext {
 		).setMVCRenderCommandName(
 			"/design_library/design_library_resources"
 		).setParameter(
-			DesignLibraryConstants.DESIGN_LIBRARY_ENTRY_ID_KEY,
+			DesignLibraryWebKeys.DESIGN_LIBRARY_ENTRY_ID_KEY,
 			_depotEntry.getDepotEntryId()
 		).buildString();
 	}

--- a/modules/apps/design-library/design-library-web/src/main/java/com/liferay/design/library/web/internal/display/context/DesignLibrarySettingsDisplayContext.java
+++ b/modules/apps/design-library/design-library-web/src/main/java/com/liferay/design/library/web/internal/display/context/DesignLibrarySettingsDisplayContext.java
@@ -6,7 +6,6 @@
 package com.liferay.design.library.web.internal.display.context;
 
 import com.liferay.depot.model.DepotEntry;
-import com.liferay.depot.service.DepotEntryLocalServiceUtil;
 import com.liferay.design.library.web.internal.constants.DesignLibraryConstants;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
@@ -26,21 +25,21 @@ import java.util.Map;
 
 /**
  * @author Mario Leandro
+ * @author Thiago Buarque
  */
 public class DesignLibrarySettingsDisplayContext {
 
 	public DesignLibrarySettingsDisplayContext(
-		HttpServletRequest httpServletRequest,
-		LiferayPortletResponse liferayPortletResponse,
-		long designLibraryEntryId) {
+		DepotEntry depotEntry, HttpServletRequest httpServletRequest,
+		LiferayPortletResponse liferayPortletResponse) {
 
+		_depotEntry = depotEntry;
 		_httpServletRequest = httpServletRequest;
 		_liferayPortletResponse = liferayPortletResponse;
-		_designLibraryEntryId = designLibraryEntryId;
 	}
 
 	public Map<String, Object> getProps() throws PortalException {
-		Group group = _getGroup();
+		Group group = _depotEntry.getGroup();
 
 		return HashMapBuilder.<String, Object>put(
 			"backURL", _getBackURL()
@@ -60,7 +59,7 @@ public class DesignLibrarySettingsDisplayContext {
 		portletDisplay.setShowBackIcon(true);
 		portletDisplay.setURLBack(_getBackURL());
 
-		Group group = _getGroup();
+		Group group = _depotEntry.getGroup();
 
 		renderResponse.setTitle(
 			LanguageUtil.format(
@@ -75,21 +74,8 @@ public class DesignLibrarySettingsDisplayContext {
 			"/design_library/design_library_resources"
 		).setParameter(
 			DesignLibraryConstants.DESIGN_LIBRARY_ENTRY_ID_KEY,
-			_designLibraryEntryId
+			_depotEntry.getDepotEntryId()
 		).buildString();
-	}
-
-	private Group _getGroup() throws PortalException {
-		if (_group != null) {
-			return _group;
-		}
-
-		DepotEntry depotEntry = DepotEntryLocalServiceUtil.getDepotEntry(
-			_designLibraryEntryId);
-
-		_group = depotEntry.getGroup();
-
-		return _group;
 	}
 
 	private ThemeDisplay _getThemeDisplay() {
@@ -97,8 +83,7 @@ public class DesignLibrarySettingsDisplayContext {
 			WebKeys.THEME_DISPLAY);
 	}
 
-	private final long _designLibraryEntryId;
-	private Group _group;
+	private final DepotEntry _depotEntry;
 	private final HttpServletRequest _httpServletRequest;
 	private final LiferayPortletResponse _liferayPortletResponse;
 

--- a/modules/apps/design-library/design-library-web/src/main/java/com/liferay/design/library/web/internal/display/context/DesignLibrarySettingsDisplayContext.java
+++ b/modules/apps/design-library/design-library-web/src/main/java/com/liferay/design/library/web/internal/display/context/DesignLibrarySettingsDisplayContext.java
@@ -73,7 +73,7 @@ public class DesignLibrarySettingsDisplayContext {
 		).setMVCRenderCommandName(
 			"/design_library/design_library_resources"
 		).setParameter(
-			DesignLibraryWebKeys.DESIGN_LIBRARY_ENTRY_ID_KEY,
+			DesignLibraryWebKeys.DESIGN_LIBRARY_ENTRY_ID,
 			_depotEntry.getDepotEntryId()
 		).buildString();
 	}

--- a/modules/apps/design-library/design-library-web/src/main/java/com/liferay/design/library/web/internal/display/context/ViewDesignLibraryAdminDisplayContext.java
+++ b/modules/apps/design-library/design-library-web/src/main/java/com/liferay/design/library/web/internal/display/context/ViewDesignLibraryAdminDisplayContext.java
@@ -7,7 +7,7 @@ package com.liferay.design.library.web.internal.display.context;
 
 import com.liferay.depot.constants.DepotActionKeys;
 import com.liferay.depot.constants.DepotConstants;
-import com.liferay.design.library.web.internal.constants.DesignLibraryConstants;
+import com.liferay.design.library.web.internal.constants.DesignLibraryWebKeys;
 import com.liferay.exportimport.constants.ExportImportPortletKeys;
 import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
 import com.liferay.petra.string.StringBundler;
@@ -86,7 +86,7 @@ public class ViewDesignLibraryAdminDisplayContext {
 				).setMVCRenderCommandName(
 					"/design_library/design_library_resources"
 				).setParameter(
-					DesignLibraryConstants.DESIGN_LIBRARY_ENTRY_ID_KEY, "{id}"
+					DesignLibraryWebKeys.DESIGN_LIBRARY_ENTRY_ID_KEY, "{id}"
 				).buildString(),
 				"pencil", "edit", LanguageUtil.get(_httpServletRequest, "edit"),
 				null, null, "link"),
@@ -110,7 +110,7 @@ public class ViewDesignLibraryAdminDisplayContext {
 		return HashMapBuilder.<String, Object>put(
 			"canAddDesignLibrary", _hasAddDepotEntryPermission()
 		).put(
-			"entryIdKey", DesignLibraryConstants.DESIGN_LIBRARY_ENTRY_ID_KEY
+			"entryIdKey", DesignLibraryWebKeys.DESIGN_LIBRARY_ENTRY_ID_KEY
 		).put(
 			"redirectURL",
 			PortletURLBuilder.createRenderURL(

--- a/modules/apps/design-library/design-library-web/src/main/java/com/liferay/design/library/web/internal/display/context/ViewDesignLibraryAdminDisplayContext.java
+++ b/modules/apps/design-library/design-library-web/src/main/java/com/liferay/design/library/web/internal/display/context/ViewDesignLibraryAdminDisplayContext.java
@@ -86,7 +86,7 @@ public class ViewDesignLibraryAdminDisplayContext {
 				).setMVCRenderCommandName(
 					"/design_library/design_library_resources"
 				).setParameter(
-					DesignLibraryWebKeys.DESIGN_LIBRARY_ENTRY_ID_KEY, "{id}"
+					DesignLibraryWebKeys.DESIGN_LIBRARY_ENTRY_ID, "{id}"
 				).buildString(),
 				"pencil", "edit", LanguageUtil.get(_httpServletRequest, "edit"),
 				null, null, "link"),
@@ -110,7 +110,7 @@ public class ViewDesignLibraryAdminDisplayContext {
 		return HashMapBuilder.<String, Object>put(
 			"canAddDesignLibrary", _hasAddDepotEntryPermission()
 		).put(
-			"entryIdKey", DesignLibraryWebKeys.DESIGN_LIBRARY_ENTRY_ID_KEY
+			"entryIdKey", DesignLibraryWebKeys.DESIGN_LIBRARY_ENTRY_ID
 		).put(
 			"redirectURL",
 			PortletURLBuilder.createRenderURL(

--- a/modules/apps/design-library/design-library-web/src/main/java/com/liferay/design/library/web/internal/portlet/action/BaseDesignLibraryMVCRenderCommand.java
+++ b/modules/apps/design-library/design-library-web/src/main/java/com/liferay/design/library/web/internal/portlet/action/BaseDesignLibraryMVCRenderCommand.java
@@ -68,7 +68,7 @@ public abstract class BaseDesignLibraryMVCRenderCommand
 		throws PortalException {
 
 		long designLibraryEntryId = ParamUtil.getLong(
-			renderRequest, DesignLibraryWebKeys.DESIGN_LIBRARY_ENTRY_ID_KEY);
+			renderRequest, DesignLibraryWebKeys.DESIGN_LIBRARY_ENTRY_ID);
 
 		DepotEntry depotEntry = depotEntryLocalService.fetchDepotEntry(
 			designLibraryEntryId);

--- a/modules/apps/design-library/design-library-web/src/main/java/com/liferay/design/library/web/internal/portlet/action/BaseDesignLibraryMVCRenderCommand.java
+++ b/modules/apps/design-library/design-library-web/src/main/java/com/liferay/design/library/web/internal/portlet/action/BaseDesignLibraryMVCRenderCommand.java
@@ -1,0 +1,97 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.design.library.web.internal.portlet.action;
+
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.design.library.web.internal.constants.DesignLibraryConstants;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.servlet.SessionErrors;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import jakarta.portlet.PortletException;
+import jakarta.portlet.RenderRequest;
+import jakarta.portlet.RenderResponse;
+
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Thiago Buarque
+ */
+public abstract class BaseDesignLibraryMVCRenderCommand
+	implements MVCRenderCommand {
+
+	@Override
+	public String render(
+			RenderRequest renderRequest, RenderResponse renderResponse)
+		throws PortletException {
+
+		try {
+			renderRequest.setAttribute(
+				DesignLibraryConstants.DESIGN_LIBRARY_ENTRY,
+				_getDepotEntry(renderRequest));
+		}
+		catch (PrincipalException principalException) {
+			SessionErrors.add(renderRequest, principalException.getClass());
+
+			return "/error.jsp";
+		}
+		catch (PortalException portalException) {
+			throw new PortletException(portalException);
+		}
+
+		return getPath();
+	}
+
+	protected abstract String getActionId();
+
+	protected abstract String getPath();
+
+	@Reference
+	protected DepotEntryLocalService depotEntryLocalService;
+
+	@Reference(target = "(model.class.name=com.liferay.depot.model.DepotEntry)")
+	protected ModelResourcePermission<DepotEntry>
+		depotEntryModelResourcePermission;
+
+	private DepotEntry _getDepotEntry(RenderRequest renderRequest)
+		throws PortalException {
+
+		long designLibraryEntryId = ParamUtil.getLong(
+			renderRequest, DesignLibraryConstants.DESIGN_LIBRARY_ENTRY_ID_KEY);
+
+		DepotEntry depotEntry = depotEntryLocalService.fetchDepotEntry(
+			designLibraryEntryId);
+
+		ThemeDisplay themeDisplay = (ThemeDisplay)renderRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		PermissionChecker permissionChecker =
+			themeDisplay.getPermissionChecker();
+
+		if ((depotEntry == null) ||
+			(depotEntry.getCompanyId() != themeDisplay.getCompanyId()) ||
+			(depotEntry.getType() != DepotConstants.TYPE_DESIGN_LIBRARY)) {
+
+			throw new PrincipalException.MustHavePermission(
+				permissionChecker, DepotEntry.class.getName(),
+				designLibraryEntryId, getActionId());
+		}
+
+		depotEntryModelResourcePermission.check(
+			permissionChecker, depotEntry, getActionId());
+
+		return depotEntry;
+	}
+
+}

--- a/modules/apps/design-library/design-library-web/src/main/java/com/liferay/design/library/web/internal/portlet/action/BaseDesignLibraryMVCRenderCommand.java
+++ b/modules/apps/design-library/design-library-web/src/main/java/com/liferay/design/library/web/internal/portlet/action/BaseDesignLibraryMVCRenderCommand.java
@@ -8,7 +8,7 @@ package com.liferay.design.library.web.internal.portlet.action;
 import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
-import com.liferay.design.library.web.internal.constants.DesignLibraryConstants;
+import com.liferay.design.library.web.internal.constants.DesignLibraryWebKeys;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
@@ -38,7 +38,7 @@ public abstract class BaseDesignLibraryMVCRenderCommand
 
 		try {
 			renderRequest.setAttribute(
-				DesignLibraryConstants.DESIGN_LIBRARY_ENTRY,
+				DesignLibraryWebKeys.DESIGN_LIBRARY_ENTRY,
 				_getDepotEntry(renderRequest));
 		}
 		catch (PrincipalException principalException) {
@@ -68,7 +68,7 @@ public abstract class BaseDesignLibraryMVCRenderCommand
 		throws PortalException {
 
 		long designLibraryEntryId = ParamUtil.getLong(
-			renderRequest, DesignLibraryConstants.DESIGN_LIBRARY_ENTRY_ID_KEY);
+			renderRequest, DesignLibraryWebKeys.DESIGN_LIBRARY_ENTRY_ID_KEY);
 
 		DepotEntry depotEntry = depotEntryLocalService.fetchDepotEntry(
 			designLibraryEntryId);

--- a/modules/apps/design-library/design-library-web/src/main/java/com/liferay/design/library/web/internal/portlet/action/DesignLibraryResourcesMVCRenderCommand.java
+++ b/modules/apps/design-library/design-library-web/src/main/java/com/liferay/design/library/web/internal/portlet/action/DesignLibraryResourcesMVCRenderCommand.java
@@ -6,17 +6,14 @@
 package com.liferay.design.library.web.internal.portlet.action;
 
 import com.liferay.design.library.constants.DesignLibraryAdminPortletKeys;
-import com.liferay.design.library.web.internal.constants.DesignLibraryConstants;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
-import com.liferay.portal.kernel.util.ParamUtil;
-
-import jakarta.portlet.RenderRequest;
-import jakarta.portlet.RenderResponse;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 
 import org.osgi.service.component.annotations.Component;
 
 /**
  * @author Gabriel Prates
+ * @author Thiago Buarque
  */
 @Component(
 	property = {
@@ -26,19 +23,15 @@ import org.osgi.service.component.annotations.Component;
 	service = MVCRenderCommand.class
 )
 public class DesignLibraryResourcesMVCRenderCommand
-	implements MVCRenderCommand {
+	extends BaseDesignLibraryMVCRenderCommand {
 
 	@Override
-	public String render(
-		RenderRequest renderRequest, RenderResponse renderResponse) {
+	protected String getActionId() {
+		return ActionKeys.VIEW;
+	}
 
-		long designLibraryEntryId = ParamUtil.getLong(
-			renderRequest, DesignLibraryConstants.DESIGN_LIBRARY_ENTRY_ID_KEY);
-
-		renderRequest.setAttribute(
-			DesignLibraryConstants.DESIGN_LIBRARY_ENTRY_ID_KEY,
-			designLibraryEntryId);
-
+	@Override
+	protected String getPath() {
 		return "/view_resources.jsp";
 	}
 

--- a/modules/apps/design-library/design-library-web/src/main/java/com/liferay/design/library/web/internal/portlet/action/DesignLibrarySettingsMVCRenderCommand.java
+++ b/modules/apps/design-library/design-library-web/src/main/java/com/liferay/design/library/web/internal/portlet/action/DesignLibrarySettingsMVCRenderCommand.java
@@ -6,17 +6,14 @@
 package com.liferay.design.library.web.internal.portlet.action;
 
 import com.liferay.design.library.constants.DesignLibraryAdminPortletKeys;
-import com.liferay.design.library.web.internal.constants.DesignLibraryConstants;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
-import com.liferay.portal.kernel.util.ParamUtil;
-
-import jakarta.portlet.RenderRequest;
-import jakarta.portlet.RenderResponse;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 
 import org.osgi.service.component.annotations.Component;
 
 /**
  * @author Mario Leandro
+ * @author Thiago Buarque
  */
 @Component(
 	property = {
@@ -25,19 +22,16 @@ import org.osgi.service.component.annotations.Component;
 	},
 	service = MVCRenderCommand.class
 )
-public class DesignLibrarySettingsMVCRenderCommand implements MVCRenderCommand {
+public class DesignLibrarySettingsMVCRenderCommand
+	extends BaseDesignLibraryMVCRenderCommand {
 
 	@Override
-	public String render(
-		RenderRequest renderRequest, RenderResponse renderResponse) {
+	protected String getActionId() {
+		return ActionKeys.UPDATE;
+	}
 
-		long designLibraryEntryId = ParamUtil.getLong(
-			renderRequest, DesignLibraryConstants.DESIGN_LIBRARY_ENTRY_ID_KEY);
-
-		renderRequest.setAttribute(
-			DesignLibraryConstants.DESIGN_LIBRARY_ENTRY_ID_KEY,
-			designLibraryEntryId);
-
+	@Override
+	protected String getPath() {
 		return "/view_settings.jsp";
 	}
 

--- a/modules/apps/design-library/design-library-web/src/main/java/com/liferay/design/library/web/internal/servlet/taglib/DesignLibraryDepotEntryBreadcrumbEntryContributorImpl.java
+++ b/modules/apps/design-library/design-library-web/src/main/java/com/liferay/design/library/web/internal/servlet/taglib/DesignLibraryDepotEntryBreadcrumbEntryContributorImpl.java
@@ -9,7 +9,7 @@ import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryService;
 import com.liferay.design.library.constants.DesignLibraryAdminPortletKeys;
-import com.liferay.design.library.web.internal.constants.DesignLibraryConstants;
+import com.liferay.design.library.web.internal.constants.DesignLibraryWebKeys;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
@@ -173,7 +173,7 @@ public class DesignLibraryDepotEntryBreadcrumbEntryContributorImpl
 			).setMVCRenderCommandName(
 				"/design_library/design_library_resources"
 			).setParameter(
-				DesignLibraryConstants.DESIGN_LIBRARY_ENTRY_ID_KEY,
+				DesignLibraryWebKeys.DESIGN_LIBRARY_ENTRY_ID_KEY,
 				depotEntry.getDepotEntryId()
 			).buildString());
 

--- a/modules/apps/design-library/design-library-web/src/main/java/com/liferay/design/library/web/internal/servlet/taglib/DesignLibraryDepotEntryBreadcrumbEntryContributorImpl.java
+++ b/modules/apps/design-library/design-library-web/src/main/java/com/liferay/design/library/web/internal/servlet/taglib/DesignLibraryDepotEntryBreadcrumbEntryContributorImpl.java
@@ -173,7 +173,7 @@ public class DesignLibraryDepotEntryBreadcrumbEntryContributorImpl
 			).setMVCRenderCommandName(
 				"/design_library/design_library_resources"
 			).setParameter(
-				DesignLibraryWebKeys.DESIGN_LIBRARY_ENTRY_ID_KEY,
+				DesignLibraryWebKeys.DESIGN_LIBRARY_ENTRY_ID,
 				depotEntry.getDepotEntryId()
 			).buildString());
 

--- a/modules/apps/design-library/design-library-web/src/main/resources/META-INF/resources/error.jsp
+++ b/modules/apps/design-library/design-library-web/src/main/resources/META-INF/resources/error.jsp
@@ -1,0 +1,12 @@
+<%--
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+--%>
+
+<%@ include file="/init.jsp" %>
+
+<liferay-ui:error-header />
+
+<liferay-ui:error-principal />

--- a/modules/apps/design-library/design-library-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/design-library/design-library-web/src/main/resources/META-INF/resources/init.jsp
@@ -12,9 +12,11 @@
 <%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/frontend-data-set" prefix="frontend-data-set" %><%@
 taglib uri="http://liferay.com/tld/react" prefix="react" %><%@
-taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
+taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
+taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
-<%@ page import="com.liferay.design.library.web.internal.constants.DesignLibraryAdminFDSNames" %><%@
+<%@ page import="com.liferay.depot.model.DepotEntry" %><%@
+page import="com.liferay.design.library.web.internal.constants.DesignLibraryAdminFDSNames" %><%@
 page import="com.liferay.design.library.web.internal.constants.DesignLibraryConstants" %><%@
 page import="com.liferay.design.library.web.internal.display.context.DesignLibraryResourcesDisplayContext" %><%@
 page import="com.liferay.design.library.web.internal.display.context.DesignLibrarySettingsDisplayContext" %><%@

--- a/modules/apps/design-library/design-library-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/design-library/design-library-web/src/main/resources/META-INF/resources/init.jsp
@@ -17,7 +17,7 @@ taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
 <%@ page import="com.liferay.depot.model.DepotEntry" %><%@
 page import="com.liferay.design.library.web.internal.constants.DesignLibraryAdminFDSNames" %><%@
-page import="com.liferay.design.library.web.internal.constants.DesignLibraryConstants" %><%@
+page import="com.liferay.design.library.web.internal.constants.DesignLibraryWebKeys" %><%@
 page import="com.liferay.design.library.web.internal.display.context.DesignLibraryResourcesDisplayContext" %><%@
 page import="com.liferay.design.library.web.internal.display.context.DesignLibrarySettingsDisplayContext" %><%@
 page import="com.liferay.design.library.web.internal.display.context.ViewDesignLibraryAdminDisplayContext" %>

--- a/modules/apps/design-library/design-library-web/src/main/resources/META-INF/resources/view_resources.jsp
+++ b/modules/apps/design-library/design-library-web/src/main/resources/META-INF/resources/view_resources.jsp
@@ -8,7 +8,7 @@
 <%@ include file="/init.jsp" %>
 
 <%
-DepotEntry depotEntry = (DepotEntry)request.getAttribute(DesignLibraryConstants.DESIGN_LIBRARY_ENTRY);
+DepotEntry depotEntry = (DepotEntry)request.getAttribute(DesignLibraryWebKeys.DESIGN_LIBRARY_ENTRY);
 
 DesignLibraryResourcesDisplayContext designLibraryResourcesDisplayContext = new DesignLibraryResourcesDisplayContext(depotEntry, request, liferayPortletResponse);
 %>

--- a/modules/apps/design-library/design-library-web/src/main/resources/META-INF/resources/view_resources.jsp
+++ b/modules/apps/design-library/design-library-web/src/main/resources/META-INF/resources/view_resources.jsp
@@ -8,27 +8,27 @@
 <%@ include file="/init.jsp" %>
 
 <%
-long designLibraryEntryId = (long)request.getAttribute(DesignLibraryConstants.DESIGN_LIBRARY_ENTRY_ID_KEY);
+DepotEntry depotEntry = (DepotEntry)request.getAttribute(DesignLibraryConstants.DESIGN_LIBRARY_ENTRY);
 
-DesignLibraryResourcesDisplayContext designLibraryResourcesDisplayContext = new DesignLibraryResourcesDisplayContext(request, liferayPortletResponse);
+DesignLibraryResourcesDisplayContext designLibraryResourcesDisplayContext = new DesignLibraryResourcesDisplayContext(depotEntry, request, liferayPortletResponse);
 %>
 
 <div>
 	<div>
 		<react:component
 			module="{DesignLibraryBreadcrumb} from design-library-web"
-			props="<%= designLibraryResourcesDisplayContext.getBreadcrumbProps(designLibraryEntryId) %>"
+			props="<%= designLibraryResourcesDisplayContext.getBreadcrumbProps() %>"
 		/>
 	</div>
 
 	<c:choose>
-		<c:when test="<%= designLibraryResourcesDisplayContext.hasContentAccess(designLibraryEntryId) %>">
+		<c:when test="<%= designLibraryResourcesDisplayContext.hasContentAccess() %>">
 			<div class="design-library-fds-wrapper design-library-fds-wrapper--resources">
 				<frontend-data-set:headless-display
-					additionalProps="<%= designLibraryResourcesDisplayContext.getFDSAdditionalProps(designLibraryEntryId) %>"
-					apiURL="<%= designLibraryResourcesDisplayContext.getAPIURL(designLibraryEntryId) %>"
+					additionalProps="<%= designLibraryResourcesDisplayContext.getFDSAdditionalProps() %>"
+					apiURL="<%= designLibraryResourcesDisplayContext.getAPIURL() %>"
 					emptyState="<%= designLibraryResourcesDisplayContext.getEmptyState() %>"
-					fdsActionDropdownItems="<%= designLibraryResourcesDisplayContext.getFDSActionDropdownItems(designLibraryEntryId) %>"
+					fdsActionDropdownItems="<%= designLibraryResourcesDisplayContext.getFDSActionDropdownItems() %>"
 					formName="fm"
 					id="<%= DesignLibraryAdminFDSNames.DESIGN_LIBRARY_RESOURCES %>"
 					propsTransformer="{DesignLibraryResourcesFDSPropsTransformer} from design-library-web"

--- a/modules/apps/design-library/design-library-web/src/main/resources/META-INF/resources/view_settings.jsp
+++ b/modules/apps/design-library/design-library-web/src/main/resources/META-INF/resources/view_settings.jsp
@@ -8,7 +8,7 @@
 <%@ include file="/init.jsp" %>
 
 <%
-DepotEntry depotEntry = (DepotEntry)request.getAttribute(DesignLibraryConstants.DESIGN_LIBRARY_ENTRY);
+DepotEntry depotEntry = (DepotEntry)request.getAttribute(DesignLibraryWebKeys.DESIGN_LIBRARY_ENTRY);
 
 DesignLibrarySettingsDisplayContext designLibrarySettingsDisplayContext = new DesignLibrarySettingsDisplayContext(depotEntry, request, liferayPortletResponse);
 

--- a/modules/apps/design-library/design-library-web/src/main/resources/META-INF/resources/view_settings.jsp
+++ b/modules/apps/design-library/design-library-web/src/main/resources/META-INF/resources/view_settings.jsp
@@ -8,9 +8,9 @@
 <%@ include file="/init.jsp" %>
 
 <%
-long designLibraryEntryId = (long)request.getAttribute(DesignLibraryConstants.DESIGN_LIBRARY_ENTRY_ID_KEY);
+DepotEntry depotEntry = (DepotEntry)request.getAttribute(DesignLibraryConstants.DESIGN_LIBRARY_ENTRY);
 
-DesignLibrarySettingsDisplayContext designLibrarySettingsDisplayContext = new DesignLibrarySettingsDisplayContext(request, liferayPortletResponse, designLibraryEntryId);
+DesignLibrarySettingsDisplayContext designLibrarySettingsDisplayContext = new DesignLibrarySettingsDisplayContext(depotEntry, request, liferayPortletResponse);
 
 designLibrarySettingsDisplayContext.setPortletDisplay(portletDisplay, renderResponse);
 %>

--- a/modules/apps/design-library/design-library-web/src/test/java/com/liferay/design/library/web/internal/display/context/DesignLibraryResourcesDisplayContextTest.java
+++ b/modules/apps/design-library/design-library-web/src/test/java/com/liferay/design/library/web/internal/display/context/DesignLibraryResourcesDisplayContextTest.java
@@ -58,6 +58,7 @@ import org.springframework.mock.web.MockHttpServletRequest;
 /**
  * @author Gabriel Prates
  * @author Lourdes Fernández Besada
+ * @author Thiago Buarque
  */
 public class DesignLibraryResourcesDisplayContextTest {
 

--- a/modules/apps/design-library/design-library-web/src/test/java/com/liferay/design/library/web/internal/display/context/DesignLibraryResourcesDisplayContextTest.java
+++ b/modules/apps/design-library/design-library-web/src/test/java/com/liferay/design/library/web/internal/display/context/DesignLibraryResourcesDisplayContextTest.java
@@ -6,7 +6,6 @@
 package com.liferay.design.library.web.internal.display.context;
 
 import com.liferay.depot.model.DepotEntry;
-import com.liferay.depot.service.DepotEntryLocalServiceUtil;
 import com.liferay.fragment.constants.FragmentActionKeys;
 import com.liferay.fragment.constants.FragmentPortletKeys;
 import com.liferay.fragment.model.FragmentCollection;
@@ -68,26 +67,21 @@ public class DesignLibraryResourcesDisplayContextTest {
 		LiferayUnitTestRule.INSTANCE;
 
 	@Before
-	public void setUp() {
+	public void setUp() throws Exception {
+		_setUpDepotEntry();
 		_setUpDesignLibraryResourcesDisplayContext();
 		_setUpJSONFactoryUtil();
 	}
 
 	@After
 	public void tearDown() {
-		_depotEntryLocalServiceUtilMockedStatic.close();
 		_languageUtilMockedStatic.close();
 		_portalUtilMockedStatic.close();
 	}
 
 	@Test
 	public void testGetAPIURL() throws Exception {
-		long designLibraryEntryId = RandomTestUtil.randomLong();
-
-		DepotEntry depotEntry = _mockDepotEntry(designLibraryEntryId);
-
-		String url = _designLibraryResourcesDisplayContext.getAPIURL(
-			designLibraryEntryId);
+		String url = _designLibraryResourcesDisplayContext.getAPIURL();
 
 		Assert.assertTrue(
 			url,
@@ -95,7 +89,7 @@ public class DesignLibraryResourcesDisplayContextTest {
 				StringBundler.concat(
 					"entryClassNames=", FragmentCollection.class.getName(), ",",
 					StyleBookEntry.class.getName(), "&filter=groupIds/any(g:g ",
-					"eq ", depotEntry.getGroupId(), ")")));
+					"eq ", _depotEntry.getGroupId(), ")")));
 	}
 
 	@Test
@@ -171,15 +165,10 @@ public class DesignLibraryResourcesDisplayContextTest {
 
 	@Test
 	public void testGetFDSActionDropdownItems() throws Exception {
-		long designLibraryEntryId = RandomTestUtil.randomLong();
-
-		_mockDepotEntry(designLibraryEntryId);
-
 		_setUpPortletURLMocks();
 
 		List<FDSActionDropdownItem> fdsActionDropdownItems =
-			_designLibraryResourcesDisplayContext.getFDSActionDropdownItems(
-				designLibraryEntryId);
+			_designLibraryResourcesDisplayContext.getFDSActionDropdownItems();
 
 		_assertFDSActionDropdownItem(
 			FragmentCollection.class.getName(), "view", "link",
@@ -206,14 +195,8 @@ public class DesignLibraryResourcesDisplayContextTest {
 	public void testGetFDSAdditionalProps() throws Exception {
 		_setUpPortletURLMocks();
 
-		long designLibraryEntryId = RandomTestUtil.randomLong();
-
-		DepotEntry depotEntry = _mockDepotEntry(designLibraryEntryId);
-
-		_assertFDSAdditionalProps(
-			designLibraryEntryId, depotEntry.getGroupId(), false);
-		_assertFDSAdditionalProps(
-			designLibraryEntryId, depotEntry.getGroupId(), true);
+		_assertFDSAdditionalProps(_depotEntry.getGroupId(), false);
+		_assertFDSAdditionalProps(_depotEntry.getGroupId(), true);
 	}
 
 	private void _assertFDSActionDropdownItem(
@@ -235,8 +218,7 @@ public class DesignLibraryResourcesDisplayContextTest {
 	}
 
 	private void _assertFDSAdditionalProps(
-			long designLibraryEntryId, long groupId,
-			boolean manageFragmentEntriesPermission)
+			long groupId, boolean manageFragmentEntriesPermission)
 		throws Exception {
 
 		Mockito.when(
@@ -248,8 +230,7 @@ public class DesignLibraryResourcesDisplayContextTest {
 		);
 
 		Map<String, Object> fdsAdditionalProps =
-			_designLibraryResourcesDisplayContext.getFDSAdditionalProps(
-				designLibraryEntryId);
+			_designLibraryResourcesDisplayContext.getFDSAdditionalProps();
 
 		Assert.assertNull(fdsAdditionalProps.get("addStyleBookEntryURL"));
 		Assert.assertFalse((Boolean)fdsAdditionalProps.get("canAddStyleBook"));
@@ -349,16 +330,15 @@ public class DesignLibraryResourcesDisplayContextTest {
 			DepotEntry depotEntry = Mockito.mock(DepotEntry.class);
 
 			Mockito.when(
+				depotEntry.getDepotEntryId()
+			).thenReturn(
+				_DEPOT_ENTRY_ID
+			);
+
+			Mockito.when(
 				depotEntry.getGroup()
 			).thenReturn(
 				group
-			);
-
-			_depotEntryLocalServiceUtilMockedStatic.when(
-				() -> DepotEntryLocalServiceUtil.getDepotEntry(
-					Mockito.anyLong())
-			).thenReturn(
-				depotEntry
 			);
 
 			_languageUtilMockedStatic.when(
@@ -390,14 +370,13 @@ public class DesignLibraryResourcesDisplayContextTest {
 			DesignLibraryResourcesDisplayContext
 				designLibraryResourcesDisplayContext =
 					new DesignLibraryResourcesDisplayContext(
-						httpServletRequest,
+						depotEntry, httpServletRequest,
 						Mockito.mock(LiferayPortletResponse.class));
 
 			List<String> labels = new ArrayList<>();
 
 			Map<String, Object> breadcrumbProps =
-				designLibraryResourcesDisplayContext.getBreadcrumbProps(
-					group.getClassPK());
+				designLibraryResourcesDisplayContext.getBreadcrumbProps();
 
 			JSONArray jsonArray = (JSONArray)breadcrumbProps.get("actionItems");
 
@@ -411,13 +390,9 @@ public class DesignLibraryResourcesDisplayContextTest {
 		}
 	}
 
-	private DepotEntry _mockDepotEntry(long designLibraryEntryId)
-		throws Exception {
-
-		DepotEntry depotEntry = Mockito.mock(DepotEntry.class);
-
+	private void _setUpDepotEntry() throws Exception {
 		Mockito.when(
-			depotEntry.getGroup()
+			_depotEntry.getGroup()
 		).thenReturn(
 			_group
 		);
@@ -425,7 +400,7 @@ public class DesignLibraryResourcesDisplayContextTest {
 		long groupId = RandomTestUtil.randomLong();
 
 		Mockito.when(
-			depotEntry.getGroupId()
+			_depotEntry.getGroupId()
 		).thenReturn(
 			groupId
 		);
@@ -435,14 +410,6 @@ public class DesignLibraryResourcesDisplayContextTest {
 		).thenReturn(
 			groupId
 		);
-
-		_depotEntryLocalServiceUtilMockedStatic.when(
-			() -> DepotEntryLocalServiceUtil.getDepotEntry(designLibraryEntryId)
-		).thenReturn(
-			depotEntry
-		);
-
-		return depotEntry;
 	}
 
 	private void _setUpDesignLibraryResourcesDisplayContext() {
@@ -503,7 +470,7 @@ public class DesignLibraryResourcesDisplayContextTest {
 
 		_designLibraryResourcesDisplayContext =
 			new DesignLibraryResourcesDisplayContext(
-				_mockHttpServletRequest, _liferayPortletResponse);
+				_depotEntry, _mockHttpServletRequest, _liferayPortletResponse);
 	}
 
 	private void _setUpJSONFactoryUtil() {
@@ -544,9 +511,7 @@ public class DesignLibraryResourcesDisplayContextTest {
 
 	private static final long _DEPOT_ENTRY_ID = 12345;
 
-	private final MockedStatic<DepotEntryLocalServiceUtil>
-		_depotEntryLocalServiceUtilMockedStatic = Mockito.mockStatic(
-			DepotEntryLocalServiceUtil.class);
+	private final DepotEntry _depotEntry = Mockito.mock(DepotEntry.class);
 	private DesignLibraryResourcesDisplayContext
 		_designLibraryResourcesDisplayContext;
 	private final PortletResourcePermission _fragmentPortletResourcePermission =

--- a/modules/apps/design-library/design-library-web/src/test/java/com/liferay/design/library/web/internal/portlet/action/DesignLibraryMVCRenderCommandTestHelper.java
+++ b/modules/apps/design-library/design-library-web/src/test/java/com/liferay/design/library/web/internal/portlet/action/DesignLibraryMVCRenderCommandTestHelper.java
@@ -7,7 +7,7 @@ package com.liferay.design.library.web.internal.portlet.action;
 
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
-import com.liferay.design.library.web.internal.constants.DesignLibraryConstants;
+import com.liferay.design.library.web.internal.constants.DesignLibraryWebKeys;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
@@ -53,7 +53,7 @@ public class DesignLibraryMVCRenderCommandTestHelper {
 		mockRenderRequest.setAttribute(WebKeys.THEME_DISPLAY, themeDisplay);
 
 		mockRenderRequest.setParameter(
-			DesignLibraryConstants.DESIGN_LIBRARY_ENTRY_ID_KEY,
+			DesignLibraryWebKeys.DESIGN_LIBRARY_ENTRY_ID_KEY,
 			String.valueOf(depotEntryId));
 
 		return mockRenderRequest;

--- a/modules/apps/design-library/design-library-web/src/test/java/com/liferay/design/library/web/internal/portlet/action/DesignLibraryMVCRenderCommandTestHelper.java
+++ b/modules/apps/design-library/design-library-web/src/test/java/com/liferay/design/library/web/internal/portlet/action/DesignLibraryMVCRenderCommandTestHelper.java
@@ -53,7 +53,7 @@ public class DesignLibraryMVCRenderCommandTestHelper {
 		mockRenderRequest.setAttribute(WebKeys.THEME_DISPLAY, themeDisplay);
 
 		mockRenderRequest.setParameter(
-			DesignLibraryWebKeys.DESIGN_LIBRARY_ENTRY_ID_KEY,
+			DesignLibraryWebKeys.DESIGN_LIBRARY_ENTRY_ID,
 			String.valueOf(depotEntryId));
 
 		return mockRenderRequest;

--- a/modules/apps/design-library/design-library-web/src/test/java/com/liferay/design/library/web/internal/portlet/action/DesignLibraryMVCRenderCommandTestHelper.java
+++ b/modules/apps/design-library/design-library-web/src/test/java/com/liferay/design/library/web/internal/portlet/action/DesignLibraryMVCRenderCommandTestHelper.java
@@ -1,0 +1,161 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.design.library.web.internal.portlet.action;
+
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.design.library.web.internal.constants.DesignLibraryConstants;
+import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.portlet.MockRenderRequest;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import jakarta.portlet.PortletRequest;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Thiago Buarque
+ */
+public class DesignLibraryMVCRenderCommandTestHelper {
+
+	public MockRenderRequest createMockRenderRequest(long depotEntryId) {
+		MockRenderRequest mockRenderRequest = new MockRenderRequest();
+
+		ThemeDisplay themeDisplay = Mockito.mock(ThemeDisplay.class);
+
+		Mockito.when(
+			themeDisplay.getCompanyId()
+		).thenReturn(
+			_COMPANY_ID
+		);
+
+		Mockito.when(
+			themeDisplay.getPermissionChecker()
+		).thenReturn(
+			_permissionChecker
+		);
+
+		mockRenderRequest.setAttribute(WebKeys.THEME_DISPLAY, themeDisplay);
+
+		mockRenderRequest.setParameter(
+			DesignLibraryConstants.DESIGN_LIBRARY_ENTRY_ID_KEY,
+			String.valueOf(depotEntryId));
+
+		return mockRenderRequest;
+	}
+
+	public void denyPermission(DepotEntry depotEntry, String actionId)
+		throws Exception {
+
+		Mockito.doThrow(
+			new PrincipalException.MustHavePermission(
+				_permissionChecker, DepotEntry.class.getName(),
+				depotEntry.getDepotEntryId(), actionId)
+		).when(
+			_depotEntryModelResourcePermission
+		).check(
+			_permissionChecker, depotEntry, actionId
+		);
+	}
+
+	public DepotEntry mockDepotEntry(int type) {
+		DepotEntry depotEntry = Mockito.mock(DepotEntry.class);
+
+		Mockito.when(
+			depotEntry.getCompanyId()
+		).thenReturn(
+			_COMPANY_ID
+		);
+
+		long depotEntryId = RandomTestUtil.randomLong();
+
+		Mockito.when(
+			depotEntry.getDepotEntryId()
+		).thenReturn(
+			depotEntryId
+		);
+
+		Mockito.when(
+			depotEntry.getType()
+		).thenReturn(
+			type
+		);
+
+		Mockito.when(
+			_depotEntryLocalService.fetchDepotEntry(depotEntryId)
+		).thenReturn(
+			depotEntry
+		);
+
+		return depotEntry;
+	}
+
+	public void setUp(
+		BaseDesignLibraryMVCRenderCommand baseDesignLibraryMVCRenderCommand) {
+
+		_portalUtilMockedStatic = Mockito.mockStatic(PortalUtil.class);
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		_portalUtilMockedStatic.when(
+			() -> PortalUtil.getHttpServletRequest(
+				Mockito.any(PortletRequest.class))
+		).thenReturn(
+			mockHttpServletRequest
+		);
+
+		_portalUtilMockedStatic.when(
+			() -> PortalUtil.getLiferayPortletRequest(
+				Mockito.any(PortletRequest.class))
+		).thenReturn(
+			Mockito.mock(LiferayPortletRequest.class)
+		);
+
+		_portalUtilMockedStatic.when(
+			() -> PortalUtil.getOriginalServletRequest(
+				Mockito.any(HttpServletRequest.class))
+		).thenReturn(
+			mockHttpServletRequest
+		);
+
+		ReflectionTestUtil.setFieldValue(
+			baseDesignLibraryMVCRenderCommand, "depotEntryLocalService",
+			_depotEntryLocalService);
+		ReflectionTestUtil.setFieldValue(
+			baseDesignLibraryMVCRenderCommand,
+			"depotEntryModelResourcePermission",
+			_depotEntryModelResourcePermission);
+	}
+
+	public void tearDown() {
+		_portalUtilMockedStatic.close();
+	}
+
+	private static final long _COMPANY_ID = 1234;
+
+	private final DepotEntryLocalService _depotEntryLocalService = Mockito.mock(
+		DepotEntryLocalService.class);
+	private final ModelResourcePermission<DepotEntry>
+		_depotEntryModelResourcePermission = Mockito.mock(
+			ModelResourcePermission.class);
+	private final PermissionChecker _permissionChecker = Mockito.mock(
+		PermissionChecker.class);
+	private MockedStatic<PortalUtil> _portalUtilMockedStatic;
+
+}

--- a/modules/apps/design-library/design-library-web/src/test/java/com/liferay/design/library/web/internal/portlet/action/DesignLibraryResourcesMVCRenderCommandTest.java
+++ b/modules/apps/design-library/design-library-web/src/test/java/com/liferay/design/library/web/internal/portlet/action/DesignLibraryResourcesMVCRenderCommandTest.java
@@ -7,7 +7,7 @@ package com.liferay.design.library.web.internal.portlet.action;
 
 import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
-import com.liferay.design.library.web.internal.constants.DesignLibraryConstants;
+import com.liferay.design.library.web.internal.constants.DesignLibraryWebKeys;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.servlet.SessionErrors;
@@ -63,7 +63,7 @@ public class DesignLibraryResourcesMVCRenderCommandTest {
 		Assert.assertSame(
 			depotEntry,
 			mockRenderRequest.getAttribute(
-				DesignLibraryConstants.DESIGN_LIBRARY_ENTRY));
+				DesignLibraryWebKeys.DESIGN_LIBRARY_ENTRY));
 	}
 
 	@Test
@@ -118,7 +118,7 @@ public class DesignLibraryResourcesMVCRenderCommandTest {
 				mockRenderRequest, new MockRenderResponse()));
 		Assert.assertNull(
 			mockRenderRequest.getAttribute(
-				DesignLibraryConstants.DESIGN_LIBRARY_ENTRY));
+				DesignLibraryWebKeys.DESIGN_LIBRARY_ENTRY));
 		Assert.assertTrue(
 			SessionErrors.contains(
 				mockRenderRequest,

--- a/modules/apps/design-library/design-library-web/src/test/java/com/liferay/design/library/web/internal/portlet/action/DesignLibraryResourcesMVCRenderCommandTest.java
+++ b/modules/apps/design-library/design-library-web/src/test/java/com/liferay/design/library/web/internal/portlet/action/DesignLibraryResourcesMVCRenderCommandTest.java
@@ -1,0 +1,135 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.design.library.web.internal.portlet.action;
+
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.design.library.web.internal.constants.DesignLibraryConstants;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.servlet.SessionErrors;
+import com.liferay.portal.kernel.test.portlet.MockRenderRequest;
+import com.liferay.portal.kernel.test.portlet.MockRenderResponse;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Thiago Buarque
+ */
+public class DesignLibraryResourcesMVCRenderCommandTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		_designLibraryMVCRenderCommandTestHelper.setUp(
+			_designLibraryResourcesMVCRenderCommand);
+	}
+
+	@After
+	public void tearDown() {
+		_designLibraryMVCRenderCommandTestHelper.tearDown();
+	}
+
+	@Test
+	public void testRender() throws Exception {
+		DepotEntry depotEntry =
+			_designLibraryMVCRenderCommandTestHelper.mockDepotEntry(
+				DepotConstants.TYPE_DESIGN_LIBRARY);
+
+		MockRenderRequest mockRenderRequest =
+			_designLibraryMVCRenderCommandTestHelper.createMockRenderRequest(
+				depotEntry.getDepotEntryId());
+
+		Assert.assertEquals(
+			"/view_resources.jsp",
+			_designLibraryResourcesMVCRenderCommand.render(
+				mockRenderRequest, new MockRenderResponse()));
+		Assert.assertSame(
+			depotEntry,
+			mockRenderRequest.getAttribute(
+				DesignLibraryConstants.DESIGN_LIBRARY_ENTRY));
+	}
+
+	@Test
+	public void testRenderWithAssetLibrary() throws Exception {
+		DepotEntry depotEntry =
+			_designLibraryMVCRenderCommandTestHelper.mockDepotEntry(
+				DepotConstants.TYPE_ASSET_LIBRARY);
+
+		_assertError(depotEntry.getDepotEntryId());
+	}
+
+	@Test
+	public void testRenderWithDepotEntryFromAnotherCompany() throws Exception {
+		DepotEntry depotEntry =
+			_designLibraryMVCRenderCommandTestHelper.mockDepotEntry(
+				DepotConstants.TYPE_DESIGN_LIBRARY);
+
+		Mockito.when(
+			depotEntry.getCompanyId()
+		).thenReturn(
+			RandomTestUtil.randomLong()
+		);
+
+		_assertError(depotEntry.getDepotEntryId());
+	}
+
+	@Test
+	public void testRenderWithNonexistentDesignLibrary() throws Exception {
+		_assertError(RandomTestUtil.randomLong());
+	}
+
+	@Test
+	public void testRenderWithoutViewPermission() throws Exception {
+		DepotEntry depotEntry =
+			_designLibraryMVCRenderCommandTestHelper.mockDepotEntry(
+				DepotConstants.TYPE_DESIGN_LIBRARY);
+
+		_designLibraryMVCRenderCommandTestHelper.denyPermission(
+			depotEntry, ActionKeys.VIEW);
+
+		_assertError(depotEntry.getDepotEntryId());
+	}
+
+	private void _assertError(long depotEntryId) throws Exception {
+		MockRenderRequest mockRenderRequest =
+			_designLibraryMVCRenderCommandTestHelper.createMockRenderRequest(
+				depotEntryId);
+
+		Assert.assertEquals(
+			"/error.jsp",
+			_designLibraryResourcesMVCRenderCommand.render(
+				mockRenderRequest, new MockRenderResponse()));
+		Assert.assertNull(
+			mockRenderRequest.getAttribute(
+				DesignLibraryConstants.DESIGN_LIBRARY_ENTRY));
+		Assert.assertTrue(
+			SessionErrors.contains(
+				mockRenderRequest,
+				PrincipalException.MustHavePermission.class));
+	}
+
+	private final DesignLibraryMVCRenderCommandTestHelper
+		_designLibraryMVCRenderCommandTestHelper =
+			new DesignLibraryMVCRenderCommandTestHelper();
+	private final DesignLibraryResourcesMVCRenderCommand
+		_designLibraryResourcesMVCRenderCommand =
+			new DesignLibraryResourcesMVCRenderCommand();
+
+}

--- a/modules/apps/design-library/design-library-web/src/test/java/com/liferay/design/library/web/internal/portlet/action/DesignLibrarySettingsMVCRenderCommandTest.java
+++ b/modules/apps/design-library/design-library-web/src/test/java/com/liferay/design/library/web/internal/portlet/action/DesignLibrarySettingsMVCRenderCommandTest.java
@@ -1,0 +1,96 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.design.library.web.internal.portlet.action;
+
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.design.library.web.internal.constants.DesignLibraryConstants;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.servlet.SessionErrors;
+import com.liferay.portal.kernel.test.portlet.MockRenderRequest;
+import com.liferay.portal.kernel.test.portlet.MockRenderResponse;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Thiago Buarque
+ */
+public class DesignLibrarySettingsMVCRenderCommandTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		_designLibraryMVCRenderCommandTestHelper.setUp(
+			_designLibrarySettingsMVCRenderCommand);
+	}
+
+	@After
+	public void tearDown() {
+		_designLibraryMVCRenderCommandTestHelper.tearDown();
+	}
+
+	@Test
+	public void testRender() throws Exception {
+		DepotEntry depotEntry =
+			_designLibraryMVCRenderCommandTestHelper.mockDepotEntry(
+				DepotConstants.TYPE_DESIGN_LIBRARY);
+
+		MockRenderRequest mockRenderRequest =
+			_designLibraryMVCRenderCommandTestHelper.createMockRenderRequest(
+				depotEntry.getDepotEntryId());
+
+		Assert.assertEquals(
+			"/view_settings.jsp",
+			_designLibrarySettingsMVCRenderCommand.render(
+				mockRenderRequest, new MockRenderResponse()));
+		Assert.assertSame(
+			depotEntry,
+			mockRenderRequest.getAttribute(
+				DesignLibraryConstants.DESIGN_LIBRARY_ENTRY));
+	}
+
+	@Test
+	public void testRenderWithoutUpdatePermission() throws Exception {
+		DepotEntry depotEntry =
+			_designLibraryMVCRenderCommandTestHelper.mockDepotEntry(
+				DepotConstants.TYPE_DESIGN_LIBRARY);
+
+		_designLibraryMVCRenderCommandTestHelper.denyPermission(
+			depotEntry, ActionKeys.UPDATE);
+
+		MockRenderRequest mockRenderRequest =
+			_designLibraryMVCRenderCommandTestHelper.createMockRenderRequest(
+				depotEntry.getDepotEntryId());
+
+		Assert.assertEquals(
+			"/error.jsp",
+			_designLibrarySettingsMVCRenderCommand.render(
+				mockRenderRequest, new MockRenderResponse()));
+		Assert.assertTrue(
+			SessionErrors.contains(
+				mockRenderRequest,
+				PrincipalException.MustHavePermission.class));
+	}
+
+	private final DesignLibraryMVCRenderCommandTestHelper
+		_designLibraryMVCRenderCommandTestHelper =
+			new DesignLibraryMVCRenderCommandTestHelper();
+	private final DesignLibrarySettingsMVCRenderCommand
+		_designLibrarySettingsMVCRenderCommand =
+			new DesignLibrarySettingsMVCRenderCommand();
+
+}

--- a/modules/apps/design-library/design-library-web/src/test/java/com/liferay/design/library/web/internal/portlet/action/DesignLibrarySettingsMVCRenderCommandTest.java
+++ b/modules/apps/design-library/design-library-web/src/test/java/com/liferay/design/library/web/internal/portlet/action/DesignLibrarySettingsMVCRenderCommandTest.java
@@ -7,7 +7,7 @@ package com.liferay.design.library.web.internal.portlet.action;
 
 import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
-import com.liferay.design.library.web.internal.constants.DesignLibraryConstants;
+import com.liferay.design.library.web.internal.constants.DesignLibraryWebKeys;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.servlet.SessionErrors;
@@ -60,7 +60,7 @@ public class DesignLibrarySettingsMVCRenderCommandTest {
 		Assert.assertSame(
 			depotEntry,
 			mockRenderRequest.getAttribute(
-				DesignLibraryConstants.DESIGN_LIBRARY_ENTRY));
+				DesignLibraryWebKeys.DESIGN_LIBRARY_ENTRY));
 	}
 
 	@Test


### PR DESCRIPTION
@brianchandotcom about [your comment](https://github.com/brianchandotcom/liferay-portal/pull/179236#issuecomment-5100849823), `DesignLibraryConstants` was the wrong name. I renamed it to `DesignLibraryWebKeys`, I don't think removing it is the way to go.

# Original description

https://liferay.atlassian.net/browse/LPD-99087

## What Is Being Fixed

The Design Library render commands read `designLibraryEntryId` straight from the request and forwarded it to the JSPs as a request attribute. The display contexts then resolved it through `DepotEntryLocalServiceUtil.getDepotEntry`, the local service, which performs no permission check. Nothing else on the path checked either — not the render commands, not the JSPs, not `MVCPortlet`.

Three things were missing. There was no permission check, so any user who could reach the Design Library control panel entry could open any depot entry by URL. There was no type validation, since `depotEntry.getType()` was never compared to `TYPE_DESIGN_LIBRARY`, so an Asset Library, Space, or Project could be targeted through the Design Library UI. And there was no company scoping, because `getDepotEntry(long)` is company-agnostic.

The exposure was information disclosure plus a permission oracle rather than direct mutation: the external reference code, group ID, descriptive name, and creator user ID were disclosed for an arbitrary depot entry, and `GroupPermissionUtil.contains(..., ASSIGN_MEMBERS)` in the breadcrumb leaked permission state. `view_resources.jsp` also called `getBreadcrumbProps` before the `hasContentAccess` gate, so the breadcrumb payload was emitted unconditionally. The minimum privilege to exploit was Design Library Member of any single library.

## How It Is Being Fixed

The resolution and the check move into a new `BaseDesignLibraryMVCRenderCommand` shared by both render commands. It resolves the entry once, verifies that it exists, that it belongs to the current company, and that its type is `TYPE_DESIGN_LIBRARY`, and then runs the `DepotEntry` model resource permission for the subclass's action ID — `VIEW` for resources, `UPDATE` for settings. Any failure raises `PrincipalException.MustHavePermission`, which the base command converts into a `SessionErrors` entry and a render of the new `error.jsp`, so the user sees an access error instead of the read-only view.

Gating in one shared place rather than per command is what closes the hole for good: the check cannot be forgotten when a new command is added, and each subclass only declares its path and action ID.

The resolved `DepotEntry` is then passed down to the JSPs and into the display contexts as a constructor argument, replacing the raw ID. Both display contexts drop their `DepotEntryLocalServiceUtil` lookups entirely, so the view can no longer re-resolve the entry unchecked, and the breadcrumb payload is built from an entry that has already passed the permission check.

## PR Check

**pr-check: PASS** — tested on `d102ee77611a94ae08bcb9e47c559bcd1253c35d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| JSP Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "d102ee77611a94ae08bcb9e47c559bcd1253c35d"} -->
