### PR TITLE
LPD-101467 Delete the test's action from the Account object before finishing

### DIFF
--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectFields.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectFields.testcase
@@ -273,6 +273,16 @@ definition {
 
 			ObjectPortlet.viewEntry(entry = "Action shot on add");
 		}
+
+		task ("Delete the action from the system object so it does not outlive the test") {
+			ObjectAdmin.openObjectAdmin();
+
+			ObjectPortlet.selectCustomObject(label = "Account");
+
+			ObjectAdmin.goToActionsTab();
+
+			ObjectAdmin.deleteActionViaUI(actionLabel = "Custom Action");
+		}
 	}
 
 	@description = "LPS-170122 - Verify the field value cannot be changed when the ready-only property condition is false"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101467

## What Is Being Fixed

`ObjectFields#CanCreateActionWithCustomFieldInSystemObjects` adds an action to the system Account object whose parameters reference the test's own custom object, and its cleanup deletes the custom object but leaves the action behind — Account is a system object that no teardown removes. From then on every serialization of Account's actions logs an error, because the action's `objectDefinitionId` parameter now points at a deleted definition and the object admin REST converter logs the lookup failure, and the Poshi error scanner fails whichever test happens to be running when that error lands in the log.

Locally the leaked action survives server restarts and poisoned every subsequent run until it was deleted by hand; on CI it poisons the remainder of the batch that runs after this test. The defect is invisible to the guilty test itself because the error only fires on later serializations, so it presents as cross-test flakiness whose victim is whichever test runs next.

No boundary exists to record: the test was born leaky, added without a cleanup step for the one artifact it creates on a system object — the only entity in its flow that outlives it.

## How It Is Being Fixed

Delete the action from the Account object at the end of the test through the existing kebab deletion macro.

Verified on a fresh clean environment: the test passes with the cleanup task, the Account object carries zero actions afterwards, and the runs that previously failed on the leaked error pass once the environment is purged. On CI the test passed in both aggregate pull request `ci:test:object` runs.

## PR Check

**pr-check: PASS** — tested on `9818310579040a00df5741ae9beeb73654d6a9a4`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Poshi Syntax | PASS |

<!-- pr-check {"result": "success", "sha": "9818310579040a00df5741ae9beeb73654d6a9a4"} -->
