### PR TITLE
LPD-96726 Control embedded item fields in Headless Search responses- #4076

### DIFF
--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceTopAssetResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceTopAssetResourceImpl.java
@@ -27,6 +27,7 @@ import com.liferay.portal.vulcan.crud.VulcanCRUDItemDelegateBuilder;
 import com.liferay.portal.vulcan.crud.VulcanCRUDItemDelegateBuilderRegistry;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
+import com.liferay.portal.vulcan.fields.NestedFieldsSupplier;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -211,30 +212,32 @@ public class PerformanceTopAssetResourceImpl
 		}
 
 		performanceTopAsset.setEmbedded(
-			() -> vulcanCRUDItemDelegateBuilder.acceptLanguage(
-				contextAcceptLanguage
-			).groupLocalService(
-				groupLocalService
-			).httpServletRequest(
-				contextHttpServletRequest
-			).httpServletResponse(
-				contextHttpServletResponse
-			).resourceActionLocalService(
-				resourceActionLocalService
-			).resourcePermissionLocalService(
-				resourcePermissionLocalService
-			).roleLocalService(
-				roleLocalService
-			).scopeChecker(
-				contextScopeChecker
-			).uriInfo(
-				contextUriInfo
-			).user(
-				contextUser
-			).build(
-			).fetchItem(
-				objectEntry.getObjectEntryId()
-			));
+			NestedFieldsSupplier.supplyScopedUnsafeSupplier(
+				"embedded",
+				() -> vulcanCRUDItemDelegateBuilder.acceptLanguage(
+					contextAcceptLanguage
+				).groupLocalService(
+					groupLocalService
+				).httpServletRequest(
+					contextHttpServletRequest
+				).httpServletResponse(
+					contextHttpServletResponse
+				).resourceActionLocalService(
+					resourceActionLocalService
+				).resourcePermissionLocalService(
+					resourcePermissionLocalService
+				).roleLocalService(
+					roleLocalService
+				).scopeChecker(
+					contextScopeChecker
+				).uriInfo(
+					contextUriInfo
+				).user(
+					contextUser
+				).build(
+				).fetchItem(
+					objectEntry.getObjectEntryId()
+				)));
 	}
 
 	@Reference

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineExportTaskExecutorImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineExportTaskExecutorImpl.java
@@ -229,43 +229,40 @@ public class BatchEngineExportTaskExecutorImpl
 			BatchEngineExportTask batchEngineExportTask, Settings settings)
 		throws Exception {
 
-		UnsyncByteArrayOutputStream unsyncByteArrayOutputStream =
-			new UnsyncByteArrayOutputStream();
-
 		Map<String, Serializable> parameters = _getParameters(
 			batchEngineExportTask);
 
-		NestedFieldsContext oldNestedFieldsContext = null;
+		BatchEngineTaskItemDelegate<?> batchEngineTaskItemDelegate =
+			_batchEngineTaskItemDelegateRegistry.getBatchEngineTaskItemDelegate(
+				batchEngineExportTask.getCompanyId(),
+				batchEngineExportTask.getClassName(),
+				batchEngineExportTask.getTaskItemDelegateName());
+
+		if (batchEngineTaskItemDelegate == null) {
+			throw new IllegalStateException(
+				"No batch engine delegate available for class name " +
+					batchEngineExportTask.getClassName());
+		}
+
+		UnsyncByteArrayOutputStream unsyncByteArrayOutputStream =
+			new UnsyncByteArrayOutputStream();
 
 		try (BatchEngineExportTaskItemWriter batchEngineExportTaskItemWriter =
 				_getBatchEngineExportTaskItemWriter(
 					batchEngineExportTask, parameters, settings,
-					unsyncByteArrayOutputStream)) {
+					unsyncByteArrayOutputStream);
 
-			BatchEngineTaskItemDelegate<?> batchEngineTaskItemDelegate =
-				_batchEngineTaskItemDelegateRegistry.
-					getBatchEngineTaskItemDelegate(
-						batchEngineExportTask.getCompanyId(),
-						batchEngineExportTask.getClassName(),
-						batchEngineExportTask.getTaskItemDelegateName());
-
-			if (batchEngineTaskItemDelegate == null) {
-				throw new IllegalStateException(
-					"No batch engine delegate available for class name " +
-						batchEngineExportTask.getClassName());
-			}
-
-			oldNestedFieldsContext =
-				NestedFieldsContextThreadLocal.getNestedFieldsContext();
-
-			NestedFieldsContextThreadLocal.setNestedFieldsContext(
-				new NestedFieldsContext(
-					NestedFieldsContextUtil.limitDepth(
-						GetterUtil.getInteger(
-							parameters.get("batchNestedFieldsDepth"))),
-					NestedFieldsContextUtil.toList(
-						MapUtil.getString(parameters, "batchNestedFields")),
-					batchEngineTaskItemDelegate.getVersion()));
+			SafeCloseable safeCloseable =
+				NestedFieldsContextThreadLocal.
+					setNestedFieldsContextWithSafeCloseable(
+						new NestedFieldsContext(
+							NestedFieldsContextUtil.limitDepth(
+								GetterUtil.getInteger(
+									parameters.get("batchNestedFieldsDepth"))),
+							NestedFieldsContextUtil.toList(
+								MapUtil.getString(
+									parameters, "batchNestedFields")),
+							batchEngineTaskItemDelegate.getVersion()))) {
 
 			int maxItems = settings.getMaxItems();
 
@@ -371,10 +368,6 @@ public class BatchEngineExportTaskExecutorImpl
 					_backgroundTaskStatusMessageSender,
 					batchEngineExportTask.getProcessedItemsCount());
 			}
-		}
-		finally {
-			NestedFieldsContextThreadLocal.setNestedFieldsContext(
-				oldNestedFieldsContext);
 		}
 
 		byte[] content = unsyncByteArrayOutputStream.toByteArray();

--- a/modules/apps/headless/headless-builder/headless-builder-impl/build.gradle
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 	compileOnly project(":apps:static:portal:portal-upgrade-api")
 	compileOnly project(":core:osgi-service-tracker-collections")
 	compileOnly project(":core:petra:petra-function")
+	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 	compileOnly project(":core:petra:petra-string")
 	testImplementation group: "org.skyscreamer", name: "jsonassert", version: "1.2.3"

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/helper/ObjectEntryHelper.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/helper/ObjectEntryHelper.java
@@ -19,6 +19,7 @@ import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.service.UserLocalService;
@@ -296,19 +297,13 @@ public class ObjectEntryHelper {
 			UnsafeSupplier<T, Exception> unsafeSupplier)
 		throws Exception {
 
-		NestedFieldsContext nestedFieldsContext = new NestedFieldsContext(
-			nestedFields.size(), nestedFields);
+		try (SafeCloseable safeCloseable =
+				NestedFieldsContextThreadLocal.
+					setNestedFieldsContextWithSafeCloseable(
+						new NestedFieldsContext(
+							nestedFields.size(), nestedFields))) {
 
-		NestedFieldsContext oldNestedFieldsContext =
-			NestedFieldsContextThreadLocal.getAndSetNestedFieldsContext(
-				nestedFieldsContext);
-
-		try {
 			return unsafeSupplier.get();
-		}
-		finally {
-			NestedFieldsContextThreadLocal.setNestedFieldsContext(
-				oldNestedFieldsContext);
 		}
 	}
 

--- a/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/resource/v1_0/SearchResultResourceImpl.java
+++ b/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/resource/v1_0/SearchResultResourceImpl.java
@@ -58,6 +58,7 @@ import com.liferay.portal.vulcan.crud.VulcanCRUDItemDelegateBuilder;
 import com.liferay.portal.vulcan.crud.VulcanCRUDItemDelegateBuilderRegistry;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
+import com.liferay.portal.vulcan.fields.NestedFieldsSupplier;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -511,32 +512,34 @@ public class SearchResultResourceImpl extends BaseSearchResultResourceImpl {
 
 		if (vulcanCRUDItemDelegateBuilder != null) {
 			searchResult.setEmbedded(
-				() -> {
-					VulcanCRUDItemDelegate vulcanCRUDItemDelegate =
-						vulcanCRUDItemDelegateBuilder.acceptLanguage(
-							contextAcceptLanguage
-						).groupLocalService(
-							groupLocalService
-						).httpServletRequest(
-							contextHttpServletRequest
-						).httpServletResponse(
-							contextHttpServletResponse
-						).resourceActionLocalService(
-							resourceActionLocalService
-						).resourcePermissionLocalService(
-							resourcePermissionLocalService
-						).roleLocalService(
-							roleLocalService
-						).scopeChecker(
-							contextScopeChecker
-						).uriInfo(
-							contextUriInfo
-						).user(
-							contextUser
-						).build();
+				NestedFieldsSupplier.supplyScopedUnsafeSupplier(
+					"embedded",
+					() -> {
+						VulcanCRUDItemDelegate vulcanCRUDItemDelegate =
+							vulcanCRUDItemDelegateBuilder.acceptLanguage(
+								contextAcceptLanguage
+							).groupLocalService(
+								groupLocalService
+							).httpServletRequest(
+								contextHttpServletRequest
+							).httpServletResponse(
+								contextHttpServletResponse
+							).resourceActionLocalService(
+								resourceActionLocalService
+							).resourcePermissionLocalService(
+								resourcePermissionLocalService
+							).roleLocalService(
+								roleLocalService
+							).scopeChecker(
+								contextScopeChecker
+							).uriInfo(
+								contextUriInfo
+							).user(
+								contextUser
+							).build();
 
-					return vulcanCRUDItemDelegate.fetchItem(entryClassPK);
-				});
+						return vulcanCRUDItemDelegate.fetchItem(entryClassPK);
+					}));
 		}
 	}
 

--- a/modules/apps/portal-search/portal-search-rest-test/src/testIntegration/java/com/liferay/portal/search/rest/resource/v1_0/test/SearchResultResourceTest.java
+++ b/modules/apps/portal-search/portal-search-rest-test/src/testIntegration/java/com/liferay/portal/search/rest/resource/v1_0/test/SearchResultResourceTest.java
@@ -24,11 +24,14 @@ import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.field.builder.TextObjectFieldBuilder;
 import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.rest.dto.v1_0.ObjectEntry;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.object.test.util.ObjectRelationshipTestUtil;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -1011,7 +1014,12 @@ public class SearchResultResourceTest extends BaseSearchResultResourceTestCase {
 		Assert.assertFalse(searchResults.isEmpty());
 
 		for (SearchResult searchResult : searchResults) {
-			Assert.assertNotNull(searchResult.getEmbedded());
+			JSONObject searchResultJSONObject = _jsonFactory.createJSONObject(
+				String.valueOf(searchResult));
+
+			Assert.assertNotNull(
+				JSONUtil.getValue(
+					searchResultJSONObject, "JSONObject/embedded"));
 		}
 	}
 
@@ -1023,58 +1031,197 @@ public class SearchResultResourceTest extends BaseSearchResultResourceTestCase {
 				false, Collections.emptyMap(), _dtoConverterRegistry, null,
 				LocaleUtil.getDefault(), null, TestPropsValues.getUser());
 
