### PR TITLE
LPD-100553 Find object definitions beyond the first result page

### DIFF
--- a/modules/apps/object/object-test/src/testFunctional/macros/json/JSONObject.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/json/JSONObject.macro
@@ -1424,7 +1424,7 @@ definition {
 		}
 
 		var curl = '''
-			${portalURL}/o/object-admin/v1.0/object-definitions \
+			${portalURL}/o/object-admin/v1.0/object-definitions?filter=name%20eq%20%27${objectName}%27 \
 				-u ${userEmailAddress}:${userPassword}
 		''';
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100553

## What Is Being Fixed

Eight Batch Planner Poshi tests were blocked in `setUp` on the `ci:test:headless` routine, build 345, all with the same error:

```
java.lang.Exception: TEST_SETUP_ERROR: No results for path: $['className']
```

`JSONObject.getObjectId` requested `/o/object-admin/v1.0/object-definitions` with neither a filter nor a page size, then searched the response body for a name match. It therefore only ever saw the first page of twenty results.

`c1f31d0 LPD-99210 Provision the CMS site unconditionally` removed the `LPD-17564` feature flag gate, so `site-initializer-cms` now creates its six `CMSBasicDocument`, `CMSBasicWebContent`, `CMSBlog`, `CMSBulkActionTask`, `CMSDefaultPermission` and `CMSExternalVideo` definitions on every instance. That raised the system object definition count from sixteen to twenty two, filling the first page entirely with system objects. Since the collection is ordered by ascending id, a test-created definition always sorts last, so it landed on page two and the lookup returned an empty id.

The caller then built `/o/object-admin/v1.0/object-definitions/` with no id, which resolves to the collection endpoint. Reading `$.className` off that `Page` body produced the error above.

The product change is intended, so the fault is in the test helper's assumption that a named definition appears within the first twenty unsorted results.

## How It Is Being Fixed

`getObjectId` now filters by name on the server, which is what `ObjectDefinitionAPI.getObjectDefinitionIdByName` already does against the same endpoint. The JSONPath predicate below it is unchanged, so the macro's semantics are identical -- it simply receives a one-item haystack instead of an arbitrary first page. This keeps the lookup correct no matter how many object definitions an instance provisions, and it fixes all twenty four call sites that share the helper.

- `modules/apps/object/object-test/src/testFunctional/macros/json/JSONObject.macro`

## Why Are There No Tests?

The change is confined to test infrastructure -- a single line in one Poshi macro -- and adds no product code. Its correctness is demonstrated by `SupportImportObjectEntriesAtInstanceLevel#CanUpdateObjectEntry` going from blocked to passing locally, along with the seven sibling tests that share the same `setUp`.

## PR Check

**pr-check: PASS** — tested on `f842d9d4f82b00b7629f77165b8e4d09edf0891c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Poshi Syntax | PASS |

<!-- pr-check {"result": "success", "sha": "f842d9d4f82b00b7629f77165b8e4d09edf0891c"} -->
