### PR TITLE
LPD-100923 Restore the instance default language even when the user language step fails

### DIFF
--- a/modules/test/playwright/tests/site-admin-web/main/fixtures/localizationPagesTest.ts
+++ b/modules/test/playwright/tests/site-admin-web/main/fixtures/localizationPagesTest.ts
@@ -5,6 +5,7 @@
 
 import {test} from '@playwright/test';
 
+import {getHeader} from '../../../../helpers/ApiHelpers';
 import {LocalizationInstanceSettingsPage} from '../pages/LocalizationInstanceSettingsPage';
 
 const localizationPagesTest = test.extend<{
@@ -22,28 +23,46 @@ const localizationPagesTest = test.extend<{
 			await use();
 		}
 		finally {
+			try {
 
-			// Render the admin UI in English regardless of the current
-			// instance default language, so the settings navigation and
-			// controls resolve when the test left the instance in another
-			// language.
+				// Render the admin UI in English regardless of the current
+				// instance default language, so the settings navigation and
+				// controls resolve when the test left the instance in another
+				// language. Both calls carry the authenticity token: without
+				// it the portal answers Forbidden, and the body it returns for
+				// that is not always JSON.
 
-			const response = await page.request.get(
-				'/o/headless-admin-user/v1.0/my-user-account'
-			);
+				const response = await page.request.get(
+					'/o/headless-admin-user/v1.0/my-user-account',
+					{headers: await getHeader(page)}
+				);
 
-			const myUserAccount = await response.json();
+				const myUserAccount = await response.json();
 
-			await page.request.patch(
-				`/o/headless-admin-user/v1.0/user-accounts/${myUserAccount.id}`,
-				{data: {languageId: 'en_US'}}
-			);
+				await page.request.patch(
+					`/o/headless-admin-user/v1.0/user-accounts/${myUserAccount.id}`,
+					{
+						data: {languageId: 'en_US'},
+						headers: await getHeader(page),
+					}
+				);
 
-			await page.reload();
+				await page.reload();
+			}
+			finally {
 
-			await localizationInstanceSettingsPage.goto('Language', false);
+				// The instance default language is instance wide state that
+				// every later test inherits, so restore it even when the steps
+				// above fail. Leaving it set fails sign-in verification,
+				// object definition labels, and site page creation across
+				// every file and worker that follows.
 
-			await localizationInstanceSettingsPage.setDefaultLanguage('en_US');
+				await localizationInstanceSettingsPage.goto('Language', false);
+
+				await localizationInstanceSettingsPage.setDefaultLanguage(
+					'en_US'
+				);
+			}
 		}
 	},
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100923

Follow-up on the same ticket. The teardown this ticket made robust still has one step that can throw before the restore it protects.

## What Is Being Fixed

The teardown sets the signed in user's language to English before it navigates the instance settings screen, and reads the user account first to learn the account id. That read carries no authenticity token, so the portal answers Forbidden, and on CI the body it returns for that is not JSON. The parse throws inside the `finally` and takes the rest of the block with it, including the instance default language restore:

```
SyntaxError: Unexpected token '<'. "<Forbidden"... is not valid JSON
  at site-admin-web/main/fixtures/localizationPagesTest.ts:35
```

Both object tests that use the fixture die on it — `objectDefinition.spec.ts:1769` and `:1951` — and since the instance default language is instance wide state, whatever the test left behind is inherited by every later test on that instance.

The cause is the missing token, not a dead session. Measured against a running portal: the same Forbidden comes back on a freshly authenticated session without the token, and clearing every cookie produces a byte identical response. With the token the read returns 200 and the account.

There is a second, quieter defect in the same place. Without the token the read yields no account id, so the patch goes to `user-accounts/undefined` and the user's language is never actually set — silently, because nothing checks the response.

## How It Is Being Fixed

Send the authenticity token on both calls, the way every other request in `ApiHelpers` already does. `my-user-account` is GET only (405 on PATCH and PUT), so the two call shape stays.

Restore the instance default language from its own `finally` as well, so a failure in the user language step still reports against the test that caused it without also skipping the restore that every later test depends on.

## Verification

Both localization tests pass locally and the instance returns to `lang="en-US"`.

The fail safe was proven by fault injection: pointing the read at an HTML page reproduces the exact `Unexpected token '<'` failure, and the test then fails and reports it **while the instance default language still comes back to English**. Before this change that same throw left the instance localized.

On CI (`ci:test:object` on this change alone, build 507035877) both tests pass and the run has the lowest failure count of the campaign, 21. Worth stating plainly: those two tests are intermittent — they have also failed on foreign builds and passed without this change on others — so the CI run is corroboration rather than proof. The deterministic evidence is the fault injection above.

## PR Check

**pr-check: PASS** — tested on `6dcd41d307f473765916f93d8c8612924995c49b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

Source Format covers the TypeScript project check for this file. Per-Module Compile and JavaScript Unit Tests matched the diff by extension but neither applies: `modules/test/playwright` is not registered in `settings.gradle`, so no Gradle project resolves for a deploy, and that module's `test` script is `playwright test`, which pr-check places out of scope.

<!-- pr-check {"result": "success", "sha": "6dcd41d307f473765916f93d8c8612924995c49b"} -->
