### PR TITLE
LPD-101071 Expect the CMS Administrator regular role in the email notification roles test

### DIFF
--- a/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/web/internal/portlet/action/test/GetEmailNotificationRolesMVCResourceCommandTest.java
+++ b/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/web/internal/portlet/action/test/GetEmailNotificationRolesMVCResourceCommandTest.java
@@ -175,6 +175,7 @@ public class GetEmailNotificationRolesMVCResourceCommandTest {
 					JSONUtil.put("name", DSRRoleConstants.NAME_DSR_SELLER),
 					JSONUtil.put("name", RoleConstants.ADMINISTRATOR),
 					JSONUtil.put("name", RoleConstants.ANALYTICS_ADMINISTRATOR),
+					JSONUtil.put("name", RoleConstants.CMS_ADMINISTRATOR),
 					JSONUtil.put("name", RoleConstants.OWNER),
 					JSONUtil.put("name", RoleConstants.PORTAL_CONTENT_REVIEWER),
 					JSONUtil.put("name", RoleConstants.POWER_USER),


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101071

## What Is Being Fixed

`GetEmailNotificationRolesMVCResourceCommandTest` hardcodes the set of regular roles the email notification roles endpoint returns for a company and asserted 16, but every company now has 17: the CMS site initializer provisions a `CMS Administrator` regular role per company, so the endpoint returned a role the test did not expect and JSONAssert failed with `regularRoles[]: Expected 16 values but got 17`.

Root cause: this got broken later by LPD-99210. Before `a57a60eb394d0` ("Remove the LPD-17564 feature flag checks", 2026-08-01) the CMS site initializer was behind the LPD-17564 feature flag and did not provision for a default company, so the endpoint returned 16 regular roles and the test passed. That change removed the flag and made CMS provision per company by default, creating the `CMS Administrator` regular role everywhere, but it did not update this test's hardcoded expectation. This is the same class of failure as LPD-99914 `0ebc902f5f62`, which added `DSR Seller` after LPD-97613 `4d0719bb3df4` removed the DSR feature flag.

## How It Is Being Fixed

Add `CMS Administrator` (`RoleConstants.CMS_ADMINISTRATOR`) to the expected regular roles.

## PR Check

**pr-check: PASS** — tested on `e067a3adc497446d20917a534bb7600b48aac33b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "e067a3adc497446d20917a534bb7600b48aac33b"} -->
