### PR TITLE
LPD-99371 Remove the custom border radius from empty state buttons

### DIFF
--- a/modules/apps/design-library/design-library-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/design-library/design-library-web/src/main/resources/META-INF/resources/css/main.scss
@@ -66,7 +66,6 @@
 	}
 
 	.c-empty-state-footer .btn {
-		border-radius: 0.5rem;
 		font-size: 0.875rem;
 		line-height: 1.15;
 		padding: 0.4375rem 0.75rem;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99371

The empty states on the Design Libraries home hardcoded `border-radius: 0.5rem` on their buttons, overriding the theme's `$btn-border-radius` and rendering them visibly rounder than every other button on the page. Dropping the declaration lets those buttons inherit the theme value, so they match the surrounding UI and keep following it if the theme changes. In the future the admin base radius will be changed from `4px` to `8px`