### PR TITLE
LPD-101463 Match the date filter input by its display format placeholder

### DIFF
--- a/modules/apps/object/object-test/src/testFunctional/macros/ObjectCustomViews.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/ObjectCustomViews.macro
@@ -222,7 +222,7 @@ definition {
 			locator1 = "FormViewBuilder#OBJECT_FIELD_BUTTON_DROPDOWN");
 
 		Type(
-			key_fieldName = "yyyy-mm-dd",
+			key_fieldName = "mm/dd/yyyy",
 			locator1 = "ObjectCustomViews#FROM_DATE_INPUT",
 			value1 = ${displayDate});
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101463

## What Is Being Fixed

`ObjectCustomViews.defineDateOnFilter` finds the view filter's date input by the `yyyy-mm-dd` placeholder, and the frontend data set date filter derives its placeholder from the viewer locale's date format now — `mm/dd/yyyy` under the `en_US` locale the tests run in — so the input is never found.

This is the same display format migration that already required the Playwright date utilities to type display-formatted values (LPD-101297), and the macro already types its date as month, day, year, so only the placeholder key was still stale.

No separate Testray boundary exists for this step: it only became reachable in `ObjectFields#AllFieldsFromRelatedObjectAreDisplayedWhenFilteringLongIntegerFields` after its earlier relationship picker (LPD-101462) and side panel save (LPD-101459) layers were fixed.

## How It Is Being Fixed

Match the date input on the display format placeholder instead, verified against the live filter panel where the derived placeholder is the lowercased locale format from the data set filter component.

Verified as the final layer of that test on a fresh clean environment, which passes end to end with this change. On CI the test passed in both aggregate pull request `ci:test:object` runs.

## PR Check

**pr-check: PASS** — tested on `3e03b37aa021bf638dade320c090882fe579a57e`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Poshi Syntax | PASS |

<!-- pr-check {"result": "success", "sha": "3e03b37aa021bf638dade320c090882fe579a57e"} -->
