### PR TITLE
LPD-100429 Ignore the malformed GraphQL post notification template tests

### DIFF
--- a/modules/apps/notification/notification-rest-test/src/testIntegration/java/com/liferay/notification/rest/resource/v1_0/test/NotificationTemplateResourceTest.java
+++ b/modules/apps/notification/notification-rest-test/src/testIntegration/java/com/liferay/notification/rest/resource/v1_0/test/NotificationTemplateResourceTest.java
@@ -104,6 +104,18 @@ public class NotificationTemplateResourceTest
 	public void testGraphQLGetNotificationTemplatesPage() throws Exception {
 	}
 
+	@Ignore
+	@Override
+	@Test
+	public void testGraphQLPostNotificationTemplate() throws Exception {
+	}
+
+	@Ignore
+	@Override
+	@Test
+	public void testGraphQLPostNotificationTemplateCopy() throws Exception {
+	}
+
 	@Override
 	@Test
 	public void testPatchNotificationTemplate() throws Exception {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100429

## What Is Being Fixed

`NotificationTemplateResourceTest.testGraphQLPostNotificationTemplate` and `testGraphQLPostNotificationTemplateCopy` emit a `Query did not parse` WARN from the GraphQL servlet, which fails the module-level `PortalLogAssertorTest` log assertion for the whole `notification-rest-test` run.

## How It Is Being Fixed

The failure is deterministic, not a data leftover. The concrete `randomNotificationTemplate()` sets the localized `body` and `subject` via `LocalizedMapUtil.getI18nMap(...)`, which keys the maps in i18n/BCP-47 form with a hyphen (`en-US`). The generated GraphQL mutation builder's `getGraphQLValue()` serializes Map entries with the key emitted raw and unquoted (`entry.getKey() + ": " + value`), so the mutation contains `body: {en-US: "..."}` and `subject: {en-US: "..."}`. A hyphen is not a legal GraphQL object-field name, so the server rejects the entire mutation.

Reproduced by un-ignoring the method and running it isolated from a clean database — verbatim: `WARN [GraphQL:581] Query did not parse : 'mutation{createNotificationTemplate(notificationTemplate: {body: {en-US: "..."}, ...})}'`. GraphQL parsing precedes any database interaction, so pollution cannot be involved.

Override both POST methods with `@Ignore`, mirroring the GraphQL GET variants that were already ignored when this coverage was added (LPS-152788, `cb57369`) for the same generator limitation. The genuine fix is a REST-Builder test-generator change (quote/escape locale-map keys), which touches every generated resource test and is out of scope for the stabilization campaign.

## PR Check

**pr-check: PASS** — tested on `635294906370f19623d089b54725f57c6b06e979`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result":"success","sha":"635294906370f19623d089b54725f57c6b06e979"} -->
