### PR TITLE
LPD-101289 Expect the DSR Seller role only where DSR runs

### DIFF
--- a/modules/apps/notification/notification-test/build.gradle
+++ b/modules/apps/notification/notification-test/build.gradle
@@ -18,7 +18,6 @@ dependencies {
 	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-test-util")
 	testIntegrationImplementation project(":apps:portal-vulcan:portal-vulcan-api")
 	testIntegrationImplementation project(":apps:portal:portal-upgrade-test-util")
-	testIntegrationImplementation project(":apps:site:site-dsr-site-initializer-api")
 	testIntegrationImplementation project(":apps:static:portal:portal-upgrade-api")
 	testIntegrationImplementation project(":apps:subscription:subscription-api")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")

--- a/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/web/internal/portlet/action/test/GetEmailNotificationRolesMVCResourceCommandTest.java
+++ b/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/web/internal/portlet/action/test/GetEmailNotificationRolesMVCResourceCommandTest.java
@@ -13,6 +13,7 @@ import com.liferay.account.service.AccountEntryLocalService;
 import com.liferay.account.service.AccountRoleLocalService;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Role;
@@ -31,12 +32,12 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
-import com.liferay.site.dsr.site.initializer.constants.DSRRoleConstants;
 
 import java.io.ByteArrayOutputStream;
 
@@ -166,35 +167,7 @@ public class GetEmailNotificationRolesMVCResourceCommandTest {
 					))
 			).put(
 				"regularRoles",
-				JSONUtil.putAll(
-					JSONUtil.put(
-						"name",
-						AccountRoleConstants.ROLE_NAME_ORDER_ADMINISTRATOR),
-					JSONUtil.put(
-						"name", AccountRoleConstants.ROLE_NAME_SUPPLIER),
-					JSONUtil.put("name", DSRRoleConstants.NAME_DSR_SELLER),
-					JSONUtil.put("name", RoleConstants.ADMINISTRATOR),
-					JSONUtil.put("name", RoleConstants.ANALYTICS_ADMINISTRATOR),
-					JSONUtil.put("name", RoleConstants.CMS_ADMINISTRATOR),
-					JSONUtil.put("name", RoleConstants.OWNER),
-					JSONUtil.put("name", RoleConstants.PORTAL_CONTENT_REVIEWER),
-					JSONUtil.put("name", RoleConstants.POWER_USER),
-					JSONUtil.put("name", RoleConstants.PUBLICATIONS_ADMIN),
-					JSONUtil.put("name", RoleConstants.PUBLICATIONS_EDITOR),
-					JSONUtil.put("name", RoleConstants.PUBLICATIONS_PUBLISHER),
-					JSONUtil.put("name", RoleConstants.PUBLICATIONS_USER),
-					JSONUtil.put("name", RoleConstants.PUBLICATIONS_VIEWER),
-					JSONUtil.put("name", RoleConstants.USER),
-					JSONUtil.put(
-						"label", regularRole1.getTitle(LocaleUtil.getDefault())
-					).put(
-						"name", regularRole1.getName()
-					),
-					JSONUtil.put(
-						"label", regularRole2.getTitle(LocaleUtil.getDefault())
-					).put(
-						"name", regularRole2.getName()
-					))
+				_getRegularRolesJSONArray(regularRole1, regularRole2)
 			).toString(),
 			byteArrayOutputStream.toString(), JSONCompareMode.LENIENT);
 
