### PR TITLE
LPD-101458 Type and assert object rich text through CKEditor 5

### DIFF
--- a/modules/apps/object/object-test/src/testFunctional/macros/ObjectNotifications.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/ObjectNotifications.macro
@@ -95,7 +95,8 @@ definition {
 		}
 
 		Type(
-			locator1 = "CKEditor#BODY_FIELD_IFRAME",
+			key_fieldLabel = "Template",
+			locator1 = "CKEditor#BODY_FIELD_CONTENTEDITABLE_WEB_CONTENT_ARTICLE",
 			value1 = ${emailBody});
 	}
 
@@ -224,7 +225,8 @@ definition {
 
 		if (isSet(emailBody)) {
 			Type(
-				locator1 = "CKEditor#BODY_FIELD_IFRAME",
+				key_fieldLabel = "Template",
+				locator1 = "CKEditor#BODY_FIELD_CONTENTEDITABLE_WEB_CONTENT_ARTICLE",
 				value1 = ${emailBody});
 		}
 

--- a/modules/apps/object/object-test/src/testFunctional/paths/ObjectPortlet.path
+++ b/modules/apps/object/object-test/src/testFunctional/paths/ObjectPortlet.path
@@ -56,6 +56,11 @@
 		<td></td>
 	</tr>
 	<tr>
+		<td>ENTRY_RICH_TEXT_EDITABLE</td>
+		<td>//label[contains(.,'${key_fieldLabel}')]//following-sibling::div//div[contains(@class,'ck-editor__editable_inline') and @contenteditable = 'true' and contains(.,'${key_value}')]</td>
+		<td></td>
+	</tr>
+	<tr>
 		<td>ENTRY_STATUS</td>
 		<td>//*[text()='${key_entry}']/../following-sibling::td//*[text()='${key_status}']</td>
 		<td></td>

--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectFields.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectFields.testcase
@@ -317,10 +317,10 @@ definition {
 		}
 
 		task ("Then it's possible to edit the field's value") {
-			AssertEditable(
+			AssertElementPresent(
 				key_fieldLabel = "Custom Field",
-				locator1 = "FormFields#RICH_TEXT_CONTENT",
-				value = "Entry Test");
+				key_value = "Entry Test",
+				locator1 = "ObjectPortlet#ENTRY_RICH_TEXT_EDITABLE");
 		}
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101458

## What Is Being Fixed

`ObjectFields#CanFormulaFieldBeUsedWithEmailNotification` and `ObjectFields#CanEditConditionalReadOnlyFieldWhenConditionIsFalse` fail on every `ci:test:object` run since 2026-04-18 with the rich text editor locator not present. The notification template's email body and the object entry's rich text field render CKEditor 5 now, an inline contenteditable division, while the object Poshi assets still drove both through CKEditor 4 locators that expect an iframe below a division whose id contains `cke`. No such iframe exists on either screen anymore.

The tests went stale when the editor default changed: 1f5d3a2fc43c4 (LPD-68023) implemented CKEditor 5 in the shared RichTextLocalized component behind the LPD-11235 flag, 3886e1ecc1daf (LPD-80539) made deprecation-type feature flags start disabled on new databases and companies, and 48a3b53cc7b14 with 245b2b606eccd (LPD-81886, merged 2026-04-16) moved LPD-11235 to the deprecation type and inverted the component's check — so from that merge on, every fresh database (every CI run) renders CKEditor 5. Testray agrees to the day: both tests last passed 2026-04-17T01:06 and first failed 2026-04-18. The flag describes CKEditor 4 as the deprecated editor, so the product direction is intentional and the correction belongs in the tests.

## How It Is Being Fixed

Type the email body through the existing CKEditor 5 path entry, scoped by the Template label the way `CKEditor.addContentInWebContent` already types web content — verified against the live template screen, where that expression matches exactly the one editor and the old iframe expression matches nothing. Assert the conditionally editable rich text field through a new `ObjectPortlet` entry that requires the labeled inline editable division to be contenteditable and to hold the expected value, verified the same way against a live entry screen. The shared `FormFields#RICH_TEXT_CONTENT` path stays untouched for its remaining forms consumer.

Both tests reproduced locally with the exact Testray error before the change. After it, the conditional read-only test passes outright, and the email notification test walks the whole template flow locally up to the mail assertion against the fake SMTP server that exists only on CI. On CI, both aggregate pull request `ci:test:object` runs show `CanFormulaFieldBeUsedWithEmailNotification` passing end to end, mail assertion included.

## PR Check

**pr-check: PASS** — tested on `e60ac842d0776da9e55170064d3eb713fd0ac6ed`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Poshi Syntax | PASS |

<!-- pr-check {"result": "success", "sha": "e60ac842d0776da9e55170064d3eb713fd0ac6ed"} -->
