### PR TITLE
LPD-100426 Delete the bare object definition row the upgrade test leaves

### DIFF
--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/upgrade/v10_19_0/test/ObjectDefinitionUpgradeProcessTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/upgrade/v10_19_0/test/ObjectDefinitionUpgradeProcessTest.java
@@ -72,33 +72,44 @@ public class ObjectDefinitionUpgradeProcessTest {
 				"rootObjectDefinitionId) values (", objectDefinitionId, ", ",
 				rootObjectDefinitionId, ")"));
 
-		_runUpgrade();
+		try {
+			_runUpgrade();
 
-		try (Connection connection = DataAccess.getConnection();
+			try (Connection connection = DataAccess.getConnection();
 
-			PreparedStatement preparedStatement = connection.prepareStatement(
-				"select name, value from ObjectDefinitionSetting where " +
-					"objectDefinitionId = ?")) {
+				PreparedStatement preparedStatement =
+					connection.prepareStatement(
+						"select name, value from ObjectDefinitionSetting " +
+							"where objectDefinitionId = ?")) {
 
-			preparedStatement.setLong(1, objectDefinitionId);
+				preparedStatement.setLong(1, objectDefinitionId);
 
-			try (ResultSet resultSet = preparedStatement.executeQuery()) {
-				while (resultSet.next()) {
-					Assert.assertEquals(
-						ObjectDefinitionSettingConstants.
-							NAME_ROOT_OBJECT_DEFINITION_IDS,
-						resultSet.getString("name"));
-					Assert.assertEquals(
-						String.valueOf(rootObjectDefinitionId),
-						resultSet.getString("value"));
+				try (ResultSet resultSet = preparedStatement.executeQuery()) {
+					while (resultSet.next()) {
+						Assert.assertEquals(
+							ObjectDefinitionSettingConstants.
+								NAME_ROOT_OBJECT_DEFINITION_IDS,
+							resultSet.getString("name"));
+						Assert.assertEquals(
+							String.valueOf(rootObjectDefinitionId),
+							resultSet.getString("value"));
+					}
+
+					DBInspector dbInspector = new DBInspector(connection);
+
+					Assert.assertFalse(
+						dbInspector.hasColumn(
+							"ObjectDefinition", "rootObjectDefinitionId"));
 				}
-
-				DBInspector dbInspector = new DBInspector(connection);
-
-				Assert.assertFalse(
-					dbInspector.hasColumn(
-						"ObjectDefinition", "rootObjectDefinitionId"));
 			}
+		}
+		finally {
+			_db.runSQL(
+				"delete from ObjectDefinition where objectDefinitionId = " +
+					objectDefinitionId);
+			_db.runSQL(
+				"delete from ObjectDefinitionSetting where " +
+					"objectDefinitionId = " + objectDefinitionId);
 		}
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100426

## What Is Being Fixed

`v10_19_0.ObjectDefinitionUpgradeProcessTest.testUpgrade` raw-inserts a bare `ObjectDefinition` row (only `objectDefinitionId` and `rootObjectDefinitionId`) to exercise the column migration, so the row's `status` column defaults to `0` — which equals `STATUS_APPROVED` — and its table name stays blank. The test never deletes the row, so DataGuard removes it during teardown, where `deleteObjectDefinition` treats the default status as approved and calls `_dropTable` with the blank name, producing the invalid SQL `DROP_TABLE_IF_EXISTS()` and a `SQLSyntaxErrorException` that fails `PortalLogAssertorTest`.

## How It Is Being Fixed

Wrap the test body in `try`/`finally` and delete the inserted `ObjectDefinition` row and the `ObjectDefinitionSetting` the upgrade derives from it, so DataGuard never removes an approved-looking, tableless leftover. This is the only test that raw-inserts a bare `ObjectDefinition`, so no other trigger remains.

## PR Check

**pr-check: PASS** — tested on `0c258f2b40fa6b62563961d57ee90a30f544bee0`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "0c258f2b40fa6b62563961d57ee90a30f544bee0"} -->
