### PR TITLE
LPD-101542 Read a DocuSign private key whose line breaks arrived escaped

### DIFF
--- a/modules/apps/digital-signature/digital-signature-impl/src/main/java/com/liferay/digital/signature/internal/web/cache/DSAccessTokenWebCacheItem.java
+++ b/modules/apps/digital-signature/digital-signature-impl/src/main/java/com/liferay/digital/signature/internal/web/cache/DSAccessTokenWebCacheItem.java
@@ -62,11 +62,13 @@ public class DSAccessTokenWebCacheItem implements WebCacheItem {
 			_environmentBaseURI = "account-d.docusign.com";
 		}
 
-		if (rsaPrivateKey != null) {
-			_rsaPrivateKeyBytes = rsaPrivateKey.getBytes();
+		if (rsaPrivateKey == null) {
+			_rsaPrivateKeyBytes = new byte[0];
 		}
 		else {
-			_rsaPrivateKeyBytes = new byte[0];
+			String pem = _getPEM(rsaPrivateKey);
+
+			_rsaPrivateKeyBytes = pem.getBytes();
 		}
 	}
 
@@ -150,6 +152,35 @@ public class DSAccessTokenWebCacheItem implements WebCacheItem {
 			token + "." + _encode(signature.sign()), "=");
 	}
 
+	private String _getPEM(String rsaPrivateKey) {
+
+		// PEMReader reads the key line by line: it looks for the line holding
+		// the begin marker, derives the end marker from that line, and decodes
+		// the lines in between. Neither base64 nor a marker contains a
+		// backslash, so a backslash followed by "n" is unambiguously an encoded
+		// line break. Decode those, then put each marker back on a line of its
+		// own. A key that already has this shape comes back unchanged.
+
+		String pem = StringUtil.replace(
+			rsaPrivateKey.trim(), "\\\\n", StringPool.NEW_LINE);
+
+		pem = StringUtil.replace(pem, "\\n", StringPool.NEW_LINE);
+
+		int beginIndex = pem.indexOf(_BEGIN_MARKER);
+		int endIndex = pem.lastIndexOf(_END_MARKER);
+
+		if ((beginIndex == -1) || (endIndex == -1)) {
+			return pem;
+		}
+
+		String body = pem.substring(
+			beginIndex + _BEGIN_MARKER.length(), endIndex);
+
+		return StringBundler.concat(
+			_BEGIN_MARKER, StringPool.NEW_LINE, body.trim(),
+			StringPool.NEW_LINE, _END_MARKER);
+	}
+
 	private Object _getUnixTime(long offset) {
 		Long unixTime = (System.currentTimeMillis() / Time.SECOND) + offset;
 
@@ -170,6 +201,11 @@ public class DSAccessTokenWebCacheItem implements WebCacheItem {
 
 		return keyFactory.generatePrivate(pkcs1EncodedKeySpec.getKeySpec());
 	}
+
+	private static final String _BEGIN_MARKER =
+		"-----BEGIN RSA PRIVATE KEY-----";
+
+	private static final String _END_MARKER = "-----END RSA PRIVATE KEY-----";
 
 	private static final long _REFRESH_TIME = Time.MINUTE * 45;
 

--- a/modules/apps/digital-signature/digital-signature-impl/src/test/java/com/liferay/digital/signature/internal/web/cache/DSAccessTokenWebCacheItemTest.java
+++ b/modules/apps/digital-signature/digital-signature-impl/src/test/java/com/liferay/digital/signature/internal/web/cache/DSAccessTokenWebCacheItemTest.java
@@ -1,0 +1,78 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.digital.signature.internal.web.cache;
+
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Shuyang Zhou
+ */
+public class DSAccessTokenWebCacheItemTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testDoubleEscapedLineBreaks() {
+		Assert.assertEquals(
+			_PEM,
+			_getPEM(
+				"-----BEGIN RSA PRIVATE KEY-----\\\\nAAAABBBBCCCC\\\\n" +
+					"DDDDEEEEFFFF\\\\n-----END RSA PRIVATE KEY-----"));
+	}
+
+	@Test
+	public void testEscapedLineBreaks() {
+		Assert.assertEquals(
+			_PEM,
+			_getPEM(
+				"-----BEGIN RSA PRIVATE KEY-----\\nAAAABBBBCCCC\\n" +
+					"DDDDEEEEFFFF\\n-----END RSA PRIVATE KEY-----"));
+	}
+
+	@Test
+	public void testGluedBeginMarker() {
+		Assert.assertEquals(
+			_PEM,
+			_getPEM(
+				"-----BEGIN RSA PRIVATE KEY-----AAAABBBBCCCC\n" +
+					"DDDDEEEEFFFF\n-----END RSA PRIVATE KEY-----"));
+	}
+
+	@Test
+	public void testNullKey() {
+		Assert.assertEquals("", _getPEM(null));
+	}
+
+	@Test
+	public void testPEMIsUnchanged() {
+		Assert.assertEquals(_PEM, _getPEM(_PEM));
+	}
+
+	private String _getPEM(String rsaPrivateKey) {
+		DSAccessTokenWebCacheItem dsAccessTokenWebCacheItem =
+			new DSAccessTokenWebCacheItem(
+				"api-username", "sandbox", "integration-key", rsaPrivateKey);
+
+		byte[] rsaPrivateKeyBytes = ReflectionTestUtil.getFieldValue(
+			dsAccessTokenWebCacheItem, "_rsaPrivateKeyBytes");
+
+		return new String(rsaPrivateKeyBytes);
+	}
+
+	private static final String _PEM =
+		"-----BEGIN RSA PRIVATE KEY-----\nAAAABBBBCCCC\nDDDDEEEEFFFF" +
+			"\n-----END RSA PRIVATE KEY-----";
+
+}

