### PR TITLE
LPD-100437 Assert the permanent form-container view-permission gating

### DIFF
--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/info/permission/provider/test/ObjectEntryInfoPermissionProviderTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/info/permission/provider/test/ObjectEntryInfoPermissionProviderTest.java
@@ -74,23 +74,8 @@ public class ObjectEntryInfoPermissionProviderTest {
 	}
 
 	@Test
-	public void testHasViewPermission() throws Exception {
-		_testHasViewPermissionForCustomObjectDefinition(
-			false, false, PermissionCheckerFactoryUtil.create(_user));
-		_testHasViewPermissionForCustomObjectDefinition(
-			false, true, PermissionThreadLocal.getPermissionChecker());
-		_testHasViewPermissionForCustomObjectDefinition(
-			true, true, PermissionThreadLocal.getPermissionChecker());
-		_testHasViewPermissionForModifiableSystemObjectDefinition(false, false);
-		_testHasViewPermissionForModifiableSystemObjectDefinition(true, false);
-		_testHasViewPermissionForSiteRole();
-		_testHasViewPermissionForUnmodifiableSystemObjectDefinition(false);
-		_testHasViewPermissionForUnmodifiableSystemObjectDefinition(true);
-	}
-
-	@Test
 	@TestInfo("LPD-83634")
-	public void testHasViewPermissionWithFF() throws Exception {
+	public void testHasViewPermission() throws Exception {
 		_testHasViewPermissionForCustomObjectDefinition(
 			false, false, PermissionCheckerFactoryUtil.create(_user));
 		_testHasViewPermissionForCustomObjectDefinition(


### PR DESCRIPTION
[LPD-100437](https://liferay.atlassian.net/browse/LPD-100437)

## What Is Being Fixed

`object-test` `ObjectEntryInfoPermissionProviderTest` kept a redundant feature-flag-off `testHasViewPermission` after the CMS feature flag lifting made the behavior it asserted obsolete.

## How It Is Being Fixed

LPD-99210 (`a57a60eb394d0`, "Remove the LPD-17564 feature flag checks", merged to master 2026-08-01) made the `enableFormContainer` gating in `ObjectEntryInfoPermissionProvider` permanent: the provider now resolves an object definition's portlet only when it enables a form container, so a custom object definition without a form container no longer grants view permission — exactly what `testHasViewPermissionWithFF` already asserts. This removes the redundant feature-flag-off `testHasViewPermission` and keeps `testHasViewPermissionWithFF` (renamed to `testHasViewPermission`) as the single test.

## PR Check

**pr-check: PASS** — tested on `982433a10ffdd9b9947dde91de68c8208adb7be2`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result":"success","sha":"982433a10ffdd9b9947dde91de68c8208adb7be2"} -->
