### PR TITLE
LPD-100118 Return the same facet counts on every object entries page

### DIFF
--- a/.claude/rules/service-builder.md
+++ b/.claude/rules/service-builder.md
@@ -1,0 +1,37 @@
+---
+
+paths:
+  - "modules/**/*-api/bnd.bnd"
+  - "modules/**/*-api/src/main/java/**/service/*Service.java"
+  - "modules/**/*-api/src/main/java/**/service/*ServiceUtil.java"
+  - "modules/**/*-api/src/main/java/**/service/*ServiceWrapper.java"
+  - "modules/**/*-api/src/main/resources/**/packageinfo"
+  - "modules/**/*-service/service.xml"
+  - "modules/**/*-service/src/main/java/**/service/impl/*Impl.java"
+  - "modules/**/*-test/src/testIntegration/java/**/service/persistence/test/*PersistenceTest.java"
+
+---
+
+# Service Builder
+
+All Service Builder API artifacts — `*LocalService.java`, `*Service.java`, `*LocalServiceUtil.java`, `*ServiceUtil.java`, `*LocalServiceWrapper.java`, `*ServiceWrapper.java`, `packageinfo`, and the `bnd.bnd` version bump in the `*-api` module — are generated. Do not hand-edit them. Add or change methods on the `*LocalServiceImpl` or `*ServiceImpl` class in the `*-service` module and let `buildService` regenerate the API. Entity, column, and finder definitions live in `service.xml`; changing them regenerates models, persistence, and base service classes the same way.
+
+## Adding or Updating Entities
+
+1. Edit `modules/.../<module>-service/service.xml`.
+
+1. Commit the `service.xml` edit.
+
+1. Run `<gradlew> buildService` from `modules/.../<module>-service` to regenerate the model, persistence, base service, and API artifacts.
+
+1. Commit the generated files.
+
+## Adding or Updating Service Methods
+
+1. Edit the impl in `modules/.../<module>-service/src/main/java/.../service/impl/<Entity>LocalServiceImpl.java` or `<Entity>ServiceImpl.java`.
+
+1. Commit the impl edit.
+
+1. Run `<gradlew> buildService` from `modules/.../<module>-service` to regenerate the API interface, `*Util`, `*Wrapper`, `packageinfo`, and `bnd.bnd`.
+
+1. Commit the generated files.

--- a/.claude/rules/service-builder.md
+++ b/.claude/rules/service-builder.md
@@ -1,37 +1,52 @@
----
-
-paths:
-  - "modules/**/*-api/bnd.bnd"
-  - "modules/**/*-api/src/main/java/**/service/*Service.java"
-  - "modules/**/*-api/src/main/java/**/service/*ServiceUtil.java"
-  - "modules/**/*-api/src/main/java/**/service/*ServiceWrapper.java"
-  - "modules/**/*-api/src/main/resources/**/packageinfo"
-  - "modules/**/*-service/service.xml"
-  - "modules/**/*-service/src/main/java/**/service/impl/*Impl.java"
-  - "modules/**/*-test/src/testIntegration/java/**/service/persistence/test/*PersistenceTest.java"
-
----
-
 # Service Builder
 
-All Service Builder API artifacts — `*LocalService.java`, `*Service.java`, `*LocalServiceUtil.java`, `*ServiceUtil.java`, `*LocalServiceWrapper.java`, `*ServiceWrapper.java`, `packageinfo`, and the `bnd.bnd` version bump in the `*-api` module — are generated. Do not hand-edit them. Add or change methods on the `*LocalServiceImpl` or `*ServiceImpl` class in the `*-service` module and let `buildService` regenerate the API. Entity, column, and finder definitions live in `service.xml`; changing them regenerates models, persistence, and base service classes the same way.
+Use these procedures whenever a task requires modifying a Liferay Service Builder module bundle.
 
-## Adding or Updating Entities
+## Module Bundle Layout
 
-1. Edit `modules/.../<module>-service/service.xml`.
+A Service Builder feature lives in three sibling modules under `modules/apps/<area>`:
 
-1. Commit the `service.xml` edit.
+- `<name>-api` — generated public API.
+- `<name>-service` — implementation. Hand-written `service.xml` and the `*Impl` classes drive everything else.
+- `<name>-test` — integration tests.
 
