### PR TITLE
LPD-100597 Scope object definition lookups to avoid missed pages

### DIFF
--- a/modules/apps/object/object-rest-test/src/testFunctional/macros/ObjectDefinitionAPI.macro
+++ b/modules/apps/object/object-rest-test/src/testFunctional/macros/ObjectDefinitionAPI.macro
@@ -597,7 +597,7 @@ definition {
 
 	@summary = "Default summary"
 	macro assertObjectDefinitionInResponse(expectedValue = null) {
-		var response = ObjectDefinitionAPI.getObjectDefinitions();
+		var response = ObjectDefinitionAPI.getObjectDefinitions(name = ${expectedValue});
 
 		var actual = JSONUtil.getWithJSONPath(${response}, "$..name");
 
@@ -1104,15 +1104,24 @@ definition {
 	}
 
 	@summary = "Default summary"
-	macro getObjectDefinitions() {
+	macro getObjectDefinitions(name = null) {
 		var portalURL = JSONCompany.getPortalURL();
 		var userPassword = PropsUtil.get("default.admin.password");
 
-		var curl = '''
-			${portalURL}/o/object-admin/v1.0/object-definitions \
-				-H Content-Type: application/json \
-				-u test@liferay.com:${userPassword}
-		''';
+		if (isSet(name)) {
+			var curl = '''
+				${portalURL}/o/object-admin/v1.0/object-definitions?filter=name%20eq%20%27${name}%27 \
+					-H Content-Type: application/json \
+					-u test@liferay.com:${userPassword}
+			''';
+		}
+		else {
+			var curl = '''
+				${portalURL}/o/object-admin/v1.0/object-definitions \
+					-H Content-Type: application/json \
+					-u test@liferay.com:${userPassword}
+			''';
+		}
 
 		var response = JSONCurlUtil.get(${curl});
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100597

## Failing Test

`LocalFile.ImportObjectDefinitions#CanCreateNewObjectDefinitionAndUpdateExistingObjectDefinitionWithImportJSONFile`
`LocalFile.ImportObjectDefinitions#CanImportJSONFileWithOnlyNewRecordsImportStrategy`
`LocalFile.ImportObjectDefinitions#CanImportJSONLFile`
`LocalFile.ImportObjectDefinitions#CanImportObjectDefinitionWithExportedJSONLFile`

`modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/ImportObjectDefinitions.testcase`

```
java.lang.Exception: FAILED: '...' doesn't contain expected text 'Teacher'/'Student'
```

## Root Cause

Commit `c1f31d0` ("LPD-99210 Provision the CMS site unconditionally") removed a feature flag gate, so site-initializer-cms now creates six CMS object definitions on every instance, raising the system object definition count from sixteen to twenty two. `ObjectDefinitionAPI.getObjectDefinitions()` requested `/o/object-admin/v1.0/object-definitions` with no filter or page size, so `assertObjectDefinitionInResponse` only ever searched the first page of twenty results — now entirely filled with system objects — and never found the newly created `Teacher`/`Student` test object definitions on the second page.

## Fix

Added an optional `name` parameter to `getObjectDefinitions()` and pass `assertObjectDefinitionInResponse`'s `expectedValue` through it, so the lookup filters server-side by name instead of relying on unpaginated page-1 results. This mirrors LPD-100553, which fixed the same root cause for a different call site (`JSONObject.getObjectId`) in the same test suite.

- `modules/apps/object/object-rest-test/src/testFunctional/macros/ObjectDefinitionAPI.macro`

## PR Check

**pr-check: PASS** — tested on `63e9f5d3a24f2cf7ac287c5f91657f99182875b2`

| Validation | Result |
| --- | --- |
| Poshi Syntax | PASS |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "63e9f5d3a24f2cf7ac287c5f91657f99182875b2"} -->
