### PR TITLE
LPD-100085 Avoid a ConcurrentModificationException deploying object definitions

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -211,7 +211,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -770,24 +769,16 @@ public class ObjectDefinitionLocalServiceImpl
 	public void deployObjectDefinition(ObjectDefinition objectDefinition) {
 		undeployObjectDefinition(objectDefinition);
 
+		_deploy(
+			_objectDefinitionDeployer,
+			_objectDefinitionDeployerServiceRegistrationsMap, objectDefinition);
+
 		for (Map.Entry
 				<ObjectDefinitionDeployer,
 				 Map<String, List<ServiceRegistration<?>>>> entry :
 					_activeServiceRegistrationsMaps.entrySet()) {
 
-			ObjectDefinitionDeployer objectDefinitionDeployer = entry.getKey();
-			Map<String, List<ServiceRegistration<?>>> serviceRegistrationsMap =
-				entry.getValue();
-
-			try (SafeCloseable safeCloseable = CompanyThreadLocal.lock(
-					objectDefinition.getCompanyId())) {
-
-				serviceRegistrationsMap.computeIfAbsent(
-					DBPartitionUtil.getPartitionKey(
-						objectDefinition.getObjectDefinitionId()),
-					objectDefinitionId -> objectDefinitionDeployer.deploy(
-						objectDefinition));
-			}
+			_deploy(entry.getKey(), entry.getValue(), objectDefinition);
 		}
 	}
 