-		ObjectDefinition objectDefinition =
+		ObjectDefinition objectDefinition1 =
 			ObjectDefinitionTestUtil.publishObjectDefinition(
 				Collections.singletonList(
 					new TextObjectFieldBuilder(
-					).labelMap(
-						LocalizedMapUtil.getLocalizedMap(
-							RandomTestUtil.randomString())
 					).indexed(
 						true
 					).indexedAsKeyword(
 						true
+					).labelMap(
+						LocalizedMapUtil.getLocalizedMap(
+							RandomTestUtil.randomString())
 					).name(
-						"testField"
-					).localized(
-						true
+						"testField1"
 					).build()));
 
-		ObjectEntry objectEntry = _objectEntryManager.addObjectEntry(
-			dtoConverterContext, objectDefinition,
+		ObjectDefinition objectDefinition2 =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				Collections.singletonList(
+					new TextObjectFieldBuilder(
+					).indexed(
+						true
+					).indexedAsKeyword(
+						true
+					).labelMap(
+						LocalizedMapUtil.getLocalizedMap(
+							RandomTestUtil.randomString())
+					).name(
+						"testField2"
+					).build()));
+
+		ObjectRelationship objectRelationship =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				_objectRelationshipLocalService, objectDefinition1,
+				objectDefinition2);
+
+		String searchValue = RandomTestUtil.randomString();
+
+		ObjectEntry objectEntry1 = _objectEntryManager.addObjectEntry(
+			dtoConverterContext, objectDefinition1,
 			new ObjectEntry() {
 				{
 					properties = HashMapBuilder.<String, Object>put(
-						"testField", RandomTestUtil.randomString()
+						"testField1", searchValue
 					).build();
 				}
 			},
 			ObjectDefinitionConstants.SCOPE_COMPANY);
 
+		String relatedValue = RandomTestUtil.randomString();
+
+		ObjectEntry objectEntry2 = _objectEntryManager.addObjectEntry(
+			dtoConverterContext, objectDefinition2,
+			new ObjectEntry() {
+				{
+					properties = HashMapBuilder.<String, Object>put(
+						"testField2", relatedValue
+					).build();
+				}
+			},
+			ObjectDefinitionConstants.SCOPE_COMPANY);
+
+		ObjectRelationshipTestUtil.relateObjectEntries(
+			objectEntry1.getId(), objectEntry2.getId(), objectRelationship,
+			TestPropsValues.getUserId());
+
 		SearchPage<SearchResult> searchPage = _postSearchPage(
 			HashMapBuilder.put(
-				"entryClassNames", objectDefinition.getClassName()
+				"entryClassNames", objectDefinition1.getClassName()
 			).put(
 				"nestedFields", "embedded"
 			).put(
-				"search", objectDefinition.getUserName()
+				"search", searchValue
 			).build(),
 			new SearchRequestBody());
 
-		Collection<SearchResult> searchResults = searchPage.getItems();
+		List<SearchResult> searchResults = ListUtil.fromCollection(
+			searchPage.getItems());
 
-		Assert.assertFalse(searchResults.isEmpty());
+		Assert.assertEquals(searchResults.toString(), 1, searchResults.size());
 
-		for (SearchResult searchResult : searchResults) {
-			Assert.assertNotNull(searchResult.getEmbedded());
-		}
+		SearchResult searchResult = searchResults.get(0);
+
+		JSONObject searchResultJSONObject = _jsonFactory.createJSONObject(
+			String.valueOf(searchResult));
+
+		Assert.assertEquals(
+			searchValue,
+			JSONUtil.getValueAsString(
+				searchResultJSONObject, "JSONObject/embedded",
+				"Object/testField1"));
+
+		Assert.assertNull(
+			JSONUtil.getValue(
+				searchResultJSONObject, "JSONObject/embedded",
+				"JSONArray/" + objectRelationship.getName()));
+
+		searchPage = _postSearchPage(
+			HashMapBuilder.put(
+				"entryClassNames", objectDefinition1.getClassName()
+			).put(
+				"nestedFields", "embedded." + objectRelationship.getName()
+			).put(
+				"search", searchValue
+			).build(),
+			new SearchRequestBody());
+
+		searchResults = ListUtil.fromCollection(searchPage.getItems());
+
+		Assert.assertEquals(searchResults.toString(), 1, searchResults.size());
+
+		searchResult = searchResults.get(0);
+
+		searchResultJSONObject = _jsonFactory.createJSONObject(
+			String.valueOf(searchResult));
+
+		Assert.assertNull(
+			JSONUtil.getValue(searchResultJSONObject, "JSONObject/embedded"));
+
+		searchPage = _postSearchPage(
+			HashMapBuilder.put(
+				"entryClassNames", objectDefinition1.getClassName()
+			).put(
+				"nestedFields",
+				"embedded,embedded." + objectRelationship.getName()
+			).put(
+				"search", searchValue
+			).build(),
+			new SearchRequestBody());
+
+		searchResults = ListUtil.fromCollection(searchPage.getItems());
+
+		Assert.assertEquals(searchResults.toString(), 1, searchResults.size());
+
+		searchResult = searchResults.get(0);
+
+		searchResultJSONObject = _jsonFactory.createJSONObject(
+			String.valueOf(searchResult));
+
+		Assert.assertEquals(
+			searchValue,
+			JSONUtil.getValueAsString(
+				searchResultJSONObject, "JSONObject/embedded",
+				"Object/testField1"));
+
+		Assert.assertNull(
+			JSONUtil.getValue(
+				searchResultJSONObject, "JSONObject/embedded",
+				"JSONArray/" + objectRelationship.getName()));
+
+		searchPage = _postSearchPage(
+			HashMapBuilder.put(
+				"entryClassNames", objectDefinition1.getClassName()
+			).put(
+				"nestedFields",
+				"embedded,embedded." + objectRelationship.getName()
+			).put(
+				"nestedFieldsDepth", "2"
+			).put(
+				"search", searchValue
+			).build(),
+			new SearchRequestBody());
+
+		searchResults = ListUtil.fromCollection(searchPage.getItems());
+
+		Assert.assertEquals(searchResults.toString(), 1, searchResults.size());
+
+		searchResult = searchResults.get(0);
+
+		searchResultJSONObject = _jsonFactory.createJSONObject(
+			String.valueOf(searchResult));
+
+		Assert.assertEquals(
+			searchValue,
+			JSONUtil.getValueAsString(
+				searchResultJSONObject, "JSONObject/embedded",
+				"Object/testField1"));
+
+		Assert.assertEquals(
+			relatedValue,
+			JSONUtil.getValueAsString(
+				searchResultJSONObject, "JSONObject/embedded",
+				"JSONArray/" + objectRelationship.getName(), "JSONObject/0",
+				"Object/testField2"));
 
 		_objectEntryManager.deleteObjectEntry(
 			testCompany.getCompanyId(), dtoConverterContext,
-			objectEntry.getExternalReferenceCode(), objectDefinition, "0");
+			objectEntry2.getExternalReferenceCode(), objectDefinition2, null);
 
