### PR TITLE
LPD-100894 Skip resource actions for an unmodifiable system object

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldLocalServiceImpl.java
@@ -1029,7 +1029,8 @@ public class ObjectFieldLocalServiceImpl
 			return objectField;
 		}
 
-		if (objectField.compareBusinessType(
+		if (!objectDefinition.isUnmodifiableSystemObject() &&
+			objectField.compareBusinessType(
 				ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT)) {
 
 			try {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100894

## What Is Being Fixed

`SystemObjectEntryInfoItemFieldValuesProviderTest#testSystemObjectEntryInfoItemFieldValuesProvider` fails with:

```
java.lang.UnsupportedOperationException
  at com.liferay.object.model.impl.ObjectDefinitionImpl.getResourceName(ObjectDefinitionImpl.java:154)
  at com.liferay.object.definition.security.permission.reso...
```

`ObjectFieldLocalServiceImpl._addObjectField` populated an attachment field's resource actions through `ObjectDefinitionResourcePermissionUtil.populateResourceActions`, which resolves `ObjectDefinitionImpl.getResourceName()`. That method throws `UnsupportedOperationException` for an unmodifiable system object, because such a definition has no per-object resource name. Adding a custom attachment object field to a system object definition such as `AccountEntry` therefore failed.

## Root Cause

LPD-99210 `a57a60eb394d0` ("Remove the LPD-17564 feature flag checks", committed to master 2026-08-01) deleted the LPD-17564 feature flag guard that had wrapped this attachment resource permission block. The block now runs unconditionally for approved definitions and reaches `getResourceName()` for unmodifiable system objects. The pre-existing early-return gate only skips system fields, not custom fields, on unmodifiable system objects, so the custom attachment field slips through.

## How It Is Being Fixed

Guard the resource action population with `isUnmodifiableSystemObject()` so it is skipped for unmodifiable system objects. The field's column is still created afterward, and the two delete and update attachment paths are unaffected because they use `getClassName()`, not `getResourceName()`.

## Testing

`SystemObjectEntryInfoItemFieldValuesProviderTest` is the existing regression test. It is FAILED on Testray build `505487123` (`[master] ci:test:object`, portal SHA `ebe09e2`, without this fix) and PASSED on build `505649975` (portal SHA `06fd2469`, the same tree plus this fix). The failure also reproduces on `brianchandotcom` master carrying none of these commits, and Testray classifies it as a Common failure, so it is master breakage rather than a branch regression.

## Question For The Reviewer

The guard lets an attachment object field persist with its resource actions unpopulated, which is a state change rather than only a suppressed exception. An adversarial review of the build-`505649975` run raised this as a candidate contributor to a separate `ObjectEntryResourceTest` failure whose ERROR log originates in `com.liferay.site.initializer.extender.internal.BundleSiteInitializer`. That link is unproven. Please confirm that no later code path depends on those resource actions being present for an unmodifiable system object.

## PR Check

**pr-check: PASS** — tested on `c61c5aef14d96b6d1af1571b31c0e0b407be6a00`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

Integration Test Compile is vacuous for the changed module — `:apps:object:object-service:compileTestIntegrationJava` reports `NO-SOURCE`, since `object-service` has no `testIntegration` tree. `:apps:object:object-test:compileTestIntegrationJava` was therefore also compiled, because that is the module holding `SystemObjectEntryInfoItemFieldValuesProviderTest`; it builds clean. Java Unit Tests used the documented full-suite fallback for `object-service` (no parallel-name counterpart exists for `ObjectFieldLocalServiceImpl`): 11 result files, 20 tests, 0 failures, 0 errors.

<!-- pr-check {"result": "success", "sha": "c61c5aef14d96b6d1af1571b31c0e0b407be6a00"} -->
