### PR TITLE
LPD-101748 Count down ServiceLatch once per awaited service

### DIFF
--- a/modules/apps/portal/portal-module-service-test/src/testIntegration/java/com/liferay/portal/module/service/test/ServiceLatchTest.java
+++ b/modules/apps/portal/portal-module-service-test/src/testIntegration/java/com/liferay/portal/module/service/test/ServiceLatchTest.java
@@ -1,0 +1,201 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.module.service.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.module.util.ServiceLatch;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceRegistration;
+
+/**
+ * @author Shuyang Zhou
+ */
+@RunWith(Arquillian.class)
+public class ServiceLatchTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() {
+		Bundle bundle = FrameworkUtil.getBundle(ServiceLatchTest.class);
+
+		_bundleContext = bundle.getBundleContext();
+	}
+
+	@Test
+	public void testCapturesTheFirstServiceOfEachAwaitedClass() {
+		ServiceA serviceA = new ServiceA() {
+		};
+		ServiceB serviceB = new ServiceB() {
+		};
+
+		ServiceRegistration<ServiceA> serviceRegistration1 =
+			_bundleContext.registerService(ServiceA.class, serviceA, null);
+		ServiceRegistration<ServiceB> serviceRegistration2 =
+			_bundleContext.registerService(ServiceB.class, serviceB, null);
+
+		try {
+			AtomicInteger openCounter = new AtomicInteger();
+
+			AtomicReference<ServiceA> serviceAAtomicReference =
+				new AtomicReference<>();
+			AtomicReference<ServiceB> serviceBAtomicReference =
+				new AtomicReference<>();
+
+			ServiceLatch serviceLatch = new ServiceLatch(_bundleContext);
+
+			serviceLatch.waitFor(ServiceA.class, serviceAAtomicReference::set);
+			serviceLatch.waitFor(ServiceB.class, serviceBAtomicReference::set);
+
+			serviceLatch.openOn(openCounter::incrementAndGet);
+
+			Assert.assertEquals(1, openCounter.get());
+			Assert.assertSame(serviceA, serviceAAtomicReference.get());
+			Assert.assertSame(serviceB, serviceBAtomicReference.get());
+		}
+		finally {
+			serviceRegistration1.unregister();
+			serviceRegistration2.unregister();
+		}
+	}
+
+	@Test
+	public void testOpensAfterEveryAwaitedServiceWithDuplicates() {
+		ServiceA serviceA1 = new ServiceA() {
+		};
+		ServiceA serviceA2 = new ServiceA() {
+		};
+
+		ServiceRegistration<ServiceA> serviceRegistration1 =
+			_bundleContext.registerService(ServiceA.class, serviceA1, null);
+		ServiceRegistration<ServiceA> serviceRegistration2 =
+			_bundleContext.registerService(ServiceA.class, serviceA2, null);
+
+		try {
+			AtomicInteger openCounter = new AtomicInteger();
+
+			List<ServiceA> serviceAs = new ArrayList<>();
+			List<ServiceB> serviceBs = new ArrayList<>();
+
+			ServiceLatch serviceLatch = new ServiceLatch(_bundleContext);
+
+			serviceLatch.waitFor(ServiceA.class, serviceAs::add);
+			serviceLatch.waitFor(ServiceB.class, serviceBs::add);
+
+			serviceLatch.openOn(openCounter::incrementAndGet);
+
+			Assert.assertEquals(serviceAs.toString(), 1, serviceAs.size());
+			Assert.assertSame(serviceA1, serviceAs.get(0));
+			Assert.assertEquals(serviceBs.toString(), 0, serviceBs.size());
+			Assert.assertEquals(0, openCounter.get());
+
+			ServiceB serviceB = new ServiceB() {
+			};
+
+			ServiceRegistration<ServiceB> serviceRegistration3 =
+				_bundleContext.registerService(ServiceB.class, serviceB, null);
+
+			try {
+				Assert.assertEquals(1, openCounter.get());
+				Assert.assertEquals(serviceAs.toString(), 1, serviceAs.size());
+				Assert.assertSame(serviceA1, serviceAs.get(0));
+				Assert.assertEquals(serviceBs.toString(), 1, serviceBs.size());
+				Assert.assertSame(serviceB, serviceBs.get(0));
+			}
+			finally {
+				serviceRegistration3.unregister();
+			}
+		}
+		finally {
+			serviceRegistration1.unregister();
+			serviceRegistration2.unregister();
+		}
+	}
+
+	@Test
+	public void testOpensAfterEveryAwaitedServiceWithReregistration() {
+		AtomicInteger openCounter = new AtomicInteger();
+
+		List<ServiceA> serviceAs = new ArrayList<>();
+		List<ServiceB> serviceBs = new ArrayList<>();
+
+		ServiceLatch serviceLatch = new ServiceLatch(_bundleContext);
+
+		serviceLatch.waitFor(ServiceA.class, serviceAs::add);
+		serviceLatch.waitFor(ServiceB.class, serviceBs::add);
+
+		serviceLatch.openOn(openCounter::incrementAndGet);
+
+		ServiceA serviceA1 = new ServiceA() {
+		};
+
+		ServiceRegistration<ServiceA> serviceRegistration1 =
+			_bundleContext.registerService(ServiceA.class, serviceA1, null);
+
+		serviceRegistration1.unregister();
+
+		ServiceA serviceA2 = new ServiceA() {
+		};
+
+		ServiceRegistration<ServiceA> serviceRegistration2 =
+			_bundleContext.registerService(ServiceA.class, serviceA2, null);
+
+		try {
+			Assert.assertEquals(serviceAs.toString(), 1, serviceAs.size());
+			Assert.assertSame(serviceA1, serviceAs.get(0));
+			Assert.assertEquals(0, openCounter.get());
+
+			ServiceB serviceB = new ServiceB() {
+			};
+
+			ServiceRegistration<ServiceB> serviceRegistration3 =
+				_bundleContext.registerService(ServiceB.class, serviceB, null);
+
+			try {
+				Assert.assertEquals(1, openCounter.get());
+				Assert.assertEquals(serviceAs.toString(), 1, serviceAs.size());
+				Assert.assertSame(serviceA1, serviceAs.get(0));
+				Assert.assertEquals(serviceBs.toString(), 1, serviceBs.size());
+				Assert.assertSame(serviceB, serviceBs.get(0));
+			}
+			finally {
+				serviceRegistration3.unregister();
+			}
+		}
+		finally {
+			serviceRegistration2.unregister();
+		}
+	}
+
+	private BundleContext _bundleContext;
+
+	private interface ServiceA {
+	}
+
+	private interface ServiceB {
+	}
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/module/util/ServiceLatch.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/module/util/ServiceLatch.java
@@ -49,15 +49,10 @@ public class ServiceLatch {
 	public <S> ServiceLatch waitFor(
 		Class<S> serviceClass, Consumer<S> serviceConsumer) {
 
-		CapturingServiceTrackerCustomizer<S> capturingServiceTrackerCustomizer =
-			new CapturingServiceTrackerCustomizer<>(serviceConsumer);
-
-		ServiceTracker<S, S> serviceTracker = new ServiceTracker<>(
-			_bundleContext, serviceClass, capturingServiceTrackerCustomizer);
-
-		capturingServiceTrackerCustomizer.setServiceTracker(serviceTracker);
-
-		_serviceTrackers.add(serviceTracker);
+		_serviceTrackers.add(
+			new ServiceTracker<>(
+				_bundleContext, serviceClass,
+				new CapturingServiceTrackerCustomizer<>(serviceConsumer)));
 
 		_serviceTrackersCount.incrementAndGet();
 
@@ -74,17 +69,11 @@ public class ServiceLatch {
 	public <S> ServiceLatch waitFor(
 		String filterString, Consumer<S> serviceConsumer) {
 
-		CapturingServiceTrackerCustomizer<S> capturingServiceTrackerCustomizer =
-			new CapturingServiceTrackerCustomizer<>(serviceConsumer);
-
 		try {
-			ServiceTracker<S, S> serviceTracker = new ServiceTracker<>(
-				_bundleContext, _bundleContext.createFilter(filterString),
-				capturingServiceTrackerCustomizer);
-
-			capturingServiceTrackerCustomizer.setServiceTracker(serviceTracker);
-
-			_serviceTrackers.add(serviceTracker);
+			_serviceTrackers.add(
+				new ServiceTracker<>(
+					_bundleContext, _bundleContext.createFilter(filterString),
+					new CapturingServiceTrackerCustomizer<>(serviceConsumer)));
 
 			_serviceTrackersCount.incrementAndGet();
 		}
@@ -140,16 +129,11 @@ public class ServiceLatch {
 			_bundleContext.ungetService(serviceReference);
 		}
 
-		public void setServiceTracker(ServiceTracker<S, S> serviceTracker) {
-			_serviceTracker = serviceTracker;
-		}
-
 		private CapturingServiceTrackerCustomizer(Consumer<S> serviceConsumer) {
 			_serviceConsumer = serviceConsumer;
 		}
 
 		private final Consumer<S> _serviceConsumer;
-		private ServiceTracker<S, S> _serviceTracker;
 
 	}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/module/util/ServiceLatch.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/module/util/ServiceLatch.java
@@ -9,6 +9,7 @@ import com.liferay.portal.kernel.dependency.manager.DependencyManagerSyncUtil;
 
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
@@ -95,6 +96,10 @@ public class ServiceLatch {
 
 		@Override
 		public S addingService(ServiceReference<S> serviceReference) {
+			if (!_satisfied.compareAndSet(false, true)) {
+				return null;
+			}
+
 			S service = _bundleContext.getService(serviceReference);
 
 			_serviceConsumer.accept(service);
@@ -133,6 +138,7 @@ public class ServiceLatch {
 			_serviceConsumer = serviceConsumer;
 		}
 
+		private final AtomicBoolean _satisfied = new AtomicBoolean();
 		private final Consumer<S> _serviceConsumer;
 
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101748

## What Is Being Fixed

Nothing is broken. This adds a capability `ServiceLatch` was never asked for.

The latch was written for callers outside OSGi, such as `portal-kernel` and `portal-impl`, waiting on singleton services that OSGi modules publish. Each awaited class has exactly one provider for the life of such a wait, so decrementing the latch's shared counter on every `addingService` event was the same as decrementing it once per awaited class, and a singleton that re-registers midway through startup means something deeper is wrong with that service anyway. Handling more than one service per awaited class was simply not a requirement.

Callers now arm the latch from inside OSGi components as well, to collect services a component would otherwise hold mandatory references to. There an awaited class can legitimately have several providers, and a provider can come and go while the latch is still pending. Under those conditions the per-event countdown reaches zero before every awaited class has appeared, so the open runnable runs while a capturing consumer has not, leaving whatever it was supposed to set unassigned. A stray countdown that lands while `openOn` is still opening trackers also lets the deferred cleanup run before the remaining tracker opens, which leaves that tracker open for good.

## How It Is Being Fixed

Each capturing customizer consumes its countdown at most once, through a `compareAndSet` guard, and ignores later services of a class it has already captured without retrieving them. The first service of each awaited class wins, which matches how every caller uses the capture.

A preceding commit removes the `ServiceTracker` back-reference each customizer carried, which has had no reader since the latch moved to a shared countdown.

There is no API change. `com.liferay.portal.kernel.module.util` is excluded from the bundle's `Export-Package`, carries no `packageinfo`, and consumers import it without a version attribute, so no version bump applies. The one removed member was a method on a private inner class, unreachable from any consumer.

`ServiceLatchTest` in `portal-module-service-test` pins the contract in three cases: duplicate providers of one awaited class neither open the latch early nor capture twice, a provider that unregisters and re-registers while the latch is pending consumes no second countdown and leaves the first capture in place, and the plain path still opens exactly once. Each case asserts the captured instances, not only the counts. All three fail before the change and pass after it, verified against a running portal built from this branch. That build also boots clean, which exercises the latch's existing callers, one per Service Builder module through the Spring extender.

## PR Check

**pr-check: PASS** — tested on `9f5f2b63f28168a35deddbe11d31bc3878c1a03a`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Full Portal Build | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "9f5f2b63f28168a35deddbe11d31bc3878c1a03a"} -->
