### PR TITLE
LPD-101043 Make the CMS object entry folder cleanup tolerate an absent folder

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/ObjectEntryFolderUtil.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/ObjectEntryFolderUtil.java
@@ -64,14 +64,12 @@ public class ObjectEntryFolderUtil {
 					setForceDeleteSystemObjectEntryFolderWithSafeCloseable(
 						true)) {
 
-			ObjectEntryFolderLocalServiceUtil.
-				deleteObjectEntryFolderByExternalReferenceCode(
-					ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS,
-					depotEntry.getGroupId(), depotEntry.getCompanyId());
-			ObjectEntryFolderLocalServiceUtil.
-				deleteObjectEntryFolderByExternalReferenceCode(
-					ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_FILES,
-					depotEntry.getGroupId(), depotEntry.getCompanyId());
+			_deleteObjectEntryFolder(
+				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS,
+				depotEntry);
+			_deleteObjectEntryFolder(
+				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_FILES,
+				depotEntry);
 		}
 	}
 
@@ -149,6 +147,22 @@ public class ObjectEntryFolderUtil {
 				TempFileEntryUtil.class.getName(), StringPool.BLANK,
 				TempFileEntryUtil.class.getName(), new UnicodeProperties(),
 				true, serviceContext);
+		}
+	}
+
+	private static void _deleteObjectEntryFolder(
+			String externalReferenceCode, DepotEntry depotEntry)
+		throws PortalException {
+
+		ObjectEntryFolder objectEntryFolder =
+			ObjectEntryFolderLocalServiceUtil.
+				fetchObjectEntryFolderByExternalReferenceCode(
+					externalReferenceCode, depotEntry.getGroupId(),
+					depotEntry.getCompanyId());
+
+		if (objectEntryFolder != null) {
+			ObjectEntryFolderLocalServiceUtil.deleteObjectEntryFolder(
+				objectEntryFolder);
 		}
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101043

## What Is Being Fixed

`ObjectEntryFolderUtil.deleteObjectEntryFolders` deleted the CMS Contents and Files system folders through the throwing `deleteObjectEntryFolderByExternalReferenceCode`. When a folder is already gone, `findByERC_G_C` raises `NoSuchObjectEntryFolderException`, which the depot `GroupModelListener` commit callback surfaces as an "Unable to execute transaction callback" ERROR in the log of otherwise passing integration tests.

Reproduced twice from a clean environment by running the full `ObjectEntryResourceTest`. Folder lifecycle probes showed the absent folder is a DataGuard teardown artifact, not a production state: at `afterClass`, DataGuard's `smartDelete` calls the service delete on the leaked system folder, the `L_` system-folder guard rejects it with `RequiredObjectEntryFolderException`, and DataGuard falls back to a raw `session.delete` of the row. DataGuard then deletes the leaked group, whose depot `GroupModelListener.onAfterRemove` commit callback deletes the depot entry, driving `deleteObjectEntryFolders` against the folder DataGuard already removed. Production removes these folders only through the same wrapper, so it never observes an absent one.

## How It Is Being Fixed

Make `deleteObjectEntryFolders` idempotent: fetch each folder and delete it only when present, mirroring the idempotent `_addObjectEntryFolder` in the same class and the tolerance DataGuard's own `smartDelete` already applies when it refetches a leftover and finds it gone. The load-bearing depot commit callback (LPS-122464) is left untouched.

## PR Check

**pr-check: PASS** — tested on `370006fd06aa62a60ace76b037e264e582b65188`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Baseline | PASS |
| Per-Module Compile | PASS |

<!-- pr-check {"result": "success", "sha": "370006fd06aa62a60ace76b037e264e582b65188"} -->