-1. Run `<gradlew> buildService` from `modules/.../<module>-service` to regenerate the model, persistence, base service, and API artifacts.
+Portal core follows the same split, with `portal-impl/service.xml` driving the API in `portal-kernel`.
 
-1. Commit the generated files.
+## Files To Leave Alone
 
-## Adding or Updating Service Methods
+Every generated Java file is tagged `@generated` in its javadoc — do not hand-edit anything carrying that tag; `buildService` rewrites it on each run. The same applies to the generated resources under `<name>-service/src/main/resources/META-INF`: `module-hbm.xml`, `portlet-model-hints.xml`, and `sql`.
 
-1. Edit the impl in `modules/.../<module>-service/src/main/java/.../service/impl/<Entity>LocalServiceImpl.java` or `<Entity>ServiceImpl.java`.
+## Editing a Service
 
-1. Commit the impl edit.
+Hand edits are confined to two inputs in the `<name>-service` module:
 
-1. Run `<gradlew> buildService` from `modules/.../<module>-service` to regenerate the API interface, `*Util`, `*Wrapper`, `packageinfo`, and `bnd.bnd`.
+- `service.xml` — entity, column, and finder definitions. Changing them regenerates the model, persistence, and base service classes.
+- The `*Impl` classes `buildService` scaffolds on first run and preserves on every subsequent run — `model/impl/<Entity>Impl.java`, `service/impl/<Entity>LocalServiceImpl.java`, and `service/impl/<Entity>ServiceImpl.java`. Add or change methods here and let the tool regenerate the API interface, `*Util`, and `*Wrapper`.
 
-1. Commit the generated files.
+Every edit must be regenerated and committed before any further work continues.
+
+### Workflow
+
+Run every step without asking for confirmation, including the commits.
+
+1. Commit the hand-written `service.xml` or `*Impl` edit.
+
+1. Run Service Builder.
+
+1. Commit the changes the tool produces or rewrites, titled `<TICKET> buildService`. Keep the regenerated output on its own, separate from the edit that caused it.
+
+1. Continue with the work.
+
+## Running Service Builder
+
+### A Single Module
+
+Run `<gradlew> buildService` from the `<name>-service` module to regenerate that module alone.
+
+### Every Module
+
+To regenerate every Service Builder module in one pass, run `ant build-services` from `portal-impl`:
+
+```bash
+(cd "${REPO_ROOT}/portal-impl" && ant build-services)
+```

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalService.java
@@ -291,7 +291,7 @@ public interface ObjectEntryLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public Map<Object, Long> getAggregationCounts(
 			long groupId, long objectDefinitionId, String aggregationTerm,
-			Predicate predicate, boolean preferApproved, int start, int end)
+			Predicate predicate, boolean preferApproved)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
@@ -436,8 +436,7 @@ public interface ObjectEntryLocalService
 	public Map<Object, Long> getOneToManyAggregationCounts(
 			long groupId, long objectDefinitionId, long objectEntryId,
 			long objectRelationshipId, String aggregationTerm,
-			Predicate predicate, boolean related, String search, int start,
-			int end)
+			Predicate predicate, boolean related, String search)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
@@ -626,4 +625,4 @@ public interface ObjectEntryLocalService
 		throws PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-404821026
+// LIFERAY-SERVICE-BUILDER-HASH:257254270

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalServiceUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalServiceUtil.java
@@ -365,12 +365,12 @@ public class ObjectEntryLocalServiceUtil {
 	public static Map<Object, Long> getAggregationCounts(
 			long groupId, long objectDefinitionId, String aggregationTerm,
 			com.liferay.petra.sql.dsl.expression.Predicate predicate,
-			boolean preferApproved, int start, int end)
+			boolean preferApproved)
 		throws PortalException {
 
 		return getService().getAggregationCounts(
 			groupId, objectDefinitionId, aggregationTerm, predicate,
-			preferApproved, start, end);
+			preferApproved);
 	}
 
 	public static com.liferay.portal.kernel.dao.orm.ExportActionableDynamicQuery
