### PR TITLE
LPD-101357 Import batch engine data before site initializers run

### DIFF
--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/bundle/BatchEngineBundleTracker.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/bundle/BatchEngineBundleTracker.java
@@ -13,6 +13,7 @@ import com.liferay.batch.engine.unit.BatchEngineUnitReader;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.module.util.ServiceLatch;
 import com.liferay.portal.kernel.servlet.InitialRequestSyncUtil;
 import com.liferay.portal.kernel.upgrade.util.UpgradeProcessUtil;
 
@@ -28,7 +29,6 @@ import org.osgi.framework.BundleEvent;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
-import org.osgi.service.component.annotations.Reference;
 import org.osgi.util.tracker.BundleTracker;
 import org.osgi.util.tracker.BundleTrackerCustomizer;
 
@@ -48,7 +48,24 @@ public class BatchEngineBundleTracker {
 
 		InitialRequestSyncUtil.registerSyncCallable(
 			() -> {
-				_bundleTracker.open();
+				ServiceLatch serviceLatch = new ServiceLatch(bundleContext);
+
+				serviceLatch.waitFor(
+					BatchEngineUnitProcessor.class,
+					batchEngineUnitProcessor ->
+						_batchEngineUnitProcessor = batchEngineUnitProcessor
+				).waitFor(
+					BatchEngineUnitReader.class,
+					batchEngineUnitReader ->
+						_batchEngineUnitReader = batchEngineUnitReader
+				).waitFor(
+					MultiCompanyBatchEngineUnitProcessor.class,
+					multiCompanyBatchEngineUnitProcessor ->
+						_multiCompanyBatchEngineUnitProcessor =
+							multiCompanyBatchEngineUnitProcessor
+				).openOn(
+					_bundleTracker::open
+				);
 
 				return null;
 			});
@@ -62,15 +79,9 @@ public class BatchEngineBundleTracker {
 	private static final Log _log = LogFactoryUtil.getLog(
 		BatchEngineBundleTracker.class);
 
-	@Reference
 	private BatchEngineUnitProcessor _batchEngineUnitProcessor;
-
-	@Reference
 	private BatchEngineUnitReader _batchEngineUnitReader;
-
 	private BundleTracker<Bundle> _bundleTracker;
-
-	@Reference
 	private MultiCompanyBatchEngineUnitProcessor
 		_multiCompanyBatchEngineUnitProcessor;
 

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BatchEngineBundleTrackerTest.java
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BatchEngineBundleTrackerTest.java
@@ -240,6 +240,24 @@ public class BatchEngineBundleTrackerTest {
 		return batchEngineImportTask.getParameterValue("dataFileName");
 	}
 
+	private void _refreshBatchEngineBundleTracker() throws Exception {
+		ComponentDescriptionDTO componentDescriptionDTO =
+			_serviceComponentRuntime.getComponentDescriptionDTO(
+				FrameworkUtil.getBundle(_batchEngineUnitReader.getClass()),
+				"com.liferay.batch.engine.internal.bundle." +
+					"BatchEngineBundleTracker");
+
+		Promise<Void> promise = _serviceComponentRuntime.disableComponent(
+			componentDescriptionDTO);
+
+		promise.getValue();
+
+		promise = _serviceComponentRuntime.enableComponent(
+			componentDescriptionDTO);
+
+		promise.getValue();
+	}
+
 	private void _testProcessBatchEngineBundle(
 			Consumer<BatchEngineImportTask> consumer, String dirName,
 			String... expectedDataFileNames)
@@ -331,6 +349,8 @@ public class BatchEngineBundleTrackerTest {
 					}),
 				null);
 
+		_refreshBatchEngineBundleTracker();
+
 		Bundle bundle = _bundleContext.installBundle(
 			RandomTestUtil.randomString(), _toInputStream(dirName));
 
@@ -367,6 +387,8 @@ public class BatchEngineBundleTrackerTest {
 				componentDescriptionDTO2);
 
 			promise.getValue();
+
+			_refreshBatchEngineBundleTracker();
 		}
 	}
 

