### PR TITLE
LPD-101451 Scope the layout tab locator to the layout designer's tab strip

### DIFF
--- a/modules/apps/object/object-test/src/testFunctional/paths/ObjectAdmin.path
+++ b/modules/apps/object/object-test/src/testFunctional/paths/ObjectAdmin.path
@@ -222,7 +222,7 @@
 	</tr>
 	<tr>
 		<td>LAYOUT_LAYOUT_TAB</td>
-		<td>//button[contains(text(), 'Layout')]</td>
+		<td>//ul[contains(@class,'side-panel-iframe__tabs')]//button[contains(text(),'Layout')]</td>
 		<td></td>
 	</tr>
 	<tr>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101451

## What Is Being Fixed

`CreateObject#FieldOptionRequired` and `CreateObject#CanSetBlockCollapsible` fail on every `ci:test:object` run since 2026-04-24, both dying at `ObjectAdmin#TAB_TYPE` with the New Layout modal covering the screen: the flow never reaches the layout designer's Layout tab.

The object layout designer opens as a side panel iframe, and `ObjectAdmin.goToLayoutTabOnLayouts` decides whether it still needs to switch into that iframe by probing for the designer's Layout tab. The locator was `//button[contains(text(), 'Layout')]`, which matches any button whose text mentions Layout, so the probe only gave the right answer while the top document happened to contain none. That stopped holding on 2026-04-21: 687a83688b993 (LPD-81198) fixed the frontend data set creation button to render its configured label instead of the hardcoded word New, so the layouts list's creation button began rendering as Add Object Layout. From then on the probe matches in the top document, skips the iframe switch, and the click presses Add Object Layout instead of the designer's tab. Testray matches to the day: both tests last passed 2026-04-21T16:0x and first failed 2026-04-24T21:0x, the commit's merge window. The label fix is legitimate product behavior, so the correction belongs in the test asset.

## How It Is Being Fixed

Scope the locator to the designer's tab strip, `ul.side-panel-iframe__tabs`, verified against the live designer: inside the iframe the new expression matches exactly the Layout tab, and in the top document it matches nothing, restoring the probe-then-select-frame guard to its intended meaning. All four usages sit in that same designer context.

Reproduced before the fix on a fresh clean environment with the exact Testray error; after the fix both tests walk the entire add tab, add block, and collapsible toggle flow. The fix also ran inside the aggregate pull request's `ci:test:object` runs, where `FieldOptionRequired` passed (`CanSetBlockCollapsible` has since been removed upstream by LPD-101324 as redundant with Playwright coverage).

## PR Check

**pr-check: PASS** — tested on `3af173e58032557498fbd2ecb17b3c2fbb92e1a5`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Poshi Syntax | PASS |

<!-- pr-check {"result": "success", "sha": "3af173e58032557498fbd2ecb17b3c2fbb92e1a5"} -->
