### PR TITLE
LCD-52880 Reconcile-time replica enforcement in the licensing reconciler

### DIFF
--- a/cloud/helm/default/templates/liferayenvironment.yaml
+++ b/cloud/helm/default/templates/liferayenvironment.yaml
@@ -10,6 +10,9 @@ spec:
     activationCodeSecretRef:
         key: {{ .Values.license.activationCodeSecretKey }}
         name: {{ .Values.license.activationCodeSecretName | default (printf "%s-activation" (include "liferay.name" .)) }}
+    {{- if not .Values.autoscaling.enabled }}
+    desiredReplicas: {{ .Values.replicaCount }}
+    {{- end }}
     marketplaceVolume:
         enabled: {{ .Values.marketplace.enabled }}
         size: {{ .Values.marketplace.size }}

--- a/cloud/helm/default/tests/marketplace_test.yaml
+++ b/cloud/helm/default/tests/marketplace_test.yaml
@@ -29,6 +29,7 @@ tests:
                         activationCodeSecretRef:
                             key: activationCode
                             name: liferay-default-activation
+                        desiredReplicas: 1
                         marketplaceVolume:
                             enabled: true
                             size: 10Gi
@@ -39,6 +40,21 @@ tests:
         set:
             marketplace.enabled: true
             marketplace.storageClassName: nfs-sc
+        template: templates/liferayenvironment.yaml
+    -   asserts:
+            -   equal:
+                    path: spec.desiredReplicas
+                    value: 3
+        it: Sets desiredReplicas from the configured replica count
+        set:
+            replicaCount: 3
+        template: templates/liferayenvironment.yaml
+    -   asserts:
+            -   notExists:
+                    path: spec.desiredReplicas
+        it: Omits desiredReplicas when autoscaling manages the replica count
+        set:
+            autoscaling.enabled: true
         template: templates/liferayenvironment.yaml
     -   asserts:
             -   equal:

--- a/cloud/helm/dxp-operator/crds/licensing.liferay.com_liferayenvironments.yaml
+++ b/cloud/helm/dxp-operator/crds/licensing.liferay.com_liferayenvironments.yaml
@@ -28,6 +28,12 @@ spec:
         -   jsonPath: .status.license.validUntil
             name: Valid-Until
             type: string
+        -   jsonPath: .spec.desiredReplicas
+            name: Desired
+            type: integer
+        -   jsonPath: .status.effectiveReplicas
+            name: Effective
+            type: integer
         -   jsonPath: .status.phase
             name: Phase
             priority: 1
@@ -73,6 +79,9 @@ spec:
                                 -   key
                                 -   name
                                 type: object
+                            desiredReplicas:
+                                format: int32
+                                type: integer
                             dxpVersion:
                                 type: string
                             environmentName:
@@ -172,6 +181,9 @@ spec:
                                 x-kubernetes-list-map-keys:
                                 -   type
                                 x-kubernetes-list-type: map
+                            effectiveReplicas:
+                                format: int32
+                                type: integer
                             environmentId:
                                 type: string
                             license:

--- a/cloud/helm/dxp-operator/templates/rbac.yaml
+++ b/cloud/helm/dxp-operator/templates/rbac.yaml
@@ -43,6 +43,8 @@ rules:
         verbs:
             -   get
             -   list
+            -   patch
+            -   update
             -   watch
     -   apiGroups:
             -   licensing.liferay.com

--- a/cloud/helm/dxp-operator/tests/rbac_test.yaml
+++ b/cloud/helm/dxp-operator/tests/rbac_test.yaml
@@ -136,6 +136,19 @@ tests:
                             -   update
                             -   watch
                     path: rules
+            -   contains:
+                    content:
+                        apiGroups:
+                            -   apps
+                        resources:
+                            -   statefulsets
+                        verbs:
+                            -   get
+                            -   list
+                            -   patch
+                            -   update
+                            -   watch
+                    path: rules
         documentSelector:
             path: kind
             value: ClusterRole

