### PR TITLE
LPD-101294 Click object web Clay dropdown options through dispatchEvent

### DIFF
--- a/modules/test/playwright/pages/object-web/object-details/EditObjectDetailsPage.ts
+++ b/modules/test/playwright/pages/object-web/object-details/EditObjectDetailsPage.ts
@@ -148,6 +148,8 @@ export class EditObjectDetailsPage {
 	async selectScope(optionName: string) {
 		await this.scopeCombobox.click();
 
-		await this.page.getByRole('option', {name: optionName}).click();
+		await this.page
+			.getByRole('option', {name: optionName})
+			.dispatchEvent('click');
 	}
 }

--- a/modules/test/playwright/pages/object-web/object-entries/ViewObjectEntriesPage.ts
+++ b/modules/test/playwright/pages/object-web/object-entries/ViewObjectEntriesPage.ts
@@ -296,7 +296,9 @@ export class ViewObjectEntriesPage {
 
 	async selectDropdownItem(fieldName: string, optionName: string) {
 		await this.page.getByLabel(fieldName).click();
-		await this.page.getByRole('option', {name: optionName}).click();
+		await this.page
+			.getByRole('option', {name: optionName})
+			.dispatchEvent('click');
 	}
 
 	async selectDropdownItemWithSearch(optionName: string) {

--- a/modules/test/playwright/pages/object-web/object-validation/ModalAddObjectValidationPage.ts
+++ b/modules/test/playwright/pages/object-web/object-validation/ModalAddObjectValidationPage.ts
@@ -29,7 +29,7 @@ export class ModalAddObjectValidationPage {
 		await this.objectValidationTypeSelect.click();
 		await this.page
 			.getByRole('option', {name: objectValidationType})
-			.click();
+			.dispatchEvent('click');
 
 		await this.saveButton.click();
 	}

--- a/modules/test/playwright/pages/object-web/object-view/EditObjectViewPage.ts
+++ b/modules/test/playwright/pages/object-web/object-view/EditObjectViewPage.ts
@@ -98,13 +98,17 @@ export class EditObjectViewPage {
 
 		await columnsCombobox.click();
 
-		await this.sidePanel.getByRole('option', {name: columnName}).click();
+		await this.sidePanel
+			.getByRole('option', {name: columnName})
+			.dispatchEvent('click');
 
 		const sortingCombobox = this.sidePanel.getByRole('combobox').last();
 
 		await sortingCombobox.click();
 
-		await this.sidePanel.getByRole('option', {name: sortOrder}).click();
+		await this.sidePanel
+			.getByRole('option', {name: sortOrder})
+			.dispatchEvent('click');
 
 		await defaultSortModal.getByRole('button', {name: 'Save'}).click();
 	}

--- a/modules/test/playwright/tests/object-web/entry/objectEntry.spec.ts
+++ b/modules/test/playwright/tests/object-web/entry/objectEntry.spec.ts
@@ -6322,7 +6322,9 @@ test.describe('Manage object entries through View Object Entries', () => {
 			await test.step('Select the "United States" prefix, fill the phone number field, and save the entry', async () => {
 				await fieldContainer.getByLabel('Country Code').click();
 
-				await page.getByRole('option', {name: /United States/}).click();
+				await page
+					.getByRole('option', {name: /United States/})
+					.dispatchEvent('click');
 
 				await expect(fieldContainer.getByText(prefix)).toBeVisible();
 

--- a/modules/test/playwright/tests/object-web/main/objectDefinition.spec.ts
+++ b/modules/test/playwright/tests/object-web/main/objectDefinition.spec.ts
@@ -879,7 +879,7 @@ test.describe('Manage object definitions through Model Builder', () => {
 
 			await page
 				.getByRole('option', {name: 'en_US language: Default'})
-				.click();
+				.dispatchEvent('click');
 
 			await expect(
 				modelBuilderRightSidebarPage.objectDefinitionPluralLabel


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101294

## What Is Being Fixed

Object web Playwright tests select Clay dropdown options with `getByRole('option', {name}).click()`. These clicks worked for months and then started timing out at the 90 second test timeout, with Playwright reporting the option as intercepted:

```
locator resolved to <button role="option" aria-selected="true" class="dropdown-item active">…
<li role="presentation"> intercepts pointer events
```

Only dropdowns whose value is already selected are affected, which is why the object entry and object definition forms are hit: the phone field country prefix, the default language, the object definition scope, the default sort order, a validation type and a picklist state are all pre-selected.

## Root Cause

A two step change in Clay's admin theme:

1. **LPD-71471** (`868a5cf310d35d0ea06ade8e0882057710af3028`, 2026-04-03) added the atlas custom properties theme. Its `_dropdowns.scss` `active-class` map sets `pointer-events: none`, deliberately making the selected dropdown item non-interactive. The rule sat **dormant**, because the admin (cadmin) theme did not yet import the custom properties atlas.
2. **LPD-85958** (`22d218049cd912fb7b6b5f87fc9cbdbce167a93c`, 2026-06-01) converted the admin theme to use Clay's CSS custom properties, pulling that atlas in. From then on the deployed admin theme `clay.css` carries the rule.

This lands exactly on the Testray green to red boundary: the last passing acceptance build predates LPD-85958 and the first failing build contains it.

Mechanism: the pre-selected option renders as `.dropdown-item.active` and is pointer transparent, so `document.elementFromPoint` at its centre returns the wrapping `<li role="presentation">`, which keeps `pointer-events: auto`. Playwright treats that as an interception and retries until the test times out.

## How It Is Being Fixed

Select these options with `dispatchEvent('click')`, which fires the click directly on the resolved option and bypasses the hit test, mirroring the pattern `FormBuilderFieldSettingsSidePanelPage` already uses. Six call sites are converted, covering the object view default sort, the object validation type, the object definition scope and default language, the object entry picklist state and the country prefix.

## Testing

Proven by undoing the cause rather than by inference:

| Condition | `.click()` on the pre-selected option |
| --- | --- |
| rule present (current master) | times out |
| `.dropdown-item.active` stripped from the served admin theme `clay.css` | passes |
| rule present, using `dispatchEvent` | passes |

On CI, run shuyangzhou#12415 shows all six target areas passing; the remaining failures in those spec files are separate, separately tracked issues. Locally, an isolation run of this commit alone on top of master passes all six converted sites (one test needed a re-run after an unrelated `Login via API failed` fixture hiccup).

Blast radius was checked because the four page objects are shared through the `objectPagesTest` fixture, which ten non-object specs also use: none of them call any of the converted methods, and the one same-named `selectScope` elsewhere belongs to `EditSXPBlueprintPage` with a different signature. The converted call sites are reached only from object web.

## PR Check

**pr-check: PASS** — tested on `94e2a19d35323ae24f3ee4ff42f37412872ca3d3`

| Validation | Result |
| --- | --- |
| Source Format (incl. TypeScript checks) | PASS |
| TypeScript type check (`tsc --noEmit`) | PASS |
| JavaScript Unit Tests | N/A — no jest suite in this module; its `test` script is the Playwright runner, exercised directly above |

<!-- pr-check {"result": "success", "sha": "94e2a19d35323ae24f3ee4ff42f37412872ca3d3"} -->
