### PR TITLE
LCD-52882 add webhook to dxp-operator chart

### DIFF
--- a/cloud/helm/dxp-operator/templates/_helpers.tpl
+++ b/cloud/helm/dxp-operator/templates/_helpers.tpl
@@ -52,3 +52,7 @@ app.kubernetes.io/name: {{ include "dxp-operator.name" . }}
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{- define "dxp-operator.webhookServiceName" -}}
+{{- printf "%s-webhook" (include "dxp-operator.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/cloud/helm/dxp-operator/templates/deployment.yaml
+++ b/cloud/helm/dxp-operator/templates/deployment.yaml
@@ -51,6 +51,9 @@ spec:
                         -   containerPort: {{ .Values.probes.port }}
                             name: health
                             protocol: TCP
+                        -   containerPort: {{ .Values.webhook.port }}
+                            name: webhook
+                            protocol: TCP
                     readinessProbe:
                         httpGet:
                             path: /readyz
@@ -63,6 +66,10 @@ spec:
                     securityContext:
                         {{- toYaml . | nindent 24 }}
                     {{- end }}
+                    volumeMounts:
+                        -   mountPath: /tmp/k8s-webhook-server/serving-certs
+                            name: webhook-certs
+                            readOnly: true
             {{- with .Values.image.pullSecrets }}
             imagePullSecrets:
                 {{- toYaml . | nindent 16 }}
@@ -80,3 +87,7 @@ spec:
             tolerations:
                 {{- toYaml . | nindent 16 }}
             {{- end }}
+            volumes:
+                -   name: webhook-certs
+                    secret:
+                        secretName: {{ include "dxp-operator.webhookServiceName" . }}

--- a/cloud/helm/dxp-operator/templates/webhook.yaml
+++ b/cloud/helm/dxp-operator/templates/webhook.yaml
@@ -1,0 +1,47 @@
+{{- $caCert := "" -}}
+{{- $namespace := include "dxp-operator.namespace" . -}}
+{{- $webhookServiceName := include "dxp-operator.webhookServiceName" . -}}
+{{- $altNames := list (printf "%s.%s.svc" $webhookServiceName $namespace) (printf "%s.%s.svc.cluster.local" $webhookServiceName $namespace) -}}
+{{- $existingSecret := lookup "v1" "Secret" $namespace $webhookServiceName -}}
+{{- $tlsCert := "" -}}
+{{- $tlsKey := "" -}}
+{{- $certificateValidityDays := int .Values.webhook.certificateValidityDays -}}
+{{- if and $existingSecret $existingSecret.data (index $existingSecret.data "tls.crt") -}}
+{{- $caCert = index $existingSecret.data "ca.crt" -}}
+{{- $tlsCert = index $existingSecret.data "tls.crt" -}}
+{{- $tlsKey = index $existingSecret.data "tls.key" -}}
+{{- else -}}
+{{- $certificateAuthority := genCA (printf "%s-webhook-ca" (include "dxp-operator.fullname" .)) $certificateValidityDays -}}
+{{- $certificate := genSignedCert (index $altNames 0) nil $altNames $certificateValidityDays $certificateAuthority -}}
+{{- $caCert = $certificateAuthority.Cert | b64enc -}}
+{{- $tlsCert = $certificate.Cert | b64enc -}}
+{{- $tlsKey = $certificate.Key | b64enc -}}
+{{- end -}}
+apiVersion: v1
+data:
+    ca.crt: {{ $caCert }}
+    tls.crt: {{ $tlsCert }}
+    tls.key: {{ $tlsKey }}
+kind: Secret
+metadata:
+    labels:
+        {{- include "dxp-operator.labels" . | nindent 8 }}
+    name: {{ $webhookServiceName }}
+    namespace: {{ $namespace }}
+type: kubernetes.io/tls
+---
+apiVersion: v1
+kind: Service
+metadata:
+    labels:
+        {{- include "dxp-operator.labels" . | nindent 8 }}
+    name: {{ $webhookServiceName }}
+    namespace: {{ $namespace }}
+spec:
+    ports:
+        -   name: https
+            port: 443
+            protocol: TCP
+            targetPort: webhook
+    selector:
+        {{- include "dxp-operator.selectorLabels" . | nindent 8 }}

--- a/cloud/helm/dxp-operator/tests/deployment_test.yaml
+++ b/cloud/helm/dxp-operator/tests/deployment_test.yaml
@@ -83,13 +83,20 @@ tests:
                         name: health
                         protocol: TCP
                     path: spec.template.spec.containers[0].ports
-            -   lengthEqual:
-                    count: 2
+            -   contains:
+                    content:
+                        containerPort: 9092
+                        name: webhook
+                        protocol: TCP
                     path: spec.template.spec.containers[0].ports
-        it: Exposes a container port for the metrics and probe ports
+            -   lengthEqual:
+                    count: 3
+                    path: spec.template.spec.containers[0].ports
+        it: Exposes a container port for the metrics, probe, and webhook ports
         set:
             metrics.port: 9090
             probes.port: 9091
+            webhook.port: 9092
     -   asserts:
             -   equal:
                     path: spec.template.spec.serviceAccountName

--- a/cloud/helm/dxp-operator/tests/webhook_test.yaml
+++ b/cloud/helm/dxp-operator/tests/webhook_test.yaml
@@ -1,0 +1,61 @@
+release:
+    name: my-release
+    namespace: my-namespace
+suite: Webhook
+templates:
+    -   templates/deployment.yaml
+    -   templates/webhook.yaml
+tests:
+    -   asserts:
+            -   equal:
+                    path: metadata.name
+                    value: my-release-liferay-dxp-operator-webhook
+            -   equal:
+                    path: spec.ports[0].port
+                    value: 443
+            -   equal:
+                    path: spec.ports[0].targetPort
+                    value: webhook
+        documentSelector:
+            path: kind
+            value: Service
+        it: Exposes the webhook service on 443 targeting the webhook port
+        template: templates/webhook.yaml
+    -   asserts:
+            -   equal:
+                    path: metadata.name
+                    value: my-release-liferay-dxp-operator-webhook
+            -   equal:
+                    path: type
+                    value: kubernetes.io/tls
+            -   isNotEmpty:
+                    path: data["ca.crt"]
+            -   isNotEmpty:
+                    path: data["tls.crt"]
+            -   isNotEmpty:
+                    path: data["tls.key"]
+        documentSelector:
+            path: kind
+            value: Secret
+        it: Generates a self-signed TLS serving certificate secret
+        template: templates/webhook.yaml
+    -   asserts:
+            -   contains:
+                    content:
+                        mountPath: /tmp/k8s-webhook-server/serving-certs
+                        name: webhook-certs
+                        readOnly: true
+                    path: spec.template.spec.containers[0].volumeMounts
+            -   contains:
+                    content:
+                        name: webhook-certs
+                        secret:
+                            secretName: my-release-liferay-dxp-operator-webhook
+                    path: spec.template.spec.volumes
+        it: Mounts the serving certificate into the manager container
+        template: templates/deployment.yaml
+    -   asserts:
+            -   hasDocuments:
+                    count: 2
+        it: Renders only the serving certificate secret and service
+        template: templates/webhook.yaml

--- a/cloud/helm/dxp-operator/values.yaml
+++ b/cloud/helm/dxp-operator/values.yaml
@@ -44,3 +44,6 @@ serviceAccount:
     create: true
     name: ""
 tolerations: []
+webhook:
+    certificateValidityDays: 3650
+    port: 9443


### PR DESCRIPTION
The values of - mountPath: /tmp/k8s-webhook-server/serving-certs are not
arbitraty and are required by the k8s API server
