### PR TITLE
LPD-35263 Automate alter() to alterColumnType() in UpgradeProcess

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -3776,6 +3776,19 @@
 			"UpgradeProcess"
 		],
 		"classStructurePattern": true,
+		"issueKey": "LPD-35263",
+		"methodsToFormat": [
+			{
+				"from": "regex:alter\\(\\s*?(?<tableClass>\\w*),\\s*?new\\s*?AlterColumnType\\(\\s*?(?<columnName>\\w*?)[\\s,]*?(?<newColumnType>\\w*)\\)\\);",
+				"to": "alterColumnType((String)${tableClass}.getField(\\\"TABLE_NAME\\\").get(null), ${columnName}, ${newColumnType});"
+			}
+		]
+	},
+	{
+		"classNames": [
+			"UpgradeProcess"
+		],
+		"classStructurePattern": true,
 		"issueKey": "LPD-35264",
 		"methodsToFormat": [
 			{

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_35263.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_35263.testjava
@@ -1,0 +1,19 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+/**
+ * @author Lucas Ferruccio
+ */
+public class LPD_35263 extends UpgradeProcess {
+
+	public void method(
+		Class<?> tableClass, String columnName, String newColumnType) {
+
+		alterColumnType((String)tableClass.getField("TABLE_NAME").get(null), columnName, newColumnType);
+	}
+
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_35263.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_35263.testjava
@@ -1,0 +1,19 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+/**
+ * @author Lucas Ferruccio
+ */
+public class LPD_35263 extends UpgradeProcess {
+
+	public void method(
+		Class<?> tableClass, String columnName, String newColumnType) {
+
+		alter(tableClass, new AlterColumnType(columnName, newColumnType));
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-35263

## What Is Being Fixed

`UpgradeProcess` subclasses change a column's type by instantiating the deprecated `AlterColumnType` class and passing it to `alter()`, as in `alter(FooTable.class, new AlterColumnType(columnName, newColumnType))`. `UpgradeProcess` already exposes `alterColumnType()` for this, so the deprecated indirection remains only because nothing rewrites the existing call sites, and new code keeps copying the old shape.

## How It Is Being Fixed

The rewrite is added to the source formatter's upgrade catch-all replacements rather than applied by hand, so every current and future call site is converted automatically. A new entry in `replacements.json` is scoped to `classNames: ["UpgradeProcess"]` with `classStructurePattern` enabled, and matches `alter(<tableClass>, new AlterColumnType(<columnName>, <newColumnType>))` via a named-group regex. It rewrites the call to `alterColumnType((String)<tableClass>.getField("TABLE_NAME").get(null), <columnName>, <newColumnType>)`, resolving the table name through the table class's `TABLE_NAME` field because `alterColumnType()` takes the name as a `String` while `alter()` took the class.

Because the entry is additive and scoped to `UpgradeProcess`, it cannot affect replacements for other class hierarchies.

The second commit adds the `LPD_35263.testjava` input and expected fixtures under `upgrade-catch-all-check`, which `UpgradeCatchAllCheckTest` picks up as a generated test case for this entry.

## PR Check

**pr-check: PASS** — tested on `e5bd893bcfd14ea29cfb7f36b549cb28d15d2e80`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Java Unit Tests | PASS |

Note on `UpgradeCatchAllCheckTest`: the run reported `tests=268, failures=2, errors=0`. This branch's own case, `Testcase-221: Testing LPD-35263.java`, passed. Both failures were verified pre-existing on master by reverting only `replacements.json` and re-running — they reproduce identically without this change:

- `Testcase-51: Testing LPD-70233.java` — `AssertionError: Missing unit test in .../expected/upgrade/upgrade-catch-all-check/LPD_70233.testjava`. The input fixture exists on master with no `expected/` counterpart.
- `Testcase-258: Testing LPD-61579.java` — `ComparisonFailure` on a `servletContext`/`request` replacement. That fixture extends `ParamAndPropertyAncestorTagImpl`, which this entry's `UpgradeProcess` scope cannot reach.

<!-- pr-check {"result": "success", "sha": "e5bd893bcfd14ea29cfb7f36b549cb28d15d2e80"} -->