@@ -576,12 +576,12 @@ public class ObjectEntryLocalServiceUtil {
 			long groupId, long objectDefinitionId, long objectEntryId,
 			long objectRelationshipId, String aggregationTerm,
 			com.liferay.petra.sql.dsl.expression.Predicate predicate,
-			boolean related, String search, int start, int end)
+			boolean related, String search)
 		throws PortalException {
 
 		return getService().getOneToManyAggregationCounts(
 			groupId, objectDefinitionId, objectEntryId, objectRelationshipId,
-			aggregationTerm, predicate, related, search, start, end);
+			aggregationTerm, predicate, related, search);
 	}
 
 	public static List<ObjectEntry> getOneToManyObjectEntries(
@@ -903,4 +903,4 @@ public class ObjectEntryLocalServiceUtil {
 			ObjectEntryLocalServiceUtil.class, ObjectEntryLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-191694864
+// LIFERAY-SERVICE-BUILDER-HASH:846990680

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalServiceWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalServiceWrapper.java
@@ -411,12 +411,12 @@ public class ObjectEntryLocalServiceWrapper
 	public java.util.Map<Object, Long> getAggregationCounts(
 			long groupId, long objectDefinitionId, String aggregationTerm,
 			com.liferay.petra.sql.dsl.expression.Predicate predicate,
-			boolean preferApproved, int start, int end)
+			boolean preferApproved)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _objectEntryLocalService.getAggregationCounts(
 			groupId, objectDefinitionId, aggregationTerm, predicate,
-			preferApproved, start, end);
+			preferApproved);
 	}
 
 	@Override
@@ -658,12 +658,12 @@ public class ObjectEntryLocalServiceWrapper
 			long groupId, long objectDefinitionId, long objectEntryId,
 			long objectRelationshipId, String aggregationTerm,
 			com.liferay.petra.sql.dsl.expression.Predicate predicate,
-			boolean related, String search, int start, int end)
+			boolean related, String search)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _objectEntryLocalService.getOneToManyAggregationCounts(
 			groupId, objectDefinitionId, objectEntryId, objectRelationshipId,
-			aggregationTerm, predicate, related, search, start, end);
+			aggregationTerm, predicate, related, search);
 	}
 
 	@Override
@@ -1042,4 +1042,4 @@ public class ObjectEntryLocalServiceWrapper
 	private ObjectEntryLocalService _objectEntryLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:428269909
+// LIFERAY-SERVICE-BUILDER-HASH:1063774189

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/service/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/service/packageinfo
@@ -1,1 +1,1 @@
-version 86.1.0
+version 87.0.0

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -866,8 +866,7 @@ public class DefaultObjectEntryManagerImpl
 					groupId, objectDefinition.getObjectDefinitionId(),
 					aggregationTerm, predicate,
 					GetterUtil.getBoolean(
-						dtoConverterContext.getAttribute("preferApproved")),
-					start, end)),
+						dtoConverterContext.getAttribute("preferApproved")))),
 			TransformUtil.transform(
 				objectEntryLocalService.getPrimaryKeys(
 					groupIds, companyId, dtoConverterContext.getUserId(),
@@ -2963,7 +2962,7 @@ public class DefaultObjectEntryManagerImpl
 						groupId, objectDefinition.getObjectDefinitionId(),
 						serviceBuilderObjectEntry.getObjectEntryId(),
 						objectRelationship.getObjectRelationshipId(),
-						aggregationTerm, predicate, true, search, start, end)),
+						aggregationTerm, predicate, true, search)),
 			_toObjectEntries(
 				dtoConverterContext,
 				objectRelatedModelsProvider.getRelatedModels(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -234,6 +234,7 @@ import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
 import com.liferay.portal.vulcan.fields.NestedFieldsContext;
 import com.liferay.portal.vulcan.fields.NestedFieldsContextThreadLocal;
 import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.scope.Scope;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
@@ -6604,14 +6605,20 @@ public class DefaultObjectEntryManagerImplTest
 
 		Page<ObjectEntry> page = _getPage(
 			Collections.singletonMap("textObjectFieldName", StringPool.BLANK),
-			_objectDefinition1);
+			_objectDefinition1, null);
 
-		assertFacets(
-			page.getFacets(),
-			List.of(
-				new Facet(
-					"textObjectFieldName",
-					List.of(new Facet.FacetValue(2, textObjectFieldValue)))));
+		List<Facet> expectedFacets = List.of(
+			new Facet(
+				"textObjectFieldName",
+				List.of(new Facet.FacetValue(2, textObjectFieldValue))));
+
+		assertFacets(page.getFacets(), expectedFacets);
+
+		page = _getPage(
+			Collections.singletonMap("textObjectFieldName", StringPool.BLANK),
+			_objectDefinition1, Pagination.of(2, 1));
+
+		assertFacets(page.getFacets(), expectedFacets);
 
 		PermissionThreadLocal.setPermissionChecker(
 			PermissionCheckerFactoryUtil.create(adminUser));
@@ -6640,18 +6647,25 @@ public class DefaultObjectEntryManagerImplTest
 		page = _getPage(
 			Collections.singletonMap(
 				_objectRelationshipFieldName, StringPool.BLANK),
-			_objectDefinition2);
+			_objectDefinition2, null);
 
