### PR TITLE
LPD-101178 Serialize ServiceWrapper application on the AOP handler

### DIFF
--- a/modules/apps/staging/staging-impl/src/main/java/com/liferay/staging/internal/service/StagingAdviceUtil.java
+++ b/modules/apps/staging/staging-impl/src/main/java/com/liferay/staging/internal/service/StagingAdviceUtil.java
@@ -21,6 +21,7 @@ import java.lang.reflect.InvocationHandler;
 import java.util.function.Function;
 
 import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
 
 /**
  * @author Dante Wang
@@ -36,20 +37,25 @@ public class StagingAdviceUtil {
 			ProxyUtil.fetchInvocationHandler(
 				service, AopInvocationHandler.class);
 
-		ServiceBag<?> serviceBag = new ServiceBag(
-			aopInvocationHandler, serviceClass,
-			(ServiceWrapper<?>)ProxyUtil.newProxyInstance(
-				AggregateClassLoader.getAggregateClassLoader(
-					PortalClassLoaderUtil.getClassLoader(),
-					StagingAdviceUtil.class.getClassLoader()),
-				new Class<?>[] {
-					IdentifiableOSGiService.class, serviceClass,
-					BaseLocalService.class, ServiceWrapper.class
-				},
-				function.apply(aopInvocationHandler.getTarget())),
-			bundleContext, bundleContext.getServiceReference(serviceClass));
+		ServiceReference<T> serviceReference =
+			bundleContext.getServiceReference(serviceClass);
 
-		return serviceBag::replace;
+		synchronized (aopInvocationHandler) {
+			ServiceBag<?> serviceBag = new ServiceBag(
+				aopInvocationHandler, serviceClass,
+				(ServiceWrapper<?>)ProxyUtil.newProxyInstance(
+					AggregateClassLoader.getAggregateClassLoader(
+						PortalClassLoaderUtil.getClassLoader(),
+						StagingAdviceUtil.class.getClassLoader()),
+					new Class<?>[] {
+						IdentifiableOSGiService.class, serviceClass,
+						BaseLocalService.class, ServiceWrapper.class
+					},
+					function.apply(aopInvocationHandler.getTarget())),
+				bundleContext, serviceReference);
+
+			return serviceBag::replace;
+		}
 	}
 
 }

--- a/portal-impl/src/com/liferay/portal/deploy/hot/ServiceBag.java
+++ b/portal-impl/src/com/liferay/portal/deploy/hot/ServiceBag.java
@@ -73,8 +73,64 @@ public class ServiceBag<V> {
 		_serviceWrapper = (ServiceWrapper<?>)nextTarget;
 	}
 
+	public void replace() {
+		synchronized (_aopInvocationHandler) {
+			_replace();
+		}
+
+		if (_serviceReference != null) {
+			_bundleContext.ungetService(_serviceReference);
+		}
+	}
+
+	private ClassLoader _getClassLoader(
+		ClassLoader classLoader, Class<?> clazz) {
+
+		try {
+			if ((classLoader == clazz.getClassLoader()) ||
+				(clazz == classLoader.loadClass(clazz.getName()))) {
+
+				return classLoader;
+			}
+		}
+		catch (ClassNotFoundException classNotFoundException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					"Unable to load class " + clazz, classNotFoundException);
+			}
+		}
+
+		return AggregateClassLoader.getAggregateClassLoader(
+			classLoader, clazz.getClassLoader());
+	}
+
+	private boolean _isLiferayOwned(Object object) {
+		Class<?> clazz = object.getClass();
+
+		String className = clazz.getName();
+
+		if (className.startsWith("com.liferay.")) {
+			return true;
+		}
+
+		InvocationHandler invocationHandler = ProxyUtil.fetchInvocationHandler(
+			object, InvocationHandler.class);
+
+		if (invocationHandler != null) {
+			clazz = invocationHandler.getClass();
+
+			className = clazz.getName();
+
+			if (className.startsWith("com.liferay.")) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 	@SuppressWarnings("unchecked")
-	public <T> void replace() {
+	private <T> void _replace() {
 		Object currentService = _aopInvocationHandler.getTarget();
 
 		ServiceWrapper<T> previousService = null;
@@ -137,56 +193,6 @@ public class ServiceBag<V> {
 
 			currentService = previousService.getWrappedService();
 		}
-
-		if (_serviceReference != null) {
-			_bundleContext.ungetService(_serviceReference);
-		}
-	}
-
-	private ClassLoader _getClassLoader(
-		ClassLoader classLoader, Class<?> clazz) {
-
-		try {
-			if ((classLoader == clazz.getClassLoader()) ||
-				(clazz == classLoader.loadClass(clazz.getName()))) {
-
-				return classLoader;
-			}
-		}
-		catch (ClassNotFoundException classNotFoundException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(
-					"Unable to load class " + clazz, classNotFoundException);
-			}
-		}
-
-		return AggregateClassLoader.getAggregateClassLoader(
-			classLoader, clazz.getClassLoader());
-	}
-
-	private boolean _isLiferayOwned(Object object) {
-		Class<?> clazz = object.getClass();
-
-		String className = clazz.getName();
-
-		if (className.startsWith("com.liferay.")) {
-			return true;
-		}
-
-		InvocationHandler invocationHandler = ProxyUtil.fetchInvocationHandler(
-			object, InvocationHandler.class);
-
-		if (invocationHandler != null) {
-			clazz = invocationHandler.getClass();
-
-			className = clazz.getName();
-
-			if (className.startsWith("com.liferay.")) {
-				return true;
-			}
-		}
-
-		return false;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(ServiceBag.class);

--- a/portal-impl/src/com/liferay/portal/deploy/hot/ServiceWrapperRegistry.java
+++ b/portal-impl/src/com/liferay/portal/deploy/hot/ServiceWrapperRegistry.java
@@ -112,12 +112,14 @@ public class ServiceWrapperRegistry {
 				ProxyUtil.fetchInvocationHandler(
 					serviceProxy, AopInvocationHandler.class);
 
-			serviceWrapper.setWrappedService(
-				(T)aopInvocationHandler.getTarget());
+			synchronized (aopInvocationHandler) {
+				serviceWrapper.setWrappedService(
+					(T)aopInvocationHandler.getTarget());
 
-			return new ServiceBag<>(
-				aopInvocationHandler, serviceTypeClass, serviceWrapper,
-				_bundleContext, serviceReference);
+				return new ServiceBag<>(
+					aopInvocationHandler, serviceTypeClass, serviceWrapper,
+					_bundleContext, serviceReference);
+			}
 		}
 
 		private <T> Closeable _getServiceBag(ServiceWrapper<T> serviceWrapper)


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101178

## What Is Being Fixed

Applying a `ServiceWrapper` to a service is a non-atomic read-modify-write on the shared `AopInvocationHandler` target: read `getTarget()`, wrap that value into the wrapper, then `setTarget(self)`. When two wrappers are applied to the same service concurrently, both threads read the same base target, both call `setTarget`, the later write wins, and the earlier wrapper is left orphaned. Every subsequent call skips it.

This corrupts `LayoutLocalService`, which is wrapped by both the layout module's `LayoutLocalServiceWrapper` (the only implementation of `copyLayoutContent`) and the staging `LayoutLocalServiceStagingAdvice`. When the module wrapper is applied from the `ServiceWrapperRegistry` tracker thread while the staging advice is applied from its own `@Activate` thread, the module wrapper is orphaned and `copyLayoutContent` reaches the throwing `portal-impl` stub. Every site initializer that copies layout content then fails with `UnsupportedOperationException`, and because that logs an ERROR it also trips `LogAssertionTestRule` and `PortalLogAssertorTest`, taking down unrelated object, DSR and CMS tests in the same run. The corrupted chain persists for the JVM lifetime, and whether it happens depends on startup thread ordering, which is why it is intermittent on CI and never reproduces in a single-threaded boot.

Diagnostic instrumentation shipped on a throwaway self-PR captured the live chain on a CI console: the two wrappers were applied 32 ms apart on two different threads, the staging advice captured the base implementation instead of the module wrapper, and all 33 stub hits in that run were preceded by an invocation whose target was the staging proxy.

## How It Is Being Fixed

Make the read-modify-write atomic per handler. `ServiceWrapperRegistry._createServiceBag` and `StagingAdviceUtil.register` hold the `AopInvocationHandler` monitor across `getTarget()` and the `ServiceBag` construction whose `setTarget` publishes the wrapper, and `ServiceBag.replace()` holds it across the chain removal. A concurrent second registration then reads the first's committed target and chains onto it instead of the stale base. The framework registry calls (`getServiceReference`, `ungetService`) are kept outside the monitor so the critical section is only the chain read-modify-write.

The monitor is the same one `AopInvocationHandler.setTarget()` already synchronized on, so no new lock object is introduced. The invocation path never acquires it — `_target` is `volatile` and `invoke()` synchronizes only on the `Method` — so no runtime service call is serialized by this change; only wrapper registration and unregistration at module activation.

### Validation

Verified with a controlled A/B on two self-PRs whose branches were identical except for this commit:

| | Without the fix | With the fix |
| --- | --- | --- |
| Jobs passed | 34 / 58 | 38 / 58 |
| Failed job axes | 24 | 20 (zero new) |
| Failed cases | 58 | 43 |

18 cases were fixed and no job axis regressed. The decisive signal is that two `PortalLogAssertorTest#testScanXMLLog` failures reporting `UnsupportedOperationException` at `LayoutLocalServiceImpl.copyLayoutContent` were present without the commit and gone with it.

The race can also be forced pre-fix under a debugger by suspending both applying threads before `setTarget` and releasing the module wrapper first; with the fix the second thread blocks on the monitor before its read, so it cannot be forced.

## PR Check

**pr-check: PASS** — tested on `fb528d2ade8fb38f02621acedb77a4c8944b612d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Full Portal Build | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

Baseline compared the branch jar against the released `com.liferay.portal.impl-131.0.0` and reported zero API deltas, so no `packageinfo` bump is owed for the `public <T> void replace()` to `public void replace()` change: the erased descriptor is unchanged and the type parameter was unused in the signature.

<!-- pr-check {"result": "success", "sha": "fb528d2ade8fb38f02621acedb77a4c8944b612d"} -->
