### PR TITLE
LPD-100436 Expect the scheduling object fields in the object definition

### DIFF
--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionResourceTest.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionResourceTest.java
@@ -189,7 +189,7 @@ public class ObjectDefinitionResourceTest
 
 		JSONArray jsonArray = jsonObject.getJSONArray("objectFields");
 
-		Assert.assertEquals(jsonArray.toString(), 7, jsonArray.length());
+		Assert.assertEquals(jsonArray.toString(), 10, jsonArray.length());
 	}
 
 	@Override


### PR DESCRIPTION
[LPD-100436](https://liferay.atlassian.net/browse/LPD-100436)

## What Is Being Fixed

`object-admin-rest-test` `ObjectDefinitionResourceTest.testGetObjectDefinitionByExternalReferenceCode` asserted that a custom object definition carries 7 `objectFields`, but a modifiable object definition now carries 10.

## How It Is Being Fixed

LPD-99210 (`a57a60eb394d0`, "Remove the LPD-17564 feature flag checks", merged to master 2026-08-01) removed the LPD-17564 CMS feature flag gate that hid the `displayDate`, `expirationDate`, and `reviewDate` scheduling fields (added earlier under LPD-44846 / `d5b354ebd7078`) on every modifiable object definition. Once the gate was lifted, those three fields became unconditionally exposed and the objectFields count rose from 7 to 10. This updates the expected count accordingly.

## PR Check

**pr-check: PASS** — tested on `70b949e2bbda3debfa7df475379a884bb30ff51e`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result":"success","sha":"70b949e2bbda3debfa7df475379a884bb30ff51e"} -->
