### PR TITLE
LPD-101297 Enter object view date filter values in display format

### DIFF
--- a/modules/test/playwright/tests/object-web/view/objectView.spec.ts
+++ b/modules/test/playwright/tests/object-web/view/objectView.spec.ts
@@ -15,6 +15,7 @@ import {globalMenuPagesTest} from '../../../fixtures/globalMenuPagesTest';
 import {loginTest} from '../../../fixtures/loginTest';
 import {objectPagesTest} from '../../../fixtures/objectPagesTest';
 import {workflowPagesTest} from '../../../fixtures/workflowPagesTest';
+import {formatDateForUI} from '../../../utils/applyFDSDateTimeRangeFilter';
 import {getRandomInt} from '../../../utils/getRandomInt';
 import getRandomString from '../../../utils/getRandomString';
 import {waitForAlert} from '../../../utils/waitForAlert';
@@ -1782,25 +1783,21 @@ test(
 
 		yesterday.setDate(yesterday.getDate() - 1);
 
-		const formatDate = (d: Date) =>
-			`${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
-
 		await page
 			.getByRole('textbox', {name: 'From'})
-			.fill(formatDate(yesterday));
+			.fill(formatDateForUI(yesterday));
 
-		await page.getByRole('textbox', {name: 'To'}).fill(formatDate(today));
+		await page
+			.getByRole('textbox', {name: 'To'})
+			.fill(formatDateForUI(today));
 
 		await page.getByRole('button', {name: 'Add Filter'}).click();
-
-		const formatDisplayDate = (d: Date) =>
-			`${d.getMonth() + 1}/${d.getDate()}/${d.getFullYear()}`;
 
 		await expect(page.getByText('1 Result Found for:')).toBeVisible();
 
 		await expect(
 			page.getByRole('button', {
-				name: `Create Date: ${formatDisplayDate(yesterday)} - ${formatDisplayDate(today)}`,
+				name: `Create Date: ${formatDateForUI(yesterday)} - ${formatDateForUI(today)}`,
 			})
 		).toBeVisible();
 
@@ -1890,25 +1887,21 @@ test(
 
 		yesterday.setDate(yesterday.getDate() - 1);
 
-		const formatDate = (d: Date) =>
-			`${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
-
 		await page
 			.getByRole('textbox', {name: 'From'})
-			.fill(formatDate(yesterday));
+			.fill(formatDateForUI(yesterday));
 
-		await page.getByRole('textbox', {name: 'To'}).fill(formatDate(today));
+		await page
+			.getByRole('textbox', {name: 'To'})
+			.fill(formatDateForUI(today));
 
 		await page.getByRole('button', {name: 'Add Filter'}).click();
-
-		const formatDisplayDate = (d: Date) =>
-			`${d.getMonth() + 1}/${d.getDate()}/${d.getFullYear()}`;
 
 		await expect(page.getByText('1 Result Found for:')).toBeVisible();
 
 		await expect(
 			page.getByRole('button', {
-				name: `Modified Date: ${formatDisplayDate(yesterday)} - ${formatDisplayDate(today)}`,
+				name: `Modified Date: ${formatDateForUI(yesterday)} - ${formatDateForUI(today)}`,
 			})
 		).toBeVisible();
 

--- a/modules/test/playwright/utils/applyFDSDateTimeRangeFilter.ts
+++ b/modules/test/playwright/utils/applyFDSDateTimeRangeFilter.ts
@@ -30,6 +30,14 @@ export async function applyFDSDateTimeRangeFilter(
 	).toBeVisible();
 }
 
+export function formatDateForUI(date: Date): string {
+	const month = String(date.getMonth() + 1).padStart(2, '0');
+	const day = String(date.getDate()).padStart(2, '0');
+	const year = date.getFullYear();
+
+	return `${month}/${day}/${year}`;
+}
+
 export function formatDateTimeForUI(date: Date): string {
 	const month = String(date.getMonth() + 1).padStart(2, '0');
 	const day = String(date.getDate()).padStart(2, '0');


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101297

## What Is Being Fixed

The object view custom view create date and modified date tests typed their From and To values as `YYYY-MM-DD`. The object view entries list filters through the frontend-data-set `DateTimeRangeFilter`, which derives its accepted format from the **viewer locale**, so under `en_US` it accepts a zero padded `MM/dd/yyyy` and rejects a year first value. The To input reported `Date is invalid.`, the Add Filter button stayed disabled, and the click on it retried until the 90 second test timeout:

```
locator resolved to <button disabled type="button" class="btn btn-sm btn-primary">Add Filter</button>
```

A screenshot of the failing run made it unambiguous: From held `2026-08-04`, To was flagged `Date is invalid.`, and Add Filter was greyed out — nothing to do with clicking.

## Root Cause

Got broken later, by two commits landing a day apart:

- `447c7970a3af8` (LPD-89563, 2026-05-20) made the filter **reject** invalid dates from its input rather than tolerate them.
- `1286edc9c0e26` (LPD-89563, 2026-05-21) switched the accepted format to the **user locale**.

The tests came from `e78eb387699c3` (LPD-82342, 2026-04-01), which moved them off Poshi and wrote the year first format. They were correct when written and stopped matching the input seven weeks later.

Worth flagging for anyone who touches this next: there is a similarly named `DateRangeFilter` in `frontend-data-set-admin-web` that genuinely does use `yyyy-MM-dd`. Reading that one first leads to the wrong conclusion; the widget in play is `frontend-data-set-web`'s `management_bar/.../DateTimeRangeFilter.tsx`, which is where the `Date is invalid.` message lives.

## How It Is Being Fixed

Type the values in the format the filter accepts, and expect the resulting filter label in it too — the format is built from `2-digit` day and month parts, so the leading zeros appear in the input and in the rendered label alike.

This follows the existing fix rather than adding a second approach. `5bda6af23b4a9` (LPD-90051, 2026-05-27) repaired the legacy CMS date filter tests, which failed the same way with `toISOString().split('T')[0]`, and introduced `utils/applyFDSDateTimeRangeFilter.ts` with `formatDateTimeForUI`. That helper targets the date **and time** variant and appends a time, whereas the object view create date and modified date filters are date only — so a date only `formatDateForUI` is added beside it and used here. The addition is purely additive, so the CMS caller is unaffected.

## Testing

A/B on the same bundle:

| Values typed | Result |
| --- | --- |
| `2026-08-04` (year first) | To shows `Date is invalid.`, Add Filter renders `<button disabled>` |
| `08/04/2026` (accepted format) | both tests pass |

Source Format (including its TypeScript checks) and `tsc --noEmit` are clean. Only these two tests change, in one spec file, with no shared page object involved.

## PR Check

**pr-check: PASS** — tested on `1dba292cb7cd036840023f44f9ae093feca2448e`

| Validation | Result |
| --- | --- |
| Source Format (incl. TypeScript checks) | PASS |
| TypeScript type check (`tsc --noEmit`) | PASS |
| JavaScript Unit Tests | N/A — no jest suite in this module; its `test` script is the Playwright runner, exercised directly above |

<!-- pr-check {"result": "success", "sha": "1dba292cb7cd036840023f44f9ae093feca2448e"} -->
