### PR TITLE
LPD-84225 Automate CommerceOrderItem inherited method rename

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -6015,6 +6015,19 @@
 	},
 	{
 		"classNames": [
+			"CommerceOrderItemLocalServiceWrapper"
+		],
+		"classStructurePattern": true,
+		"issueKey": "LPD-84225",
+		"methodsToFormat": [
+			{
+				"from": "CommerceOrderItem fetchCommerceOrderItemByBookedQuantityId",
+				"to": "CommerceOrderItem\n\t\tfetchCommerceOrderItemByCommerceInventoryBookedQuantityId"
+			}
+		]
+	},
+	{
+		"classNames": [
 			"PhoneLocalService",
 			"PhoneLocalServiceUtil",
 			"PhoneService",

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_84225.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_84225.testjava
@@ -1,0 +1,18 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+/**
+ * @author Lucas Ferruccio
+ */
+public class LPD_84225 extends CommerceOrderItemLocalServiceWrapper {
+
+	@Override
+	public CommerceOrderItem
+		fetchCommerceOrderItemByCommerceInventoryBookedQuantityId() {
+	}
+
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_84225.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_84225.testjava
@@ -1,0 +1,17 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+/**
+ * @author Lucas Ferruccio
+ */
+public class LPD_84225 extends CommerceOrderItemLocalServiceWrapper {
+
+	@Override
+	public CommerceOrderItem fetchCommerceOrderItemByBookedQuantityId() {
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-84225

## What Is Being Fixed

`CommerceOrderItemLocalServiceWrapper.fetchCommerceOrderItemByBookedQuantityId` was renamed to `fetchCommerceOrderItemByCommerceInventoryBookedQuantityId`. Client code that overrides that inherited method through the service wrapper still declares the old name, which no longer corresponds to anything on the parent, so the customization breaks on upgrade. The source formatter's upgrade check had no rule for this rename, leaving every affected override to be found and corrected by hand.

## How It Is Being Fixed

Adds an entry to the source formatter's `replacements.json` for the upgrade catch-all check, keyed to `LPD-84225` and scoped by `classNames` to `CommerceOrderItemLocalServiceWrapper` so the rewrite reaches only subclasses of that wrapper. The entry pairs `classStructurePattern` with a `methodsToFormat` rule mapping the old declaration to the new one. Because the longer method name pushes the declaration past the line limit, the replacement value carries the wrap explicitly, moving the `CommerceOrderItem` return type onto its own indented line so the result is already what the formatter would demand on a subsequent pass.

Two fixtures cover the rule in `UpgradeCatchAllCheckTest`: an input file overriding the old method and the expected rewritten output.

## PR Check

**pr-check: SKIPPED** — pr-check reported FAIL, but both failures are `UpgradeCatchAllCheckTest` cases already red on master (`LPD-70233`, `LPD-61579`) and unrelated to this branch; this branch's own case passes and Source Format passed.

<!-- pr-check {"reason": "pr-check reported FAIL, but both failures are UpgradeCatchAllCheckTest cases already red on master (LPD-70233, LPD-61579) and unrelated to this branch; this branch's own case passes and Source Format passed.", "result": "skipped", "sha": "c6db112d28687e30be00fc65311d4d9e65667b0e"} -->
