### PR TITLE
LPD-31352 Replace aui:container with clay:container in JSPs

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -3548,6 +3548,14 @@
 		"issueKey": "LPD-31312"
 	},
 	{
+		"from": "regex:aui:container",
+		"issueKey": "LPD-31352",
+		"to": "clay:container",
+		"validExtensions": [
+			"jsp"
+		]
+	},
+	{
 		"classNames": [
 			"CustomFacetPortletPreferences"
 		],

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_31352.testjsp
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_31352.testjsp
@@ -1,0 +1,8 @@
+<%--
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+--%>
+
+<clay:container></clay:container>

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_31352.testjsp
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_31352.testjsp
@@ -1,0 +1,8 @@
+<%--
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+--%>
+
+<aui:container></aui:container>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-31352

## What Is Being Fixed

The `aui:container` tag is deprecated in favor of `clay:container`, but JSPs across the repository still use it and nothing rewrote those usages automatically. Every occurrence had to be found and migrated by hand, so the deprecated tag kept reappearing in new code.

## How It Is Being Fixed

The source formatter already owns this class of mechanical upgrade through the catch-all replacement table, so the change adds an entry there rather than introducing a new check. The entry declares `aui:container` as the pattern and `clay:container` as its replacement, scoped to the `jsp` extension so the rewrite only reaches JSPs. Because the pattern matches the tag name rather than a whole element, the single entry rewrites both the opening and the closing tag.

The accompanying fixtures cover the upgrade catch-all check, asserting that the formatter turns `<aui:container></aui:container>` into `<clay:container></clay:container>`.

## PR Check

**pr-check: PASS** — tested on `cad200dba0b87fb65aa2c051f17aadd4bbe0ea3f`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "cad200dba0b87fb65aa2c051f17aadd4bbe0ea3f"} -->
