### PR TITLE
LPD-101459 Return to the top frame after saving in an object side panel

### DIFF
--- a/modules/apps/object/object-test/src/testFunctional/macros/ObjectAdmin.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/ObjectAdmin.macro
@@ -1587,6 +1587,19 @@ definition {
 	}
 
 	@summary = "Default summary"
+	macro saveSidePanel() {
+		Click(
+			key_text = "Save",
+			locator1 = "Button#ANY");
+
+		SelectFrame(value1 = "relative=top");
+
+		WaitForPageLoad();
+
+		WaitForLiferayEvent.initializeLiferayEventLog();
+	}
+
+	@summary = "Default summary"
 	macro searchInDefinePermissions(search = null) {
 		Type(
 			locator1 = "RolesPermissionsNavigation#SEARCH_FIELD",

--- a/modules/apps/object/object-test/src/testFunctional/macros/ObjectCustomViews.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/ObjectCustomViews.macro
@@ -17,7 +17,7 @@ definition {
 				locator1 = "ObjectCustomViews#CHECKBOX_COLUMN_OPTION");
 		}
 
-		PortletEntry.save();
+		ObjectCustomViews.clickSave();
 
 		SelectFrame(locator1 = "IFrame#IFRAME");
 	}
@@ -127,7 +127,7 @@ definition {
 			locator1 = "ObjectCustomViews#ADD_VIEW_NAME",
 			value1 = ${viewName});
 
-		PortletEntry.save();
+		ObjectCustomViews.clickSave();
 	}
 
 	@summary = "Default summary"
@@ -191,6 +191,15 @@ definition {
 			locator1 = "ObjectCustomViews#DROPDOWN_BUTTON_ON_OBJECT_VIEW");
 
 		SelectFrame(locator1 = "ObjectCustomViews#VIEW_DROPDOWN_MENU_ON_MODAL_DEFAULT_SORT");
+	}
+
+	@summary = "Default summary"
+	macro clickSave() {
+		Click(
+			key_text = "Save",
+			locator1 = "Button#ANY");
+
+		WaitForLiferayEvent.initializeLiferayEventLog();
 	}
 
 	@summary = "Default summary"

--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectFields.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectFields.testcase
@@ -94,7 +94,7 @@ definition {
 				relationshipsLabelName = "Relationship",
 				tabName = "Relationship Tab");
 
-			PortletEntry.save();
+			ObjectAdmin.saveSidePanel();
 
 			ObjectAdmin.openObjectAdmin();
 
