### PR TITLE
LPD-100039 Rename scheduler Date getters to match naming conventions

### DIFF
--- a/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/dto/v1_0/converter/CTCollectionDTOConverter.java
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/dto/v1_0/converter/CTCollectionDTOConverter.java
@@ -101,7 +101,7 @@ public class CTCollectionDTOConverter
 			return null;
 		}
 
-		return _schedulerEngineHelper.getStartTime(schedulerResponse);
+		return _schedulerEngineHelper.getStartDate(schedulerResponse);
 	}
 
 	private String _getStatusMessage(
@@ -154,7 +154,7 @@ public class CTCollectionDTOConverter
 					return null;
 				}
 
-				Date scheduledDate = SchedulerEngineHelperUtil.getStartTime(
+				Date scheduledDate = SchedulerEngineHelperUtil.getStartDate(
 					schedulerResponse);
 
 				return _language.format(

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/scheduler/PublishSchedulerImpl.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/scheduler/PublishSchedulerImpl.java
@@ -65,7 +65,7 @@ public class PublishSchedulerImpl implements PublishScheduler {
 
 		return new ScheduledPublishInfo(
 			ctCollection, schedulerResponse.getJobName(),
-			_schedulerEngineHelper.getStartTime(schedulerResponse),
+			_schedulerEngineHelper.getStartDate(schedulerResponse),
 			message.getLong("userId"));
 	}
 
@@ -96,7 +96,7 @@ public class PublishSchedulerImpl implements PublishScheduler {
 
 				return new ScheduledPublishInfo(
 					ctCollection, schedulerResponse.getJobName(),
-					_schedulerEngineHelper.getStartTime(schedulerResponse),
+					_schedulerEngineHelper.getStartDate(schedulerResponse),
 					message.getLong("userId"));
 			});
 	}

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/search/spi/model/index/contributor/CTCollectionModelDocumentContributor.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/search/spi/model/index/contributor/CTCollectionModelDocumentContributor.java
@@ -74,7 +74,7 @@ public class CTCollectionModelDocumentContributor
 				return null;
 			}
 
-			return _schedulerEngineHelper.getStartTime(schedulerResponse);
+			return _schedulerEngineHelper.getStartDate(schedulerResponse);
 		}
 		catch (SchedulerException schedulerException) {
 			if (_log.isWarnEnabled()) {

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/search/spi/model/index/contributor/CTEntryModelDocumentContributor.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/search/spi/model/index/contributor/CTEntryModelDocumentContributor.java
@@ -168,7 +168,7 @@ public class CTEntryModelDocumentContributor
 					StorageType.PERSISTED);
 
 			if (schedulerResponse != null) {
-				return _schedulerEngineHelper.getStartTime(schedulerResponse);
+				return _schedulerEngineHelper.getStartDate(schedulerResponse);
 			}
 		}
 		catch (SchedulerException schedulerException) {

--- a/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/internal/helper/DispatchTriggerHelper.java
+++ b/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/internal/helper/DispatchTriggerHelper.java
@@ -118,7 +118,7 @@ public class DispatchTriggerHelper {
 			return null;
 		}
 
-		return _schedulerEngineHelper.getNextFireTime(schedulerResponse);
+		return _schedulerEngineHelper.getNextFireDate(schedulerResponse);
 	}
 
 	public Date getPreviousFireDate(
@@ -134,7 +134,7 @@ public class DispatchTriggerHelper {
 			return null;
 		}
 
-		return _schedulerEngineHelper.getPreviousFireTime(schedulerResponse);
+		return _schedulerEngineHelper.getPreviousFireDate(schedulerResponse);
 	}
 
 	private String _getGroupName(DispatchTrigger dispatchTrigger) {

--- a/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/internal/portal/kernel/scheduler/SchedulerResponseManagerImpl.java
+++ b/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/internal/portal/kernel/scheduler/SchedulerResponseManagerImpl.java
@@ -44,7 +44,7 @@ public class SchedulerResponseManagerImpl implements SchedulerResponseManager {
 			return null;
 		}
 
-		return _schedulerEngineHelper.getNextFireTime(schedulerResponse);
+		return _schedulerEngineHelper.getNextFireDate(schedulerResponse);
 	}
 
 	@Override

