### PR TITLE
LPD-101466 Save the read only field through the side panel

### DIFF
--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectFields.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectFields.testcase
@@ -894,7 +894,7 @@ definition {
 
 			ObjectAdmin.clickFieldsSearchableSectionRadioOption(radioOption = "True");
 
-			CreateObject.saveObject();
+			ObjectAdmin.saveSidePanel();
 		}
 
 		task ("When viewing the added entry") {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101466

## What Is Being Fixed

`ObjectFields#CannotEditReadOnlyFieldWhenTrue` saves the field's read only property from the fields side panel through `CreateObject.saveObject`, and fails intermittently with the faces the deterministic side panel tests showed before their saves were corrected: the macro's success message assertion races the transient toast, and its page load wait can land in the torn down panel frame.

The cause is the same 2026-02-25 → 2026-02-26 infrastructure boundary recorded for the deterministic side panel cluster (LPD-101459), which made panel success toasts transient. This site races it rather than losing every run, so Testray records streaks rather than a clean flip, and this week's pull request baselines catch it.

## How It Is Being Fixed

Move the save to `ObjectAdmin.saveSidePanel`, the macro added by LPD-101459, which clicks Save inside the panel, returns to the top frame, waits for the parent page the panel reloads, and reinitializes the event log there without asserting the transient toast. The save stays verified because the test's later steps assert the field's read only behavior.

Verified individually on a fresh clean environment, passing end to end. On CI the test passed in both aggregate pull request `ci:test:object` runs.

## PR Check

**pr-check: PASS** — tested on `c8ed2e3c627d1a58044d5489ae6f2a37eddedd11`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Poshi Syntax | PASS |

<!-- pr-check {"result": "success", "sha": "c8ed2e3c627d1a58044d5489ae6f2a37eddedd11"} -->
