### PR TITLE
LPD-100907 Skip the CMS default permission lookup for company scope

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-api/src/main/java/com/liferay/site/cms/site/initializer/util/CMSDefaultPermissionUtil.java
+++ b/modules/apps/site/site-cms-site-initializer-api/src/main/java/com/liferay/site/cms/site/initializer/util/CMSDefaultPermissionUtil.java
@@ -179,6 +179,13 @@ public class CMSDefaultPermissionUtil {
 			FilterFactory<Predicate> filterFactory)
 		throws PortalException {
 
+		// A company scoped folder (group id 0) has no depot group and
+		// therefore no depot level default permissions to inherit.
+
+		if (objectEntryFolder.getGroupId() == 0) {
+			return null;
+		}
+
 		ObjectDefinition objectDefinition =
 			ObjectDefinitionLocalServiceUtil.
 				fetchObjectDefinitionByExternalReferenceCode(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100907

## What Is Being Fixed

`DefaultObjectEntryManagerImplTest#testAddObjectEntryWithMissingObjectEntryFolderReference`. Object entry creation fails when the folder reference resolves to a company scoped object entry folder:

```
com.liferay.portal.kernel.exception.NoSuchGroupException: No Group exists with the primary key 0
  (wrapped in a ModelListenerException from CMS ObjectEntryFolderModelListener.onAfterCreate)
```

`CMSDefaultPermissionUtil.getCMSDefaultPermissionJSONObject` resolved the folder's group with `GroupLocalServiceUtil.getGroup`, which throws for a company scoped folder because such a folder has no group (group primary key 0).

## Root Cause

LPD-99210 `a57a60eb394d0` ("Remove the LPD-17564 feature flag checks", committed to master 2026-08-01) removed the LPD-17564 gate that had disabled the CMS `ObjectEntryFolderModelListener`, so the listener now runs for company scoped object entry folders it was never designed to service.

## How It Is Being Fixed

Return null for a company scoped folder at the top of the method, before the object definition lookup and the parent inheritance branch.

Guarding at the top rather than immediately before the `getGroup` call is safe: every statement skipped is declared `@Transactional(readOnly = true)` with no side effect, and the fetched object definition is only an existence probe. Because `getGroup(0)` always threw, no company scoped folder ever completed that branch successfully, so the guard can only turn an exception into null.

Returning early also closes an unintended cross scope match. `L_CMS_DEFAULT_PERMISSION` is a company scoped object definition, so `ObjectEntrySearchUtil.getObjectEntryIndexPredicate` pins the parent inheritance lookup to the company id and to group id 0 and never consults the caller's group ids, leaving the external reference code as the only discriminator. A company scoped folder whose parent shares an external reference code with a space folder holding stored default permissions would otherwise inherit that space's permissions.

## Testing

A/B across two Testray builds that share the same base `b455e4a152322`: on build `505487123` (no guard) `DefaultObjectEntryManagerImplTest` failed both `testAddObjectEntryWithMissingObjectEntryFolderReference` and `testToObjectEntry`; on build `505863622` (this change, run in isolation as shuyangzhou#12409) only `testToObjectEntry` fails. The folder reference test is turned green by this change. The remaining `testToObjectEntry` failure is a separate LPD-99210 action set mismatch — the expected map at the base contains no `get-by-scope` key at all — and is tracked elsewhere.

`CMSDefaultPermissionUtilTest` and the other test classes that directly exercise this utility and its listener all pass on that build.

Both CI batches from #12409 were triaged case by case against Testray history and against master acceptance build `505664587` (`EE Development Acceptance (master) - 22`), whose SHA is that same base:

- `ci:test:object` `505863622`, 106 non-passed. All 7 Java failures are explained by fixes absent from the base. The 47 Poshi failures are a byte-identical name set with byte-identical error text versus the guardless build; Playwright differs by 6 names, all browser level (`net::ERR_ABORTED`, execution context destroyed, `dragTo` timeout).
- `ci:test:relevant` `505884475`, 48 non-passed. All five `modules/apps/site` Java failures are red on the base itself, with independent causes pinned to LPD-100130 `48e3e7f3eeedd`, LPD-100486 `e85c2871efa73` and LPD-100516 `b6526b71a2b78`. `modules-compile[modules/apps/site]` reporting UNTESTED is a Testray bookkeeping artifact (`ModulesBatchBuildTestrayCaseResult:132-158` emits it when the Jenkins job succeeded but no per module directory report exists); the compile job itself passed, and the roughly 37 "testIntegration was not executed" rows are its cascade. The four `PortalLogAssertorTest` axes are the known chronic case; axis 0/2 logs a `NoSuchGroupException` for a ghost group, not for group 0.

## Follow-Up

`ResetAssetPermissionUtil.java:124-151` still holds an unguarded copy of the same parent-branch-then-`getGroup` shape, so this change does not remove every company scope `NoSuchGroupException` path.

## PR Check

**pr-check: PASS** — tested on `281d0f46565840cca0a72a60bb9a414d47b264c6`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

Baseline ran on `site-cms-site-initializer-api` (`Export-Package` present, `Bundle-Version` 4.5.0) with `--rerun-tasks --no-build-cache` and produced no report; the change adds no `public` or `protected` member, so no version bump is owed. Integration Test Compile is `NO-SOURCE` for the changed module, so Cross-Module Compile carried the real signal across the three `testIntegration` consumers of `CMSDefaultPermissionUtil`: `bulk-rest-test`, `headless-cms-test` and `site-cms-site-initializer-test`. Java Unit Tests has nothing to run — the module has no `src/test`, and the `CMSDefaultPermissionUtilTest` counterpart is an integration test.

<!-- pr-check {"result": "success", "sha": "281d0f46565840cca0a72a60bb9a414d47b264c6"} -->
