### PR TITLE
LPD-100431 Expect the get-by-scope action in related object entries

### DIFF
--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryRelatedObjectsResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryRelatedObjectsResourceTest.java
@@ -810,6 +810,18 @@ public class ObjectEntryRelatedObjectsResourceTest {
 					"href", href
 				)
 			).put(
+				"get-by-scope",
+				JSONFactoryUtil.createJSONObject(
+				).put(
+					"method", "GET"
+				).put(
+					"href",
+					StringBundler.concat(
+						"http://localhost:",
+						PortalUtil.getPortalServerPort(false), "/o",
+						_objectDefinition1.getRESTContextPath(), "/scopes/0")
+				)
+			).put(
 				"update",
 				JSONFactoryUtil.createJSONObject(
 				).put(
@@ -875,6 +887,18 @@ public class ObjectEntryRelatedObjectsResourceTest {
 					"method", "GET"
 				).put(
 					"href", href
+				)
+			).put(
+				"get-by-scope",
+				JSONFactoryUtil.createJSONObject(
+				).put(
+					"method", "GET"
+				).put(
+					"href",
+					StringBundler.concat(
+						"http://localhost:",
+						PortalUtil.getPortalServerPort(false), "/o",
+						_objectDefinition2.getRESTContextPath(), "/scopes/0")
 				)
 			).put(
 				"update",
@@ -944,6 +968,18 @@ public class ObjectEntryRelatedObjectsResourceTest {
 					"method", "GET"
 				).put(
 					"href", href
+				)
+			).put(
+				"get-by-scope",
+				JSONFactoryUtil.createJSONObject(
+				).put(
+					"method", "GET"
+				).put(
+					"href",
+					StringBundler.concat(
+						"http://localhost:",
+						PortalUtil.getPortalServerPort(false), "/o",
+						_objectDefinition1.getRESTContextPath(), "/scopes/0")
 				)
 			).put(
 				"update",


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100431

## What Is Being Fixed

Three related-object action assertions in `ObjectEntryRelatedObjectsResourceTest` fail with `Unexpected: get-by-scope`. The `get-by-scope` object entry action was gated behind the LPD-17564 feature flag and suppressed in the integration test environment; that gate was removed, so the action is now emitted for every object entry, and the strict `JSONCompareMode.NON_EXTENSIBLE` comparisons reject the extra action.

## How It Is Being Fixed

Add the expected `get-by-scope` action to each of the three assertions and **keep** the strict `NON_EXTENSIBLE` comparison, matching how the sibling `ObjectEntryResourceTest` was updated for the same change (`6a6a39eb`) rather than relaxing the assertions to `LENIENT` — this preserves the exact-set coverage.

The action value was captured empirically from the actual response: `{method: GET, href: http://localhost:<port>/o<definition REST context path>/scopes/0}`, where the scope group is a literal `0` (company scope) and the definition is the endpoint's parent object definition (not the related definition).

**Root cause:** LPD-99210 `a57a60eb394d0` removed the LPD-17564 gate on the `get-by-scope` action in `DefaultObjectEntryManagerImpl`.

## PR Check

**pr-check: PASS** — tested on `20890d2d96b31f14dd8394fa6a0be47fd291a035`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result":"success","sha":"20890d2d96b31f14dd8394fa6a0be47fd291a035"} -->
