### PR TITLE
LPD-99920 Expect allowStandaloneObjectEntry to be ignored on a POST

### DIFF
--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionResourceTest.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionResourceTest.java
@@ -3187,29 +3187,35 @@ public class ObjectDefinitionResourceTest
 	private void _testPostObjectDefinitionWithAllowStandaloneObjectEntry()
 		throws Exception {
 
-		Assert.assertEquals(
-			400,
-			HTTPTestUtil.invokeToHttpCode(
-				JSONUtil.put(
-					"label", RandomTestUtil.randomLocaleStringMap()
-				).put(
-					"name", ObjectDefinitionTestUtil.getRandomName()
-				).put(
-					"objectDefinitionSettings",
-					JSONUtil.putAll(
-						JSONUtil.put(
-							"name",
-							ObjectDefinitionSettingConstants.
-								NAME_ALLOW_STANDALONE_OBJECT_ENTRY
-						).put(
-							"value", "true"
-						))
-				).put(
-					"pluralLabel", RandomTestUtil.randomLocaleStringMap()
-				).put(
-					"scope", ObjectDefinitionConstants.SCOPE_COMPANY
-				).toString(),
-				"object-admin/v1.0/object-definitions", Http.Method.POST));
+		JSONObject objectDefinitionJSONObject = HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				"label", RandomTestUtil.randomLocaleStringMap()
+			).put(
+				"name", ObjectDefinitionTestUtil.getRandomName()
+			).put(
+				"objectDefinitionSettings",
+				JSONUtil.putAll(
+					JSONUtil.put(
+						"name",
+						ObjectDefinitionSettingConstants.
+							NAME_ALLOW_STANDALONE_OBJECT_ENTRY
+					).put(
+						"value", "true"
+					))
+			).put(
+				"pluralLabel", RandomTestUtil.randomLocaleStringMap()
+			).put(
+				"scope", ObjectDefinitionConstants.SCOPE_COMPANY
+			).toString(),
+			"object-admin/v1.0/object-definitions", Http.Method.POST);
+
+		Assert.assertFalse(
+			objectDefinitionJSONObject.toString(),
+			objectDefinitionJSONObject.getBoolean(
+				"allowStandaloneObjectEntry"));
+
+		objectDefinitionResource.deleteObjectDefinition(
+			objectDefinitionJSONObject.getLong("id"));
 	}
 
 	private void _testPostObjectDefinitionWithAssigneeObjectField()


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99920

## What Is Being Fixed

`ObjectDefinitionResourceTest._testPostObjectDefinitionWithAllowStandaloneObjectEntry` asserted that posting an object definition with the `allowStandaloneObjectEntry` setting returns `400`, but it now returns `200`, so the test fails with `expected:<400> but was:<200>`. The failure reproduces in isolation on a fresh environment, so it is not a cross-test pollution failure; Testray shows the case last passed on 2026-06-09.

Root cause: got broken later by `00bb25f0060ea` ("LPD-97186 Allow saving a root model descendant object definition", 2026-07-07), which removed the `ObjectDefinitionSettingNameException.NotAllowedNames` validation that returned `400` for `allowStandaloneObjectEntry` on a non root descendant object definition and made the setting system managed. A standalone post now succeeds and simply ignores the setting. The stale `400` assertion was written by `e53fb520944b3` ("LPD-86399 Move the logic to the corresponding tests (POST and PUT) ...", 2026-05-11) for the old behavior; LPD-97186 updated the implementation and local service tests but left this REST assertion behind.

## How It Is Being Fixed

Post the object definition, assert the created definition does not have `allowStandaloneObjectEntry` (the setting is now silently ignored), and delete the created definition, since the successful post now creates a definition that must be cleaned up rather than being rejected.

## PR Check

**pr-check: PASS** — tested on `2bf3eded17e63d31ee30c9e6f1b54b4bd9a42c90`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "2bf3eded17e63d31ee30c9e6f1b54b4bd9a42c90"} -->
