### PR TITLE
LPD-99965 LPD-99991 Scope the MCP OpenAPI cache per company and invalidate it

### DIFF
--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/model/listener/ObjectDefinitionModelListener.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/model/listener/ObjectDefinitionModelListener.java
@@ -21,12 +21,14 @@ public class ObjectDefinitionModelListener
 
 	@Override
 	public void onAfterCreate(ObjectDefinition objectDefinition) {
-		ToolSetUtil.clearOpenAPIJSONObjectCache();
+		ToolSetUtil.clearOpenAPIJSONObjectCache(
+			objectDefinition.getCompanyId());
 	}
 
 	@Override
 	public void onAfterRemove(ObjectDefinition objectDefinition) {
-		ToolSetUtil.clearOpenAPIJSONObjectCache();
+		ToolSetUtil.clearOpenAPIJSONObjectCache(
+			objectDefinition.getCompanyId());
 	}
 
 	@Override
@@ -34,7 +36,8 @@ public class ObjectDefinitionModelListener
 		ObjectDefinition originalObjectDefinition,
 		ObjectDefinition objectDefinition) {
 
-		ToolSetUtil.clearOpenAPIJSONObjectCache();
+		ToolSetUtil.clearOpenAPIJSONObjectCache(
+			objectDefinition.getCompanyId());
 	}
 
 }

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/model/listener/ObjectDefinitionModelListener.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/model/listener/ObjectDefinitionModelListener.java
@@ -1,0 +1,40 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.mcp.server.rest.internal.model.listener;
+
+import com.liferay.mcp.server.rest.internal.util.ToolSetUtil;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.portal.kernel.model.BaseModelListener;
+import com.liferay.portal.kernel.model.ModelListener;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Alejandro Tardín
+ */
+@Component(service = ModelListener.class)
+public class ObjectDefinitionModelListener
+	extends BaseModelListener<ObjectDefinition> {
+
+	@Override
+	public void onAfterCreate(ObjectDefinition objectDefinition) {
+		ToolSetUtil.clearOpenAPIJSONObjectCache();
+	}
+
+	@Override
+	public void onAfterRemove(ObjectDefinition objectDefinition) {
+		ToolSetUtil.clearOpenAPIJSONObjectCache();
+	}
+
+	@Override
+	public void onAfterUpdate(
+		ObjectDefinition originalObjectDefinition,
+		ObjectDefinition objectDefinition) {
+
+		ToolSetUtil.clearOpenAPIJSONObjectCache();
+	}
+
+}

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/model/listener/ObjectFieldModelListener.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/model/listener/ObjectFieldModelListener.java
@@ -1,0 +1,38 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.mcp.server.rest.internal.model.listener;
+
+import com.liferay.mcp.server.rest.internal.util.ToolSetUtil;
+import com.liferay.object.model.ObjectField;
+import com.liferay.portal.kernel.model.BaseModelListener;
+import com.liferay.portal.kernel.model.ModelListener;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Alejandro Tardín
+ */
+@Component(service = ModelListener.class)
+public class ObjectFieldModelListener extends BaseModelListener<ObjectField> {
+
+	@Override
+	public void onAfterCreate(ObjectField objectField) {
+		ToolSetUtil.clearOpenAPIJSONObjectCache();
+	}
+
+	@Override
+	public void onAfterRemove(ObjectField objectField) {
+		ToolSetUtil.clearOpenAPIJSONObjectCache();
+	}
+
+	@Override
+	public void onAfterUpdate(
+		ObjectField originalObjectField, ObjectField objectField) {
+
+		ToolSetUtil.clearOpenAPIJSONObjectCache();
+	}
+
+}

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/model/listener/ObjectFieldModelListener.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/model/listener/ObjectFieldModelListener.java
@@ -20,19 +20,19 @@ public class ObjectFieldModelListener extends BaseModelListener<ObjectField> {
 
 	@Override
 	public void onAfterCreate(ObjectField objectField) {
-		ToolSetUtil.clearOpenAPIJSONObjectCache();
+		ToolSetUtil.clearOpenAPIJSONObjectCache(objectField.getCompanyId());
 	}
 
 	@Override
 	public void onAfterRemove(ObjectField objectField) {
-		ToolSetUtil.clearOpenAPIJSONObjectCache();
+		ToolSetUtil.clearOpenAPIJSONObjectCache(objectField.getCompanyId());
 	}
 
 	@Override
 	public void onAfterUpdate(
 		ObjectField originalObjectField, ObjectField objectField) {
 
-		ToolSetUtil.clearOpenAPIJSONObjectCache();
+		ToolSetUtil.clearOpenAPIJSONObjectCache(objectField.getCompanyId());
 	}
 
 }

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/ToolSetUtil.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/ToolSetUtil.java
@@ -76,7 +76,7 @@ public class ToolSetUtil {
 		return OpenAPIUtil.getTool(
 			!Objects.equals(toolSetName, _TOOL_SET_NAME),
 			_getOpenAPIJSONObject(
-				_getOpenAPIBrief(toolSetName), httpServletRequest),
+				httpServletRequest, _getOpenAPIBrief(toolSetName)),
 			toolName);
 	}
 