-		assertFacets(
-			page.getFacets(),
-			List.of(
-				new Facet(
-					_objectRelationshipFieldName,
-					List.of(
-						new Facet.FacetValue(
-							1, String.valueOf(parentObjectEntry1.getId())),
-						new Facet.FacetValue(
-							2, String.valueOf(parentObjectEntry2.getId()))))));
+		expectedFacets = List.of(
+			new Facet(
+				_objectRelationshipFieldName,
+				List.of(
+					new Facet.FacetValue(
+						1, String.valueOf(parentObjectEntry1.getId())),
+					new Facet.FacetValue(
+						2, String.valueOf(parentObjectEntry2.getId())))));
+
+		assertFacets(page.getFacets(), expectedFacets);
+
+		page = _getPage(
+			Collections.singletonMap(
+				_objectRelationshipFieldName, StringPool.BLANK),
+			_objectDefinition2, Pagination.of(2, 1));
+
+		assertFacets(page.getFacets(), expectedFacets);
 
 		_defaultObjectEntryManager.updateObjectEntry(
 			_simpleDTOConverterContext, _objectDefinition2,
@@ -6667,7 +6681,7 @@ public class DefaultObjectEntryManagerImplTest
 		page = _getPage(
 			Collections.singletonMap(
 				_objectRelationshipFieldName, StringPool.BLANK),
-			_objectDefinition2);
+			_objectDefinition2, null);
 
 		assertFacets(
 			page.getFacets(),
@@ -6686,7 +6700,7 @@ public class DefaultObjectEntryManagerImplTest
 		page = _getPage(
 			Collections.singletonMap(
 				_objectRelationshipFieldName, StringPool.BLANK),
-			_objectDefinition2);
+			_objectDefinition2, null);
 
 		assertFacets(
 			page.getFacets(),
@@ -7389,25 +7403,18 @@ public class DefaultObjectEntryManagerImplTest
 				},
 				_companyObjectEntryA.getId(), _companyObjectRelationshipA_AA);
 
-		Page<ObjectEntry> page =
-			_defaultObjectEntryManager.getRelatedObjectEntries(
-				new Aggregation() {
-					{
-						setAggregationTerms(
-							Collections.singletonMap(
-								"textObjectFieldName", StringPool.BLANK));
-					}
-				},
-				_createDTOConverterContext(),
-				_companyObjectEntryA.getExternalReferenceCode(), null,
-				_companyObjectRelationshipA_AA, null, null, null, null);
+		List<Facet> expectedFacets = List.of(
+			new Facet(
+				"textObjectFieldName",
+				List.of(new Facet.FacetValue(2, textObjectFieldValue))));
 
-		assertFacets(
-			page.getFacets(),
-			List.of(
-				new Facet(
-					"textObjectFieldName",
-					List.of(new Facet.FacetValue(2, textObjectFieldValue)))));
+		Page<ObjectEntry> page = _getRelatedObjectEntriesPage(null);
+
+		assertFacets(page.getFacets(), expectedFacets);
+
+		page = _getRelatedObjectEntriesPage(Pagination.of(2, 1));
+
+		assertFacets(page.getFacets(), expectedFacets);
 
 		_objectEntryLocalService.deleteObjectEntry(objectEntryAA1.getId());
 		_objectEntryLocalService.deleteObjectEntry(objectEntryAA2.getId());
