### PR TITLE
LPD-100589 Stop LanguageOverrideResourceImpl from redeclaring EntityModelResource

### DIFF
--- a/modules/apps/headless/headless-admin-language-override/headless-admin-language-override-impl/src/main/java/com/liferay/headless/admin/language/override/internal/resource/v1_0/LanguageOverrideResourceImpl.java
+++ b/modules/apps/headless/headless-admin-language-override/headless-admin-language-override-impl/src/main/java/com/liferay/headless/admin/language/override/internal/resource/v1_0/LanguageOverrideResourceImpl.java
@@ -20,7 +20,6 @@ import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
-import com.liferay.portal.vulcan.resource.EntityModelResource;
 
 import jakarta.ws.rs.core.MultivaluedMap;
 
@@ -39,7 +38,7 @@ import org.osgi.service.component.annotations.ServiceScope;
 	scope = ServiceScope.PROTOTYPE, service = LanguageOverrideResource.class
 )
 public class LanguageOverrideResourceImpl
-	extends BaseLanguageOverrideResourceImpl implements EntityModelResource {
+	extends BaseLanguageOverrideResourceImpl {
 
 	@Override
 	public void deleteLanguageOverrideByExternalReferenceCode(


### PR DESCRIPTION
Fixing failure reported by Claude in https://liferay.slack.com/archives/CLCD3DQLF/p1786116250979079