### PR TITLE
LPD-101364 Wait for the workflow configuration tab before searching its asset types

### DIFF
--- a/modules/test/playwright/pages/portal-workflow-kaleo-designer-web/ConfigurationTabPage.ts
+++ b/modules/test/playwright/pages/portal-workflow-kaleo-designer-web/ConfigurationTabPage.ts
@@ -32,6 +32,18 @@ export class ConfigurationTabPage {
 
 	private async clickAssetTypeEditButton(assetType: string) {
 
+		// Callers reach this tab either through goTo, which waits for the tab's
+		// own address, or by clicking the tab link themselves and continuing
+		// straight into an assignment. Until that navigation lands, the tab the
+		// caller came from is still on screen, and its management bar carries
+		// its own enabled search form, so a submit sent in that window filters
+		// that other table and leaves this one empty for good. Wait for the
+		// address before touching the search form.
+
+		await this.page.waitForURL((url) =>
+			url.href.includes('=configuration')
+		);
+
 		// The table lists every workflow enabled asset type in the instance and
 		// pages at twenty rows, which leaves a generated object definition on the
 		// boundary of the first page. Filter by name so the lookup does not


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101364

Follow-up on the same ticket. The search this ticket added lands on the wrong screen when the caller has not finished switching tabs.

## What Is Being Fixed

Assigning a workflow to an asset type searches the configuration tab's table for the asset type and clicks its edit button. Object tests fail there on continuous integration with the row never found, and a longer wait does not help.

Callers reach this tab two ways: `goTo`, which clicks the tab link and then waits for the tab's own address, and three tests, which click the tab link themselves and continue straight into the assignment. Until that navigation lands the previous tab is still on screen, and its management bar carries its own search form whose submit button is already enabled. The assignment fills that form and submits it, the keywords apply to the other tab's table, and this tab then arrives filtered by an asset type name it has no column for, so the table stays empty however long the assertion waits. All seventeen `goTo` callers are immune because `goTo` already waits for the address; every affected test is one of the callers that clicks the link itself.

Waiting for the submit button to be enabled does not settle this, because that gate cannot tell one tab's management bar from another's and the enabled button it finds belongs to the previous tab.

## How It Is Being Fixed

Wait for the tab's address inside the assignment, so the search form always belongs to the table being searched, no matter how the caller navigated.

Reproduced deterministically on a fresh clean environment: with twelve filler definitions pushing the target off the table's first page and six seconds of latency on the tab's requests, the assignment fills the previous tab's search form and the edit button is never found, and sampling the document during that window shows the previous tab's table and its enabled submit button throughout. With the address wait in place the same scenario finds the row and passes.

Measured against Testray on a `ci:test:object` run of this change alone, it fixes one test and unblocks another:

| test | evidence |
| --- | --- |
| `objectActiveInactive` workflow metrics | fails on every recent build, including the foreign `ci:test:bpm` 8190 and 8239 and EE Development Acceptance 23; passes only with this change |
| `objectView` edit a filter | fails at this search on every build without the change; gets past it with the change, then fails later on an unrelated assertion of its own |
| `objectWorkflow` My Workflow Tasks preview | also passes here, but it is intermittent on master, so this change does not claim it |

## PR Check

**pr-check: PASS** — tested on `a1b1ba547200c6bdbaa224a8fafa977df4925919`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

Source Format covers the TypeScript project check for this file. Per-Module Compile matched the diff by extension but has no module to deploy: `modules/test/playwright` is not registered in `settings.gradle`, so no Gradle project resolves for it. JavaScript Unit Tests matched as well, but that module's `test` script is `playwright test`, and Playwright is out of scope for pr-check; the `ci:test:object` run above covers it instead.

<!-- pr-check {"result": "success", "sha": "a1b1ba547200c6bdbaa224a8fafa977df4925919"} -->