@@ -11575,7 +11582,7 @@ public class DefaultObjectEntryManagerImplTest
 
 	private Page<ObjectEntry> _getPage(
 			Map<String, String> aggregationTerms,
-			ObjectDefinition objectDefinition)
+			ObjectDefinition objectDefinition, Pagination pagination)
 		throws Exception {
 
 		return _defaultObjectEntryManager.getObjectEntries(
@@ -11588,7 +11595,24 @@ public class DefaultObjectEntryManagerImplTest
 			new DefaultDTOConverterContext(
 				false, Collections.emptyMap(), dtoConverterRegistry, null,
 				LocaleUtil.getDefault(), null, _user),
-			StringPool.BLANK, null, null, null);
+			StringPool.BLANK, pagination, null, null);
+	}
+
+	private Page<ObjectEntry> _getRelatedObjectEntriesPage(
+			Pagination pagination)
+		throws Exception {
+
+		return _defaultObjectEntryManager.getRelatedObjectEntries(
+			new Aggregation() {
+				{
+					setAggregationTerms(
+						Collections.singletonMap(
+							"textObjectFieldName", StringPool.BLANK));
+				}
+			},
+			_createDTOConverterContext(),
+			_companyObjectEntryA.getExternalReferenceCode(), null,
+			_companyObjectRelationshipA_AA, pagination, null, null, null);
 	}
 
 	private Timestamp _getTimestamp(String dateString) throws Exception {

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -1101,7 +1101,7 @@ public class ObjectEntryLocalServiceImpl
 	@Override
 	public Map<Object, Long> getAggregationCounts(
 			long groupId, long objectDefinitionId, String aggregationTerm,
-			Predicate predicate, boolean preferApproved, int start, int end)
+			Predicate predicate, boolean preferApproved)
 		throws PortalException {
 
 		Map<Object, Long> aggregationCounts = new HashMap<>();
@@ -1153,8 +1153,6 @@ public class ObjectEntryLocalServiceImpl
 			)
 		).groupBy(
 			table.getColumn(objectField.getDBColumnName())
-		).limit(
-			start, end
 		);
 
 		for (Object[] values : (List<Object[]>)dslQuery(dslQuery)) {
@@ -1457,8 +1455,7 @@ public class ObjectEntryLocalServiceImpl
 	public Map<Object, Long> getOneToManyAggregationCounts(
 			long groupId, long objectDefinitionId, long objectEntryId,
 			long objectRelationshipId, String aggregationTerm,
-			Predicate predicate, boolean related, String search, int start,
-			int end)
+			Predicate predicate, boolean related, String search)
 		throws PortalException {
 
 		ObjectDefinition objectDefinition =
@@ -1485,8 +1482,6 @@ public class ObjectEntryLocalServiceImpl
 			related, search
 		).groupBy(
 			table.getColumn(objectField.getDBColumnName())
-		).limit(
-			start, end
 		);
 
 		Map<Object, Long> aggregationCounts = new HashMap<>();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100118
https://liferay.atlassian.net/browse/LPD-89971

## What Is Being Fixed

The object entries aggregation queries grouped by the aggregated field and then applied the request's pagination window to that grouped query, so the limit sliced facet buckets instead of entries. A request for the second page skipped the buckets the first page had reported, leaving `facetValues` empty. Aggregations describe the whole result set, so they must not depend on the requested page.

Every other headless API computes aggregations through `SearchUtil`, where pagination only sets the hits window and Elasticsearch counts over the full matched set. Objects is the only place where facets are hand-written SQL, and the only one affected.

## How It Is Being Fixed

`getAggregationCounts` and `getOneToManyAggregationCounts` no longer accept `start` and `end`, and their DSL queries drop the `limit` clause, so the grouping always runs over the entire result set. `DefaultObjectEntryManagerImpl` stops forwarding the pagination window at both call sites.

Removing those parameters changes the exported `com.liferay.object.service` package, so Service Builder regenerated the API in its own commit and the package version moved from `86.1.0` to `87.0.0` — the major bump bnd's baseline recommends for the removal. No other module in the repository calls either method, but the bump is what signals the break to out-of-repo consumers.

`DefaultObjectEntryManagerImplTest` now asserts the same facets with and without a pagination window, on both the object entries and the related object entries paths, so a reintroduced limit fails the test.

This branch also carries LPD-89971, which documents the Service Builder workflow rule that the split between the fix and its regenerated output follows.

## PR Check

**pr-check: PASS** — tested on `cf023690ff4a7907e892a10acb932afde87f30d4`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "cf023690ff4a7907e892a10acb932afde87f30d4"} -->
