### PR TITLE
LPD-100430 Reject an object field with an unresolvable business type

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldLocalServiceImpl.java
@@ -1572,14 +1572,15 @@ public class ObjectFieldLocalServiceImpl
 				objectField.setDBType(objectFieldBusinessType.getDBType());
 			}
 		}
-		else if (objectFieldDBTypes.contains(dbType) &&
+		else if (Validator.isNull(businessType) &&
+				 objectFieldDBTypes.contains(dbType) &&
 				 _businessTypes.containsKey(dbType)) {
 
 			objectField.setBusinessType(_businessTypes.get(dbType));
 			objectField.setDBType(dbType);
 		}
 		else {
-			if (!businessType.isEmpty()) {
+			if (Validator.isNotNull(businessType)) {
 				_handleException(
 					new ObjectFieldBusinessTypeException(
 						"Invalid business type " + businessType),


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100430

## What Is Being Fixed

When a named object field business type cannot be resolved because its `ObjectFieldBusinessType` component is momentarily absent from the registry — for example during a runtime module deployment — `ObjectFieldLocalServiceImpl._setBusinessTypeAndDBType` silently persisted a *different* business type than the one requested: the default business type for the incoming DB type. A field requested as `Attachment` carrying a `Long` DB type was stored as `LongInteger`, so the field permanently claimed the wrong type and its type-specific settings were rejected downstream. This is a silent data-integrity corruption, not a transient error, and it only requires the request to carry a registered DB type — which a named type such as `Attachment` always does.

## How It Is Being Fixed

Require a null business type before applying the DB type default, so a named but unresolvable business type falls through to an explicit `ObjectFieldBusinessTypeException` ("Invalid business type") instead of silently downgrading. The caller then fails loudly and can retry once the component is available, rather than writing a wrong type that has to be discovered and corrected later. Reading the business type with `Validator.isNotNull` also removes an unguarded `isEmpty` call that would throw a `NullPointerException` on a null business type.

**Root cause:** born this way in `c7207196877d0b` (LPS-144872 "Validate and set the businessType and DBType values"), which applied the DB type default whenever the named business type did not resolve, without distinguishing a genuinely absent (null) business type from a named one whose component was momentarily unavailable.

## PR Check

**pr-check: PASS** — tested on `18e223f91700afe4c86b639d703b612915e69d3e`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Baseline | PASS (no exported-API change; `object-service` exports nothing, private method) |
| Per-Module Compile | PASS |

<!-- pr-check {"result":"success","sha":"18e223f91700afe4c86b639d703b612915e69d3e"} -->
