### PR TITLE
LPD-100428 Delete the auto-wired assignee actions in EmailNotificationTypeTest

### DIFF
--- a/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/internal/type/test/EmailNotificationTypeTest.java
+++ b/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/internal/type/test/EmailNotificationTypeTest.java
@@ -51,6 +51,7 @@ import com.liferay.object.action.trigger.ObjectActionTriggerRegistry;
 import com.liferay.object.action.util.ObjectActionThreadLocal;
 import com.liferay.object.constants.ObjectActionExecutorConstants;
 import com.liferay.object.constants.ObjectActionKeys;
+import com.liferay.object.constants.ObjectActionNameConstants;
 import com.liferay.object.constants.ObjectActionTriggerConstants;
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
@@ -1036,6 +1037,22 @@ public class EmailNotificationTypeTest extends BaseNotificationTypeTest {
 					).name(
 						"assignee"
 					).build()));
+
+		ObjectAction objectAction = objectActionLocalService.fetchObjectAction(
+			objectDefinition.getObjectDefinitionId(),
+			ObjectActionNameConstants.NAME_NOTIFY_ASSIGNEE_ON_AFTER_ADD);
+
+		if (objectAction != null) {
+			objectActionLocalService.deleteObjectAction(objectAction);
+		}
+
+		objectAction = objectActionLocalService.fetchObjectAction(
+			objectDefinition.getObjectDefinitionId(),
+			ObjectActionNameConstants.NAME_NOTIFY_ASSIGNEE_ON_AFTER_UPDATE);
+
+		if (objectAction != null) {
+			objectActionLocalService.deleteObjectAction(objectAction);
+		}
 
 		addNotificationTemplateObjectAction(
 			Arrays.asList(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100428

## What Is Being Fixed

`EmailNotificationTypeTest.testSendNotificationToAssignee` fails and cascades into the rest of the class. Publishing an object definition with an assignee field auto-wires assignee user-notification object actions (added by LPD-97905); the test then adds its own email notification action, so a single object entry produces two notification queue entries. `assertNotificationQueueEntrySubject` fetches every notification queue entry and asserts exactly one, then deletes it — so it fails with two, and because it throws before the delete, every later method in the class inherits the stray entry and also fails.

## How It Is Being Fixed

Before adding the test's own email action, delete the two auto-wired assignee notification object actions by name (`NOTIFY_ASSIGNEE_ON_AFTER_ADD` and `NOTIFY_ASSIGNEE_ON_AFTER_UPDATE`), mirroring the product's own `ObjectFieldModelListener._deleteNotifyAssigneeObjectActions`. The unrelated `ASSIGN_TO_ME` action is left in place; an isolated run shows exactly two entries and never three, confirming it does not fire a notification on entry add.

Verified with an isolated A/B from a clean queue: without the change the method fails (`expected:<1> but was:<2>` — the auto-wired `userNotification` "You have a new assignment." plus the test's own email); with the change it passes with only the email entry, and DataGuard sweeps the queue back to zero afterward.

## PR Check

**pr-check: PASS** — tested on `3e319a24a37ff87bdc81b857525f426afb71099c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result":"success","sha":"3e319a24a37ff87bdc81b857525f426afb71099c"} -->
