### PR TITLE
LPD-100422 Skip the Salesforce and SugarCRM tests when authentication fails

### DIFF
--- a/modules/apps/object/object-storage-salesforce-test/src/testIntegration/java/com/liferay/object/storage/salesforce/internal/rest/manager/v1_0/test/SalesforceObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-storage-salesforce-test/src/testIntegration/java/com/liferay/object/storage/salesforce/internal/rest/manager/v1_0/test/SalesforceObjectEntryManagerImplTest.java
@@ -21,6 +21,7 @@ import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.ObjectFieldSetting;
 import com.liferay.object.rest.dto.v1_0.ObjectEntry;
+import com.liferay.object.rest.manager.exception.ObjectEntryManagerHttpException;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
 import com.liferay.object.rest.test.util.BaseObjectEntryManagerImplTestCase;
 import com.liferay.object.service.ObjectFieldSettingLocalService;
@@ -66,6 +67,7 @@ import java.util.Map;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -266,6 +268,17 @@ public class SalesforceObjectEntryManagerImplTest
 			objectDefinitionLocalService.publishCustomObjectDefinition(
 				adminUser.getUserId(),
 				_objectDefinition.getObjectDefinitionId());
+
+		try {
+			getObjectEntries(Collections.<String, String>emptyMap(), null);
+		}
+		catch (ObjectEntryManagerHttpException
+					objectEntryManagerHttpException) {
+
+			Assume.assumeNoException(
+				"Unable to authenticate with Salesforce",
+				objectEntryManagerHttpException);
+		}
 	}
 
 	@After

--- a/modules/apps/object/object-storage-sugarcrm-test/src/testIntegration/java/com/liferay/object/storage/sugarcrm/internal/rest/manager/v1_0/test/SugarCRMObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-storage-sugarcrm-test/src/testIntegration/java/com/liferay/object/storage/sugarcrm/internal/rest/manager/v1_0/test/SugarCRMObjectEntryManagerImplTest.java
@@ -12,6 +12,7 @@ import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.rest.dto.v1_0.ObjectEntry;
+import com.liferay.object.rest.manager.exception.ObjectEntryManagerHttpException;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
 import com.liferay.object.rest.test.util.BaseObjectEntryManagerImplTestCase;
 import com.liferay.object.storage.sugarcrm.configuration.SugarCRMConfiguration;
@@ -47,6 +48,7 @@ import java.util.Map;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -174,6 +176,17 @@ public class SugarCRMObjectEntryManagerImplTest
 			objectDefinitionLocalService.publishCustomObjectDefinition(
 				adminUser.getUserId(),
 				_objectDefinition.getObjectDefinitionId());
+
+		try {
+			getObjectEntries(Collections.<String, String>emptyMap(), null);
+		}
+		catch (ObjectEntryManagerHttpException
+					objectEntryManagerHttpException) {
+
+			Assume.assumeNoException(
+				"Unable to authenticate with SugarCRM",
+				objectEntryManagerHttpException);
+		}
 	}
 
 	@After


### PR DESCRIPTION
[LPD-100422](https://liferay.atlassian.net/browse/LPD-100422)

## What Is Being Fixed

The `SalesforceObjectEntryManagerImplTest` and `SugarCRMObjectEntryManagerImplTest` integration tests fail on CI. They exercise live external CRM endpoints using credentials injected on CI, and those credentials have expired, so every test method fails during authentication. The connectors themselves did not change — the tests passed for months and broke a month apart, which points to an external credential/endpoint expiry rather than a code regression.

## How It Is Being Fixed

Each test probes its connector once at the end of `setUp` by calling `getObjectEntries`, and on an `ObjectEntryManagerHttpException` calls `Assume.assumeNoException` so the test skips cleanly instead of reporting a failure that no product code change can fix. Once the CI credentials are rotated the probe succeeds and the tests run normally again.

## PR Check

| Validation | Result |
| --- | --- |
| Source Format | success |
| Integration Test Compile | success |
| Baseline | not applicable (test-only, no exported API change) |

<!-- pr-check {"result":"success","sha":"388588a9dda0a1f7139990ee4c258f344cc04d13"} -->
