### PR TITLE
LPD-99922 Expect modifiedBy and no comments in the batch planner field test

### DIFF
--- a/modules/apps/batch-planner/batch-planner-rest-test/src/testIntegration/java/com/liferay/batch/planner/rest/resource/v1_0/test/FieldResourceTest.java
+++ b/modules/apps/batch-planner/batch-planner-rest-test/src/testIntegration/java/com/liferay/batch/planner/rest/resource/v1_0/test/FieldResourceTest.java
@@ -124,7 +124,6 @@ public class FieldResourceTest extends BaseFieldResourceTestCase {
 
 		assertEqualsIgnoringOrder(
 			ListUtil.fromArray(
-				_toField(null, "comments", false, "array", null),
 				_toField(null, "defaultLanguageId", false, "string", null),
 				_toField(null, "displayDate", false, "string", null),
 				_toField(null, "expirationDate", false, "string", null),
@@ -132,6 +131,7 @@ public class FieldResourceTest extends BaseFieldResourceTestCase {
 				_toField(null, "friendlyUrlPath", false, "string", null),
 				_toField(null, "friendlyUrlPath_i18n", false, "object", null),
 				_toField(null, "keywords", false, "array", "CSV"),
+				_toField(null, "modifiedBy", false, null, null),
 				_toField(
 					null, "objectEntryFolderExternalReferenceCode", false,
 					"string", null),


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99922

## What Is Being Fixed

`FieldResourceTest.testGetPlanInternalClassNameKeyFieldsPage` asserts the batch planner field list for an object entry, expecting a `comments` field and no `modifiedBy` field, but the object entry REST field surface changed: the actual list now omits `comments` and includes `modifiedBy`, so the two lists differ by one field each way (23 fields on each side). The failure reproduces in isolation, so it is not a cross-test pollution failure; Testray shows the case last passed on 2026-06-09.

Root cause: got broken later by two changes that reshaped the object entry field surface without updating this batch planner test. `df3b8e6b29a03` and `495f75c23b6cf` ("LPD-93214 move comments from ObjectEntry into SystemProperties", 2026-06-21) moved `comments` from the ObjectEntry top level into `SystemProperties`, which `ObjectEntryOpenAPIContributor` strips when the object definition has neither comments nor versioning enabled; the test's definition has comments disabled, so `comments` no longer appears. `fbfec5fd0c751` ("LPD-89977 add the field modifiedBy to get the info from modifier", 2026-06-11) added the `modifiedBy` field. Both landed after the test last passed on 2026-06-09.

## How It Is Being Fixed

Drop `comments` from the expected fields and add `modifiedBy`, matching the existing `removedBy` entry as an untyped Creator reference.

## PR Check

**pr-check: PASS** — tested on `fb392bca4cf888e7b8dd9dfcd7382edc80c974e5`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "fb392bca4cf888e7b8dd9dfcd7382edc80c974e5"} -->
