### PR TITLE
LPD-101167 Assert the code.jsp 404 warning in attachment URL tests

### DIFF
--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -218,6 +218,7 @@ import com.liferay.portal.spring.hibernate.PortletTransactionManager;
 import com.liferay.portal.spring.transaction.TransactionExecutor;
 import com.liferay.portal.spring.transaction.TransactionInterceptor;
 import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
 import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.FeatureFlags;
@@ -19121,25 +19122,43 @@ public class ObjectEntryResourceTest {
 
 		// Documents and media source, file from URL not found
 
+		String notFoundPath = "/" + RandomTestUtil.randomString();
+
 		String httpCode404URL = StringBundler.concat(
 			"http://", company.getVirtualHostname(), ":",
-			PortalUtil.getPortalServerPort(false), "/",
-			RandomTestUtil.randomString());
+			PortalUtil.getPortalServerPort(false), notFoundPath);
 
-		_testPatchPutCustomObjectEntryWithAttachmentField(
-			fileEntry -> JSONUtil.put(
-				"status", "BAD_REQUEST"
-			).put(
-				"title",
-				"Unable to download file from " + httpCode404URL +
-					", unexpected HTTP code: 404"
-			),
-			_toFileEntry(
-				RandomTestUtil.randomString() + ".txt", httpCode404URL, null,
-				null, customFileEntry1.getMimeType()),
-			httpMethod, null, objectDefinition,
-			_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE,
-			useExternalReferenceCode);
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"portal_web.docroot.errors.code_jsp", LoggerTestUtil.WARN)) {
+
+			_testPatchPutCustomObjectEntryWithAttachmentField(
+				fileEntry -> JSONUtil.put(
+					"status", "BAD_REQUEST"
+				).put(
+					"title",
+					"Unable to download file from " + httpCode404URL +
+						", unexpected HTTP code: 404"
+				),
+				_toFileEntry(
+					RandomTestUtil.randomString() + ".txt", httpCode404URL,
+					null, null, customFileEntry1.getMimeType()),
+				httpMethod, null, objectDefinition,
+				_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE,
+				useExternalReferenceCode);
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
+
+			LogEntry logEntry = logEntries.get(0);
+
+			Assert.assertEquals(LoggerTestUtil.WARN, logEntry.getPriority());
+
+			String message = logEntry.getMessage();
+
+			Assert.assertTrue(message, message.contains("code=\"404\""));
+			Assert.assertTrue(message, message.contains("uri=" + notFoundPath));
+		}
 
 		// Documents and media source, file from URL with unsupported protocol
 
@@ -20095,24 +20114,43 @@ public class ObjectEntryResourceTest {
 
 		// Documents and media source, file from URL not found
 
+		String notFoundPath = "/" + RandomTestUtil.randomString();
+
 		String resourceNotFoundFileURL = StringBundler.concat(
 			"http://", company.getVirtualHostname(), ":",
-			PortalUtil.getPortalServerPort(false), "/",
-			RandomTestUtil.randomString());
+			PortalUtil.getPortalServerPort(false), notFoundPath);
 
-		_testPostCustomObjectEntryWithAttachmentObjectField(
-			fileEntry -> JSONUtil.put(
-				"status", "BAD_REQUEST"
-			).put(
-				"title",
-				"Unable to download file from " + resourceNotFoundFileURL +
-					", unexpected HTTP code: 404"
-			),
-			_toFileEntry(
-				RandomTestUtil.randomString() + ".txt", resourceNotFoundFileURL,
-				null, _group.getGroupId(), customFileEntry1.getMimeType()),
-			null, objectDefinition,
-			_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE);
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"portal_web.docroot.errors.code_jsp", LoggerTestUtil.WARN)) {
+
+			_testPostCustomObjectEntryWithAttachmentObjectField(
+				fileEntry -> JSONUtil.put(
+					"status", "BAD_REQUEST"
+				).put(
+					"title",
+					"Unable to download file from " + resourceNotFoundFileURL +
+						", unexpected HTTP code: 404"
+				),
+				_toFileEntry(
+					RandomTestUtil.randomString() + ".txt",
+					resourceNotFoundFileURL, null, _group.getGroupId(),
+					customFileEntry1.getMimeType()),
+				null, objectDefinition,
+				_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE);
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
+
+			LogEntry logEntry = logEntries.get(0);
+
+			Assert.assertEquals(LoggerTestUtil.WARN, logEntry.getPriority());
+
+			String message = logEntry.getMessage();
+
+			Assert.assertTrue(message, message.contains("code=\"404\""));
+			Assert.assertTrue(message, message.contains("uri=" + notFoundPath));
+		}
 
 		// Documents and media source, file from URL with unsupported protocol
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101167

## What Is Being Fixed

`ObjectEntryResourceTest` has two "file from URL not found" negative cases that make a real HTTP GET against a random path on the running portal. The portal answers with a 404 rendered by `portal-web/docroot/errors/code.jsp`, which logs the 404 at WARN under the logger `portal_web.docroot.errors.code_jsp`. When `ObjectEntryResourceTest` shares the modules-integration batch with `PortalLogAssertorTest`, that scanner reads the XML log and fails on the leaked WARN, so the failure is order-dependent and only appears in the shared batch.

The neighboring host-down and malformed-URL cases already capture the `DefaultObjectEntryManagerImpl` ERROR logger, but the two 404 subcases had no capture because the 404 path logs on a server request thread through `code.jsp` rather than through the manager. The gap was born under LPD-40575 (2024-12-23).

## How It Is Being Fixed

Wrap each 404 case in a `portal_web.docroot.errors.code_jsp` capture at WARN and assert the resulting `LogEntry`: exactly one WARN whose message carries the 404 code and the request URI. Capturing at WARN records the entry for the assertion and, because `configureLog4JLogger` sets the logger non-additive for the scope, also keeps the WARN out of the file appender that `PortalLogAssertorTest` scans. Asserting the entry rather than silently swallowing it proves each case triggers precisely the expected 404 and that nothing else leaks. The form mirrors the existing `PortalErrorCodeTest.testAccessErrorsCodeJsp` precedent.

## PR Check

**pr-check: PASS** — tested on `9c22417da4a5d1a5e6c6dfd324b3dbd132ca60d0`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result":"success","sha":"9c22417da4a5d1a5e6c6dfd324b3dbd132ca60d0"} -->