@@ -1083,31 +1074,29 @@ public class ObjectDefinitionLocalServiceImpl
 	public void setAopProxy(Object aopProxy) {
 		super.setAopProxy(aopProxy);
 
-		Map<String, List<ServiceRegistration<?>>>
-			activeServiceRegistrationsMap = new ConcurrentHashMap<>();
-		ObjectDefinitionDeployer objectDefinitionDeployer =
-			new ObjectDefinitionDeployerImpl(
-				_accountEntryLocalService,
-				_accountEntryOrganizationRelLocalService,
-				_assetEntryLocalService, _bundleContext,
-				_depotEntryGroupRelLocalService, _depotEntryLocalService,
-				_dlFileEntryLocalService, _groupLocalService,
-				_kaleoDefinitionLocalService, _listTypeLocalService,
-				_objectActionLocalService, objectDefinitionLocalService,
-				_objectDefinitionSettingLocalService,
-				_objectEntryFolderLocalService, _objectEntryLocalService,
-				_objectEntryService, _objectFieldBusinessTypeRegistry,
-				_objectFieldLocalService, _objectFolderLocalService,
-				_objectLayoutLocalService, _objectLayoutTabLocalService,
-				_objectRelationshipLocalService, _objectScopeProviderRegistry,
-				_objectViewLocalService, _organizationLocalService, _portal,
-				_portletLocalService, _resourceActions, _userLocalService,
-				_resourcePermissionLocalService, _searchLocalizationHelper,
-				_sharingModelResourcePermissionConfigurator,
-				_systemEventLocalService, _textEmbeddingDocumentContributor,
-				_workflowDefinitionLinkLocalService,
-				_workflowStatusModelPreFilterContributor,
-				_userGroupRoleLocalService);
+		_objectDefinitionDeployerServiceRegistrationsMap =
+			new ConcurrentHashMap<>();
+		_objectDefinitionDeployer = new ObjectDefinitionDeployerImpl(
+			_accountEntryLocalService, _accountEntryOrganizationRelLocalService,
+			_assetEntryLocalService, _bundleContext,
+			_depotEntryGroupRelLocalService, _depotEntryLocalService,
+			_dlFileEntryLocalService, _groupLocalService,
+			_kaleoDefinitionLocalService, _listTypeLocalService,
+			_objectActionLocalService, objectDefinitionLocalService,
+			_objectDefinitionSettingLocalService,
+			_objectEntryFolderLocalService, _objectEntryLocalService,
+			_objectEntryService, _objectFieldBusinessTypeRegistry,
+			_objectFieldLocalService, _objectFolderLocalService,
+			_objectLayoutLocalService, _objectLayoutTabLocalService,
+			_objectRelationshipLocalService, _objectScopeProviderRegistry,
+			_objectViewLocalService, _organizationLocalService, _portal,
+			_portletLocalService, _resourceActions, _userLocalService,
+			_resourcePermissionLocalService, _searchLocalizationHelper,
+			_sharingModelResourcePermissionConfigurator,
+			_systemEventLocalService, _textEmbeddingDocumentContributor,
+			_workflowDefinitionLinkLocalService,
+			_workflowStatusModelPreFilterContributor,
+			_userGroupRoleLocalService);
 
 		_companyLocalService.forEachCompanyId(
 			companyId -> {
@@ -1115,8 +1104,8 @@ public class ObjectDefinitionLocalServiceImpl
 					objectDefinitionLocalService.getObjectDefinitions(
 						companyId, WorkflowConstants.STATUS_APPROVED);
 
-				activeServiceRegistrationsMap.putAll(
-					objectDefinitionDeployer.deploy(
+				_objectDefinitionDeployerServiceRegistrationsMap.putAll(
+					_objectDefinitionDeployer.deploy(
 						companyId,
 						ListUtil.filter(
 							objectDefinitions,
@@ -1136,9 +1125,6 @@ public class ObjectDefinitionLocalServiceImpl
 							_objectRelationshipLocalService, objectDefinition));
 				}
 			});
-
-		_activeServiceRegistrationsMaps.put(
-			objectDefinitionDeployer, activeServiceRegistrationsMap);
 
 		_objectDefinitionDeployerServiceTracker = new ServiceTracker<>(
 			_bundleContext, ObjectDefinitionDeployer.class,
@@ -1215,30 +1201,16 @@ public class ObjectDefinitionLocalServiceImpl
 			return;
 		}
 
+		_undeploy(
+			_objectDefinitionDeployer,
+			_objectDefinitionDeployerServiceRegistrationsMap, objectDefinition);
+
 		for (Map.Entry
 				<ObjectDefinitionDeployer,
 				 Map<String, List<ServiceRegistration<?>>>> entry :
 					_activeServiceRegistrationsMaps.entrySet()) {
 
-			ObjectDefinitionDeployer objectDefinitionDeployer = entry.getKey();
-
-			objectDefinitionDeployer.undeploy(objectDefinition);
-
-			Map<String, List<ServiceRegistration<?>>> serviceRegistrationsMap =
-				entry.getValue();
-
-			List<ServiceRegistration<?>> serviceRegistrations =
-				serviceRegistrationsMap.remove(
-					DBPartitionUtil.getPartitionKey(
-						objectDefinition.getObjectDefinitionId()));
-
-			if (serviceRegistrations != null) {
-				for (ServiceRegistration<?> serviceRegistration :
-						serviceRegistrations) {
-
-					serviceRegistration.unregister();
-				}
-			}
+			_undeploy(entry.getKey(), entry.getValue(), objectDefinition);
 		}
 
 		_invalidatePortalCache(objectDefinition);
@@ -2307,6 +2279,22 @@ public class ObjectDefinitionLocalServiceImpl
 			"model.resource." + objectDefinition.getClassName());
 	}
 
+	private void _deploy(
+		ObjectDefinitionDeployer objectDefinitionDeployer,
+		Map<String, List<ServiceRegistration<?>>> serviceRegistrationsMap,
+		ObjectDefinition objectDefinition) {
+
+		try (SafeCloseable safeCloseable = CompanyThreadLocal.lock(
+				objectDefinition.getCompanyId())) {
+
+			serviceRegistrationsMap.computeIfAbsent(
+				DBPartitionUtil.getPartitionKey(
+					objectDefinition.getObjectDefinitionId()),
+				objectDefinitionId -> objectDefinitionDeployer.deploy(
+					objectDefinition));
+		}
+	}
+
 	private void _dropTable(String dbTableName) {
 		runSQL("DROP_TABLE_IF_EXISTS(" + dbTableName + ")");
 	}
@@ -2693,6 +2681,27 @@ public class ObjectDefinitionLocalServiceImpl
 				setValidationErrors(validationErrors);
 			}
 		};
