### PR TITLE
LPD-101535 Semantic versioning

### DIFF
--- a/modules/apps/commerce/commerce-test-util/bnd.bnd
+++ b/modules/apps/commerce/commerce-test-util/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Commerce Test Utilities
 Bundle-SymbolicName: com.liferay.commerce.test.util
-Bundle-Version: 33.0.1
+Bundle-Version: 33.1.0
 Export-Package:\
 	com.liferay.commerce.test.util,\
 	com.liferay.commerce.test.util.context,\

--- a/modules/apps/commerce/commerce-test-util/src/main/resources/com/liferay/commerce/test/util/validator/packageinfo
+++ b/modules/apps/commerce/commerce-test-util/src/main/resources/com/liferay/commerce/test/util/validator/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101535

## What Is Being Fixed

Every branch that carries 93a19a06642b8 (LPD-99094) fails the baseline check with `modules-semantic-versioning[modules/apps/commerce]`. That commit added `getValidateCount()` to `TestAccountEntryValidator`, which lives in `com.liferay.commerce.test.util.validator`, an exported package of the `commerce-test-util` bundle, and raised neither the package version nor the bundle version.

It surfaced from the object side: `modules-semantic-versioning[modules/apps/commerce]` shows up in every `ci:test:object` run of the object stabilization branch and is caused by nothing in it.

## How It Is Being Fixed

Raise the exported package from 1.0.0 to 1.1.0 and the bundle from 33.0.1 to 33.1.0. The change is additive — a new method on an existing class — so a minor bump is what semantic versioning calls for and no breaking change entry applies.

Both numbers are the tool's own recommendation. Without the bump the baseline report reads:

```
PACKAGE_NAME                                       DELTA      CUR_VER    BASE_VER   REC_VER    WARNINGS
* com.liferay.commerce.test.util.validator           MINOR      1.0.0      1.0.0      1.1.0      VERSION INCREASE REQUIRED
	<   class      com.liferay.commerce.test.util.validator.TestAccountEntryValidator
		+   method     getValidateCount()
			+   return     int
[Baseline Warning] Bundle Version Change Recommended: 33.1.0
```

With the bump the report is empty.

## PR Check

**pr-check: PASS** — tested on `dfceca58f52dfdc6775100d8f5a6cab518f03b26`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Structural Smoke | PASS |
| Per-Module Compile | PASS |
| Baseline | PASS |

<!-- pr-check {"result": "success", "sha": "dfceca58f52dfdc6775100d8f5a6cab518f03b26"} -->