--- a/modules/apps/digital-signature/digital-signature-test/src/testFunctional/macros/DigitalSignature.macro
+++ b/modules/apps/digital-signature/digital-signature-test/src/testFunctional/macros/DigitalSignature.macro
@@ -1,6 +1,16 @@
 definition {
 
 	@summary = "Default summary"
+	macro addDMDocument(dmDocumentFile = null) {
+		DMNavigator.openDocumentsAndMediaAdmin(siteURLKey = "guest");
+
+		DMDocument.addCP(
+			dmDocumentDescription = "DM Document Description",
+			dmDocumentFile = ${dmDocumentFile},
+			dmDocumentTitle = "DM Document Title");
+	}
+
+	@summary = "Default summary"
 	macro addMoreRecipient(fullName = null, recipientEmail = null) {
 		Click(locator1 = "DigitalSignatureListView#DIGITAL_SIGNATURE_ADD_RECIPIENT");
 
@@ -109,18 +119,25 @@ definition {
 
 	@summary = "Default summary"
 	macro createEnvelope(dmDocumentFile = null, addName = null, addFullName = null, addSubject = null, addEmail = null, addMessage = null) {
-		DMNavigator.openDocumentsAndMediaAdmin(siteURLKey = "guest");
+		DigitalSignature.addDMDocument(dmDocumentFile = ${dmDocumentFile});
 
-		DMDocument.addCP(
-			dmDocumentDescription = "DM Document Description",
-			dmDocumentFile = ${dmDocumentFile},
-			dmDocumentTitle = "DM Document Title");
+		DigitalSignature.createEnvelopeForDMDocument(
+			addEmail = ${addEmail},
+			addFullName = ${addFullName},
+			addMessage = ${addMessage},
+			addName = ${addName},
+			addSubject = ${addSubject});
+	}
 
+	@summary = "Default summary"
+	macro createEnvelopeForDMDocument(addName = null, addFullName = null, addSubject = null, addEmail = null, addMessage = null) {
 		Navigator.openURL();
 
 		ProductMenu.gotoPortlet(
 			category = "Content & Data",
 			portlet = "Digital Signature");
+
+		DigitalSignature.waitForListViewLoad();
 
 		LexiconEntry.gotoAdd();
 
@@ -175,6 +192,8 @@ definition {
 		ProductMenu.gotoPortlet(
 			category = "Content & Data",
 			portlet = "Digital Signature");
+
+		DigitalSignature.waitForListViewLoad();
 
 		LexiconEntry.gotoAdd();
 
@@ -251,6 +270,8 @@ definition {
 
 	@summary = "Default summary"
 	macro deleteEnvelope(envelopeName = null) {
+		DigitalSignature.waitForListViewLoad();
+
 		Refresh();
 
 		Click(
@@ -258,6 +279,8 @@ definition {
 			locator1 = "Link#ANY");
 
 		AssertElementPresent(locator1 = "TextInput#HIDDEN");
+
+		DigitalSignature.waitForListViewLoad();
 
 		var value = selenium.getElementValue("TextInput#HIDDEN");
 
@@ -380,6 +403,15 @@ definition {
 	}
 
 	@summary = "Default summary"
+	macro selectItemsPerPage(itemsPerPage = null) {
+		Click(locator1 = "DigitalSignatureListView#DIGITAL_SIGNATURE_ITEMS_PER_PAGE");
+
+		Click(
+			key_itemsPerPage = ${itemsPerPage},
+			locator1 = "DigitalSignatureListView#DIGITAL_SIGNATURE_ITEMS_PER_PAGE_OPTION");
+	}
+
+	@summary = "Default summary"
 	macro selectSiteStrategy(siteStrategy = null) {
 		Select(
 			locator1 = "DigitalSignatureConfiguration#SITE_SETTINGS_STRATEGY",
@@ -452,6 +484,11 @@ definition {
 		AssertElementPresent(
 			fileTitle = ${documentTitle},
 			locator1 = "DigitalSignatureEnvelopeSettings#DIGITAL_SIGNATURE_MODAL_UNSUPPORTED_FILE");
+	}
+
+	@summary = "Default summary"
+	macro waitForListViewLoad() {
+		AssertElementNotPresent(locator1 = "DigitalSignatureListView#DIGITAL_SIGNATURE_LOADING_INDICATOR");
 	}
 
 }

--- a/modules/apps/digital-signature/digital-signature-test/src/testFunctional/macros/DigitalSignature.macro
+++ b/modules/apps/digital-signature/digital-signature-test/src/testFunctional/macros/DigitalSignature.macro
@@ -257,6 +257,8 @@ definition {
 
 	@summary = "Default summary"
 	macro deleteCreatedDM() {
+		DigitalSignature.waitForListViewLoad();
+
 		DMNavigator.openDocumentsAndMediaAdmin(siteURLKey = "guest");
 
 		PortletEntry.selectAll();

--- a/modules/apps/digital-signature/digital-signature-test/src/testFunctional/paths/DigitalSignatureListView.path
+++ b/modules/apps/digital-signature/digital-signature-test/src/testFunctional/paths/DigitalSignatureListView.path
@@ -21,6 +21,16 @@
 	<td></td>
 </tr>
 <tr>
+	<td>DIGITAL_SIGNATURE_ITEMS_PER_PAGE</td>
+	<td>//button[@aria-label = 'Items Per Page']</td>
+	<td></td>
+</tr>
+<tr>
+	<td>DIGITAL_SIGNATURE_ITEMS_PER_PAGE_OPTION</td>
+	<td>//div[contains(@class, 'dropdown-menu-select')]//button[@role = 'option' and normalize-space(.) = '${key_itemsPerPage} items']</td>
+	<td></td>
+</tr>
+<tr>
 	<td>DIGITAL_SIGNATURE_NAVIGATE_NEXT</td>
 	<td>//*[contains(@aria-label, 'Go to the next page')]</td>
 	<td></td>
@@ -68,6 +78,11 @@
 <tr>
 	<td>DIGITAL_SIGNATURE_RECENT_CREATE_DATE</td>
 	<td>//td[contains(., 'a few seconds ago')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>DIGITAL_SIGNATURE_LOADING_INDICATOR</td>
+	<td>//div[contains(@class, 'envelope-list')]//span[contains(@class, 'loading-animation')]</td>
 	<td></td>
 </tr>
 </tbody>

--- a/modules/apps/digital-signature/digital-signature-test/src/testFunctional/tests/DigitalSignatureListView.testcase
+++ b/modules/apps/digital-signature/digital-signature-test/src/testFunctional/tests/DigitalSignatureListView.testcase
@@ -86,6 +86,25 @@ definition {
 	@description = "LPS-131206. Verify if is possible navigate between pages"
 	@priority = 3
 	test CanNavigateBetweenPages {
+		task ("Given more envelopes exist than one page holds") {
+			DigitalSignature.addDMDocument(dmDocumentFile = "Alice's Adventures in Wonderland.pdf");
+
+			for (var envelopeNumber : list "1,2,3,4,5") {
+				DigitalSignature.createEnvelopeForDMDocument(
+					addEmail = "test@liferay.com",
+					addFullName = "Recipient Full Name",
+					addMessage = "Email Message",
+					addName = "Poshi Test CanNavigateBetweenPages ${envelopeNumber}",
+					addSubject = "Email Subject");
+
+				Button.click(button = "Send");
+
+				Alert.viewSuccessMessageText(successMessage = "Your envelope was created successfully.");
+
+				DigitalSignature.waitForListViewLoad();
+			}
+		}
+
 		task ("When a User Test Goes to Digital Signature") {
 			Navigator.openURL();
 
@@ -95,7 +114,19 @@ definition {
 		}
 
 		task ("Then it is possible to navigate between pages") {
+			DigitalSignature.selectItemsPerPage(itemsPerPage = 4);
+
 			DigitalSignature.canPageNavigator();
+		}
+
+		task ("Clean up the envelopes and the document") {
+			DigitalSignature.selectItemsPerPage(itemsPerPage = 20);
+
+			for (var envelopeNumber : list "1,2,3,4,5") {
+				DigitalSignature.deleteEnvelope(envelopeName = "Poshi Test CanNavigateBetweenPages ${envelopeNumber}");
+			}
+
+			DigitalSignature.deleteCreatedDM();
 		}
 	}
 

--- a/modules/apps/digital-signature/digital-signature-test/src/testFunctional/tests/DigitalSignatureListView.testcase
+++ b/modules/apps/digital-signature/digital-signature-test/src/testFunctional/tests/DigitalSignatureListView.testcase
@@ -218,6 +218,8 @@ definition {
 		}
 
 		task ("Then the user can see that an envelope have more than one recipient on list") {
+			DigitalSignature.waitForListViewLoad();
+
 			Refresh();
 
 			DigitalSignature.viewMoreRecipient();
@@ -225,6 +227,8 @@ definition {
 			DigitalSignature.deleteEnvelope(envelopeName = "Poshi Test HaveMoreRecipientsThanOne");
 
 			AssertElementNotPresent(locator1 = "DigitalSignatureListView#DIGITAL_SIGNATURE_RECIPIENTS_BADGE");
+
+			DigitalSignature.waitForListViewLoad();
 
 			DMNavigator.openDocumentsAndMediaAdmin(siteURLKey = "guest");
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101542

## What Is Being Fixed

Every digital signature test that talks to DocuSign has failed since 2026-06-22 — twelve of them in every `ci:test:object` run. The credentials are valid: a direct JWT grant against `account-d.docusign.com` returns a bearer token, and a local portal fed the same values created a real envelope in the sandbox.

The portal hands the RSA private key straight to `net.oauth.signature.pem.PEMReader`, which is line based — it finds the line holding the begin marker, derives the end marker from that same line, and decodes what lies between. The key currently written to `test.properties` has its line breaks escaped as the two characters backslash and n, so it arrives as a single line with no end marker line, and its begin marker is glued to the first base64 characters. Either alone is fatal with `Invalid PEM file: No end marker`, and `DSAccessTokenWebCacheItem.convert` logs that at debug level and returns an empty JSON object — so the portal signs nothing and every DocuSign call fails with nothing in the log to explain why.

CI is tracking the feed itself in LRCI-8036 but will not ship it until next week, and the same shape reaches the field whenever a key is copied out of a JSON or properties secret store.

`CanNavigateBetweenPages` then still failed for its own reason: it asserted that the envelope list offers a next page without creating a single envelope, so it could only pass while the shared account happened to hold more than twenty envelopes left behind by earlier runs.

## How It Is Being Fixed

Decode the escaped line breaks and put each marker back on a line of its own before handing the key to the parser. Verified against the real credentials with the parser itself:

| key as fed | parses before | parses after |
| --- | --- | --- |
| escaped line breaks, glued begin marker (what CI writes today) | no | yes |
| escaped line breaks, begin marker on its own line | no | yes |
| doubly escaped line breaks | no | yes |
| real line breaks, glued begin marker | no | yes |
| a correct PEM | yes | yes, byte for byte identical |

So it repairs every broken shape and is inert once the feed is corrected. A unit test pins each row plus the null case.

The pagination test now creates the five envelopes it needs, pages through them at a page size of four, and voids them. Entering the list starts an asynchronous fetch through `GetDSEnvelopesMVCResourceCommand`, and navigating away mid flight aborts it and logs a `ClientAbortException` that fails the whole Poshi run, so the creation and delete flows wait for the list to finish loading before they navigate.

## Verification

Locally the whole `DigitalSignatureListView` file passes from a wiped database **while being fed the deliberately mis-escaped key**, with zero `ClientAbortException` and no ERROR lines in any log.

On CI, nine of the twelve failures cleared with no digital signature regression:

| fixed | |
| --- | --- |
| `ListView#CanDownloadEnvelopeByEnvelopeDescription` | `ListView#CanViewCorrectDate` |
| `ListView#CanDownloadEnvelopeByEnvelopeList` | `ListView#CanViewEnvelopeDetails` |
| `ListView#CanNavigateBetweenPages` | `ListView#DigitalSignatureCanBeEnabled` |
| `ListView#HaveMoreRecipientsThanOne` | `EnvelopeSettings#CanAddMoreThan1Document` |
| `EnvelopeSettings#CanViewSuccessMessage` | |

The pass is attributable to this change rather than to a corrected feed: the rescued tests failed on every earlier build, including the foreign `ci:test:bpm` 8239, and pass only on the builds carrying this branch.

The three still failing are unrelated to credentials — `DigitalSignatureDM#CanCollectDigitalSignatureByButton` and `#CanGetMultipleSignaturesByButton` (`ElementNotInteractableException`), and `SiteSettings#CanEnableDigitalSignatureBySiteSettings` (non editable `apiUsername` field).

## PR Check

**pr-check: PASS** — tested on `f23f930626dfac7517b481dbf844f53f48d78bc9`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Poshi Syntax | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "f23f930626dfac7517b481dbf844f53f48d78bc9"} -->
