### PR TITLE
LPD-100229 Stop sorting the object entry collection by create date

### DIFF
--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/collection/provider/ObjectEntrySingleFormVariationInfoCollectionProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/collection/provider/ObjectEntrySingleFormVariationInfoCollectionProvider.java
@@ -802,7 +802,6 @@ public class ObjectEntrySingleFormVariationInfoCollectionProvider
 	};
 
 	private static final Sort[] _SORTS_DEFAULT_OBJECT_ENTRY = {
-		new Sort(Field.CREATE_DATE, Sort.LONG_TYPE, false),
 		new Sort("id", Sort.LONG_TYPE, false)
 	};
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100229

## What Is Being Fixed

`ObjectEntrySingleFormVariationInfoCollectionProvider` applied a default sort of create date then primary key on its two object entry manager paths. Create date lives on the joined `ObjectEntry` table and no `ObjectEntry` index matches this query's object definition, group and company equality prefix, so the database had to materialize and sort every matching entry on each collection render instead of walking the driving table's primary key and stopping at the page limit.

Introduced by 519da7256eb6cd79a26c5061ace068b085810d21, which added the create date key to make the results deterministic. Determinism was genuinely missing, but only for the display-all-items configuration, which passes `QueryUtil.ALL_POS` for both positions and so skips the default sort that `_applyOrderBy` injects. Every paginated configuration already ordered by the object entry id and was already deterministic, so there the create date key bought no determinism and cost the plan a full sort.

Measured with `EXPLAIN ANALYZE` against a schema clone carrying the exact generated index set, with 300000 entries in one object definition:

| | pre | post |
| --- | --- | --- |
| MySQL 8, first page of 20 | 0.29 ms, ordered primary key scan of 20 rows | 669 ms, sort of 300000 |
| PostgreSQL 16, first page of 20 | 0.465 ms with an ordered plan | no ordered plan exists; sort is mandatory |
| PostgreSQL 16, display all items | no sort | sort spills to disk (external merge) |

## How It Is Being Fixed

Order by the `"id"` system object field alone. The primary key is unique and therefore already a total order, while create date ties whenever entries are created within the same millisecond, so the primary key was resolving the order in every case that mattered. The two keys also agree in normal operation, because the id is allocated from the counter and the create date is stamped in the same method and transaction, and no API can supply a create date. The indexer path keeps its create date ordering, where the sort is a top-N comparison on indexed doc values rather than a database sort.

A supporting index was measured and rejected: it ties the sort change on the case it targets, collapses to a full sort under depot or multi-group scope where the group predicate becomes an `IN` list, is ignored outright by the PostgreSQL planner, and Service Builder cannot emit the required column order because it pins any column whose name ends in `Date` last.

## PR Check

**pr-check: PASS** — tested on `8d96ceb4c027c06fbe69f427814402b9f08ee090`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |
