### PR TITLE
LPD-100095 Skip deleting a missing notification recipient

### DIFF
--- a/modules/apps/notification/notification-api/src/main/java/com/liferay/notification/model/NotificationQueueEntry.java
+++ b/modules/apps/notification/notification-api/src/main/java/com/liferay/notification/model/NotificationQueueEntry.java
@@ -51,7 +51,10 @@ public interface NotificationQueueEntry
 
 			};
 
-	public NotificationRecipient getNotificationRecipient();
+	public NotificationRecipient fetchNotificationRecipient();
+
+	public NotificationRecipient getNotificationRecipient()
+		throws com.liferay.portal.kernel.exception.PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:417033831
+// LIFERAY-SERVICE-BUILDER-HASH:-1888033065

--- a/modules/apps/notification/notification-api/src/main/java/com/liferay/notification/model/NotificationQueueEntryWrapper.java
+++ b/modules/apps/notification/notification-api/src/main/java/com/liferay/notification/model/NotificationQueueEntryWrapper.java
@@ -162,6 +162,11 @@ public class NotificationQueueEntryWrapper
 		return wrap(model.cloneWithOriginalValues());
 	}
 
+	@Override
+	public NotificationRecipient fetchNotificationRecipient() {
+		return model.fetchNotificationRecipient();
+	}
+
 	/**
 	 * Returns the body of this notification queue entry.
 	 *
@@ -253,7 +258,9 @@ public class NotificationQueueEntryWrapper
 	}
 
 	@Override
-	public NotificationRecipient getNotificationRecipient() {
+	public NotificationRecipient getNotificationRecipient()
+		throws com.liferay.portal.kernel.exception.PortalException {
+
 		return model.getNotificationRecipient();
 	}
 
@@ -560,4 +567,4 @@ public class NotificationQueueEntryWrapper
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-590199076
+// LIFERAY-SERVICE-BUILDER-HASH:-805724170

--- a/modules/apps/notification/notification-api/src/main/java/com/liferay/notification/model/NotificationTemplate.java
+++ b/modules/apps/notification/notification-api/src/main/java/com/liferay/notification/model/NotificationTemplate.java
@@ -51,7 +51,10 @@ public interface NotificationTemplate
 
 			};
 
-	public NotificationRecipient getNotificationRecipient();
+	public NotificationRecipient fetchNotificationRecipient();
+
+	public NotificationRecipient getNotificationRecipient()
+		throws com.liferay.portal.kernel.exception.PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:92732762
+// LIFERAY-SERVICE-BUILDER-HASH:995283146

--- a/modules/apps/notification/notification-api/src/main/java/com/liferay/notification/model/NotificationTemplateWrapper.java
+++ b/modules/apps/notification/notification-api/src/main/java/com/liferay/notification/model/NotificationTemplateWrapper.java
@@ -177,6 +177,11 @@ public class NotificationTemplateWrapper
 	}
 
 	@Override
+	public NotificationRecipient fetchNotificationRecipient() {
+		return model.fetchNotificationRecipient();
+	}
+
+	@Override
 	public String[] getAvailableLanguageIds() {
 		return model.getAvailableLanguageIds();
 	}
@@ -409,7 +414,9 @@ public class NotificationTemplateWrapper
 	}
 
 	@Override
-	public NotificationRecipient getNotificationRecipient() {
+	public NotificationRecipient getNotificationRecipient()
+		throws com.liferay.portal.kernel.exception.PortalException {
+
 		return model.getNotificationRecipient();
 	}
 
@@ -998,4 +1005,4 @@ public class NotificationTemplateWrapper
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1692387255
+// LIFERAY-SERVICE-BUILDER-HASH:401666449

--- a/modules/apps/notification/notification-api/src/main/java/com/liferay/notification/util/NotificationRecipientSettingUtil.java
+++ b/modules/apps/notification/notification-api/src/main/java/com/liferay/notification/util/NotificationRecipientSettingUtil.java
@@ -53,7 +53,7 @@ public class NotificationRecipientSettingUtil {
 		NotificationQueueEntry notificationQueueEntry) {
 
 		NotificationRecipient notificationRecipient =
-			notificationQueueEntry.getNotificationRecipient();
+			notificationQueueEntry.fetchNotificationRecipient();
 
 		if (notificationRecipient == null) {
 			return Collections.emptyMap();

--- a/modules/apps/notification/notification-api/src/main/resources/com/liferay/notification/model/packageinfo
+++ b/modules/apps/notification/notification-api/src/main/resources/com/liferay/notification/model/packageinfo
@@ -1,1 +1,1 @@
-version 4.4.0
+version 4.5.0

--- a/modules/apps/notification/notification-service/src/main/java/com/liferay/notification/internal/type/UserNotificationType.java
+++ b/modules/apps/notification/notification-service/src/main/java/com/liferay/notification/internal/type/UserNotificationType.java
@@ -90,7 +90,11 @@ public class UserNotificationType extends BaseNotificationType {
 		NotificationQueueEntry notificationQueueEntry) {
 
 		NotificationRecipient notificationRecipient =
-			notificationQueueEntry.getNotificationRecipient();
+			notificationQueueEntry.fetchNotificationRecipient();
+
+		if (notificationRecipient == null) {
+			return StringPool.BLANK;
+		}
 
 		List<String> values = new ArrayList<>();
 

--- a/modules/apps/notification/notification-service/src/main/java/com/liferay/notification/model/impl/NotificationQueueEntryImpl.java
+++ b/modules/apps/notification/notification-service/src/main/java/com/liferay/notification/model/impl/NotificationQueueEntryImpl.java
@@ -8,6 +8,7 @@ package com.liferay.notification.model.impl;
 import com.liferay.notification.model.NotificationRecipient;
 import com.liferay.notification.service.NotificationRecipientLocalServiceUtil;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 
@@ -15,6 +16,12 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
  * @author Gabriel Albuquerque
  */
 public class NotificationQueueEntryImpl extends NotificationQueueEntryBaseImpl {
+
+	@Override
+	public NotificationRecipient fetchNotificationRecipient() {
+		return NotificationRecipientLocalServiceUtil.
+			fetchNotificationRecipientByClassPK(getNotificationQueueEntryId());
+	}
 
 	@Override
 	public String getClassName() {
@@ -31,9 +38,11 @@ public class NotificationQueueEntryImpl extends NotificationQueueEntryBaseImpl {
 	}
 
 	@Override
-	public NotificationRecipient getNotificationRecipient() {
+	public NotificationRecipient getNotificationRecipient()
+		throws PortalException {
+
 		return NotificationRecipientLocalServiceUtil.
-			fetchNotificationRecipientByClassPK(getNotificationQueueEntryId());
+			getNotificationRecipientByClassPK(getNotificationQueueEntryId());
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/notification/notification-service/src/main/java/com/liferay/notification/model/impl/NotificationTemplateImpl.java
+++ b/modules/apps/notification/notification-service/src/main/java/com/liferay/notification/model/impl/NotificationTemplateImpl.java
@@ -7,6 +7,7 @@ package com.liferay.notification.model.impl;
 
 import com.liferay.notification.model.NotificationRecipient;
 import com.liferay.notification.service.NotificationRecipientLocalServiceUtil;
+import com.liferay.portal.kernel.exception.PortalException;
 
 /**
  * @author Gabriel Albuquerque
@@ -14,9 +15,17 @@ import com.liferay.notification.service.NotificationRecipientLocalServiceUtil;
 public class NotificationTemplateImpl extends NotificationTemplateBaseImpl {
 
 	@Override
-	public NotificationRecipient getNotificationRecipient() {
+	public NotificationRecipient fetchNotificationRecipient() {
 		return NotificationRecipientLocalServiceUtil.
 			fetchNotificationRecipientByClassPK(getNotificationTemplateId());
+	}
+
+	@Override
+	public NotificationRecipient getNotificationRecipient()
+		throws PortalException {
+
+		return NotificationRecipientLocalServiceUtil.
+			getNotificationRecipientByClassPK(getNotificationTemplateId());
 	}
 
 }

--- a/modules/apps/notification/notification-service/src/main/java/com/liferay/notification/service/impl/NotificationQueueEntryLocalServiceImpl.java
+++ b/modules/apps/notification/notification-service/src/main/java/com/liferay/notification/service/impl/NotificationQueueEntryLocalServiceImpl.java
@@ -188,17 +188,19 @@ public class NotificationQueueEntryLocalServiceImpl
 				notificationQueueEntry.getNotificationQueueEntryId());
 
 		NotificationRecipient notificationRecipient =
-			notificationQueueEntry.getNotificationRecipient();
+			notificationQueueEntry.fetchNotificationRecipient();
 
-		_notificationRecipientLocalService.deleteNotificationRecipient(
-			notificationRecipient);
+		if (notificationRecipient != null) {
+			_notificationRecipientLocalService.deleteNotificationRecipient(
+				notificationRecipient);
 
-		for (NotificationRecipientSetting notificationRecipientSetting :
-				notificationRecipient.getNotificationRecipientSettings()) {
+			for (NotificationRecipientSetting notificationRecipientSetting :
+					notificationRecipient.getNotificationRecipientSettings()) {
 
-			_notificationRecipientSettingLocalService.
-				deleteNotificationRecipientSetting(
-					notificationRecipientSetting);
+				_notificationRecipientSettingLocalService.
+					deleteNotificationRecipientSetting(
+						notificationRecipientSetting);
+			}
 		}
 
 		Repository repository = _getRepository(notificationQueueEntry);

--- a/modules/apps/notification/notification-service/src/main/java/com/liferay/notification/service/impl/NotificationTemplateLocalServiceImpl.java
+++ b/modules/apps/notification/notification-service/src/main/java/com/liferay/notification/service/impl/NotificationTemplateLocalServiceImpl.java
@@ -311,17 +311,19 @@ public class NotificationTemplateLocalServiceImpl
 			notificationTemplate, ResourceConstants.SCOPE_INDIVIDUAL);
 
 		NotificationRecipient notificationRecipient =
-			notificationTemplate.getNotificationRecipient();
+			notificationTemplate.fetchNotificationRecipient();
 
-		_notificationRecipientLocalService.deleteNotificationRecipient(
-			notificationRecipient);
+		if (notificationRecipient != null) {
+			_notificationRecipientLocalService.deleteNotificationRecipient(
+				notificationRecipient);
 
-		for (NotificationRecipientSetting notificationRecipientSetting :
-				notificationRecipient.getNotificationRecipientSettings()) {
+			for (NotificationRecipientSetting notificationRecipientSetting :
+					notificationRecipient.getNotificationRecipientSettings()) {
 
-			_notificationRecipientSettingLocalService.
-				deleteNotificationRecipientSetting(
-					notificationRecipientSetting);
+				_notificationRecipientSettingLocalService.
+					deleteNotificationRecipientSetting(
+						notificationRecipientSetting);
+			}
 		}
 
 		List<NotificationQueueEntry> notificationQueueEntries =

--- a/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/internal/type/test/UserNotificationTypeTest.java
+++ b/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/internal/type/test/UserNotificationTypeTest.java
@@ -674,7 +674,9 @@ public class UserNotificationTypeTest extends BaseNotificationTypeTest {
 			userFullName, notificationRecipientSetting.getValue());
 	}
 
-	private void _assertNotificationRecipientSettings(User... users) {
+	private void _assertNotificationRecipientSettings(User... users)
+		throws Exception {
+
 		NotificationRecipient notificationRecipient =
 			notificationQueueEntry.getNotificationRecipient();
 

--- a/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/service/test/NotificationTemplateLocalServiceTest.java
+++ b/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/service/test/NotificationTemplateLocalServiceTest.java
@@ -16,6 +16,7 @@ import com.liferay.notification.exception.NotificationTemplateExternalReferenceC
 import com.liferay.notification.model.NotificationRecipient;
 import com.liferay.notification.model.NotificationRecipientSetting;
 import com.liferay.notification.model.NotificationTemplate;
+import com.liferay.notification.service.NotificationRecipientLocalService;
 import com.liferay.notification.service.NotificationRecipientSettingLocalService;
 import com.liferay.notification.service.NotificationTemplateLocalService;
 import com.liferay.notification.test.util.NotificationTemplateUtil;
@@ -184,6 +185,32 @@ public class NotificationTemplateLocalServiceTest {
 			notificationTemplate);
 	}
 
+	@FeatureFlag("LPD-17564")
+	@Test
+	public void testDeleteNotificationTemplateWithMissingNotificationRecipient()
+		throws Exception {
+
+		User user = TestPropsValues.getUser();
+
+		NotificationTemplate notificationTemplate =
+			_notificationTemplateLocalService.addNotificationTemplate(
+				_externalReferenceCode, user.getUserId(),
+				NotificationConstants.TYPE_EMAIL);
+
+		NotificationRecipient notificationRecipient =
+			notificationTemplate.fetchNotificationRecipient();
+
+		Assert.assertNotNull(notificationRecipient);
+
+		_notificationRecipientLocalService.deleteNotificationRecipient(
+			notificationRecipient);
+
+		Assert.assertNull(notificationTemplate.fetchNotificationRecipient());
+
+		_notificationTemplateLocalService.deleteNotificationTemplate(
+			notificationTemplate);
+	}
+
 	private void _assertNotificationRecipientSetting(
 			String name, long notificationRecipientId)
 		throws Exception {
@@ -200,6 +227,10 @@ public class NotificationTemplateLocalServiceTest {
 	}
 
 	private String _externalReferenceCode;
+
+	@Inject
+	private NotificationRecipientLocalService
+		_notificationRecipientLocalService;
 
 	@Inject
 	private NotificationRecipientSettingLocalService


### PR DESCRIPTION
[LPD-100095](https://liferay.atlassian.net/browse/LPD-100095)

## What Is Being Fixed

Deleting a `NotificationTemplate` or `NotificationQueueEntry` whose `NotificationRecipient` row is already gone threw a `NullPointerException`, because `deleteNotificationTemplate` and `deleteNotificationQueueEntry` dereferenced the recipient without a null check. Since the notification `CompanyModelListener` deletes every company template during company deletion, a single recipient-less template made `CompanyLocalService.deleteCompany` throw. Under `DataGuardTestRule`'s leftover cleanup this aborted the service delete and fell back to a raw persistence delete that bypassed `PortalInstances.removeCompany`, orphaning the company in `PortalInstancePool` — a "ghost" company that later surfaced in Objects tests as `NoSuchObjectFolderException` / `NoSuchCompanyException` / `NoSuchRoleException`.

`getNotificationRecipient()` was also mis-contracted: it looked the recipient up by the model's own primary key and returned `null` when absent, yet its `get` name implied non-null, so callers dereferenced it unguarded.

## How It Is Being Fixed

Split the model accessor into `fetchNotificationRecipient()` (nullable) and `getNotificationRecipient()` (throwing). Callers that tolerate a missing recipient use the nullable fetch and handle `null`; callers that require the recipient keep `getNotificationRecipient()`, which now fails fast with a clear exception instead of dereferencing `null`. `deleteNotificationTemplate` and `deleteNotificationQueueEntry` fetch nullably and guard the recipient deletion and its setting cleanup on a non-null recipient, so deleting a recipient-less template or queue entry is idempotent.

## PR Check

**pr-check: PASS** — tested on `1d0a59ec1911be20be71f0817f7e524e3656d398`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Service Builder | PASS |
| Baseline | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "1d0a59ec1911be20be71f0817f7e524e3656d398"} -->
