### PR TITLE
LPD-101115 Provision the commerce order notification template as a system template

### DIFF
--- a/modules/apps/commerce/commerce-notification-service/src/main/java/com/liferay/commerce/notification/internal/instance/lifecycle/AddCommerceOrderNotificationPortalInstanceLifecycleListener.java
+++ b/modules/apps/commerce/commerce-notification-service/src/main/java/com/liferay/commerce/notification/internal/instance/lifecycle/AddCommerceOrderNotificationPortalInstanceLifecycleListener.java
@@ -11,11 +11,13 @@ import com.liferay.notification.rest.dto.v1_0.util.NotificationUtil;
 import com.liferay.notification.service.NotificationTemplateLocalService;
 import com.liferay.notification.type.NotificationType;
 import com.liferay.notification.type.NotificationTypeServiceTracker;
+import com.liferay.object.definition.util.ObjectDefinitionThreadLocal;
 import com.liferay.object.model.ObjectAction;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.service.ObjectActionLocalService;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.instance.lifecycle.BasePortalInstanceLifecycleListener;
@@ -128,8 +130,13 @@ public class AddCommerceOrderNotificationPortalInstanceLifecycleListener
 			NotificationUtil.toNotificationTemplate(
 				0L, notificationTemplate, _objectDefinitionLocalService, user));
 
-		_notificationTemplateLocalService.addNotificationTemplate(
-			notificationContext);
+		try (SafeCloseable safeCloseable =
+				ObjectDefinitionThreadLocal.
+					setSkipBundleAllowedCheckWithSafeCloseable(true)) {
+
+			_notificationTemplateLocalService.addNotificationTemplate(
+				notificationContext);
+		}
 	}
 
 	private void _verifyCommerceOrderObjectAction(long companyId)

--- a/modules/apps/commerce/commerce-notification-service/src/main/resources/com/liferay/commerce/notification/internal/instance/lifecycle/dependencies/notification-template.json
+++ b/modules/apps/commerce/commerce-notification-service/src/main/resources/com/liferay/commerce/notification/internal/instance/lifecycle/dependencies/notification-template.json
@@ -26,7 +26,7 @@
 	"subject": {
 		"en_US": "Order #[%COMMERCEORDER_ID%]"
 	},
-	"system": false,
+	"system": true,
 	"type": "email",
 	"typeLabel": "Email"
 }


### PR DESCRIPTION
[LPD-101115](https://liferay.atlassian.net/browse/LPD-101115)

## What Is Being Fixed

`AddCommerceOrderNotificationPortalInstanceLifecycleListener` provisions the `L_COMMERCE_ORDER_TEMPLATE` notification template for every company at startup, but the call throws and the listener swallows the exception, so the template is silently never created. `CompanyModelListenerTest.testOnBeforeRemove` then fails asserting the template exists for the default company (a `Common` failure on CI, e.g. Testray build 506136031).

## How It Is Being Fixed

The notification framework enforces two guards in `addNotificationTemplate`: the reserved `L_` external reference code prefix (`EXTERNAL_REFERENCE_CODE_PREFIX_SYSTEM_NOTIFICATION_TEMPLATE`) is only allowed on a system template, and a system template may only be added by an allowed invoker. The template shipped `"system": false`, so it was rejected with `MustNotStartWithPrefix`; marking it system exposes the invoker-bundle guard because the listener adds directly (not through the batch engine that the allowlist recognizes).

The fix sets `"system": true` on the commerce order `notification-template.json` (the `L_` prefix is the reserved system-template prefix, so an `L_` template is a system template by the framework's own rule) and wraps the direct `addNotificationTemplate` call in `ObjectDefinitionThreadLocal.setSkipBundleAllowedCheckWithSafeCloseable(true)`, the same trusted-internal-provisioner pattern used by `ObjectFieldModelListener` and `ObjectActionLocalServiceImpl`. Merchants keep subject, body, and recipient editability; only the name and from address are protected and the template becomes non-deletable, which is appropriate for a Liferay-provisioned default.

Root cause: LPD-97613 `4d0719bb3df4177a3d539e48066b28e55ab276a6` ("Remove FF") removed the `!FeatureFlagManagerUtil.isEnabled(companyId, "LPD-66359")` bypass that had allowed this non-system `L_` template, replacing it with a narrow escape hatch that only permits the prefix when a `GroupConstants.DSR` group exists. No DSR site exists in a plain portal, so after that change the commerce order notification template could never be provisioned. The prefix reservation itself was introduced by LPD-60998 `895b6e534383f`.

## PR Check

**pr-check: PASS** — tested on `51fadad506dc6b0a3b0816c0625b987b77bd7555`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |

<!-- pr-check {"result": "success", "sha": "51fadad506dc6b0a3b0816c0625b987b77bd7555"} -->
