### PR TITLE
LPD-101539 Poll for temporary attachment deletion instead of asserting one read

### DIFF
--- a/modules/test/playwright/tests/object-web/entry/objectEntry.spec.ts
+++ b/modules/test/playwright/tests/object-web/entry/objectEntry.spec.ts
@@ -6073,9 +6073,16 @@ test.describe('Manage object entries through View Object Entries', () => {
 			.getByRole('button', {name: 'astronaut.png'})
 			.waitFor({state: 'visible'});
 
-		expect(
-			await apiHelpers.headlessDelivery.getDocument(fileEntryId1)
-		).toEqual({status: 'NOT_FOUND'});
+		// The replaced temporary file is deleted asynchronously, so poll
+		// instead of asserting the very first read
+
+		await expect
+			.poll(
+				async () =>
+					await apiHelpers.headlessDelivery.getDocument(fileEntryId1),
+				{timeout: 30 * 1000}
+			)
+			.toEqual({status: 'NOT_FOUND'});
 
 		const fileEntryId2 = await page.getAttribute(
 			'input[data-field-name^="testAttachment"]',
@@ -6094,9 +6101,13 @@ test.describe('Manage object entries through View Object Entries', () => {
 
 		await viewObjectEntriesPage.deleteFileButton.click();
 
-		expect(
-			await apiHelpers.headlessDelivery.getDocument(fileEntryId2)
-		).toEqual({status: 'NOT_FOUND'});
+		await expect
+			.poll(
+				async () =>
+					await apiHelpers.headlessDelivery.getDocument(fileEntryId2),
+				{timeout: 30 * 1000}
+			)
+			.toEqual({status: 'NOT_FOUND'});
 
 		// Verify that the file is removed after page reload
 
@@ -6116,9 +6127,13 @@ test.describe('Manage object entries through View Object Entries', () => {
 
 		await page.reload();
 
-		expect(
-			await apiHelpers.headlessDelivery.getDocument(fileEntryId3)
-		).toEqual({status: 'NOT_FOUND'});
+		await expect
+			.poll(
+				async () =>
+					await apiHelpers.headlessDelivery.getDocument(fileEntryId3),
+				{timeout: 30 * 1000}
+			)
+			.toEqual({status: 'NOT_FOUND'});
 
 		// Verify that the file is saved successfully when clicking submit
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101539

## What Is Being Fixed

The object entry attachment test asserts that a temporary file entry is gone immediately after the interface updates, and fails intermittently on loaded continuous integration runs with the document still live. The product is behaving as designed; the test is asserting an ordering that does not exist.

Temporary attachment cleanup is fire and forget. `Attachment.tsx` calls `deleteFileEntry()` without awaiting it from all three paths the test exercises — replacing the file, the delete button, and `window.onbeforeunload`, which cannot await at all because the browser is leaving the page. In each case the screen is repainted on the statement right after the un-awaited call:

```tsx
const handleDelete = () => {
	deleteFileEntry();               // request leaves, nobody waits
	setAttachment(null);             // screen already updated
	onChange({target: {value: ''}});
};
```

So waiting for the interface cannot help — the repaint is guaranteed to happen before the delete completes.

The assertion also runs outside the browser. `apiHelpers.headlessDelivery.getDocument` reaches the portal through `page.request` (`ApiHelpers.ts:377`), which shares the browser context's cookies but issues its own connection from the Node process. The browser's DELETE and the test's GET are two independent requests with no ordering between them anywhere.

## How It Is Being Fixed

Poll the three deletion assertions with a thirty second timeout instead of reading once. The assertion itself is unchanged — only how often it is asked. A file that genuinely never gets deleted still fails, thirty seconds later, so this does not mask a real cleanup defect.

## PR Check

**pr-check: PASS** — tested on `4f23ee8cd9ef401d8e4c858e7dc750e94b8c6d74`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

Source Format covers the TypeScript project check for this file. Per-Module Compile and JavaScript Unit Tests matched the diff by extension but neither applies: `modules/test/playwright` is not registered in `settings.gradle`, so no Gradle project resolves for a deploy, and that module's `test` script is `playwright test`, which pr-check places out of scope.

<!-- pr-check {"result": "success", "sha": "4f23ee8cd9ef401d8e4c858e7dc750e94b8c6d74"} -->
