### PR TITLE
LPD-99956 Always show the current version in the version history

### DIFF
--- a/modules/apps/layout/layout-content-web/src/main/java/com/liferay/layout/content/web/internal/display/context/LayoutContentVersionDisplayContext.java
+++ b/modules/apps/layout/layout-content-web/src/main/java/com/liferay/layout/content/web/internal/display/context/LayoutContentVersionDisplayContext.java
@@ -56,25 +56,13 @@ public class LayoutContentVersionDisplayContext {
 				"availableSegmentsExperiences",
 				_getAvailableSegmentsExperiences()
 			).put(
+				"currentVersion", _getCurrentVersion()
+			).put(
 				"defaultLanguageId",
 				LocaleUtil.toLanguageId(_themeDisplay.getSiteDefaultLocale())
 			).put(
 				"defaultUserImageSrc",
 				_themeDisplay.getPathImage() + "/user_portrait?img_id=0"
-			).put(
-				"draftName",
-				() -> {
-					Layout layout = _themeDisplay.getLayout();
-
-					return layout.getName(_themeDisplay.getLocale());
-				}
-			).put(
-				"hasDraft",
-				() -> {
-					Layout layout = _themeDisplay.getLayout();
-
-					return !layout.isApproved();
-				}
 			).put(
 				"pageSpecificationVersionsURL",
 				_getPageSpecificationVersionsURL()
@@ -128,6 +116,16 @@ public class LayoutContentVersionDisplayContext {
 						_httpServletRequest, active ? "active" : "inactive")
 				).build();
 			});
