### PR TITLE
LPD-100573 Resolve the scope site name from the running instance

### DIFF
--- a/modules/apps/batch-planner/batch-planner-test/src/testFunctional/macros/ImportExport.macro
+++ b/modules/apps/batch-planner/batch-planner-test/src/testFunctional/macros/ImportExport.macro
@@ -276,7 +276,7 @@ definition {
 		ImportExport.selectEntity(entityType = ${entityType});
 
 		if (isSet(scope)) {
-			var scope = TestCase.getSiteName(siteName = "Liferay DXP Site");
+			var scope = ImportExport.getScopeSiteName();
 
 			Select(
 				locator1 = "Select#SCOPE_CONFIGURATION",
@@ -347,6 +347,20 @@ definition {
 		Button.click(button = "Export");
 
 		WaitForElementPresent(locator1 = "ImportExport#EXECUTION_SUCCESS");
+	}
+
+	@summary = "Default summary"
+	macro getScopeSiteName() {
+		var testLiferayVirtualInstance = PropsUtil.get("test.liferay.virtual.instance");
+
+		if (${testLiferayVirtualInstance} == "true") {
+			var siteName = TestCase.getSiteName();
+
+			return ${siteName};
+		}
+		else {
+			return "Liferay DXP Site";
+		}
 	}
 
 	@summary = "Default summary"

--- a/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/SupportImportObjectEntriesWithSiteScope.testcase
+++ b/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/SupportImportObjectEntriesWithSiteScope.testcase
@@ -165,7 +165,7 @@ definition {
 		}
 
 		task ("Then 'Scope' is present with default and Global sites in dropdown list") {
-			var scope = TestCase.getSiteName(siteName = "Liferay DXP Site");
+			var scope = ImportExport.getScopeSiteName();
 
 			AssertElementPresent(locator1 = "Select#SCOPE_CONFIGURATION");
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100573

## What Is Being Fixed

Four Batch Planner Poshi tests in `SupportImportObjectEntriesWithSiteScope` fail on the `ci:test:headless` routine whenever they get far enough to run. On builds 342 through 344 they failed like this:

```
CanSeeScopeSelecterInImportFile
  java.lang.Exception: Actual text "Global i-0e5e364ff2fc01624" does not match pattern
  "(?iu)Global Liferay DXP Site" at "//div[label[contains(.,'Scope')]]/select"

CanCreateAndUpdateExistingSiteScopedObjectEntriesWithSameFile
CanUpdateSiteScopedObjectEntry
CannotCreateSiteScopedObjectEntryWithoutRequiredFields
  org.openqa.selenium.NoSuchElementException: Cannot locate option with text: Liferay DXP Site
```

All four share one fault. Two call sites resolved the scope site name with `TestCase.getSiteName(siteName = "Liferay DXP Site")` — `ImportExport.macro` line 279, which selects the scope, and `SupportImportObjectEntriesWithSiteScope.testcase` line 168, which asserts the dropdown text.

`TestCase.getSiteName` only resolves the name dynamically when `siteName` is `"Liferay"` or unset; any other value is returned unchanged. Passing the literal therefore bypassed the resolution and pinned the expected text to whatever a developer machine is called. These were the only two call sites in the repository passing a string literal, against 153 that pass a variable and 10 that pass nothing.

On CI `test.liferay.virtual.instance` is true, so the default site is named after the portal host and the literal never matches. Locally the property is false and the site's `descriptiveName` really is `Liferay DXP Site`, which is why this only ever failed on CI.

## How It Is Being Fixed

Both call sites now use a new `ImportExport.getScopeSiteName` macro, which returns `TestCase.getSiteName()` when `test.liferay.virtual.instance` is true and the literal otherwise.

Dropping the argument alone would not work: `TestCase.getSiteName()` returns `"Liferay DXP"` in the non-virtual-instance EE case, which does not match the local site's actual name. Branching on the property is what makes it correct in both environments. The virtual-instance branch is known to produce the right value because `TestCase.getSiteName()` computes the portal URL with the scheme and port stripped, which is exactly the `i-0e5e364ff2fc01624` string CI reported as the actual text.

- `modules/apps/batch-planner/batch-planner-test/src/testFunctional/macros/ImportExport.macro`
- `modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/SupportImportObjectEntriesWithSiteScope.testcase`

## Why Are There No Tests?

The change is confined to Poshi test code and adds no product code. It repairs four existing tests rather than adding new coverage. The local branch of the new macro preserves the behavior that passes on a developer machine today; the CI branch is inferred from the actual text CI reported and needs a CI run to confirm.

## PR Check

**pr-check: PASS** — tested on `2cd7ed9fb337a6b8fcf46141cdcd5bbdbefacd33`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Poshi Syntax | PASS |

<!-- pr-check {"result": "success", "sha": "2cd7ed9fb337a6b8fcf46141cdcd5bbdbefacd33"} -->
