### PR TITLE
LPD-100438 Restore enableIndexSearch clobbered by the v9_2_0 upgrade test

### DIFF
--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/upgrade/v9_2_0/test/ObjectDefinitionUpgradeProcessTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/upgrade/v9_2_0/test/ObjectDefinitionUpgradeProcessTest.java
@@ -10,6 +10,7 @@ import com.liferay.object.field.builder.TextObjectFieldBuilder;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
@@ -20,7 +21,9 @@ import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -60,10 +63,40 @@ public class ObjectDefinitionUpgradeProcessTest {
 	@After
 	public void tearDown() throws Exception {
 		_objectDefinitionLocalService.deleteObjectDefinition(_objectDefinition);
+
+		for (long objectDefinitionId : _objectDefinitionIds) {
+			ObjectDefinition objectDefinition =
+				_objectDefinitionLocalService.getObjectDefinition(
+					objectDefinitionId);
+
+			objectDefinition.setEnableIndexSearch(false);
+
+			_objectDefinitionLocalService.updateObjectDefinition(
+				objectDefinition);
+		}
 	}
 
 	@Test
 	public void testUpgrade() throws Exception {
+
+		// The upgrade flips enableIndexSearch on every object definition with a
+		// single unscoped SQL statement. Capture the definitions it will change
+		// so tearDown can restore them, keeping this out-of-context run from
+		// polluting the enableIndexSearch state of pre-existing definitions.
+
+		for (ObjectDefinition objectDefinition :
+				_objectDefinitionLocalService.getObjectDefinitions(
+					QueryUtil.ALL_POS, QueryUtil.ALL_POS)) {
+
+			if (!objectDefinition.isEnableIndexSearch() &&
+				(objectDefinition.getObjectDefinitionId() !=
+					_objectDefinition.getObjectDefinitionId())) {
+
+				_objectDefinitionIds.add(
+					objectDefinition.getObjectDefinitionId());
+			}
+		}
+
 		UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
 			_upgradeStepRegistrator,
 			"com.liferay.object.internal.upgrade.v9_2_0." +
@@ -78,6 +111,8 @@ public class ObjectDefinitionUpgradeProcessTest {
 	}
 
 	private static ObjectDefinition _objectDefinition;
+
+	private final List<Long> _objectDefinitionIds = new ArrayList<>();
 
 	@Inject
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;


### PR DESCRIPTION
[LPD-100438](https://liferay.atlassian.net/browse/LPD-100438)

## What Is Being Fixed

A cluster of flaky `NullPointerException`s in `object-test` (`ObjectEntryFolderLocalServiceTest` and siblings, thrown in `ObjectEntryLocalServiceImpl._reindex`) — cross-test pollution left by an out-of-context upgrade test.

## How It Is Being Fixed

`object-test` `v9_2_0.ObjectDefinitionUpgradeProcessTest` directly runs the ancient v9_2_0 `ObjectDefinitionUpgradeProcess`, whose `doUpgrade` is a single **unscoped** `update ObjectDefinition set enableIndexSearch = TRUE` over every row. It flips every pre-existing definition to `enableIndexSearch=true` and deletes only its own, leaving a batch-imported system definition like `CMSDefaultPermission` (imported `false`, no entry indexer) clobbered — a later test that adds one of its entries then reaches `_reindex`, looks up a null indexer, and throws. It is ordering-bound because the raw SQL never invalidates the entity cache. This captures the definitions the upgrade will flip before running it and restores their `enableIndexSearch` state in `tearDown`. The bug was latent since the test was added and only started failing once LPD-99210 (`a57a60eb394d0`) un-gated CMS provisioning in tests.

## PR Check

**pr-check: PASS** — tested on `6a5b935ce49e0b2e17f195e640e276c074653018`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result":"success","sha":"6a5b935ce49e0b2e17f195e640e276c074653018"} -->
