### PR TITLE
LPD-99923 Do not coerce a non-numeric long field filter value to zero

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
@@ -757,9 +757,13 @@ public class PredicateExpressionVisitorImpl
 				value = right;
 			}
 
+			String valueString = String.valueOf(value);
+
 			if (Objects.equals(
 					objectFieldBusinessType.getDBType(),
-					ObjectFieldConstants.DB_TYPE_LONG)) {
+					ObjectFieldConstants.DB_TYPE_LONG) &&
+				(Validator.isNull(valueString) ||
+				 Validator.isNumber(valueString))) {
 
 				return GetterUtil.getLong(value);
 			}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99923

## What Is Being Fixed

`PredicateExpressionVisitorImpl._getValue` coerced every `DB_TYPE_LONG` object field's filter value to a `Long` with `GetterUtil.getLong`, which returns `0` for a non-numeric string. Because every object definition has a system object field named `id` of business type `LongInteger`, a substring filter such as `contains(id, '<non-numeric>')` resolved its value to `0` and degraded to `lower(castText(id)) like '%0%'`, matching every visible object entry whose id contains the digit `0` instead of matching nothing. It surfaced intermittently in `DefaultObjectEntryManagerImplTest.testGetObjectEntries`, whose `contains(id, RandomTestUtil.randomString())` assertion expects no matches (it failed about 2 of 6 runs depending on the visible entries' auto-increment ids).

Root cause: got broken later by `e1d9311fecea76f0c08cefeac4a62a127000c506` ("LPD-96854 Fix SQLGrammarException filtering by empty relationship ERC on Postgres", 2026-07-02), which removed the `Validator.isNumber` guard from the `DB_TYPE_LONG` branch so an empty relationship external reference code would coerce to `0` and avoid a PostgreSQL `bigint = ''` comparison error. That change also caused every non-numeric value on a long field, including a `contains` or `startsWith` substring value, to coerce to `0`.

## How It Is Being Fixed

Guard the coercion so it runs only when the value is numeric or empty. A numeric value coerces as before, an empty value still coerces to `0` (an unlinked relationship's external reference code, whose long foreign key column defaults to `0`, preserving the LPD-96854 PostgreSQL fix), and a non-numeric substring value stays a string and produces the intended textual comparison.

## PR Check

**pr-check: PASS** — tested on `04b0c0fcf8ac04594fc1689776d82a441b4665e8`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Baseline | PASS |

<!-- pr-check {"result": "success", "sha": "04b0c0fcf8ac04594fc1689776d82a441b4665e8"} -->
