### PR TITLE
LPD-83978 Fix Jest suites broken by the enhanced source editing plugin

### DIFF
--- a/modules/apps/data-engine/data-engine-taglib/jest-setup.config.js
+++ b/modules/apps/data-engine/data-engine-taglib/jest-setup.config.js
@@ -25,6 +25,7 @@ jest.mock('@ckeditor/ckeditor5-media-embed/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-mention/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-minimap/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-page-break/dist/index', () => ({}));
+jest.mock('@ckeditor/ckeditor5-source-editing-enhanced/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-special-characters/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-style/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-table/dist/index', () => ({}));

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/jest-setup.config.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/jest-setup.config.js
@@ -25,6 +25,7 @@ jest.mock('@ckeditor/ckeditor5-media-embed/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-mention/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-minimap/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-page-break/dist/index', () => ({}));
+jest.mock('@ckeditor/ckeditor5-source-editing-enhanced/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-special-characters/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-style/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-table/dist/index', () => ({}));

--- a/modules/apps/layout/layout-content-page-editor-web/jest-setup.config.js
+++ b/modules/apps/layout/layout-content-page-editor-web/jest-setup.config.js
@@ -48,6 +48,7 @@ jest.mock('@ckeditor/ckeditor5-media-embed/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-mention/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-minimap/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-page-break/dist/index', () => ({}));
+jest.mock('@ckeditor/ckeditor5-source-editing-enhanced/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-special-characters/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-style/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-table/dist/index', () => ({}));

--- a/modules/apps/notification/notification-web/jest-setup.config.js
+++ b/modules/apps/notification/notification-web/jest-setup.config.js
@@ -25,6 +25,7 @@ jest.mock('@ckeditor/ckeditor5-media-embed/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-mention/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-minimap/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-page-break/dist/index', () => ({}));
+jest.mock('@ckeditor/ckeditor5-source-editing-enhanced/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-special-characters/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-style/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-table/dist/index', () => ({}));

--- a/modules/apps/object/object-web/jest-setup.config.js
+++ b/modules/apps/object/object-web/jest-setup.config.js
@@ -25,6 +25,7 @@ jest.mock('@ckeditor/ckeditor5-media-embed/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-mention/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-minimap/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-page-break/dist/index', () => ({}));
+jest.mock('@ckeditor/ckeditor5-source-editing-enhanced/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-special-characters/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-style/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-table/dist/index', () => ({}));

--- a/modules/apps/questions/questions-web/jest-setup.config.js
+++ b/modules/apps/questions/questions-web/jest-setup.config.js
@@ -33,6 +33,7 @@ jest.mock('@ckeditor/ckeditor5-media-embed/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-mention/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-minimap/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-page-break/dist/index', () => ({}));
+jest.mock('@ckeditor/ckeditor5-source-editing-enhanced/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-special-characters/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-style/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-table/dist/index', () => ({}));

--- a/modules/apps/translation/translation-web/jest-setup.config.js
+++ b/modules/apps/translation/translation-web/jest-setup.config.js
@@ -25,6 +25,7 @@ jest.mock('@ckeditor/ckeditor5-media-embed/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-mention/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-minimap/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-page-break/dist/index', () => ({}));
+jest.mock('@ckeditor/ckeditor5-source-editing-enhanced/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-special-characters/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-style/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-table/dist/index', () => ({}));


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-83978

## What Is Being Fixed

Seven modules cannot run their Jest suites. Each of them keeps a `jest-setup.config.js` that stubs the CKEditor packages `getDefaultEditorConfig.ts` imports, but `@ckeditor/ckeditor5-source-editing-enhanced` was never added to that list when the Enhanced Source Editing plugin was enabled. Loading the plugin for real pulls in CodeMirror, whose `@marijn/find-cluster-break` dependency points `main` at ESM source that Jest 27 cannot parse, and the plugin then extends a `View` class that resolves to `undefined` because `ckeditor5-ui` is itself stubbed. The two symptoms are `SyntaxError: Unexpected token 'export'` and `TypeError: Super expression must either be null or a function`. In `dynamic-data-mapping-form-field-type` this left 7 of 27 suites unable to run.

## How It Is Being Fixed

Add the missing stub. The whole CodeMirror chain is reachable only through this plugin, so stubbing it keeps CodeMirror out of the test run and nothing about the Jest resolver or transform configuration needs to change. The seven stub lists are byte-identical copies of one another, so the entry is added to all seven to keep them in sync.

That duplication is the underlying hazard here and is left for a follow-up: adding any CKEditor plugin to `getDefaultEditorConfig.ts` silently breaks all seven modules until seven identical files are updated in lockstep, which is exactly what happened. Moving the block into the shared `setup.js` under `frontend-sdk/node-scripts/util/jest` would fix it once and also cover the affected modules that have no setup file at all, but it changes CKEditor resolution for every frontend module and does not belong in this fix.

## Why Are There No Tests?

The change touches only Jest setup configuration, not shipped code, so there is no new behavior to cover. Its coverage is the seven existing suites it unblocks, which previously could not run at all — 339 tests in `dynamic-data-mapping-form-field-type` and 963 in `layout-content-page-editor-web` among them.

## PR Check

**pr-check: FAIL** — tested on `c012a3782341c44b5ed65bccd00c72016174a59a`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| JavaScript Unit Tests | FAIL |

`object-web` accounts for the failure: 51 of 52 suites pass, and the one that fails, `ObjectEntryStatusDataRenderer.spec.tsx`, is a date and locale mismatch — it expects `Oct 20, 2025 10:00 AM` and receives `oct 20, 2025 10:00`. It fails identically with this commit stashed, so it predates this change and is unrelated to it. The other six modules pass in full: `data-engine-taglib` 55 tests, `dynamic-data-mapping-form-field-type` 339, `layout-content-page-editor-web` 963, `notification-web` 20, `questions-web` 8, `translation-web` 27.

Two deviations from the standard run are worth recording. Source Format was run as `node-scripts format --check` per module rather than `ant format-source-current-branch`, because this branch is based on `brianchandotcom/liferay-portal` master and `GitUtil` in `current-branch` mode returned 74 unrelated queued files without any of the seven changed here; the per-module run does cover them, and all seven report clean. Per-Module Compile matched the diff but was trimmed to keep the run inside its time budget, on the grounds that `jest-setup.config.js` sits outside `src/main/resources` and is never compiled into the bundle.

<!-- pr-check {"result": "failure", "sha": "c012a3782341c44b5ed65bccd00c72016174a59a"} -->
