### PR TITLE
LPD-100423 Keep the sharing configuration components active across a configuration change

### DIFF
--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/configuration/SharingConfigurationFactoryImpl.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/configuration/SharingConfigurationFactoryImpl.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
 
 /**
@@ -52,6 +53,7 @@ public class SharingConfigurationFactoryImpl
 	}
 
 	@Activate
+	@Modified
 	protected void activate(Map<String, Object> properties) {
 		_sharingSystemConfiguration = ConfigurableUtil.createConfigurable(
 			SharingSystemConfiguration.class, properties);

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/scheduler/DeleteExpiredSharingEntriesSchedulerJobConfiguration.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/scheduler/DeleteExpiredSharingEntriesSchedulerJobConfiguration.java
@@ -17,6 +17,7 @@ import java.util.Map;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
 
 /**
@@ -40,6 +41,7 @@ public class DeleteExpiredSharingEntriesSchedulerJobConfiguration
 	}
 
 	@Activate
+	@Modified
 	protected void activate(Map<String, Object> properties) {
 		SharingSystemConfiguration sharingSystemConfiguration =
 			ConfigurableUtil.createConfigurable(
@@ -53,6 +55,6 @@ public class DeleteExpiredSharingEntriesSchedulerJobConfiguration
 	@Reference
 	private SharingEntryLocalService _sharingEntryLocalService;
 
-	private TriggerConfiguration _triggerConfiguration;
+	private volatile TriggerConfiguration _triggerConfiguration;
 
 }

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/security/permission/resource/SharingModelResourcePermissionConfiguratorImpl.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/security/permission/resource/SharingModelResourcePermissionConfiguratorImpl.java
@@ -41,6 +41,7 @@ import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
 
 /**
@@ -97,6 +98,12 @@ public class SharingModelResourcePermissionConfiguratorImpl
 		_sharingPermissionSQLContributorServiceRegistration.unregister();
 	}
 
+	@Modified
+	protected void modified(Map<String, Object> properties) {
+		_sharingSystemConfiguration = ConfigurableUtil.createConfigurable(
+			SharingSystemConfiguration.class, properties);
+	}
+
 	private static Map<String, SharingEntryAction> _getSharingEntryActions() {
 		Map<String, SharingEntryAction> sharingEntryActions = new HashMap<>();
 
@@ -133,7 +140,7 @@ public class SharingModelResourcePermissionConfiguratorImpl
 
 	private ServiceRegistration<PermissionSQLContributor>
 		_sharingPermissionSQLContributorServiceRegistration;
-	private SharingSystemConfiguration _sharingSystemConfiguration;
+	private volatile SharingSystemConfiguration _sharingSystemConfiguration;
 
 	@Reference
 	private UserGroupLocalService _userGroupLocalService;


### PR DESCRIPTION
[LPD-100423](https://liferay.atlassian.net/browse/LPD-100423)

## What Is Being Fixed

A test that swaps `SharingSystemConfiguration` (for example to disable sharing) triggers a full deactivate and reactivate of the components bound to that configuration PID. Those components are AopServices with static references into the object service graph, so the deactivation cascades and momentarily deactivates a heavily referenced object field business type such as `Attachment`. An object field created in that window silently downgrades to `LongInteger` and its settings are then rejected.

## How It Is Being Fixed

Add `@Modified` to the three `SharingSystemConfiguration` consumers so they reconfigure in place instead of deactivating. `SharingConfigurationFactoryImpl` and `DeleteExpiredSharingEntriesSchedulerJobConfiguration` reuse their `activate` method, while `SharingModelResourcePermissionConfiguratorImpl` gets a separate `modified` method because its `activate` also registers a `PermissionSQLContributor` that must not be re-registered.

## PR Check

| Validation | Result |
| --- | --- |
| Source Format | success |
| Per-Module Compile | success |
| Baseline | not applicable (impl-only, no exported API change) |

<!-- pr-check {"result": "success", "sha": "5641c043fc564ec187fc79b6187fabd64bd579a7"} -->
