### PR TITLE
LPD-101017 Restore the CodeMirror symbols for the CKEditor build

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/node-scripts.config.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/node-scripts.config.js
@@ -98,6 +98,14 @@ module.exports = {
 	],
 	main: './src/main/resources/META-INF/resources/js/index.ts',
 	symbols: {
+		'@codemirror/autocomplete': ['*'],
+		'@codemirror/commands': ['*'],
+		'@codemirror/lang-html': ['*'],
+		'@codemirror/lang-markdown': ['*'],
+		'@codemirror/language': ['*'],
+		'@codemirror/state': ['*'],
+		'@codemirror/theme-one-dark': ['*'],
+		'@codemirror/view': ['*'],
 		'frontend-editor-ckeditor-web/plugins/DocumentLinkSelector': [
 			'default',
 		],

--- a/modules/node-scripts.config.js
+++ b/modules/node-scripts.config.js
@@ -10,7 +10,7 @@
  */
 
 module.exports = {
-	hash: '88474fa0a0ccfde8360345e128a3830689f15d65027be7d3ec22391e26046507',
+	hash: '02af141ac4c76a96102d8ea45680fb91bcfb31519feede94f6d0b17167594c64',
 	imports: {
 		'@liferay/accessibility-menu-web': [],
 		'@liferay/accessibility-settings-state-web': [],
@@ -577,6 +577,14 @@ module.exports = {
 			'__UNSTABLE_DataClient',
 			'useProvider',
 		],
+		'@codemirror/autocomplete': ['*'],
+		'@codemirror/commands': ['*'],
+		'@codemirror/lang-html': ['*'],
+		'@codemirror/lang-markdown': ['*'],
+		'@codemirror/language': ['*'],
+		'@codemirror/state': ['*'],
+		'@codemirror/theme-one-dark': ['*'],
+		'@codemirror/view': ['*'],
 		'frontend-editor-ckeditor-web/plugins/DocumentLinkSelector': [
 			'default',
 		],


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101017

## What Is Being Fixed

A merge collision dropped the eight `@codemirror/*` symbol overrides from `modules/node-scripts.config.js`, breaking the frontend-editor-ckeditor-web build. The overrides are needed because the CodeMirror packages cannot be required from Node.js, so the build cannot infer the symbols they export.

## How It Is Being Fixed

The overrides are declared in `frontend-editor-ckeditor-web/node-scripts.config.js`, the module that exports those packages, rather than in the generated global config. The global `modules/node-scripts.config.js` is marked `AUTO-GENERATED: DO NOT EDIT` and is rebuilt from every module's own config, with a `hash` field holding a sha256 of the merged imports and symbols, so entries written directly into it are dropped on the next regeneration and leave the freshness check reporting the file as outdated. Declaring the symbols at the source and regenerating makes the fix reproducible and brings the hash back in sync.

## Why Are There No Tests?

This restores a build-configuration entry lost in a merge collision; the frontend-editor-ckeditor-web build itself is the verification and is exercised by CI.

## PR Check

**pr-check: SKIPPED** — The branch is based on brian/master, so local master is not a valid diff baseline and the skill's rebase precondition would rewrite 358 unrelated commits. The global node-scripts config freshness check and the source format check were instead run directly on the two changed files, and both pass.

<!-- pr-check {"reason": "The branch is based on brian/master, so local master is not a valid diff baseline and the skill's rebase precondition would rewrite 358 unrelated commits. The global node-scripts config freshness check and the source format check were instead run directly on the two changed files, and both pass.", "result": "skipped", "sha": "76b2ab766475211af18e059d2907dad4468f0c34"} -->
