### PR TITLE
LPD-100432 Restore DataGuard's company-first leftover deletion order

### DIFF
--- a/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
@@ -53,7 +53,6 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Deque;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -411,7 +410,7 @@ public class DataGuardTestRuleUtil {
 		Map<String, PersistedModelLocalService> persistedModelLocalServices =
 			_getPersistedModelLocalServices();
 
-		Map<String, List<BaseModel<?>>> dataMap = new HashMap<>();
+		Map<String, List<BaseModel<?>>> dataMap = new LinkedHashMap<>();
 
 		for (Map.Entry<String, PersistedModelLocalService> entry :
 				persistedModelLocalServices.entrySet()) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100432

## What Is Being Fixed

DataGuard captured its leftover models into a `HashMap`, so the company-first prioritization built into `_getPersistedModelLocalServices` was discarded to hash-bucket order and `_autoDeleteLeftovers` deleted a leaked company's children before the company itself. Deleting those children individually hit product guards (e.g. `RequiredRoleException` on default account roles) and already-orphaned children (`NoSuchObjectDefinition`), each falling back to a raw row delete that skipped the model's own cleanup and left orphaned workflow resource permissions behind — surfacing as cross-test pollution (`NoSuchObjectFolder`, `NoSuchCompany`, `RequiredRole`/`Principal` exceptions) in later tests.

## How It Is Being Fixed

Capture the leftovers into a `LinkedHashMap` so the company-first order survives and a leaked company is deleted top-down through its own cascade, which removes every dependent cleanly. This also makes the test-side workaround of deleting a leaked company by hand unnecessary (two such `tearDown` cleanups were verified redundant and dropped).

**Root cause:** `abd50bf46228a` (LPD-42488, "revert back to map, it can still be used as the interface", Jorge Avalos) reverted the `LinkedHashMap` that an earlier commit in the same ticket (`2c84bab9566be`, "use LinkedHashMap to ensure order") had introduced to preserve the deletion order the company-first prioritization (`b6c5b12046faf`) depends on — silently turning that prioritization into dead code ever since.

## CI Verification

Ran through CI on a self-PR: **`ci:test:relevant` passed clean (14/14 jobs)** and **`ci:test:stable` clean (9/9)**. The `ci:test:object` failures are pre-existing brian/CMS-lifting (LPD-99210) fallout plus functional (Playwright/Poshi) flakes — 107 of 122 are functional tests that do not use DataGuard, and no failure references a DataGuard leftover, `smartDelete`, or company-teardown error, so none are attributable to this change.

## PR Check

**pr-check: PASS** — tested on `4e493c3edb840ad21eb7b24a7b7c8c7cb1a3e670`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result":"success","sha":"4e493c3edb840ad21eb7b24a7b7c8c7cb1a3e670"} -->