+	}
+
+	private Map<String, Object> _getCurrentVersion() {
+		Layout layout = _themeDisplay.getLayout();
+
+		return HashMapBuilder.<String, Object>put(
+			"name", layout.getName(_themeDisplay.getLocale())
+		).put(
+			"status", layout.isApproved() ? "approved" : "draft"
+		).build();
 	}
 
 	private String _getPageSpecificationVersionsURL() throws PortalException {

--- a/modules/apps/layout/layout-content-web/src/main/resources/META-INF/resources/js/components/VersionHistory.tsx
+++ b/modules/apps/layout/layout-content-web/src/main/resources/META-INF/resources/js/components/VersionHistory.tsx
@@ -81,9 +81,9 @@ export default function VersionHistory({config}: Props) {
 			>
 				{versions ? (
 					<VersionList
-						draftName={
-							config.hasDraft && matches(config.draftName)
-								? config.draftName
+						currentVersion={
+							matches(config.currentVersion.name)
+								? config.currentVersion
 								: undefined
 						}
 						searching={Boolean(keywords)}

--- a/modules/apps/layout/layout-content-web/src/main/resources/META-INF/resources/js/components/VersionList.tsx
+++ b/modules/apps/layout/layout-content-web/src/main/resources/META-INF/resources/js/components/VersionList.tsx
@@ -11,21 +11,19 @@ import ClaySticker from '@clayui/sticker';
 import {dateUtils, sub} from 'frontend-js-web';
 import React, {useState} from 'react';
 
-import {config} from '../config';
+import {CurrentVersion, config} from '../config';
 import useKeyboardNavigation from '../hooks/useKeyboardNavigation';
-import {PageVersion, VersionStatus} from '../types/PageVersion';
-
-const DRAFT_KEY = 'draft';
+import {PageVersion, Status} from '../types/PageVersion';
 
 const STATUSES: Record<
-	VersionStatus,
+	Status,
 	{displayType: 'secondary' | 'success'; label: string}
 > = {
-	Approved: {
+	approved: {
 		displayType: 'success',
 		label: Liferay.Language.get('published'),
 	},
-	Draft: {
+	draft: {
 		displayType: 'secondary',
 		label: Liferay.Language.get('draft'),
 	},
@@ -34,25 +32,27 @@ const STATUSES: Record<
 type Row = {
 	key: string;
 	name: string;
+	status: Status;
 	version?: PageVersion;
 };
 
 export default function VersionList({
-	draftName,
+	currentVersion,
 	searching,
 	versions,
 }: {
-	draftName?: string;
+	currentVersion?: CurrentVersion;
 	searching: boolean;
 	versions: PageVersion[];
 }) {
 	const [selectedKey, setSelectedKey] = useState<string>();
 
 	const rows: Row[] = [
-		...(draftName ? [{key: DRAFT_KEY, name: draftName}] : []),
+		...(currentVersion ? [{key: 'current', ...currentVersion}] : []),
 		...versions.map((version) => ({
 			key: version.externalReferenceCode,
 			name: version.name,
+			status: version.status,
 			version,
 		})),
 	];
@@ -90,14 +90,12 @@ export default function VersionList({
 			className="mb-0 version-history__list"
 			role="listbox"
 		>
-			{rows.map(({key, name, version}, index) => {
+			{rows.map(({key, name, status, version}, index) => {
 				const navigationProps = getItemProps(index);
 
 				const selected = activeKey === key;
 
-				const status = version
-					? STATUSES[version.status]
-					: STATUSES.Draft;
+				const {displayType, label} = STATUSES[status];
 
 				return (
 					<ClayList.Item
@@ -157,17 +155,17 @@ export default function VersionList({
 								</ClayList.ItemText>
 							) : null}
 
-							{version ? (
-								<ClayList.ItemText>
-									{sub(Liferay.Language.get('version-x'), [
-										version.version,
-									])}
-								</ClayList.ItemText>
-							) : null}
+							<ClayList.ItemText>
+								{version
+									? sub(Liferay.Language.get('version-x'), [
+											version.version,
+										])
+									: Liferay.Language.get('current-version')}
+							</ClayList.ItemText>
 
 							<ClayList.ItemText>
-								<ClayLabel displayType={status.displayType}>
-									{status.label}
+								<ClayLabel displayType={displayType}>
+									{label}
 								</ClayLabel>
 							</ClayList.ItemText>
 						</ClayList.ItemField>

--- a/modules/apps/layout/layout-content-web/src/main/resources/META-INF/resources/js/config.ts
+++ b/modules/apps/layout/layout-content-web/src/main/resources/META-INF/resources/js/config.ts
@@ -5,9 +5,16 @@
 
 import {SegmentExperience} from '@liferay/layout-js-components-web';
 
+import {Status} from './types/PageVersion';
+
 export type AvailableLanguage = {
 	languageIcon: string;
 	w3cLanguageId: string;
+};
+
+export type CurrentVersion = {
+	name: string;
+	status: Status;
 };
 
 export type Config = {
@@ -15,10 +22,9 @@ export type Config = {
 		Record<Liferay.Language.Locale, AvailableLanguage>
 	>;
 	availableSegmentsExperiences: SegmentExperience[];
+	currentVersion: CurrentVersion;
 	defaultLanguageId: Liferay.Language.Locale;
 	defaultUserImageSrc: string;
-	draftName: string;
-	hasDraft: boolean;
 	pageSpecificationVersionsURL: string;
 };
 

--- a/modules/apps/layout/layout-content-web/src/main/resources/META-INF/resources/js/services/PageVersionService.ts
+++ b/modules/apps/layout/layout-content-web/src/main/resources/META-INF/resources/js/services/PageVersionService.ts
@@ -4,14 +4,28 @@
  */
 
 import {config} from '../config';
-import {PageVersion} from '../types/PageVersion';
+import {PageVersion, Status} from '../types/PageVersion';
 import ApiHelper from './ApiHelper';
 
+type PageVersionResponse = Omit<PageVersion, 'status'> & {
+	status: Capitalize<Status>;
+};
+
 async function getPageVersions(signal?: AbortSignal) {
-	return await ApiHelper.get<{items: PageVersion[]}>(
+	const {data, error} = await ApiHelper.get<{items: PageVersionResponse[]}>(
 		config.pageSpecificationVersionsURL,
 		signal
 	);
+
+	return {
+		data: data && {
+			items: data.items.map((item) => ({
+				...item,
+				status: item.status.toLowerCase() as Status,
+			})),
+		},
+		error,
+	};
 }
 
 export default {getPageVersions};

--- a/modules/apps/layout/layout-content-web/src/main/resources/META-INF/resources/js/types/PageVersion.ts
+++ b/modules/apps/layout/layout-content-web/src/main/resources/META-INF/resources/js/types/PageVersion.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-export type VersionStatus = 'Approved' | 'Draft';
+export type Status = 'approved' | 'draft';
 
 export type PageVersion = {
 	creator?: {
@@ -15,7 +15,7 @@ export type PageVersion = {
 	dateModified: string;
 	externalReferenceCode: string;
 	name: string;
-	status: VersionStatus;
+	status: Status;
 	statusDate: string;
 	version: number;
 };

--- a/modules/apps/layout/layout-content-web/src/test/java/com/liferay/layout/content/web/internal/display/context/LayoutContentVersionDisplayContextTest.java
+++ b/modules/apps/layout/layout-content-web/src/test/java/com/liferay/layout/content/web/internal/display/context/LayoutContentVersionDisplayContextTest.java
@@ -91,15 +91,21 @@ public class LayoutContentVersionDisplayContextTest {
 
 		Map<String, Object> config = (Map<String, Object>)context.get("config");
 
+		Map<String, Object> currentVersion = (Map<String, Object>)config.get(
+			"currentVersion");
+
+		Assert.assertEquals(
+			_draftLayout.getName(_locale), currentVersion.get("name"));
+		Assert.assertEquals(
+			_draftLayout.isApproved() ? "approved" : "draft",
+			currentVersion.get("status"));
+
 		Assert.assertEquals(
 			LocaleUtil.toLanguageId(_siteDefaultLocale),
 			config.get("defaultLanguageId"));
 		Assert.assertEquals(
 			_themeDisplay.getPathImage() + "/user_portrait?img_id=0",
 			config.get("defaultUserImageSrc"));
-		Assert.assertEquals(
-			_draftLayout.getName(_locale), config.get("draftName"));
-		Assert.assertEquals(!_draftLayout.isApproved(), config.get("hasDraft"));
 		Assert.assertEquals(
 			StringBundler.concat(
 				"/o/headless-admin-site/v1.0/sites/",

--- a/modules/apps/layout/layout-content-web/src/test/java/com/liferay/layout/content/web/internal/display/context/LayoutContentVersionDisplayContextTest.java
+++ b/modules/apps/layout/layout-content-web/src/test/java/com/liferay/layout/content/web/internal/display/context/LayoutContentVersionDisplayContextTest.java
@@ -91,6 +91,28 @@ public class LayoutContentVersionDisplayContextTest {
 
 		Map<String, Object> config = (Map<String, Object>)context.get("config");
 
+		_assertAvailableLanguages(
+			(Map<String, Object>)config.get("availableLanguages"), _locale,
+			_siteDefaultLocale);
+
+		List<Map<String, Object>> availableSegmentsExperiences =
+			(List<Map<String, Object>>)config.get(
+				"availableSegmentsExperiences");
+
+		_assertSegmentsExperience(
+			true, winnerSegmentsExperience,
+			availableSegmentsExperiences.get(0));
+		_assertSegmentsExperience(
+			false, loserSegmentsExperience,
+			availableSegmentsExperiences.get(1));
+		_assertSegmentsExperience(
+			true, defaultSegmentsExperience,
+			availableSegmentsExperiences.get(2));
+
+		Assert.assertEquals(
+			availableSegmentsExperiences.toString(), 3,
+			availableSegmentsExperiences.size());
+
 		Map<String, Object> currentVersion = (Map<String, Object>)config.get(
 			"currentVersion");
 
@@ -113,28 +135,6 @@ public class LayoutContentVersionDisplayContextTest {
 				_publishedLayout.getExternalReferenceCode(),
 				"/page-specification-versions"),
 			config.get("pageSpecificationVersionsURL"));
-
-		_assertAvailableLanguages(
-			(Map<String, Object>)config.get("availableLanguages"), _locale,
-			_siteDefaultLocale);
-
-		List<Map<String, Object>> availableSegmentsExperiences =
-			(List<Map<String, Object>>)config.get(
-				"availableSegmentsExperiences");
-
-		_assertSegmentsExperience(
-			true, winnerSegmentsExperience,
-			availableSegmentsExperiences.get(0));
-		_assertSegmentsExperience(
-			false, loserSegmentsExperience,
-			availableSegmentsExperiences.get(1));
-		_assertSegmentsExperience(
-			true, defaultSegmentsExperience,
-			availableSegmentsExperiences.get(2));
-
-		Assert.assertEquals(
-			availableSegmentsExperiences.toString(), 3,
-			availableSegmentsExperiences.size());
 	}
 
 	private void _assertAvailableLanguages(

--- a/modules/apps/layout/layout-content-web/test/js/components/VersionHistory.test.tsx
+++ b/modules/apps/layout/layout-content-web/test/js/components/VersionHistory.test.tsx
@@ -15,7 +15,6 @@ import React from 'react';
 import '@testing-library/jest-dom';
 
 import VersionHistory from '../../../src/main/resources/META-INF/resources/js/components/VersionHistory';
-import {PageVersion} from '../../../src/main/resources/META-INF/resources/js/types/PageVersion';
 
 jest.mock('@liferay/layout-js-components-web', () => {
 	const react = require('react');
@@ -41,7 +40,7 @@ jest.mock('frontend-js-web', () => ({
 	fetch: jest.fn(),
 }));
 
-const VERSIONS: PageVersion[] = [
+const VERSIONS = [
 	{
 		creator: {
 			externalReferenceCode: 'MARIA_ARCE',
@@ -84,7 +83,7 @@ function mockSmallScreen() {
 	mockUseMediaQuery.mockReturnValue(false);
 }
 
-function mockVersions(versions: PageVersion[]) {
+function mockVersions(versions: typeof VERSIONS) {
 	mockFetch.mockReturnValue(
 		Promise.resolve({
 			json: () => Promise.resolve({items: versions}),
@@ -93,7 +92,7 @@ function mockVersions(versions: PageVersion[]) {
 	);
 }
 
-function queryDraftItem() {
+function queryCurrentItem() {
 	return document.querySelector('.lexicon-icon-sheets')?.closest('li');
 }
 
@@ -103,10 +102,12 @@ function renderComponent({hasDraft = false} = {}) {
 			config={{
 				availableLanguages: {},
 				availableSegmentsExperiences: [],
+				currentVersion: {
+					name: 'Home',
+					status: hasDraft ? 'draft' : 'approved',
+				},
 				defaultLanguageId: 'en_US',
 				defaultUserImageSrc: '/image/user_portrait?img_id=0',
-				draftName: 'Home',
-				hasDraft,
 				pageSpecificationVersionsURL: 'url',
 			}}
 		/>
@@ -177,16 +178,20 @@ describe('VersionHistory', () => {
 		).toBeInTheDocument();
 	});
 
-	it('shows an empty state when there are no versions', async () => {
+	it('only shows the current version item when there are no versions', async () => {
 		mockLargeScreen();
 
 		renderComponent();
 
-		expect(
-			await screen.findByText('there-are-no-results')
-		).toBeInTheDocument();
+		await waitFor(() =>
+			expect(screen.getAllByRole('option')).toHaveLength(1)
+		);
 
-		expect(screen.queryByText('no-results-found')).not.toBeInTheDocument();
+		expect(screen.getByRole('option')).toBe(queryCurrentItem());
+
+		expect(
+			screen.queryByText('there-are-no-results')
+		).not.toBeInTheDocument();
 	});
 
 	it('shows the search empty state when nothing matches the search', async () => {
@@ -196,7 +201,7 @@ describe('VersionHistory', () => {
 		renderComponent();
 
 		await waitFor(() =>
-			expect(screen.getAllByRole('option')).toHaveLength(2)
+			expect(screen.getAllByRole('option')).toHaveLength(3)
 		);
 
 		await userEvent.type(screen.getByLabelText('search-form'), 'zzz');
@@ -217,27 +222,32 @@ describe('VersionHistory', () => {
 		renderComponent();
 
 		await waitFor(() =>
-			expect(screen.getAllByRole('option')).toHaveLength(2)
+			expect(screen.getAllByRole('option')).toHaveLength(3)
 		);
 
 		expect(screen.getByText('Home Halloween')).toBeInTheDocument();
-		expect(screen.getByText('Home')).toBeInTheDocument();
+		expect(screen.getAllByText('Home')).toHaveLength(2);
 	});
 
-	it('does not render a draft item when there is no draft', async () => {
+	it('renders the current version item as published when there is no draft', async () => {
 		mockLargeScreen();
 		mockVersions(VERSIONS);
 
 		renderComponent();
 
 		await waitFor(() =>
-			expect(screen.getAllByRole('option')).toHaveLength(2)
+			expect(screen.getAllByRole('option')).toHaveLength(3)
 		);
 
-		expect(queryDraftItem()).toBeUndefined();
+		const [first] = screen.getAllByRole('option');
+
+		expect(first).toBe(queryCurrentItem());
+		expect(first).toHaveTextContent('Home');
+		expect(first).toHaveTextContent('current-version');
+		expect(first).toHaveTextContent('published');
 	});
 
-	it('renders the draft on top when there is a draft', async () => {
+	it('renders the current version item as draft when there is a draft', async () => {
 		mockLargeScreen();
 		mockVersions(VERSIONS);
 
@@ -249,26 +259,13 @@ describe('VersionHistory', () => {
 
 		const [first] = screen.getAllByRole('option');
 
-		expect(first).toBe(queryDraftItem());
+		expect(first).toBe(queryCurrentItem());
 		expect(first).toHaveTextContent('Home');
+		expect(first).toHaveTextContent('current-version');
 		expect(first).toHaveTextContent('draft');
 	});
 
-	it('renders the draft even when the page has no versions', async () => {
-		mockLargeScreen();
-
-		renderComponent({hasDraft: true});
-
-		await waitFor(() =>
-			expect(screen.getAllByRole('option')).toHaveLength(1)
-		);
-
-		expect(
-			screen.queryByText('there-are-no-results')
-		).not.toBeInTheDocument();
-	});
-
-	it('filters out the draft when it does not match the search', async () => {
+	it('filters out the current version item when it does not match the search', async () => {
 		mockLargeScreen();
 		mockVersions(VERSIONS);
 
@@ -281,42 +278,26 @@ describe('VersionHistory', () => {
 		await userEvent.type(screen.getByLabelText('search-form'), 'Halloween');
 
 		expect(screen.getAllByRole('option')).toHaveLength(1);
-		expect(queryDraftItem()).toBeUndefined();
+		expect(queryCurrentItem()).toBeUndefined();
 	});
 
-	it('selects the draft by default when there is a draft', async () => {
-		mockLargeScreen();
-		mockVersions(VERSIONS);
-
-		renderComponent({hasDraft: true});
-
-		await waitFor(() =>
-			expect(screen.getAllByRole('option')).toHaveLength(3)
-		);
-
-		const [draft, ...rest] = screen.getAllByRole('option');
-
-		expect(draft).toHaveClass('active');
-
-		for (const item of rest) {
-			expect(item).not.toHaveClass('active');
-		}
-	});
-
-	it('selects the first version by default when there is no draft', async () => {
+	it('selects the current version item by default', async () => {
 		mockLargeScreen();
 		mockVersions(VERSIONS);
 
 		renderComponent();
 
 		await waitFor(() =>
-			expect(screen.getAllByRole('option')).toHaveLength(2)
+			expect(screen.getAllByRole('option')).toHaveLength(3)
 		);
 
-		const [first, second] = screen.getAllByRole('option');
+		const [current, ...rest] = screen.getAllByRole('option');
 
-		expect(first).toHaveClass('active');
-		expect(second).not.toHaveClass('active');
+		expect(current).toHaveClass('active');
+
+		for (const item of rest) {
+			expect(item).not.toHaveClass('active');
+		}
 	});
 
 	it('selects an item when it is clicked', async () => {
@@ -329,17 +310,17 @@ describe('VersionHistory', () => {
 			expect(screen.getAllByRole('option')).toHaveLength(3)
 		);
 
-		const [draft, version] = screen.getAllByRole('option');
+		const [current, version] = screen.getAllByRole('option');
 
 		await userEvent.click(version);
 
 		expect(version).toHaveClass('active');
 		expect(version).toHaveAttribute('aria-selected', 'true');
-		expect(draft).not.toHaveClass('active');
+		expect(current).not.toHaveClass('active');
 
-		await userEvent.click(draft);
+		await userEvent.click(current);
 
-		expect(draft).toHaveClass('active');
+		expect(current).toHaveClass('active');
 		expect(version).not.toHaveClass('active');
 	});
 
@@ -374,11 +355,11 @@ describe('VersionHistory', () => {
 			expect(screen.getAllByRole('option')).toHaveLength(3)
 		);
 
-		const [draft, second, third] = screen.getAllByRole('option');
+		const [current, second, third] = screen.getAllByRole('option');
 
-		draft.focus();
+		current.focus();
 
-		expect(draft).toHaveFocus();
+		expect(current).toHaveFocus();
 
 		await userEvent.keyboard('{ArrowDown}');
 
@@ -458,7 +439,7 @@ describe('VersionHistory', () => {
 		).toBeInTheDocument();
 
 		expect(screen.getByText('draft')).toBeInTheDocument();
-		expect(screen.getByText('published')).toBeInTheDocument();
+		expect(screen.getAllByText('published')).toHaveLength(2);
 	});
 
 	it('filters the versions by name and by modifier', async () => {
@@ -468,7 +449,7 @@ describe('VersionHistory', () => {
 		renderComponent();
 
 		await waitFor(() =>
-			expect(screen.getAllByRole('option')).toHaveLength(2)
+			expect(screen.getAllByRole('option')).toHaveLength(3)
 		);
 
 		const search = screen.getByLabelText('search-form');


### PR DESCRIPTION
Just inlining [this](https://github.com/brianchandotcom/liferay-portal/pull/179640#issuecomment-5168413738) and sorting

---

https://liferay.atlassian.net/browse/LPD-99956

## What Is Being Fixed

The placeholder at the top of the version history only appeared when the page had a draft, so a page with no pending changes showed no entry for its current state. The entry also lacked the version line that every other row in the list has, and the backend exposed the current state through two loose config values, `draftName` and `hasDraft`, which only made sense together.

## How It Is Being Fixed

The display context now sends a single `currentVersion` object with a `name` and a `status` key (`approved` or `draft`), so the frontend receives keys and resolves the labels itself, the same way it already did for the versions coming from the headless API. The list always renders that entry, labelled `Published` when there is no draft and `Draft` when there is one, with a `Current Version` line above the label mirroring the `Version N` line of the other rows.

On the frontend, the status vocabulary is unified in a single lowercase `Status` type. Since the headless API returns the capitalized enum, the conversion happens once in `PageVersionService`, at the boundary, which lets `VersionList` index a single `STATUSES` map for every row without conditionals.

## PR Check

**pr-check: PASS** — tested on `357960dd81e469b7755b0eab054dba64ae9416b7`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Java Unit Tests | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "357960dd81e469b7755b0eab054dba64ae9416b7"} -->