--- a/modules/apps/dispatch/dispatch-test/src/testIntegration/java/com/liferay/dispatch/service/test/DispatchTriggerLocalServiceTest.java
+++ b/modules/apps/dispatch/dispatch-test/src/testIntegration/java/com/liferay/dispatch/service/test/DispatchTriggerLocalServiceTest.java
@@ -725,7 +725,7 @@ public class DispatchTriggerLocalServiceTest {
 
 		Assert.assertNotNull(schedulerResponse);
 
-		Date date = _schedulerEngineHelper.getNextFireTime(schedulerResponse);
+		Date date = _schedulerEngineHelper.getNextFireDate(schedulerResponse);
 
 		Calendar nextFireCalendar = CalendarFactoryUtil.getCalendar();
 

--- a/modules/apps/portal-scheduler/portal-scheduler/src/main/java/com/liferay/portal/scheduler/internal/SchedulerEngineHelperImpl.java
+++ b/modules/apps/portal-scheduler/portal-scheduler/src/main/java/com/liferay/portal/scheduler/internal/SchedulerEngineHelperImpl.java
@@ -96,7 +96,7 @@ public class SchedulerEngineHelperImpl implements SchedulerEngineHelper {
 	}
 
 	@Override
-	public Date getEndTime(SchedulerResponse schedulerResponse) {
+	public Date getEndDate(SchedulerResponse schedulerResponse) {
 		Message message = schedulerResponse.getMessage();
 
 		JobState jobState = (JobState)message.get(SchedulerEngine.JOB_STATE);
@@ -122,7 +122,7 @@ public class SchedulerEngineHelperImpl implements SchedulerEngineHelper {
 	}
 
 	@Override
-	public Date getNextFireTime(SchedulerResponse schedulerResponse) {
+	public Date getNextFireDate(SchedulerResponse schedulerResponse) {
 		Message message = schedulerResponse.getMessage();
 
 		JobState jobState = (JobState)message.get(SchedulerEngine.JOB_STATE);
@@ -139,7 +139,7 @@ public class SchedulerEngineHelperImpl implements SchedulerEngineHelper {
 	}
 
 	@Override
-	public Date getPreviousFireTime(SchedulerResponse schedulerResponse) {
+	public Date getPreviousFireDate(SchedulerResponse schedulerResponse) {
 		Message message = schedulerResponse.getMessage();
 
 		JobState jobState = (JobState)message.get(SchedulerEngine.JOB_STATE);
@@ -187,7 +187,7 @@ public class SchedulerEngineHelperImpl implements SchedulerEngineHelper {
 	}
 
 	@Override
-	public Date getStartTime(SchedulerResponse schedulerResponse) {
+	public Date getStartDate(SchedulerResponse schedulerResponse) {
 		Message message = schedulerResponse.getMessage();
 
 		JobState jobState = (JobState)message.get(SchedulerEngine.JOB_STATE);

--- a/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/manager/test/SitemapRegenerationSchedulerTest.java
+++ b/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/manager/test/SitemapRegenerationSchedulerTest.java
@@ -686,7 +686,7 @@ public class SitemapRegenerationSchedulerTest {
 		Assert.assertEquals(
 			schedulerResponses.toString(), 1, schedulerResponses.size());
 
-		return _schedulerEngineHelper.getStartTime(schedulerResponses.get(0));
+		return _schedulerEngineHelper.getStartDate(schedulerResponses.get(0));
 	}
 
 	private static final String _CLASS_NAME_SITEMAP_MANAGER_IMPL =

--- a/modules/apps/staging/staging-processes-web/src/main/resources/META-INF/resources/scheduled_list/scheduled_publish_processes.jsp
+++ b/modules/apps/staging/staging-processes-web/src/main/resources/META-INF/resources/scheduled_list/scheduled_publish_processes.jsp
@@ -54,11 +54,11 @@ ScheduledPublishProcessesDisplayContext scheduledPublishProcessesDisplayContext 
 			<liferay-ui:search-container-column-date
 				name="create-date"
 				orderable="<%= true %>"
-				value="<%= SchedulerEngineHelperUtil.getStartTime(schedulerResponse) %>"
+				value="<%= SchedulerEngineHelperUtil.getStartDate(schedulerResponse) %>"
 			/>
 
 			<%
-			Date endDate = SchedulerEngineHelperUtil.getEndTime(schedulerResponse);
+			Date endDate = SchedulerEngineHelperUtil.getEndDate(schedulerResponse);
 			%>
 
 			<c:choose>
@@ -66,7 +66,7 @@ ScheduledPublishProcessesDisplayContext scheduledPublishProcessesDisplayContext 
 					<liferay-ui:search-container-column-date
 						name="end-date"
 						orderable="<%= true %>"
-						value="<%= SchedulerEngineHelperUtil.getEndTime(schedulerResponse) %>"
+						value="<%= SchedulerEngineHelperUtil.getEndDate(schedulerResponse) %>"
 					/>
 				</c:when>
 				<c:otherwise>

--- a/portal-kernel/src/com/liferay/portal/kernel/scheduler/SchedulerEngineHelper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/scheduler/SchedulerEngineHelper.java
@@ -28,13 +28,13 @@ public interface SchedulerEngineHelper {
 			String jobName, String groupName, StorageType storageType)
 		throws SchedulerException;
 
-	public Date getEndTime(SchedulerResponse schedulerResponse);
+	public Date getEndDate(SchedulerResponse schedulerResponse);
 
 	public TriggerState getJobState(SchedulerResponse schedulerResponse);
 
-	public Date getNextFireTime(SchedulerResponse schedulerResponse);
+	public Date getNextFireDate(SchedulerResponse schedulerResponse);
 
-	public Date getPreviousFireTime(SchedulerResponse schedulerResponse);
+	public Date getPreviousFireDate(SchedulerResponse schedulerResponse);
 
 	public SchedulerResponse getScheduledJob(
 			String jobName, String groupName, StorageType storageType)
@@ -49,7 +49,7 @@ public interface SchedulerEngineHelper {
 			String groupName, StorageType storageType)
 		throws SchedulerException;
 
-	public Date getStartTime(SchedulerResponse schedulerResponse);
+	public Date getStartDate(SchedulerResponse schedulerResponse);
 
 	public void pause(String jobName, String groupName, StorageType storageType)
 		throws SchedulerException;

--- a/portal-kernel/src/com/liferay/portal/kernel/scheduler/SchedulerEngineHelperUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/scheduler/SchedulerEngineHelperUtil.java
@@ -48,11 +48,11 @@ public class SchedulerEngineHelperUtil {
 		schedulerEngineHelper.delete(jobName, groupName, storageType);
 	}
 
-	public static Date getEndTime(SchedulerResponse schedulerResponse) {
+	public static Date getEndDate(SchedulerResponse schedulerResponse) {
 		SchedulerEngineHelper schedulerEngineHelper =
 			_schedulerEngineHelperSnapshot.get();
 
-		return schedulerEngineHelper.getEndTime(schedulerResponse);
+		return schedulerEngineHelper.getEndDate(schedulerResponse);
 	}
 
 	public static SchedulerResponse getScheduledJob(
@@ -95,11 +95,11 @@ public class SchedulerEngineHelperUtil {
 		return schedulerEngineHelper.getScheduledJobs(groupName, storageType);
 	}
 
-	public static Date getStartTime(SchedulerResponse schedulerResponse) {
+	public static Date getStartDate(SchedulerResponse schedulerResponse) {
 		SchedulerEngineHelper schedulerEngineHelper =
 			_schedulerEngineHelperSnapshot.get();
 
-		return schedulerEngineHelper.getStartTime(schedulerResponse);
+		return schedulerEngineHelper.getStartDate(schedulerResponse);
 	}
 
 	public static void pause(

--- a/portal-kernel/src/com/liferay/portal/kernel/scheduler/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/scheduler/packageinfo
@@ -1,1 +1,1 @@
-version 21.1.0
+version 22.0.0


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100039

## What Is Being Fixed

`SchedulerEngineHelper` declared four methods that return a `java.util.Date` but were named with a `Time` suffix: `getEndTime`, `getNextFireTime`, `getPreviousFireTime`, and `getStartTime`. The current naming convention requires a method returning a `Date` to carry `Date` in its name rather than `Time`, so these names misstated what the methods hand back. `SchedulerEngineHelperUtil`, the static facade in front of the same interface, carried the same problem on its `getEndTime` and `getStartTime` methods.

## How It Is Being Fixed

The four interface methods are renamed to `getEndDate`, `getNextFireDate`, `getPreviousFireDate`, and `getStartDate`, and `SchedulerEngineHelperImpl` is renamed to match. The two static methods on `SchedulerEngineHelperUtil` are renamed to `getEndDate` and `getStartDate` so the facade agrees with the interface it fronts instead of preserving the old names as a second vocabulary. Parameter lists and return types are untouched throughout, so this is a pure rename.

Every call site moves with the rename: the change tracking DTO converter, publish scheduler, and two model document contributors; the dispatch trigger helper and scheduler response manager; three scriptlet references in the staging processes `scheduled_publish_processes.jsp`; and the two integration tests that assert on these values.

Removing six public methods from an exported package breaks it, so `com.liferay.portal.kernel.scheduler` moves from `21.1.0` to `22.0.0`. That bump is isolated in a separate baseline commit carrying the `# breaking` block that documents the rename and the reasoning.

## Why Are There No Tests?

This is a rename with no behavior change — no branch, boundary, or return value differs, so there is no new behavior for a test to pin down. Correctness here is a compile-time property, and it is verified by the checks below: the full portal build compiled and deployed every module against the renamed kernel API, `compileTestIntegrationJava` passed for all five test modules that reference these types, and `compileJSP` covered the scriptlet edits that a plain deploy would have bundled without compiling. The existing coverage that exercises these methods — `DispatchTriggerLocalServiceTest` and `SitemapRegenerationSchedulerTest` — was updated to the new names and continues to assert the same values.

## PR Check

**pr-check: PASS** — tested on `7cff095f30604c8438aa5ba2e142f6793989d18f`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Full Portal Build | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| JSP Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "7cff095f30604c8438aa5ba2e142f6793989d18f"} -->
