### PR TITLE
LPD-101442 Restore the import active assertions the formatting step swapped

### DIFF
--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/object/definitions/portlet/action/test/ObjectDefinitionExportImportTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/object/definitions/portlet/action/test/ObjectDefinitionExportImportTest.java
@@ -412,13 +412,20 @@ public class ObjectDefinitionExportImportTest extends BaseExportImportTestCase {
 					"TestImportObjectDefinition", null)));
 
 		importJSON(
-			false, "TESTIMPORTOBJECTDEFINITION", json,
-			"TestImportObjectDefinition");
-		importJSON(
 			true, "TESTIMPORTOBJECTDEFINITION", json,
 			"TestImportObjectDefinition");
 
 		ObjectDefinition objectDefinition =
+			objectDefinitionResource.getObjectDefinitionByExternalReferenceCode(
+				"TESTIMPORTOBJECTDEFINITION");
+
+		Assert.assertTrue(objectDefinition.getActive());
+
+		importJSON(
+			false, "TESTIMPORTOBJECTDEFINITION", json,
+			"TestImportObjectDefinition");
+
+		objectDefinition =
 			objectDefinitionResource.getObjectDefinitionByExternalReferenceCode(
 				"TESTIMPORTOBJECTDEFINITION");
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101442

## What Is Being Fixed

`ObjectDefinitionExportImportTest#testImportObjectDefinitionWithActive` fails on every `ci:test:object` run since 2026-08-05, and drags `testImportObjectDefinitionWithObjectFolderExternalReferenceCode` down with it: both tests share an external reference code, the failing test skips its trailing delete, and the leftover published definition makes the folder test's first import raise `ObjectDefinitionStatusException` inside the import action, which swallows it into an error response the test never reads.

The test was authored correctly. LPD-99246's test commit b28c53b20101e runs green as written — import active, import inactive, assert inactive, import active, assert active — verifying deactivation and reactivation through the import action's update path. The formatting commit 09d9be9eed6fd that entered master alongside it carries exactly one change: it swaps the boolean arguments of the two adjacent `importJSON` calls, putting `false` before `true`, and removes the blank line between them, so the test asserts an inactive state immediately after importing with active set. The class failed from the first CI run containing the commits (2026-08-05T06:12Z, hours after the 01:45:39Z formatting commit) and never passed afterwards. The repository's own source formatter reproduces no such reorder in either current-branch or single-file mode.

## How It Is Being Fixed

Restore the authored assertions, and interleave a read and assertion of the definition's active state after every import. The interleaving documents each state transition and leaves no two `importJSON` calls adjacent, so a formatting step that sorts consecutive identical calls has nothing to act on.

Verified: the authored version passes as written, the merged version fails at the swapped assertion, and the restored test passes 4 of 4 twice in a row on a clean environment, folder test included. Both methods also passed inside the aggregate pull request's `ci:test:object` run.

## PR Check

**pr-check: PASS** — tested on `be0b2659872bd58e602a98653ad1c6423d6a20d5`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "be0b2659872bd58e602a98653ad1c6423d6a20d5"} -->
