### PR TITLE
LPD-99918 Delete the test system vocabulary with a group delete in process

### DIFF
--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -189,6 +189,7 @@ import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.GroupThreadLocal;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.Http;
@@ -21068,7 +21069,17 @@ public class ObjectEntryResourceTest {
 				"id"
 			));
 
-		_assetVocabularyLocalService.deleteVocabulary(systemAssetVocabulary);
+		boolean deleteInProcess = GroupThreadLocal.isDeleteInProcess();
+
+		try {
+			GroupThreadLocal.setDeleteInProcess(true);
+
+			_assetVocabularyLocalService.deleteVocabulary(
+				systemAssetVocabulary);
+		}
+		finally {
+			GroupThreadLocal.setDeleteInProcess(deleteInProcess);
+		}
 
 		// Cannot add a category from an unassociated vocabulary
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99918

## What Is Being Fixed

`ObjectEntryResourceTest` (via `_testPostObjectEntryWithCrossSiteTaxonomyCategories` in `testPostObjectEntryWithTaxonomyCategories`) creates a **system** asset vocabulary (`AssetVocabularySettingsHelper.setSystem(true)`) to verify a category can be added from one, then deletes it directly. A system vocabulary can only be removed while a group or import delete is in process, so the direct delete throws `SystemVocabularyException.MustNotDelete` and fails the test (deterministic; fails in isolation).

Root cause: born broken in `ee6da833` ("LPD-74644 Add coverage for categories from shared vocabularies", 2026-07-04), which added the system vocabulary and its direct deletion after `c79e6679` ("LPD-93225 Add 'system' setting to asset vocabularies", 2026-06-24) had already made deleting a system vocabulary throw `MustNotDelete`.

## How It Is Being Fixed

Wrap the deletion in `GroupThreadLocal.setDeleteInProcess(true)` in a try/finally, the same idiom other tests use to remove a system vocabulary. Verified on a fresh environment: the method passes and the full class runs without this failure.

## PR Check

**pr-check: PASS** — tested on `4ae2a2e5938b788dadbbec0787378acf22f73691`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "4ae2a2e5938b788dadbbec0787378acf22f73691"} -->
