### PR TITLE
LPD-98241 Enable mapping categories and vocabularies for Object entries

### DIFF
--- a/modules/apps/object/object-info-api/bnd.bnd
+++ b/modules/apps/object/object-info-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Object Info API
 Bundle-SymbolicName: com.liferay.object.info.api
-Bundle-Version: 7.0.1
+Bundle-Version: 8.0.0
 Export-Package:\
 	com.liferay.object.info.collection.provider.util,\
 	com.liferay.object.info.field.converter,\

--- a/modules/apps/object/object-info-api/src/main/java/com/liferay/object/info/item/provider/util/ObjectEntryInfoItemFormProviderUtil.java
+++ b/modules/apps/object/object-info-api/src/main/java/com/liferay/object/info/item/provider/util/ObjectEntryInfoItemFormProviderUtil.java
@@ -55,6 +55,7 @@ public class ObjectEntryInfoItemFormProviderUtil {
 
 	public static InfoForm getInfoForm(
 			InfoFieldSet basicInformationInfoFieldSet,
+			InfoFieldSet categorizationInfoFieldSet,
 			InfoFieldSet displayPageInfoFieldSet,
 			InfoItemFieldReaderFieldSetProvider
 				infoItemFieldReaderFieldSetProvider,
@@ -71,6 +72,12 @@ public class ObjectEntryInfoItemFormProviderUtil {
 		return InfoForm.builder(
 		).infoFieldSetEntry(
 			basicInformationInfoFieldSet
+		).infoFieldSetEntry(
+			unsafeConsumer -> {
+				if (categorizationInfoFieldSet != null) {
+					unsafeConsumer.accept(categorizationInfoFieldSet);
+				}
+			}
 		).<NoSuchFormVariationException>infoFieldSetEntry(
 			unsafeConsumer -> {
 				if (objectDefinitionId != 0) {

--- a/modules/apps/object/object-info-api/src/main/resources/com/liferay/object/info/item/provider/util/packageinfo
+++ b/modules/apps/object/object-info-api/src/main/resources/com/liferay/object/info/item/provider/util/packageinfo
@@ -1,1 +1,1 @@
-version 4.0.0
+version 5.0.0

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/system/info/item/provider/SystemObjectEntryInfoItemFormProvider.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/system/info/item/provider/SystemObjectEntryInfoItemFormProvider.java
@@ -138,7 +138,7 @@ public class SystemObjectEntryInfoItemFormProvider
 			).name(
 				"basic-information"
 			).build(),
-			displayPageInfoFieldSet, _infoItemFieldReaderFieldSetProvider,
+			null, displayPageInfoFieldSet, _infoItemFieldReaderFieldSetProvider,
 			_itemClassName, _objectActionLocalService, _objectDefinition,
 			objectDefinitionId, _objectDefinitionLocalService,
 			_objectFieldInfoFieldConverter, _objectFieldLocalService,

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/info/item/provider/test/ObjectEntryInfoItemFieldValuesProviderTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/info/item/provider/test/ObjectEntryInfoItemFieldValuesProviderTest.java
@@ -6,6 +6,9 @@
 package com.liferay.object.web.internal.info.item.provider.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.kernel.model.AssetCategory;
+import com.liferay.asset.kernel.model.AssetVocabulary;
+import com.liferay.asset.test.util.AssetTestUtil;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.test.util.DLTestUtil;
@@ -86,6 +89,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
@@ -360,6 +364,95 @@ public class ObjectEntryInfoItemFieldValuesProviderTest {
 
 			Assert.assertNotNull(
 				downloadURLInfoFieldValue.getValue(LocaleUtil.US));
+		}
+		finally {
+			ServiceContextThreadLocal.popServiceContext();
+		}
+	}
+
+	@Test
+	public void testObjectEntryInfoItemFieldValuesProviderWithCategorization()
+		throws Exception {
+
+		String objectFieldName = "a" + RandomTestUtil.randomString();
+
+		_objectDefinition = _addObjectDefinition(
+			new TextObjectFieldBuilder(
+			).labelMap(
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString())
+			).name(
+				objectFieldName
+			).build());
+
+		_objectDefinition =
+			_objectDefinitionLocalService.publishCustomObjectDefinition(
+				TestPropsValues.getUserId(),
+				_objectDefinition.getObjectDefinitionId());
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId());
+
+		AssetVocabulary assetVocabulary = AssetTestUtil.addVocabulary(
+			_group.getGroupId());
+
+		AssetCategory assetCategory = AssetTestUtil.addCategory(
+			_group.getGroupId(), assetVocabulary.getVocabularyId());
+
+		serviceContext.setAssetCategoryIds(
+			new long[] {assetCategory.getCategoryId()});
+
+		String assetTagName = RandomTestUtil.randomString();
+
+		serviceContext.setAssetTagNames(new String[] {assetTagName});
+
+		ObjectEntry objectEntry = _objectEntryLocalService.addObjectEntry(
+			_group.getGroupId(), TestPropsValues.getUserId(),
+			_objectDefinition.getObjectDefinitionId(),
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			null,
+			HashMapBuilder.<String, Serializable>put(
+				objectFieldName, RandomTestUtil.randomString()
+			).build(),
+			serviceContext);
+
+		_pushServiceContext(_getThemeDisplay(StringPool.BLANK, "UTC"));
+
+		try {
+			InfoItemFieldValuesProvider<ObjectEntry>
+				infoItemFieldValuesProvider =
+					_infoItemServiceRegistry.getFirstInfoItemService(
+						InfoItemFieldValuesProvider.class,
+						_objectDefinition.getClassName());
+
+			InfoItemFieldValues infoItemFieldValues =
+				infoItemFieldValuesProvider.getInfoItemFieldValues(objectEntry);
+
+			InfoFieldValue<Object> categoriesInfoFieldValue =
+				infoItemFieldValues.getInfoFieldValue("categories");
+
+			List<KeyLocalizedLabelPair> keyLocalizedLabelPairs =
+				(List<KeyLocalizedLabelPair>)
+					categoriesInfoFieldValue.getValue();
+
+			Assert.assertEquals(
+				keyLocalizedLabelPairs.toString(), 1,
+				keyLocalizedLabelPairs.size());
+
+			KeyLocalizedLabelPair keyLocalizedLabelPair =
+				keyLocalizedLabelPairs.get(0);
+
+			Assert.assertEquals(
+				assetCategory.getName(), keyLocalizedLabelPair.getKey());
+
+			InfoFieldValue<Object> tagNamesInfoFieldValue =
+				infoItemFieldValues.getInfoFieldValue("tagNames");
+
+			List<String> tagNames =
+				(List<String>)tagNamesInfoFieldValue.getValue();
+
+			Assert.assertEquals(tagNames.toString(), 1, tagNames.size());
+
+			Assert.assertEquals(assetTagName, tagNames.get(0));
 		}
 		finally {
 			ServiceContextThreadLocal.popServiceContext();

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/info/item/provider/test/ObjectEntryInfoItemFormProviderTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/info/item/provider/test/ObjectEntryInfoItemFormProviderTest.java
@@ -6,11 +6,15 @@
 package com.liferay.object.web.internal.info.item.provider.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.kernel.model.AssetVocabulary;
+import com.liferay.asset.test.util.AssetTestUtil;
 import com.liferay.info.field.InfoField;
 import com.liferay.info.field.InfoFieldSet;
+import com.liferay.info.field.type.CategoriesInfoFieldType;
 import com.liferay.info.field.type.OptionInfoFieldType;
 import com.liferay.info.field.type.RelationshipInfoFieldType;
 import com.liferay.info.field.type.SelectInfoFieldType;
+import com.liferay.info.field.type.TagsInfoFieldType;
 import com.liferay.info.form.InfoForm;
 import com.liferay.info.item.InfoItemReference;
 import com.liferay.info.item.InfoItemServiceRegistry;
@@ -27,8 +31,11 @@ import com.liferay.list.type.service.ListTypeEntryLocalService;
 import com.liferay.object.constants.ObjectActionExecutorConstants;
 import com.liferay.object.constants.ObjectActionTriggerConstants;
 import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.constants.ObjectDefinitionSettingConstants;
 import com.liferay.object.constants.ObjectFieldSettingConstants;
+import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.object.constants.ObjectRelationshipConstants;
+import com.liferay.object.definition.setting.builder.ObjectDefinitionSettingBuilder;
 import com.liferay.object.field.builder.AttachmentObjectFieldBuilder;
 import com.liferay.object.field.builder.PicklistObjectFieldBuilder;
 import com.liferay.object.field.builder.TextObjectFieldBuilder;
@@ -39,6 +46,7 @@ import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.ObjectFieldSetting;
+import com.liferay.object.model.ObjectFolder;
 import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.model.ObjectState;
 import com.liferay.object.model.ObjectStateFlow;
@@ -47,6 +55,7 @@ import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.service.ObjectFieldSettingLocalService;
+import com.liferay.object.service.ObjectFolderLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.object.service.ObjectStateFlowLocalService;
 import com.liferay.object.service.ObjectStateLocalService;
@@ -58,11 +67,16 @@ import com.liferay.object.test.util.TreeTestUtil;
 import com.liferay.object.tree.Edge;
 import com.liferay.object.tree.Node;
 import com.liferay.object.tree.Tree;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -122,6 +136,7 @@ public class ObjectEntryInfoItemFormProviderTest {
 		_listTypeEntry3 = _addListTypeEntry();
 
 		_childObjectDefinition = _addObjectDefinition(
+			true,
 			new AttachmentObjectFieldBuilder(
 			).labelMap(
 				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString())
@@ -252,13 +267,54 @@ public class ObjectEntryInfoItemFormProviderTest {
 	@Test
 	public void testGetInfoForm() throws Exception {
 		_testGetInfoFormWithAttachmentObjectField();
+		_testGetInfoFormWithCategorization();
 		_testGetInfoFormWithEdgeObjectRelationship();
 		_testGetInfoFormWithEnableObjectEntrySchedule();
 		_testGetInfoFormWithManyToManyObjectRelationship();
 		_testGetInfoFormWithObjectAction();
 		_testGetInfoFormWithObjectRelationship();
+		_testGetInfoFormWithoutCategorization();
 		_testGetInfoFormWithPicklistObjectField();
 		_testGetInfoFormWithRootObjectDefinition();
+	}
+
+	private ObjectDefinition _addCMSObjectDefinition() throws Exception {
+		ObjectFolder objectFolder =
+			_objectFolderLocalService.getOrAddEmptyObjectFolder(
+				ObjectFolderConstants.
+					EXTERNAL_REFERENCE_CODE_CONTENT_STRUCTURES,
+				TestPropsValues.getCompanyId(), TestPropsValues.getUserId());
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.addCustomObjectDefinition(
+				null, TestPropsValues.getUserId(),
+				objectFolder.getObjectFolderId(), null, true, false, true,
+				false, true, false, false, false, false, null,
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+				ObjectDefinitionTestUtil.getRandomName(), null, null,
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+				true, ObjectDefinitionConstants.SCOPE_DEPOT,
+				ObjectDefinitionConstants.STORAGE_TYPE_DEFAULT,
+				Collections.singletonList(
+					new ObjectDefinitionSettingBuilder(
+					).name(
+						ObjectDefinitionSettingConstants.NAME_ACCEPT_ALL_GROUPS
+					).value(
+						StringPool.TRUE
+					).build()),
+				Collections.singletonList(
+					new TextObjectFieldBuilder(
+					).labelMap(
+						LocalizedMapUtil.getLocalizedMap(
+							RandomTestUtil.randomString())
+					).name(
+						"a" + RandomTestUtil.randomString()
+					).build()),
+				Collections.emptyList(), new ServiceContext());
+
+		return _objectDefinitionLocalService.publishCustomObjectDefinition(
+			TestPropsValues.getUserId(),
+			objectDefinition.getObjectDefinitionId());
 	}
 
 	private ListTypeEntry _addListTypeEntry() throws Exception {
@@ -271,12 +327,13 @@ public class ObjectEntryInfoItemFormProviderTest {
 			_listTypeDefinition.isSystem());
 	}
 
-	private ObjectDefinition _addObjectDefinition(ObjectField... objectFields)
+	private ObjectDefinition _addObjectDefinition(
+			boolean enableCategorization, ObjectField... objectFields)
 		throws Exception {
 
 		return _objectDefinitionLocalService.addCustomObjectDefinition(
-			null, TestPropsValues.getUserId(), 0, null, true, false, true,
-			false, true, false, false, false, false, null,
+			null, TestPropsValues.getUserId(), 0, null, enableCategorization,
+			false, true, false, true, false, false, false, false, null,
 			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
 			ObjectDefinitionTestUtil.getRandomName(), null, null,
 			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
@@ -386,6 +443,48 @@ public class ObjectEntryInfoItemFormProviderTest {
 			objectField.getObjectFieldId() + "#mimeType", _childInfoForm);
 		_assertInfoField(
 			objectField.getObjectFieldId() + "#size", _childInfoForm);
+	}
+
+	private void _testGetInfoFormWithCategorization() throws Exception {
+		Group cmsGroup = _groupLocalService.getGroup(
+			TestPropsValues.getCompanyId(), GroupConstants.CMS);
+
+		_cmsObjectDefinition = _addCMSObjectDefinition();
+
+		_assetVocabulary = AssetTestUtil.addVocabulary(cmsGroup.getGroupId());
+
+		_group = GroupTestUtil.addGroup();
+
+		AssetVocabulary siteAssetVocabulary = AssetTestUtil.addVocabulary(
+			_group.getGroupId());
+
+		InfoForm infoForm = _getInfoForm(_cmsObjectDefinition);
+
+		InfoFieldSet infoFieldSet = (InfoFieldSet)infoForm.getInfoFieldSetEntry(
+			"categorization");
+
+		Assert.assertNotNull(
+			infoFieldSet.getInfoFieldSetEntry(_assetVocabulary.getName()));
+		Assert.assertNull(
+			infoFieldSet.getInfoFieldSetEntry(siteAssetVocabulary.getName()));
+
+		infoForm = _getInfoForm(_childObjectDefinition);
+
+		infoFieldSet = (InfoFieldSet)infoForm.getInfoFieldSetEntry(
+			"categorization");
+
+		InfoField<?> categoriesInfoField =
+			(InfoField<?>)infoFieldSet.getInfoFieldSetEntry("categories");
+
+		Assert.assertEquals(
+			CategoriesInfoFieldType.INSTANCE,
+			categoriesInfoField.getInfoFieldType());
+
+		InfoField<?> tagNamesInfoField =
+			(InfoField<?>)infoFieldSet.getInfoFieldSetEntry("tagNames");
+
+		Assert.assertEquals(
+			TagsInfoFieldType.INSTANCE, tagNamesInfoField.getInfoFieldType());
 	}
 
 	private void _testGetInfoFormWithEdgeObjectRelationship() throws Exception {
@@ -500,6 +599,26 @@ public class ObjectEntryInfoItemFormProviderTest {
 		Assert.assertNotNull(
 			relationshipInfoFieldSet.getInfoFieldSetEntry(
 				"picklistObjectFieldName"));
+	}
+
+	private void _testGetInfoFormWithoutCategorization() throws Exception {
+		_objectDefinition = _addObjectDefinition(
+			false,
+			new TextObjectFieldBuilder(
+			).labelMap(
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString())
+			).name(
+				"a" + RandomTestUtil.randomString()
+			).build());
+
+		_objectDefinition =
+			_objectDefinitionLocalService.publishCustomObjectDefinition(
+				TestPropsValues.getUserId(),
+				_objectDefinition.getObjectDefinitionId());
+
+		InfoForm infoForm = _getInfoForm(_objectDefinition);
+
+		Assert.assertNull(infoForm.getInfoFieldSetEntry("categorization"));
 	}
 
 	private void _testGetInfoFormWithPicklistObjectField() throws Exception {
@@ -640,8 +759,20 @@ public class ObjectEntryInfoItemFormProviderTest {
 		return serviceContext;
 	}
 
+	@DeleteAfterTestRun
+	private AssetVocabulary _assetVocabulary;
+
 	private InfoForm _childInfoForm;
 	private ObjectDefinition _childObjectDefinition;
+
+	@DeleteAfterTestRun
+	private ObjectDefinition _cmsObjectDefinition;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private GroupLocalService _groupLocalService;
 
 	@Inject
 	private InfoItemServiceRegistry _infoItemServiceRegistry;
@@ -674,6 +805,9 @@ public class ObjectEntryInfoItemFormProviderTest {
 	@Inject
 	private ListTypeEntryLocalService _listTypeEntryLocalService;
 
+	@DeleteAfterTestRun
+	private ObjectDefinition _objectDefinition;
+
 	private ObjectDefinition _objectDefinitionA;
 	private ObjectDefinition _objectDefinitionAA;
 	private ObjectDefinition _objectDefinitionAAA;
@@ -689,6 +823,9 @@ public class ObjectEntryInfoItemFormProviderTest {
 
 	@Inject
 	private ObjectFieldSettingLocalService _objectFieldSettingLocalService;
+
+	@Inject
+	private ObjectFolderLocalService _objectFolderLocalService;
 
 	@DeleteAfterTestRun
 	private ObjectRelationship _objectRelationship;

--- a/modules/apps/object/object-web/build.gradle
+++ b/modules/apps/object/object-web/build.gradle
@@ -16,6 +16,7 @@ dependencies {
 	compileOnly project(":apps:application-list:application-list-api")
 	compileOnly project(":apps:asset:asset-api")
 	compileOnly project(":apps:asset:asset-display-page-api")
+	compileOnly project(":apps:asset:asset-info-api")
 	compileOnly project(":apps:asset:asset-taglib")
 	compileOnly project(":apps:bulk:bulk-selection-api")
 	compileOnly project(":apps:change-tracking:change-tracking-api")

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -7,6 +7,7 @@ package com.liferay.object.web.internal.deployer;
 
 import com.liferay.application.list.PanelApp;
 import com.liferay.asset.display.page.portlet.AssetDisplayPageFriendlyURLProvider;
+import com.liferay.asset.info.item.provider.AssetEntryInfoItemFieldSetProvider;
 import com.liferay.asset.kernel.model.AssetRendererFactory;
 import com.liferay.asset.kernel.service.AssetCategoryLocalService;
 import com.liferay.asset.kernel.service.AssetEntryLocalService;
@@ -226,8 +227,9 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 
 		InfoItemFormProvider<ObjectEntry> infoItemFormProvider =
 			new ObjectEntryInfoItemFormProvider(
-				_displayPageInfoItemFieldSetProvider, objectDefinition,
-				_infoItemFieldReaderFieldSetProvider,
+				_assetEntryInfoItemFieldSetProvider,
+				_displayPageInfoItemFieldSetProvider, _groupLocalService,
+				objectDefinition, _infoItemFieldReaderFieldSetProvider,
 				_listTypeEntryLocalService, _objectActionLocalService,
 				_objectDefinitionLocalService, objectFieldInfoFieldConverter,
 				_objectFieldLocalService, _objectFieldSettingLocalService,
@@ -356,6 +358,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 			_bundleContext.registerService(
 				InfoItemFieldValuesProvider.class,
 				new ObjectEntryInfoItemFieldValuesProvider(
+					_assetEntryInfoItemFieldSetProvider,
 					_displayPageInfoItemFieldSetProvider, _dlAppLocalService,
 					_dlURLHelper, _friendlyURLEntryLocalService,
 					_infoItemFieldReaderFieldSetProvider,
@@ -773,6 +776,10 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 	@Reference
 	private AssetDisplayPageFriendlyURLProvider
 		_assetDisplayPageFriendlyURLProvider;
+
+	@Reference
+	private AssetEntryInfoItemFieldSetProvider
+		_assetEntryInfoItemFieldSetProvider;
 
 	@Reference
 	private AssetEntryLocalService _assetEntryLocalService;

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFieldValuesProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFieldValuesProvider.java
@@ -5,9 +5,11 @@
 
 package com.liferay.object.web.internal.info.item.provider;
 
+import com.liferay.asset.info.item.provider.AssetEntryInfoItemFieldSetProvider;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.util.DLURLHelper;
 import com.liferay.friendly.url.service.FriendlyURLEntryLocalService;
+import com.liferay.info.exception.NoSuchInfoItemException;
 import com.liferay.info.field.InfoField;
 import com.liferay.info.field.InfoFieldValue;
 import com.liferay.info.field.type.RelationshipInfoFieldType;
@@ -46,6 +48,8 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.cache.thread.local.Lifecycle;
 import com.liferay.portal.kernel.cache.thread.local.ThreadLocalCache;
 import com.liferay.portal.kernel.cache.thread.local.ThreadLocalCacheManager;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
@@ -75,6 +79,7 @@ public class ObjectEntryInfoItemFieldValuesProvider
 	implements InfoItemFieldValuesProvider<ObjectEntry> {
 
 	public ObjectEntryInfoItemFieldValuesProvider(
+		AssetEntryInfoItemFieldSetProvider assetEntryInfoItemFieldSetProvider,
 		DisplayPageInfoItemFieldSetProvider displayPageInfoItemFieldSetProvider,
 		DLAppLocalService dlAppLocalService, DLURLHelper dlURLHelper,
 		FriendlyURLEntryLocalService friendlyURLEntryLocalService,
@@ -94,6 +99,8 @@ public class ObjectEntryInfoItemFieldValuesProvider
 		TemplateInfoItemFieldSetProvider templateInfoItemFieldSetProvider,
 		UserLocalService userLocalService) {
 
+		_assetEntryInfoItemFieldSetProvider =
+			assetEntryInfoItemFieldSetProvider;
 		_displayPageInfoItemFieldSetProvider =
 			displayPageInfoItemFieldSetProvider;
 		_dlAppLocalService = dlAppLocalService;
@@ -244,6 +251,20 @@ public class ObjectEntryInfoItemFieldValuesProvider
 			new InfoFieldValue<>(
 				ObjectEntryInfoItemFields.userProfileImageInfoField,
 				_getWebImage(objectEntry.getUserId())));
+
+		if (_objectDefinition.isEnableCategorization()) {
+			try {
+				objectEntryFieldValues.addAll(
+					_assetEntryInfoItemFieldSetProvider.getInfoFieldValues(
+						_objectDefinition.getClassName(),
+						objectEntry.getObjectEntryId()));
+			}
+			catch (NoSuchInfoItemException noSuchInfoItemException) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(noSuchInfoItemException);
+				}
+			}
+		}
 
 		ThemeDisplay themeDisplay = ObjectEntryInfoItemUtil.getThemeDisplay();
 
@@ -465,6 +486,11 @@ public class ObjectEntryInfoItemFieldValuesProvider
 		return webImage;
 	}
 
+	private static final Log _log = LogFactoryUtil.getLog(
+		ObjectEntryInfoItemFieldValuesProvider.class);
+
+	private final AssetEntryInfoItemFieldSetProvider
+		_assetEntryInfoItemFieldSetProvider;
 	private final DisplayPageInfoItemFieldSetProvider
 		_displayPageInfoItemFieldSetProvider;
 	private final DLAppLocalService _dlAppLocalService;

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFormProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFormProvider.java
@@ -5,6 +5,7 @@
 
 package com.liferay.object.web.internal.info.item.provider;
 
+import com.liferay.asset.info.item.provider.AssetEntryInfoItemFieldSetProvider;
 import com.liferay.info.field.InfoFieldSet;
 import com.liferay.info.form.InfoForm;
 import com.liferay.info.item.field.reader.InfoItemFieldReaderFieldSetProvider;
@@ -26,6 +27,9 @@ import com.liferay.object.service.ObjectFieldSettingLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.template.info.item.provider.TemplateInfoItemFieldSetProvider;
 
@@ -37,8 +41,9 @@ public class ObjectEntryInfoItemFormProvider
 	implements InfoItemFormProvider<ObjectEntry> {
 
 	public ObjectEntryInfoItemFormProvider(
+		AssetEntryInfoItemFieldSetProvider assetEntryInfoItemFieldSetProvider,
 		DisplayPageInfoItemFieldSetProvider displayPageInfoItemFieldSetProvider,
-		ObjectDefinition objectDefinition,
+		GroupLocalService groupLocalService, ObjectDefinition objectDefinition,
 		InfoItemFieldReaderFieldSetProvider infoItemFieldReaderFieldSetProvider,
 		ListTypeEntryLocalService listTypeEntryLocalService,
 		ObjectActionLocalService objectActionLocalService,
@@ -52,8 +57,11 @@ public class ObjectEntryInfoItemFormProvider
 		TemplateInfoItemFieldSetProvider templateInfoItemFieldSetProvider,
 		UserLocalService userLocalService) {
 
+		_assetEntryInfoItemFieldSetProvider =
+			assetEntryInfoItemFieldSetProvider;
 		_displayPageInfoItemFieldSetProvider =
 			displayPageInfoItemFieldSetProvider;
+		_groupLocalService = groupLocalService;
 		_objectDefinition = objectDefinition;
 		_infoItemFieldReaderFieldSetProvider =
 			infoItemFieldReaderFieldSetProvider;
@@ -83,6 +91,35 @@ public class ObjectEntryInfoItemFormProvider
 	@Override
 	public InfoForm getInfoForm(String formVariationKey, long groupId) {
 		return _getInfoForm(groupId);
+	}
+
+	private long _getCategorizationGroupId(long groupId) {
+		if (_objectDefinition.isCMS()) {
+			Group group = _groupLocalService.fetchGroup(
+				_objectDefinition.getCompanyId(), GroupConstants.CMS);
+
+			if (group != null) {
+				return group.getGroupId();
+			}
+		}
+
+		return groupId;
+	}
+
+	private InfoFieldSet _getCategorizationInfoFieldSet(long groupId) {
+		if (!_objectDefinition.isEnableCategorization()) {
+			return null;
+		}
+
+		long categorizationGroupId = _getCategorizationGroupId(groupId);
+
+		if (categorizationGroupId == 0) {
+			return _assetEntryInfoItemFieldSetProvider.getInfoFieldSet(
+				_objectDefinition.getClassName());
+		}
+
+		return _assetEntryInfoItemFieldSetProvider.getInfoFieldSet(
+			_objectDefinition.getClassName(), 0, categorizationGroupId);
 	}
 
 	private InfoForm _getInfoForm(long groupId) {
@@ -125,6 +162,7 @@ public class ObjectEntryInfoItemFormProvider
 				).name(
 					"basic-information"
 				).build(),
+				_getCategorizationInfoFieldSet(groupId),
 				_displayPageInfoItemFieldSetProvider.getInfoFieldSet(
 					_objectDefinition.getClassName(), StringPool.BLANK,
 					ObjectEntry.class.getSimpleName(), groupId),
@@ -140,8 +178,11 @@ public class ObjectEntryInfoItemFormProvider
 		}
 	}
 
+	private final AssetEntryInfoItemFieldSetProvider
+		_assetEntryInfoItemFieldSetProvider;
 	private final DisplayPageInfoItemFieldSetProvider
 		_displayPageInfoItemFieldSetProvider;
+	private final GroupLocalService _groupLocalService;
 	private final InfoItemFieldReaderFieldSetProvider
 		_infoItemFieldReaderFieldSetProvider;
 	private final ListTypeEntryLocalService _listTypeEntryLocalService;

--- a/modules/apps/object/object-web/src/test/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFieldValuesProviderTest.java
+++ b/modules/apps/object/object-web/src/test/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFieldValuesProviderTest.java
@@ -5,6 +5,7 @@
 
 package com.liferay.object.web.internal.info.item.provider;
 
+import com.liferay.asset.info.item.provider.AssetEntryInfoItemFieldSetProvider;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.util.DLURLHelper;
 import com.liferay.friendly.url.service.FriendlyURLEntryLocalService;
@@ -109,6 +110,7 @@ public class ObjectEntryInfoItemFieldValuesProviderTest {
 
 		_objectEntryInfoItemFieldValuesProvider =
 			new ObjectEntryInfoItemFieldValuesProvider(
+				Mockito.mock(AssetEntryInfoItemFieldSetProvider.class),
 				displayPageInfoItemFieldSetProvider,
 				Mockito.mock(DLAppLocalService.class),
 				Mockito.mock(DLURLHelper.class),


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98241

## What Is Being Fixed

When mapping a fragment field against a Basic Web Content (CMS) collection, vocabularies and categories were not available as mapping sources, unlike DXP-default Web Content. Basic Web Content (CMS) is backed by a Liferay Object, and the Object info item form never contributed the asset categorization field set.

## How It Is Being Fixed

The Object info item providers now mirror the JournalArticle providers. When an object definition has categorization enabled, ObjectEntryInfoItemFormProvider adds the AssetEntryInfoItemFieldSetProvider categorization field set to the info form, and ObjectEntryInfoItemFieldValuesProvider contributes the matching category, vocabulary, and tag values for default-storage object entries. For CMS objects the vocabulary lookup is scoped to the CMS group, where their vocabularies live, so the object's own vocabularies appear and unrelated site vocabularies do not. The categorization field set is ordered above the display page grouping. This applies to all categorization-enabled objects, not only CMS.

## PR Check

**pr-check: PASS** — tested on `1bb81284a2a066590ea58ea943bbd17461d98423`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "1bb81284a2a066590ea58ea943bbd17461d98423"} -->