@@ -112,7 +112,7 @@ definition {
 
 			ObjectCustomViews.addColumnsViaUI(addColumns = "Custom Long Integer Field");
 
-			PortletEntry.save();
+			ObjectAdmin.saveSidePanel();
 
 			ObjectCustomViews.goToViewsDetails(label = "Custom Views");
 
@@ -120,7 +120,7 @@ definition {
 
 			ObjectCustomViews.addNewFilterViaUI(filterBy = "Create Date");
 
-			PortletEntry.save();
+			ObjectAdmin.saveSidePanel();
 		}
 
 		task ("When an entry is added and the filter is set in the view entry page") {
@@ -363,7 +363,7 @@ definition {
 
 			ObjectField.typeStorageFolder(content = "/folderDM");
 
-			PortletEntry.save();
+			ObjectAdmin.saveSidePanel();
 		}
 
 		task ("Add an entry on Custom Object") {
@@ -696,7 +696,7 @@ definition {
 
 			ObjectCustomViews.addColumnsViaUI(addColumns = "Custom Decimal Field 1,Custom Decimal Field 2,Custom Formula Field");
 
-			PortletEntry.save();
+			ObjectAdmin.saveSidePanel();
 		}
 
 		task ("When the value of the fields is added") {
@@ -1066,7 +1066,7 @@ definition {
 
 			ObjectCustomViews.addColumnsViaUI(addColumns = "Custom Field,External Reference Code");
 
-			PortletEntry.save();
+			ObjectAdmin.saveSidePanel();
 		}
 
 		task ("Create an entry via API") {
@@ -1248,7 +1248,7 @@ definition {
 
 			ObjectCustomViews.addColumnsViaUI(addColumns = "Custom Field,External Reference Code");
 
-			PortletEntry.save();
+			ObjectAdmin.saveSidePanel();
 		}
 
 		task ("Assert the entry is created only when the ERC value is greater than the integer value") {
@@ -1595,7 +1595,7 @@ definition {
 				filterBy = "Field Picklist",
 				filterValue = "Picklist Item Test");
 
-			PortletEntry.save();
+			ObjectAdmin.saveSidePanel();
 		}
 
 		task ("Assert that the filter option is on Custom Object") {
@@ -1820,7 +1820,7 @@ definition {
 		task ("When the long text field value is updated to receive 65000 characters") {
 			ObjectField.typeValueOnLimitCharacters(newValue = 65000);
 
-			PortletEntry.save();
+			ObjectAdmin.saveSidePanel();
 		}
 
 		task ("and When adding an object entry") {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101459

## What Is Being Fixed

Six ObjectFields tests fail on every `ci:test:object` run since 2026-02-26 — `CanSetERCFieldAsTitleField`, `CanUseERCFieldWithExpressionBuilder`, `ExcludesIsAvailableForPicklistFields`, `CanManageFormulaFieldWithView`, `MaximumCharactersLongTextField` directly, and `CanEditPublishedObjectStorageFolder` at its storage folder save. All die the same way: a five-second timeout waiting for the document body, with the failure screenshot showing the side panel already gone and the parent list reloaded while the driver still waits inside the dead frame.

Saving an object view, or a field edited from the fields tab, happens inside the side panel iframe, and the panel closes itself on save and reloads the parent page. `PortletEntry.save` clicks Save and then asserts the success message and reinitializes the Liferay event log in whatever frame the driver is on — so called from inside the panel, those follow-up steps run against an iframe being torn down: the message check degrades to a warning (which Poshi turns into a failure at test end) and the event log wait times out.

Testray dates the break to a single window: all five directly affected tests passed at 2026-02-25T22:0x (build 441000129) and failed with the body timeout from 2026-02-26T02:0x on, across every routine. The panel has closed on save since dcfca6f3abac8 (LPS-147590, 2022), so the tests' pattern survived on how the closed panel used to die; no object-web commit in that window touches the views editor or panel host, so the behavior change rode in through shared infrastructure, with 8b4373809f745 (LPD-80538, merged 2026-02-26) the closest candidate in the window. The mechanism and boundary are established directly; the infrastructure commit is cited as nearest candidate rather than verified culprit.

## How It Is Being Fixed

Add `ObjectAdmin.saveSidePanel` — click Save inside the panel, return to the top frame, wait for the parent page the panel reloads, and reinitialize the event log there — and use it at the nine in-panel save sites across the six affected tests. The macro deliberately does not assert the success toast: the panel fires the toast on the parent and reloads it three hundred milliseconds later, so the assertion catches or misses the flash by luck, and misses accumulate as verification warnings that fail the test. The parent reload is the reliable signal the save went through, and each test's subsequent steps assert the saved data. The same transience moves the two view-flow save sites to `ObjectCustomViews.clickSave`. Saves made from the top document, whose success message persists, keep using `PortletEntry.save`.

Each test reproduced individually on a fresh clean environment, failing exactly as Testray records, and verified green after. On CI, all seven affected test cases passed in both aggregate pull request `ci:test:object` runs.

## PR Check

**pr-check: PASS** — tested on `ede5585c4565f77a7a831e36562822c44490f3ea`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Poshi Syntax | PASS |

<!-- pr-check {"result": "success", "sha": "ede5585c4565f77a7a831e36562822c44490f3ea"} -->
