### PR TITLE
LPD-98533 Drop the empty trailing p_l_id from the usages URL

### DIFF
--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/display/context/LayoutClassedModelUsagesDisplayContext.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/display/context/LayoutClassedModelUsagesDisplayContext.java
@@ -413,7 +413,6 @@ public class LayoutClassedModelUsagesDisplayContext {
 		sb.append(className);
 		sb.append("&classPK=");
 		sb.append(String.valueOf(classPK));
-		sb.append("&p_l_id=");
 
 		return sb.toString();
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98533

## What Is Being Fixed

`LayoutClassedModelUsagesDisplayContext` built the usages URL with a trailing `&p_l_id=` that carried no value, so every request for a web content's layout usages sent an empty parameter. `LayoutClassedModelUsagesDisplayContextTest.testGetUsagesData` has been failing on master since the build at `22f1e28ffdd87`.

## How It Is Being Fixed

Reordering the query string so that the plid leads it left the original append of `"&p_l_id="` at the bottom of the method, after the plid had already been written behind `?p_l_id=`. Removing that leftover append restores the intended URL and brings the append count back in line with the `StringBundler(8)` capacity.

## Why Are There No Tests?

`LayoutClassedModelUsagesDisplayContextTest.testGetUsagesData` already asserts the exact URL this commit produces. The test landed in master and is currently failing; this commit makes it pass, so no new coverage is warranted.

## PR Check

**pr-check: PASS** — tested on `4239db1fbce5e91aa51115ba7d4ddb04431428de`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "4239db1fbce5e91aa51115ba7d4ddb04431428de"} -->
