### PR TITLE
LPD-100907 Make the object definition tests tolerate CMS provisioning

### DIFF
--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionResourceTest.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionResourceTest.java
@@ -75,7 +75,6 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalService;
-import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
@@ -93,7 +92,6 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropsValues;
-import com.liferay.portal.kernel.util.ProxyUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.SystemProperties;
 import com.liferay.portal.kernel.util.TextFormatter;
@@ -195,32 +193,7 @@ public class ObjectDefinitionResourceTest
 	@Override
 	@Test
 	public void testGetObjectDefinitionsPage() throws Exception {
-		ObjectDefinitionResource.Builder builder =
-			ReflectionTestUtil.getFieldValue(
-				objectDefinitionResource, "_builder");
-
-		ReflectionTestUtil.setFieldValue(
-			this, "objectDefinitionResource",
-			ProxyUtil.newProxyInstance(
-				ObjectDefinitionResourceTest.class.getClassLoader(),
-				new Class<?>[] {ObjectDefinitionResource.class},
-				(proxy, method, args) -> {
-					if (Objects.equals(
-							method.getName(), "getObjectDefinitionsPage")) {
-
-						args[3] = Pagination.of(1, 20);
-					}
-
-					return method.invoke(builder.build(), args);
-				}));
-
-		try {
-			super.testGetObjectDefinitionsPage();
-		}
-		finally {
-			ReflectionTestUtil.setFieldValue(
-				this, "objectDefinitionResource", builder.build());
-		}
+		super.testGetObjectDefinitionsPage();
 
 		ObjectDefinition modifiableSystemObjectDefinition1 =
 			_addObjectDefinition(_randomModifiableSystemObjectDefinition());

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionResourceTest.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionResourceTest.java
@@ -312,27 +312,41 @@ public class ObjectDefinitionResourceTest
 		objectDefinition2 = testGetObjectDefinitionsPage_addObjectDefinition(
 			objectDefinition2);
 
+		Set<Long> objectDefinitionIds = Set.of(
+			objectDefinition1.getId(), objectDefinition2.getId());
+
+		Page<ObjectDefinition> objectDefinitionsPage =
+			objectDefinitionResource.getObjectDefinitionsPage(
+				null, null, null, Pagination.of(1, 1), null);
+
+		Pagination pagination = Pagination.of(
+			1, (int)objectDefinitionsPage.getTotalCount() + 10);
+
 		Page<ObjectDefinition> ascPage =
 			objectDefinitionResource.getObjectDefinitionsPage(
-				null, null, null, null, "name:asc");
+				null, null, null, pagination, "name:asc");
 
-		List<ObjectDefinition> objectDefinitions =
-			(List<ObjectDefinition>)ascPage.getItems();
+		List<ObjectDefinition> objectDefinitions = ListUtil.filter(
+			(List<ObjectDefinition>)ascPage.getItems(),
+			objectDefinition -> objectDefinitionIds.contains(
+				objectDefinition.getId()));
 
 		assertEquals(
 			Arrays.asList(objectDefinition1, objectDefinition2),
-			objectDefinitions.subList(2, 4));
+			objectDefinitions);
 
 		Page<ObjectDefinition> descPage =
 			objectDefinitionResource.getObjectDefinitionsPage(
-				null, null, null, null, "name:desc");
+				null, null, null, pagination, "name:desc");
 
-		objectDefinitions = (List<ObjectDefinition>)descPage.getItems();
+		objectDefinitions = ListUtil.filter(
+			(List<ObjectDefinition>)descPage.getItems(),
+			objectDefinition -> objectDefinitionIds.contains(
+				objectDefinition.getId()));
 
 		assertEquals(
 			Arrays.asList(objectDefinition2, objectDefinition1),
-			objectDefinitions.subList(
-				objectDefinitions.size() - 4, objectDefinitions.size() - 2));
+			objectDefinitions);
 
 		_objectDefinitionLocalService.deleteObjectDefinition(
 			objectDefinition1.getId());
@@ -2299,9 +2313,41 @@ public class ObjectDefinitionResourceTest
 			actualPermissionsJSONArray = jsonObject.getJSONArray("items");
 		}
 
