### PR TITLE
LPD-101152 Guard the friendly URL batch portlet data handler check against an unresolvable class name

### DIFF
--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
@@ -886,6 +886,10 @@ public class FriendlyURLEntryLocalServiceImpl
 
 		String className = _portal.fetchClassName(classNameId);
 
+		if (Validator.isNull(className)) {
+			return false;
+		}
+
 		String[] classNames = StringUtil.split(
 			className, ResourceActionsUtil.getCompositeModelNameSeparator());
 


### PR DESCRIPTION
[LPD-101152](https://liferay.atlassian.net/browse/LPD-101152)

## What Is Being Fixed

`FriendlyURLEntryLocalServiceImpl._isBatchPortletDataHandler` read `_portal.fetchClassName(classNameId)`, split it, and indexed `classNames[0]` without checking the class name resolved. During a batch import that creates object entries for an object definition with a custom friendly URL separator, the class name id resolves to `0` (see below), `fetchClassName(0)` returns an empty string, `StringUtil.split("")` returns an empty array, and `classNames[0]` throws `ArrayIndexOutOfBoundsException`. The batch executor logs it as an ERROR, so `PortalLogAssertorTest.testScanXMLLog` fails.

## How It Is Being Fixed

Guard the check: if the class name is null or blank, return `false`. A model whose class name cannot be resolved is, by definition, not a batch portlet data handler, so `false` is the correct answer for object entries and the array index no longer throws.

Why the id is `0`: the caller passes `getClassNameId(objectDefinition.getClassName())`; `ClassNameLocalServiceImpl.getClassName(value)` returns the null-ClassName sentinel (id 0) when the value is blank, and `_getClassName` returns the class name as-is (including blank) for an unmodifiable system object — so a system object definition provisioned with an empty `className` keeps it blank while its entries and friendly URLs are created.

Root cause: born broken in `fdb2d324829cb` (LPD-74703), which added `_isBatchPortletDataHandler` and the `isBatchImportInProcess()` branch that indexes `classNames[0]` with no guard for an unresolvable class name.

## PR Check

**pr-check: PASS** — tested on `329428e7fd80e8a3831069c1295ca94b71f94307`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |

<!-- pr-check {"result": "success", "sha": "329428e7fd80e8a3831069c1295ca94b71f94307"} -->