+	}
+
+	private void _undeploy(
+		ObjectDefinitionDeployer objectDefinitionDeployer,
+		Map<String, List<ServiceRegistration<?>>> serviceRegistrationsMap,
+		ObjectDefinition objectDefinition) {
+
+		objectDefinitionDeployer.undeploy(objectDefinition);
+
+		List<ServiceRegistration<?>> serviceRegistrations =
+			serviceRegistrationsMap.remove(
+				DBPartitionUtil.getPartitionKey(
+					objectDefinition.getObjectDefinitionId()));
+
+		if (serviceRegistrations != null) {
+			for (ServiceRegistration<?> serviceRegistration :
+					serviceRegistrations) {
+
+				serviceRegistration.unregister();
+			}
+		}
 	}
 
 	private ObjectDefinition _update(ObjectDefinition objectDefinition) {
@@ -4036,8 +4045,7 @@ public class ObjectDefinitionLocalServiceImpl
 
 	private final Map
 		<ObjectDefinitionDeployer, Map<String, List<ServiceRegistration<?>>>>
-			_activeServiceRegistrationsMaps = Collections.synchronizedMap(
-				new LinkedHashMap<>());
+			_activeServiceRegistrationsMaps = new ConcurrentHashMap<>();
 	private final Set<String>
 		_allowedModifiableSystemObjectDefinitionSettingNames = Set.of(
 			ObjectDefinitionSettingConstants.NAME_AUTOGENERATED_GROUP_ID,
@@ -4113,6 +4121,9 @@ public class ObjectDefinitionLocalServiceImpl
 	@Reference
 	private ObjectActionLocalService _objectActionLocalService;
 
+	private ObjectDefinitionDeployer _objectDefinitionDeployer;
+	private Map<String, List<ServiceRegistration<?>>>
+		_objectDefinitionDeployerServiceRegistrationsMap;
 	private ServiceTracker<ObjectDefinitionDeployer, ObjectDefinitionDeployer>
 		_objectDefinitionDeployerServiceTracker;
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100085

## What Is Being Fixed

`ObjectDefinitionLocalServiceImpl.deployObjectDefinition` and `undeployObjectDefinition` iterate `_activeServiceRegistrationsMaps` — a `Collections.synchronizedMap` backed by a `LinkedHashMap` — through its `entrySet` view without holding the map's monitor, while the `ObjectDefinitionDeployer` service tracker concurrently puts and removes entries as deployers come and go. A structural modification during an in-progress iteration throws `ConcurrentModificationException`, because a `LinkedHashMap`'s `entrySet` iterator is fail-fast.

## How It Is Being Fixed

The `LinkedHashMap` only existed to make the primary `ObjectDefinitionDeployerImpl` (set in `setAopProxy`) deploy first. That guarantee is preserved explicitly: the primary deployer and its service registrations are held in their own fields and deployed/undeployed first, and only the tracked deployers remain in `_activeServiceRegistrationsMaps`, restored to a `ConcurrentHashMap` whose weakly-consistent iterator tolerates concurrent puts and removes. The shared per-deployer logic moves into `_deploy`/`_undeploy` helpers.

Root cause: LPS-135650 (`4452d66ad2846564ec09636e8face798e1a48e94`) changed this map from a `ConcurrentHashMap` to a `Collections.synchronizedMap(new LinkedHashMap<>())` so the primary deployer would deploy first. The `entrySet` iteration and the tracker's concurrent puts/removes both already existed and were safe against a `ConcurrentHashMap`'s weakly-consistent iterator; they became a `ConcurrentModificationException` only against the `LinkedHashMap`'s fail-fast iterator.

## PR Check

**pr-check: PASS** — tested on `911f8e30385569f26616fd87c592dba94ffe62c7`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "911f8e30385569f26616fd87c592dba94ffe62c7"} -->