+		// The response includes permissions granted by the environment beyond
+		// this request, for example the company scoped CMS Administrator grant
+		// present on every object definition, so keep only the roles this
+		// request asserts. The comparison still verifies that every requested
+		// permission round trips with its exact action IDs, independent of the
+		// provisioning grants that vary across environments.
+
+		Set<String> expectedRoleNames = new HashSet<>();
+
+		for (int i = 0; i < expectedPermissionsJSONArray.length(); i++) {
+			JSONObject expectedPermissionJSONObject =
+				expectedPermissionsJSONArray.getJSONObject(i);
+
+			expectedRoleNames.add(
+				expectedPermissionJSONObject.getString("roleName"));
+		}
+
+		JSONArray filteredActualPermissionsJSONArray =
+			_jsonFactory.createJSONArray();
+
+		for (int i = 0; i < actualPermissionsJSONArray.length(); i++) {
+			JSONObject actualPermissionJSONObject =
+				actualPermissionsJSONArray.getJSONObject(i);
+
+			if (expectedRoleNames.contains(
+					actualPermissionJSONObject.getString("roleName"))) {
+
+				filteredActualPermissionsJSONArray.put(
+					actualPermissionJSONObject);
+			}
+		}
+
 		JSONAssert.assertEquals(
 			String.valueOf(expectedPermissionsJSONArray),
-			String.valueOf(actualPermissionsJSONArray),
+			String.valueOf(filteredActualPermissionsJSONArray),
 			JSONCompareMode.LENIENT);
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100907

## What Is Being Fixed

Two assertions in `ObjectDefinitionResourceTest` assumed the test's own object definitions were the only ones in the company:

`testGetObjectDefinitionsPageWithSortString` expected the two definitions it creates at fixed offsets within the returned page.

`testPutObjectDefinitionByExternalReferenceCode`, through the `_assertObjectDefinitionWithPermissions` helper, compared the returned permissions exactly, which the company scoped CMS Administrator grant rejects.

## Root Cause

LPD-99210 `a57a60eb394d0` ("Remove the LPD-17564 feature flag checks", committed to master 2026-08-01) removed the LPD-17564 CMS feature flag gate, so the CMS site initializer runs unconditionally on every company. Before the lift the flag was off in the test environment, so CMS provisioned neither its own object definitions nor the company scoped CMS Administrator grant, and both assertions held. Once the gate was removed those environment provisioned artifacts appeared and both assertions went stale.

## How It Is Being Fixed

`testGetObjectDefinitionsPageWithSortString` sizes the page to `totalCount` plus ten and filters the sorted items to the two definition ids it creates before asserting their order. `_assertObjectDefinitionWithPermissions` filters the returned permissions to the roles the request asserts, so an environment provisioned grant no longer fails the comparison. Neither change weakens what the test asserts; both stop it from assuming it is alone in the company.

## Included Cleanup

The first commit drops a dynamic proxy in `testGetObjectDefinitionsPage` that rewrote the pagination argument to `Pagination.of(1, 20)`. LPD-45903 `51cd3b740aeef` added that workaround because the generated base sized its listing query with a fixed `Pagination.of(1, 10)`. LPD-100439 `b14bcd6beaa66` ("Size the generated listing page test to the actual row count") changed `base_resource_test_case.ftl` to read the real total and re-query with `Pagination.of(1, (int)totalCount + 2)`, and the regeneration in `fa74bd8e44357` applied that to `BaseObjectDefinitionResourceTestCase`. The proxy is therefore redundant. This is dead code removal enabled by that upstream change, not a failure fix.

## Testing

`ObjectDefinitionResourceTest` is PASSED on Testray build `505487123` (`[master] ci:test:object`, portal SHA `ebe09e2`), which carries this fix. There is no Testray record of the red state, because the fix was already part of that branch before its first CI run; the failures were observed locally when the CMS feature flag lift landed.

## PR Check

**pr-check: PASS** — tested on `430a71cf59a9e1e2fd93500ff0a83b7142157b9c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Integration Test Compile | PASS |

Both commits touch only `ObjectDefinitionResourceTest.java` under `src/testIntegration`. Two further validations matched the diff mechanically but are excluded by their own trigger: Per-Module Compile excludes a module whose only Java change is under `src/testIntegration`, since Integration Test Compile already covers it and a `-test` module deploys no runtime bundle; Java Unit Tests scopes in `src/test` but explicitly not `src/testIntegration`. Full Portal Build, REST Builder, Service Builder, Baseline and Structural Smoke did not match.

<!-- pr-check {"result": "success", "sha": "430a71cf59a9e1e2fd93500ff0a83b7142157b9c"} -->
