### PR TITLE
LPD-98680 Call persistence directly instead of hopping through a same-bundle service pass-through

### DIFF
--- a/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderFiltersTest.java
+++ b/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderFiltersTest.java
@@ -197,6 +197,7 @@ public class AssetListAssetEntryProviderFiltersTest {
 			).put(
 				_OBJECT_FIELD_NAME_TEXT, title
 			).build());
+
 		_addObjectEntry(
 			HashMapBuilder.<String, Serializable>put(
 				_OBJECT_FIELD_NAME_INTEGER, priority

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/impl/CTCollectionLocalServiceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/impl/CTCollectionLocalServiceImpl.java
@@ -1093,7 +1093,7 @@ public class CTCollectionLocalServiceImpl
 		moveCTEntries(
 			fromCTCollectionId, toCTCollectionId,
 			Collections.singletonList(
-				_ctEntryPersistence.fetchByC_MCNI_MCPK(
+				_ctEntryPersistence.findByC_MCNI_MCPK(
 					fromCTCollectionId, modelClassNameId, modelClassPK)));
 	}
 

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/impl/CTCollectionLocalServiceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/impl/CTCollectionLocalServiceImpl.java
@@ -45,6 +45,7 @@ import com.liferay.change.tracking.service.persistence.CTCommentPersistence;
 import com.liferay.change.tracking.service.persistence.CTEntryPersistence;
 import com.liferay.change.tracking.service.persistence.CTMessagePersistence;
 import com.liferay.change.tracking.service.persistence.CTPreferencesPersistence;
+import com.liferay.change.tracking.service.persistence.CTSchemaVersionPersistence;
 import com.liferay.change.tracking.service.persistence.CTScorePersistence;
 import com.liferay.change.tracking.spi.display.CTDisplayRenderer;
 import com.liferay.change.tracking.spi.resolver.ConstraintResolver;
@@ -594,7 +595,7 @@ public class CTCollectionLocalServiceImpl
 
 		if (count == 1) {
 			CTSchemaVersion ctSchemaVersion =
-				_ctSchemaVersionLocalService.fetchCTSchemaVersion(
+				_ctSchemaVersionPersistence.fetchByPrimaryKey(
 					ctCollection.getSchemaVersionId());
 
 			if ((ctSchemaVersion != null) &&
@@ -1092,7 +1093,7 @@ public class CTCollectionLocalServiceImpl
 		moveCTEntries(
 			fromCTCollectionId, toCTCollectionId,
 			Collections.singletonList(
-				_ctEntryLocalService.fetchCTEntry(
+				_ctEntryPersistence.fetchByC_MCNI_MCPK(
 					fromCTCollectionId, modelClassNameId, modelClassPK)));
 	}
 
@@ -1871,6 +1872,9 @@ public class CTCollectionLocalServiceImpl
 
 	@Reference
 	private CTSchemaVersionLocalService _ctSchemaVersionLocalService;
+
+	@Reference
+	private CTSchemaVersionPersistence _ctSchemaVersionPersistence;
 
 	@Reference
 	private CTScorePersistence _ctScorePersistence;

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/impl/CTCollectionServiceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/impl/CTCollectionServiceImpl.java
@@ -219,7 +219,7 @@ public class CTCollectionServiceImpl extends CTCollectionServiceBaseImpl {
 		_ctCollectionModelResourcePermission.check(
 			getPermissionChecker(), ctCollectionId, CTActionKeys.PUBLISH);
 
-		CTCollection ctCollection = ctCollectionLocalService.getCTCollection(
+		CTCollection ctCollection = ctCollectionPersistence.findByPrimaryKey(
 			ctCollectionId);
 
 		if (ctCollection.getStatus() == WorkflowConstants.STATUS_APPROVED) {

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/impl/CTPreferencesServiceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/impl/CTPreferencesServiceImpl.java
@@ -11,8 +11,8 @@ import com.liferay.change.tracking.exception.CTStagingEnabledException;
 import com.liferay.change.tracking.model.CTCollection;
 import com.liferay.change.tracking.model.CTPreferences;
 import com.liferay.change.tracking.model.CTPreferencesTable;
-import com.liferay.change.tracking.service.CTCollectionLocalService;
 import com.liferay.change.tracking.service.base.CTPreferencesServiceBaseImpl;
+import com.liferay.change.tracking.service.persistence.CTCollectionPersistence;
 import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -52,7 +52,7 @@ public class CTPreferencesServiceImpl extends CTPreferencesServiceBaseImpl {
 
 		if (ctCollectionId != CTConstants.CT_COLLECTION_ID_PRODUCTION) {
 			CTCollection ctCollection =
-				_ctCollectionLocalService.fetchCTCollection(ctCollectionId);
+				_ctCollectionPersistence.fetchByPrimaryKey(ctCollectionId);
 
 			if ((ctCollection == null) || !ctCollection.isInProgress()) {
 				return null;
@@ -136,14 +136,14 @@ public class CTPreferencesServiceImpl extends CTPreferencesServiceBaseImpl {
 		return null;
 	}
 
-	@Reference
-	private CTCollectionLocalService _ctCollectionLocalService;
-
 	@Reference(
 		target = "(model.class.name=com.liferay.change.tracking.model.CTCollection)"
 	)
 	private ModelResourcePermission<CTCollection>
 		_ctCollectionModelResourcePermission;
+
+	@Reference
+	private CTCollectionPersistence _ctCollectionPersistence;
 
 	@Reference
 	private GroupLocalService _groupLocalService;

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/impl/CTProcessLocalServiceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/impl/CTProcessLocalServiceImpl.java
@@ -11,6 +11,7 @@ import com.liferay.change.tracking.model.CTProcess;
 import com.liferay.change.tracking.service.CTCollectionLocalService;
 import com.liferay.change.tracking.service.CTPreferencesLocalService;
 import com.liferay.change.tracking.service.base.CTProcessLocalServiceBaseImpl;
+import com.liferay.change.tracking.service.persistence.CTCollectionPersistence;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.background.task.model.BackgroundTask;
@@ -54,7 +55,7 @@ public class CTProcessLocalServiceImpl extends CTProcessLocalServiceBaseImpl {
 	public CTProcess addCTProcess(long userId, long ctCollectionId)
 		throws PortalException {
 
-		CTCollection ctCollection = _ctCollectionLocalService.getCTCollection(
+		CTCollection ctCollection = _ctCollectionPersistence.findByPrimaryKey(
 			ctCollectionId);
 
 		if (ctCollection.getStatus() == WorkflowConstants.STATUS_APPROVED) {
@@ -143,7 +144,7 @@ public class CTProcessLocalServiceImpl extends CTProcessLocalServiceBaseImpl {
 					BackgroundTaskConstants.STATUS_SUCCESSFUL) {
 
 				CTCollection ctCollection =
-					_ctCollectionLocalService.fetchCTCollection(
+					_ctCollectionPersistence.fetchByPrimaryKey(
 						ctProcess.getCtCollectionId());
 
 				if (ctCollection != null) {
@@ -184,6 +185,9 @@ public class CTProcessLocalServiceImpl extends CTProcessLocalServiceBaseImpl {
 
 	@Reference
 	private CTCollectionLocalService _ctCollectionLocalService;
+
+	@Reference
+	private CTCollectionPersistence _ctCollectionPersistence;
 
 	@Reference
 	private CTPreferencesLocalService _ctPreferencesLocalService;

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/impl/CTProcessServiceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/impl/CTProcessServiceImpl.java
@@ -49,7 +49,8 @@ public class CTProcessServiceImpl extends CTProcessServiceBaseImpl {
 		_ctProcessModelResourcePermission.check(
 			getPermissionChecker(), ctProcessId, ActionKeys.DELETE);
 
-		CTProcess ctProcess = ctProcessLocalService.getCTProcess(ctProcessId);
+		CTProcess ctProcess = ctProcessPersistence.findByPrimaryKey(
+			ctProcessId);
 
 		return ctProcessLocalService.deleteCTProcess(ctProcess);
 	}

--- a/modules/apps/commerce/commerce-order-rule-service/src/main/java/com/liferay/commerce/order/rule/service/impl/COREntryLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-order-rule-service/src/main/java/com/liferay/commerce/order/rule/service/impl/COREntryLocalServiceImpl.java
@@ -373,7 +373,7 @@ public class COREntryLocalServiceImpl extends COREntryLocalServiceBaseImpl {
 			ServiceContext serviceContext)
 		throws PortalException {
 
-		COREntry corEntry = corEntryLocalService.getCOREntry(corEntryId);
+		COREntry corEntry = corEntryPersistence.findByPrimaryKey(corEntryId);
 
 		corEntry.setActive(active);
 		corEntry.setDescription(description);

--- a/modules/apps/commerce/commerce-order-rule-service/src/main/java/com/liferay/commerce/order/rule/service/impl/COREntryRelServiceImpl.java
+++ b/modules/apps/commerce/commerce-order-rule-service/src/main/java/com/liferay/commerce/order/rule/service/impl/COREntryRelServiceImpl.java
@@ -12,6 +12,7 @@ import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.util.OrderByComparator;
 
 import java.util.List;
@@ -46,7 +47,7 @@ public class COREntryRelServiceImpl extends COREntryRelServiceBaseImpl {
 
 	@Override
 	public void deleteCOREntryRel(long corEntryRelId) throws PortalException {
-		COREntryRel corEntryRel = corEntryRelLocalService.getCOREntryRel(
+		COREntryRel corEntryRel = corEntryRelPersistence.findByPrimaryKey(
 			corEntryRelId);
 
 		_corEntryModelResourcePermission.check(
@@ -84,8 +85,9 @@ public class COREntryRelServiceImpl extends COREntryRelServiceBaseImpl {
 		_corEntryModelResourcePermission.check(
 			getPermissionChecker(), corEntryId, ActionKeys.VIEW);
 
-		return corEntryRelLocalService.fetchCOREntryRel(
-			className, classPK, corEntryId);
+		return corEntryRelPersistence.fetchByC_C_C(
+			_classNameLocalService.getClassNameId(className), classPK,
+			corEntryId);
 	}
 
 	@Override
@@ -188,7 +190,7 @@ public class COREntryRelServiceImpl extends COREntryRelServiceBaseImpl {
 	public COREntryRel getCOREntryRel(long corEntryRelId)
 		throws PortalException {
 
-		COREntryRel corEntryRel = corEntryRelLocalService.getCOREntryRel(
+		COREntryRel corEntryRel = corEntryRelPersistence.findByPrimaryKey(
 			corEntryRelId);
 
 		_corEntryModelResourcePermission.check(
@@ -205,7 +207,7 @@ public class COREntryRelServiceImpl extends COREntryRelServiceBaseImpl {
 		_corEntryModelResourcePermission.check(
 			getPermissionChecker(), corEntryId, ActionKeys.VIEW);
 
-		return corEntryRelLocalService.getCOREntryRels(corEntryId);
+		return corEntryRelPersistence.findByCOREntryId(corEntryId);
 	}
 
 	@Override
@@ -217,7 +219,7 @@ public class COREntryRelServiceImpl extends COREntryRelServiceBaseImpl {
 		_corEntryModelResourcePermission.check(
 			getPermissionChecker(), corEntryId, ActionKeys.VIEW);
 
-		return corEntryRelLocalService.getCOREntryRels(
+		return corEntryRelPersistence.findByCOREntryId(
 			corEntryId, start, end, orderByComparator);
 	}
 
@@ -226,8 +228,11 @@ public class COREntryRelServiceImpl extends COREntryRelServiceBaseImpl {
 		_corEntryModelResourcePermission.check(
 			getPermissionChecker(), corEntryId, ActionKeys.VIEW);
 
-		return corEntryRelLocalService.getCOREntryRelsCount(corEntryId);
+		return corEntryRelPersistence.countByCOREntryId(corEntryId);
 	}
+
+	@Reference
+	private ClassNameLocalService _classNameLocalService;
 
 	@Reference(
 		target = "(model.class.name=com.liferay.commerce.order.rule.model.COREntry)"

--- a/modules/apps/commerce/commerce-order-rule-service/src/main/java/com/liferay/commerce/order/rule/service/impl/COREntryServiceImpl.java
+++ b/modules/apps/commerce/commerce-order-rule-service/src/main/java/com/liferay/commerce/order/rule/service/impl/COREntryServiceImpl.java
@@ -68,7 +68,7 @@ public class COREntryServiceImpl extends COREntryServiceBaseImpl {
 
 	@Override
 	public COREntry fetchCOREntry(long corEntryId) throws PortalException {
-		COREntry corEntry = corEntryLocalService.fetchCOREntry(corEntryId);
+		COREntry corEntry = corEntryPersistence.fetchByPrimaryKey(corEntryId);
 
 		if (corEntry != null) {
 			_corEntryModelResourcePermission.check(
@@ -83,9 +83,8 @@ public class COREntryServiceImpl extends COREntryServiceBaseImpl {
 			long companyId, String externalReferenceCode)
 		throws PortalException {
 
-		COREntry corEntry =
-			corEntryLocalService.fetchCOREntryByExternalReferenceCode(
-				externalReferenceCode, companyId);
+		COREntry corEntry = corEntryPersistence.fetchByERC_C(
+			externalReferenceCode, companyId);
 
 		if (corEntry != null) {
 			_corEntryModelResourcePermission.check(
@@ -121,7 +120,7 @@ public class COREntryServiceImpl extends COREntryServiceBaseImpl {
 		portletResourcePermission.check(
 			getPermissionChecker(), null, COREntryActionKeys.VIEW_COR_ENTRIES);
 
-		return corEntryLocalService.getCOREntries(
+		return corEntryPersistence.findByC_A_LikeType(
 			companyId, active, type, start, end);
 	}
 
@@ -144,7 +143,7 @@ public class COREntryServiceImpl extends COREntryServiceBaseImpl {
 		_corEntryModelResourcePermission.check(
 			getPermissionChecker(), corEntryId, ActionKeys.VIEW);
 
-		return corEntryLocalService.getCOREntry(corEntryId);
+		return corEntryPersistence.findByPrimaryKey(corEntryId);
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPAttachmentFileEntryLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPAttachmentFileEntryLocalServiceImpl.java
@@ -645,7 +645,7 @@ public class CPAttachmentFileEntryLocalServiceImpl
 					start, end
 				)),
 			cpAttachmentFileEntryId ->
-				cpAttachmentFileEntryLocalService.getCPAttachmentFileEntry(
+				cpAttachmentFileEntryPersistence.findByPrimaryKey(
 					(Long)cpAttachmentFileEntryId));
 	}
 

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPAttachmentFileEntryServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPAttachmentFileEntryServiceImpl.java
@@ -13,9 +13,9 @@ import com.liferay.commerce.product.exception.NoSuchCPDefinitionException;
 import com.liferay.commerce.product.model.CPAttachmentFileEntry;
 import com.liferay.commerce.product.model.CPDefinition;
 import com.liferay.commerce.product.model.CommerceCatalog;
-import com.liferay.commerce.product.service.CPDefinitionLocalService;
 import com.liferay.commerce.product.service.CommerceCatalogLocalService;
 import com.liferay.commerce.product.service.base.CPAttachmentFileEntryServiceBaseImpl;
+import com.liferay.commerce.product.service.persistence.CPDefinitionPersistence;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
 import com.liferay.petra.function.transform.TransformUtil;
@@ -139,7 +139,7 @@ public class CPAttachmentFileEntryServiceImpl
 		throws PortalException {
 
 		CPAttachmentFileEntry cpAttachmentFileEntry =
-			cpAttachmentFileEntryLocalService.fetchCPAttachmentFileEntry(
+			cpAttachmentFileEntryPersistence.fetchByPrimaryKey(
 				cpAttachmentFileEntryId);
 
 		if (cpAttachmentFileEntry != null) {
@@ -322,7 +322,7 @@ public class CPAttachmentFileEntryServiceImpl
 		throws PortalException {
 
 		CPAttachmentFileEntry cpAttachmentFileEntry =
-			cpAttachmentFileEntryLocalService.getCPAttachmentFileEntry(
+			cpAttachmentFileEntryPersistence.findByPrimaryKey(
 				cpAttachmentFileEntryId);
 
 		if (cpAttachmentFileEntry != null) {
@@ -379,7 +379,7 @@ public class CPAttachmentFileEntryServiceImpl
 	private void _checkCommerceCatalog(long cpDefinitionId, String actionId)
 		throws PortalException {
 
-		CPDefinition cpDefinition = _cpDefinitionLocalService.fetchCPDefinition(
+		CPDefinition cpDefinition = _cpDefinitionPersistence.fetchByPrimaryKey(
 			cpDefinitionId);
 
 		if (cpDefinition == null) {
@@ -414,7 +414,7 @@ public class CPAttachmentFileEntryServiceImpl
 		throws PortalException {
 
 		_checkCPAttachmentFileEntryPermissions(
-			cpAttachmentFileEntryLocalService.getCPAttachmentFileEntry(
+			cpAttachmentFileEntryPersistence.findByPrimaryKey(
 				cpAttachmentFileEntryId));
 	}
 
@@ -461,7 +461,7 @@ public class CPAttachmentFileEntryServiceImpl
 		_commerceCatalogModelResourcePermission;
 
 	@Reference
-	private CPDefinitionLocalService _cpDefinitionLocalService;
+	private CPDefinitionPersistence _cpDefinitionPersistence;
 
 	@Reference
 	private DLFileEntryLocalService _dlFileEntryLocalService;

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPConfigurationEntryLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPConfigurationEntryLocalServiceImpl.java
@@ -431,6 +431,10 @@ public class CPConfigurationEntryLocalServiceImpl
 				parentCPConfigurationList.getCPConfigurationListId();
 		}
 
+		if (parentCPConfigurationEntry == null) {
+			return null;
+		}
+
 		return _cpConfigurationEntrySettingLocalService.
 			fetchCPConfigurationEntrySetting(
 				parentCPConfigurationEntry.getCPConfigurationEntryId(),

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPConfigurationEntryLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPConfigurationEntryLocalServiceImpl.java
@@ -171,7 +171,7 @@ public class CPConfigurationEntryLocalServiceImpl
 		throws PortalException {
 
 		for (CPConfigurationEntry cpConfigurationEntry :
-				cpConfigurationEntryLocalService.getCPConfigurationEntries(
+				cpConfigurationEntryPersistence.findByCPConfigurationListId(
 					cpConfigurationListId)) {
 
 			cpConfigurationEntryLocalService.deleteCPConfigurationEntry(
@@ -416,7 +416,7 @@ public class CPConfigurationEntryLocalServiceImpl
 
 		while (parentCPConfigurationEntry == null) {
 			parentCPConfigurationEntry =
-				cpConfigurationEntryLocalService.fetchCPConfigurationEntry(
+				cpConfigurationEntryPersistence.fetchByC_C_C(
 					cpConfigurationEntry.getClassNameId(),
 					cpConfigurationEntry.getClassPK(), cpConfigurationListId);
 

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPConfigurationEntryServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPConfigurationEntryServiceImpl.java
@@ -67,7 +67,7 @@ public class CPConfigurationEntryServiceImpl
 		throws PortalException {
 
 		CPConfigurationEntry cpConfigurationEntry =
-			cpConfigurationEntryLocalService.getCPConfigurationEntry(
+			cpConfigurationEntryPersistence.findByPrimaryKey(
 				cpConfigurationEntryId);
 
 		_checkCommerceCatalog(
@@ -83,7 +83,7 @@ public class CPConfigurationEntryServiceImpl
 		throws PortalException {
 
 		CPConfigurationEntry cpConfigurationEntry =
-			cpConfigurationEntryLocalService.getCPConfigurationEntry(
+			cpConfigurationEntryPersistence.findByPrimaryKey(
 				cpConfigurationEntryId);
 
 		_checkCommerceCatalog(
@@ -98,7 +98,7 @@ public class CPConfigurationEntryServiceImpl
 		throws PortalException {
 
 		CPConfigurationEntry cpConfigurationEntry =
-			cpConfigurationEntryLocalService.getCPConfigurationEntry(
+			cpConfigurationEntryPersistence.findByC_C_C(
 				classNameId, classPK, cpConfigurationListId);
 
 		_checkCommerceCatalog(
@@ -139,7 +139,7 @@ public class CPConfigurationEntryServiceImpl
 		throws PortalException {
 
 		CPConfigurationEntry cpConfigurationEntry =
-			cpConfigurationEntryLocalService.getCPConfigurationEntry(
+			cpConfigurationEntryPersistence.findByPrimaryKey(
 				cpConfigurationEntryId);
 
 		_checkCommerceCatalog(

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPConfigurationListLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPConfigurationListLocalServiceImpl.java
@@ -203,7 +203,7 @@ public class CPConfigurationListLocalServiceImpl
 				}
 
 				CPConfigurationList parentCPConfigurationList =
-					cpConfigurationListLocalService.getCPConfigurationList(
+					cpConfigurationListPersistence.findByPrimaryKey(
 						parentCPConfigurationListId);
 
 				parentCPConfigurationListId =
@@ -681,7 +681,7 @@ public class CPConfigurationListLocalServiceImpl
 			}
 
 			CPConfigurationList cpConfigurationList =
-				cpConfigurationListLocalService.fetchCPConfigurationList(
+				cpConfigurationListPersistence.fetchByPrimaryKey(
 					parentCPConfigurationListId);
 
 			if ((cpConfigurationList != null) &&

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPConfigurationListRelLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPConfigurationListRelLocalServiceImpl.java
@@ -17,8 +17,8 @@ import com.liferay.commerce.product.model.CPConfigurationList;
 import com.liferay.commerce.product.model.CPConfigurationListRel;
 import com.liferay.commerce.product.model.CPConfigurationListRelTable;
 import com.liferay.commerce.product.model.CPConfigurationListTable;
-import com.liferay.commerce.product.service.CPConfigurationListLocalService;
 import com.liferay.commerce.product.service.base.CPConfigurationListRelLocalServiceBaseImpl;
+import com.liferay.commerce.product.service.persistence.CPConfigurationListPersistence;
 import com.liferay.petra.sql.dsl.DSLFunctionFactoryUtil;
 import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.petra.sql.dsl.Table;
@@ -365,7 +365,7 @@ public class CPConfigurationListRelLocalServiceImpl
 		throws PortalException {
 
 		CPConfigurationList cpConfigurationList =
-			_cpConfigurationListLocalService.getCPConfigurationList(
+			_cpConfigurationListPersistence.findByPrimaryKey(
 				cpConfigurationListId);
 
 		if (cpConfigurationList.isMaster()) {
@@ -385,7 +385,7 @@ public class CPConfigurationListRelLocalServiceImpl
 	private ClassNameLocalService _classNameLocalService;
 
 	@Reference
-	private CPConfigurationListLocalService _cpConfigurationListLocalService;
+	private CPConfigurationListPersistence _cpConfigurationListPersistence;
 
 	@Reference
 	private CustomSQL _customSQL;

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPConfigurationListRelServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPConfigurationListRelServiceImpl.java
@@ -8,15 +8,16 @@ package com.liferay.commerce.product.service.impl;
 import com.liferay.commerce.product.model.CPConfigurationList;
 import com.liferay.commerce.product.model.CPConfigurationListRel;
 import com.liferay.commerce.product.model.CommerceCatalog;
-import com.liferay.commerce.product.service.CPConfigurationListLocalService;
 import com.liferay.commerce.product.service.CommerceCatalogLocalService;
 import com.liferay.commerce.product.service.base.CPConfigurationListRelServiceBaseImpl;
+import com.liferay.commerce.product.service.persistence.CPConfigurationListPersistence;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.util.OrderByComparator;
 
@@ -69,7 +70,7 @@ public class CPConfigurationListRelServiceImpl
 		throws PortalException {
 
 		CPConfigurationListRel cpConfigurationListRel =
-			cpConfigurationListRelLocalService.getCPConfigurationListRel(
+			cpConfigurationListRelPersistence.findByPrimaryKey(
 				cpConfigurationListRelId);
 
 		_checkCommerceCatalog(
@@ -108,8 +109,9 @@ public class CPConfigurationListRelServiceImpl
 
 		_checkCommerceCatalog(cpConfigurationListId, ActionKeys.VIEW);
 
-		return cpConfigurationListRelLocalService.fetchCPConfigurationListRel(
-			className, classPK, cpConfigurationListId);
+		return cpConfigurationListRelPersistence.fetchByC_C_C(
+			_classNameLocalService.getClassNameId(className), classPK,
+			cpConfigurationListId);
 	}
 
 	@Override
@@ -190,7 +192,7 @@ public class CPConfigurationListRelServiceImpl
 			long cpConfigurationListRelId)
 		throws PortalException {
 
-		return cpConfigurationListRelLocalService.getCPConfigurationListRel(
+		return cpConfigurationListRelPersistence.findByPrimaryKey(
 			cpConfigurationListRelId);
 	}
 
@@ -201,7 +203,7 @@ public class CPConfigurationListRelServiceImpl
 
 		_checkCommerceCatalog(cpConfigurationListId, ActionKeys.VIEW);
 
-		return cpConfigurationListRelLocalService.getCPConfigurationListRels(
+		return cpConfigurationListRelPersistence.findByCPConfigurationListId(
 			cpConfigurationListId);
 	}
 
@@ -213,7 +215,7 @@ public class CPConfigurationListRelServiceImpl
 
 		_checkCommerceCatalog(cpConfigurationListId, ActionKeys.VIEW);
 
-		return cpConfigurationListRelLocalService.getCPConfigurationListRels(
+		return cpConfigurationListRelPersistence.findByCPConfigurationListId(
 			cpConfigurationListId, start, end, orderByComparator);
 	}
 
@@ -236,8 +238,9 @@ public class CPConfigurationListRelServiceImpl
 
 		_checkCommerceCatalog(cpConfigurationListId, ActionKeys.VIEW);
 
-		return cpConfigurationListRelLocalService.getCPConfigurationListRels(
-			className, cpConfigurationListId, start, end, orderByComparator);
+		return cpConfigurationListRelPersistence.findByC_C(
+			_classNameLocalService.getClassNameId(className),
+			cpConfigurationListId, start, end, orderByComparator);
 	}
 
 	@Override
@@ -266,7 +269,7 @@ public class CPConfigurationListRelServiceImpl
 		throws PortalException {
 
 		CPConfigurationList cpConfigurationList =
-			_cpConfigurationListLocalService.getCPConfigurationList(
+			_cpConfigurationListPersistence.findByPrimaryKey(
 				cpConfigurationListId);
 
 		CommerceCatalog commerceCatalog =
@@ -282,6 +285,9 @@ public class CPConfigurationListRelServiceImpl
 	}
 
 	@Reference
+	private ClassNameLocalService _classNameLocalService;
+
+	@Reference
 	private CommerceCatalogLocalService _commerceCatalogLocalService;
 
 	@Reference(
@@ -291,6 +297,6 @@ public class CPConfigurationListRelServiceImpl
 		_commerceCatalogModelResourcePermission;
 
 	@Reference
-	private CPConfigurationListLocalService _cpConfigurationListLocalService;
+	private CPConfigurationListPersistence _cpConfigurationListPersistence;
 
 }

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPConfigurationListServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPConfigurationListServiceImpl.java
@@ -105,7 +105,7 @@ public class CPConfigurationListServiceImpl
 		throws PortalException {
 
 		CPConfigurationList cpConfigurationList =
-			cpConfigurationListLocalService.getCPConfigurationList(
+			cpConfigurationListPersistence.findByPrimaryKey(
 				cpConfigurationListId);
 
 		_checkCommerceCatalog(
@@ -138,7 +138,7 @@ public class CPConfigurationListServiceImpl
 		throws PortalException {
 
 		CPConfigurationList cpConfigurationList =
-			cpConfigurationListLocalService.getCPConfigurationList(
+			cpConfigurationListPersistence.findByPrimaryKey(
 				cpConfigurationLisId);
 
 		_checkCommerceCatalog(
@@ -194,8 +194,8 @@ public class CPConfigurationListServiceImpl
 
 		_checkCommerceCatalog(groupId, ActionKeys.VIEW);
 
-		return cpConfigurationListLocalService.getMasterCPConfigurationList(
-			groupId);
+		return cpConfigurationListPersistence.findByG_M_First(
+			groupId, true, null);
 	}
 
 	@Indexable(type = IndexableType.REINDEX)

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPDefinitionLinkServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPDefinitionLinkServiceImpl.java
@@ -302,7 +302,7 @@ public class CPDefinitionLinkServiceImpl
 
 		for (int i = 0; i < cProductIds.length; i++) {
 			CPDefinition cpDefinition =
-				_cpDefinitionPersistence.fetchByPrimaryKey(cpDefinitionIds2[i]);
+				_cpDefinitionPersistence.findByPrimaryKey(cpDefinitionIds2[i]);
 
 			cProductIds[i] = cpDefinition.getCProductId();
 		}

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPDefinitionLinkServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPDefinitionLinkServiceImpl.java
@@ -10,9 +10,9 @@ import com.liferay.commerce.product.model.CPDefinition;
 import com.liferay.commerce.product.model.CPDefinitionLink;
 import com.liferay.commerce.product.model.CProduct;
 import com.liferay.commerce.product.model.CommerceCatalog;
-import com.liferay.commerce.product.service.CPDefinitionLocalService;
 import com.liferay.commerce.product.service.CommerceCatalogLocalService;
 import com.liferay.commerce.product.service.base.CPDefinitionLinkServiceBaseImpl;
+import com.liferay.commerce.product.service.persistence.CPDefinitionPersistence;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
@@ -66,8 +66,7 @@ public class CPDefinitionLinkServiceImpl
 		throws PortalException {
 
 		CPDefinitionLink cpDefinitionLink =
-			cpDefinitionLinkLocalService.getCPDefinitionLink(
-				cpDefinitionLinkId);
+			cpDefinitionLinkPersistence.findByPrimaryKey(cpDefinitionLinkId);
 
 		_checkCommerceCatalog(
 			cpDefinitionLink.getCPDefinitionId(), ActionKeys.UPDATE);
@@ -85,8 +84,7 @@ public class CPDefinitionLinkServiceImpl
 		throws PortalException {
 
 		CPDefinitionLink cpDefinitionLink =
-			cpDefinitionLinkLocalService.fetchCPDefinitionLink(
-				cpDefinitionLinkId);
+			cpDefinitionLinkPersistence.fetchByPrimaryKey(cpDefinitionLinkId);
 
 		if (cpDefinitionLink != null) {
 			_checkCommerceCatalog(
@@ -108,7 +106,7 @@ public class CPDefinitionLinkServiceImpl
 
 		_checkCommerceCatalog(cpDefinitionId, ActionKeys.VIEW);
 
-		return cpDefinitionLinkLocalService.fetchCPDefinitionLink(
+		return cpDefinitionLinkPersistence.fetchByC_C_T(
 			cpDefinitionId, cProductId, type);
 	}
 
@@ -117,8 +115,7 @@ public class CPDefinitionLinkServiceImpl
 		throws PortalException {
 
 		CPDefinitionLink cpDefinitionLink =
-			cpDefinitionLinkLocalService.getCPDefinitionLink(
-				cpDefinitionLinkId);
+			cpDefinitionLinkPersistence.findByPrimaryKey(cpDefinitionLinkId);
 
 		CProduct cProduct = cpDefinitionLink.getCProduct();
 
@@ -128,8 +125,7 @@ public class CPDefinitionLinkServiceImpl
 		_checkCommerceCatalog(
 			cpDefinitionLink.getCPDefinitionId(), ActionKeys.VIEW);
 
-		return cpDefinitionLinkLocalService.getCPDefinitionLink(
-			cpDefinitionLinkId);
+		return cpDefinitionLinkPersistence.findByPrimaryKey(cpDefinitionLinkId);
 	}
 
 	@Override
@@ -138,8 +134,7 @@ public class CPDefinitionLinkServiceImpl
 
 		_checkCommerceCatalog(cpDefinitionId, ActionKeys.VIEW);
 
-		return cpDefinitionLinkLocalService.getCPDefinitionLinks(
-			cpDefinitionId);
+		return cpDefinitionLinkPersistence.findByCPDefinitionId(cpDefinitionId);
 	}
 
 	@Override
@@ -171,7 +166,7 @@ public class CPDefinitionLinkServiceImpl
 
 		_checkCommerceCatalog(cpDefinitionId, ActionKeys.VIEW);
 
-		return cpDefinitionLinkLocalService.getCPDefinitionLinks(
+		return cpDefinitionLinkPersistence.findByCPD_S(
 			cpDefinitionId, status, start, end);
 	}
 
@@ -205,7 +200,7 @@ public class CPDefinitionLinkServiceImpl
 
 		_checkCommerceCatalog(cpDefinitionId, ActionKeys.VIEW);
 
-		return cpDefinitionLinkLocalService.getCPDefinitionLinks(
+		return cpDefinitionLinkPersistence.findByCPD_T_S(
 			cpDefinitionId, type, status, start, end, orderByComparator);
 	}
 
@@ -217,7 +212,7 @@ public class CPDefinitionLinkServiceImpl
 
 		_checkCommerceCatalog(cpDefinitionId, ActionKeys.VIEW);
 
-		return cpDefinitionLinkLocalService.getCPDefinitionLinks(
+		return cpDefinitionLinkPersistence.findByCPD_T(
 			cpDefinitionId, type, start, end, orderByComparator);
 	}
 
@@ -227,7 +222,7 @@ public class CPDefinitionLinkServiceImpl
 
 		_checkCommerceCatalog(cpDefinitionId, ActionKeys.VIEW);
 
-		return cpDefinitionLinkLocalService.getCPDefinitionLinksCount(
+		return cpDefinitionLinkPersistence.countByCPDefinitionId(
 			cpDefinitionId);
 	}
 
@@ -258,7 +253,7 @@ public class CPDefinitionLinkServiceImpl
 
 		_checkCommerceCatalog(cpDefinitionId, ActionKeys.VIEW);
 
-		return cpDefinitionLinkLocalService.getCPDefinitionLinksCount(
+		return cpDefinitionLinkPersistence.countByCPD_T_S(
 			cpDefinitionId, type, status);
 	}
 
@@ -273,8 +268,7 @@ public class CPDefinitionLinkServiceImpl
 		throws PortalException {
 
 		CPDefinitionLink cpDefinitionLink =
-			cpDefinitionLinkLocalService.getCPDefinitionLink(
-				cpDefinitionLinkId);
+			cpDefinitionLinkPersistence.findByPrimaryKey(cpDefinitionLinkId);
 
 		_checkCommerceCatalog(
 			cpDefinitionLink.getCPDefinitionId(), ActionKeys.UPDATE);
@@ -308,8 +302,7 @@ public class CPDefinitionLinkServiceImpl
 
 		for (int i = 0; i < cProductIds.length; i++) {
 			CPDefinition cpDefinition =
-				_cpDefinitionLocalService.fetchCPDefinition(
-					cpDefinitionIds2[i]);
+				_cpDefinitionPersistence.fetchByPrimaryKey(cpDefinitionIds2[i]);
 
 			cProductIds[i] = cpDefinition.getCProductId();
 		}
@@ -321,7 +314,7 @@ public class CPDefinitionLinkServiceImpl
 	private void _checkCommerceCatalog(long cpDefinitionId, String actionId)
 		throws PortalException {
 
-		CPDefinition cpDefinition = _cpDefinitionLocalService.fetchCPDefinition(
+		CPDefinition cpDefinition = _cpDefinitionPersistence.fetchByPrimaryKey(
 			cpDefinitionId);
 
 		if (cpDefinition == null) {
@@ -350,6 +343,6 @@ public class CPDefinitionLinkServiceImpl
 		_commerceCatalogModelResourcePermission;
 
 	@Reference
-	private CPDefinitionLocalService _cpDefinitionLocalService;
+	private CPDefinitionPersistence _cpDefinitionPersistence;
 
 }

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPDefinitionLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPDefinitionLocalServiceImpl.java
@@ -54,7 +54,6 @@ import com.liferay.commerce.product.model.impl.CPDefinitionImpl;
 import com.liferay.commerce.product.model.impl.CPDefinitionModelImpl;
 import com.liferay.commerce.product.service.CPAttachmentFileEntryLocalService;
 import com.liferay.commerce.product.service.CPConfigurationEntryLocalService;
-import com.liferay.commerce.product.service.CPConfigurationListLocalService;
 import com.liferay.commerce.product.service.CPDefinitionLinkLocalService;
 import com.liferay.commerce.product.service.CPDefinitionOptionRelLocalService;
 import com.liferay.commerce.product.service.CPDefinitionSpecificationOptionValueLocalService;
@@ -67,6 +66,8 @@ import com.liferay.commerce.product.service.CommerceChannelLocalService;
 import com.liferay.commerce.product.service.CommerceChannelRelLocalService;
 import com.liferay.commerce.product.service.base.CPDefinitionLocalServiceBaseImpl;
 import com.liferay.commerce.product.service.persistence.CPAttachmentFileEntryPersistence;
+import com.liferay.commerce.product.service.persistence.CPConfigurationEntryPersistence;
+import com.liferay.commerce.product.service.persistence.CPConfigurationListPersistence;
 import com.liferay.commerce.product.service.persistence.CPDefinitionLinkPersistence;
 import com.liferay.commerce.product.service.persistence.CPDefinitionOptionRelPersistence;
 import com.liferay.commerce.product.service.persistence.CPDefinitionOptionValueRelPersistence;
@@ -498,7 +499,7 @@ public class CPDefinitionLocalServiceImpl
 		User user = _userLocalService.getUser(userId);
 
 		CPDefinition originalCPDefinition =
-			cpDefinitionLocalService.getCPDefinition(cpDefinitionId);
+			cpDefinitionPersistence.findByPrimaryKey(cpDefinitionId);
 
 		CPDefinition newCPDefinition =
 			(CPDefinition)originalCPDefinition.clone();
@@ -863,7 +864,7 @@ public class CPDefinitionLocalServiceImpl
 		throws PortalException {
 
 		CPDefinition sourceCPDefinition =
-			cpDefinitionLocalService.getCPDefinition(sourceCPDefinitionId);
+			cpDefinitionPersistence.findByPrimaryKey(sourceCPDefinitionId);
 
 		return cpDefinitionLocalService.copyCPDefinition(
 			sourceCPDefinitionId, sourceCPDefinition.getGroupId(),
@@ -877,7 +878,7 @@ public class CPDefinitionLocalServiceImpl
 		throws PortalException {
 
 		CPDefinition sourceCPDefinition =
-			cpDefinitionLocalService.getCPDefinition(sourceCPDefinitionId);
+			cpDefinitionPersistence.findByPrimaryKey(sourceCPDefinitionId);
 
 		CProduct sourceCProduct = sourceCPDefinition.getCProduct();
 
@@ -898,7 +899,7 @@ public class CPDefinitionLocalServiceImpl
 			(status == WorkflowConstants.STATUS_DRAFT)) {
 
 			for (CPDefinition cProductCPDefinition :
-					cpDefinitionLocalService.getCProductCPDefinitions(
+					cpDefinitionPersistence.findByC_S(
 						sourceCPDefinition.getCProductId(),
 						WorkflowConstants.STATUS_DRAFT, QueryUtil.ALL_POS,
 						QueryUtil.ALL_POS)) {
@@ -997,11 +998,11 @@ public class CPDefinitionLocalServiceImpl
 		}
 
 		CPConfigurationList masterCPConfigurationList =
-			_cpConfigurationListLocalService.getMasterCPConfigurationList(
-				sourceCPDefinition.getGroupId());
+			_cpConfigurationListPersistence.findByG_M_First(
+				sourceCPDefinition.getGroupId(), true, null);
 
 		CPConfigurationEntry cpConfigurationEntry =
-			_cpConfigurationEntryLocalService.fetchCPConfigurationEntry(
+			_cpConfigurationEntryPersistence.fetchByC_C_C(
 				_classNameLocalService.getClassNameId(
 					CPDefinition.class.getName()),
 				sourceCPDefinitionId, masterCPConfigurationList.getGroupId());
@@ -1331,7 +1332,7 @@ public class CPDefinitionLocalServiceImpl
 
 			if (publishedCPDefinitionId == cpDefinition.getCPDefinitionId()) {
 				List<CPDefinition> cpDefinitions =
-					cpDefinitionLocalService.getCProductCPDefinitions(
+					cpDefinitionPersistence.findByC_S(
 						cProduct.getCProductId(),
 						WorkflowConstants.STATUS_APPROVED, QueryUtil.ALL_POS,
 						QueryUtil.ALL_POS,
@@ -1970,8 +1971,10 @@ public class CPDefinitionLocalServiceImpl
 		long groupId, long cpDefinitionId) {
 
 		CPDisplayLayout cpDisplayLayout =
-			_cpDisplayLayoutLocalService.fetchCPDisplayLayout(
-				groupId, CPDefinition.class, cpDefinitionId);
+			_cpDisplayLayoutPersistence.fetchByG_C_C(
+				groupId,
+				_classNameLocalService.getClassNameId(CPDefinition.class),
+				cpDefinitionId);
 
 		if (cpDisplayLayout == null) {
 			return null;
@@ -1983,8 +1986,10 @@ public class CPDefinitionLocalServiceImpl
 	@Override
 	public String getLayoutUuid(long groupId, long cpDefinitionId) {
 		CPDisplayLayout cpDisplayLayout =
-			_cpDisplayLayoutLocalService.fetchCPDisplayLayout(
-				groupId, CPDefinition.class, cpDefinitionId);
+			_cpDisplayLayoutPersistence.fetchByG_C_C(
+				groupId,
+				_classNameLocalService.getClassNameId(CPDefinition.class),
+				cpDefinitionId);
 
 		if (cpDisplayLayout == null) {
 			return null;
@@ -2060,9 +2065,8 @@ public class CPDefinitionLocalServiceImpl
 
 	@Override
 	public boolean hasChildCPDefinitions(long cpDefinitionId) {
-		int count =
-			_cpDefinitionOptionRelLocalService.getCPDefinitionOptionRelsCount(
-				cpDefinitionId);
+		int count = _cpDefinitionOptionRelPersistence.countByCPDefinitionId(
+			cpDefinitionId);
 
 		if ((count <= 0) ||
 			!_cpDefinitionOptionRelLocalService.
@@ -2091,7 +2095,7 @@ public class CPDefinitionLocalServiceImpl
 
 	@Override
 	public boolean isPublishedCPDefinition(long cpDefinitionId) {
-		CPDefinition cpDefinition = cpDefinitionLocalService.fetchCPDefinition(
+		CPDefinition cpDefinition = cpDefinitionPersistence.fetchByPrimaryKey(
 			cpDefinitionId);
 
 		if (cpDefinition == null) {
@@ -2115,7 +2119,7 @@ public class CPDefinitionLocalServiceImpl
 	@Override
 	public boolean isVersionable(long cpDefinitionId) {
 		return cpDefinitionLocalService.isVersionable(
-			cpDefinitionLocalService.fetchCPDefinition(cpDefinitionId));
+			cpDefinitionPersistence.fetchByPrimaryKey(cpDefinitionId));
 	}
 
 	@Override
@@ -2390,7 +2394,7 @@ public class CPDefinitionLocalServiceImpl
 			long cpDefinitionId, boolean enable)
 		throws PortalException {
 
-		CPDefinition cpDefinition = cpDefinitionLocalService.getCPDefinition(
+		CPDefinition cpDefinition = cpDefinitionPersistence.findByPrimaryKey(
 			cpDefinitionId);
 
 		cpDefinition.setAccountGroupFilterEnabled(enable);
@@ -2439,7 +2443,7 @@ public class CPDefinitionLocalServiceImpl
 			long cpDefinitionId, boolean enable)
 		throws PortalException {
 
-		CPDefinition cpDefinition = cpDefinitionLocalService.getCPDefinition(
+		CPDefinition cpDefinition = cpDefinitionPersistence.findByPrimaryKey(
 			cpDefinitionId);
 
 		cpDefinition.setChannelFilterEnabled(enable);
@@ -2484,13 +2488,13 @@ public class CPDefinitionLocalServiceImpl
 			String externalReferenceCode, long cpDefinitionId)
 		throws PortalException {
 
-		CPDefinition cpDefinition = cpDefinitionLocalService.getCPDefinition(
+		CPDefinition cpDefinition = cpDefinitionPersistence.findByPrimaryKey(
 			cpDefinitionId);
 
 		_cProductLocalService.updateCProductExternalReferenceCode(
 			externalReferenceCode, cpDefinition.getCProductId());
 
-		return cpDefinitionLocalService.getCPDefinition(cpDefinitionId);
+		return cpDefinitionPersistence.findByPrimaryKey(cpDefinitionId);
 	}
 
 	@Indexable(type = IndexableType.REINDEX)
@@ -2585,7 +2589,7 @@ public class CPDefinitionLocalServiceImpl
 						cProduct.getPublishedCPDefinitionId())) {
 
 					CPDefinition publishedCPDefinition =
-						cpDefinitionLocalService.fetchCPDefinition(
+						cpDefinitionPersistence.fetchByPrimaryKey(
 							cProduct.getPublishedCPDefinitionId());
 
 					if (publishedCPDefinition != null) {
@@ -3050,8 +3054,7 @@ public class CPDefinitionLocalServiceImpl
 		}
 
 		int cpDefinitionOptionRelsCount =
-			_cpDefinitionOptionRelLocalService.getCPDefinitionOptionRelsCount(
-				cpDefinitionId, true);
+			_cpDefinitionOptionRelPersistence.countByC_SC(cpDefinitionId, true);
 
 		if (cpDefinitionOptionRelsCount == 0) {
 			return;
@@ -3628,7 +3631,10 @@ public class CPDefinitionLocalServiceImpl
 	private CPConfigurationEntryLocalService _cpConfigurationEntryLocalService;
 
 	@Reference
-	private CPConfigurationListLocalService _cpConfigurationListLocalService;
+	private CPConfigurationEntryPersistence _cpConfigurationEntryPersistence;
+
+	@Reference
+	private CPConfigurationListPersistence _cpConfigurationListPersistence;
 
 	@Reference
 	private CPDefinitionLinkLocalService _cpDefinitionLinkLocalService;

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPDefinitionOptionRelLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPDefinitionOptionRelLocalServiceImpl.java
@@ -19,10 +19,11 @@ import com.liferay.commerce.product.model.CPInstanceOptionValueRel;
 import com.liferay.commerce.product.model.CPOption;
 import com.liferay.commerce.product.service.CPDefinitionOptionValueRelLocalService;
 import com.liferay.commerce.product.service.CPInstanceLocalService;
-import com.liferay.commerce.product.service.CPOptionLocalService;
 import com.liferay.commerce.product.service.base.CPDefinitionOptionRelLocalServiceBaseImpl;
 import com.liferay.commerce.product.service.persistence.CPDefinitionOptionValueRelPersistence;
 import com.liferay.commerce.product.service.persistence.CPInstanceOptionValueRelPersistence;
+import com.liferay.commerce.product.service.persistence.CPInstancePersistence;
+import com.liferay.commerce.product.service.persistence.CPOptionPersistence;
 import com.liferay.commerce.product.util.CPJSONUtil;
 import com.liferay.expando.kernel.service.ExpandoRowLocalService;
 import com.liferay.petra.string.StringPool;
@@ -99,7 +100,7 @@ public class CPDefinitionOptionRelLocalServiceImpl
 			ServiceContext serviceContext)
 		throws PortalException {
 
-		CPOption cpOption = _cpOptionLocalService.getCPOption(cpOptionId);
+		CPOption cpOption = _cpOptionPersistence.findByPrimaryKey(cpOptionId);
 
 		return cpDefinitionOptionRelLocalService.addCPDefinitionOptionRel(
 			cpDefinitionId, cpOptionId, cpOption.getNameMap(),
@@ -137,7 +138,7 @@ public class CPDefinitionOptionRelLocalServiceImpl
 
 		_validateCommerceOptionTypeKey(commerceOptionTypeKey, skuContributor);
 
-		CPOption cpOption = _cpOptionLocalService.getCPOption(cpOptionId);
+		CPOption cpOption = _cpOptionPersistence.findByPrimaryKey(cpOptionId);
 
 		_validateCPDefinitionOptionKey(cpDefinitionId, cpOption.getKey());
 
@@ -227,7 +228,7 @@ public class CPDefinitionOptionRelLocalServiceImpl
 
 		_validateCommerceOptionTypeKey(commerceOptionTypeKey, skuContributor);
 
-		CPOption cpOption = _cpOptionLocalService.getCPOption(cpOptionId);
+		CPOption cpOption = _cpOptionPersistence.findByPrimaryKey(cpOptionId);
 
 		_validateCPDefinitionOptionKey(cpDefinitionId, cpOption.getKey());
 
@@ -408,7 +409,7 @@ public class CPDefinitionOptionRelLocalServiceImpl
 		throws PortalException {
 
 		List<CPDefinitionOptionRel> cpDefinitionOptionRels =
-			cpDefinitionOptionRelLocalService.getCPDefinitionOptionRels(
+			cpDefinitionOptionRelPersistence.findByCPDefinitionId(
 				cpDefinitionId, QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 
 		for (CPDefinitionOptionRel cpDefinitionOptionRel :
@@ -612,7 +613,7 @@ public class CPDefinitionOptionRelLocalServiceImpl
 				long cpInstanceId)
 		throws PortalException {
 
-		CPInstance cpInstance = _cpInstanceLocalService.getCPInstance(
+		CPInstance cpInstance = _cpInstancePersistence.findByPrimaryKey(
 			cpInstanceId);
 
 		if (cpInstance.isInactive()) {
@@ -862,7 +863,7 @@ public class CPDefinitionOptionRelLocalServiceImpl
 		throws PortalException {
 
 		CPDefinitionOptionRel cpDefinitionOptionRel =
-			cpDefinitionOptionRelLocalService.getCPDefinitionOptionRel(
+			cpDefinitionOptionRelPersistence.findByPrimaryKey(
 				cpDefinitionOptionRelId);
 
 		return cpDefinitionOptionRelLocalService.updateCPDefinitionOptionRel(
@@ -1236,7 +1237,10 @@ public class CPDefinitionOptionRelLocalServiceImpl
 		_cpInstanceOptionValueRelPersistence;
 
 	@Reference
-	private CPOptionLocalService _cpOptionLocalService;
+	private CPInstancePersistence _cpInstancePersistence;
+
+	@Reference
+	private CPOptionPersistence _cpOptionPersistence;
 
 	@Reference
 	private ExpandoRowLocalService _expandoRowLocalService;

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPDefinitionOptionRelServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPDefinitionOptionRelServiceImpl.java
@@ -10,10 +10,10 @@ import com.liferay.commerce.product.model.CPDefinition;
 import com.liferay.commerce.product.model.CPDefinitionOptionRel;
 import com.liferay.commerce.product.model.CPInstance;
 import com.liferay.commerce.product.model.CommerceCatalog;
-import com.liferay.commerce.product.service.CPDefinitionLocalService;
-import com.liferay.commerce.product.service.CPInstanceLocalService;
 import com.liferay.commerce.product.service.CommerceCatalogLocalService;
 import com.liferay.commerce.product.service.base.CPDefinitionOptionRelServiceBaseImpl;
+import com.liferay.commerce.product.service.persistence.CPDefinitionPersistence;
+import com.liferay.commerce.product.service.persistence.CPInstancePersistence;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.search.BaseModelSearchResult;
@@ -97,7 +97,7 @@ public class CPDefinitionOptionRelServiceImpl
 		throws PortalException {
 
 		CPDefinitionOptionRel cpDefinitionOptionRel =
-			cpDefinitionOptionRelLocalService.getCPDefinitionOptionRel(
+			cpDefinitionOptionRelPersistence.findByPrimaryKey(
 				cpDefinitionOptionRelId);
 
 		_checkCommerceCatalog(
@@ -113,7 +113,7 @@ public class CPDefinitionOptionRelServiceImpl
 		throws PortalException {
 
 		CPDefinitionOptionRel cpDefinitionOptionRel =
-			cpDefinitionOptionRelLocalService.fetchCPDefinitionOptionRel(
+			cpDefinitionOptionRelPersistence.fetchByPrimaryKey(
 				cpDefinitionOptionRelId);
 
 		if (cpDefinitionOptionRel != null) {
@@ -131,7 +131,7 @@ public class CPDefinitionOptionRelServiceImpl
 
 		_checkCommerceCatalog(cpDefinitionId, ActionKeys.VIEW);
 
-		return cpDefinitionOptionRelLocalService.fetchCPDefinitionOptionRel(
+		return cpDefinitionOptionRelPersistence.fetchByC_C(
 			cpDefinitionId, cpOptionId);
 	}
 
@@ -141,7 +141,7 @@ public class CPDefinitionOptionRelServiceImpl
 		throws PortalException {
 
 		CPDefinitionOptionRel cpDefinitionOptionRel =
-			cpDefinitionOptionRelLocalService.getCPDefinitionOptionRel(
+			cpDefinitionOptionRelPersistence.findByPrimaryKey(
 				cpDefinitionOptionRelId);
 
 		_checkCommerceCatalog(
@@ -169,7 +169,7 @@ public class CPDefinitionOptionRelServiceImpl
 				long cpInstanceId)
 		throws PortalException {
 
-		CPInstance cpInstance = _cpInstanceLocalService.getCPInstance(
+		CPInstance cpInstance = _cpInstancePersistence.findByPrimaryKey(
 			cpInstanceId);
 
 		_checkCommerceCatalog(cpInstance.getCPDefinitionId(), ActionKeys.VIEW);
@@ -197,7 +197,7 @@ public class CPDefinitionOptionRelServiceImpl
 
 		_checkCommerceCatalog(cpDefinitionId, ActionKeys.VIEW);
 
-		return cpDefinitionOptionRelLocalService.getCPDefinitionOptionRels(
+		return cpDefinitionOptionRelPersistence.findByCPDefinitionId(
 			cpDefinitionId, start, end);
 	}
 
@@ -209,7 +209,7 @@ public class CPDefinitionOptionRelServiceImpl
 
 		_checkCommerceCatalog(cpDefinitionId, ActionKeys.VIEW);
 
-		return cpDefinitionOptionRelLocalService.getCPDefinitionOptionRels(
+		return cpDefinitionOptionRelPersistence.findByCPDefinitionId(
 			cpDefinitionId, start, end, orderByComparator);
 	}
 
@@ -219,7 +219,7 @@ public class CPDefinitionOptionRelServiceImpl
 
 		_checkCommerceCatalog(cpDefinitionId, ActionKeys.VIEW);
 
-		return cpDefinitionOptionRelLocalService.getCPDefinitionOptionRelsCount(
+		return cpDefinitionOptionRelPersistence.countByCPDefinitionId(
 			cpDefinitionId);
 	}
 
@@ -230,7 +230,7 @@ public class CPDefinitionOptionRelServiceImpl
 
 		_checkCommerceCatalog(cpDefinitionId, ActionKeys.VIEW);
 
-		return cpDefinitionOptionRelLocalService.getCPDefinitionOptionRelsCount(
+		return cpDefinitionOptionRelPersistence.countByC_SC(
 			cpDefinitionId, skuContributor);
 	}
 
@@ -269,7 +269,7 @@ public class CPDefinitionOptionRelServiceImpl
 		throws PortalException {
 
 		CPDefinitionOptionRel cpDefinitionOptionRel =
-			cpDefinitionOptionRelLocalService.getCPDefinitionOptionRel(
+			cpDefinitionOptionRelPersistence.findByPrimaryKey(
 				cpDefinitionOptionRelId);
 
 		_checkCommerceCatalog(
@@ -292,7 +292,7 @@ public class CPDefinitionOptionRelServiceImpl
 		throws PortalException {
 
 		CPDefinitionOptionRel cpDefinitionOptionRel =
-			cpDefinitionOptionRelLocalService.getCPDefinitionOptionRel(
+			cpDefinitionOptionRelPersistence.findByPrimaryKey(
 				cpDefinitionOptionRelId);
 
 		_checkCommerceCatalog(
@@ -308,7 +308,7 @@ public class CPDefinitionOptionRelServiceImpl
 	private void _checkCommerceCatalog(long cpDefinitionId, String actionId)
 		throws PortalException {
 
-		CPDefinition cpDefinition = _cpDefinitionLocalService.fetchCPDefinition(
+		CPDefinition cpDefinition = _cpDefinitionPersistence.fetchByPrimaryKey(
 			cpDefinitionId);
 
 		if (cpDefinition == null) {
@@ -337,9 +337,9 @@ public class CPDefinitionOptionRelServiceImpl
 		_commerceCatalogModelResourcePermission;
 
 	@Reference
-	private CPDefinitionLocalService _cpDefinitionLocalService;
+	private CPDefinitionPersistence _cpDefinitionPersistence;
 
 	@Reference
-	private CPInstanceLocalService _cpInstanceLocalService;
+	private CPInstancePersistence _cpInstancePersistence;
 
 }

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPDefinitionOptionValueRelLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPDefinitionOptionValueRelLocalServiceImpl.java
@@ -31,10 +31,11 @@ import com.liferay.commerce.product.service.CPDefinitionOptionRelLocalService;
 import com.liferay.commerce.product.service.CPInstanceLocalService;
 import com.liferay.commerce.product.service.CPInstanceOptionValueRelLocalService;
 import com.liferay.commerce.product.service.CPInstanceUnitOfMeasureLocalService;
-import com.liferay.commerce.product.service.CPOptionLocalService;
-import com.liferay.commerce.product.service.CPOptionValueLocalService;
 import com.liferay.commerce.product.service.base.CPDefinitionOptionValueRelLocalServiceBaseImpl;
 import com.liferay.commerce.product.service.persistence.CPDefinitionOptionRelPersistence;
+import com.liferay.commerce.product.service.persistence.CPInstancePersistence;
+import com.liferay.commerce.product.service.persistence.CPOptionPersistence;
+import com.liferay.commerce.product.service.persistence.CPOptionValuePersistence;
 import com.liferay.expando.kernel.model.ExpandoBridge;
 import com.liferay.expando.kernel.service.ExpandoRowLocalService;
 import com.liferay.info.pagination.Pagination;
@@ -139,7 +140,7 @@ public class CPDefinitionOptionValueRelLocalServiceImpl
 		key = _friendlyURLNormalizer.normalize(key);
 
 		CPDefinitionOptionRel cpDefinitionOptionRel =
-			_cpDefinitionOptionRelLocalService.getCPDefinitionOptionRel(
+			_cpDefinitionOptionRelPersistence.findByPrimaryKey(
 				cpDefinitionOptionRelId);
 
 		_validate(
@@ -236,7 +237,7 @@ public class CPDefinitionOptionValueRelLocalServiceImpl
 		key = _friendlyURLNormalizer.normalize(key);
 
 		CPDefinitionOptionRel cpDefinitionOptionRel =
-			_cpDefinitionOptionRelLocalService.getCPDefinitionOptionRel(
+			_cpDefinitionOptionRelPersistence.findByPrimaryKey(
 				cpDefinitionOptionRelId);
 
 		_validate(0, cpDefinitionOptionRel, 0, key, StringPool.BLANK);
@@ -516,7 +517,7 @@ public class CPDefinitionOptionValueRelLocalServiceImpl
 		long cpDefinitionOptionRelId) {
 
 		CPDefinitionOptionRel cpDefinitionOptionRel =
-			_cpDefinitionOptionRelLocalService.fetchCPDefinitionOptionRel(
+			_cpDefinitionOptionRelPersistence.fetchByPrimaryKey(
 				cpDefinitionOptionRelId);
 
 		if (cpDefinitionOptionRel.isDefinedExternally()) {
@@ -533,7 +534,7 @@ public class CPDefinitionOptionValueRelLocalServiceImpl
 		long cpDefinitionOptionRelId, int start, int end) {
 
 		CPDefinitionOptionRel cpDefinitionOptionRel =
-			_cpDefinitionOptionRelLocalService.fetchCPDefinitionOptionRel(
+			_cpDefinitionOptionRelPersistence.fetchByPrimaryKey(
 				cpDefinitionOptionRelId);
 
 		if ((cpDefinitionOptionRel != null) &&
@@ -553,7 +554,7 @@ public class CPDefinitionOptionValueRelLocalServiceImpl
 		OrderByComparator<CPDefinitionOptionValueRel> orderByComparator) {
 
 		CPDefinitionOptionRel cpDefinitionOptionRel =
-			_cpDefinitionOptionRelLocalService.fetchCPDefinitionOptionRel(
+			_cpDefinitionOptionRelPersistence.fetchByPrimaryKey(
 				cpDefinitionOptionRelId);
 
 		if (cpDefinitionOptionRel.isDefinedExternally()) {
@@ -672,10 +673,10 @@ public class CPDefinitionOptionValueRelLocalServiceImpl
 		throws PortalException {
 
 		CPDefinitionOptionRel cpDefinitionOptionRel =
-			_cpDefinitionOptionRelLocalService.getCPDefinitionOptionRel(
+			_cpDefinitionOptionRelPersistence.findByPrimaryKey(
 				cpDefinitionOptionRelId);
 
-		CPOption cpOption = _cpOptionLocalService.fetchCPOption(
+		CPOption cpOption = _cpOptionPersistence.fetchByPrimaryKey(
 			cpDefinitionOptionRel.getCPOptionId());
 
 		if (cpOption == null) {
@@ -683,7 +684,7 @@ public class CPDefinitionOptionValueRelLocalServiceImpl
 		}
 
 		List<CPOptionValue> cpOptionValues =
-			_cpOptionValueLocalService.getCPOptionValues(
+			_cpOptionValuePersistence.findByCPOptionId(
 				cpOption.getCPOptionId(), QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 
 		Map<String, Serializable> expandoBridgeAttributes =
@@ -758,7 +759,7 @@ public class CPDefinitionOptionValueRelLocalServiceImpl
 		throws PortalException {
 
 		CPDefinitionOptionRel cpDefinitionOptionRel =
-			_cpDefinitionOptionRelLocalService.fetchCPDefinitionOptionRel(
+			_cpDefinitionOptionRelPersistence.fetchByPrimaryKey(
 				cpDefinitionOptionRelId);
 
 		if (cpDefinitionOptionRel.isDefinedExternally()) {
@@ -784,7 +785,7 @@ public class CPDefinitionOptionValueRelLocalServiceImpl
 		throws PortalException {
 
 		CPDefinitionOptionRel cpDefinitionOptionRel =
-			_cpDefinitionOptionRelLocalService.fetchCPDefinitionOptionRel(
+			_cpDefinitionOptionRelPersistence.fetchByPrimaryKey(
 				cpDefinitionOptionRelId);
 
 		if (cpDefinitionOptionRel.isDefinedExternally()) {
@@ -1089,7 +1090,7 @@ public class CPDefinitionOptionValueRelLocalServiceImpl
 			return cpDefinitionOptionValueRel;
 		}
 
-		CPInstance cpInstance = _cpInstanceLocalService.getCPInstance(
+		CPInstance cpInstance = _cpInstancePersistence.findByPrimaryKey(
 			cpInstanceId);
 
 		cpDefinitionOptionValueRel.setCPInstanceUuid(
@@ -1359,14 +1360,17 @@ public class CPDefinitionOptionValueRelLocalServiceImpl
 		_cpInstanceOptionValueRelLocalService;
 
 	@Reference
+	private CPInstancePersistence _cpInstancePersistence;
+
+	@Reference
 	private CPInstanceUnitOfMeasureLocalService
 		_cpInstanceUnitOfMeasureLocalService;
 
 	@Reference
-	private CPOptionLocalService _cpOptionLocalService;
+	private CPOptionPersistence _cpOptionPersistence;
 
 	@Reference
-	private CPOptionValueLocalService _cpOptionValueLocalService;
+	private CPOptionValuePersistence _cpOptionValuePersistence;
 
 	@Reference
 	private ExpandoRowLocalService _expandoRowLocalService;

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPDefinitionOptionValueRelLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPDefinitionOptionValueRelLocalServiceImpl.java
@@ -520,7 +520,9 @@ public class CPDefinitionOptionValueRelLocalServiceImpl
 			_cpDefinitionOptionRelPersistence.fetchByPrimaryKey(
 				cpDefinitionOptionRelId);
 
-		if (cpDefinitionOptionRel.isDefinedExternally()) {
+		if ((cpDefinitionOptionRel != null) &&
+			cpDefinitionOptionRel.isDefinedExternally()) {
+
 			return _cpCollectionProviderHelper.getCPDefinitionOptionValueRels(
 				cpDefinitionOptionRel, null, null);
 		}
@@ -557,7 +559,9 @@ public class CPDefinitionOptionValueRelLocalServiceImpl
 			_cpDefinitionOptionRelPersistence.fetchByPrimaryKey(
 				cpDefinitionOptionRelId);
 
-		if (cpDefinitionOptionRel.isDefinedExternally()) {
+		if ((cpDefinitionOptionRel != null) &&
+			cpDefinitionOptionRel.isDefinedExternally()) {
+
 			return _cpCollectionProviderHelper.getCPDefinitionOptionValueRels(
 				cpDefinitionOptionRel, null, Pagination.of(end, start));
 		}
@@ -762,7 +766,9 @@ public class CPDefinitionOptionValueRelLocalServiceImpl
 			_cpDefinitionOptionRelPersistence.fetchByPrimaryKey(
 				cpDefinitionOptionRelId);
 
-		if (cpDefinitionOptionRel.isDefinedExternally()) {
+		if ((cpDefinitionOptionRel != null) &&
+			cpDefinitionOptionRel.isDefinedExternally()) {
+
 			return new BaseModelSearchResult<>(
 				_cpCollectionProviderHelper.getCPDefinitionOptionValueRels(
 					companyId, groupId, cpDefinitionOptionRel, keywords,
@@ -788,7 +794,9 @@ public class CPDefinitionOptionValueRelLocalServiceImpl
 			_cpDefinitionOptionRelPersistence.fetchByPrimaryKey(
 				cpDefinitionOptionRelId);
 
-		if (cpDefinitionOptionRel.isDefinedExternally()) {
+		if ((cpDefinitionOptionRel != null) &&
+			cpDefinitionOptionRel.isDefinedExternally()) {
+
 			return _cpCollectionProviderHelper.
 				getCPDefinitionOptionValueRelsCount(
 					companyId, groupId, cpDefinitionOptionRel, keywords);

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPDefinitionOptionValueRelServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPDefinitionOptionValueRelServiceImpl.java
@@ -10,10 +10,10 @@ import com.liferay.commerce.product.model.CPDefinition;
 import com.liferay.commerce.product.model.CPDefinitionOptionRel;
 import com.liferay.commerce.product.model.CPDefinitionOptionValueRel;
 import com.liferay.commerce.product.model.CommerceCatalog;
-import com.liferay.commerce.product.service.CPDefinitionLocalService;
-import com.liferay.commerce.product.service.CPDefinitionOptionRelLocalService;
 import com.liferay.commerce.product.service.CommerceCatalogLocalService;
 import com.liferay.commerce.product.service.base.CPDefinitionOptionValueRelServiceBaseImpl;
+import com.liferay.commerce.product.service.persistence.CPDefinitionOptionRelPersistence;
+import com.liferay.commerce.product.service.persistence.CPDefinitionPersistence;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.search.BaseModelSearchResult;
@@ -56,7 +56,7 @@ public class CPDefinitionOptionValueRelServiceImpl
 		throws PortalException {
 
 		CPDefinitionOptionRel cpDefinitionOptionRel =
-			_cpDefinitionOptionRelLocalService.getCPDefinitionOptionRel(
+			_cpDefinitionOptionRelPersistence.findByPrimaryKey(
 				cpDefinitionOptionRelId);
 
 		_checkCommerceCatalog(
@@ -77,7 +77,7 @@ public class CPDefinitionOptionValueRelServiceImpl
 		throws PortalException {
 
 		CPDefinitionOptionRel cpDefinitionOptionRel =
-			_cpDefinitionOptionRelLocalService.getCPDefinitionOptionRel(
+			_cpDefinitionOptionRelPersistence.findByPrimaryKey(
 				cpDefinitionOptionRelId);
 
 		_checkCommerceCatalog(
@@ -99,7 +99,7 @@ public class CPDefinitionOptionValueRelServiceImpl
 				getCPDefinitionOptionValueRel(cpDefinitionOptionValueRelId);
 
 		CPDefinitionOptionRel cpDefinitionOptionRel =
-			_cpDefinitionOptionRelLocalService.getCPDefinitionOptionRel(
+			_cpDefinitionOptionRelPersistence.findByPrimaryKey(
 				cpDefinitionOptionValueRel.getCPDefinitionOptionRelId());
 
 		_checkCommerceCatalog(
@@ -120,7 +120,7 @@ public class CPDefinitionOptionValueRelServiceImpl
 
 		if (cpDefinitionOptionValueRel != null) {
 			CPDefinitionOptionRel cpDefinitionOptionRel =
-				_cpDefinitionOptionRelLocalService.getCPDefinitionOptionRel(
+				_cpDefinitionOptionRelPersistence.findByPrimaryKey(
 					cpDefinitionOptionValueRel.getCPDefinitionOptionRelId());
 
 			_checkCommerceCatalog(
@@ -141,7 +141,7 @@ public class CPDefinitionOptionValueRelServiceImpl
 
 		if (cpDefinitionOptionValueRel != null) {
 			CPDefinitionOptionRel cpDefinitionOptionRel =
-				_cpDefinitionOptionRelLocalService.getCPDefinitionOptionRel(
+				_cpDefinitionOptionRelPersistence.findByPrimaryKey(
 					cpDefinitionOptionValueRel.getCPDefinitionOptionRelId());
 
 			_checkCommerceCatalog(
@@ -161,7 +161,7 @@ public class CPDefinitionOptionValueRelServiceImpl
 				getCPDefinitionOptionValueRel(cpDefinitionOptionValueRelId);
 
 		CPDefinitionOptionRel cpDefinitionOptionRel =
-			_cpDefinitionOptionRelLocalService.getCPDefinitionOptionRel(
+			_cpDefinitionOptionRelPersistence.findByPrimaryKey(
 				cpDefinitionOptionValueRel.getCPDefinitionOptionRelId());
 
 		_checkCommerceCatalog(
@@ -177,7 +177,7 @@ public class CPDefinitionOptionValueRelServiceImpl
 		throws PortalException {
 
 		CPDefinitionOptionRel cpDefinitionOptionRel =
-			_cpDefinitionOptionRelLocalService.getCPDefinitionOptionRel(
+			_cpDefinitionOptionRelPersistence.findByPrimaryKey(
 				cpDefinitionOptionRelId);
 
 		_checkCommerceCatalog(
@@ -194,7 +194,7 @@ public class CPDefinitionOptionValueRelServiceImpl
 		throws PortalException {
 
 		CPDefinitionOptionRel cpDefinitionOptionRel =
-			_cpDefinitionOptionRelLocalService.getCPDefinitionOptionRel(
+			_cpDefinitionOptionRelPersistence.findByPrimaryKey(
 				cpDefinitionOptionRelId);
 
 		_checkCommerceCatalog(
@@ -225,7 +225,7 @@ public class CPDefinitionOptionValueRelServiceImpl
 		throws PortalException {
 
 		CPDefinitionOptionRel cpDefinitionOptionRel =
-			_cpDefinitionOptionRelLocalService.getCPDefinitionOptionRel(
+			_cpDefinitionOptionRelPersistence.findByPrimaryKey(
 				cpDefinitionOptionRelId);
 
 		_checkCommerceCatalog(
@@ -245,7 +245,7 @@ public class CPDefinitionOptionValueRelServiceImpl
 				getCPDefinitionOptionValueRel(cpDefinitionOptionValueRelId);
 
 		CPDefinitionOptionRel cpDefinitionOptionRel =
-			_cpDefinitionOptionRelLocalService.getCPDefinitionOptionRel(
+			_cpDefinitionOptionRelPersistence.findByPrimaryKey(
 				cpDefinitionOptionValueRel.getCPDefinitionOptionRelId());
 
 		_checkCommerceCatalog(
@@ -264,7 +264,7 @@ public class CPDefinitionOptionValueRelServiceImpl
 		throws PortalException {
 
 		CPDefinitionOptionRel cpDefinitionOptionRel =
-			_cpDefinitionOptionRelLocalService.getCPDefinitionOptionRel(
+			_cpDefinitionOptionRelPersistence.findByPrimaryKey(
 				cpDefinitionOptionRelId);
 
 		_checkCommerceCatalog(
@@ -283,7 +283,7 @@ public class CPDefinitionOptionValueRelServiceImpl
 		throws PortalException {
 
 		CPDefinitionOptionRel cpDefinitionOptionRel =
-			_cpDefinitionOptionRelLocalService.getCPDefinitionOptionRel(
+			_cpDefinitionOptionRelPersistence.findByPrimaryKey(
 				cpDefinitionOptionRelId);
 
 		_checkCommerceCatalog(
@@ -307,7 +307,7 @@ public class CPDefinitionOptionValueRelServiceImpl
 				getCPDefinitionOptionValueRel(cpDefinitionOptionValueRelId);
 
 		CPDefinitionOptionRel cpDefinitionOptionRel =
-			_cpDefinitionOptionRelLocalService.getCPDefinitionOptionRel(
+			_cpDefinitionOptionRelPersistence.findByPrimaryKey(
 				cpDefinitionOptionValueRel.getCPDefinitionOptionRelId());
 
 		_checkCommerceCatalog(
@@ -331,7 +331,7 @@ public class CPDefinitionOptionValueRelServiceImpl
 				getCPDefinitionOptionValueRel(cpDefinitionOptionValueRelId);
 
 		CPDefinitionOptionRel cpDefinitionOptionRel =
-			_cpDefinitionOptionRelLocalService.getCPDefinitionOptionRel(
+			_cpDefinitionOptionRelPersistence.findByPrimaryKey(
 				cpDefinitionOptionValueRel.getCPDefinitionOptionRelId());
 
 		_checkCommerceCatalog(
@@ -345,7 +345,7 @@ public class CPDefinitionOptionValueRelServiceImpl
 	private void _checkCommerceCatalog(long cpDefinitionId, String actionId)
 		throws PortalException {
 
-		CPDefinition cpDefinition = _cpDefinitionLocalService.fetchCPDefinition(
+		CPDefinition cpDefinition = _cpDefinitionPersistence.fetchByPrimaryKey(
 			cpDefinitionId);
 
 		if (cpDefinition == null) {
@@ -374,10 +374,9 @@ public class CPDefinitionOptionValueRelServiceImpl
 		_commerceCatalogModelResourcePermission;
 
 	@Reference
-	private CPDefinitionLocalService _cpDefinitionLocalService;
+	private CPDefinitionOptionRelPersistence _cpDefinitionOptionRelPersistence;
 
 	@Reference
-	private CPDefinitionOptionRelLocalService
-		_cpDefinitionOptionRelLocalService;
+	private CPDefinitionPersistence _cpDefinitionPersistence;
 
 }

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPDefinitionServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPDefinitionServiceImpl.java
@@ -197,7 +197,7 @@ public class CPDefinitionServiceImpl extends CPDefinitionServiceBaseImpl {
 	public CPDefinition fetchCPDefinition(long cpDefinitionId)
 		throws PortalException {
 
-		CPDefinition cpDefinition = cpDefinitionLocalService.fetchCPDefinition(
+		CPDefinition cpDefinition = cpDefinitionPersistence.fetchByPrimaryKey(
 			cpDefinitionId);
 
 		if (cpDefinition != null) {
@@ -284,7 +284,7 @@ public class CPDefinitionServiceImpl extends CPDefinitionServiceBaseImpl {
 
 		_checkCommerceCatalogByCPDefinitionId(cpDefinitionId, ActionKeys.VIEW);
 
-		return cpDefinitionLocalService.getCPDefinition(cpDefinitionId);
+		return cpDefinitionPersistence.findByPrimaryKey(cpDefinitionId);
 	}
 
 	@Override
@@ -316,8 +316,7 @@ public class CPDefinitionServiceImpl extends CPDefinitionServiceBaseImpl {
 
 		_checkCommerceCatalog(cProduct.getGroupId(), ActionKeys.VIEW);
 
-		return cpDefinitionLocalService.getCProductCPDefinition(
-			cProductId, version);
+		return cpDefinitionPersistence.findByC_V(cProductId, version);
 	}
 
 	@Override
@@ -329,7 +328,7 @@ public class CPDefinitionServiceImpl extends CPDefinitionServiceBaseImpl {
 
 		_checkCommerceCatalog(cProduct.getGroupId(), ActionKeys.VIEW);
 
-		return cpDefinitionLocalService.getCProductCPDefinitions(
+		return cpDefinitionPersistence.findByC_S(
 			cProduct.getCProductId(), status, start, end);
 	}
 
@@ -595,7 +594,7 @@ public class CPDefinitionServiceImpl extends CPDefinitionServiceBaseImpl {
 			long cpDefinitionId, String actionId)
 		throws PortalException {
 
-		CPDefinition cpDefinition = cpDefinitionLocalService.fetchCPDefinition(
+		CPDefinition cpDefinition = cpDefinitionPersistence.fetchByPrimaryKey(
 			cpDefinitionId);
 
 		if (cpDefinition == null) {

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPDefinitionSpecificationOptionValueServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPDefinitionSpecificationOptionValueServiceImpl.java
@@ -9,9 +9,9 @@ import com.liferay.commerce.product.exception.NoSuchCPDefinitionException;
 import com.liferay.commerce.product.model.CPDefinition;
 import com.liferay.commerce.product.model.CPDefinitionSpecificationOptionValue;
 import com.liferay.commerce.product.model.CommerceCatalog;
-import com.liferay.commerce.product.service.CPDefinitionLocalService;
 import com.liferay.commerce.product.service.CommerceCatalogLocalService;
 import com.liferay.commerce.product.service.base.CPDefinitionSpecificationOptionValueServiceBaseImpl;
+import com.liferay.commerce.product.service.persistence.CPDefinitionPersistence;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
@@ -238,7 +238,7 @@ public class CPDefinitionSpecificationOptionValueServiceImpl
 	private void _checkCommerceCatalog(long cpDefinitionId, String actionId)
 		throws PortalException {
 
-		CPDefinition cpDefinition = _cpDefinitionLocalService.fetchCPDefinition(
+		CPDefinition cpDefinition = _cpDefinitionPersistence.fetchByPrimaryKey(
 			cpDefinitionId);
 
 		if (cpDefinition == null) {
@@ -267,6 +267,6 @@ public class CPDefinitionSpecificationOptionValueServiceImpl
 		_commerceCatalogModelResourcePermission;
 
 	@Reference
-	private CPDefinitionLocalService _cpDefinitionLocalService;
+	private CPDefinitionPersistence _cpDefinitionPersistence;
 
 }

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPDisplayLayoutServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPDisplayLayoutServiceImpl.java
@@ -10,9 +10,9 @@ import com.liferay.commerce.product.exception.NoSuchCPDefinitionException;
 import com.liferay.commerce.product.model.CPDefinition;
 import com.liferay.commerce.product.model.CPDisplayLayout;
 import com.liferay.commerce.product.model.CommerceCatalog;
-import com.liferay.commerce.product.service.CPDefinitionLocalService;
 import com.liferay.commerce.product.service.CommerceCatalogLocalService;
 import com.liferay.commerce.product.service.base.CPDisplayLayoutServiceBaseImpl;
+import com.liferay.commerce.product.service.persistence.CPDefinitionPersistence;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Layout;
@@ -62,7 +62,7 @@ public class CPDisplayLayoutServiceImpl extends CPDisplayLayoutServiceBaseImpl {
 		throws PortalException {
 
 		CPDisplayLayout cpDisplayLayout =
-			cpDisplayLayoutLocalService.getCPDisplayLayout(cpDisplayLayoutId);
+			cpDisplayLayoutPersistence.findByPrimaryKey(cpDisplayLayoutId);
 
 		GroupPermissionUtil.check(
 			getPermissionChecker(), cpDisplayLayout.getGroupId(),
@@ -80,7 +80,7 @@ public class CPDisplayLayoutServiceImpl extends CPDisplayLayoutServiceBaseImpl {
 		throws PortalException {
 
 		CPDisplayLayout cpDisplayLayout =
-			cpDisplayLayoutLocalService.fetchCPDisplayLayout(cpDisplayLayoutId);
+			cpDisplayLayoutPersistence.fetchByPrimaryKey(cpDisplayLayoutId);
 
 		if (cpDisplayLayout != null) {
 			if (Validator.isNotNull(cpDisplayLayout.getLayoutUuid())) {
@@ -102,7 +102,7 @@ public class CPDisplayLayoutServiceImpl extends CPDisplayLayoutServiceBaseImpl {
 		throws PortalException {
 
 		CPDisplayLayout cpDisplayLayout =
-			cpDisplayLayoutLocalService.getCPDisplayLayout(cpDisplayLayoutId);
+			cpDisplayLayoutPersistence.findByPrimaryKey(cpDisplayLayoutId);
 
 		if (Validator.isNotNull(cpDisplayLayout.getLayoutUuid())) {
 			LayoutPermissionUtil.check(
@@ -137,7 +137,7 @@ public class CPDisplayLayoutServiceImpl extends CPDisplayLayoutServiceBaseImpl {
 		throws PortalException {
 
 		CPDisplayLayout cpDisplayLayout =
-			cpDisplayLayoutLocalService.getCPDisplayLayout(cpDisplayLayoutId);
+			cpDisplayLayoutPersistence.findByPrimaryKey(cpDisplayLayoutId);
 
 		if (Validator.isNotNull(layoutUuid)) {
 			LayoutPermissionUtil.check(
@@ -159,7 +159,7 @@ public class CPDisplayLayoutServiceImpl extends CPDisplayLayoutServiceBaseImpl {
 
 		if (className.equals(CPDefinition.class.getName())) {
 			CPDefinition cpDefinition =
-				_cpDefinitionLocalService.fetchCPDefinition(classPK);
+				_cpDefinitionPersistence.fetchByPrimaryKey(classPK);
 
 			if (cpDefinition == null) {
 				throw new NoSuchCPDefinitionException();
@@ -202,7 +202,7 @@ public class CPDisplayLayoutServiceImpl extends CPDisplayLayoutServiceBaseImpl {
 		_commerceCatalogModelResourcePermission;
 
 	@Reference
-	private CPDefinitionLocalService _cpDefinitionLocalService;
+	private CPDefinitionPersistence _cpDefinitionPersistence;
 
 	@Reference
 	private LayoutLocalService _layoutLocalService;

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPInstanceServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPInstanceServiceImpl.java
@@ -10,10 +10,10 @@ import com.liferay.commerce.product.model.CPDefinition;
 import com.liferay.commerce.product.model.CPInstance;
 import com.liferay.commerce.product.model.CProduct;
 import com.liferay.commerce.product.model.CommerceCatalog;
-import com.liferay.commerce.product.service.CPDefinitionLocalService;
 import com.liferay.commerce.product.service.CommerceCatalogLocalService;
 import com.liferay.commerce.product.service.CommerceCatalogService;
 import com.liferay.commerce.product.service.base.CPInstanceServiceBaseImpl;
+import com.liferay.commerce.product.service.persistence.CPDefinitionPersistence;
 import com.liferay.commerce.product.service.persistence.CProductPersistence;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.aop.AopService;
@@ -169,7 +169,7 @@ public class CPInstanceServiceImpl extends CPInstanceServiceBaseImpl {
 	public CPInstance fetchCPInstance(long cpInstanceId)
 		throws PortalException {
 
-		CPInstance cpInstance = cpInstanceLocalService.fetchCPInstance(
+		CPInstance cpInstance = cpInstancePersistence.fetchByPrimaryKey(
 			cpInstanceId);
 
 		if (cpInstance != null) {
@@ -185,9 +185,8 @@ public class CPInstanceServiceImpl extends CPInstanceServiceBaseImpl {
 			String externalReferenceCode, long companyId)
 		throws PortalException {
 
-		CPInstance cpInstance =
-			cpInstanceLocalService.fetchCPInstanceByExternalReferenceCode(
-				externalReferenceCode, companyId);
+		CPInstance cpInstance = cpInstancePersistence.fetchByERC_C(
+			externalReferenceCode, companyId);
 
 		if (cpInstance != null) {
 			_checkCommerceCatalogByCPDefinitionId(
@@ -239,7 +238,7 @@ public class CPInstanceServiceImpl extends CPInstanceServiceBaseImpl {
 
 	@Override
 	public CPInstance getCPInstance(long cpInstanceId) throws PortalException {
-		CPInstance cpInstance = cpInstanceLocalService.getCPInstance(
+		CPInstance cpInstance = cpInstancePersistence.findByPrimaryKey(
 			cpInstanceId);
 
 		_checkCommerceCatalogByCPDefinitionId(
@@ -365,7 +364,7 @@ public class CPInstanceServiceImpl extends CPInstanceServiceBaseImpl {
 			ServiceContext serviceContext)
 		throws PortalException {
 
-		CPInstance cpInstance = cpInstanceLocalService.getCPInstance(
+		CPInstance cpInstance = cpInstancePersistence.findByPrimaryKey(
 			cpInstanceId);
 
 		_checkCommerceCatalogByCPDefinitionId(
@@ -394,7 +393,7 @@ public class CPInstanceServiceImpl extends CPInstanceServiceBaseImpl {
 			long cpInstanceId, String externalReferenceCode)
 		throws PortalException {
 
-		CPInstance cpInstance = cpInstanceLocalService.getCPInstance(
+		CPInstance cpInstance = cpInstancePersistence.findByPrimaryKey(
 			cpInstanceId);
 
 		_checkCommerceCatalogByCPDefinitionId(
@@ -410,7 +409,7 @@ public class CPInstanceServiceImpl extends CPInstanceServiceBaseImpl {
 			BigDecimal cost, ServiceContext serviceContext)
 		throws PortalException {
 
-		CPInstance cpInstance = cpInstanceLocalService.getCPInstance(
+		CPInstance cpInstance = cpInstancePersistence.findByPrimaryKey(
 			cpInstanceId);
 
 		_checkCommerceCatalogByCPDefinitionId(
@@ -426,7 +425,7 @@ public class CPInstanceServiceImpl extends CPInstanceServiceBaseImpl {
 			double weight, ServiceContext serviceContext)
 		throws PortalException {
 
-		CPInstance cpInstance = cpInstanceLocalService.getCPInstance(
+		CPInstance cpInstance = cpInstancePersistence.findByPrimaryKey(
 			cpInstanceId);
 
 		_checkCommerceCatalogByCPDefinitionId(
@@ -448,7 +447,7 @@ public class CPInstanceServiceImpl extends CPInstanceServiceBaseImpl {
 			long deliveryMaxSubscriptionCycles)
 		throws PortalException {
 
-		CPInstance cpInstance = cpInstanceLocalService.getCPInstance(
+		CPInstance cpInstance = cpInstancePersistence.findByPrimaryKey(
 			cpInstanceId);
 
 		_checkCommerceCatalogByCPDefinitionId(
@@ -482,7 +481,7 @@ public class CPInstanceServiceImpl extends CPInstanceServiceBaseImpl {
 			long cpDefinitionId, String actionId)
 		throws PortalException {
 
-		CPDefinition cpDefinition = _cpDefinitionLocalService.fetchCPDefinition(
+		CPDefinition cpDefinition = _cpDefinitionPersistence.fetchByPrimaryKey(
 			cpDefinitionId);
 
 		if (cpDefinition == null) {
@@ -514,7 +513,7 @@ public class CPInstanceServiceImpl extends CPInstanceServiceBaseImpl {
 	private CommerceCatalogService _commerceCatalogService;
 
 	@Reference
-	private CPDefinitionLocalService _cpDefinitionLocalService;
+	private CPDefinitionPersistence _cpDefinitionPersistence;
 
 	@Reference
 	private CProductPersistence _cProductPersistence;

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPInstanceUnitOfMeasureLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPInstanceUnitOfMeasureLocalServiceImpl.java
@@ -109,8 +109,7 @@ public class CPInstanceUnitOfMeasureLocalServiceImpl
 		throws PortalException {
 
 		CPInstanceUnitOfMeasure cpInstanceUnitOfMeasure =
-			cpInstanceUnitOfMeasureLocalService.fetchCPInstanceUnitOfMeasure(
-				cpInstanceId, key);
+			cpInstanceUnitOfMeasurePersistence.fetchByC_K(cpInstanceId, key);
 
 		if (cpInstanceUnitOfMeasure == null) {
 			return cpInstanceUnitOfMeasureLocalService.

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPInstanceUnitOfMeasureServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPInstanceUnitOfMeasureServiceImpl.java
@@ -8,9 +8,9 @@ package com.liferay.commerce.product.service.impl;
 import com.liferay.commerce.product.model.CPInstance;
 import com.liferay.commerce.product.model.CPInstanceUnitOfMeasure;
 import com.liferay.commerce.product.model.CommerceCatalog;
-import com.liferay.commerce.product.service.CPInstanceLocalService;
 import com.liferay.commerce.product.service.CommerceCatalogLocalService;
 import com.liferay.commerce.product.service.base.CPInstanceUnitOfMeasureServiceBaseImpl;
+import com.liferay.commerce.product.service.persistence.CPInstancePersistence;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
@@ -80,7 +80,7 @@ public class CPInstanceUnitOfMeasureServiceImpl
 		throws PortalException {
 
 		CPInstanceUnitOfMeasure cpInstanceUnitOfMeasure =
-			cpInstanceUnitOfMeasureLocalService.getCPInstanceUnitOfMeasure(
+			cpInstanceUnitOfMeasurePersistence.findByPrimaryKey(
 				cpInstanceUnitOfMeasureId);
 
 		_checkCommerceCatalog(
@@ -96,7 +96,7 @@ public class CPInstanceUnitOfMeasureServiceImpl
 		throws PortalException {
 
 		CPInstanceUnitOfMeasure cpInstanceUnitOfMeasure =
-			cpInstanceUnitOfMeasureLocalService.fetchCPInstanceUnitOfMeasure(
+			cpInstanceUnitOfMeasurePersistence.fetchByPrimaryKey(
 				cpInstanceUnitOfMeasureId);
 
 		if (cpInstanceUnitOfMeasure != null) {
@@ -114,8 +114,7 @@ public class CPInstanceUnitOfMeasureServiceImpl
 
 		_checkCommerceCatalog(cpInstanceId, ActionKeys.VIEW);
 
-		return cpInstanceUnitOfMeasureLocalService.fetchCPInstanceUnitOfMeasure(
-			cpInstanceId, key);
+		return cpInstanceUnitOfMeasurePersistence.fetchByC_K(cpInstanceId, key);
 	}
 
 	@Override
@@ -156,7 +155,7 @@ public class CPInstanceUnitOfMeasureServiceImpl
 		throws PortalException {
 
 		CPInstanceUnitOfMeasure cpInstanceUnitOfMeasure =
-			cpInstanceUnitOfMeasureLocalService.getCPInstanceUnitOfMeasure(
+			cpInstanceUnitOfMeasurePersistence.findByPrimaryKey(
 				cpInstanceUnitOfMeasureId);
 
 		_checkCommerceCatalog(
@@ -172,8 +171,7 @@ public class CPInstanceUnitOfMeasureServiceImpl
 
 		_checkCommerceCatalog(cpInstanceId, ActionKeys.VIEW);
 
-		return cpInstanceUnitOfMeasureLocalService.getCPInstanceUnitOfMeasure(
-			cpInstanceId, key);
+		return cpInstanceUnitOfMeasurePersistence.findByC_K(cpInstanceId, key);
 	}
 
 	@Override
@@ -184,7 +182,7 @@ public class CPInstanceUnitOfMeasureServiceImpl
 
 		_checkCommerceCatalog(cpInstanceId, ActionKeys.VIEW);
 
-		return cpInstanceUnitOfMeasureLocalService.getCPInstanceUnitOfMeasures(
+		return cpInstanceUnitOfMeasurePersistence.findByCPInstanceId(
 			cpInstanceId, start, end, orderByComparator);
 	}
 
@@ -219,7 +217,7 @@ public class CPInstanceUnitOfMeasureServiceImpl
 	private void _checkCommerceCatalog(long cpInstanceId, String actionId)
 		throws PortalException {
 
-		CPInstance cpInstance = _cpInstanceLocalService.getCPInstance(
+		CPInstance cpInstance = _cpInstancePersistence.findByPrimaryKey(
 			cpInstanceId);
 
 		CommerceCatalog commerceCatalog =
@@ -244,6 +242,6 @@ public class CPInstanceUnitOfMeasureServiceImpl
 		_commerceCatalogModelResourcePermission;
 
 	@Reference
-	private CPInstanceLocalService _cpInstanceLocalService;
+	private CPInstancePersistence _cpInstancePersistence;
 
 }

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPMeasurementUnitServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPMeasurementUnitServiceImpl.java
@@ -8,6 +8,7 @@ package com.liferay.commerce.product.service.impl;
 import com.liferay.commerce.product.constants.CPActionKeys;
 import com.liferay.commerce.product.model.CPMeasurementUnit;
 import com.liferay.commerce.product.service.base.CPMeasurementUnitServiceBaseImpl;
+import com.liferay.commerce.product.util.comparator.CPMeasurementUnitPriorityComparator;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
@@ -68,8 +69,7 @@ public class CPMeasurementUnitServiceImpl
 		throws PortalException {
 
 		CPMeasurementUnit cpMeasurementUnit =
-			cpMeasurementUnitLocalService.fetchCPMeasurementUnit(
-				cpMeasurementUnitId);
+			cpMeasurementUnitPersistence.fetchByPrimaryKey(cpMeasurementUnitId);
 
 		if (cpMeasurementUnit != null) {
 			_cpMeasurementUnitModelResourcePermission.check(
@@ -84,8 +84,7 @@ public class CPMeasurementUnitServiceImpl
 		throws PortalException {
 
 		CPMeasurementUnit cpMeasurementUnit =
-			cpMeasurementUnitLocalService.fetchCPMeasurementUnit(
-				companyId, key);
+			cpMeasurementUnitPersistence.fetchByC_K(companyId, key);
 
 		if (cpMeasurementUnit != null) {
 			_cpMeasurementUnitModelResourcePermission.check(
@@ -121,8 +120,9 @@ public class CPMeasurementUnitServiceImpl
 		throws PortalException {
 
 		CPMeasurementUnit cpMeasurementUnit =
-			cpMeasurementUnitLocalService.fetchPrimaryCPMeasurementUnit(
-				companyId, type);
+			cpMeasurementUnitPersistence.fetchByC_P_T_First(
+				companyId, true, type,
+				CPMeasurementUnitPriorityComparator.getInstance(false));
 
 		if (cpMeasurementUnit != null) {
 			_cpMeasurementUnitModelResourcePermission.check(
@@ -140,7 +140,7 @@ public class CPMeasurementUnitServiceImpl
 		_cpMeasurementUnitModelResourcePermission.check(
 			getPermissionChecker(), cpMeasurementUnitId, ActionKeys.VIEW);
 
-		return cpMeasurementUnitLocalService.getCPMeasurementUnit(
+		return cpMeasurementUnitPersistence.findByPrimaryKey(
 			cpMeasurementUnitId);
 	}
 
@@ -153,7 +153,7 @@ public class CPMeasurementUnitServiceImpl
 		_checkPortletResourcePermission(
 			CPActionKeys.VIEW_COMMERCE_PRODUCT_MEASUREMENT_UNITS);
 
-		return cpMeasurementUnitLocalService.getCPMeasurementUnits(
+		return cpMeasurementUnitPersistence.findByC_T(
 			companyId, type, start, end, orderByComparator);
 	}
 
@@ -166,7 +166,7 @@ public class CPMeasurementUnitServiceImpl
 		_checkPortletResourcePermission(
 			CPActionKeys.VIEW_COMMERCE_PRODUCT_MEASUREMENT_UNITS);
 
-		return cpMeasurementUnitLocalService.getCPMeasurementUnits(
+		return cpMeasurementUnitPersistence.findByCompanyId(
 			companyId, start, end, orderByComparator);
 	}
 
@@ -177,8 +177,7 @@ public class CPMeasurementUnitServiceImpl
 		_checkPortletResourcePermission(
 			CPActionKeys.VIEW_COMMERCE_PRODUCT_MEASUREMENT_UNITS);
 
-		return cpMeasurementUnitLocalService.getCPMeasurementUnitsCount(
-			companyId);
+		return cpMeasurementUnitPersistence.countByCompanyId(companyId);
 	}
 
 	@Override
@@ -188,8 +187,7 @@ public class CPMeasurementUnitServiceImpl
 		_checkPortletResourcePermission(
 			CPActionKeys.VIEW_COMMERCE_PRODUCT_MEASUREMENT_UNITS);
 
-		return cpMeasurementUnitLocalService.getCPMeasurementUnitsCount(
-			companyId, type);
+		return cpMeasurementUnitPersistence.countByC_T(companyId, type);
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPOptionCategoryServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPOptionCategoryServiceImpl.java
@@ -71,9 +71,8 @@ public class CPOptionCategoryServiceImpl
 					externalReferenceCode, serviceContext.getCompanyId());
 
 		if ((cpOptionCategory == null) && (cpOptionCategoryId > 0)) {
-			cpOptionCategory =
-				cpOptionCategoryLocalService.fetchCPOptionCategory(
-					cpOptionCategoryId);
+			cpOptionCategory = cpOptionCategoryPersistence.fetchByPrimaryKey(
+				cpOptionCategoryId);
 		}
 
 		if (cpOptionCategory == null) {
@@ -111,8 +110,7 @@ public class CPOptionCategoryServiceImpl
 		throws PortalException {
 
 		CPOptionCategory cpOptionCategory =
-			cpOptionCategoryLocalService.fetchCPOptionCategory(
-				cpOptionCategoryId);
+			cpOptionCategoryPersistence.fetchByPrimaryKey(cpOptionCategoryId);
 
 		if (cpOptionCategory != null) {
 			_cpOptionCategoryModelResourcePermission.check(
@@ -148,8 +146,7 @@ public class CPOptionCategoryServiceImpl
 		_cpOptionCategoryModelResourcePermission.check(
 			getPermissionChecker(), cpOptionCategoryId, ActionKeys.VIEW);
 
-		return cpOptionCategoryLocalService.getCPOptionCategory(
-			cpOptionCategoryId);
+		return cpOptionCategoryPersistence.findByPrimaryKey(cpOptionCategoryId);
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPOptionLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPOptionLocalServiceImpl.java
@@ -270,7 +270,7 @@ public class CPOptionLocalServiceImpl extends CPOptionLocalServiceBaseImpl {
 			String externalReferenceCode, long cpOptionId)
 		throws PortalException {
 
-		CPOption cpOption = cpOptionLocalService.getCPOption(cpOptionId);
+		CPOption cpOption = cpOptionPersistence.findByPrimaryKey(cpOptionId);
 
 		cpOption.setExternalReferenceCode(externalReferenceCode);
 

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPOptionServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPOptionServiceImpl.java
@@ -64,9 +64,8 @@ public class CPOptionServiceImpl extends CPOptionServiceBaseImpl {
 			String key, ServiceContext serviceContext)
 		throws PortalException {
 
-		CPOption cpOption =
-			cpOptionLocalService.fetchCPOptionByExternalReferenceCode(
-				externalReferenceCode, serviceContext.getCompanyId());
+		CPOption cpOption = cpOptionPersistence.fetchByERC_C(
+			externalReferenceCode, serviceContext.getCompanyId());
 
 		if (cpOption == null) {
 			PortletResourcePermission portletResourcePermission =
@@ -93,7 +92,7 @@ public class CPOptionServiceImpl extends CPOptionServiceBaseImpl {
 
 	@Override
 	public CPOption fetchCPOption(long cpOptionId) throws PortalException {
-		CPOption cpOption = cpOptionLocalService.fetchCPOption(cpOptionId);
+		CPOption cpOption = cpOptionPersistence.fetchByPrimaryKey(cpOptionId);
 
 		if (cpOption != null) {
 			_cpOptionModelResourcePermission.check(
@@ -107,7 +106,7 @@ public class CPOptionServiceImpl extends CPOptionServiceBaseImpl {
 	public CPOption fetchCPOption(long companyId, String key)
 		throws PortalException {
 
-		CPOption cpOption = cpOptionLocalService.fetchCPOption(companyId, key);
+		CPOption cpOption = cpOptionPersistence.fetchByC_K(companyId, key);
 
 		if (cpOption != null) {
 			_cpOptionModelResourcePermission.check(
@@ -122,9 +121,8 @@ public class CPOptionServiceImpl extends CPOptionServiceBaseImpl {
 			String externalReferenceCode, long companyId)
 		throws PortalException {
 
-		CPOption cpOption =
-			cpOptionLocalService.fetchCPOptionByExternalReferenceCode(
-				externalReferenceCode, companyId);
+		CPOption cpOption = cpOptionPersistence.fetchByERC_C(
+			externalReferenceCode, companyId);
 
 		if (cpOption != null) {
 			_cpOptionModelResourcePermission.check(
@@ -140,7 +138,7 @@ public class CPOptionServiceImpl extends CPOptionServiceBaseImpl {
 			OrderByComparator<CPOption> orderByComparator)
 		throws PortalException {
 
-		return cpOptionLocalService.findCPOptionByCompanyId(
+		return cpOptionPersistence.filterFindByCompanyId(
 			companyId, start, end, orderByComparator);
 	}
 
@@ -149,7 +147,7 @@ public class CPOptionServiceImpl extends CPOptionServiceBaseImpl {
 		_cpOptionModelResourcePermission.check(
 			getPermissionChecker(), cpOptionId, ActionKeys.VIEW);
 
-		return cpOptionLocalService.getCPOption(cpOptionId);
+		return cpOptionPersistence.findByPrimaryKey(cpOptionId);
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPOptionValueLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPOptionValueLocalServiceImpl.java
@@ -177,7 +177,7 @@ public class CPOptionValueLocalServiceImpl
 	@Override
 	public void deleteCPOptionValues(long cpOptionId) throws PortalException {
 		List<CPOptionValue> cpOptionValues =
-			cpOptionValueLocalService.getCPOptionValues(
+			cpOptionValuePersistence.findByCPOptionId(
 				cpOptionId, QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 
 		for (CPOptionValue cpOptionValue : cpOptionValues) {

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPOptionValueServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPOptionValueServiceImpl.java
@@ -55,9 +55,8 @@ public class CPOptionValueServiceImpl extends CPOptionValueServiceBaseImpl {
 			ServiceContext serviceContext)
 		throws PortalException {
 
-		CPOptionValue cpOptionValue =
-			cpOptionValueLocalService.fetchCPOptionValueByExternalReferenceCode(
-				externalReferenceCode, serviceContext.getCompanyId());
+		CPOptionValue cpOptionValue = cpOptionValuePersistence.fetchByERC_C(
+			externalReferenceCode, serviceContext.getCompanyId());
 
 		if (cpOptionValue == null) {
 			_cpOptionModelResourcePermission.check(
@@ -74,7 +73,7 @@ public class CPOptionValueServiceImpl extends CPOptionValueServiceBaseImpl {
 		throws PortalException {
 
 		CPOptionValue cpOptionValue =
-			cpOptionValueLocalService.fetchCPOptionValue(cpOptionValueId);
+			cpOptionValuePersistence.fetchByPrimaryKey(cpOptionValueId);
 
 		_cpOptionModelResourcePermission.check(
 			getPermissionChecker(), cpOptionValue.getCPOptionId(),
@@ -88,7 +87,7 @@ public class CPOptionValueServiceImpl extends CPOptionValueServiceBaseImpl {
 		throws PortalException {
 
 		CPOptionValue cpOptionValue =
-			cpOptionValueLocalService.fetchCPOptionValue(cpOptionValueId);
+			cpOptionValuePersistence.fetchByPrimaryKey(cpOptionValueId);
 
 		if (cpOptionValue != null) {
 			_cpOptionModelResourcePermission.check(
@@ -104,9 +103,8 @@ public class CPOptionValueServiceImpl extends CPOptionValueServiceBaseImpl {
 			String externalReferenceCode, long companyId)
 		throws PortalException {
 
-		CPOptionValue cpOptionValue =
-			cpOptionValueLocalService.fetchCPOptionValueByExternalReferenceCode(
-				externalReferenceCode, companyId);
+		CPOptionValue cpOptionValue = cpOptionValuePersistence.fetchByERC_C(
+			externalReferenceCode, companyId);
 
 		if (cpOptionValue != null) {
 			_cpOptionModelResourcePermission.check(
@@ -121,8 +119,8 @@ public class CPOptionValueServiceImpl extends CPOptionValueServiceBaseImpl {
 	public CPOptionValue getCPOptionValue(long cpOptionValueId)
 		throws PortalException {
 
-		CPOptionValue cpOptionValue =
-			cpOptionValueLocalService.getCPOptionValue(cpOptionValueId);
+		CPOptionValue cpOptionValue = cpOptionValuePersistence.findByPrimaryKey(
+			cpOptionValueId);
 
 		_cpOptionModelResourcePermission.check(
 			getPermissionChecker(), cpOptionValue.getCPOptionId(),
@@ -139,7 +137,7 @@ public class CPOptionValueServiceImpl extends CPOptionValueServiceBaseImpl {
 		_cpOptionModelResourcePermission.check(
 			getPermissionChecker(), cpOptionId, ActionKeys.VIEW);
 
-		return cpOptionValueLocalService.getCPOptionValues(
+		return cpOptionValuePersistence.findByCPOptionId(
 			cpOptionId, start, end);
 	}
 
@@ -148,7 +146,7 @@ public class CPOptionValueServiceImpl extends CPOptionValueServiceBaseImpl {
 		_cpOptionModelResourcePermission.check(
 			getPermissionChecker(), cpOptionId, ActionKeys.VIEW);
 
-		return cpOptionValueLocalService.getCPOptionValuesCount(cpOptionId);
+		return cpOptionValuePersistence.countByCPOptionId(cpOptionId);
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPOptionValueServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPOptionValueServiceImpl.java
@@ -72,8 +72,8 @@ public class CPOptionValueServiceImpl extends CPOptionValueServiceBaseImpl {
 	public void deleteCPOptionValue(long cpOptionValueId)
 		throws PortalException {
 
-		CPOptionValue cpOptionValue =
-			cpOptionValuePersistence.fetchByPrimaryKey(cpOptionValueId);
+		CPOptionValue cpOptionValue = cpOptionValuePersistence.findByPrimaryKey(
+			cpOptionValueId);
 
 		_cpOptionModelResourcePermission.check(
 			getPermissionChecker(), cpOptionValue.getCPOptionId(),

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPSpecificationOptionServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPSpecificationOptionServiceImpl.java
@@ -16,6 +16,7 @@ import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.security.permission.resource.PortletResourcePermission;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.util.FriendlyURLNormalizer;
 
 import java.util.Locale;
 import java.util.Map;
@@ -75,8 +76,8 @@ public class CPSpecificationOptionServiceImpl
 		throws PortalException {
 
 		CPSpecificationOption cpSpecificationOption =
-			cpSpecificationOptionLocalService.fetchCPSpecificationOption(
-				companyId, key);
+			cpSpecificationOptionPersistence.fetchByC_K(
+				companyId, _friendlyURLNormalizer.normalize(key));
 
 		if (cpSpecificationOption != null) {
 			_cpSpecificationOptionModelResourcePermission.check(
@@ -115,7 +116,7 @@ public class CPSpecificationOptionServiceImpl
 		_cpSpecificationOptionModelResourcePermission.check(
 			getPermissionChecker(), cpSpecificationOptionId, ActionKeys.VIEW);
 
-		return cpSpecificationOptionLocalService.getCPSpecificationOption(
+		return cpSpecificationOptionPersistence.findByPrimaryKey(
 			cpSpecificationOptionId);
 	}
 
@@ -125,8 +126,8 @@ public class CPSpecificationOptionServiceImpl
 		throws PortalException {
 
 		CPSpecificationOption cpSpecificationOption =
-			cpSpecificationOptionLocalService.getCPSpecificationOption(
-				companyId, key);
+			cpSpecificationOptionPersistence.findByC_K(
+				companyId, _friendlyURLNormalizer.normalize(key));
 
 		_cpSpecificationOptionModelResourcePermission.check(
 			getPermissionChecker(), cpSpecificationOption, ActionKeys.VIEW);
@@ -168,5 +169,8 @@ public class CPSpecificationOptionServiceImpl
 	)
 	private ModelResourcePermission<CPSpecificationOption>
 		_cpSpecificationOptionModelResourcePermission;
+
+	@Reference
+	private FriendlyURLNormalizer _friendlyURLNormalizer;
 
 }

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPTaxCategoryServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPTaxCategoryServiceImpl.java
@@ -97,7 +97,7 @@ public class CPTaxCategoryServiceImpl extends CPTaxCategoryServiceBaseImpl {
 			getPermissionChecker(), null,
 			CPActionKeys.VIEW_COMMERCE_PRODUCT_TAX_CATEGORIES);
 
-		return cpTaxCategoryLocalService.getCPTaxCategories(companyId);
+		return cpTaxCategoryPersistence.findByCompanyId(companyId);
 	}
 
 	@Override
@@ -110,7 +110,7 @@ public class CPTaxCategoryServiceImpl extends CPTaxCategoryServiceBaseImpl {
 			getPermissionChecker(), null,
 			CPActionKeys.VIEW_COMMERCE_PRODUCT_TAX_CATEGORIES);
 
-		return cpTaxCategoryLocalService.getCPTaxCategories(
+		return cpTaxCategoryPersistence.findByCompanyId(
 			companyId, start, end, orderByComparator);
 	}
 
@@ -120,7 +120,7 @@ public class CPTaxCategoryServiceImpl extends CPTaxCategoryServiceBaseImpl {
 			getPermissionChecker(), null,
 			CPActionKeys.VIEW_COMMERCE_PRODUCT_TAX_CATEGORIES);
 
-		return cpTaxCategoryLocalService.getCPTaxCategoriesCount(companyId);
+		return cpTaxCategoryPersistence.countByCompanyId(companyId);
 	}
 
 	@Override
@@ -130,7 +130,7 @@ public class CPTaxCategoryServiceImpl extends CPTaxCategoryServiceBaseImpl {
 		_modelResourcePermission.check(
 			getPermissionChecker(), cpTaxCategoryId, ActionKeys.VIEW);
 
-		return cpTaxCategoryLocalService.getCPTaxCategory(cpTaxCategoryId);
+		return cpTaxCategoryPersistence.findByPrimaryKey(cpTaxCategoryId);
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-product-type-grouped-service/src/main/java/com/liferay/commerce/product/type/grouped/service/impl/CPDefinitionGroupedEntryServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-type-grouped-service/src/main/java/com/liferay/commerce/product/type/grouped/service/impl/CPDefinitionGroupedEntryServiceImpl.java
@@ -151,7 +151,7 @@ public class CPDefinitionGroupedEntryServiceImpl
 		throws PortalException {
 
 		CPDefinitionGroupedEntry cpDefinitionGroupedEntry =
-			cpDefinitionGroupedEntryLocalService.getCPDefinitionGroupedEntry(
+			cpDefinitionGroupedEntryPersistence.findByPrimaryKey(
 				cpDefinitionGroupedEntryId);
 
 		if (cpDefinitionGroupedEntry != null) {

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CPDefinitionInventoryServiceImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CPDefinitionInventoryServiceImpl.java
@@ -59,7 +59,7 @@ public class CPDefinitionInventoryServiceImpl
 		throws PortalException {
 
 		CPDefinitionInventory cpDefinitionInventory =
-			cpDefinitionInventoryLocalService.getCPDefinitionInventory(
+			cpDefinitionInventoryPersistence.findByPrimaryKey(
 				cpDefinitionInventoryId);
 
 		_checkCommerceCatalog(
@@ -97,7 +97,7 @@ public class CPDefinitionInventoryServiceImpl
 		throws PortalException {
 
 		CPDefinitionInventory cpDefinitionInventory =
-			cpDefinitionInventoryLocalService.getCPDefinitionInventory(
+			cpDefinitionInventoryPersistence.findByPrimaryKey(
 				cpDefinitionInventoryId);
 
 		_checkCommerceCatalog(

--- a/modules/apps/commerce/commerce-shop-by-diagram-service/src/main/java/com/liferay/commerce/shop/by/diagram/service/impl/CSDiagramEntryLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-shop-by-diagram-service/src/main/java/com/liferay/commerce/shop/by/diagram/service/impl/CSDiagramEntryLocalServiceImpl.java
@@ -12,6 +12,7 @@ import com.liferay.commerce.shop.by.diagram.model.CSDiagramEntry;
 import com.liferay.commerce.shop.by.diagram.model.CSDiagramPin;
 import com.liferay.commerce.shop.by.diagram.service.CSDiagramPinLocalService;
 import com.liferay.commerce.shop.by.diagram.service.base.CSDiagramEntryLocalServiceBaseImpl;
+import com.liferay.commerce.shop.by.diagram.service.persistence.CSDiagramPinPersistence;
 import com.liferay.expando.kernel.service.ExpandoRowLocalService;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
@@ -97,7 +98,7 @@ public class CSDiagramEntryLocalServiceImpl
 		csDiagramEntry = csDiagramEntryPersistence.remove(csDiagramEntry);
 
 		List<CSDiagramPin> csDiagramPins =
-			_csDiagramPinLocalService.getCSDiagramPins(
+			_csDiagramPinPersistence.findByCPDefinitionId(
 				csDiagramEntry.getCPDefinitionId(), QueryUtil.ALL_POS,
 				QueryUtil.ALL_POS);
 
@@ -185,7 +186,7 @@ public class CSDiagramEntryLocalServiceImpl
 		throws PortalException {
 
 		CSDiagramEntry csDiagramEntry =
-			csDiagramEntryLocalService.getCSDiagramEntry(csDiagramEntryId);
+			csDiagramEntryPersistence.findByPrimaryKey(csDiagramEntryId);
 
 		_validate(csDiagramEntry, csDiagramEntry.getCPDefinitionId(), sequence);
 
@@ -218,6 +219,9 @@ public class CSDiagramEntryLocalServiceImpl
 
 	@Reference
 	private CSDiagramPinLocalService _csDiagramPinLocalService;
+
+	@Reference
+	private CSDiagramPinPersistence _csDiagramPinPersistence;
 
 	@Reference
 	private ExpandoRowLocalService _expandoRowLocalService;

--- a/modules/apps/commerce/commerce-shop-by-diagram-service/src/main/java/com/liferay/commerce/shop/by/diagram/service/impl/CSDiagramEntryServiceImpl.java
+++ b/modules/apps/commerce/commerce-shop-by-diagram-service/src/main/java/com/liferay/commerce/shop/by/diagram/service/impl/CSDiagramEntryServiceImpl.java
@@ -78,7 +78,7 @@ public class CSDiagramEntryServiceImpl extends CSDiagramEntryServiceBaseImpl {
 		_cpDefinitionModelResourcePermission.check(
 			getPermissionChecker(), cpDefinitionId, ActionKeys.UPDATE);
 
-		return csDiagramEntryLocalService.fetchCSDiagramEntry(
+		return csDiagramEntryPersistence.fetchByCPDI_S(
 			cpDefinitionId, sequence);
 	}
 
@@ -119,7 +119,7 @@ public class CSDiagramEntryServiceImpl extends CSDiagramEntryServiceBaseImpl {
 		_cpDefinitionModelResourcePermission.check(
 			getPermissionChecker(), cpDefinitionId, ActionKeys.UPDATE);
 
-		return csDiagramEntryLocalService.getCSDiagramEntries(
+		return csDiagramEntryPersistence.findByCPDefinitionId(
 			cpDefinitionId, start, end);
 	}
 
@@ -130,8 +130,7 @@ public class CSDiagramEntryServiceImpl extends CSDiagramEntryServiceBaseImpl {
 		_cpDefinitionModelResourcePermission.check(
 			getPermissionChecker(), cpDefinitionId, ActionKeys.UPDATE);
 
-		return csDiagramEntryLocalService.getCSDiagramEntriesCount(
-			cpDefinitionId);
+		return csDiagramEntryPersistence.countByCPDefinitionId(cpDefinitionId);
 	}
 
 	@Override
@@ -139,7 +138,7 @@ public class CSDiagramEntryServiceImpl extends CSDiagramEntryServiceBaseImpl {
 		throws PortalException {
 
 		CSDiagramEntry csDiagramEntry =
-			csDiagramEntryLocalService.getCSDiagramEntry(csDiagramEntryId);
+			csDiagramEntryPersistence.findByPrimaryKey(csDiagramEntryId);
 
 		_cpDefinitionModelResourcePermission.check(
 			getPermissionChecker(), csDiagramEntry.getCPDefinitionId(),
@@ -168,7 +167,7 @@ public class CSDiagramEntryServiceImpl extends CSDiagramEntryServiceBaseImpl {
 		throws PortalException {
 
 		CSDiagramEntry csDiagramEntry =
-			csDiagramEntryLocalService.getCSDiagramEntry(csDiagramEntryId);
+			csDiagramEntryPersistence.findByPrimaryKey(csDiagramEntryId);
 
 		_cpDefinitionModelResourcePermission.check(
 			getPermissionChecker(), csDiagramEntry.getCPDefinitionId(),

--- a/modules/apps/commerce/commerce-shop-by-diagram-service/src/main/java/com/liferay/commerce/shop/by/diagram/service/impl/CSDiagramPinLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-shop-by-diagram-service/src/main/java/com/liferay/commerce/shop/by/diagram/service/impl/CSDiagramPinLocalServiceImpl.java
@@ -91,7 +91,7 @@ public class CSDiagramPinLocalServiceImpl
 			String sequence)
 		throws PortalException {
 
-		CSDiagramPin csDiagramPin = csDiagramPinLocalService.getCSDiagramPin(
+		CSDiagramPin csDiagramPin = csDiagramPinPersistence.findByPrimaryKey(
 			csDiagramPinId);
 
 		csDiagramPin.setPositionX(positionX);

--- a/modules/apps/commerce/commerce-shop-by-diagram-service/src/main/java/com/liferay/commerce/shop/by/diagram/service/impl/CSDiagramPinServiceImpl.java
+++ b/modules/apps/commerce/commerce-shop-by-diagram-service/src/main/java/com/liferay/commerce/shop/by/diagram/service/impl/CSDiagramPinServiceImpl.java
@@ -66,14 +66,14 @@ public class CSDiagramPinServiceImpl extends CSDiagramPinServiceBaseImpl {
 
 	@Override
 	public CSDiagramPin fetchCSDiagramPin(long csDiagramPinId) {
-		return csDiagramPinLocalService.fetchCSDiagramPin(csDiagramPinId);
+		return csDiagramPinPersistence.fetchByPrimaryKey(csDiagramPinId);
 	}
 
 	@Override
 	public CSDiagramPin getCSDiagramPin(long csDiagramPinId)
 		throws PortalException {
 
-		CSDiagramPin csDiagramPin = csDiagramPinLocalService.getCSDiagramPin(
+		CSDiagramPin csDiagramPin = csDiagramPinPersistence.findByPrimaryKey(
 			csDiagramPinId);
 
 		_cpDefinitionModelResourcePermission.check(
@@ -91,7 +91,7 @@ public class CSDiagramPinServiceImpl extends CSDiagramPinServiceBaseImpl {
 		_cpDefinitionModelResourcePermission.check(
 			getPermissionChecker(), cpDefinitionId, ActionKeys.UPDATE);
 
-		return csDiagramPinLocalService.getCSDiagramPins(
+		return csDiagramPinPersistence.findByCPDefinitionId(
 			cpDefinitionId, start, end);
 	}
 
@@ -102,7 +102,7 @@ public class CSDiagramPinServiceImpl extends CSDiagramPinServiceBaseImpl {
 		_cpDefinitionModelResourcePermission.check(
 			getPermissionChecker(), cpDefinitionId, ActionKeys.UPDATE);
 
-		return csDiagramPinLocalService.getCSDiagramPinsCount(cpDefinitionId);
+		return csDiagramPinPersistence.countByCPDefinitionId(cpDefinitionId);
 	}
 
 	@Override
@@ -111,7 +111,7 @@ public class CSDiagramPinServiceImpl extends CSDiagramPinServiceBaseImpl {
 			String sequence)
 		throws PortalException {
 
-		CSDiagramPin csDiagramPin = csDiagramPinLocalService.getCSDiagramPin(
+		CSDiagramPin csDiagramPin = csDiagramPinPersistence.findByPrimaryKey(
 			csDiagramPinId);
 
 		_cpDefinitionModelResourcePermission.check(

--- a/modules/apps/commerce/commerce-shop-by-diagram-service/src/main/java/com/liferay/commerce/shop/by/diagram/service/impl/CSDiagramSettingLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-shop-by-diagram-service/src/main/java/com/liferay/commerce/shop/by/diagram/service/impl/CSDiagramSettingLocalServiceImpl.java
@@ -112,8 +112,7 @@ public class CSDiagramSettingLocalServiceImpl
 		throws PortalException {
 
 		CSDiagramSetting csDiagramSetting =
-			csDiagramSettingLocalService.getCSDiagramSetting(
-				csDiagramSettingId);
+			csDiagramSettingPersistence.findByPrimaryKey(csDiagramSettingId);
 
 		csDiagramSetting.setCPAttachmentFileEntryId(cpAttachmentFileEntryId);
 		csDiagramSetting.setColor(color);

--- a/modules/apps/commerce/commerce-shop-by-diagram-service/src/main/java/com/liferay/commerce/shop/by/diagram/service/impl/CSDiagramSettingServiceImpl.java
+++ b/modules/apps/commerce/commerce-shop-by-diagram-service/src/main/java/com/liferay/commerce/shop/by/diagram/service/impl/CSDiagramSettingServiceImpl.java
@@ -60,8 +60,7 @@ public class CSDiagramSettingServiceImpl
 		throws PortalException {
 
 		CSDiagramSetting csDiagramSetting =
-			csDiagramSettingLocalService.getCSDiagramSetting(
-				csDiagramSettingId);
+			csDiagramSettingPersistence.findByPrimaryKey(csDiagramSettingId);
 
 		_cpDefinitionModelResourcePermission.check(
 			getPermissionChecker(), csDiagramSetting.getCPDefinitionId(),
@@ -78,8 +77,7 @@ public class CSDiagramSettingServiceImpl
 		_cpDefinitionModelResourcePermission.check(
 			getPermissionChecker(), cpDefinitionId, ActionKeys.UPDATE);
 
-		return csDiagramSettingLocalService.getCSDiagramSettingByCPDefinitionId(
-			cpDefinitionId);
+		return csDiagramSettingPersistence.findByCPDefinitionId(cpDefinitionId);
 	}
 
 	@Override
@@ -89,8 +87,7 @@ public class CSDiagramSettingServiceImpl
 		throws PortalException {
 
 		CSDiagramSetting csDiagramSetting =
-			csDiagramSettingLocalService.getCSDiagramSetting(
-				csDiagramSettingId);
+			csDiagramSettingPersistence.findByPrimaryKey(csDiagramSettingId);
 
 		_cpDefinitionModelResourcePermission.check(
 			getPermissionChecker(), csDiagramSetting.getCPDefinitionId(),

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/service/impl/DDLRecordLocalServiceImpl.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/service/impl/DDLRecordLocalServiceImpl.java
@@ -15,7 +15,6 @@ import com.liferay.dynamic.data.lists.model.DDLFormRecord;
 import com.liferay.dynamic.data.lists.model.DDLRecord;
 import com.liferay.dynamic.data.lists.model.DDLRecordSet;
 import com.liferay.dynamic.data.lists.model.DDLRecordVersion;
-import com.liferay.dynamic.data.lists.service.DDLRecordVersionLocalService;
 import com.liferay.dynamic.data.lists.service.base.DDLRecordLocalServiceBaseImpl;
 import com.liferay.dynamic.data.lists.service.persistence.DDLRecordSetPersistence;
 import com.liferay.dynamic.data.lists.service.persistence.DDLRecordVersionPersistence;
@@ -584,8 +583,8 @@ public class DDLRecordLocalServiceImpl extends DDLRecordLocalServiceBaseImpl {
 			ServiceContext serviceContext)
 		throws PortalException {
 
-		DDLRecordVersion recordVersion =
-			_ddlRecordVersionLocalService.getRecordVersion(recordId, version);
+		DDLRecordVersion recordVersion = _ddlRecordVersionPersistence.findByR_V(
+			recordId, version);
 
 		if (!recordVersion.isApproved()) {
 			return;
@@ -1355,9 +1354,6 @@ public class DDLRecordLocalServiceImpl extends DDLRecordLocalServiceBaseImpl {
 
 	@Reference
 	private DDLRecordSetPersistence _ddlRecordSetPersistence;
-
-	@Reference
-	private DDLRecordVersionLocalService _ddlRecordVersionLocalService;
 
 	@Reference
 	private DDLRecordVersionPersistence _ddlRecordVersionPersistence;

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/service/impl/DDLRecordServiceImpl.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/service/impl/DDLRecordServiceImpl.java
@@ -106,7 +106,7 @@ public class DDLRecordServiceImpl extends DDLRecordServiceBaseImpl {
 	 */
 	@Override
 	public void deleteRecord(long recordId) throws PortalException {
-		DDLRecord record = ddlRecordLocalService.getDDLRecord(recordId);
+		DDLRecord record = ddlRecordPersistence.findByPrimaryKey(recordId);
 
 		_ddlRecordSetModelResourcePermission.check(
 			getPermissionChecker(), record.getRecordSetId(), ActionKeys.DELETE);
@@ -123,7 +123,7 @@ public class DDLRecordServiceImpl extends DDLRecordServiceBaseImpl {
 	 */
 	@Override
 	public DDLRecord getRecord(long recordId) throws PortalException {
-		DDLRecord record = ddlRecordLocalService.getDDLRecord(recordId);
+		DDLRecord record = ddlRecordPersistence.findByPrimaryKey(recordId);
 
 		_ddlRecordSetModelResourcePermission.check(
 			getPermissionChecker(), record.getRecordSetId(), ActionKeys.VIEW);
@@ -160,7 +160,7 @@ public class DDLRecordServiceImpl extends DDLRecordServiceBaseImpl {
 			long recordId, String version, ServiceContext serviceContext)
 		throws PortalException {
 
-		DDLRecord record = ddlRecordLocalService.getDDLRecord(recordId);
+		DDLRecord record = ddlRecordPersistence.findByPrimaryKey(recordId);
 
 		_ddlRecordSetModelResourcePermission.check(
 			getPermissionChecker(), record.getRecordSetId(), ActionKeys.UPDATE);
@@ -190,7 +190,7 @@ public class DDLRecordServiceImpl extends DDLRecordServiceBaseImpl {
 			DDMFormValues ddmFormValues, ServiceContext serviceContext)
 		throws PortalException {
 
-		DDLRecord record = ddlRecordLocalService.getDDLRecord(recordId);
+		DDLRecord record = ddlRecordPersistence.findByPrimaryKey(recordId);
 
 		_ddlRecordSetModelResourcePermission.check(
 			getPermissionChecker(), record.getRecordSetId(), ActionKeys.UPDATE);
@@ -222,7 +222,7 @@ public class DDLRecordServiceImpl extends DDLRecordServiceBaseImpl {
 			ServiceContext serviceContext)
 		throws PortalException {
 
-		DDLRecord record = ddlRecordLocalService.getDDLRecord(recordId);
+		DDLRecord record = ddlRecordPersistence.findByPrimaryKey(recordId);
 
 		_ddlRecordSetModelResourcePermission.check(
 			getPermissionChecker(), record.getRecordSetId(), ActionKeys.UPDATE);

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/service/impl/DDLRecordSetServiceImpl.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/service/impl/DDLRecordSetServiceImpl.java
@@ -108,7 +108,7 @@ public class DDLRecordSetServiceImpl extends DDLRecordSetServiceBaseImpl {
 	public DDLRecordSet fetchRecordSet(long recordSetId)
 		throws PortalException {
 
-		DDLRecordSet recordSet = ddlRecordSetLocalService.fetchRecordSet(
+		DDLRecordSet recordSet = ddlRecordSetPersistence.fetchByPrimaryKey(
 			recordSetId);
 
 		if (recordSet == null) {
@@ -135,7 +135,7 @@ public class DDLRecordSetServiceImpl extends DDLRecordSetServiceBaseImpl {
 		_ddlRecordSetModelResourcePermission.check(
 			getPermissionChecker(), recordSetId, ActionKeys.VIEW);
 
-		return ddlRecordSetLocalService.getRecordSet(recordSetId);
+		return ddlRecordSetPersistence.findByPrimaryKey(recordSetId);
 	}
 
 	/**

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/service/impl/DDLRecordSetVersionServiceImpl.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/service/impl/DDLRecordSetVersionServiceImpl.java
@@ -52,8 +52,7 @@ public class DDLRecordSetVersionServiceImpl
 		throws PortalException {
 
 		DDLRecordSetVersion recordSetVersion =
-			ddlRecordSetVersionLocalService.getRecordSetVersion(
-				recordSetVersionId);
+			ddlRecordSetVersionPersistence.findByPrimaryKey(recordSetVersionId);
 
 		_ddlRecordSetModelResourcePermission.check(
 			getPermissionChecker(), recordSetVersion.getRecordSetId(),
@@ -71,7 +70,7 @@ public class DDLRecordSetVersionServiceImpl
 		_ddlRecordSetModelResourcePermission.check(
 			getPermissionChecker(), recordSetId, ActionKeys.VIEW);
 
-		return ddlRecordSetVersionLocalService.getRecordSetVersions(
+		return ddlRecordSetVersionPersistence.findByRecordSetId(
 			recordSetId, start, end, orderByComparator);
 	}
 
@@ -82,8 +81,7 @@ public class DDLRecordSetVersionServiceImpl
 		_ddlRecordSetModelResourcePermission.check(
 			getPermissionChecker(), recordSetId, ActionKeys.VIEW);
 
-		return ddlRecordSetVersionLocalService.getRecordSetVersionsCount(
-			recordSetId);
+		return ddlRecordSetVersionPersistence.countByRecordSetId(recordSetId);
 	}
 
 	@Reference(

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/service/impl/DDLRecordVersionServiceImpl.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/service/impl/DDLRecordVersionServiceImpl.java
@@ -51,7 +51,7 @@ public class DDLRecordVersionServiceImpl
 		throws PortalException {
 
 		DDLRecordVersion recordVersion =
-			ddlRecordVersionLocalService.getRecordVersion(recordVersionId);
+			ddlRecordVersionPersistence.findByPrimaryKey(recordVersionId);
 
 		_ddlRecordSetModelResourcePermission.check(
 			getPermissionChecker(), recordVersion.getRecordSetId(),

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMDataProviderInstanceServiceImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMDataProviderInstanceServiceImpl.java
@@ -79,7 +79,7 @@ public class DDMDataProviderInstanceServiceImpl
 		throws PortalException {
 
 		DDMDataProviderInstance dataProviderInstance =
-			ddmDataProviderInstanceLocalService.fetchDataProviderInstance(
+			ddmDataProviderInstancePersistence.fetchByPrimaryKey(
 				dataProviderInstanceId);
 
 		if (dataProviderInstance == null) {
@@ -120,7 +120,7 @@ public class DDMDataProviderInstanceServiceImpl
 		_ddmDataProviderInstanceModelResourcePermission.check(
 			getPermissionChecker(), dataProviderInstanceId, ActionKeys.VIEW);
 
-		return ddmDataProviderInstanceLocalService.getDataProviderInstance(
+		return ddmDataProviderInstancePersistence.findByPrimaryKey(
 			dataProviderInstanceId);
 	}
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMFormInstanceLocalServiceImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMFormInstanceLocalServiceImpl.java
@@ -26,6 +26,7 @@ import com.liferay.dynamic.data.mapping.service.DDMFormInstanceVersionLocalServi
 import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
 import com.liferay.dynamic.data.mapping.service.base.DDMFormInstanceLocalServiceBaseImpl;
 import com.liferay.dynamic.data.mapping.service.persistence.DDMFormInstanceVersionPersistence;
+import com.liferay.dynamic.data.mapping.service.persistence.DDMStructurePersistence;
 import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
 import com.liferay.dynamic.data.mapping.storage.StorageType;
 import com.liferay.dynamic.data.mapping.util.DDMFormFactory;
@@ -244,7 +245,7 @@ public class DDMFormInstanceLocalServiceImpl
 
 		long structureId = ddmFormInstance.getStructureId();
 
-		if (_ddmStructureLocalService.fetchDDMStructure(structureId) != null) {
+		if (_ddmStructurePersistence.fetchByPrimaryKey(structureId) != null) {
 			_ddmStructureLocalService.deleteStructure(structureId);
 		}
 
@@ -497,7 +498,7 @@ public class DDMFormInstanceLocalServiceImpl
 	private Locale _getDDMFormDefaultLocale(long ddmStructureId)
 		throws PortalException {
 
-		DDMStructure ddmStructure = _ddmStructureLocalService.getDDMStructure(
+		DDMStructure ddmStructure = _ddmStructurePersistence.findByPrimaryKey(
 			ddmStructureId);
 
 		DDMForm ddmForm = ddmStructure.getDDMForm();
@@ -552,7 +553,7 @@ public class DDMFormInstanceLocalServiceImpl
 	private long _getStructureVersionId(long ddmStructureId)
 		throws PortalException {
 
-		DDMStructure ddmStructure = _ddmStructureLocalService.getStructure(
+		DDMStructure ddmStructure = _ddmStructurePersistence.findByPrimaryKey(
 			ddmStructureId);
 
 		DDMStructureVersion ddmStructureVersion =
@@ -741,7 +742,7 @@ public class DDMFormInstanceLocalServiceImpl
 	private void _validateStructureId(long ddmStructureId)
 		throws PortalException {
 
-		DDMStructure ddmStructure = _ddmStructureLocalService.fetchStructure(
+		DDMStructure ddmStructure = _ddmStructurePersistence.fetchByPrimaryKey(
 			ddmStructureId);
 
 		if (ddmStructure == null) {
@@ -773,6 +774,9 @@ public class DDMFormInstanceLocalServiceImpl
 
 	@Reference
 	private DDMStructureLocalService _ddmStructureLocalService;
+
+	@Reference
+	private DDMStructurePersistence _ddmStructurePersistence;
 
 	@Reference(target = "(ddm.form.values.deserializer.type=json)")
 	private DDMFormValuesDeserializer _jsonDDMFormValuesDeserializer;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMFormInstanceRecordServiceImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMFormInstanceRecordServiceImpl.java
@@ -72,7 +72,7 @@ public class DDMFormInstanceRecordServiceImpl
 		_ddmFormInstanceRecordModelResourcePermission.check(
 			getPermissionChecker(), ddmFormInstanceRecordId, ActionKeys.VIEW);
 
-		return ddmFormInstanceRecordLocalService.getFormInstanceRecord(
+		return ddmFormInstanceRecordPersistence.findByPrimaryKey(
 			ddmFormInstanceRecordId);
 	}
 
@@ -84,7 +84,7 @@ public class DDMFormInstanceRecordServiceImpl
 		_ddmFormInstanceModelResourcePermission.check(
 			getPermissionChecker(), ddmFormInstanceId, ActionKeys.VIEW);
 
-		return ddmFormInstanceRecordLocalService.getFormInstanceRecords(
+		return ddmFormInstanceRecordPersistence.findByFormInstanceId(
 			ddmFormInstanceId);
 	}
 
@@ -108,7 +108,7 @@ public class DDMFormInstanceRecordServiceImpl
 		_ddmFormInstanceModelResourcePermission.check(
 			getPermissionChecker(), ddmFormInstanceId, ActionKeys.VIEW);
 
-		return ddmFormInstanceRecordLocalService.getFormInstanceRecordsCount(
+		return ddmFormInstanceRecordPersistence.countByFormInstanceId(
 			ddmFormInstanceId);
 	}
 
@@ -119,7 +119,7 @@ public class DDMFormInstanceRecordServiceImpl
 		throws PortalException {
 
 		DDMFormInstanceRecord ddmFormInstanceRecord =
-			ddmFormInstanceRecordLocalService.getFormInstanceRecord(
+			ddmFormInstanceRecordPersistence.findByPrimaryKey(
 				ddmFormInstanceRecordId);
 
 		_ddmFormInstanceRecordModelResourcePermission.check(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMFormInstanceServiceImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMFormInstanceServiceImpl.java
@@ -101,7 +101,7 @@ public class DDMFormInstanceServiceImpl extends DDMFormInstanceServiceBaseImpl {
 		throws PortalException {
 
 		DDMFormInstance ddmFormInstance =
-			ddmFormInstanceLocalService.fetchFormInstance(ddmFormInstanceId);
+			ddmFormInstancePersistence.fetchByPrimaryKey(ddmFormInstanceId);
 
 		if (ddmFormInstance == null) {
 			return null;
@@ -121,7 +121,7 @@ public class DDMFormInstanceServiceImpl extends DDMFormInstanceServiceBaseImpl {
 		_ddmFormInstanceModelResourcePermission.check(
 			getPermissionChecker(), ddmFormInstanceId, ActionKeys.VIEW);
 
-		return ddmFormInstanceLocalService.getFormInstance(ddmFormInstanceId);
+		return ddmFormInstancePersistence.findByPrimaryKey(ddmFormInstanceId);
 	}
 
 	@Override

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMFormInstanceVersionServiceImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMFormInstanceVersionServiceImpl.java
@@ -39,7 +39,7 @@ public class DDMFormInstanceVersionServiceImpl
 		throws PortalException {
 
 		DDMFormInstanceVersion ddmFormInstanceVersion =
-			ddmFormInstanceVersionLocalService.getFormInstanceVersion(
+			ddmFormInstanceVersionPersistence.findByPrimaryKey(
 				ddmFormInstanceVersionId);
 
 		_ddmFormInstanceVersionPermissionModelResourcePermission.check(
@@ -58,7 +58,7 @@ public class DDMFormInstanceVersionServiceImpl
 		_ddmFormInstanceVersionPermissionModelResourcePermission.check(
 			getPermissionChecker(), ddmFormInstanceId, ActionKeys.VIEW);
 
-		return ddmFormInstanceVersionLocalService.getFormInstanceVersions(
+		return ddmFormInstanceVersionPersistence.findByFormInstanceId(
 			ddmFormInstanceId, start, end, orderByComparator);
 	}
 
@@ -69,7 +69,7 @@ public class DDMFormInstanceVersionServiceImpl
 		_ddmFormInstanceVersionPermissionModelResourcePermission.check(
 			getPermissionChecker(), ddmFormInstanceId, ActionKeys.VIEW);
 
-		return ddmFormInstanceVersionLocalService.getFormInstanceVersionsCount(
+		return ddmFormInstanceVersionPersistence.countByFormInstanceId(
 			ddmFormInstanceId);
 	}
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMStorageLinkLocalServiceImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMStorageLinkLocalServiceImpl.java
@@ -7,8 +7,8 @@ package com.liferay.dynamic.data.mapping.service.impl;
 
 import com.liferay.dynamic.data.mapping.model.DDMStorageLink;
 import com.liferay.dynamic.data.mapping.model.DDMStructureVersion;
-import com.liferay.dynamic.data.mapping.service.DDMStructureVersionLocalService;
 import com.liferay.dynamic.data.mapping.service.base.DDMStorageLinkLocalServiceBaseImpl;
+import com.liferay.dynamic.data.mapping.service.persistence.DDMStructureVersionPersistence;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -37,7 +37,7 @@ public class DDMStorageLinkLocalServiceImpl
 		throws PortalException {
 
 		DDMStructureVersion ddmStructureVersion =
-			_ddmStructureVersionLocalService.getDDMStructureVersion(
+			_ddmStructureVersionPersistence.findByPrimaryKey(
 				structureVersionId);
 
 		long storageLinkId = counterLocalService.increment();
@@ -111,8 +111,7 @@ public class DDMStorageLinkLocalServiceImpl
 	public List<DDMStorageLink> getStructureStorageLinks(long structureId) {
 		return ddmStorageLinkPersistence.findByStructureVersionId(
 			ListUtil.toLongArray(
-				_ddmStructureVersionLocalService.getStructureVersions(
-					structureId),
+				_ddmStructureVersionPersistence.findByStructureId(structureId),
 				DDMStructureVersion::getStructureVersionId));
 	}
 
@@ -120,8 +119,7 @@ public class DDMStorageLinkLocalServiceImpl
 	public int getStructureStorageLinksCount(long structureId) {
 		return ddmStorageLinkPersistence.countByStructureVersionId(
 			ListUtil.toLongArray(
-				_ddmStructureVersionLocalService.getStructureVersions(
-					structureId),
+				_ddmStructureVersionPersistence.findByStructureId(structureId),
 				DDMStructureVersion::getStructureVersionId));
 	}
 
@@ -154,6 +152,6 @@ public class DDMStorageLinkLocalServiceImpl
 	}
 
 	@Reference
-	private DDMStructureVersionLocalService _ddmStructureVersionLocalService;
+	private DDMStructureVersionPersistence _ddmStructureVersionPersistence;
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMStructureLayoutServiceImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMStructureLayoutServiceImpl.java
@@ -39,7 +39,7 @@ public class DDMStructureLayoutServiceImpl
 
 	@Override
 	public int getStructureLayoutsCount(long groupId) {
-		return ddmStructureLayoutLocalService.getStructureLayoutsCount(groupId);
+		return ddmStructureLayoutPersistence.countByGroupId(groupId);
 	}
 
 	@Override

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMStructureLocalServiceImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMStructureLocalServiceImpl.java
@@ -546,7 +546,7 @@ public class DDMStructureLocalServiceImpl
 		// Structure versions
 
 		List<DDMStructureVersion> structureVersions =
-			_ddmStructureVersionLocalService.getStructureVersions(
+			_ddmStructureVersionPersistence.findByStructureId(
 				structure.getStructureId());
 
 		for (DDMStructureVersion structureVersion : structureVersions) {
@@ -1318,8 +1318,7 @@ public class DDMStructureLocalServiceImpl
 		throws PortalException {
 
 		DDMStructureVersion structureVersion =
-			_ddmStructureVersionLocalService.getStructureVersion(
-				structureId, version);
+			_ddmStructureVersionPersistence.findByS_V(structureId, version);
 
 		if (!structureVersion.isApproved()) {
 			throw new InvalidStructureVersionException(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMStructureServiceImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMStructureServiceImpl.java
@@ -231,9 +231,8 @@ public class DDMStructureServiceImpl extends DDMStructureServiceBaseImpl {
 			String externalReferenceCode, long groupId, long classNameId)
 		throws PortalException {
 
-		DDMStructure ddmStructure =
-			ddmStructureLocalService.fetchStructureByExternalReferenceCode(
-				externalReferenceCode, groupId, classNameId);
+		DDMStructure ddmStructure = ddmStructurePersistence.fetchByERC_G_C(
+			externalReferenceCode, groupId, classNameId);
 
 		if (ddmStructure != null) {
 			_ddmStructureModelResourcePermission.check(
@@ -322,9 +321,8 @@ public class DDMStructureServiceImpl extends DDMStructureServiceBaseImpl {
 			String externalReferenceCode, long groupId, long classNameId)
 		throws PortalException {
 
-		DDMStructure structure =
-			ddmStructureLocalService.getStructureByExternalReferenceCode(
-				externalReferenceCode, groupId, classNameId);
+		DDMStructure structure = ddmStructurePersistence.findByERC_G_C(
+			externalReferenceCode, groupId, classNameId);
 
 		_ddmStructureModelResourcePermission.check(
 			getPermissionChecker(), structure, ActionKeys.VIEW);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMStructureVersionServiceImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMStructureVersionServiceImpl.java
@@ -48,8 +48,7 @@ public class DDMStructureVersionServiceImpl
 		throws PortalException {
 
 		DDMStructureVersion structureVersion =
-			ddmStructureVersionLocalService.getStructureVersion(
-				structureVersionId);
+			ddmStructureVersionPersistence.findByPrimaryKey(structureVersionId);
 
 		_ddmStructureModelResourcePermission.check(
 			getPermissionChecker(), structureVersion.getStructureId(),
@@ -67,7 +66,7 @@ public class DDMStructureVersionServiceImpl
 		_ddmStructureModelResourcePermission.check(
 			getPermissionChecker(), structureId, ActionKeys.VIEW);
 
-		return ddmStructureVersionLocalService.getStructureVersions(
+		return ddmStructureVersionPersistence.findByStructureId(
 			structureId, start, end, orderByComparator);
 	}
 
@@ -78,8 +77,7 @@ public class DDMStructureVersionServiceImpl
 		_ddmStructureModelResourcePermission.check(
 			getPermissionChecker(), structureId, ActionKeys.VIEW);
 
-		return ddmStructureVersionLocalService.getStructureVersionsCount(
-			structureId);
+		return ddmStructureVersionPersistence.countByStructureId(structureId);
 	}
 
 	@Reference(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMTemplateLocalServiceImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMTemplateLocalServiceImpl.java
@@ -1016,8 +1016,7 @@ public class DDMTemplateLocalServiceImpl
 		throws PortalException {
 
 		DDMTemplateVersion templateVersion =
-			_ddmTemplateVersionLocalService.getTemplateVersion(
-				templateId, version);
+			_ddmTemplateVersionPersistence.findByT_V(templateId, version);
 
 		if (!templateVersion.isApproved()) {
 			throw new InvalidTemplateVersionException(
@@ -1483,7 +1482,7 @@ public class DDMTemplateLocalServiceImpl
 
 		byte[] smallImageBytes = null;
 
-		DDMTemplate template = ddmTemplateLocalService.getDDMTemplate(
+		DDMTemplate template = ddmTemplatePersistence.findByPrimaryKey(
 			templateId);
 
 		if (smallImage) {
@@ -1592,7 +1591,7 @@ public class DDMTemplateLocalServiceImpl
 			boolean cacheable, ServiceContext serviceContext)
 		throws PortalException {
 
-		DDMTemplate template = ddmTemplateLocalService.getDDMTemplate(
+		DDMTemplate template = ddmTemplatePersistence.findByPrimaryKey(
 			templateId);
 
 		File smallImageFile = _getSmallImageFile(template);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMTemplateServiceImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMTemplateServiceImpl.java
@@ -366,9 +366,8 @@ public class DDMTemplateServiceImpl extends DDMTemplateServiceBaseImpl {
 			String externalReferenceCode, long groupId)
 		throws PortalException {
 
-		DDMTemplate ddmTemplate =
-			ddmTemplateLocalService.getDDMTemplateByExternalReferenceCode(
-				externalReferenceCode, groupId);
+		DDMTemplate ddmTemplate = ddmTemplatePersistence.findByERC_G(
+			externalReferenceCode, groupId);
 
 		_ddmTemplateModelResourcePermission.check(
 			getPermissionChecker(), ddmTemplate, ActionKeys.VIEW);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMTemplateVersionServiceImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMTemplateVersionServiceImpl.java
@@ -48,8 +48,7 @@ public class DDMTemplateVersionServiceImpl
 		throws PortalException {
 
 		DDMTemplateVersion templateVersion =
-			ddmTemplateVersionLocalService.getTemplateVersion(
-				templateVersionId);
+			ddmTemplateVersionPersistence.findByPrimaryKey(templateVersionId);
 
 		_ddmTemplateModelResourcePermission.check(
 			getPermissionChecker(), templateVersion.getTemplateId(),
@@ -67,7 +66,7 @@ public class DDMTemplateVersionServiceImpl
 		_ddmTemplateModelResourcePermission.check(
 			getPermissionChecker(), templateId, ActionKeys.VIEW);
 
-		return ddmTemplateVersionLocalService.getTemplateVersions(
+		return ddmTemplateVersionPersistence.findByTemplateId(
 			templateId, start, end, orderByComparator);
 	}
 
@@ -78,8 +77,7 @@ public class DDMTemplateVersionServiceImpl
 		_ddmTemplateModelResourcePermission.check(
 			getPermissionChecker(), templateId, ActionKeys.VIEW);
 
-		return ddmTemplateVersionLocalService.getTemplateVersionsCount(
-			templateId);
+		return ddmTemplateVersionPersistence.countByTemplateId(templateId);
 	}
 
 	@Reference(

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBCommentLocalServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBCommentLocalServiceImpl.java
@@ -16,8 +16,8 @@ import com.liferay.knowledge.base.model.KBArticle;
 import com.liferay.knowledge.base.model.KBComment;
 import com.liferay.knowledge.base.model.KBTemplate;
 import com.liferay.knowledge.base.service.KBArticleLocalService;
-import com.liferay.knowledge.base.service.KBTemplateLocalService;
 import com.liferay.knowledge.base.service.base.KBCommentLocalServiceBaseImpl;
+import com.liferay.knowledge.base.service.persistence.KBTemplatePersistence;
 import com.liferay.knowledge.base.util.comparator.KBCommentCreateDateComparator;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.aop.AopService;
@@ -457,7 +457,7 @@ public class KBCommentLocalServiceImpl extends KBCommentLocalServiceBaseImpl {
 			kbComment.getClassPK(), WorkflowConstants.STATUS_APPROVED);
 
 		if (kbArticle == null) {
-			KBTemplate kbTemplate = _kbTemplateLocalService.fetchKBTemplate(
+			KBTemplate kbTemplate = _kbTemplatePersistence.fetchByPrimaryKey(
 				kbComment.getClassPK());
 
 			if (kbTemplate != null) {
@@ -532,7 +532,7 @@ public class KBCommentLocalServiceImpl extends KBCommentLocalServiceBaseImpl {
 				jsonObject.put("title", kbArticle.getTitle());
 			}
 			else if (className.equals(KBTemplate.class.getName())) {
-				kbTemplate = _kbTemplateLocalService.getKBTemplate(
+				kbTemplate = _kbTemplatePersistence.findByPrimaryKey(
 					kbComment.getClassPK());
 
 				jsonObject.put("title", kbTemplate.getTitle());
@@ -565,7 +565,7 @@ public class KBCommentLocalServiceImpl extends KBCommentLocalServiceBaseImpl {
 	private KBArticleLocalService _kbArticleLocalService;
 
 	@Reference
-	private KBTemplateLocalService _kbTemplateLocalService;
+	private KBTemplatePersistence _kbTemplatePersistence;
 
 	@Reference
 	private RatingsEntryLocalService _ratingsEntryLocalService;

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBCommentServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBCommentServiceImpl.java
@@ -12,6 +12,7 @@ import com.liferay.knowledge.base.model.KBArticle;
 import com.liferay.knowledge.base.model.KBComment;
 import com.liferay.knowledge.base.service.KBArticleLocalService;
 import com.liferay.knowledge.base.service.base.KBCommentServiceBaseImpl;
+import com.liferay.knowledge.base.service.persistence.KBArticlePersistence;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
@@ -62,7 +63,7 @@ public class KBCommentServiceImpl extends KBCommentServiceBaseImpl {
 		_kbCommentModelResourcePermission.check(
 			getPermissionChecker(), kbCommentId, KBActionKeys.VIEW);
 
-		return kbCommentLocalService.getKBComment(kbCommentId);
+		return kbCommentPersistence.findByPrimaryKey(kbCommentId);
 	}
 
 	@Override
@@ -266,7 +267,7 @@ public class KBCommentServiceImpl extends KBCommentServiceBaseImpl {
 				"Only KB articles support suggestions");
 		}
 
-		KBArticle kbArticle = _kbArticleLocalService.fetchKBArticle(classPK);
+		KBArticle kbArticle = _kbArticlePersistence.fetchByPrimaryKey(classPK);
 
 		if (kbArticle != null) {
 			kbArticle = _kbArticleLocalService.getLatestKBArticle(
@@ -296,6 +297,9 @@ public class KBCommentServiceImpl extends KBCommentServiceBaseImpl {
 	)
 	private ModelResourcePermission<KBArticle>
 		_kbArticleModelResourcePermission;
+
+	@Reference
+	private KBArticlePersistence _kbArticlePersistence;
 
 	@Reference(
 		target = "(model.class.name=com.liferay.knowledge.base.model.KBComment)"

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBFolderServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBFolderServiceImpl.java
@@ -84,7 +84,7 @@ public class KBFolderServiceImpl extends KBFolderServiceBaseImpl {
 
 	@Override
 	public KBFolder fetchKBFolder(long kbFolderId) throws PortalException {
-		KBFolder kbFolder = kbFolderLocalService.fetchKBFolder(kbFolderId);
+		KBFolder kbFolder = kbFolderPersistence.fetchByPrimaryKey(kbFolderId);
 
 		if (kbFolder != null) {
 			_kbFolderModelResourcePermission.check(
@@ -117,7 +117,7 @@ public class KBFolderServiceImpl extends KBFolderServiceBaseImpl {
 		_kbFolderModelResourcePermission.check(
 			getPermissionChecker(), kbFolderId, KBActionKeys.VIEW);
 
-		return kbFolderLocalService.getKBFolder(kbFolderId);
+		return kbFolderPersistence.findByPrimaryKey(kbFolderId);
 	}
 
 	@Override
@@ -125,9 +125,8 @@ public class KBFolderServiceImpl extends KBFolderServiceBaseImpl {
 			long groupId, String externalReferenceCode)
 		throws PortalException {
 
-		KBFolder kbFolder =
-			kbFolderLocalService.getKBFolderByExternalReferenceCode(
-				externalReferenceCode, groupId);
+		KBFolder kbFolder = kbFolderPersistence.findByERC_G(
+			externalReferenceCode, groupId);
 
 		_kbFolderModelResourcePermission.check(
 			getPermissionChecker(), kbFolder, KBActionKeys.VIEW);
@@ -203,7 +202,8 @@ public class KBFolderServiceImpl extends KBFolderServiceBaseImpl {
 
 		_kbFolderModelResourcePermission.check(
 			getPermissionChecker(),
-			kbFolderLocalService.getKBFolder(kbFolderId), ActionKeys.DELETE);
+			kbFolderPersistence.findByPrimaryKey(kbFolderId),
+			ActionKeys.DELETE);
 
 		return kbFolderLocalService.moveKBFolderToTrash(
 			getUserId(), kbFolderId);

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBTemplateServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBTemplateServiceImpl.java
@@ -101,7 +101,7 @@ public class KBTemplateServiceImpl extends KBTemplateServiceBaseImpl {
 		_kbTemplateModelResourcePermission.check(
 			getPermissionChecker(), kbTemplateId, KBActionKeys.VIEW);
 
-		return kbTemplateLocalService.getKBTemplate(kbTemplateId);
+		return kbTemplatePersistence.findByPrimaryKey(kbTemplateId);
 	}
 
 	@Override

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/display/context/LayoutClassedModelUsagesDisplayContext.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/display/context/LayoutClassedModelUsagesDisplayContext.java
@@ -401,7 +401,7 @@ public class LayoutClassedModelUsagesDisplayContext {
 	private String _getLayoutClassedModelUsagesURL(
 		String className, long classPK) {
 
-		StringBundler sb = new StringBundler(9);
+		StringBundler sb = new StringBundler(8);
 
 		sb.append(
 			PortalUtil.getPortalURL(

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBCategoryLocalServiceImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBCategoryLocalServiceImpl.java
@@ -16,6 +16,7 @@ import com.liferay.message.boards.model.impl.MBCategoryImpl;
 import com.liferay.message.boards.service.MBMailingListLocalService;
 import com.liferay.message.boards.service.MBThreadLocalService;
 import com.liferay.message.boards.service.base.MBCategoryLocalServiceBaseImpl;
+import com.liferay.message.boards.service.persistence.MBMailingListPersistence;
 import com.liferay.message.boards.service.persistence.MBMessagePersistence;
 import com.liferay.message.boards.service.persistence.MBThreadPersistence;
 import com.liferay.petra.string.StringPool;
@@ -261,9 +262,8 @@ public class MBCategoryLocalServiceImpl extends MBCategoryLocalServiceBaseImpl {
 
 		// Mailing list
 
-		MBMailingList mbMailingList =
-			_mbMailingListLocalService.fetchCategoryMailingList(
-				category.getGroupId(), category.getCategoryId());
+		MBMailingList mbMailingList = _mbMailingListPersistence.fetchByG_C(
+			category.getGroupId(), category.getCategoryId());
 
 		if (mbMailingList != null) {
 			_mbMailingListLocalService.deleteMailingList(mbMailingList);
@@ -845,9 +845,8 @@ public class MBCategoryLocalServiceImpl extends MBCategoryLocalServiceBaseImpl {
 
 		// Mailing list
 
-		MBMailingList mailingList =
-			_mbMailingListLocalService.fetchCategoryMailingList(
-				category.getGroupId(), category.getCategoryId());
+		MBMailingList mailingList = _mbMailingListPersistence.fetchByG_C(
+			category.getGroupId(), category.getCategoryId());
 
 		if (mailingList != null) {
 			_mbMailingListLocalService.updateMailingList(
@@ -1224,6 +1223,9 @@ public class MBCategoryLocalServiceImpl extends MBCategoryLocalServiceBaseImpl {
 
 	@Reference
 	private MBMailingListLocalService _mbMailingListLocalService;
+
+	@Reference
+	private MBMailingListPersistence _mbMailingListPersistence;
 
 	@Reference
 	private MBMessagePersistence _mbMessagePersistence;

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBCategoryServiceImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBCategoryServiceImpl.java
@@ -16,6 +16,7 @@ import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermi
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermissionUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.FriendlyURLNormalizer;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
@@ -108,9 +109,8 @@ public class MBCategoryServiceImpl extends MBCategoryServiceBaseImpl {
 	public void deleteCategory(String externalReferenceCode, long groupId)
 		throws PortalException {
 
-		MBCategory category =
-			mbCategoryLocalService.getMBCategoryByExternalReferenceCode(
-				externalReferenceCode, groupId);
+		MBCategory category = mbCategoryPersistence.findByERC_G(
+			externalReferenceCode, groupId);
 
 		_categoryModelResourcePermission.check(
 			getPermissionChecker(), category, ActionKeys.DELETE);
@@ -122,8 +122,10 @@ public class MBCategoryServiceImpl extends MBCategoryServiceBaseImpl {
 	public MBCategory fetchMBCategory(long groupId, String friendlyURL)
 		throws PortalException {
 
-		MBCategory mbCategory = mbCategoryLocalService.fetchMBCategory(
-			groupId, friendlyURL);
+		MBCategory mbCategory = mbCategoryPersistence.fetchByG_F(
+			groupId,
+			_friendlyURLNormalizer.normalizeWithEncodingPeriodsAndSlashes(
+				friendlyURL));
 
 		if (mbCategory == null) {
 			return null;
@@ -432,8 +434,10 @@ public class MBCategoryServiceImpl extends MBCategoryServiceBaseImpl {
 	public MBCategory getMBCategory(long groupId, String friendlyURL)
 		throws PortalException {
 
-		MBCategory mbCategory = mbCategoryLocalService.getMBCategory(
-			groupId, friendlyURL);
+		MBCategory mbCategory = mbCategoryPersistence.findByG_F(
+			groupId,
+			_friendlyURLNormalizer.normalizeWithEncodingPeriodsAndSlashes(
+				friendlyURL));
 
 		_categoryModelResourcePermission.check(
 			getPermissionChecker(), mbCategory, ActionKeys.VIEW);
@@ -611,5 +615,8 @@ public class MBCategoryServiceImpl extends MBCategoryServiceBaseImpl {
 	)
 	private ModelResourcePermission<MBCategory>
 		_categoryModelResourcePermission;
+
+	@Reference
+	private FriendlyURLNormalizer _friendlyURLNormalizer;
 
 }

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMessageLocalServiceImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMessageLocalServiceImpl.java
@@ -47,6 +47,7 @@ import com.liferay.message.boards.service.MBDiscussionLocalService;
 import com.liferay.message.boards.service.MBThreadLocalService;
 import com.liferay.message.boards.service.base.MBMessageLocalServiceBaseImpl;
 import com.liferay.message.boards.service.persistence.MBCategoryPersistence;
+import com.liferay.message.boards.service.persistence.MBDiscussionPersistence;
 import com.liferay.message.boards.service.persistence.MBThreadPersistence;
 import com.liferay.message.boards.settings.MBGroupServiceSettings;
 import com.liferay.message.boards.social.MBActivityKeys;
@@ -781,7 +782,7 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 
 			if (message.isDiscussion()) {
 				MBDiscussion discussion =
-					_mbDiscussionLocalService.getThreadDiscussion(
+					_mbDiscussionPersistence.findByThreadId(
 						message.getThreadId());
 
 				_mbDiscussionLocalService.deleteMBDiscussion(
@@ -907,7 +908,8 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 				IndexerRegistryUtil.nullSafeGetIndexer(MBMessage.class);
 
 			mbMessageIndexer.reindex(
-				mbMessageLocalService.getMBMessage(thread.getRootMessageId()));
+				mbMessagePersistence.findByPrimaryKey(
+					thread.getRootMessageId()));
 		}
 
 		// Asset
@@ -2476,9 +2478,8 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 		CommentGroupServiceConfiguration commentGroupServiceConfiguration =
 			_getCommentGroupServiceConfiguration(message.getGroupId());
 
-		MBDiscussion mbDiscussion =
-			_mbDiscussionLocalService.getThreadDiscussion(
-				message.getThreadId());
+		MBDiscussion mbDiscussion = _mbDiscussionPersistence.findByThreadId(
+			message.getThreadId());
 
 		String contentURL = (String)serviceContext.getAttribute("contentURL");
 
@@ -2689,7 +2690,7 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 		if (message.getParentMessageId() !=
 				MBMessageConstants.DEFAULT_PARENT_MESSAGE_ID) {
 
-			MBMessage parentMessage = mbMessageLocalService.getMessage(
+			MBMessage parentMessage = mbMessagePersistence.findByPrimaryKey(
 				message.getParentMessageId());
 
 			Date modifiedDate = parentMessage.getModifiedDate();
@@ -3170,6 +3171,9 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 
 	@Reference
 	private MBDiscussionLocalService _mbDiscussionLocalService;
+
+	@Reference
+	private MBDiscussionPersistence _mbDiscussionPersistence;
 
 	@Reference
 	private MBThreadLocalService _mbThreadLocalService;

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMessageServiceImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMessageServiceImpl.java
@@ -15,8 +15,9 @@ import com.liferay.message.boards.model.MBMessage;
 import com.liferay.message.boards.model.MBMessageDisplay;
 import com.liferay.message.boards.model.MBThread;
 import com.liferay.message.boards.service.MBCategoryLocalService;
-import com.liferay.message.boards.service.MBThreadLocalService;
 import com.liferay.message.boards.service.base.MBMessageServiceBaseImpl;
+import com.liferay.message.boards.service.persistence.MBCategoryPersistence;
+import com.liferay.message.boards.service.persistence.MBThreadPersistence;
 import com.liferay.message.boards.util.comparator.MessageCreateDateComparator;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringBundler;
@@ -42,6 +43,7 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.permission.UserPermissionUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.FriendlyURLNormalizer;
 import com.liferay.portal.kernel.util.HtmlParser;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.ObjectValuePair;
@@ -279,7 +281,7 @@ public class MBMessageServiceImpl extends MBMessageServiceBaseImpl {
 			long messageId, String fileName, File file, String mimeType)
 		throws PortalException {
 
-		MBMessage message = mbMessageLocalService.getMBMessage(messageId);
+		MBMessage message = mbMessagePersistence.findByPrimaryKey(messageId);
 
 		if (_lockManager.isLocked(
 				MBThread.class.getName(), message.getThreadId())) {
@@ -374,8 +376,10 @@ public class MBMessageServiceImpl extends MBMessageServiceBaseImpl {
 	public MBMessage fetchMBMessageByUrlSubject(long groupId, String urlSubject)
 		throws PortalException {
 
-		MBMessage mbMessage = mbMessageLocalService.fetchMBMessageByUrlSubject(
-			groupId, urlSubject);
+		MBMessage mbMessage = mbMessagePersistence.fetchByG_US(
+			groupId,
+			_friendlyURLNormalizer.normalizeWithEncodingPeriodsAndSlashes(
+				urlSubject));
 
 		if (mbMessage == null) {
 			return null;
@@ -424,7 +428,7 @@ public class MBMessageServiceImpl extends MBMessageServiceBaseImpl {
 		String name = StringPool.BLANK;
 		String description = StringPool.BLANK;
 
-		MBCategory category = _mbCategoryLocalService.fetchMBCategory(
+		MBCategory category = _mbCategoryPersistence.fetchByPrimaryKey(
 			categoryId);
 
 		if (category == null) {
@@ -687,9 +691,8 @@ public class MBMessageServiceImpl extends MBMessageServiceBaseImpl {
 			String externalReferenceCode, long groupId)
 		throws PortalException {
 
-		MBMessage mbMessage =
-			mbMessageLocalService.getMBMessageByExternalReferenceCode(
-				externalReferenceCode, groupId);
+		MBMessage mbMessage = mbMessagePersistence.findByERC_G(
+			externalReferenceCode, groupId);
 
 		_messageModelResourcePermission.check(
 			getPermissionChecker(), mbMessage, ActionKeys.VIEW);
@@ -702,7 +705,7 @@ public class MBMessageServiceImpl extends MBMessageServiceBaseImpl {
 		_messageModelResourcePermission.check(
 			getPermissionChecker(), messageId, ActionKeys.VIEW);
 
-		return mbMessageLocalService.getMessage(messageId);
+		return mbMessagePersistence.findByPrimaryKey(messageId);
 	}
 
 	@Override
@@ -771,7 +774,7 @@ public class MBMessageServiceImpl extends MBMessageServiceBaseImpl {
 
 		List<MBMessage> messages = new ArrayList<>();
 
-		MBThread thread = _mbThreadLocalService.getThread(threadId);
+		MBThread thread = _mbThreadPersistence.findByPrimaryKey(threadId);
 
 		if (_messageModelResourcePermission.contains(
 				getPermissionChecker(), thread.getRootMessageId(),
@@ -927,7 +930,7 @@ public class MBMessageServiceImpl extends MBMessageServiceBaseImpl {
 				message.getGroupId(), message.getCategoryId(),
 				ActionKeys.UPDATE_THREAD_PRIORITY)) {
 
-			MBThread thread = _mbThreadLocalService.getThread(
+			MBThread thread = _mbThreadPersistence.findByPrimaryKey(
 				message.getThreadId());
 
 			priority = thread.getPriority();
@@ -1065,6 +1068,9 @@ public class MBMessageServiceImpl extends MBMessageServiceBaseImpl {
 	private DiscussionPermission _discussionPermission;
 
 	@Reference
+	private FriendlyURLNormalizer _friendlyURLNormalizer;
+
+	@Reference
 	private GroupLocalService _groupLocalService;
 
 	@Reference
@@ -1080,7 +1086,10 @@ public class MBMessageServiceImpl extends MBMessageServiceBaseImpl {
 	private MBCategoryLocalService _mbCategoryLocalService;
 
 	@Reference
-	private MBThreadLocalService _mbThreadLocalService;
+	private MBCategoryPersistence _mbCategoryPersistence;
+
+	@Reference
+	private MBThreadPersistence _mbThreadPersistence;
 
 	@Reference(
 		target = "(model.class.name=com.liferay.message.boards.model.MBMessage)"

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBSuspiciousActivityServiceImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBSuspiciousActivityServiceImpl.java
@@ -61,15 +61,14 @@ public class MBSuspiciousActivityServiceImpl
 	public List<MBSuspiciousActivity> getMessageSuspiciousActivities(
 		long messageId) {
 
-		return mbSuspiciousActivityLocalService.getMessageSuspiciousActivities(
-			messageId);
+		return mbSuspiciousActivityPersistence.findByMessageId(messageId);
 	}
 
 	@Override
 	public MBSuspiciousActivity getSuspiciousActivity(long suspiciousActivityId)
 		throws PortalException {
 
-		return mbSuspiciousActivityLocalService.getSuspiciousActivity(
+		return mbSuspiciousActivityPersistence.findByPrimaryKey(
 			suspiciousActivityId);
 	}
 
@@ -77,8 +76,7 @@ public class MBSuspiciousActivityServiceImpl
 	public List<MBSuspiciousActivity> getThreadSuspiciousActivities(
 		long threadId) {
 
-		return mbSuspiciousActivityLocalService.getThreadSuspiciousActivities(
-			threadId);
+		return mbSuspiciousActivityPersistence.findByThreadId(threadId);
 	}
 
 	@Override

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBThreadLocalServiceImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBThreadLocalServiceImpl.java
@@ -25,6 +25,7 @@ import com.liferay.message.boards.model.impl.MBTreeWalkerImpl;
 import com.liferay.message.boards.service.MBDiscussionLocalService;
 import com.liferay.message.boards.service.base.MBThreadLocalServiceBaseImpl;
 import com.liferay.message.boards.service.persistence.MBCategoryPersistence;
+import com.liferay.message.boards.service.persistence.MBDiscussionPersistence;
 import com.liferay.message.boards.service.persistence.MBMessageFinder;
 import com.liferay.message.boards.service.persistence.MBMessagePersistence;
 import com.liferay.message.boards.util.comparator.MessageCreateDateComparator;
@@ -190,9 +191,8 @@ public class MBThreadLocalServiceImpl extends MBThreadLocalServiceBaseImpl {
 
 		// Discussion
 
-		MBDiscussion discussion =
-			_mbDiscussionLocalService.fetchThreadDiscussion(
-				thread.getThreadId());
+		MBDiscussion discussion = _mbDiscussionPersistence.fetchByThreadId(
+			thread.getThreadId());
 
 		if (discussion != null) {
 			_mbDiscussionLocalService.deleteMBDiscussion(
@@ -543,7 +543,7 @@ public class MBThreadLocalServiceImpl extends MBThreadLocalServiceBaseImpl {
 
 		Set<Long> userIds = new HashSet<>();
 
-		MBThread thread = mbThreadLocalService.getThread(threadId);
+		MBThread thread = mbThreadPersistence.findByPrimaryKey(threadId);
 
 		List<MBMessage> messages = _mbMessagePersistence.findByThreadId(
 			threadId);
@@ -781,7 +781,7 @@ public class MBThreadLocalServiceImpl extends MBThreadLocalServiceBaseImpl {
 
 		Set<Long> userIds = new HashSet<>();
 
-		MBThread thread = mbThreadLocalService.getThread(threadId);
+		MBThread thread = mbThreadPersistence.findByPrimaryKey(threadId);
 
 		List<MBMessage> messages = _mbMessagePersistence.findByThreadId(
 			threadId);
@@ -1210,6 +1210,9 @@ public class MBThreadLocalServiceImpl extends MBThreadLocalServiceBaseImpl {
 
 	@Reference
 	private MBDiscussionLocalService _mbDiscussionLocalService;
+
+	@Reference
+	private MBDiscussionPersistence _mbDiscussionPersistence;
 
 	@Reference
 	private MBMessageFinder _mbMessageFinder;

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBThreadServiceImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBThreadServiceImpl.java
@@ -14,6 +14,7 @@ import com.liferay.message.boards.service.MBCategoryService;
 import com.liferay.message.boards.service.MBMessageLocalService;
 import com.liferay.message.boards.service.base.MBThreadServiceBaseImpl;
 import com.liferay.message.boards.service.persistence.MBMessageFinder;
+import com.liferay.message.boards.service.persistence.MBMessagePersistence;
 import com.liferay.message.boards.service.persistence.impl.constants.MBPersistenceConstants;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringBundler;
@@ -371,7 +372,7 @@ public class MBThreadServiceImpl extends MBThreadServiceBaseImpl {
 					MBThread.class.getName(), " and class PK ", threadId));
 		}
 
-		MBThread thread = mbThreadLocalService.getThread(threadId);
+		MBThread thread = mbThreadPersistence.findByPrimaryKey(threadId);
 
 		ModelResourcePermissionUtil.check(
 			_categoryModelResourcePermission, getPermissionChecker(),
@@ -390,7 +391,7 @@ public class MBThreadServiceImpl extends MBThreadServiceBaseImpl {
 	public MBThread moveThreadFromTrash(long categoryId, long threadId)
 		throws PortalException {
 
-		MBThread thread = mbThreadLocalService.getThread(threadId);
+		MBThread thread = mbThreadPersistence.findByPrimaryKey(threadId);
 
 		ModelResourcePermissionUtil.check(
 			_categoryModelResourcePermission, getPermissionChecker(),
@@ -462,7 +463,7 @@ public class MBThreadServiceImpl extends MBThreadServiceBaseImpl {
 
 		PermissionChecker permissionChecker = getPermissionChecker();
 
-		MBMessage message = _mbMessageLocalService.getMessage(messageId);
+		MBMessage message = _mbMessagePersistence.findByPrimaryKey(messageId);
 
 		ModelResourcePermissionUtil.check(
 			_categoryModelResourcePermission, getPermissionChecker(),
@@ -478,7 +479,7 @@ public class MBThreadServiceImpl extends MBThreadServiceBaseImpl {
 
 	@Override
 	public void unlockThread(long threadId) throws PortalException {
-		MBThread thread = mbThreadLocalService.getThread(threadId);
+		MBThread thread = mbThreadPersistence.findByPrimaryKey(threadId);
 
 		ModelResourcePermissionUtil.check(
 			_categoryModelResourcePermission, getPermissionChecker(),
@@ -572,6 +573,9 @@ public class MBThreadServiceImpl extends MBThreadServiceBaseImpl {
 
 	@Reference
 	private MBMessageLocalService _mbMessageLocalService;
+
+	@Reference
+	private MBMessagePersistence _mbMessagePersistence;
 
 	private long _mbThreadLockExpirationTime;
 

--- a/modules/apps/portal-language/portal-language-override-service/src/main/java/com/liferay/portal/language/override/service/impl/PLOEntryServiceImpl.java
+++ b/modules/apps/portal-language/portal-language-override-service/src/main/java/com/liferay/portal/language/override/service/impl/PLOEntryServiceImpl.java
@@ -78,7 +78,7 @@ public class PLOEntryServiceImpl extends PLOEntryServiceBaseImpl {
 		PortalPermissionUtil.check(
 			getPermissionChecker(), PLOActionKeys.MANAGE_LANGUAGE_OVERRIDES);
 
-		return ploEntryLocalService.getPLOEntries(companyId);
+		return ploEntryPersistence.findByCompanyId(companyId);
 	}
 
 	@Override
@@ -86,7 +86,7 @@ public class PLOEntryServiceImpl extends PLOEntryServiceBaseImpl {
 		PortalPermissionUtil.check(
 			getPermissionChecker(), PLOActionKeys.MANAGE_LANGUAGE_OVERRIDES);
 
-		return ploEntryLocalService.getPLOEntriesCount(companyId);
+		return ploEntryPersistence.countByCompanyId(companyId);
 	}
 
 	@Override

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/service/impl/SXPBlueprintServiceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/service/impl/SXPBlueprintServiceImpl.java
@@ -68,7 +68,7 @@ public class SXPBlueprintServiceImpl extends SXPBlueprintServiceBaseImpl {
 	public SXPBlueprint fetchSXPBlueprint(long sxpBlueprintId)
 		throws PortalException {
 
-		SXPBlueprint sxpBlueprint = sxpBlueprintLocalService.fetchSXPBlueprint(
+		SXPBlueprint sxpBlueprint = sxpBlueprintPersistence.fetchByPrimaryKey(
 			sxpBlueprintId);
 
 		if (sxpBlueprint != null) {
@@ -84,9 +84,8 @@ public class SXPBlueprintServiceImpl extends SXPBlueprintServiceBaseImpl {
 			String externalReferenceCode, long companyId)
 		throws PortalException {
 
-		SXPBlueprint sxpBlueprint =
-			sxpBlueprintLocalService.fetchSXPBlueprintByExternalReferenceCode(
-				externalReferenceCode, companyId);
+		SXPBlueprint sxpBlueprint = sxpBlueprintPersistence.fetchByERC_C(
+			externalReferenceCode, companyId);
 
 		if (sxpBlueprint != null) {
 			_sxpBlueprintModelResourcePermission.check(
@@ -100,7 +99,7 @@ public class SXPBlueprintServiceImpl extends SXPBlueprintServiceBaseImpl {
 	public SXPBlueprint getSXPBlueprint(long sxpBlueprintId)
 		throws PortalException {
 
-		SXPBlueprint sxpBlueprint = sxpBlueprintLocalService.getSXPBlueprint(
+		SXPBlueprint sxpBlueprint = sxpBlueprintPersistence.findByPrimaryKey(
 			sxpBlueprintId);
 
 		_sxpBlueprintModelResourcePermission.check(
@@ -115,9 +114,8 @@ public class SXPBlueprintServiceImpl extends SXPBlueprintServiceBaseImpl {
 			long companyId, String externalReferenceCode)
 		throws PortalException {
 
-		SXPBlueprint sxpBlueprint =
-			sxpBlueprintLocalService.getSXPBlueprintByExternalReferenceCode(
-				externalReferenceCode, companyId);
+		SXPBlueprint sxpBlueprint = sxpBlueprintPersistence.findByERC_C(
+			externalReferenceCode, companyId);
 
 		_sxpBlueprintModelResourcePermission.check(
 			getPermissionChecker(), sxpBlueprint,

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/service/impl/SXPElementServiceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/service/impl/SXPElementServiceImpl.java
@@ -79,7 +79,7 @@ public class SXPElementServiceImpl extends SXPElementServiceBaseImpl {
 	public SXPElement fetchSXPElement(long sxpElementId)
 		throws PortalException {
 
-		SXPElement sxpElement = sxpElementLocalService.fetchSXPElement(
+		SXPElement sxpElement = sxpElementPersistence.fetchByPrimaryKey(
 			sxpElementId);
 
 		if (sxpElement != null) {
@@ -95,9 +95,8 @@ public class SXPElementServiceImpl extends SXPElementServiceBaseImpl {
 			String externalReferenceCode, long companyId)
 		throws PortalException {
 
-		SXPElement sxpElement =
-			sxpElementLocalService.fetchSXPElementByExternalReferenceCode(
-				externalReferenceCode, companyId);
+		SXPElement sxpElement = sxpElementPersistence.fetchByERC_C(
+			externalReferenceCode, companyId);
 
 		if (sxpElement != null) {
 			_sxpElementModelResourcePermission.check(
@@ -109,7 +108,7 @@ public class SXPElementServiceImpl extends SXPElementServiceBaseImpl {
 
 	@Override
 	public SXPElement getSXPElement(long sxpElementId) throws PortalException {
-		SXPElement sxpElement = sxpElementLocalService.getSXPElement(
+		SXPElement sxpElement = sxpElementPersistence.findByPrimaryKey(
 			sxpElementId);
 
 		_sxpElementModelResourcePermission.check(
@@ -123,9 +122,8 @@ public class SXPElementServiceImpl extends SXPElementServiceBaseImpl {
 			String externalReferenceCode, long companyId)
 		throws PortalException {
 
-		SXPElement sxpElement =
-			sxpElementLocalService.getSXPElementByExternalReferenceCode(
-				externalReferenceCode, companyId);
+		SXPElement sxpElement = sxpElementPersistence.findByERC_C(
+			externalReferenceCode, companyId);
 
 		_sxpElementModelResourcePermission.check(
 			getPermissionChecker(), sxpElement, ActionKeys.VIEW);

--- a/portal-impl/src/com/liferay/portal/service/impl/ImageServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ImageServiceImpl.java
@@ -18,7 +18,7 @@ public class ImageServiceImpl extends ImageServiceBaseImpl {
 
 	@Override
 	public Image getImage(long imageId) throws PortalException {
-		return imageLocalService.getImage(imageId);
+		return imagePersistence.findByPrimaryKey(imageId);
 	}
 
 }

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutSetBranchLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutSetBranchLocalServiceImpl.java
@@ -37,6 +37,7 @@ import com.liferay.portal.kernel.service.LayoutRevisionLocalService;
 import com.liferay.portal.kernel.service.RecentLayoutSetBranchLocalService;
 import com.liferay.portal.kernel.service.ResourceLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.persistence.ImagePersistence;
 import com.liferay.portal.kernel.service.persistence.LayoutBranchPersistence;
 import com.liferay.portal.kernel.service.persistence.LayoutPersistence;
 import com.liferay.portal.kernel.service.persistence.LayoutRevisionPersistence;
@@ -123,7 +124,7 @@ public class LayoutSetBranchLocalServiceImpl
 		layoutSetBranch.setLogoId(logoId);
 
 		if (logo) {
-			Image logoImage = _imageLocalService.getImage(logoId);
+			Image logoImage = _imagePersistence.findByPrimaryKey(logoId);
 
 			long layoutSetBranchLogoId = counterLocalService.increment();
 
@@ -667,6 +668,9 @@ public class LayoutSetBranchLocalServiceImpl
 
 	@BeanReference(type = ImageLocalService.class)
 	private ImageLocalService _imageLocalService;
+
+	@BeanReference(type = ImagePersistence.class)
+	private ImagePersistence _imagePersistence;
 
 	@BeanReference(type = LayoutBranchLocalService.class)
 	private LayoutBranchLocalService _layoutBranchLocalService;

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutSetLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutSetLocalServiceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.VirtualHostLocalService;
 import com.liferay.portal.kernel.service.persistence.GroupPersistence;
+import com.liferay.portal.kernel.service.persistence.ImagePersistence;
 import com.liferay.portal.kernel.service.persistence.LayoutPersistence;
 import com.liferay.portal.kernel.service.persistence.LayoutSetBranchPersistence;
 import com.liferay.portal.kernel.service.persistence.VirtualHostPersistence;
@@ -613,7 +614,7 @@ public class LayoutSetLocalServiceImpl extends LayoutSetLocalServiceBaseImpl {
 			layoutSet.setLogoId(liveLayoutSet.getLogoId());
 
 			if (liveLayoutSet.isLogo()) {
-				Image logoImage = _imageLocalService.getImage(
+				Image logoImage = _imagePersistence.findByPrimaryKey(
 					liveLayoutSet.getLogoId());
 
 				long logoId = counterLocalService.increment();
@@ -704,6 +705,9 @@ public class LayoutSetLocalServiceImpl extends LayoutSetLocalServiceBaseImpl {
 
 	@BeanReference(type = ImageLocalService.class)
 	private ImageLocalService _imageLocalService;
+
+	@BeanReference(type = ImagePersistence.class)
+	private ImagePersistence _imagePersistence;
 
 	@BeanReference(type = LayoutLocalService.class)
 	private LayoutLocalService _layoutLocalService;

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -1874,7 +1874,7 @@ public class DLFileEntryLocalServiceImpl
 
 		serviceContext.setCommand(Constants.REVERT);
 
-		DLFileEntry dlFileEntry = dlFileEntryLocalService.getFileEntry(
+		DLFileEntry dlFileEntry = dlFileEntryPersistence.findByPrimaryKey(
 			fileEntryId);
 
 		long fileEntryTypeId = _getValidFileEntryTypeId(
@@ -2082,7 +2082,7 @@ public class DLFileEntryLocalServiceImpl
 
 		User user = _userPersistence.findByPrimaryKey(userId);
 
-		DLFileEntry dlFileEntry = dlFileEntryLocalService.getFileEntry(
+		DLFileEntry dlFileEntry = dlFileEntryPersistence.findByPrimaryKey(
 			fileEntryId);
 
 		dlFileEntry.setFileEntryTypeId(fileEntryTypeId);
@@ -2311,7 +2311,7 @@ public class DLFileEntryLocalServiceImpl
 			return Objects.equals(lock.getUuid(), lockUuid);
 		}
 
-		DLFileEntry dlFileEntry = dlFileEntryLocalService.getFileEntry(
+		DLFileEntry dlFileEntry = dlFileEntryPersistence.findByPrimaryKey(
 			fileEntryId);
 
 		return _dlFolderLocalService.verifyInheritableLock(

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryServiceImpl.java
@@ -246,7 +246,7 @@ public class DLFileEntryServiceImpl extends DLFileEntryServiceBaseImpl {
 
 	@Override
 	public DLFileEntry fetchFileEntry(long fileEntryId) throws PortalException {
-		DLFileEntry dlFileEntry = dlFileEntryLocalService.fetchDLFileEntry(
+		DLFileEntry dlFileEntry = dlFileEntryPersistence.fetchByPrimaryKey(
 			fileEntryId);
 
 		if (dlFileEntry != null) {
@@ -266,7 +266,7 @@ public class DLFileEntryServiceImpl extends DLFileEntryServiceBaseImpl {
 	public DLFileEntry fetchFileEntry(long groupId, long folderId, String title)
 		throws PortalException {
 
-		DLFileEntry dlFileEntry = dlFileEntryLocalService.fetchFileEntry(
+		DLFileEntry dlFileEntry = dlFileEntryPersistence.fetchByG_F_T(
 			groupId, folderId, title);
 
 		if (dlFileEntry != null) {
@@ -287,9 +287,8 @@ public class DLFileEntryServiceImpl extends DLFileEntryServiceBaseImpl {
 			long groupId, String externalReferenceCode)
 		throws PortalException {
 
-		DLFileEntry dlFileEntry =
-			dlFileEntryLocalService.fetchFileEntryByExternalReferenceCode(
-				groupId, externalReferenceCode);
+		DLFileEntry dlFileEntry = dlFileEntryPersistence.fetchByERC_G(
+			externalReferenceCode, groupId);
 
 		if (dlFileEntry != null) {
 			ModelResourcePermission<DLFileEntry>
@@ -566,7 +565,7 @@ public class DLFileEntryServiceImpl extends DLFileEntryServiceBaseImpl {
 		fileEntryModelResourcePermission.check(
 			getPermissionChecker(), fileEntryId, ActionKeys.VIEW);
 
-		return dlFileEntryLocalService.getFileEntry(fileEntryId);
+		return dlFileEntryPersistence.findByPrimaryKey(fileEntryId);
 	}
 
 	@Override
@@ -616,9 +615,8 @@ public class DLFileEntryServiceImpl extends DLFileEntryServiceBaseImpl {
 				ModelResourcePermissionRegistryUtil.getModelResourcePermission(
 					DLFileEntry.class.getName());
 
-		DLFileEntry dlFileEntry =
-			dlFileEntryLocalService.getFileEntryByFileName(
-				groupId, folderId, fileName);
+		DLFileEntry dlFileEntry = dlFileEntryPersistence.findByG_F_FN(
+			groupId, folderId, fileName);
 
 		dlFileEntryModelResourcePermission.check(
 			getPermissionChecker(), dlFileEntry, ActionKeys.VIEW);

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryTypeServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryTypeServiceImpl.java
@@ -140,7 +140,7 @@ public class DLFileEntryTypeServiceImpl extends DLFileEntryTypeServiceBaseImpl {
 				getPermissionChecker(), fileEntryTypeId, ActionKeys.VIEW);
 		}
 
-		return dlFileEntryTypeLocalService.getFileEntryType(fileEntryTypeId);
+		return dlFileEntryTypePersistence.findByPrimaryKey(fileEntryTypeId);
 	}
 
 	@Override
@@ -175,7 +175,7 @@ public class DLFileEntryTypeServiceImpl extends DLFileEntryTypeServiceBaseImpl {
 			dlFileEntryTypePersistence.filterFindByGroupId(groupIds));
 
 		DLFileEntryType basicDocumentDLFileEntryType =
-			dlFileEntryTypeLocalService.fetchDLFileEntryType(
+			dlFileEntryTypePersistence.fetchByPrimaryKey(
 				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT);
 
 		if (basicDocumentDLFileEntryType != null) {

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileShortcutLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileShortcutLocalServiceImpl.java
@@ -198,7 +198,7 @@ public class DLFileShortcutLocalServiceImpl
 	@Override
 	public void deleteFileShortcut(long fileShortcutId) throws PortalException {
 		DLFileShortcut fileShortcut =
-			dlFileShortcutLocalService.getDLFileShortcut(fileShortcutId);
+			dlFileShortcutPersistence.findByPrimaryKey(fileShortcutId);
 
 		dlFileShortcutLocalService.deleteFileShortcut(fileShortcut);
 	}

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileShortcutServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileShortcutServiceImpl.java
@@ -72,9 +72,8 @@ public class DLFileShortcutServiceImpl extends DLFileShortcutServiceBaseImpl {
 	public void deleteFileShortcut(String externalReferenceCode, long groupId)
 		throws PortalException {
 
-		DLFileShortcut fileShortcut =
-			dlFileShortcutLocalService.getDLFileShortcutByExternalReferenceCode(
-				externalReferenceCode, groupId);
+		DLFileShortcut fileShortcut = dlFileShortcutPersistence.findByERC_G(
+			externalReferenceCode, groupId);
 
 		ModelResourcePermission<FileShortcut>
 			fileShortcutModelResourcePermission =
@@ -93,9 +92,8 @@ public class DLFileShortcutServiceImpl extends DLFileShortcutServiceBaseImpl {
 			String externalReferenceCode, long groupId)
 		throws PortalException {
 
-		DLFileShortcut fileShortcut =
-			dlFileShortcutLocalService.getDLFileShortcutByExternalReferenceCode(
-				externalReferenceCode, groupId);
+		DLFileShortcut fileShortcut = dlFileShortcutPersistence.findByERC_G(
+			externalReferenceCode, groupId);
 
 		ModelResourcePermission<FileShortcut>
 			fileShortcutModelResourcePermission =
@@ -121,7 +119,7 @@ public class DLFileShortcutServiceImpl extends DLFileShortcutServiceBaseImpl {
 		fileShortcutModelResourcePermission.check(
 			getPermissionChecker(), fileShortcutId, ActionKeys.VIEW);
 
-		return dlFileShortcutLocalService.getFileShortcut(fileShortcutId);
+		return dlFileShortcutPersistence.findByPrimaryKey(fileShortcutId);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileVersionServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileVersionServiceImpl.java
@@ -28,7 +28,7 @@ public class DLFileVersionServiceImpl extends DLFileVersionServiceBaseImpl {
 			ModelResourcePermissionRegistryUtil.getModelResourcePermission(
 				FileEntry.class.getName());
 
-		DLFileVersion fileVersion = dlFileVersionLocalService.getFileVersion(
+		DLFileVersion fileVersion = dlFileVersionPersistence.findByPrimaryKey(
 			fileVersionId);
 
 		fileEntryModelResourcePermission.check(

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFolderLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFolderLocalServiceImpl.java
@@ -645,7 +645,7 @@ public class DLFolderLocalServiceImpl extends DLFolderLocalServiceBaseImpl {
 		String uuid, long groupId, long parentFolderId, String name,
 		int count) {
 
-		DLFolder dlFolder = dlFolderLocalService.fetchFolder(
+		DLFolder dlFolder = dlFolderPersistence.fetchByG_P_N(
 			groupId, parentFolderId, name);
 
 		if (dlFolder == null) {

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFolderServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFolderServiceImpl.java
@@ -71,7 +71,7 @@ public class DLFolderServiceImpl extends DLFolderServiceBaseImpl {
 			ModelResourcePermissionRegistryUtil.getModelResourcePermission(
 				DLFolder.class.getName());
 
-		DLFolder dlFolder = dlFolderLocalService.getFolder(folderId);
+		DLFolder dlFolder = dlFolderPersistence.findByPrimaryKey(folderId);
 
 		dlFolderModelResourcePermission.check(
 			getPermissionChecker(), dlFolder, ActionKeys.DELETE);
@@ -98,9 +98,8 @@ public class DLFolderServiceImpl extends DLFolderServiceBaseImpl {
 			ModelResourcePermissionRegistryUtil.getModelResourcePermission(
 				DLFolder.class.getName());
 
-		DLFolder dlFolder =
-			dlFolderLocalService.getDLFolderByExternalReferenceCode(
-				externalReferenceCode, groupId);
+		DLFolder dlFolder = dlFolderPersistence.findByERC_G(
+			externalReferenceCode, groupId);
 
 		dlFolderModelResourcePermission.check(
 			getPermissionChecker(), dlFolder, ActionKeys.VIEW);
@@ -175,7 +174,7 @@ public class DLFolderServiceImpl extends DLFolderServiceBaseImpl {
 			ModelResourcePermissionRegistryUtil.getModelResourcePermission(
 				DLFolder.class.getName());
 
-		DLFolder dlFolder = dlFolderLocalService.getFolder(folderId);
+		DLFolder dlFolder = dlFolderPersistence.findByPrimaryKey(folderId);
 
 		dlFolderModelResourcePermission.check(
 			getPermissionChecker(), dlFolder, ActionKeys.VIEW);
@@ -191,7 +190,7 @@ public class DLFolderServiceImpl extends DLFolderServiceBaseImpl {
 			ModelResourcePermissionRegistryUtil.getModelResourcePermission(
 				DLFolder.class.getName());
 
-		DLFolder dlFolder = dlFolderLocalService.getFolder(
+		DLFolder dlFolder = dlFolderPersistence.findByG_P_N(
 			groupId, parentFolderId, name);
 
 		dlFolderModelResourcePermission.check(
@@ -699,7 +698,7 @@ public class DLFolderServiceImpl extends DLFolderServiceBaseImpl {
 			ModelResourcePermissionRegistryUtil.getModelResourcePermission(
 				DLFolder.class.getName());
 
-		DLFolder dlFolder = dlFolderLocalService.getFolder(folderId);
+		DLFolder dlFolder = dlFolderPersistence.findByPrimaryKey(folderId);
 
 		dlFolderModelResourcePermission.check(
 			getPermissionChecker(), dlFolder, ActionKeys.UPDATE);
@@ -719,7 +718,7 @@ public class DLFolderServiceImpl extends DLFolderServiceBaseImpl {
 
 		PermissionChecker permissionChecker = getPermissionChecker();
 
-		DLFolder dlFolder = dlFolderLocalService.getFolder(folderId);
+		DLFolder dlFolder = dlFolderPersistence.findByPrimaryKey(folderId);
 
 		dlFolderModelResourcePermission.check(
 			permissionChecker, dlFolder, ActionKeys.UPDATE);
@@ -755,7 +754,7 @@ public class DLFolderServiceImpl extends DLFolderServiceBaseImpl {
 	public void unlockFolder(long folderId, String lockUuid)
 		throws PortalException {
 
-		DLFolder dlFolder = dlFolderLocalService.fetchFolder(folderId);
+		DLFolder dlFolder = dlFolderPersistence.fetchByPrimaryKey(folderId);
 
 		if (dlFolder != null) {
 			ModelResourcePermission<DLFolder> dlFolderModelResourcePermission =


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98680

## What Is Being Fixed

A service method that delegates to a same-bundle local service method whose body is just a persistence finder read pays a full AOP proxy invocation for nothing. This removes 315 such hops across 13 modules.

They surfaced through a source formatter check under review at ling-alan-huang#4326. The earlier round of this cleanup missed them: the check derived the entity from the reference name with `upperCaseFirstLetter`, so `_ctCollectionLocalService` became `CtCollection`, the `CtCollectionLocalService` import lookup missed, and the call site was skipped without a word. Once the check resolves all caps entity names, every hop behind CT, COR, CP, CS, DDL, DDM, DL, KB, MB, PLO and SXP appears at once.

## How It Is Being Fixed

- 20 commits convert the 315 call sites. 241 are a plain receiver and method swap, 60 inject the target persistence of another entity in the same bundle and drop the local service reference the conversion orphans, and 14 reproduce the argument handling the pass-through performed on the way to its finder: a class name id lookup, friendly URL normalization, the ordering comparator a first result finder supplies, and one argument order swap.
- 5 commits harden the nullability that inlining makes plain. These are the only behavior changes here. Where the enclosing method's contract is nullable it keeps returning null, and where the entity is required the read moves to the finder that raises the `NoSuch*Exception` naming what is missing. Every one of those methods already declares `PortalException`.
- 1 commit fixes 2 unrelated source format drift issues in files this cleanup does not touch. It is safe to drop.

A conversion was made only where the target method's body is a single persistence read with no side-effecting AOP annotation on the method or its class, caller and target share a bundle, and the finder and its argument order are reproduced exactly. No registered `ServiceWrapper` overrides any bypassed method, checked across 54 wrapper files.

## Testing

The source formatter check is not in this pull, so it ships separately once it is final. The same tree with the check applied ran green on shuyangzhou#12398: `ci:test:sf` passed 1 out of 1 and `ci:test:stable` passed 12 out of 12. `ci:test:relevant` was noisy but nothing was attributable: a concurrent unrelated pull on the same base failed 180 classes to that run's 150, sharing 115, and every class in a module this branch touches was already failing on `EE Development Acceptance (master)` 14 through 16 or is chronic at 5 to 7 of the last 8 runs.

## PR Check

| Validation | Result |
| --- | --- |
| Source Format | PASS. `format-source-current-branch` reports 0 and converges in one round. A full repo `format-source-all` with auto fix on is clean at 0 issues and 0 files modified. |
| Baseline | PASS. No exported API changes, so no version bump is required. |
| Service Builder / REST Builder | PASS. Full repo `ant build-services` and `ant build-rests` produce no generated code drift. |
| Per-Module Compile | PASS. portal-impl `ant compile` plus `compileJava` on all 13 touched modules. |
| Integration Test Compile | PASS. `:apps:asset:asset-list-test:compileTestIntegrationJava`. |

<!-- pr-check {"result": "success", "sha": "3767f247b7f33150b908d0a3c2d324987ee841bc"} -->
