### PR TITLE
LPD-100085 Make the deployer service registrations map final

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -4120,7 +4120,7 @@ public class ObjectDefinitionLocalServiceImpl
 	private ObjectActionLocalService _objectActionLocalService;
 
 	private ObjectDefinitionDeployer _objectDefinitionDeployer;
-	private Map<String, List<ServiceRegistration<?>>>
+	private final Map<String, List<ServiceRegistration<?>>>
 		_objectDefinitionDeployerServiceRegistrationsMap =
 			new ConcurrentHashMap<>();
 	private ServiceTracker<ObjectDefinitionDeployer, ObjectDefinitionDeployer>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100085

## What Is Being Fixed

`ObjectDefinitionLocalServiceImpl._objectDefinitionDeployerServiceRegistrationsMap` is assigned in exactly one place, its own declaration, but is not declared `final`.

## How It Is Being Fixed

Declare it `final`. This became possible with b08b3cf2994b81d685cac0dc1bc43c62a80b5e30, which moved `new ConcurrentHashMap<>()` out of `setAopProxy` and into the declaration. The map's contents are still mutated, through `putAll` and the deploy and undeploy helpers; only the reference is now fixed.

## Verification

Source Format and `:apps:object:object-service:compileJava` both pass. The compile is the meaningful check here, because `javac` rejects a `final` field that is assigned more than once, so a successful build is proof that the declaration holds the only assignment.
