### PR TITLE
LPD-100427 Commit Service Builder output for AccountEntryLocalService

### DIFF
--- a/modules/apps/account/account-api/src/main/java/com/liferay/account/service/AccountEntryLocalService.java
+++ b/modules/apps/account/account-api/src/main/java/com/liferay/account/service/AccountEntryLocalService.java
@@ -460,4 +460,4 @@ public interface AccountEntryLocalService
 		throws PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:346013718
+// LIFERAY-SERVICE-BUILDER-HASH:1496696136


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100427

## What Is Being Fixed

LPD-100427 was merged as `865fafb01a0dd`, which added a null guard around the account entry's site group in `AccountEntryLocalServiceImpl.deleteAccountEntry`. That commit changed a `*LocalServiceImpl`, which is a Service Builder input, but the regenerated `AccountEntryLocalService` interface was not committed alongside it.

As a result `master` currently carries a stale Service Builder hash:

```
// LIFERAY-SERVICE-BUILDER-HASH:346013718
```

Running Service Builder against `master` therefore produces a diff, which CI's Service Builder check reports as a failure.

## How It Is Being Fixed

This commits the regenerated `AccountEntryLocalService` interface, updating the hash to match the merged implementation:

```
// LIFERAY-SERVICE-BUILDER-HASH:1496696136
```

The change is one line in generated output. No exported API member is added, removed, or altered, so no `packageinfo` or `Bundle-Version` bump is owed, and Baseline passes unchanged.

The commit is kept separate from the implementation it regenerates, per the convention that a regeneration commit stays pure so it can be dropped and re-run on rebase. Authorship of the original auto-generated commit is preserved.

Verified by running `buildService` on this branch against the merged implementation: it reproduces exactly this output with zero drift.

## PR Check

**pr-check: PASS** — tested on `eae0460fdb7824c417873ec922d517c10d0126c0`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

Cross-Module Compile expansion was capped: `AccountEntryLocalService` has 31 `testIntegration` consumers against a cap of 8, so the expansion was skipped and `account-test` was compiled directly. The diff changes no method signature, only a generated hash comment.

<!-- pr-check {"result": "success", "sha": "eae0460fdb7824c417873ec922d517c10d0126c0"} -->