@@ -106,7 +106,7 @@ public class ToolSetUtil {
 		return Page.of(
 			OpenAPIUtil.getToolSummaries(
 				_getOpenAPIJSONObject(
-					_getOpenAPIBrief(toolSetName), httpServletRequest)));
+					httpServletRequest, _getOpenAPIBrief(toolSetName))));
 	}
 
 	public static Response invokeTool(
@@ -175,7 +175,7 @@ public class ToolSetUtil {
 							dataMaskExternalReferenceCodes, StringPool.COMMA)
 					).build(),
 					inputJSONObject,
-					_getOpenAPIJSONObject(openAPIBrief, httpServletRequest),
+					_getOpenAPIJSONObject(httpServletRequest, openAPIBrief),
 					toolName, _getUser(httpServletRequest)));
 
 		String content = response.getContent();
@@ -294,7 +294,7 @@ public class ToolSetUtil {
 	}
 
 	private static JSONObject _getOpenAPIJSONObject(
-		OpenAPIBrief openAPIBrief, HttpServletRequest httpServletRequest) {
+		HttpServletRequest httpServletRequest, OpenAPIBrief openAPIBrief) {
 
 		return _openAPIJSONObjectCache.computeIfAbsent(
 			StringBundler.concat(

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/ToolSetUtil.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/ToolSetUtil.java
@@ -61,6 +61,10 @@ import org.osgi.service.jaxrs.runtime.dto.RuntimeDTO;
  */
 public class ToolSetUtil {
 
+	public static void clearOpenAPIJSONObjectCache() {
+		_openAPIJSONObjectCache.clear();
+	}
+
 	public static Tool getTool(
 		HttpServletRequest httpServletRequest, String toolName,
 		String toolSetName) {

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/ToolSetUtil.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/ToolSetUtil.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -42,6 +43,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -61,8 +63,10 @@ import org.osgi.service.jaxrs.runtime.dto.RuntimeDTO;
  */
 public class ToolSetUtil {
 
-	public static void clearOpenAPIJSONObjectCache() {
-		_openAPIJSONObjectCache.clear();
+	public static void clearOpenAPIJSONObjectCache(long companyId) {
+		Set<String> keys = _openAPIJSONObjectCache.keySet();
+
+		keys.removeIf(key -> key.startsWith(companyId + StringPool.POUND));
 	}
 
 	public static Tool getTool(
@@ -293,8 +297,13 @@ public class ToolSetUtil {
 		OpenAPIBrief openAPIBrief, HttpServletRequest httpServletRequest) {
 
 		return _openAPIJSONObjectCache.computeIfAbsent(
-			openAPIBrief._basePath + openAPIBrief._openAPIPath,
-			path -> {
+			StringBundler.concat(
+				PortalUtil.getCompanyId(httpServletRequest), StringPool.POUND,
+				openAPIBrief._basePath, openAPIBrief._openAPIPath),
+			key -> {
+				String path =
+					openAPIBrief._basePath + openAPIBrief._openAPIPath;
+
 				try {
 					VulcanRequestForwarder vulcanRequestForwarder =
 						_vulcanRequestForwarderSnapshot.get();

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/ToolSetUtil.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/ToolSetUtil.java
@@ -64,7 +64,7 @@ import org.osgi.service.jaxrs.runtime.dto.RuntimeDTO;
 public class ToolSetUtil {
 
 	public static void clearOpenAPIJSONObjectCache(long companyId) {
-		Set<String> keys = _openAPIJSONObjectCache.keySet();
+		Set<String> keys = _openAPIJSONObjects.keySet();
 
 		keys.removeIf(key -> key.startsWith(companyId + StringPool.POUND));
 	}
@@ -296,7 +296,7 @@ public class ToolSetUtil {
 	private static JSONObject _getOpenAPIJSONObject(
 		HttpServletRequest httpServletRequest, OpenAPIBrief openAPIBrief) {
 
-		return _openAPIJSONObjectCache.computeIfAbsent(
+		return _openAPIJSONObjects.computeIfAbsent(
 			StringBundler.concat(
 				PortalUtil.getCompanyId(httpServletRequest), StringPool.POUND,
 				openAPIBrief._basePath, openAPIBrief._openAPIPath),
@@ -462,7 +462,7 @@ public class ToolSetUtil {
 	private static final Snapshot<JaxrsServiceRuntime>
 		_jaxrsServiceRuntimeSnapshot = new Snapshot<>(
 			ToolSetUtil.class, JaxrsServiceRuntime.class);
-	private static final Map<String, JSONObject> _openAPIJSONObjectCache =
+	private static final Map<String, JSONObject> _openAPIJSONObjects =
 		new ConcurrentHashMap<>();
 	private static final Snapshot<VulcanRequestForwarder>
 		_vulcanRequestForwarderSnapshot = new Snapshot<>(

--- a/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/resource/v1_0/test/ToolResourceTest.java
+++ b/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/resource/v1_0/test/ToolResourceTest.java
@@ -53,16 +53,11 @@ public class ToolResourceTest extends BaseToolResourceTestCase {
 	@Override
 	@Test
 	public void testGetToolSetToolSetNameTool() throws Exception {
-
-		// Tool from a REST application
-
 		Tool tool = toolResource.getToolSetToolSetNameTool(
 			"mcp-server-v1.0", "getToolSetsPage");
 
 		Assert.assertEquals("getToolSetsPage", tool.getName());
 		Assert.assertNotNull(tool.getInputSchema());
-
-		// Object field added after the tool was requested
 
 		ObjectDefinition objectDefinition =
 			ObjectDefinitionTestUtil.publishObjectDefinition();
@@ -90,8 +85,6 @@ public class ToolResourceTest extends BaseToolResourceTestCase {
 				"JSONObject/body", "JSONObject/properties"),
 			false);
 
-		// Object definition with the same name in another company
-
 		String objectDefinitionName = ObjectDefinitionTestUtil.getRandomName();
 		String objectFieldName = "a" + RandomTestUtil.randomString(8);
 
@@ -117,8 +110,6 @@ public class ToolResourceTest extends BaseToolResourceTestCase {
 				"JSONObject/inputSchema", "JSONObject/properties",
 				"JSONObject/body", "JSONObject/properties"),
 			false);
-
-		// Same tool requested by the other company
 
 		HTTPTestUtil.customize(
 		).withCredentials(

--- a/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/resource/v1_0/test/ToolResourceTest.java
+++ b/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/resource/v1_0/test/ToolResourceTest.java
@@ -10,15 +10,25 @@ import com.liferay.mcp.server.rest.client.dto.v1_0.Tool;
 import com.liferay.mcp.server.rest.client.http.HttpInvoker;
 import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
 import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.test.util.CompanyTestUtil;
+import com.liferay.portal.kernel.test.util.HTTPTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
@@ -80,6 +90,61 @@ public class ToolResourceTest extends BaseToolResourceTestCase {
 				"JSONObject/body", "JSONObject/properties"),
 			false);
 
+		// Object definition with the same name in another company
+
+		String objectDefinitionName = ObjectDefinitionTestUtil.getRandomName();
+		String objectFieldName = "a" + RandomTestUtil.randomString(8);
+
+		ObjectDefinition companyObjectDefinition = _publishObjectDefinition(
+			objectDefinitionName, objectFieldName, TestPropsValues.getUserId());
+
+		Company company = CompanyTestUtil.addCompany();
+
+		User user = UserTestUtil.getAdminUser(company.getCompanyId());
+
+		String otherObjectFieldName = "a" + RandomTestUtil.randomString(8);
+
+		_publishObjectDefinition(
+			objectDefinitionName, otherObjectFieldName, user.getUserId());
+
+		JSONAssert.assertEquals(
+			JSONUtil.put(
+				objectFieldName, JSONUtil.put("type", "string")
+			).toString(),
+			JSONUtil.getValueAsString(
+				JSONFactoryUtil.createJSONObject(
+					String.valueOf(_getTool(companyObjectDefinition))),
+				"JSONObject/inputSchema", "JSONObject/properties",
+				"JSONObject/body", "JSONObject/properties"),
+			false);
+
+		// Same tool requested by the other company
+
+		HTTPTestUtil.customize(
+		).withCredentials(
+			user.getEmailAddress(), PropsValues.DEFAULT_ADMIN_PASSWORD
+		).apply(
+			() -> JSONAssert.assertEquals(
+				JSONUtil.put(
+					otherObjectFieldName, JSONUtil.put("type", "string")
+				).toString(),
+				JSONUtil.getValueAsString(
+					JSONFactoryUtil.createJSONObject(
+						HTTPTestUtil.invokeToString(
+							null,
+							StringBundler.concat(
+								"mcp-server/v1.0/tool-sets/",
+								_getToolSetName(companyObjectDefinition),
+								"/tools/post",
+								companyObjectDefinition.getShortName()),
+							HashMapBuilder.put(
+								"Host", company.getVirtualHostname()
+							).build(),
+							Http.Method.GET)),
+					"JSONObject/inputSchema", "JSONObject/properties",
+					"JSONObject/body", "JSONObject/properties"),
+				false)
+		);
 	}
 
 	@Override
@@ -168,6 +233,27 @@ public class ToolResourceTest extends BaseToolResourceTestCase {
 		return StringUtil.replace(
 			restContextPath.substring(1), CharPool.SLASH, CharPool.DASH);
 	}
+
+	private ObjectDefinition _publishObjectDefinition(
+			String name, String objectFieldName, long userId)
+		throws Exception {
+
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.addCustomObjectDefinition(name, userId);
+
+		_objectFieldLocalService.addCustomObjectField(
+			null, userId, 0, objectDefinition.getObjectDefinitionId(),
+			ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+			ObjectFieldConstants.DB_TYPE_STRING, false, false, null,
+			LocalizedMapUtil.getLocalizedMap(objectFieldName), false,
+			objectFieldName, null, null, false, false, Collections.emptyList());
+
+		return _objectDefinitionLocalService.publishCustomObjectDefinition(
+			userId, objectDefinition.getObjectDefinitionId());
+	}
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
 
 	@Inject
 	private ObjectFieldLocalService _objectFieldLocalService;

--- a/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/resource/v1_0/test/ToolResourceTest.java
+++ b/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/resource/v1_0/test/ToolResourceTest.java
@@ -8,18 +8,30 @@ package com.liferay.mcp.server.rest.resource.v1_0.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.mcp.server.rest.client.dto.v1_0.Tool;
 import com.liferay.mcp.server.rest.client.http.HttpInvoker;
+import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.service.ObjectFieldLocalService;
+import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.petra.string.CharPool;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
 import java.util.Base64;
+import java.util.Collections;
 
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import org.skyscreamer.jsonassert.JSONAssert;
 
 /**
  * @author Alejandro Tardín
@@ -31,11 +43,43 @@ public class ToolResourceTest extends BaseToolResourceTestCase {
 	@Override
 	@Test
 	public void testGetToolSetToolSetNameTool() throws Exception {
+
+		// Tool from a REST application
+
 		Tool tool = toolResource.getToolSetToolSetNameTool(
 			"mcp-server-v1.0", "getToolSetsPage");
 
 		Assert.assertEquals("getToolSetsPage", tool.getName());
 		Assert.assertNotNull(tool.getInputSchema());
+
+		// Object field added after the tool was requested
+
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition();
+
+		_getTool(objectDefinition);
+
+		String name = "a" + RandomTestUtil.randomString(8);
+
+		_objectFieldLocalService.addCustomObjectField(
+			null, TestPropsValues.getUserId(), 0,
+			objectDefinition.getObjectDefinitionId(),
+			ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+			ObjectFieldConstants.DB_TYPE_STRING, false, false, null,
+			LocalizedMapUtil.getLocalizedMap(name), false, name, null, null,
+			false, false, Collections.emptyList());
+
+		JSONAssert.assertEquals(
+			JSONUtil.put(
+				name, JSONUtil.put("type", "string")
+			).toString(),
+			JSONUtil.getValueAsString(
+				JSONFactoryUtil.createJSONObject(
+					String.valueOf(_getTool(objectDefinition))),
+				"JSONObject/inputSchema", "JSONObject/properties",
+				"JSONObject/body", "JSONObject/properties"),
+			false);
+
 	}
 
 	@Override
@@ -111,5 +155,21 @@ public class ToolResourceTest extends BaseToolResourceTestCase {
 		Assert.assertTrue(itemJSONObject.has("id"));
 		Assert.assertFalse(itemJSONObject.has("title"));
 	}
+
+	private Tool _getTool(ObjectDefinition objectDefinition) throws Exception {
+		return toolResource.getToolSetToolSetNameTool(
+			_getToolSetName(objectDefinition),
+			"post" + objectDefinition.getShortName());
+	}
+
+	private String _getToolSetName(ObjectDefinition objectDefinition) {
+		String restContextPath = objectDefinition.getRESTContextPath();
+
+		return StringUtil.replace(
+			restContextPath.substring(1), CharPool.SLASH, CharPool.DASH);
+	}
+
+	@Inject
+	private ObjectFieldLocalService _objectFieldLocalService;
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99965
https://liferay.atlassian.net/browse/LPD-99991

## What Is Being Fixed

`ToolSetUtil` caches a tool set's OpenAPI document in a static map keyed on the tool set's base path plus its OpenAPI path. A tool's input schema is derived from that document, and two defects follow from the key and from the entry's lifetime.

**LPD-99965 — the document is served across companies.** The document is generated for the company that requested it: `OpenAPIResourceImpl` and `FilterableFieldsOpenAPIContributor` both read `CompanyThreadLocal`, so filterable fields derived from one instance's object definitions end up in it. With no company in the key, the first company to request a tool set fills the entry and every other company is served its schemas — including property names taken from another tenant's object definitions.

**LPD-99991 — the document is never invalidated.** Nothing drops the entry, so the schemas a tool set advertises keep the shape they had when the document was first requested until the server restarts. Adding an object field does not change the tool that writes to that object.

The cache cannot simply be removed: Vulcan sets `setCacheTTL(0L)` in `OpenAPIResourceImpl`, so each `/openapi.json` is regenerated per request, and one document costs about a second on a local instance. `ToolSetUtil` resolves one per tool while building the servlet.

## How It Is Being Fixed

**The company is part of the key.** `_getOpenAPIJSONObject` prefixes the key with the company resolved from the request through `PortalUtil`, so it is resolved the same way the forwarded request resolves it and no caller has to pass it.

**Model listeners invalidate it.** `ObjectDefinitionModelListener` and `ObjectFieldModelListener` clear the cache on after-create, after-update and after-remove. A separate object field listener is needed because adding a field changes the entity model without touching the definition row. Vulcan regenerates the document on every request, so dropping the entry is enough to pick up the change. Now that the key carries the company, the listeners drop only that company's documents instead of the whole cache.

## Tests

Both cases are covered in the overridden `ToolResourceTest.testGetToolSetToolSetNameTool`, and each fails only for its own defect:

- *Object field added after the tool was requested* — requests an object-backed tool, adds a field, and asserts the field shows up in the input schema without a restart.
- *Object definition with the same name in another company* — publishes the same object definition in two companies with a different field each, so both share one tool set path and therefore one cache key, and asserts each company is served its own schema.

`ToolResourceTest` passes locally, 5/5.

## PR Check

**pr-check: PASS** — tested on `c190293f39d718b107710ad729f78c2dc81f59fd`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | PASS |

Cross-Module Compile matched on the `*Util.java` filename rule; `ToolSetUtil` is internal to `mcp-server-rest-impl` and has no consumers outside it, so there was nothing to compile.

<!-- pr-check {"result": "success", "sha": "c190293f39d718b107710ad729f78c2dc81f59fd"} -->

