### PR TITLE
LPD-100424 Skip a DataGuard leftover that was already deleted by a parent's cascade

### DIFF
--- a/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
@@ -165,17 +165,24 @@ public class DataGuardTestRuleUtil {
 			}
 		}
 
+		BaseModel<?> persistedBaseModel = (BaseModel<?>)persistedModel;
+
+		PersistedModel refetchedPersistedModel =
+			persistedModelLocalService.fetchPersistedModel(
+				persistedBaseModel.getPrimaryKeyObj());
+
+		if (refetchedPersistedModel == null) {
+			return;
+		}
+
 		try {
 			if (deleteMethod == null) {
-				persistedModelLocalService.deletePersistedModel(persistedModel);
+				persistedModelLocalService.deletePersistedModel(
+					refetchedPersistedModel);
 			}
 			else {
-				BaseModel<?> baseModel = (BaseModel<?>)persistedModel;
-
 				deleteMethod.invoke(
-					persistedModelLocalService,
-					persistedModelLocalService.getPersistedModel(
-						baseModel.getPrimaryKeyObj()));
+					persistedModelLocalService, refetchedPersistedModel);
 			}
 		}
 		catch (Throwable throwable1) {


### PR DESCRIPTION
[LPD-100424](https://liferay.atlassian.net/browse/LPD-100424)

## What Is Being Fixed

When DataGuard deletes the leftover models a test created, a model can already be gone because deleting its parent cascaded to it (for example a company or group deletion cascading away its layouts and segments experiences). DataGuard fetched each leftover with a throwing `getPersistedModel` and then deleted it, so a leftover already removed by a parent's cascade raised a `NoSuchModelException` and added exception noise to the test's cleanup.

## How It Is Being Fixed

Fetch the persisted model with the non-throwing `fetchPersistedModel` before deleting it, and return early when it is already gone, so DataGuard tolerates a leftover that was removed by a parent's cascade instead of throwing.

## PR Check

| Validation | Result |
| --- | --- |
| Source Format | success |
| Compile (portal-test) | success |
| Baseline | not applicable (test utility, no exported API change) |

<!-- pr-check {"result": "success", "sha": "1c2fdeefe69a7fc033012779d6213de3be90d448"} -->
