### PR TITLE
LPD-100929 Expect the full object entry action set in testToObjectEntry

### DIFF
--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -8985,15 +8985,31 @@ public class DefaultObjectEntryManagerImplTest
 
 		Map<String, Map<String, String>> objectEntryActions =
 			HashMapBuilder.<String, Map<String, String>>put(
+				"copy", Collections.emptyMap()
+			).put(
+				"copy-replace", Collections.emptyMap()
+			).put(
 				"delete", Collections.emptyMap()
+			).put(
+				"duplicate", Collections.emptyMap()
 			).put(
 				"expire", Collections.emptyMap()
 			).put(
 				"get", Collections.emptyMap()
 			).put(
+				"get-by-scope", Collections.emptyMap()
+			).put(
+				"move", Collections.emptyMap()
+			).put(
+				"move-replace", Collections.emptyMap()
+			).put(
 				"permissions", Collections.emptyMap()
 			).put(
 				"replace", Collections.emptyMap()
+			).put(
+				"restore", Collections.emptyMap()
+			).put(
+				"share", Collections.emptyMap()
 			).put(
 				"update", Collections.emptyMap()
 			).put(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100929

## What Is Being Fixed

`DefaultObjectEntryManagerImplTest.testToObjectEntry` compared each object entry's actions against a hardcoded expected map that omitted `copy`, `copy-replace`, `duplicate`, `get-by-scope`, `move`, `move-replace`, `restore` and `share`. `DefaultObjectEntryManagerImpl` now produces those actions unconditionally for an entry the caller can act on, and the assertion requires every actual action key to be present in the expected map, so the test failed.

Root cause: LPD-99210 `a57a60eb394d0` ("Remove the LPD-17564 feature flag checks", committed to master 2026-08-01) removed the LPD-17564 guards from the object entry action suppliers in `DefaultObjectEntryManagerImpl`, so the previously gated actions are now always produced. The test's expected map still listed only the feature-flag-off subset.

## How It Is Being Fixed

List the full set of object entry actions the manager produces in the expected map (a test-only change adding the eight omitted keys).

## PR Check

**pr-check: PASS** — tested on `7025e9042fef3d0e1c2dd9fc7ecd34e0554025d1`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "7025e9042fef3d0e1c2dd9fc7ecd34e0554025d1"} -->
