### PR TITLE
LPD-99438 Annotate the batch engine task company configuration

### DIFF
--- a/modules/apps/batch-engine/batch-engine-api/bnd.bnd
+++ b/modules/apps/batch-engine/batch-engine-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Batch Engine API
 Bundle-SymbolicName: com.liferay.batch.engine.api
-Bundle-Version: 39.0.0
+Bundle-Version: 38.1.0
 Export-Package:\
 	com.liferay.batch.engine,\
 	com.liferay.batch.engine.action,\

--- a/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/configuration/BatchEngineTaskCompanyConfiguration.java
+++ b/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/configuration/BatchEngineTaskCompanyConfiguration.java
@@ -9,6 +9,8 @@ import aQute.bnd.annotation.metatype.Meta;
 
 import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
 
+import org.osgi.annotation.versioning.ProviderType;
+
 /**
  * @author Matija Petanjek
  */
@@ -21,6 +23,7 @@ import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClass
 	localization = "content/Language",
 	name = "batch-engine-task-company-configuration-name"
 )
+@ProviderType
 public interface BatchEngineTaskCompanyConfiguration {
 
 	@Meta.AD(

--- a/modules/apps/batch-engine/batch-engine-api/src/main/resources/com/liferay/batch/engine/configuration/packageinfo
+++ b/modules/apps/batch-engine/batch-engine-api/src/main/resources/com/liferay/batch/engine/configuration/packageinfo
@@ -1,1 +1,1 @@
-version 4.0.0
+version 3.1.0


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99438

## What Is Being Fixed

The callback URL validation added under this ticket put two new settings on `BatchEngineTaskCompanyConfiguration`, an exported interface. An unannotated interface is a consumer type, so gaining a method is a breaking change: bnd baseline pushed `com.liferay.batch.engine.api` from 38.0.1 to 39.0.0 and the configuration package from 3.0.0 to 4.0.0.

Release branches do not take major version bumps, so the fix cannot be backported as it stands. It is needed on release-2026.q2, release-2026.q1, release-2025.q1 and release-2024.q1, and it also missed the 2026.q3 cut by four days.

## How It Is Being Fixed

Nothing implements a metatype configuration interface. Configuration Admin builds a reflective proxy from it, so no consumer can break when a method is added. Marking the interface `@ProviderType` states what was already true and reduces the classification from major to minor, which release branches accept routinely.

The versions drop accordingly, to 38.1.0 and 3.1.0. Baseline confirms it: major before the annotation, minor after, and clean at the new versions. The last published artifact is 38.0.0, so neither 38.0.1 nor 39.0.0 was ever released and lowering them is safe.

## Why Are There No Tests?

The change is build metadata. Its correctness is enforced by the batch-engine-api baseline task, which fails when the version does not match the classified API change and passes with the minor bump. The behavior behind the configuration is already covered by `BatchEngineImportTaskExecutorTest#testImportBlogPostingsWithCallbackURL`, added earlier under this same ticket.

## PR Check

**pr-check: PASS** — tested on `f5a784d8764ebba80d433e977078ba5ccdc42826`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "f5a784d8764ebba80d433e977078ba5ccdc42826"} -->
