### PR TITLE
LPD-101462 Pick the layout tab relationship through the autocomplete

### DIFF
--- a/modules/apps/object/object-test/src/testFunctional/macros/ObjectAdmin.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/ObjectAdmin.macro
@@ -618,14 +618,12 @@ definition {
 			locator1 = "ObjectAdmin#TAB_LABEL_NAME",
 			value1 = ${tabName});
 
-		Click(
-			key_labelName = "Relationship",
-			locator1 = "ObjectAdmin#CLAY_GENERIC_BUTTON");
+		Click(locator1 = "ObjectAdmin#RELATIONSHIP_AUTOCOMPLETE");
 
 		if (isSet(relationshipsLabelName)) {
 			Click(
 				key_optionName = ${relationshipsLabelName},
-				locator1 = "ObjectAdmin#CLAY_GENERIC_DROPDOWN_ITEM");
+				locator1 = "ObjectAdmin#RELATIONSHIP_AUTOCOMPLETE_ITEM");
 		}
 
 		Click(

--- a/modules/apps/object/object-test/src/testFunctional/paths/ObjectAdmin.path
+++ b/modules/apps/object/object-test/src/testFunctional/paths/ObjectAdmin.path
@@ -56,6 +56,16 @@
 		<td></td>
 	</tr>
 	<tr>
+		<td>RELATIONSHIP_AUTOCOMPLETE</td>
+		<td>//input[@id = 'relationshipAutocomplete']</td>
+		<td></td>
+	</tr>
+	<tr>
+		<td>RELATIONSHIP_AUTOCOMPLETE_ITEM</td>
+		<td>//div[contains(@class,'dropdown-menu-select')]//button[contains(@class,'dropdown-item') and contains(.,'${key_optionName}')]</td>
+		<td></td>
+	</tr>
+	<tr>
 		<td>SAVE_CUSTOM_OBJECT</td>
 		<td>//button[contains(text(),'Save')]</td>
 		<td></td>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101462

## What Is Being Fixed

`ObjectAdmin.addTabRelationshipsOnLayout` picked the relationship for a new relationships layout tab through a generic select button locator — a button with the combobox role inside the labeled form group — and `ObjectFields#AllFieldsFromRelatedObjectAreDisplayedWhenFilteringLongIntegerFields` fails there with the button not present.

The test went stale when the picker changed: 4833c70acf7c6 (LPD-83176, committed 2026-03-19) replaced the relationship select in the add tab modal with a Clay autocomplete that searches relationships on the server — an input with the `relationshipAutocomplete` id whose menu opens on focus — so no combobox button exists in that form group anymore.

No CI boundary can be claimed for this breakage: the test was already failing at an earlier step by then (the side panel save problem tracked by LPD-101459), so the dates Testray records belong to that earlier layer, and this failure only surfaces once it is repaired.

## How It Is Being Fixed

Click the autocomplete input to open its menu and pick the item by label through locators scoped to the autocomplete dropdown, verified against the live modal markup. The input is addressed by its own identifier, and the item locator is scoped to the autocomplete's dropdown container rather than to any dropdown item on the page.

Verified on a fresh clean environment together with the side panel save correction, which the same test needs to reach this step at all. On CI the test passed in both aggregate pull request `ci:test:object` runs.

## PR Check

**pr-check: PASS** — tested on `cb90490c7ca1b239def5b8902310fec953d0d433`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Poshi Syntax | PASS |

<!-- pr-check {"result": "success", "sha": "cb90490c7ca1b239def5b8902310fec953d0d433"} -->