--- a/cloud/operator/Tiltfile
+++ b/cloud/operator/Tiltfile
@@ -22,6 +22,7 @@ environment_names = [
 
 def environment_yaml(name):
 	namespace = "liferay-" + name
+	workload = name + "-liferay"
 
 	return "\n".join(
 	    [
@@ -41,13 +42,34 @@ def environment_yaml(name):
 	        "    activationCodeSecretRef:",
 	        "        key: activationCode",
 	        "        name: " + name + "-activation",
+	        "    desiredReplicas: 3",
 	        "    dxpVersion: 2026.q3.0",
 	        "    environmentName: \"" + name + "\"",
 	        "    marketplaceVolume:",
 	        "        size: 10Gi",
 	        "        storageClassName: local-path",
 	        "    workloadRef:",
-	        "        name: liferay-default",
+	        "        name: " + workload,
+	        "---",
+	        "apiVersion: apps/v1",
+	        "kind: StatefulSet",
+	        "metadata:",
+	        "    name: " + workload,
+	        "    namespace: " + namespace,
+	        "spec:",
+	        "    replicas: 3",
+	        "    selector:",
+	        "        matchLabels:",
+	        "            app: " + workload,
+	        "    serviceName: " + workload,
+	        "    template:",
+	        "        metadata:",
+	        "            labels:",
+	        "                app: " + workload,
+	        "        spec:",
+	        "            containers:",
+	        "                -   image: registry.k8s.io/pause:3.9",
+	        "                    name: liferay",
 	    ]
 	)
 
@@ -65,6 +87,7 @@ docker_build_with_restart(
 
 for name in environment_names:
 	namespace = "liferay-" + name
+	workload = name + "-liferay"
 
 	k8s_yaml(blob(environment_yaml(name)))
 
@@ -79,6 +102,12 @@ for name in environment_names:
 	        "liferay-dxp-operator",
 	        "operator-infra",
 	    ],
+	)
+
+	k8s_resource(
+	    labels=["environments"],
+	    resource_deps=[namespace],
+	    workload=workload,
 	)
 
 	cmd_button(

--- a/cloud/operator/resources/api/licensing/v1alpha1/liferayenvironment_types.go
+++ b/cloud/operator/resources/api/licensing/v1alpha1/liferayenvironment_types.go
@@ -28,6 +28,8 @@ type LicenseStatus struct {
 // +kubebuilder:printcolumn:JSONPath=`.status.conditions[?(@.type=="Activated")].status`,name="Activated",type=string
 // +kubebuilder:printcolumn:JSONPath=`.status.license.maxClusterNodes`,name="Max",type=integer
 // +kubebuilder:printcolumn:JSONPath=`.status.license.validUntil`,name="Valid-Until",type=string
+// +kubebuilder:printcolumn:JSONPath=`.spec.desiredReplicas`,name="Desired",type=integer
+// +kubebuilder:printcolumn:JSONPath=`.status.effectiveReplicas`,name="Effective",type=integer
 // +kubebuilder:printcolumn:JSONPath=`.status.phase`,name="Phase",priority=1,type=string
 // +kubebuilder:printcolumn:JSONPath=`.status.environmentId`,name="Environment-ID",priority=1,type=string
 // +kubebuilder:printcolumn:JSONPath=`.status.activatedAt`,name="Activated-At",priority=1,type=date
@@ -54,6 +56,9 @@ type LiferayEnvironmentSpec struct {
 	ActivationCodeSecretRef SecretKeyRef `json:"activationCodeSecretRef"`
 
 	// +optional
+	DesiredReplicas *int32 `json:"desiredReplicas,omitempty"`
+
+	// +optional
 	DxpVersion string `json:"dxpVersion,omitempty"`
 
 	// +optional
@@ -74,6 +79,9 @@ type LiferayEnvironmentStatus struct {
 	// +listType=map
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
+
+	// +optional
+	EffectiveReplicas *int32 `json:"effectiveReplicas,omitempty"`
 
 	// +optional
 	EnvironmentID string `json:"environmentId,omitempty"`

--- a/cloud/operator/resources/go.mod
+++ b/cloud/operator/resources/go.mod
@@ -4,6 +4,7 @@ go 1.24.4
 
 require (
 	github.com/caarlos0/env/v11 v11.3.1
+	k8s.io/api v0.33.1
 	k8s.io/apimachinery v0.33.1
 	k8s.io/client-go v0.33.1
 	sigs.k8s.io/controller-runtime v0.21.0
@@ -63,7 +64,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.33.1 // indirect
 	k8s.io/apiextensions-apiserver v0.33.0 // indirect
 	k8s.io/code-generator v0.33.0 // indirect
 	k8s.io/gengo/v2 v2.0.0-20250207200755-1244d31929d7 // indirect

--- a/cloud/operator/resources/internal/controller/licensing/liferayenvironment_controller.go
+++ b/cloud/operator/resources/internal/controller/licensing/liferayenvironment_controller.go
@@ -21,6 +21,7 @@ import (
 	licensingv1alpha1 "github.com/liferay/liferay-portal/cloud/operator/api/licensing/v1alpha1"
 	license "github.com/liferay/liferay-portal/cloud/operator/internal/license"
 	provisioning "github.com/liferay/liferay-portal/cloud/operator/internal/provisioning"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	errors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/api/meta"
@@ -37,6 +38,7 @@ const (
 	conditionActivated             = "Activated"
 	conditionLicenseValid          = "LicenseValid"
 	conditionProvisioningReachable = "ProvisioningReachable"
+	conditionReplicasCountValid    = "ReplicasCountValid"
 	entitlementsSecretSuffix       = "-entitlements"
 	environmentLabel               = "licensing.liferay.com/environment"
 	identitySecretSuffix           = "-identity"
@@ -44,6 +46,7 @@ const (
 
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;patch;update;watch
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=create;get;list;patch;update;watch
+// +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;patch;update;watch
 func (liferayEnvironmentReconciler *LiferayEnvironmentReconciler) Reconcile(
 	context context.Context,
 	request controllerruntime.Request,
@@ -274,6 +277,12 @@ func (liferayEnvironmentReconciler *LiferayEnvironmentReconciler) Reconcile(
 		},
 	)
 
+	if error := liferayEnvironmentReconciler.enforceReplicaCeiling(
+		context, liferayEnvironment, entitlements.MaxClusterNodes,
+	); error != nil {
+		return controllerruntime.Result{}, error
+	}
+
 	liferayEnvironment.Status.Phase = "Ready"
 
 	return liferayEnvironmentReconciler.finishAfter(
@@ -301,6 +310,116 @@ func (liferayEnvironmentReconciler *LiferayEnvironmentReconciler) SetupWithManag
 	).Complete(
 		liferayEnvironmentReconciler,
 	)
+}
+
+func (liferayEnvironmentReconciler *LiferayEnvironmentReconciler) enforceReplicaCeiling(
+	context context.Context,
+	liferayEnvironment *licensingv1alpha1.LiferayEnvironment,
+	maxClusterNodes int32,
+) error {
+	logger := logf.FromContext(context)
+
+	if maxClusterNodes <= 0 {
+		liferayEnvironment.Status.EffectiveReplicas = nil
+
+		meta.SetStatusCondition(
+			&liferayEnvironment.Status.Conditions,
+			metav1.Condition{
+				Message: "The licensed maximum cluster node count is not yet known.",
+				Reason:  "MaxClusterNodesUnknown",
+				Status:  metav1.ConditionUnknown,
+				Type:    conditionReplicasCountValid,
+			},
+		)
+
+		return nil
+	}
+
+	statefulSet := &appsv1.StatefulSet{}
+
+	getError := liferayEnvironmentReconciler.Get(
+		context, types.NamespacedName{
+			Name:      liferayEnvironment.Spec.WorkloadRef.Name,
+			Namespace: liferayEnvironment.Namespace,
+		}, statefulSet)
+
+	if errors.IsNotFound(getError) {
+		logger.V(1).Info(
+			"Workload not found; skipping replica enforcement",
+			"workload", liferayEnvironment.Spec.WorkloadRef.Name,
+		)
+
+		liferayEnvironment.Status.EffectiveReplicas = nil
+
+		meta.SetStatusCondition(
+			&liferayEnvironment.Status.Conditions,
+			metav1.Condition{
+				Message: fmt.Sprintf(
+					"Workload StatefulSet %q was not found.",
+					liferayEnvironment.Spec.WorkloadRef.Name,
+				),
+				Reason: "WorkloadNotFound",
+				Status: metav1.ConditionUnknown,
+				Type:   conditionReplicasCountValid,
+			},
+		)
+
+		return nil
+	}
+
+	if getError != nil {
+		return getError
+	}
+
+	desiredReplicas := resolveDesiredReplicas(liferayEnvironment, statefulSet)
+
+	effectiveReplicas := min(desiredReplicas, maxClusterNodes)
+
+	if statefulSet.Spec.Replicas == nil || *statefulSet.Spec.Replicas != effectiveReplicas {
+		statefulSet.Spec.Replicas = &effectiveReplicas
+
+		if error := liferayEnvironmentReconciler.Update(context, statefulSet); error != nil {
+			return error
+		}
+
+		logger.Info(
+			"Enforced licensed replica ceiling",
+			"desiredReplicas", desiredReplicas,
+			"effectiveReplicas", effectiveReplicas,
+			"maxClusterNodes", maxClusterNodes,
+			"workload", statefulSet.Name,
+		)
+	}
+
+	liferayEnvironment.Status.EffectiveReplicas = &effectiveReplicas
+
+	if desiredReplicas > maxClusterNodes {
+		meta.SetStatusCondition(
+			&liferayEnvironment.Status.Conditions,
+			metav1.Condition{
+				Message: fmt.Sprintf(
+					"Requested %d replicas exceeds the licensed maximum of %d; capping to %d.",
+					desiredReplicas, maxClusterNodes, effectiveReplicas,
+				),
+				Reason: "ExceedsLicensedMaximum",
+				Status: metav1.ConditionFalse,
+				Type:   conditionReplicasCountValid,
+			},
+		)
+
+		return nil
+	}
+
+	meta.SetStatusCondition(
+		&liferayEnvironment.Status.Conditions,
+		metav1.Condition{
+			Reason: "WithinLicensedLimit",
+			Status: metav1.ConditionTrue,
+			Type:   conditionReplicasCountValid,
+		},
+	)
+
+	return nil
 }
 
 func (liferayEnvironmentReconciler *LiferayEnvironmentReconciler) ensureIdentity(
@@ -557,6 +676,21 @@ func (liferayEnvironmentReconciler *LiferayEnvironmentReconciler) readActivation
 	}
 
 	return string(code), nil
+}
+
+func resolveDesiredReplicas(
+	liferayEnvironment *licensingv1alpha1.LiferayEnvironment,
+	statefulSet *appsv1.StatefulSet,
+) int32 {
+	if liferayEnvironment.Spec.DesiredReplicas != nil {
+		return *liferayEnvironment.Spec.DesiredReplicas
+	}
+
+	if statefulSet.Spec.Replicas != nil {
+		return *statefulSet.Spec.Replicas
+	}
+
+	return 1
 }
 
 func (liferayEnvironmentReconciler *LiferayEnvironmentReconciler) resolveDxpVersion(

--- a/cloud/operator/resources/internal/controller/licensing/liferayenvironment_controller_test.go
+++ b/cloud/operator/resources/internal/controller/licensing/liferayenvironment_controller_test.go
@@ -1,0 +1,275 @@
+package licensing
+
+import (
+	"context"
+	"testing"
+
+	licensingv1alpha1 "github.com/liferay/liferay-portal/cloud/operator/api/licensing/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	meta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
+	types "k8s.io/apimachinery/pkg/types"
+	client "sigs.k8s.io/controller-runtime/pkg/client"
+	fake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestEnforceReplicaCeiling(t *testing.T) {
+	testCases := map[string]struct {
+		desiredReplicas   *int32
+		expectedCondition metav1.ConditionStatus
+		expectedEffective *int32
+		expectedReason    string
+		expectedReplicas  *int32
+		maxClusterNodes   int32
+		workloadExists    bool
+		workloadReplicas  *int32
+	}{
+		"caps replicas above the licensed maximum": {
+			desiredReplicas:   pointerInt32(5),
+			expectedCondition: metav1.ConditionFalse,
+			expectedEffective: pointerInt32(3),
+			expectedReason:    "ExceedsLicensedMaximum",
+			expectedReplicas:  pointerInt32(3),
+			maxClusterNodes:   3,
+			workloadExists:    true,
+			workloadReplicas:  pointerInt32(5),
+		},
+		"caps the current replicas when desired is unset": {
+			desiredReplicas:   nil,
+			expectedCondition: metav1.ConditionFalse,
+			expectedEffective: pointerInt32(2),
+			expectedReason:    "ExceedsLicensedMaximum",
+			expectedReplicas:  pointerInt32(2),
+			maxClusterNodes:   2,
+			workloadExists:    true,
+			workloadReplicas:  pointerInt32(4),
+		},
+		"defaults to a single replica when neither desired nor current is set": {
+			desiredReplicas:   nil,
+			expectedCondition: metav1.ConditionTrue,
+			expectedEffective: pointerInt32(1),
+			expectedReason:    "WithinLicensedLimit",
+			expectedReplicas:  pointerInt32(1),
+			maxClusterNodes:   5,
+			workloadExists:    true,
+			workloadReplicas:  nil,
+		},
+		"reports when the workload does not exist": {
+			desiredReplicas:   pointerInt32(3),
+			expectedCondition: metav1.ConditionUnknown,
+			expectedEffective: nil,
+			expectedReason:    "WorkloadNotFound",
+			expectedReplicas:  nil,
+			maxClusterNodes:   3,
+			workloadExists:    false,
+			workloadReplicas:  nil,
+		},
+		"scales a running workload down to the ceiling": {
+			desiredReplicas:   pointerInt32(5),
+			expectedCondition: metav1.ConditionFalse,
+			expectedEffective: pointerInt32(3),
+			expectedReason:    "ExceedsLicensedMaximum",
+			expectedReplicas:  pointerInt32(3),
+			maxClusterNodes:   3,
+			workloadExists:    true,
+			workloadReplicas:  pointerInt32(5),
+		},
+		"skips enforcement when the ceiling is unknown": {
+			desiredReplicas:   pointerInt32(3),
+			expectedCondition: metav1.ConditionUnknown,
+			expectedEffective: nil,
+			expectedReason:    "MaxClusterNodesUnknown",
+			expectedReplicas:  pointerInt32(3),
+			maxClusterNodes:   0,
+			workloadExists:    true,
+			workloadReplicas:  pointerInt32(3),
+		},
+		"within the licensed limit": {
+			desiredReplicas:   pointerInt32(2),
+			expectedCondition: metav1.ConditionTrue,
+			expectedEffective: pointerInt32(2),
+			expectedReason:    "WithinLicensedLimit",
+			expectedReplicas:  pointerInt32(2),
+			maxClusterNodes:   3,
+			workloadExists:    true,
+			workloadReplicas:  pointerInt32(2),
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			liferayEnvironment := &licensingv1alpha1.LiferayEnvironment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "dev",
+					Namespace: "liferay-dev",
+				},
+				Spec: licensingv1alpha1.LiferayEnvironmentSpec{
+					DesiredReplicas: testCase.desiredReplicas,
+					WorkloadRef: licensingv1alpha1.WorkloadRef{
+						Name: "dev-liferay",
+					},
+				},
+			}
+
+			objects := []client.Object{}
+
+			if testCase.workloadExists {
+				objects = append(objects, &appsv1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "dev-liferay",
+						Namespace: "liferay-dev",
+					},
+					Spec: appsv1.StatefulSetSpec{
+						Replicas: testCase.workloadReplicas,
+					},
+				})
+			}
+
+			reconciler := &LiferayEnvironmentReconciler{
+				Client: newFakeClient(t, objects...),
+			}
+
+			if error := reconciler.enforceReplicaCeiling(
+				context.Background(), liferayEnvironment, testCase.maxClusterNodes,
+			); error != nil {
+				t.Fatalf("Unexpected error from enforceReplicaCeiling: %v", error)
+			}
+
+			assertReplicasEqual(
+				t, "status.effectiveReplicas",
+				testCase.expectedEffective,
+				liferayEnvironment.Status.EffectiveReplicas,
+			)
+
+			condition := meta.FindStatusCondition(
+				liferayEnvironment.Status.Conditions, conditionReplicasCountValid,
+			)
+
+			if condition == nil {
+				t.Fatalf("Expected a %s condition, got none", conditionReplicasCountValid)
+			}
+
+			if condition.Status != testCase.expectedCondition {
+				t.Errorf(
+					"Condition status = %q, want %q",
+					condition.Status, testCase.expectedCondition,
+				)
+			}
+
+			if condition.Reason != testCase.expectedReason {
+				t.Errorf(
+					"Condition reason = %q, want %q",
+					condition.Reason, testCase.expectedReason,
+				)
+			}
+
+			if !testCase.workloadExists {
+				return
+			}
+
+			statefulSet := &appsv1.StatefulSet{}
+
+			if error := reconciler.Get(
+				context.Background(), types.NamespacedName{
+					Name:      "dev-liferay",
+					Namespace: "liferay-dev",
+				}, statefulSet); error != nil {
+				t.Fatalf("Unable to read the workload: %v", error)
+			}
+
+			assertReplicasEqual(
+				t, "statefulSet.spec.replicas",
+				testCase.expectedReplicas, statefulSet.Spec.Replicas,
+			)
+		})
+	}
+}
+
+func TestResolveDesiredReplicas(t *testing.T) {
+	testCases := map[string]struct {
+		desiredReplicas  *int32
+		expected         int32
+		workloadReplicas *int32
+	}{
+		"defaults to one replica": {
+			desiredReplicas:  nil,
+			expected:         1,
+			workloadReplicas: nil,
+		},
+		"falls back to the running replica count": {
+			desiredReplicas:  nil,
+			expected:         2,
+			workloadReplicas: pointerInt32(2),
+		},
+		"prefers the operator intent": {
+			desiredReplicas:  pointerInt32(4),
+			expected:         4,
+			workloadReplicas: pointerInt32(2),
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			liferayEnvironment := &licensingv1alpha1.LiferayEnvironment{
+				Spec: licensingv1alpha1.LiferayEnvironmentSpec{
+					DesiredReplicas: testCase.desiredReplicas,
+				},
+			}
+
+			statefulSet := &appsv1.StatefulSet{
+				Spec: appsv1.StatefulSetSpec{
+					Replicas: testCase.workloadReplicas,
+				},
+			}
+
+			if actual := resolveDesiredReplicas(
+				liferayEnvironment, statefulSet,
+			); actual != testCase.expected {
+				t.Errorf("Unexpected resolveDesiredReplicas result: got %d, want %d", actual, testCase.expected)
+			}
+		})
+	}
+}
+
+func assertReplicasEqual(t *testing.T, field string, expected *int32, actual *int32) {
+	t.Helper()
+
+	if expected == nil {
+		if actual != nil {
+			t.Errorf("Unexpected %s: got %d, want nil", field, *actual)
+		}
+
+		return
+	}
+
+	if actual == nil {
+		t.Errorf("Unexpected %s: got nil, want %d", field, *expected)
+
+		return
+	}
+
+	if *actual != *expected {
+		t.Errorf("Unexpected %s: got %d, want %d", field, *actual, *expected)
+	}
+}
+
+func newFakeClient(t *testing.T, objects ...client.Object) client.Client {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+
+	if error := appsv1.AddToScheme(scheme); error != nil {
+		t.Fatalf("Unable to register the apps/v1 scheme: %v", error)
+	}
+
+	if error := licensingv1alpha1.AddToScheme(scheme); error != nil {
+		t.Fatalf("Unable to register the licensing scheme: %v", error)
+	}
+
+	return fake.NewClientBuilder().WithObjects(objects...).WithScheme(scheme).Build()
+}
+
+func pointerInt32(value int32) *int32 {
+	return &value
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LCD-52880

Also includes updates to the Tiltfile that allow for easy testing of the reconciliation. It defaults to 3 replicas for the dummy liferay sts, but will gracefully scale down to 1 once the license is reconciled with `maxClusterNodes=1`.