-		_objectDefinitionLocalService.deleteObjectDefinition(
-			objectDefinition.getObjectDefinitionId());
+		_objectEntryManager.deleteObjectEntry(
+			testCompany.getCompanyId(), dtoConverterContext,
+			objectEntry1.getExternalReferenceCode(), objectDefinition1, null);
 	}
 
 	private void _testPostSearchPageWithEmptyScope() throws Exception {
@@ -1603,6 +1750,9 @@ public class SearchResultResourceTest extends BaseSearchResultResourceTestCase {
 		filter = "object.entry.manager.storage.type=" + ObjectDefinitionConstants.STORAGE_TYPE_DEFAULT
 	)
 	private ObjectEntryManager _objectEntryManager;
+
+	@Inject
+	private ObjectRelationshipLocalService _objectRelationshipLocalService;
 
 	private SearchEngine _searchEngine;
 

--- a/modules/apps/portal-vulcan/portal-vulcan-api/bnd.bnd
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Vulcan API
 Bundle-SymbolicName: com.liferay.portal.vulcan.api
-Bundle-Version: 48.9.0
+Bundle-Version: 49.0.0
 Export-Package:\
 	com.liferay.portal.vulcan.accept.language,\
 	com.liferay.portal.vulcan.aggregation,\

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/fields/NestedFieldsContextThreadLocal.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/fields/NestedFieldsContextThreadLocal.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.vulcan.fields;
 
 import com.liferay.petra.lang.CentralizedThreadLocal;
+import com.liferay.petra.lang.SafeCloseable;
 
 /**
  * @author Ivica Cardic
@@ -32,8 +33,14 @@ public class NestedFieldsContextThreadLocal {
 		_nestedFieldsContext.set(nestedFieldsContext);
 	}
 
-	private static final ThreadLocal<NestedFieldsContext> _nestedFieldsContext =
-		new CentralizedThreadLocal<>(
+	public static SafeCloseable setNestedFieldsContextWithSafeCloseable(
+		NestedFieldsContext nestedFieldsContext) {
+
+		return _nestedFieldsContext.setWithSafeCloseable(nestedFieldsContext);
+	}
+
+	private static final CentralizedThreadLocal<NestedFieldsContext>
+		_nestedFieldsContext = new CentralizedThreadLocal<>(
 			NestedFieldsContextThreadLocal.class + "._nestedFieldsContext");
 
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/fields/NestedFieldsContextThreadLocal.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/fields/NestedFieldsContextThreadLocal.java
@@ -13,16 +13,6 @@ import com.liferay.petra.lang.SafeCloseable;
  */
 public class NestedFieldsContextThreadLocal {
 
-	public static NestedFieldsContext getAndSetNestedFieldsContext(
-		NestedFieldsContext nestedFieldsContext) {
-
-		NestedFieldsContext oldNestedFieldsContext = getNestedFieldsContext();
-
-		setNestedFieldsContext(nestedFieldsContext);
-
-		return oldNestedFieldsContext;
-	}
-
 	public static NestedFieldsContext getNestedFieldsContext() {
 		return _nestedFieldsContext.get();
 	}

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/fields/NestedFieldsSupplier.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/fields/NestedFieldsSupplier.java
@@ -142,17 +142,12 @@ public class NestedFieldsSupplier<T> {
 			nestedFieldUnsafeSuppliers.put(
 				nestedField,
 				() -> {
-					NestedFieldsContext oldNestedFieldsContext =
-						NestedFieldsContextThreadLocal.
-							getAndSetNestedFieldsContext(
-								clonedNestedFieldsContext);
+					try (SafeCloseable safeCloseable =
+							NestedFieldsContextThreadLocal.
+								setNestedFieldsContextWithSafeCloseable(
+									clonedNestedFieldsContext)) {
 
-					try {
 						return unsafeSupplier.get();
-					}
-					finally {
-						NestedFieldsContextThreadLocal.setNestedFieldsContext(
-							oldNestedFieldsContext);
 					}
 				});
 		}

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/fields/NestedFieldsSupplier.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/fields/NestedFieldsSupplier.java
@@ -7,6 +7,8 @@ package com.liferay.portal.vulcan.fields;
 
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.util.ListUtil;
 
 import java.util.HashMap;
@@ -83,6 +85,30 @@ public class NestedFieldsSupplier<T> {
 		return nestedFieldValues;
 	}
 
+	public static <T> UnsafeSupplier<T, Exception> supplyScopedUnsafeSupplier(
+		String nestedField, UnsafeSupplier<T, Exception> unsafeSupplier) {
+
+		NestedFieldsContext oldNestedFieldsContext =
+			NestedFieldsContextThreadLocal.getNestedFieldsContext();
+
+		if (oldNestedFieldsContext == null) {
+			return () -> null;
+		}
+
+		NestedFieldsContext nestedFieldsContext = _createNestedFieldsContext(
+			nestedField, oldNestedFieldsContext);
+
+		return () -> {
+			try (SafeCloseable safeCloseable =
+					NestedFieldsContextThreadLocal.
+						setNestedFieldsContextWithSafeCloseable(
+							nestedFieldsContext)) {
+
+				return supply(nestedField, __ -> unsafeSupplier.get());
+			}
+		};
+	}
+
 	public static Map<String, UnsafeSupplier<Object, Exception>>
 			supplyUnsafeSupplier(
 				UnsafeFunction
@@ -134,6 +160,38 @@ public class NestedFieldsSupplier<T> {
 		nestedFieldsContext.decrementCurrentDepth();
 
 		return nestedFieldUnsafeSuppliers;
+	}
+
+	private static NestedFieldsContext _createNestedFieldsContext(
+		String nestedField, NestedFieldsContext nestedFieldsContext) {
+
+		String prefix = nestedField + ".";
+
+		List<String> nestedFields = TransformUtil.transform(
+			nestedFieldsContext.getNestedFields(),
+			currentNestedField -> {
+				if (currentNestedField.equals(nestedField)) {
+					return nestedField;
+				}
+
+				if (currentNestedField.startsWith(prefix)) {
+					return currentNestedField.substring(prefix.length());
+				}
+
+				return null;
+			});
+
+		NestedFieldsContext scopedNestedFieldsContext = new NestedFieldsContext(
+			nestedFieldsContext.getDepth(), nestedFieldsContext.getMessage(),
+			nestedFields, nestedFieldsContext.getPathParameters(),
+			nestedFieldsContext.getQueryParameters(),
+			nestedFieldsContext.getResourceVersion());
+
+		for (int i = 0; i < nestedFieldsContext.getCurrentDepth(); i++) {
+			scopedNestedFieldsContext.incrementCurrentDepth();
+		}
+
+		return scopedNestedFieldsContext;
 	}
 
 	private static boolean _mustProcessNestedFields(

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/fields/packageinfo
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/fields/packageinfo
@@ -1,1 +1,1 @@
-version 6.1.0
+version 7.0.0

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/crud/VulcanCRUDItemDelegateBuilderImpl.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/crud/VulcanCRUDItemDelegateBuilderImpl.java
@@ -5,6 +5,7 @@
 
 package com.liferay.portal.vulcan.internal.crud;
 
+import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.GroupLocalService;
@@ -14,8 +15,12 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.crud.VulcanCRUDItemDelegate;
 import com.liferay.portal.vulcan.crud.VulcanCRUDItemDelegateBuilder;
+import com.liferay.portal.vulcan.fields.NestedFieldsContext;
+import com.liferay.portal.vulcan.fields.NestedFieldsContextThreadLocal;
+import com.liferay.portal.vulcan.internal.fields.NestedFieldsSetterUtil;
 import com.liferay.portal.vulcan.jaxrs.context.ContextDataInjector;
 import com.liferay.portal.vulcan.jaxrs.context.ContextDataInjectorBuilder;
+import com.liferay.portal.vulcan.pagination.Pagination;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -59,11 +64,26 @@ public class VulcanCRUDItemDelegateBuilderImpl
 
 	@Override
 	public VulcanCRUDItemDelegate build() throws Exception {
+		NestedFieldsContext nestedFieldsContext =
+			NestedFieldsContextThreadLocal.getNestedFieldsContext();
+
 		ContextDataInjector contextDataInjector =
 			_contextDataInjectorBuilder.acceptLanguage(
 				_acceptLanguage
 			).company(
 				_company
+			).fallbackContextValueFunction(
+				contextClass -> {
+					if (nestedFieldsContext == null) {
+						return null;
+					}
+
+					if (contextClass == Pagination.class) {
+						return Pagination.of(-1, -1);
+					}
+
+					return null;
+				}
 			).groupLocalService(
 				_groupLocalService
 			).httpServletRequest(
@@ -84,8 +104,16 @@ public class VulcanCRUDItemDelegateBuilderImpl
 				_user
 			).build();
 
-		return (VulcanCRUDItemDelegate)contextDataInjector.inject(
-			_vulcanCRUDItemDelegate);
+		VulcanCRUDItemDelegate vulcanCRUDItemDelegate =
+			(VulcanCRUDItemDelegate)contextDataInjector.inject(
+				_vulcanCRUDItemDelegate);
+
+		if (nestedFieldsContext != null) {
+			return _withNestedFields(
+				contextDataInjector, vulcanCRUDItemDelegate);
+		}
+
+		return vulcanCRUDItemDelegate;
 	}
 
 	@Override
@@ -174,6 +202,41 @@ public class VulcanCRUDItemDelegateBuilderImpl
 		_company = company;
 		_contextDataInjectorBuilder = contextDataInjectorBuilder;
 		_vulcanCRUDItemDelegate = vulcanCRUDItemDelegate;
+	}
+
+	private VulcanCRUDItemDelegate _withNestedFields(
+		ContextDataInjector contextDataInjector,
+		VulcanCRUDItemDelegate vulcanCRUDItemDelegate) {
+
+		return new VulcanCRUDItemDelegate() {
+
+			@Override
+			public Object fetchItem(Long id) {
+				return _setNestedFields(vulcanCRUDItemDelegate.fetchItem(id));
+			}
+
+			@Override
+			public Object getItem(Long id) throws Exception {
+				return _setNestedFields(vulcanCRUDItemDelegate.getItem(id));
+			}
+
+			private Object _setNestedFields(Object item) {
+				if (item == null) {
+					return null;
+				}
+
+				try {
+					NestedFieldsSetterUtil.setNestedFields(
+						item, contextDataInjector);
+				}
+				catch (Exception exception) {
+					return ReflectionUtil.throwException(exception);
+				}
+
+				return item;
+			}
+
+		};
 	}
 
 	private AcceptLanguage _acceptLanguage;

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/fields/NestedFieldsSetterUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/fields/NestedFieldsSetterUtil.java
@@ -78,6 +78,8 @@ public class NestedFieldsSetterUtil {
 			NestedFieldsContextThreadLocal.getNestedFieldsContext();
 
 		if ((nestedFieldsContext == null) ||
+			(nestedFieldsContext.getCurrentDepth() >=
+				nestedFieldsContext.getDepth()) ||
 			ListUtil.isEmpty(nestedFieldsContext.getNestedFields())) {
 
 			return;

--- a/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/dto/v1_0/BatchTestEntity.java
+++ b/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/dto/v1_0/BatchTestEntity.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
@@ -24,6 +25,8 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 
 import java.io.Serializable;
 
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
@@ -137,6 +140,48 @@ public class BatchTestEntity implements Serializable {
 	@JsonIgnore
 	private Supplier<com.liferay.portal.vulcan.custom.field.CustomField[]>
 		_customFieldsSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	@Valid
+	public Object getEmbeddedNestedField() {
+		if (_embeddedNestedFieldSupplier != null) {
+			embeddedNestedField = _embeddedNestedFieldSupplier.get();
+
+			_embeddedNestedFieldSupplier = null;
+		}
+
+		return embeddedNestedField;
+	}
+
+	public void setEmbeddedNestedField(Object embeddedNestedField) {
+		this.embeddedNestedField = embeddedNestedField;
+
+		_embeddedNestedFieldSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setEmbeddedNestedField(
+		UnsafeSupplier<Object, Exception> embeddedNestedFieldUnsafeSupplier) {
+
+		_embeddedNestedFieldSupplier = () -> {
+			try {
+				return embeddedNestedFieldUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Object embeddedNestedField;
+
+	@JsonIgnore
+	private Supplier<Object> _embeddedNestedFieldSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema
 	public String getExternalReferenceCode() {
@@ -446,6 +491,40 @@ public class BatchTestEntity implements Serializable {
 			sb.append("]");
 		}
 
+		Object embeddedNestedField = getEmbeddedNestedField();
+
+		if (embeddedNestedField != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"embeddedNestedField\": ");
+
+			if (embeddedNestedField instanceof Collection) {
+				sb.append(
+					JSONFactoryUtil.createJSONArray(
+						(Collection<?>)embeddedNestedField));
+			}
+			else if (embeddedNestedField instanceof Map) {
+				sb.append(
+					JSONFactoryUtil.createJSONObject(
+						(Map<?, ?>)embeddedNestedField));
+			}
+			else if (embeddedNestedField instanceof Object[]) {
+				sb.append(
+					JSONFactoryUtil.createJSONArray(
+						Arrays.asList((Object[])embeddedNestedField)));
+			}
+			else if (embeddedNestedField instanceof String) {
+				sb.append("\"");
+				sb.append(_escape((String)embeddedNestedField));
+				sb.append("\"");
+			}
+			else {
+				sb.append(embeddedNestedField);
+			}
+		}
+
 		String externalReferenceCode = getExternalReferenceCode();
 
 		if (externalReferenceCode != null) {
@@ -636,4 +715,4 @@ public class BatchTestEntity implements Serializable {
 	private Map<String, Serializable> _extendedProperties;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-891969782
+// LIFERAY-REST-BUILDER-HASH:-1419626643

--- a/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/dto/v1_0/BatchTestEntity.java
+++ b/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/dto/v1_0/BatchTestEntity.java
@@ -258,29 +258,29 @@ public class BatchTestEntity implements Serializable {
 	private Supplier<String> _nameSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema
-	public String getNestedField() {
-		if (_nestedFieldSupplier != null) {
-			nestedField = _nestedFieldSupplier.get();
+	public String getNestedField1() {
+		if (_nestedField1Supplier != null) {
+			nestedField1 = _nestedField1Supplier.get();
 
-			_nestedFieldSupplier = null;
+			_nestedField1Supplier = null;
 		}
 
-		return nestedField;
+		return nestedField1;
 	}
 
-	public void setNestedField(String nestedField) {
-		this.nestedField = nestedField;
+	public void setNestedField1(String nestedField1) {
+		this.nestedField1 = nestedField1;
 
-		_nestedFieldSupplier = null;
+		_nestedField1Supplier = null;
 	}
 
 	@JsonIgnore
-	public void setNestedField(
-		UnsafeSupplier<String, Exception> nestedFieldUnsafeSupplier) {
+	public void setNestedField1(
+		UnsafeSupplier<String, Exception> nestedField1UnsafeSupplier) {
 
-		_nestedFieldSupplier = () -> {
+		_nestedField1Supplier = () -> {
 			try {
-				return nestedFieldUnsafeSupplier.get();
+				return nestedField1UnsafeSupplier.get();
 			}
 			catch (RuntimeException runtimeException) {
 				throw runtimeException;
@@ -293,10 +293,51 @@ public class BatchTestEntity implements Serializable {
 
 	@GraphQLField
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
-	protected String nestedField;
+	protected String nestedField1;
 
 	@JsonIgnore
-	private Supplier<String> _nestedFieldSupplier;
+	private Supplier<String> _nestedField1Supplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public String getNestedField2() {
+		if (_nestedField2Supplier != null) {
+			nestedField2 = _nestedField2Supplier.get();
+
+			_nestedField2Supplier = null;
+		}
+
+		return nestedField2;
+	}
+
+	public void setNestedField2(String nestedField2) {
+		this.nestedField2 = nestedField2;
+
+		_nestedField2Supplier = null;
+	}
+
+	@JsonIgnore
+	public void setNestedField2(
+		UnsafeSupplier<String, Exception> nestedField2UnsafeSupplier) {
+
+		_nestedField2Supplier = () -> {
+			try {
+				return nestedField2UnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String nestedField2;
+
+	@JsonIgnore
+	private Supplier<String> _nestedField2Supplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema
 	@Valid
@@ -449,18 +490,34 @@ public class BatchTestEntity implements Serializable {
 			sb.append("\"");
 		}
 
-		String nestedField = getNestedField();
+		String nestedField1 = getNestedField1();
 
-		if (nestedField != null) {
+		if (nestedField1 != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
 			}
 
-			sb.append("\"nestedField\": ");
+			sb.append("\"nestedField1\": ");
 
 			sb.append("\"");
 
-			sb.append(_escape(nestedField));
+			sb.append(_escape(nestedField1));
+
+			sb.append("\"");
+		}
+
+		String nestedField2 = getNestedField2();
+
+		if (nestedField2 != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"nestedField2\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(nestedField2));
 
 			sb.append("\"");
 		}
@@ -579,4 +636,4 @@ public class BatchTestEntity implements Serializable {
 	private Map<String, Serializable> _extendedProperties;
 
 }
-// LIFERAY-REST-BUILDER-HASH:306781238
+// LIFERAY-REST-BUILDER-HASH:-891969782

--- a/modules/util/portal-tools-rest-builder-test-client-js/src/models/BatchTestEntity.ts
+++ b/modules/util/portal-tools-rest-builder-test-client-js/src/models/BatchTestEntity.ts
@@ -13,6 +13,7 @@
 	export class BatchTestEntity {
 			"acceptAllLanguages"?: boolean;
 			"customFields"?: Array<any>;
+			"embeddedNestedField"?: object;
 			"externalReferenceCode"?: string;
 			"id"?: number;
 			"name"?: string;
@@ -36,6 +37,11 @@
 			baseName: "customFields",
 			name: "customFields",
 			type: "Array<any>",
+		},
+		{
+			baseName: "embeddedNestedField",
+			name: "embeddedNestedField",
+			type: "object",
 		},
 		{
 			baseName: "externalReferenceCode",

--- a/modules/util/portal-tools-rest-builder-test-client-js/src/models/BatchTestEntity.ts
+++ b/modules/util/portal-tools-rest-builder-test-client-js/src/models/BatchTestEntity.ts
@@ -16,7 +16,8 @@
 			"externalReferenceCode"?: string;
 			"id"?: number;
 			"name"?: string;
-			"nestedField"?: string;
+			"nestedField1"?: string;
+			"nestedField2"?: string;
 			"relatedCompanyTestEntity"?: CompanyTestEntity;
 
 		static "discriminator": string | undefined = undefined;
@@ -52,8 +53,13 @@
 			type: "string",
 		},
 		{
-			baseName: "nestedField",
-			name: "nestedField",
+			baseName: "nestedField1",
+			name: "nestedField1",
+			type: "string",
+		},
+		{
+			baseName: "nestedField2",
+			name: "nestedField2",
 			type: "string",
 		},
 		{

--- a/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/dto/v1_0/BatchTestEntity.java
+++ b/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/dto/v1_0/BatchTestEntity.java
@@ -78,6 +78,27 @@ public class BatchTestEntity implements Cloneable, Serializable {
 		com.liferay.portal.tools.rest.builder.test.client.custom.field.
 			CustomField[] customFields;
 
+	public Object getEmbeddedNestedField() {
+		return embeddedNestedField;
+	}
+
+	public void setEmbeddedNestedField(Object embeddedNestedField) {
+		this.embeddedNestedField = embeddedNestedField;
+	}
+
+	public void setEmbeddedNestedField(
+		UnsafeSupplier<Object, Exception> embeddedNestedFieldUnsafeSupplier) {
+
+		try {
+			embeddedNestedField = embeddedNestedFieldUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Object embeddedNestedField;
+
 	public String getExternalReferenceCode() {
 		return externalReferenceCode;
 	}
@@ -236,4 +257,4 @@ public class BatchTestEntity implements Cloneable, Serializable {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:2110654550
+// LIFERAY-REST-BUILDER-HASH:-1455668970

--- a/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/dto/v1_0/BatchTestEntity.java
+++ b/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/dto/v1_0/BatchTestEntity.java
@@ -137,26 +137,47 @@ public class BatchTestEntity implements Cloneable, Serializable {
 
 	protected String name;
 
-	public String getNestedField() {
-		return nestedField;
+	public String getNestedField1() {
+		return nestedField1;
 	}
 
-	public void setNestedField(String nestedField) {
-		this.nestedField = nestedField;
+	public void setNestedField1(String nestedField1) {
+		this.nestedField1 = nestedField1;
 	}
 
-	public void setNestedField(
-		UnsafeSupplier<String, Exception> nestedFieldUnsafeSupplier) {
+	public void setNestedField1(
+		UnsafeSupplier<String, Exception> nestedField1UnsafeSupplier) {
 
 		try {
-			nestedField = nestedFieldUnsafeSupplier.get();
+			nestedField1 = nestedField1UnsafeSupplier.get();
 		}
 		catch (Exception e) {
 			throw new RuntimeException(e);
 		}
 	}
 
-	protected String nestedField;
+	protected String nestedField1;
+
+	public String getNestedField2() {
+		return nestedField2;
+	}
+
+	public void setNestedField2(String nestedField2) {
+		this.nestedField2 = nestedField2;
+	}
+
+	public void setNestedField2(
+		UnsafeSupplier<String, Exception> nestedField2UnsafeSupplier) {
+
+		try {
+			nestedField2 = nestedField2UnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String nestedField2;
 
 	public CompanyTestEntity getRelatedCompanyTestEntity() {
 		return relatedCompanyTestEntity;
@@ -215,4 +236,4 @@ public class BatchTestEntity implements Cloneable, Serializable {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-2072763945
+// LIFERAY-REST-BUILDER-HASH:2110654550

--- a/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/serdes/v1_0/BatchTestEntitySerDes.java
+++ b/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/serdes/v1_0/BatchTestEntitySerDes.java
@@ -76,6 +76,23 @@ public class BatchTestEntitySerDes {
 			sb.append("]");
 		}
 
+		if (batchTestEntity.getEmbeddedNestedField() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"embeddedNestedField\": ");
+
+			if (batchTestEntity.getEmbeddedNestedField() instanceof String) {
+				sb.append("\"");
+				sb.append((String)batchTestEntity.getEmbeddedNestedField());
+				sb.append("\"");
+			}
+			else {
+				sb.append(batchTestEntity.getEmbeddedNestedField());
+			}
+		}
+
 		if (batchTestEntity.getExternalReferenceCode() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -190,6 +207,15 @@ public class BatchTestEntitySerDes {
 				String.valueOf(batchTestEntity.getCustomFields()));
 		}
 
+		if (batchTestEntity.getEmbeddedNestedField() == null) {
+			map.put("embeddedNestedField", null);
+		}
+		else {
+			map.put(
+				"embeddedNestedField",
+				String.valueOf(batchTestEntity.getEmbeddedNestedField()));
+		}
+
 		if (batchTestEntity.getExternalReferenceCode() == null) {
 			map.put("externalReferenceCode", null);
 		}
@@ -265,6 +291,11 @@ public class BatchTestEntitySerDes {
 				return false;
 			}
 			else if (Objects.equals(
+						jsonParserFieldName, "embeddedNestedField")) {
+
+				return false;
+			}
+			else if (Objects.equals(
 						jsonParserFieldName, "externalReferenceCode")) {
 
 				return false;
@@ -320,6 +351,14 @@ public class BatchTestEntitySerDes {
 					}
 
 					batchTestEntity.setCustomFields(customFieldsArray);
+				}
+			}
+			else if (Objects.equals(
+						jsonParserFieldName, "embeddedNestedField")) {
+
+				if (jsonParserFieldValue != null) {
+					batchTestEntity.setEmbeddedNestedField(
+						(Object)jsonParserFieldValue);
 				}
 			}
 			else if (Objects.equals(
@@ -443,4 +482,4 @@ public class BatchTestEntitySerDes {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:1571080986
+// LIFERAY-REST-BUILDER-HASH:282030032

--- a/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/serdes/v1_0/BatchTestEntitySerDes.java
+++ b/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/serdes/v1_0/BatchTestEntitySerDes.java
@@ -114,16 +114,30 @@ public class BatchTestEntitySerDes {
 			sb.append("\"");
 		}
 
-		if (batchTestEntity.getNestedField() != null) {
+		if (batchTestEntity.getNestedField1() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
 			}
 
-			sb.append("\"nestedField\": ");
+			sb.append("\"nestedField1\": ");
 
 			sb.append("\"");
 
-			sb.append(_escape(batchTestEntity.getNestedField()));
+			sb.append(_escape(batchTestEntity.getNestedField1()));
+
+			sb.append("\"");
+		}
+
+		if (batchTestEntity.getNestedField2() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"nestedField2\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(batchTestEntity.getNestedField2()));
 
 			sb.append("\"");
 		}
@@ -199,13 +213,22 @@ public class BatchTestEntitySerDes {
 			map.put("name", String.valueOf(batchTestEntity.getName()));
 		}
 
-		if (batchTestEntity.getNestedField() == null) {
-			map.put("nestedField", null);
+		if (batchTestEntity.getNestedField1() == null) {
+			map.put("nestedField1", null);
 		}
 		else {
 			map.put(
-				"nestedField",
-				String.valueOf(batchTestEntity.getNestedField()));
+				"nestedField1",
+				String.valueOf(batchTestEntity.getNestedField1()));
+		}
+
+		if (batchTestEntity.getNestedField2() == null) {
+			map.put("nestedField2", null);
+		}
+		else {
+			map.put(
+				"nestedField2",
+				String.valueOf(batchTestEntity.getNestedField2()));
 		}
 
 		if (batchTestEntity.getRelatedCompanyTestEntity() == null) {
@@ -252,7 +275,10 @@ public class BatchTestEntitySerDes {
 			else if (Objects.equals(jsonParserFieldName, "name")) {
 				return false;
 			}
-			else if (Objects.equals(jsonParserFieldName, "nestedField")) {
+			else if (Objects.equals(jsonParserFieldName, "nestedField1")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "nestedField2")) {
 				return false;
 			}
 			else if (Objects.equals(
@@ -315,9 +341,15 @@ public class BatchTestEntitySerDes {
 					batchTestEntity.setName((String)jsonParserFieldValue);
 				}
 			}
-			else if (Objects.equals(jsonParserFieldName, "nestedField")) {
+			else if (Objects.equals(jsonParserFieldName, "nestedField1")) {
 				if (jsonParserFieldValue != null) {
-					batchTestEntity.setNestedField(
+					batchTestEntity.setNestedField1(
+						(String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "nestedField2")) {
+				if (jsonParserFieldValue != null) {
+					batchTestEntity.setNestedField2(
 						(String)jsonParserFieldValue);
 				}
 			}
@@ -411,4 +443,4 @@ public class BatchTestEntitySerDes {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-527591277
+// LIFERAY-REST-BUILDER-HASH:1571080986

--- a/modules/util/portal-tools-rest-builder-test-impl/rest-openapi.yaml
+++ b/modules/util/portal-tools-rest-builder-test-impl/rest-openapi.yaml
@@ -35,7 +35,9 @@ components:
                     type: integer
                 name:
                     type: string
-                nestedField:
+                nestedField1:
+                    type: string
+                nestedField2:
                     type: string
                 relatedCompanyTestEntity:
                     $ref: "#/components/schemas/CompanyTestEntity"

--- a/modules/util/portal-tools-rest-builder-test-impl/rest-openapi.yaml
+++ b/modules/util/portal-tools-rest-builder-test-impl/rest-openapi.yaml
@@ -27,6 +27,8 @@ components:
                     items:
                         type: customField
                     type: array
+                embeddedNestedField:
+                    type: object
                 externalReferenceCode:
                     type: string
                 id:

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/graphql/query/v1_0/Query.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/graphql/query/v1_0/Query.java
@@ -249,7 +249,7 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {batchTestEntity(batchTestEntityId: ___){acceptAllLanguages, customFields, externalReferenceCode, id, name, nestedField, relatedCompanyTestEntity}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {batchTestEntity(batchTestEntityId: ___){acceptAllLanguages, customFields, externalReferenceCode, id, name, nestedField1, nestedField2, relatedCompanyTestEntity}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField
 	public BatchTestEntity batchTestEntity(
@@ -266,7 +266,7 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {batchTestEntityByExternalReferenceCode(externalReferenceCode: ___){acceptAllLanguages, customFields, externalReferenceCode, id, name, nestedField, relatedCompanyTestEntity}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {batchTestEntityByExternalReferenceCode(externalReferenceCode: ___){acceptAllLanguages, customFields, externalReferenceCode, id, name, nestedField1, nestedField2, relatedCompanyTestEntity}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField
 	public BatchTestEntity batchTestEntityByExternalReferenceCode(
@@ -2150,4 +2150,4 @@ public class Query {
 	private com.liferay.portal.kernel.model.User _user;
 
 }
-// LIFERAY-REST-BUILDER-HASH:268900490
+// LIFERAY-REST-BUILDER-HASH:-284527880

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/graphql/query/v1_0/Query.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/graphql/query/v1_0/Query.java
@@ -249,7 +249,7 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {batchTestEntity(batchTestEntityId: ___){acceptAllLanguages, customFields, externalReferenceCode, id, name, nestedField1, nestedField2, relatedCompanyTestEntity}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {batchTestEntity(batchTestEntityId: ___){acceptAllLanguages, customFields, embeddedNestedField, externalReferenceCode, id, name, nestedField1, nestedField2, relatedCompanyTestEntity}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField
 	public BatchTestEntity batchTestEntity(
@@ -266,7 +266,7 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {batchTestEntityByExternalReferenceCode(externalReferenceCode: ___){acceptAllLanguages, customFields, externalReferenceCode, id, name, nestedField1, nestedField2, relatedCompanyTestEntity}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {batchTestEntityByExternalReferenceCode(externalReferenceCode: ___){acceptAllLanguages, customFields, embeddedNestedField, externalReferenceCode, id, name, nestedField1, nestedField2, relatedCompanyTestEntity}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField
 	public BatchTestEntity batchTestEntityByExternalReferenceCode(
@@ -2150,4 +2150,4 @@ public class Query {
 	private com.liferay.portal.kernel.model.User _user;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-284527880
+// LIFERAY-REST-BUILDER-HASH:2136133290

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseBatchTestEntityResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseBatchTestEntityResourceImpl.java
@@ -257,7 +257,7 @@ public abstract class BaseBatchTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/batch-test-entities' -d $'{"acceptAllLanguages": ___, "customFields": ___, "externalReferenceCode": ___, "name": ___, "nestedField1": ___, "nestedField2": ___, "relatedCompanyTestEntity": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/batch-test-entities' -d $'{"acceptAllLanguages": ___, "customFields": ___, "embeddedNestedField": ___, "externalReferenceCode": ___, "name": ___, "nestedField1": ___, "nestedField2": ___, "relatedCompanyTestEntity": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(content = @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/json", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = BatchTestEntity.class)), description = "The Batch Test Entity to create. Supply the entity fields directly in the body; the server assigns the identifier.")
@@ -327,7 +327,7 @@ public abstract class BaseBatchTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/batch-test-entities/by-external-reference-code/{externalReferenceCode}' -d $'{"acceptAllLanguages": ___, "customFields": ___, "externalReferenceCode": ___, "name": ___, "nestedField1": ___, "nestedField2": ___, "relatedCompanyTestEntity": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/batch-test-entities/by-external-reference-code/{externalReferenceCode}' -d $'{"acceptAllLanguages": ___, "customFields": ___, "embeddedNestedField": ___, "externalReferenceCode": ___, "name": ___, "nestedField1": ___, "nestedField2": ___, "relatedCompanyTestEntity": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -1095,4 +1095,4 @@ public abstract class BaseBatchTestEntityResourceImpl
 		LogFactoryUtil.getLog(BaseBatchTestEntityResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:1468327018
+// LIFERAY-REST-BUILDER-HASH:-1964683350

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseBatchTestEntityResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseBatchTestEntityResourceImpl.java
@@ -257,7 +257,7 @@ public abstract class BaseBatchTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/batch-test-entities' -d $'{"acceptAllLanguages": ___, "customFields": ___, "externalReferenceCode": ___, "name": ___, "nestedField": ___, "relatedCompanyTestEntity": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/batch-test-entities' -d $'{"acceptAllLanguages": ___, "customFields": ___, "externalReferenceCode": ___, "name": ___, "nestedField1": ___, "nestedField2": ___, "relatedCompanyTestEntity": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(content = @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/json", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = BatchTestEntity.class)), description = "The Batch Test Entity to create. Supply the entity fields directly in the body; the server assigns the identifier.")
@@ -327,7 +327,7 @@ public abstract class BaseBatchTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/batch-test-entities/by-external-reference-code/{externalReferenceCode}' -d $'{"acceptAllLanguages": ___, "customFields": ___, "externalReferenceCode": ___, "name": ___, "nestedField": ___, "relatedCompanyTestEntity": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/batch-test-entities/by-external-reference-code/{externalReferenceCode}' -d $'{"acceptAllLanguages": ___, "customFields": ___, "externalReferenceCode": ___, "name": ___, "nestedField1": ___, "nestedField2": ___, "relatedCompanyTestEntity": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -1095,4 +1095,4 @@ public abstract class BaseBatchTestEntityResourceImpl
 		LogFactoryUtil.getLog(BaseBatchTestEntityResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:557589322
+// LIFERAY-REST-BUILDER-HASH:1468327018

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BatchTestEntityResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BatchTestEntityResourceImpl.java
@@ -16,6 +16,8 @@ import com.liferay.portal.tools.rest.builder.test.dto.v1_0.BatchTestEntity;
 import com.liferay.portal.tools.rest.builder.test.dto.v1_0.CompanyTestEntity;
 import com.liferay.portal.tools.rest.builder.test.resource.v1_0.BatchTestEntityResource;
 import com.liferay.portal.tools.rest.builder.test.resource.v1_0.CompanyTestEntityResource;
+import com.liferay.portal.vulcan.crud.VulcanCRUDItemDelegate;
+import com.liferay.portal.vulcan.crud.VulcanCRUDItemDelegateBuilderRegistry;
 import com.liferay.portal.vulcan.custom.field.CustomField;
 import com.liferay.portal.vulcan.fields.NestedField;
 import com.liferay.portal.vulcan.fields.NestedFieldId;
@@ -362,6 +364,39 @@ public class BatchTestEntityResourceImpl
 							return customField;
 						},
 						CustomField.class));
+				setEmbeddedNestedField(
+					NestedFieldsSupplier.supplyScopedUnsafeSupplier(
+						"embeddedNestedField",
+						() -> {
+							VulcanCRUDItemDelegate vulcanCRUDItemDelegate =
+								_vulcanCRUDItemDelegateBuilderRegistry.builder(
+									contextCompany,
+									BatchTestEntity.class.getName()
+								).acceptLanguage(
+									contextAcceptLanguage
+								).groupLocalService(
+									groupLocalService
+								).httpServletRequest(
+									contextHttpServletRequest
+								).httpServletResponse(
+									contextHttpServletResponse
+								).resourceActionLocalService(
+									resourceActionLocalService
+								).resourcePermissionLocalService(
+									resourcePermissionLocalService
+								).roleLocalService(
+									roleLocalService
+								).scopeChecker(
+									contextScopeChecker
+								).uriInfo(
+									contextUriInfo
+								).user(
+									contextUser
+								).build();
+
+							return vulcanCRUDItemDelegate.fetchItem(
+								originalBatchTestEntity.getId());
+						}));
 				setExternalReferenceCode(
 					originalBatchTestEntity.getExternalReferenceCode());
 				setId(originalBatchTestEntity.getId());
@@ -408,5 +443,9 @@ public class BatchTestEntityResourceImpl
 
 	@Reference
 	private CompanyTestEntityResource.Factory _factory;
+
+	@Reference
+	private VulcanCRUDItemDelegateBuilderRegistry
+		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BatchTestEntityResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BatchTestEntityResourceImpl.java
@@ -17,6 +17,8 @@ import com.liferay.portal.tools.rest.builder.test.dto.v1_0.CompanyTestEntity;
 import com.liferay.portal.tools.rest.builder.test.resource.v1_0.BatchTestEntityResource;
 import com.liferay.portal.tools.rest.builder.test.resource.v1_0.CompanyTestEntityResource;
 import com.liferay.portal.vulcan.custom.field.CustomField;
+import com.liferay.portal.vulcan.fields.NestedField;
+import com.liferay.portal.vulcan.fields.NestedFieldId;
 import com.liferay.portal.vulcan.fields.NestedFieldsSupplier;
 import com.liferay.portal.vulcan.pagination.Page;
 
@@ -35,7 +37,10 @@ import org.osgi.service.component.annotations.ServiceScope;
  */
 @Component(
 	properties = "OSGI-INF/liferay/rest/v1_0/batch-test-entity.properties",
-	property = "export.import.vulcan.batch.engine.task.item.delegate=true",
+	property = {
+		"export.import.vulcan.batch.engine.task.item.delegate=true",
+		"nested.field.support=true"
+	},
 	scope = ServiceScope.PROTOTYPE, service = BatchTestEntityResource.class
 )
 public class BatchTestEntityResourceImpl
@@ -90,6 +95,13 @@ public class BatchTestEntityResourceImpl
 		return _toBatchTestEntity(batchTestEntity);
 	}
 
+	@NestedField(parentClass = BatchTestEntity.class, value = "nestedField2")
+	public String getBatchTestEntityNestedField2(
+		@NestedFieldId(value = "id") Long id) {
+
+		return "nestedField2-" + id;
+	}
+
 	@Override
 	public ExportImportDescriptor getExportImportDescriptor() {
 		return new ExportImportDescriptor() {
@@ -117,7 +129,8 @@ public class BatchTestEntityResourceImpl
 
 			@Override
 			public List<String> getNestedFields() {
-				return Arrays.asList("nestedField", "relatedCompanyTestEntity");
+				return Arrays.asList(
+					"nestedField1", "nestedField2", "relatedCompanyTestEntity");
 			}
 
 			@Override
@@ -353,11 +366,11 @@ public class BatchTestEntityResourceImpl
 					originalBatchTestEntity.getExternalReferenceCode());
 				setId(originalBatchTestEntity.getId());
 				setName(originalBatchTestEntity.getName());
-				setNestedField(
+				setNestedField1(
 					() -> NestedFieldsSupplier.supply(
-						"nestedField",
+						"nestedField1",
 						nestedField ->
-							originalBatchTestEntity.getNestedField()));
+							originalBatchTestEntity.getNestedField1()));
 				setRelatedCompanyTestEntity(
 					() -> NestedFieldsSupplier.supply(
 						"relatedCompanyTestEntity",

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/exportimport/test/BatchTestEntityExportImportTest.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/exportimport/test/BatchTestEntityExportImportTest.java
@@ -120,7 +120,7 @@ public class BatchTestEntityExportImportTest {
 			LocaleUtil.getDefault()
 		).parameters(
 			"nestedFields",
-			"customFields.attributeType,nestedField,relatedCompanyTestEntity"
+			"customFields.attributeType,nestedField1,relatedCompanyTestEntity"
 		).build();
 		_companyTestEntityResource = CompanyTestEntityResource.builder(
 		).authentication(
@@ -204,7 +204,7 @@ public class BatchTestEntityExportImportTest {
 							RandomTestUtil.randomString());
 						name = StringUtil.toLowerCase(
 							RandomTestUtil.randomString());
-						nestedField = StringUtil.toLowerCase(
+						nestedField1 = StringUtil.toLowerCase(
 							RandomTestUtil.randomString());
 					}
 				});
@@ -233,7 +233,7 @@ public class BatchTestEntityExportImportTest {
 							RandomTestUtil.randomString());
 						name = StringUtil.toLowerCase(
 							RandomTestUtil.randomString());
-						nestedField = StringUtil.toLowerCase(
+						nestedField1 = StringUtil.toLowerCase(
 							RandomTestUtil.randomString());
 					}
 				});
@@ -310,7 +310,7 @@ public class BatchTestEntityExportImportTest {
 							RandomTestUtil.randomString());
 						name = StringUtil.toLowerCase(
 							RandomTestUtil.randomString());
-						nestedField = StringUtil.toLowerCase(
+						nestedField1 = StringUtil.toLowerCase(
 							RandomTestUtil.randomString());
 						relatedCompanyTestEntity = companyTestEntity1;
 					}
@@ -335,7 +335,7 @@ public class BatchTestEntityExportImportTest {
 							RandomTestUtil.randomString());
 						name = StringUtil.toLowerCase(
 							RandomTestUtil.randomString());
-						nestedField = StringUtil.toLowerCase(
+						nestedField1 = StringUtil.toLowerCase(
 							RandomTestUtil.randomString());
 						relatedCompanyTestEntity = companyTestEntity2;
 					}
@@ -435,7 +435,7 @@ public class BatchTestEntityExportImportTest {
 							RandomTestUtil.randomString());
 						name = StringUtil.toLowerCase(
 							RandomTestUtil.randomString());
-						nestedField = StringUtil.toLowerCase(
+						nestedField1 = StringUtil.toLowerCase(
 							RandomTestUtil.randomString());
 						relatedCompanyTestEntity = companyTestEntity1;
 					}
@@ -460,7 +460,7 @@ public class BatchTestEntityExportImportTest {
 						externalReferenceCode = externalReferenceCode2;
 						name = StringUtil.toLowerCase(
 							RandomTestUtil.randomString());
-						nestedField = StringUtil.toLowerCase(
+						nestedField1 = StringUtil.toLowerCase(
 							RandomTestUtil.randomString());
 						relatedCompanyTestEntity = companyTestEntity2;
 					}
@@ -565,7 +565,7 @@ public class BatchTestEntityExportImportTest {
 							RandomTestUtil.randomString());
 						name = StringUtil.toLowerCase(
 							RandomTestUtil.randomString());
-						nestedField = StringUtil.toLowerCase(
+						nestedField1 = StringUtil.toLowerCase(
 							RandomTestUtil.randomString());
 					}
 				});
@@ -776,7 +776,7 @@ public class BatchTestEntityExportImportTest {
 							RandomTestUtil.randomString());
 						name = StringUtil.toLowerCase(
 							RandomTestUtil.randomString());
-						nestedField = StringUtil.toLowerCase(
+						nestedField1 = StringUtil.toLowerCase(
 							RandomTestUtil.randomString());
 					}
 				});
@@ -840,8 +840,8 @@ public class BatchTestEntityExportImportTest {
 		Assert.assertEquals(
 			batchTestEntity.getName(), batchTestEntity2.getName());
 		Assert.assertEquals(
-			batchTestEntity.getNestedField(),
-			batchTestEntity2.getNestedField());
+			batchTestEntity.getNestedField1(),
+			batchTestEntity2.getNestedField1());
 
 		CompanyTestEntity relatedCompanyTestEntity1 =
 			batchTestEntity.getRelatedCompanyTestEntity();

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseBatchTestEntityResourceTestCase.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseBatchTestEntityResourceTestCase.java
@@ -212,7 +212,8 @@ public abstract class BaseBatchTestEntityResourceTestCase {
 
 		batchTestEntity.setExternalReferenceCode(regex);
 		batchTestEntity.setName(regex);
-		batchTestEntity.setNestedField(regex);
+		batchTestEntity.setNestedField1(regex);
+		batchTestEntity.setNestedField2(regex);
 
 		String json = BatchTestEntitySerDes.toJSON(batchTestEntity);
 
@@ -222,7 +223,8 @@ public abstract class BaseBatchTestEntityResourceTestCase {
 
 		Assert.assertEquals(regex, batchTestEntity.getExternalReferenceCode());
 		Assert.assertEquals(regex, batchTestEntity.getName());
-		Assert.assertEquals(regex, batchTestEntity.getNestedField());
+		Assert.assertEquals(regex, batchTestEntity.getNestedField1());
+		Assert.assertEquals(regex, batchTestEntity.getNestedField2());
 	}
 
 	@Test
@@ -1323,8 +1325,16 @@ public abstract class BaseBatchTestEntityResourceTestCase {
 				continue;
 			}
 
-			if (Objects.equals("nestedField", additionalAssertFieldName)) {
-				if (batchTestEntity.getNestedField() == null) {
+			if (Objects.equals("nestedField1", additionalAssertFieldName)) {
+				if (batchTestEntity.getNestedField1() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("nestedField2", additionalAssertFieldName)) {
+				if (batchTestEntity.getNestedField2() == null) {
 					valid = false;
 				}
 
@@ -1523,10 +1533,21 @@ public abstract class BaseBatchTestEntityResourceTestCase {
 				continue;
 			}
 
-			if (Objects.equals("nestedField", additionalAssertFieldName)) {
+			if (Objects.equals("nestedField1", additionalAssertFieldName)) {
 				if (!Objects.deepEquals(
-						batchTestEntity1.getNestedField(),
-						batchTestEntity2.getNestedField())) {
+						batchTestEntity1.getNestedField1(),
+						batchTestEntity2.getNestedField1())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("nestedField2", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						batchTestEntity1.getNestedField2(),
+						batchTestEntity2.getNestedField2())) {
 
 					return false;
 				}
@@ -1762,8 +1783,54 @@ public abstract class BaseBatchTestEntityResourceTestCase {
 			return sb.toString();
 		}
 
-		if (entityFieldName.equals("nestedField")) {
-			Object object = batchTestEntity.getNestedField();
+		if (entityFieldName.equals("nestedField1")) {
+			Object object = batchTestEntity.getNestedField1();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("nestedField2")) {
+			Object object = batchTestEntity.getNestedField2();
 
 			String value = String.valueOf(object);
 
@@ -1865,7 +1932,9 @@ public abstract class BaseBatchTestEntityResourceTestCase {
 					RandomTestUtil.randomString());
 				id = RandomTestUtil.randomLong();
 				name = StringUtil.toLowerCase(RandomTestUtil.randomString());
-				nestedField = StringUtil.toLowerCase(
+				nestedField1 = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				nestedField2 = StringUtil.toLowerCase(
 					RandomTestUtil.randomString());
 			}
 		};
@@ -2139,4 +2208,4 @@ public abstract class BaseBatchTestEntityResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-787316301
+// LIFERAY-REST-BUILDER-HASH:1018030429

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseBatchTestEntityResourceTestCase.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseBatchTestEntityResourceTestCase.java
@@ -1308,6 +1308,16 @@ public abstract class BaseBatchTestEntityResourceTestCase {
 			}
 
 			if (Objects.equals(
+					"embeddedNestedField", additionalAssertFieldName)) {
+
+				if (batchTestEntity.getEmbeddedNestedField() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
 					"externalReferenceCode", additionalAssertFieldName)) {
 
 				if (batchTestEntity.getExternalReferenceCode() == null) {
@@ -1500,6 +1510,19 @@ public abstract class BaseBatchTestEntityResourceTestCase {
 			}
 
 			if (Objects.equals(
+					"embeddedNestedField", additionalAssertFieldName)) {
+
+				if (!Objects.deepEquals(
+						batchTestEntity1.getEmbeddedNestedField(),
+						batchTestEntity2.getEmbeddedNestedField())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
 					"externalReferenceCode", additionalAssertFieldName)) {
 
 				if (!Objects.deepEquals(
@@ -1682,6 +1705,11 @@ public abstract class BaseBatchTestEntityResourceTestCase {
 		}
 
 		if (entityFieldName.equals("customFields")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("embeddedNestedField")) {
 			throw new IllegalArgumentException(
 				"Invalid entity field " + entityFieldName);
 		}
@@ -2208,4 +2236,4 @@ public abstract class BaseBatchTestEntityResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1018030429
+// LIFERAY-REST-BUILDER-HASH:-1399474926

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BatchTestEntityResourceTest.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BatchTestEntityResourceTest.java
@@ -6,9 +6,33 @@
 package com.liferay.portal.tools.rest.builder.test.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.oauth2.provider.scope.ScopeChecker;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.tools.rest.builder.test.client.dto.v1_0.BatchTestEntity;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.crud.VulcanCRUDItemDelegate;
+import com.liferay.portal.vulcan.crud.VulcanCRUDItemDelegateBuilderRegistry;
+import com.liferay.portal.vulcan.fields.NestedFieldsContext;
+import com.liferay.portal.vulcan.fields.NestedFieldsContextThreadLocal;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+
+import org.junit.Assert;
+import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
 
 /**
  * @author Alejandro Tardín
@@ -16,6 +40,69 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 public class BatchTestEntityResourceTest
 	extends BaseBatchTestEntityResourceTestCase {
+
+	@Override
+	@Test
+	public void testVulcanCRUDItemDelegateGetItem() throws Exception {
+		super.testVulcanCRUDItemDelegateGetItem();
+
+		BatchTestEntity batchTestEntity = randomBatchTestEntity();
+
+		BatchTestEntity postBatchTestEntity =
+			batchTestEntityResource.postBatchTestEntity(batchTestEntity);
+
+		VulcanCRUDItemDelegate vulcanCRUDItemDelegate =
+			_buildVulcanCRUDItemDelegate();
+
+		com.liferay.portal.tools.rest.builder.test.dto.v1_0.BatchTestEntity
+			batchTestEntity1 =
+				(com.liferay.portal.tools.rest.builder.test.dto.v1_0.
+					BatchTestEntity)vulcanCRUDItemDelegate.fetchItem(
+						postBatchTestEntity.getId());
+
+		Assert.assertNull(batchTestEntity1.getNestedField());
+
+		com.liferay.portal.tools.rest.builder.test.dto.v1_0.BatchTestEntity
+			batchTestEntity2 =
+				(com.liferay.portal.tools.rest.builder.test.dto.v1_0.
+					BatchTestEntity)vulcanCRUDItemDelegate.getItem(
+						postBatchTestEntity.getId());
+
+		Assert.assertNull(batchTestEntity2.getNestedField());
+
+		NestedFieldsContext oldNestedFieldsContext =
+			NestedFieldsContextThreadLocal.getAndSetNestedFieldsContext(
+				new NestedFieldsContext(
+					1, Arrays.asList("nestedField"), "v1.0"));
+
+		try {
+			vulcanCRUDItemDelegate = _buildVulcanCRUDItemDelegate();
+
+			com.liferay.portal.tools.rest.builder.test.dto.v1_0.BatchTestEntity
+				batchTestEntity3 =
+					(com.liferay.portal.tools.rest.builder.test.dto.v1_0.
+						BatchTestEntity)vulcanCRUDItemDelegate.fetchItem(
+							postBatchTestEntity.getId());
+
+			Assert.assertEquals(
+				batchTestEntity.getNestedField(),
+				batchTestEntity3.getNestedField());
+
+			com.liferay.portal.tools.rest.builder.test.dto.v1_0.BatchTestEntity
+				batchTestEntity4 =
+					(com.liferay.portal.tools.rest.builder.test.dto.v1_0.
+						BatchTestEntity)vulcanCRUDItemDelegate.getItem(
+							postBatchTestEntity.getId());
+
+			Assert.assertEquals(
+				batchTestEntity.getNestedField(),
+				batchTestEntity4.getNestedField());
+		}
+		finally {
+			NestedFieldsContextThreadLocal.setNestedFieldsContext(
+				oldNestedFieldsContext);
+		}
+	}
 
 	@Override
 	protected BatchTestEntity
@@ -78,5 +165,83 @@ public class BatchTestEntityResourceTest
 		return batchTestEntityResource.postBatchTestEntity(
 			randomBatchTestEntity());
 	}
+
+	private VulcanCRUDItemDelegate _buildVulcanCRUDItemDelegate()
+		throws Exception {
+
+		return _vulcanCRUDItemDelegateBuilderRegistry.builder(
+			testCompany,
+			"com.liferay.portal.tools.rest.builder.test.dto.v1_0." +
+				"BatchTestEntity"
+		).acceptLanguage(
+			new AcceptLanguage() {
+
+				@Override
+				public List<Locale> getLocales() {
+					return Arrays.asList(LocaleUtil.getDefault());
+				}
+
+				@Override
+				public String getPreferredLanguageId() {
+					return LocaleUtil.toLanguageId(LocaleUtil.getDefault());
+				}
+
+				@Override
+				public Locale getPreferredLocale() {
+					return LocaleUtil.getDefault();
+				}
+
+			}
+		).groupLocalService(
+			_groupLocalService
+		).httpServletRequest(
+			new MockHttpServletRequest() {
+
+				@Override
+				public StringBuffer getRequestURL() {
+					return new StringBuffer(
+						StringBundler.concat(
+							"http://localhost:",
+							PortalUtil.getPortalServerPort(false), "/o/v1.0/",
+							RandomTestUtil.randomString(), "/",
+							RandomTestUtil.randomString()));
+				}
+
+			}
+		).httpServletResponse(
+			new MockHttpServletResponse()
+		).resourceActionLocalService(
+			_resourceActionLocalService
+		).resourcePermissionLocalService(
+			_resourcePermissionLocalService
+		).roleLocalService(
+			_roleLocalService
+		).scopeChecker(
+			_scopeChecker
+		).uriInfo(
+			testVulcanCRUDItemDelegate_getUriInfo()
+		).user(
+			testVulcanCRUDItemDelegate_getUser()
+		).build();
+	}
+
+	@Inject
+	private GroupLocalService _groupLocalService;
+
+	@Inject
+	private ResourceActionLocalService _resourceActionLocalService;
+
+	@Inject
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Inject
+	private RoleLocalService _roleLocalService;
+
+	@Inject
+	private ScopeChecker _scopeChecker;
+
+	@Inject
+	private VulcanCRUDItemDelegateBuilderRegistry
+		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BatchTestEntityResourceTest.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BatchTestEntityResourceTest.java
@@ -60,7 +60,8 @@ public class BatchTestEntityResourceTest
 					BatchTestEntity)vulcanCRUDItemDelegate.fetchItem(
 						postBatchTestEntity.getId());
 
-		Assert.assertNull(batchTestEntity1.getNestedField());
+		Assert.assertNull(batchTestEntity1.getNestedField1());
+		Assert.assertNull(batchTestEntity1.getNestedField2());
 
 		com.liferay.portal.tools.rest.builder.test.dto.v1_0.BatchTestEntity
 			batchTestEntity2 =
@@ -68,12 +69,13 @@ public class BatchTestEntityResourceTest
 					BatchTestEntity)vulcanCRUDItemDelegate.getItem(
 						postBatchTestEntity.getId());
 
-		Assert.assertNull(batchTestEntity2.getNestedField());
+		Assert.assertNull(batchTestEntity2.getNestedField1());
+		Assert.assertNull(batchTestEntity2.getNestedField2());
 
 		NestedFieldsContext oldNestedFieldsContext =
 			NestedFieldsContextThreadLocal.getAndSetNestedFieldsContext(
 				new NestedFieldsContext(
-					1, Arrays.asList("nestedField"), "v1.0"));
+					1, Arrays.asList("nestedField1", "nestedField2"), "v1.0"));
 
 		try {
 			vulcanCRUDItemDelegate = _buildVulcanCRUDItemDelegate();
@@ -85,8 +87,11 @@ public class BatchTestEntityResourceTest
 							postBatchTestEntity.getId());
 
 			Assert.assertEquals(
-				batchTestEntity.getNestedField(),
-				batchTestEntity3.getNestedField());
+				batchTestEntity.getNestedField1(),
+				batchTestEntity3.getNestedField1());
+			Assert.assertEquals(
+				"nestedField2-" + postBatchTestEntity.getId(),
+				batchTestEntity3.getNestedField2());
 
 			com.liferay.portal.tools.rest.builder.test.dto.v1_0.BatchTestEntity
 				batchTestEntity4 =
@@ -95,8 +100,11 @@ public class BatchTestEntityResourceTest
 							postBatchTestEntity.getId());
 
 			Assert.assertEquals(
-				batchTestEntity.getNestedField(),
-				batchTestEntity4.getNestedField());
+				batchTestEntity.getNestedField1(),
+				batchTestEntity4.getNestedField1());
+			Assert.assertEquals(
+				"nestedField2-" + postBatchTestEntity.getId(),
+				batchTestEntity4.getNestedField2());
 		}
 		finally {
 			NestedFieldsContextThreadLocal.setNestedFieldsContext(

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BatchTestEntityResourceTest.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BatchTestEntityResourceTest.java
@@ -7,6 +7,7 @@ package com.liferay.portal.tools.rest.builder.test.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.oauth2.provider.scope.ScopeChecker;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
@@ -72,12 +73,13 @@ public class BatchTestEntityResourceTest
 		Assert.assertNull(batchTestEntity2.getNestedField1());
 		Assert.assertNull(batchTestEntity2.getNestedField2());
 
-		NestedFieldsContext oldNestedFieldsContext =
-			NestedFieldsContextThreadLocal.getAndSetNestedFieldsContext(
-				new NestedFieldsContext(
-					1, Arrays.asList("nestedField1", "nestedField2"), "v1.0"));
+		try (SafeCloseable safeCloseable =
+				NestedFieldsContextThreadLocal.
+					setNestedFieldsContextWithSafeCloseable(
+						new NestedFieldsContext(
+							1, Arrays.asList("nestedField1", "nestedField2"),
+							"v1.0"))) {
 
-		try {
 			vulcanCRUDItemDelegate = _buildVulcanCRUDItemDelegate();
 
 			com.liferay.portal.tools.rest.builder.test.dto.v1_0.BatchTestEntity
@@ -105,10 +107,6 @@ public class BatchTestEntityResourceTest
 			Assert.assertEquals(
 				"nestedField2-" + postBatchTestEntity.getId(),
 				batchTestEntity4.getNestedField2());
-		}
-		finally {
-			NestedFieldsContextThreadLocal.setNestedFieldsContext(
-				oldNestedFieldsContext);
 		}
 	}
 

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BatchTestEntityResourceTest.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BatchTestEntityResourceTest.java
@@ -9,11 +9,15 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.oauth2.provider.scope.ScopeChecker;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.test.util.HTTPTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.test.rule.Inject;
@@ -41,6 +45,74 @@ import org.springframework.mock.web.MockHttpServletResponse;
 @RunWith(Arquillian.class)
 public class BatchTestEntityResourceTest
 	extends BaseBatchTestEntityResourceTestCase {
+
+	@Override
+	@Test
+	public void testGetBatchTestEntity() throws Exception {
+		super.testGetBatchTestEntity();
+
+		BatchTestEntity postBatchTestEntity =
+			batchTestEntityResource.postBatchTestEntity(
+				randomBatchTestEntity());
+
+		BatchTestEntity batchTestEntity =
+			batchTestEntityResource.getBatchTestEntity(
+				postBatchTestEntity.getId());
+
+		Assert.assertNull(batchTestEntity.getEmbeddedNestedField());
+
+		JSONObject batchTestEntityJSONObject = _getBatchTestEntityJSONObject(
+			postBatchTestEntity.getId(), "nestedFields=embeddedNestedField");
+
+		Assert.assertEquals(
+			postBatchTestEntity.getName(),
+			JSONUtil.getValueAsString(
+				batchTestEntityJSONObject, "JSONObject/embeddedNestedField",
+				"Object/name"));
+		Assert.assertNull(
+			JSONUtil.getValue(
+				batchTestEntityJSONObject, "JSONObject/embeddedNestedField",
+				"Object/nestedField2"));
+
+		batchTestEntityJSONObject = _getBatchTestEntityJSONObject(
+			postBatchTestEntity.getId(),
+			"nestedFields=embeddedNestedField.nestedField2");
+
+		Assert.assertNull(
+			JSONUtil.getValue(
+				batchTestEntityJSONObject, "JSONObject/embeddedNestedField"));
+
+		batchTestEntityJSONObject = _getBatchTestEntityJSONObject(
+			postBatchTestEntity.getId(),
+			"nestedFields=embeddedNestedField,embeddedNestedField." +
+				"nestedField2");
+
+		Assert.assertEquals(
+			postBatchTestEntity.getName(),
+			JSONUtil.getValueAsString(
+				batchTestEntityJSONObject, "JSONObject/embeddedNestedField",
+				"Object/name"));
+		Assert.assertNull(
+			JSONUtil.getValue(
+				batchTestEntityJSONObject, "JSONObject/embeddedNestedField",
+				"Object/nestedField2"));
+
+		batchTestEntityJSONObject = _getBatchTestEntityJSONObject(
+			postBatchTestEntity.getId(),
+			"nestedFields=embeddedNestedField,embeddedNestedField." +
+				"nestedField2&nestedFieldsDepth=2");
+
+		Assert.assertEquals(
+			postBatchTestEntity.getName(),
+			JSONUtil.getValueAsString(
+				batchTestEntityJSONObject, "JSONObject/embeddedNestedField",
+				"Object/name"));
+		Assert.assertEquals(
+			"nestedField2-" + postBatchTestEntity.getId(),
+			JSONUtil.getValueAsString(
+				batchTestEntityJSONObject, "JSONObject/embeddedNestedField",
+				"Object/nestedField2"));
+	}
 
 	@Override
 	@Test
@@ -229,6 +301,18 @@ public class BatchTestEntityResourceTest
 		).user(
 			testVulcanCRUDItemDelegate_getUser()
 		).build();
+	}
+
+	private JSONObject _getBatchTestEntityJSONObject(
+			Long batchTestEntityId, String queryString)
+		throws Exception {
+
+		return HTTPTestUtil.invokeToJSONObject(
+			null,
+			StringBundler.concat(
+				"portal-tools-rest-builder-test/v1.0/batch-test-entities/",
+				batchTestEntityId, "?", queryString),
+			Http.Method.GET);
 	}
 
 	@Inject

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/RESTDTOSetCallCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/RESTDTOSetCallCheck.java
@@ -328,23 +328,23 @@ public class RESTDTOSetCallCheck extends BaseCheck {
 			return false;
 		}
 
-		DetailAST qualifierDetailAST = firstChildDetailAST.getFirstChild();
+		List<String> names = getNames(firstChildDetailAST, false);
 
-		if (qualifierDetailAST.getType() != TokenTypes.IDENT) {
+		if (names.size() != 2) {
 			return false;
 		}
 
 		String fullyQualifiedTypeName = null;
 
-		String qualifierName = qualifierDetailAST.getText();
+		String methodCallClassName = names.get(0);
 
-		if (Character.isUpperCase(qualifierName.charAt(0))) {
+		if (Character.isUpperCase(methodCallClassName.charAt(0))) {
 			fullyQualifiedTypeName = getFullyQualifiedTypeName(
-				qualifierName, detailAST, false);
+				methodCallClassName, detailAST, false);
 		}
 		else {
 			fullyQualifiedTypeName = getVariableTypeName(
-				detailAST, qualifierName, false, false, true);
+				detailAST, methodCallClassName, false, false, true);
 		}
 
 		if (fullyQualifiedTypeName == null) {
@@ -358,8 +358,6 @@ public class RESTDTOSetCallCheck extends BaseCheck {
 			return false;
 		}
 
-		String methodName = getMethodName(methodCallDetailAST);
-
 		for (JavaTerm javaTerm : javaClass.getChildJavaTerms()) {
 			if (!javaTerm.isJavaMethod()) {
 				continue;
@@ -367,7 +365,7 @@ public class RESTDTOSetCallCheck extends BaseCheck {
 
 			JavaMethod javaMethod = (JavaMethod)javaTerm;
 
-			if (!StringUtil.equals(methodName, javaMethod.getName())) {
+			if (!StringUtil.equals(names.get(1), javaMethod.getName())) {
 				continue;
 			}
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/RESTDTOSetCallCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/RESTDTOSetCallCheck.java
@@ -77,13 +77,14 @@ public class RESTDTOSetCallCheck extends BaseCheck {
 			if ((childDetailAST == null) ||
 				(childDetailAST.findFirstToken(TokenTypes.METHOD_REF) !=
 					null) ||
-				(childDetailAST.getType() == TokenTypes.LAMBDA)) {
+				(childDetailAST.getType() == TokenTypes.LAMBDA) ||
+				_hasUnsafeSupplierReturnType(absolutePath, childDetailAST)) {
 
 				return;
 			}
 		}
 
-		JavaClass javaClass = _getDTOJavaClass(
+		JavaClass javaClass = _getJavaClass(
 			absolutePath, fullyQualifiedTypeName);
 
 		if ((javaClass == null) ||
@@ -228,11 +229,11 @@ public class RESTDTOSetCallCheck extends BaseCheck {
 		return _bundleSymbolicNamesMap;
 	}
 
-	private JavaClass _getDTOJavaClass(
+	private JavaClass _getJavaClass(
 		String absolutePath, String fullyQualifiedTypeName) {
 
-		if (_dtoJavaClasses.containsKey(fullyQualifiedTypeName)) {
-			return _dtoJavaClasses.get(fullyQualifiedTypeName);
+		if (_javaClasses.containsKey(fullyQualifiedTypeName)) {
+			return _javaClasses.get(fullyQualifiedTypeName);
 		}
 
 		File javaFile = JavaSourceUtil.getJavaFile(
@@ -249,7 +250,7 @@ public class RESTDTOSetCallCheck extends BaseCheck {
 			javaClass = JavaClassParser.parseJavaClass(
 				SourceUtil.getAbsolutePath(javaFile), FileUtil.read(javaFile));
 
-			_dtoJavaClasses.put(fullyQualifiedTypeName, javaClass);
+			_javaClasses.put(fullyQualifiedTypeName, javaClass);
 
 			return javaClass;
 		}
@@ -306,6 +307,84 @@ public class RESTDTOSetCallCheck extends BaseCheck {
 		return false;
 	}
 
+	private boolean _hasUnsafeSupplierReturnType(
+		String absolutePath, DetailAST detailAST) {
+
+		if (detailAST.getType() != TokenTypes.EXPR) {
+			return false;
+		}
+
+		DetailAST methodCallDetailAST = detailAST.getFirstChild();
+
+		if ((methodCallDetailAST == null) ||
+			(methodCallDetailAST.getType() != TokenTypes.METHOD_CALL)) {
+
+			return false;
+		}
+
+		DetailAST firstChildDetailAST = methodCallDetailAST.getFirstChild();
+
+		if (firstChildDetailAST.getType() != TokenTypes.DOT) {
+			return false;
+		}
+
+		DetailAST qualifierDetailAST = firstChildDetailAST.getFirstChild();
+
+		if (qualifierDetailAST.getType() != TokenTypes.IDENT) {
+			return false;
+		}
+
+		String fullyQualifiedTypeName = null;
+
+		String qualifierName = qualifierDetailAST.getText();
+
+		if (Character.isUpperCase(qualifierName.charAt(0))) {
+			fullyQualifiedTypeName = getFullyQualifiedTypeName(
+				qualifierName, detailAST, false);
+		}
+		else {
+			fullyQualifiedTypeName = getVariableTypeName(
+				detailAST, qualifierName, false, false, true);
+		}
+
+		if (fullyQualifiedTypeName == null) {
+			return false;
+		}
+
+		JavaClass javaClass = _getJavaClass(
+			absolutePath, fullyQualifiedTypeName);
+
+		if (javaClass == null) {
+			return false;
+		}
+
+		String methodName = getMethodName(methodCallDetailAST);
+
+		for (JavaTerm javaTerm : javaClass.getChildJavaTerms()) {
+			if (!javaTerm.isJavaMethod()) {
+				continue;
+			}
+
+			JavaMethod javaMethod = (JavaMethod)javaTerm;
+
+			if (!StringUtil.equals(methodName, javaMethod.getName())) {
+				continue;
+			}
+
+			JavaSignature javaSignature = javaMethod.getSignature();
+
+			String returnType = javaSignature.getReturnType();
+
+			if ((returnType != null) &&
+				returnType.startsWith("UnsafeSupplier")) {
+
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 	private static final String _MSG_MOVE_STATEMENT = "statement.move";
 
 	private static final String _MSG_USE_SET_METHOD_INSTEAD =
@@ -315,7 +394,7 @@ public class RESTDTOSetCallCheck extends BaseCheck {
 		RESTDTOSetCallCheck.class);
 
 	private volatile Map<String, String> _bundleSymbolicNamesMap;
-	private final Map<String, JavaClass> _dtoJavaClasses = new HashMap<>();
+	private final Map<String, JavaClass> _javaClasses = new HashMap<>();
 	private volatile String _rootDirName;
 
 }


### PR DESCRIPTION
Forwarded manually from: https://github.com/liferay-headless/liferay-portal/pull/4076

---

https://liferay.atlassian.net/browse/LPD-96726

More context: https://github.com/liferay-headless/liferay-portal/pull/3989

## What Is Being Fixed

There was no way to control which embedded item fields are returned for Headless Search API results. Nested-field resolution leaked the generic `nestedFields` parameter into the Vulcan CRUD item delegate, coupling the embedded output to unrelated request state and producing inconsistent embedded fields.

## How It Is Being Fixed

The existing `nestedFields` parameter now supports an `embedded.` prefix on the Search API, so a request can declare exactly which nested fields of the embedded item to resolve (e.g. `nestedFields=embedded.taxonomyCategoryBriefs`).

- `NestedFieldsSupplier.supplyScopedUnsafeSupplier` scopes the `NestedFieldsContext` to a single property: the returned supplier only resolves when the property token is requested, rewrites the prefixed entries (`embedded.foo` → `foo`) for the nested resolution, resolves to `null` when no context is active, and honors the `nestedFieldsDepth` budget.
- `SearchResultResourceImpl` and `PerformanceTopAssetResourceImpl` set the `embedded` field through that scoped supplier, so the embedded item is fetched lazily and only with the fields the request asked for.
- `VulcanCRUDItemDelegateBuilderImpl` wraps the delegate so `NestedFieldsSetterUtil` resolves the `@NestedField` annotated fields of each fetched item against the active context, with a fallback context value (e.g. `Pagination`) for nested-field providers that require it. The setter now also enforces the depth budget, matching the supplier-based nested fields.
- `NestedFieldsContextThreadLocal` drops `getAndSetNestedFieldsContext` in favor of the `SafeCloseable` variant, bumping `portal-vulcan-api` to 49.0.0.
- `RESTDTOSetCallCheck` now allows DTO set calls whose argument is a method invocation returning an `UnsafeSupplier`, so the scoped supplier can be passed directly to generated DTO setters.

The behavior is covered by integration tests in `SearchResultResourceTest` and `BatchTestEntityResourceTest`, where the batch test entity embeds itself through the CRUD item delegate and asserts the scoped context, the lazy resolution, and the depth budget.

## PR Check

**pr-check: PASS** — tested on `49260784ac5d3a1403f309b925bf220dde8d5386`

| Validation | Result |
| --- | --- |
| REST Builder | PASS |
| Source Format | PASS |
| Transaction Usage | PASS |
| Full Portal Build | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "49260784ac5d3a1403f309b925bf220dde8d5386"} -->
