### PR TITLE
LPD-101460 Check the renamed attachment library toggle when adding the field

### DIFF
--- a/modules/apps/object/object-test/src/testFunctional/macros/ObjectAdmin.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/ObjectAdmin.macro
@@ -255,7 +255,7 @@ definition {
 
 				if (isSet(enableShowFiles)) {
 					Check.checkNotVisible(
-						key_toggleSwitchLabel = "Show Files in Documents and Media",
+						key_toggleSwitchLabel = "Show Uploaded Files in Library",
 						locator1 = "ToggleSwitch#ANY_TOGGLE_SWITCH");
 				}
 			}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101460

## What Is Being Fixed

`ObjectFields#CanEditPublishedObjectStorageFolder` fails with the attachment field's library visibility toggle locator not present: `ObjectAdmin.addObjectFieldViaUI` enables it through a toggle labeled "Show Files in Documents and Media", which no longer exists.

The test went stale when the attachment field UI was reworked: af1ebf14846af (LPD-78043, committed 2026-02-27) adapted the attachment field to the new source options and replaced that toggle — the sources in the Request Files dropdown carry storage suffixes now and the toggle is labeled "Show Uploaded Files in Library", rendered only once a Documents and Media source is selected, verified against the live add field form. The test's Testray boundary matches the commit: last passed 2026-02-25T22:05, first failed on 2026-02-26.

## How It Is Being Fixed

Correct the toggle label in the macro. The macro already selects the source before checking the toggle, so the label is the only correction; the test's option value stays untouched because the locator matches on containment and the old value is a prefix of the renamed option, while the full new label cannot be used at all since the apostrophe in it breaks the single-quoted xpath interpolation.

Verified together with the side panel save correction (LPD-101459), which the test's later storage folder edit also needs, on a fresh clean environment. On CI the test passed in both aggregate pull request `ci:test:object` runs.

## PR Check

**pr-check: PASS** — tested on `d1bbf1cb526e821a736630e5c7d65bdc3d7a5de4`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Poshi Syntax | PASS |

<!-- pr-check {"result": "success", "sha": "d1bbf1cb526e821a736630e5c7d65bdc3d7a5de4"} -->
