### PR TITLE
LPD-100562 Create the taxonomy category in the object entry's scope

### DIFF
--- a/modules/apps/object/object-rest-test/src/testFunctional/tests/DisableKeywordsAndCategoriesWhenCategorizationIsNotEnabled.testcase
+++ b/modules/apps/object/object-rest-test/src/testFunctional/tests/DisableKeywordsAndCategoriesWhenCategorizationIsNotEnabled.testcase
@@ -21,7 +21,7 @@ definition {
 
 		TaxonomyVocabularyAPI.deleteTaxonomyVocabularyByErc(
 			externalReferenceCode = "erc",
-			groupName = "Guest");
+			groupName = "Global");
 
 		if (${testLiferayVirtualInstance} == "true") {
 			PortalInstances.tearDownCP();
@@ -61,7 +61,7 @@ definition {
 		task ("And Given taxonomyVocabulary with name 'vocabulary' created") {
 			var responseFromVocabulary = TaxonomyVocabularyAPI.createTaxonomyVocabulary(
 				externalReferenceCode = "erc",
-				groupName = "Guest",
+				groupName = "Global",
 				name = "Vocabulary");
 		}
 
@@ -116,7 +116,7 @@ definition {
 		task ("And Given taxonomyVocabulary with name 'vocabulary' created") {
 			var responseFromVocabulary = TaxonomyVocabularyAPI.createTaxonomyVocabulary(
 				externalReferenceCode = "erc",
-				groupName = "Guest",
+				groupName = "Global",
 				name = "Vocabulary");
 		}
 

--- a/modules/apps/object/object-rest-test/src/testFunctional/tests/ManageCategoriesForObjectEntries.testcase
+++ b/modules/apps/object/object-rest-test/src/testFunctional/tests/ManageCategoriesForObjectEntries.testcase
@@ -12,7 +12,7 @@ definition {
 		task ("Given taxonomyVocabulary with name 'vocabulary' created") {
 			var responseFromVocabulary = TaxonomyVocabularyAPI.createTaxonomyVocabulary(
 				externalReferenceCode = "erc",
-				groupName = "Guest",
+				groupName = "Global",
 				name = "vocabulary");
 		}
 
@@ -36,7 +36,7 @@ definition {
 
 		ObjectAdmin.deleteAllCustomObjectsViaAPI();
 
-		TaxonomyVocabularyAPI.deleteAllTaxonomyVocabulary(groupName = "Guest");
+		TaxonomyVocabularyAPI.deleteAllTaxonomyVocabulary(groupName = "Global");
 
 		if (${testLiferayVirtualInstance} == "true") {
 			PortalInstances.tearDownCP();
@@ -256,7 +256,6 @@ definition {
 				en_US_plural_label = "students",
 				fieldName = "name",
 				fieldValue = "Tom",
-				groupName = "Global",
 				scopeKey = "true");
 		}
 
@@ -302,6 +301,7 @@ definition {
 				en_US_plural_label = "students",
 				fieldName = "name",
 				fieldValue = "Tom",
+				groupName = "Global",
 				scopeKey = "true");
 		}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100562

## Failing Test

`ManageCategoriesForObjectEntries#CanEmptyTaxonomyCategoryBriefsOfObjectEntry`

`ManageCategoriesForObjectEntries#CanFilterEntriesByTaxonomyCategory`

`ManageCategoriesForObjectEntries#CanGetTaxonomyCategoryBriefsOfEntriesCollection`

`ManageCategoriesForObjectEntries#CanGetTaxonomyCategoryBriefsOfObjectEntry`

`DisableKeywordsAndCategoriesWhenCategorizationIsNotEnabled#CannotGetKeywordsAndCategoriesValuesWhenCategorizationNotEnabled`

`modules/apps/object/object-rest-test/src/testFunctional/tests/ManageCategoriesForObjectEntries.testcase`

`modules/apps/object/object-rest-test/src/testFunctional/tests/DisableKeywordsAndCategoriesWhenCategorizationIsNotEnabled.testcase`

```
com.jayway.jsonpath.PathNotFoundException: No results for path: $['id']
```

Along the way, two more tests in the same file turned out to fail for the identical reason on the update path, just with a different symptom because the response body they check does carry an `id`:

`ManageCategoriesForObjectEntries#CanUpdateEntryWithExistingTaxonomyCategory` — `java.lang.Exception: FAILED: expected 'category_child', actual was ''`

`ManageCategoriesForObjectEntries#CanUpdateSiteScopedObjectEntryWithTaxonomyCategoryOfDifferentSiteScope` — `java.lang.Exception: FAILED: expected 'category_parent', actual was ''`

## Root Cause

Commit `5d59d5b` ("LPD-74644 Validate brief group before creating empty asset category") made the object entry REST APIs reject an asset category that does not belong to the entry's own group or one of its ancestors. `ManageCategoriesForObjectEntries.testcase`'s `setUp` creates its taxonomy vocabulary on the **Guest** site, but the object definitions the tests build default to **company** scope, which puts entries in the company group. Guest is a sibling of the company group, not an ancestor, so attaching the category is now rejected with a 400 whose body carries no `id` — the exact JSONPath the assertion-free tests read. The two update-path tests hit the same validation on `PUT`, but since their own assertions read a different field, the rejection surfaces as an empty `taxonomyCategoryBriefs` instead of the missing-`id` exception.

## Fix

Both testcases move the vocabulary from the Guest site to the **Global** site. Global is the company group, and — critically — an ancestor of every other site, so a category anchored there is valid for both the company-scoped and site-scoped entries these tests build; one change covers every case. Moving the vocabulary would otherwise invert what `ManageCategoriesForObjectEntries`'s two scope-specific tests are meant to demonstrate, so `CanUpdateSiteScopedObjectEntryWithTaxonomyCategoryOfDifferentSiteScope` and `CanUpdateSiteScopedObjectEntryWithTaxonomyCategoryWithinSameScope` swap which site their own entry is created on, keeping one genuinely cross-scope and the other same-scope.

- `modules/apps/object/object-rest-test/src/testFunctional/tests/ManageCategoriesForObjectEntries.testcase`
- `modules/apps/object/object-rest-test/src/testFunctional/tests/DisableKeywordsAndCategoriesWhenCategorizationIsNotEnabled.testcase`

## Why Are There No Tests?

Test-only fix for an outdated Poshi assertion (verdict: Outdated test per LPD-74644's now-correct validation). No product code changed — the diff is entirely inside the two testcase files being repaired, and their own existing assertions are what verify the fix, confirmed passing locally after previously failing on master.

## PR Check

**pr-check: PASS** — tested on `cf7e9f6b67bb047ea764aae5b17cc3e4067ff67a`

| Validation | Result |
| --- | --- |
| Poshi Syntax | PASS |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "cf7e9f6b67bb047ea764aae5b17cc3e4067ff67a"} -->