--- a/modules/apps/site-initializer/site-initializer-welcome-test/src/testIntegration/java/com/liferay/site/initializer/welcome/test/WelcomeSiteInitializerTest.java
+++ b/modules/apps/site-initializer/site-initializer-welcome-test/src/testIntegration/java/com/liferay/site/initializer/welcome/test/WelcomeSiteInitializerTest.java
@@ -29,9 +29,11 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.model.PortletPreferences;
+import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
@@ -43,6 +45,8 @@ import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -131,6 +135,49 @@ public class WelcomeSiteInitializerTest {
 				layout.getPlid()));
 
 		Assert.assertTrue(html.contains("Enjoy using the best DXP on Earth!"));
+	}
+
+	@Test
+	@TestInfo("LPD-101357")
+	public void testCookiePolicyLayoutUtilityPageEntryWidgets()
+		throws Exception {
+
+		Group group = _groupLocalService.getGroup(
+			TestPropsValues.getCompanyId(), GroupConstants.GUEST);
+
+		Layout layout =
+			LayoutUtilityPageEntryLayoutProviderUtil.
+				getDefaultLayoutUtilityPageEntryLayout(
+					group.getGroupId(),
+					LayoutUtilityPageEntryConstants.TYPE_COOKIE_POLICY);
+
+		Assert.assertNotNull(layout);
+
+		List<FragmentEntryLink> fragmentEntryLinks =
+			_fragmentEntryLinkLocalService.getFragmentEntryLinksByPlid(
+				group.getGroupId(), layout.getPlid());
+
+		int widgetCount = 0;
+
+		for (FragmentEntryLink fragmentEntryLink : fragmentEntryLinks) {
+			JSONObject jsonObject = _jsonFactory.createJSONObject(
+				fragmentEntryLink.getEditableValues());
+
+			String portletId = jsonObject.getString("portletId");
+
+			if (Validator.isNull(portletId)) {
+				continue;
+			}
+
+			widgetCount++;
+
+			Assert.assertNotNull(
+				portletId,
+				_portletLocalService.fetchPortletById(
+					group.getCompanyId(), portletId));
+		}
+
+		Assert.assertEquals(fragmentEntryLinks.toString(), 4, widgetCount);
 	}
 
 	@Test
@@ -407,6 +454,9 @@ public class WelcomeSiteInitializerTest {
 
 	@DeleteAfterTestRun
 	private Group _group;
+
+	@Inject
+	private GroupLocalService _groupLocalService;
 
 	@Inject
 	private JSONFactory _jsonFactory;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101357

## What Is Being Fixed

On a clean install the seeded Cookie Policy utility page renders without its four cookie-list widgets: the page ends up with 11 FragmentEntryLinks instead of 15, and the page linked from the consent banner discloses no cookies. Root cause is commit 212b21be00320eda0596aa619e24042fa69a884b (LPD-99210), which deferred batch engine imports to the first request. `InitialRequestSyncUtil` runs its callables in registration order: the welcome site initializer's callable registers when the first company is created during `MainServlet.init`, while `BatchEngineBundleTracker` could not activate until its mandatory references resolved — a chain gated on the `portal.initialized` module service lifecycle that `MainServlet.init` registers only after creating the company. The batch callable therefore always landed behind the welcome callable, so every fresh install imported the welcome page before the cookie object definitions existed, and the widget importer silently dropped the four Widget nodes.

## How It Is Being Fixed

The mandatory references are replaced with a `ServiceLatch` armed inside the sync callable, so the component activates when its bundle starts — long before the first company registers — putting the batch import callable ahead of every portal instance lifecycle callable. On the first request the latch finds the services already registered and opens the bundle tracker inline on the request thread, preserving the order within the sync pass. When the callable fires while the services are not yet available (a redeploy of the bundle re-fires it inline before the module's own services finish re-registering), the latch defers the open until the last service appears, so batch imports re-arm instead of being lost.

A regression guard asserts the default company's seeded Cookie Policy page keeps its four portlet-bearing FragmentEntryLinks — that page is a direct artifact of the boot's first-request ordering, so a fresh-database CI run fails whenever the ordering regresses. `BatchEngineBundleTrackerTest` now bounces the tracker component explicitly after substituting services, since the zero-reference design no longer reacts to service churn the way the old mandatory references did.

Verified on a fresh database: registration lands at bundle start before company creation, and the first request imports the cookies batch data before the welcome site initializer runs, producing all four widgets.

## PR Check

**pr-check: PASS** — tested on `2cb5a66d61d500533f35d45bc4a1bdb844d27430`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "2cb5a66d61d500533f35d45bc4a1bdb844d27430"} -->
