### PR TITLE
LPD-100427 Skip deleting a missing account entry group

### DIFF
--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountEntryLocalServiceImpl.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountEntryLocalServiceImpl.java
@@ -48,6 +48,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Organization;
 import com.liferay.portal.kernel.model.ResourceConstants;
@@ -349,7 +350,11 @@ public class AccountEntryLocalServiceImpl
 
 		// Group
 
-		_groupLocalService.deleteGroup(accountEntry.getAccountEntryGroup());
+		Group group = accountEntry.getAccountEntryGroup();
+
+		if (group != null) {
+			_groupLocalService.deleteGroup(group);
+		}
 
 		// Asset
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100427

## What Is Being Fixed

`AccountEntryLocalServiceImpl.deleteAccountEntry` deletes the account entry's site group by passing the nullable `getAccountEntryGroup()` to `GroupLocalService.deleteGroup`, which dereferences it (`group.isCompany()`). In production the group is always present, but during DataGuard teardown it can already be gone: an account entry's group is a separate leftover of class name `AccountEntry`, and DataGuard deletes leftovers without regard to dependencies — it prioritizes only `Company` and otherwise deletes in OSGi service-registration order, where the `Group` service precedes the `AccountEntry` service. So DataGuard deletes the group before the account entry, and the subsequent `deleteAccountEntry` throws a `NullPointerException`.

## How It Is Being Fixed

Guard against a null group before `deleteGroup`, so `deleteAccountEntry` tolerates a group DataGuard has already deleted and the teardown can finish removing the leftover account entry. Reproduced minimally: a test that creates one account entry and leaves it as a leftover triggers the NPE in DataGuard's teardown deterministically, with no leaked company required.

## PR Check

**pr-check: PASS** — tested on `fad86b2a195461655abbeb376658363c7e52edfe`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "fad86b2a195461655abbeb376658363c7e52edfe"} -->
