### PR TITLE
LPD-101464 Save the object action modal without the toast race

### DIFF
--- a/modules/apps/object/object-test/src/testFunctional/macros/ObjectAdmin.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/ObjectAdmin.macro
@@ -1283,7 +1283,7 @@ definition {
 					checkboxName = ${fieldName},
 					locator1 = "Checkbox#ANY_CHECKBOX");
 
-				PortletEntry.save();
+				ObjectCustomViews.clickSave();
 
 				SelectFrame(locator1 = "ObjectAction#IFRAME_SIDE_PANEL");
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101464

## What Is Being Fixed

`ObjectFields#CanCreateActionWithCustomFieldInSystemObjects` fails intermittently — roughly one run in three, in long alternating streaks in Testray — with the same two faces the deterministic side panel tests showed before their saves were corrected: a body timeout inside the save's event log reinitialization, or a verification warning on the success message, depending on where the race lands.

The action form saves through `PortletEntry.save` from the modal inside the actions side panel, and the success toast that macro asserts is transient there, so the assertion and the event log reinitialization race the modal teardown. The cause is the same 2026-02-25 → 2026-02-26 infrastructure boundary recorded for the deterministic side panel cluster (LPD-101459), which made panel and modal success toasts transient; this site merely races it instead of losing every time, so Testray records streaks rather than a clean flip.

## How It Is Being Fixed

Move that save to `ObjectCustomViews.clickSave`, which saves and reinitializes the event log without asserting the toast — matching the other branch of the same `fillObjectAction` macro, which already saves that way. The save stays verified because the test's later steps assert the created action and its data.

Verified individually on a fresh clean environment, passing end to end. On CI the test passed in both aggregate pull request `ci:test:object` runs.

## PR Check

**pr-check: PASS** — tested on `758e85d20ba55f8a24cc07afd6b9975b3039d55f`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Poshi Syntax | PASS |

<!-- pr-check {"result": "success", "sha": "758e85d20ba55f8a24cc07afd6b9975b3039d55f"} -->
