### PR TITLE
LPD-101066 Guard the SugarCRM object entry filter against a null filter string

### DIFF
--- a/modules/apps/object/object-storage-sugarcrm/src/main/java/com/liferay/object/storage/sugarcrm/internal/rest/manager/v1_0/SugarCRMObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-storage-sugarcrm/src/main/java/com/liferay/object/storage/sugarcrm/internal/rest/manager/v1_0/SugarCRMObjectEntryManagerImpl.java
@@ -190,11 +190,11 @@ public class SugarCRMObjectEntryManagerImpl
 		StringBuilder sb, ObjectDefinition objectDefinition,
 		String filterString) {
 
-		filterString = StringUtil.trim(filterString);
-
-		if (filterString.isEmpty()) {
+		if (Validator.isNull(filterString)) {
 			return;
 		}
+
+		filterString = StringUtil.trim(filterString);
 
 		sb.append("&filter");
 		sb.append(StringPool.EQUAL);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101066

## What Is Being Fixed

`SugarCRMObjectEntryManagerImpl._appendFilter` trimmed the filter string with `StringUtil.trim` and then called `isEmpty` on it. `StringUtil.trim` returns `null` for a `null` input, so a null filter string threw a `NullPointerException` on the `isEmpty` call. The filter string is optional — `ObjectEntryResourceImpl._getFilterString` returns `null` when there is no request URI info, and `ObjectDefinitionGraphQLDTOContributor` passes the `"filter"` attribute which is `null` when the query has no filter — so a filter-less REST or GraphQL read of a SugarCRM backed object definition reached `_appendFilter` with a null filter string and failed.

Root cause: LPD-6987 `da99c26368c61` (2024-04-03) created the connector with `_appendFilter` written as `if (!filterString.trim().isEmpty())`, assuming a non-null filter string with no null guard. LPD-11274 `e5ed7189e7836` later replaced `String.trim()` with `StringUtil.trim(filterString)`, which only moved the `NullPointerException` from the trim call to the `isEmpty` call. The `SugarCRMObjectEntryManagerImplTest` authentication probe (LPD-100422) calls `getObjectEntries` with a null filter string, which reached `_appendFilter` and surfaced the born-broken `NullPointerException` as a hard test failure the `ObjectEntryManagerHttpException` catch cannot skip.

## How It Is Being Fixed

Return early when the filter string is null, using `Validator.isNull`, before trimming it.

## PR Check

**pr-check: PASS** — tested on `2ac73c2dad739676ebed55d344470443c245db44`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Baseline | PASS |
| Per-Module Compile | PASS |

<!-- pr-check {"result": "success", "sha": "2ac73c2dad739676ebed55d344470443c245db44"} -->
