### PR TITLE
LPD-99919 Skip indexing an object entry with a missing object definition

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
@@ -447,6 +447,10 @@ public class ObjectEntryModelDocumentContributor
 
 		ObjectDefinition objectDefinition = objectEntry.getObjectDefinition();
 
+		if (objectDefinition == null) {
+			return;
+		}
+
 		FieldArray fieldArray = (FieldArray)document.getField(
 			"nestedFieldArray");
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99919

## What Is Being Fixed

`ObjectEntryModelDocumentContributor` resolves the object definition with `objectEntry.getObjectDefinition()` (nullable `fetchObjectDefinition` underneath), then dereferences it for the external reference code, name, and object field keywords. When an object definition is deleted while one of its entries is still being asynchronously reindexed, the fetch returns null and the dereference throws a `NullPointerException` that `contribute()` catches and logs as `"Unable to index object entry <id>"` — a spurious error in the run.

Root cause: born broken in `dd5391de` ("LPS-138444 ... build default content at index time"), which added the unguarded `fetchObjectDefinition` lookup and dereferences. `950def31` ("LPD-74849 Use transient ObjectDefinition cache") only swapped the nullable lookup for the equally nullable transient cache — a red herring.

## How It Is Being Fixed

Return early when the object definition is null, so an entry being torn down along with its definition is simply skipped.

## PR Check

**pr-check: PASS** — tested on `6ea7b508c1ea3ec4bd2f023aa79e38e13d58358d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "6ea7b508c1ea3ec4bd2f023aa79e38e13d58358d"} -->