@@ -223,6 +196,46 @@ public class GetEmailNotificationRolesMVCResourceCommandTest {
 		return _roleLocalService.addRole(
 			RandomTestUtil.randomString(), user.getUserId(), null, 0,
 			RandomTestUtil.randomString(), null, null, type, null, null);
+	}
+
+	private JSONArray _getRegularRolesJSONArray(
+		Role regularRole1, Role regularRole2) {
+
+		JSONArray regularRolesJSONArray = JSONUtil.putAll(
+			JSONUtil.put(
+				"name", AccountRoleConstants.ROLE_NAME_ORDER_ADMINISTRATOR),
+			JSONUtil.put("name", AccountRoleConstants.ROLE_NAME_SUPPLIER),
+			JSONUtil.put("name", RoleConstants.ADMINISTRATOR),
+			JSONUtil.put("name", RoleConstants.ANALYTICS_ADMINISTRATOR),
+			JSONUtil.put("name", RoleConstants.CMS_ADMINISTRATOR),
+			JSONUtil.put("name", RoleConstants.OWNER),
+			JSONUtil.put("name", RoleConstants.PORTAL_CONTENT_REVIEWER),
+			JSONUtil.put("name", RoleConstants.POWER_USER),
+			JSONUtil.put("name", RoleConstants.PUBLICATIONS_ADMIN),
+			JSONUtil.put("name", RoleConstants.PUBLICATIONS_EDITOR),
+			JSONUtil.put("name", RoleConstants.PUBLICATIONS_PUBLISHER),
+			JSONUtil.put("name", RoleConstants.PUBLICATIONS_USER),
+			JSONUtil.put("name", RoleConstants.PUBLICATIONS_VIEWER),
+			JSONUtil.put("name", RoleConstants.USER),
+			JSONUtil.put(
+				"label", regularRole1.getTitle(LocaleUtil.getDefault())
+			).put(
+				"name", regularRole1.getName()
+			),
+			JSONUtil.put(
+				"label", regularRole2.getTitle(LocaleUtil.getDefault())
+			).put(
+				"name", regularRole2.getName()
+			));
+
+		// The DSR site initializer creates the DSR roles, and it is deployed on
+		// CI but excluded from the portal bundle.
+
+		if (Validator.isNotNull(System.getenv("JENKINS_HOME"))) {
+			regularRolesJSONArray.put(JSONUtil.put("name", "DSR Seller"));
+		}
+
+		return regularRolesJSONArray;
 	}
 
 	@Inject


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101289

## What Is Being Fixed

`GetEmailNotificationRolesMVCResourceCommandTest` asserts the complete set of regular roles, including the DSR Seller role, against a `LENIENT` JSON comparison that still checks array size. That single expectation cannot be correct in both environments: the DSR site initializer creates the DSR roles, and it is now built on CI but excluded from the portal bundle, so the role is present on CI and absent locally. The test therefore passes on CI and fails locally with:

```
java.lang.AssertionError: regularRoles[]: Expected 17 values but got 16
```

## Root Cause

LPD-100525 is self conflicting between CI and local runs:

- `378ce21dd12e4a57fae29688ee0ddc257218a2c1` (2026-08-03) deleted `.lfrbuild-portal` from 11 DSR modules. Nothing cleaned up the dependents, so it also broke the build: `LiferayCIPlugin` requires every project dependency of a `testIntegration` task to carry a build marker, so the whole `notification-test` module failed **before running a single test** and reported all 15 of its test classes as `was not executed`. In the last object suite run that was 15 of the 70 reported failures, inflating the count and hiding the module's real results on every run since.
- `f1ebf0bc0ddd3` (2026-08-05) then added `.lfrbuild-ci` to the same 11 modules. That repaired the build, but left the modules built on CI and absent from the bundle, so any test asserting a DSR created role now passes on CI and fails locally.

The expectation itself came from `0ebc902f5f628` (LPD-99914) and was correct while DSR was still shipped in the bundle.

Separately, this same test failed on CI earlier with the identical `Expected 17 values but got 16` message for an unrelated reason: the ServiceWrapper lost update race stopped the site initializers from creating their roles. That is fixed by `fb528d2ade8fb38f02621acedb77a4c8944b612d` (LPD-101178).

## How It Is Being Fixed

The DSR Seller entry is added only when `JENKINS_HOME` is set, the existing convention for telling CI from local runs in integration tests. The expected array moves into a named private method so the conditional reads clearly and the assertion stays a single expression.

The `DSRRoleConstants` import and the project dependency on `site-dsr-site-initializer-api` are dropped in favour of the literal role name. The constant is a compile time `String` literal that javac inlines, so the dependency never existed at runtime and was the only reason `notification-test` referenced DSR at all.

## Testing

Verified against a clean environment, with a recreated database and wiped `osgi/state` and Elasticsearch data:

| Condition | Expected roles | Result |
| --- | --- | --- |
| `JENKINS_HOME` unset | 16 | passes |
| portal restarted under `JENKINS_HOME` | 17 | fails `Expected 17 values but got 16` |

The second row is the point: it confirms the conditional is evaluated in the portal JVM where the test body actually runs, so CI receives the DSR Seller expectation. `JENKINS_HOME` was read back from `/proc` to confirm the portal process carries it. The full `notification-test` module runs 16 test classes and 190 tests with no failures and no errors logged; before the marker was restored the same task ran nothing at all.

## PR Check

**pr-check: PASS** — tested on `5aefc8fb9e7a181b2068547a8a67794a1c3a5aab`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Structural Smoke | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "5aefc8fb9e7a181b2068547a8a67794a1c3a5aab"} -->
