### PR TITLE
LPD-100923 Reset the instance default language robustly in the teardown

### DIFF
--- a/modules/test/playwright/tests/site-admin-web/main/fixtures/localizationPagesTest.ts
+++ b/modules/test/playwright/tests/site-admin-web/main/fixtures/localizationPagesTest.ts
@@ -15,14 +15,34 @@ const localizationPagesTest = test.extend<{
 		await use(new LocalizationInstanceSettingsPage(page));
 	},
 	restoreInstanceDefaultLanguage: async (
-		{localizationInstanceSettingsPage},
+		{localizationInstanceSettingsPage, page},
 		use
 	) => {
 		try {
 			await use();
 		}
 		finally {
+
+			// Render the admin UI in English regardless of the current
+			// instance default language, so the settings navigation and
+			// controls resolve when the test left the instance in another
+			// language.
+
+			const response = await page.request.get(
+				'/o/headless-admin-user/v1.0/my-user-account'
+			);
+
+			const myUserAccount = await response.json();
+
+			await page.request.patch(
+				`/o/headless-admin-user/v1.0/user-accounts/${myUserAccount.id}`,
+				{data: {languageId: 'en_US'}}
+			);
+
+			await page.reload();
+
 			await localizationInstanceSettingsPage.goto('Language', false);
+
 			await localizationInstanceSettingsPage.setDefaultLanguage('en_US');
 		}
 	},


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100923

## What Is Being Fixed

The `restoreInstanceDefaultLanguage` Playwright teardown reset the instance default language by navigating the Instance Settings localization UI and selecting `en_US`, but that navigation and the Default Language control are located by their English labels. When a test left the instance in another language, those labels rendered in that language, so the reset could not find its own controls and timed out, leaving the instance in the changed language. Because the object-web Playwright run shares one bundle across every project (CI isolates per batch), a leaked `pt_BR` default then cascaded into unrelated tests whose English label locators no longer matched.

Root cause: LPD-82332 `0025089e30a07` ("Applying code review changes", 2026-03-31) introduced the fixture already in this form, in the same commit that added the tests which set the instance default to `pt_BR` through it — so it was born unable to undo its own language change.

## How It Is Being Fixed

Patch the current user's `languageId` to `en_US` through the authenticated `headless-admin-user` request (`my-user-account` then `user-accounts/{id}`) before the reset, so the admin UI renders in English regardless of the instance default and the settings navigation and Default Language control resolve.

## PR Check

**pr-check: PASS** — tested on `07f0bfb65cbc9979df27261de1501c9bb202d8a4`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "07f0bfb65cbc9979df27261de1501c9bb202d8a4"} -->
