### PR TITLE
LPD-101364 Search the workflow configuration asset type before editing it

### DIFF
--- a/modules/test/playwright/pages/portal-workflow-kaleo-designer-web/ConfigurationTabPage.ts
+++ b/modules/test/playwright/pages/portal-workflow-kaleo-designer-web/ConfigurationTabPage.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {Locator, Page} from '@playwright/test';
+import {Locator, Page, expect} from '@playwright/test';
 
 import {waitForAlert} from '../../utils/waitForAlert';
 import {ProcessBuilderPage} from './ProcessBuilderPage';
@@ -31,7 +31,11 @@ export class ConfigurationTabPage {
 	}
 
 	private async clickAssetTypeEditButton(assetType: string) {
-		await this.page.waitForLoadState('networkidle');
+
+		// The table lists every workflow enabled asset type in the instance and
+		// pages at twenty rows, which leaves a generated object definition on the
+		// boundary of the first page. Filter by name so the lookup does not
+		// depend on how many asset types the instance happens to hold.
 
 		const editButton = this.page
 			.getByRole('row')
@@ -42,6 +46,26 @@ export class ConfigurationTabPage {
 				}),
 			})
 			.getByRole('button', {name: 'Edit'});
+
+		// The search submit button is served disabled and the toolbar's script
+		// enables it only once it runs. It is the form's default button, and a
+		// form whose default button is disabled ignores Enter, so wait for the
+		// button itself before submitting. No load state can stand in for it:
+		// the tab arrives through a single page application navigation, after
+		// which load and networkidle resolve while the button is still
+		// disabled.
+
+		await expect(
+			this.page.locator('.management-bar button[type="submit"]')
+		).toBeEnabled();
+
+		const searchInput = this.page.getByPlaceholder('Search for');
+
+		await searchInput.fill(assetType);
+
+		await searchInput.press('Enter');
+
+		await expect(editButton).toBeVisible();
 
 		await editButton.click();
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101364

## What Is Being Fixed

`object-web/entry/objectActiveInactive.spec.ts` ("Verify that pending and completed Object entries with workflow are not displayed on the Workflow Metrics page when inactivated") stopped passing on every routine, including plain master builds: Testray records its last pass on 2026-07-18 followed by 66 consecutive failures, always timing out on the asset type row's Edit button in the Process Builder configuration tab.

## How It Is Being Fixed

The configuration tab pages at twenty rows and, measured on a clean instance, nineteen of the thirty six workflow enabled asset types sort before a generated `ObjectDefinition` name, so the row a test creates lands on the last slot of the first page with zero margin; any concurrently created asset type pushes it to the second page where nothing pages forward. The page object now filters the table by asset type name, removing the dependency on the instance's asset type population, and waits for the management toolbar's search submit button to be enabled before submitting, because the button is served disabled until the toolbar's script runs and a form whose default button is disabled ignores Enter entirely — a condition no page load state expresses on this single page application navigation.

Verified against the forced failing condition locally (six filler asset types pushing the target off the first page: the previous lookup fails with the exact Testray error, the new one passes), and on CI where pull request run shuyangzhou#12418 flipped the test to passing against its 0-for-66 baseline while `objectEntry.spec.ts`'s friendly URL workflow test, which shares the changed page object, stayed green.

## PR Check

**pr-check: PASS** — tested on `541f746d3a0dd88122c6866b365cf323b9636b4e`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "541f746d3a0dd88122c6866b365cf323b9636b4e"} -->
