### PR TITLE
LPD-100440 Stabilize the object definition resource list tests

### DIFF
--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionResourceTest.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionResourceTest.java
@@ -75,7 +75,6 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalService;
-import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
@@ -93,7 +92,6 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropsValues;
-import com.liferay.portal.kernel.util.ProxyUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.SystemProperties;
 import com.liferay.portal.kernel.util.TextFormatter;
@@ -195,32 +193,7 @@ public class ObjectDefinitionResourceTest
 	@Override
 	@Test
 	public void testGetObjectDefinitionsPage() throws Exception {
-		ObjectDefinitionResource.Builder builder =
-			ReflectionTestUtil.getFieldValue(
-				objectDefinitionResource, "_builder");
-
-		ReflectionTestUtil.setFieldValue(
-			this, "objectDefinitionResource",
-			ProxyUtil.newProxyInstance(
-				ObjectDefinitionResourceTest.class.getClassLoader(),
-				new Class<?>[] {ObjectDefinitionResource.class},
-				(proxy, method, args) -> {
-					if (Objects.equals(
-							method.getName(), "getObjectDefinitionsPage")) {
-
-						args[3] = Pagination.of(1, 20);
-					}
-
-					return method.invoke(builder.build(), args);
-				}));
-
-		try {
-			super.testGetObjectDefinitionsPage();
-		}
-		finally {
-			ReflectionTestUtil.setFieldValue(
-				this, "objectDefinitionResource", builder.build());
-		}
+		super.testGetObjectDefinitionsPage();
 
 		ObjectDefinition modifiableSystemObjectDefinition1 =
 			_addObjectDefinition(_randomModifiableSystemObjectDefinition());

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionResourceTest.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionResourceTest.java
@@ -312,27 +312,41 @@ public class ObjectDefinitionResourceTest
 		objectDefinition2 = testGetObjectDefinitionsPage_addObjectDefinition(
 			objectDefinition2);
 
+		Set<Long> objectDefinitionIds = Set.of(
+			objectDefinition1.getId(), objectDefinition2.getId());
+
+		Page<ObjectDefinition> objectDefinitionsPage =
+			objectDefinitionResource.getObjectDefinitionsPage(
+				null, null, null, Pagination.of(1, 1), null);
+
+		Pagination pagination = Pagination.of(
+			1, (int)objectDefinitionsPage.getTotalCount() + 10);
+
 		Page<ObjectDefinition> ascPage =
 			objectDefinitionResource.getObjectDefinitionsPage(
-				null, null, null, null, "name:asc");
+				null, null, null, pagination, "name:asc");
 
-		List<ObjectDefinition> objectDefinitions =
-			(List<ObjectDefinition>)ascPage.getItems();
+		List<ObjectDefinition> objectDefinitions = ListUtil.filter(
+			(List<ObjectDefinition>)ascPage.getItems(),
+			objectDefinition -> objectDefinitionIds.contains(
+				objectDefinition.getId()));
 
 		assertEquals(
 			Arrays.asList(objectDefinition1, objectDefinition2),
-			objectDefinitions.subList(2, 4));
+			objectDefinitions);
 
 		Page<ObjectDefinition> descPage =
 			objectDefinitionResource.getObjectDefinitionsPage(
-				null, null, null, null, "name:desc");
+				null, null, null, pagination, "name:desc");
 
-		objectDefinitions = (List<ObjectDefinition>)descPage.getItems();
+		objectDefinitions = ListUtil.filter(
+			(List<ObjectDefinition>)descPage.getItems(),
+			objectDefinition -> objectDefinitionIds.contains(
+				objectDefinition.getId()));
 
 		assertEquals(
 			Arrays.asList(objectDefinition2, objectDefinition1),
-			objectDefinitions.subList(
-				objectDefinitions.size() - 4, objectDefinitions.size() - 2));
+			objectDefinitions);
 
 		_objectDefinitionLocalService.deleteObjectDefinition(
 			objectDefinition1.getId());
@@ -2299,9 +2313,41 @@ public class ObjectDefinitionResourceTest
 			actualPermissionsJSONArray = jsonObject.getJSONArray("items");
 		}
 
+		// The response includes permissions granted by the environment beyond
+		// this request, for example the company scoped CMS Administrator grant
+		// present on every object definition, so keep only the roles this
+		// request asserts. The comparison still verifies that every requested
+		// permission round trips with its exact action IDs, independent of the
+		// provisioning grants that vary across environments.
+
+		Set<String> expectedRoleNames = new HashSet<>();
+
+		for (int i = 0; i < expectedPermissionsJSONArray.length(); i++) {
+			JSONObject expectedPermissionJSONObject =
+				expectedPermissionsJSONArray.getJSONObject(i);
+
+			expectedRoleNames.add(
+				expectedPermissionJSONObject.getString("roleName"));
+		}
+
+		JSONArray filteredActualPermissionsJSONArray =
+			_jsonFactory.createJSONArray();
+
+		for (int i = 0; i < actualPermissionsJSONArray.length(); i++) {
+			JSONObject actualPermissionJSONObject =
+				actualPermissionsJSONArray.getJSONObject(i);
+
+			if (expectedRoleNames.contains(
+					actualPermissionJSONObject.getString("roleName"))) {
+
+				filteredActualPermissionsJSONArray.put(
+					actualPermissionJSONObject);
+			}
+		}
+
 		JSONAssert.assertEquals(
 			String.valueOf(expectedPermissionsJSONArray),
-			String.valueOf(actualPermissionsJSONArray),
+			String.valueOf(filteredActualPermissionsJSONArray),
 			JSONCompareMode.LENIENT);
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100440

## What Is Being Fixed

Two issues in the object definition list tests in `ObjectDefinitionResourceTest`:

1. The object-specific `getObjectDefinitionsPage` proxy that widened the listing page is now redundant — the generated base test case already sizes the page to the actual row count (LPD-100439, merged), so the override only duplicates that logic.
2. After the LPD-99210 CMS feature flag lift (`a57a60eb394d0`), the CMS site initializer provisions extra object definitions and grants a company-scoped CMS Administrator permission on every object definition. `testGetObjectDefinitionsPageWithSortString` (fixed sort offsets) and the permissions comparison (exact match) therefore fail.

## How It Is Being Fixed

Drop the proxy so `testGetObjectDefinitionsPage` calls `super` directly, relying on the base page sizing. Size the sorted page to `totalCount + 10` and filter the items to the two definition ids the test creates before asserting their order. Filter the returned permissions to the roles the request asserts, ignoring the company-scoped CMS Administrator grant.

## PR Check

**pr-check: PASS** — tested on `c8abe1fc0593b2cca2e6d0e431994a8b01950638`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |
| Integration Test (ObjectDefinitionResourceTest) | PASS — 33 tests, 0 failures, 0 errors |

Verified on a clean brian bundle (`ant all`, fresh `lportal_pim` + cleared osgi/state and ES): `ObjectDefinitionResourceTest` runs fully green with zero ERROR logs, including the two changed spots (`testGetObjectDefinitionsPage`, `testGetObjectDefinitionsPageWithSortString`).

<!-- pr-check {"result":"success","sha":"c8abe1fc0593b2cca2e6d0e431994a8b01950638"} -->
