### PR TITLE
LPD-100569 Flush pending writes on both sides of the company scope

### DIFF
--- a/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceDBPartitionTest.java
+++ b/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceDBPartitionTest.java
@@ -181,6 +181,26 @@ public class CompanyLocalServiceDBPartitionTest
 	}
 
 	@Test
+	public void testAddCompanyDoesNotWriteToDefaultPartition()
+		throws Exception {
+
+		Company company = CompanyTestUtil.addCompany();
+
+		try {
+			Assert.assertEquals(
+				0,
+				_getResourcePermissionsCount(
+					defaultPartitionName, company.getCompanyId()));
+		}
+		finally {
+			companyLocalService.deleteCompany(company);
+
+			_deleteResourcePermissions(
+				defaultPartitionName, company.getCompanyId());
+		}
+	}
+
+	@Test
 	public void testAddCompanyUsesVirtualHostCounter() throws Exception {
 		long counter = _counterLocalService.increment();
 
@@ -1168,6 +1188,21 @@ public class CompanyLocalServiceDBPartitionTest
 		}
 	}
 
+	private void _deleteResourcePermissions(
+			String partitionName, long companyId)
+		throws Exception {
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				StringBundler.concat(
+					"delete from ", partitionName,
+					".ResourcePermission where companyId = ?"))) {
+
+			preparedStatement.setLong(1, companyId);
+
+			preparedStatement.executeUpdate();
+		}
+	}
+
 	private int _getDBPartitionsCount() throws Exception {
 		DatabaseMetaData databaseMetaData = connection.getMetaData();
 
@@ -1184,6 +1219,25 @@ public class CompanyLocalServiceDBPartitionTest
 		}
 
 		throw new SQLException("At least one database partition is required");
+	}
+
+	private int _getResourcePermissionsCount(
+			String partitionName, long companyId)
+		throws Exception {
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				StringBundler.concat(
+					"select count(*) COUNT_VALUE from ", partitionName,
+					".ResourcePermission where companyId = ?"))) {
+
+			preparedStatement.setLong(1, companyId);
+
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				resultSet.next();
+
+				return resultSet.getInt("COUNT_VALUE");
+			}
+		}
 	}
 
 	private long _getRulesCount(String partitionName) throws Exception {

--- a/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceDBPartitionTest.java
+++ b/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceDBPartitionTest.java
@@ -48,6 +48,8 @@ import com.liferay.portal.kernel.service.RepositoryLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.VirtualHostLocalService;
+import com.liferay.portal.kernel.spring.orm.LastSessionRecorderHelper;
+import com.liferay.portal.kernel.spring.orm.LastSessionRecorderHelperUtil;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.AssumeTestRule;
@@ -198,6 +200,61 @@ public class CompanyLocalServiceDBPartitionTest
 			_deleteResourcePermissions(
 				defaultPartitionName, company.getCompanyId());
 		}
+	}
+
+	@Test
+	public void testAddCompanyFlushesPendingWritesBeforeApplyingNewCompany()
+		throws Exception {
+
+		List<Long> companyIds = new ArrayList<>();
+
+		Thread currentThread = Thread.currentThread();
+
+		LastSessionRecorderHelper lastSessionRecorderHelper =
+			ReflectionTestUtil.getFieldValue(
+				LastSessionRecorderHelperUtil.class,
+				"_lastSessionRecorderHelper");
+
+		ReflectionTestUtil.setFieldValue(
+			LastSessionRecorderHelperUtil.class, "_lastSessionRecorderHelper",
+			new LastSessionRecorderHelper() {
+
+				@Override
+				public void syncLastSessionState() {
+					lastSessionRecorderHelper.syncLastSessionState();
+				}
+
+				@Override
+				public void syncLastSessionState(boolean portalSessionOnly) {
+
+					// Only a full sync flushes every session, so it is the
+					// one a company scope switch depends on
+
+					if (!portalSessionOnly &&
+						(currentThread == Thread.currentThread())) {
+
+						companyIds.add(CompanyThreadLocal.getCompanyId());
+					}
+
+					lastSessionRecorderHelper.syncLastSessionState(
+						portalSessionOnly);
+				}
+
+			});
+
+		try {
+			_company1 = CompanyTestUtil.addCompany();
+		}
+		finally {
+			ReflectionTestUtil.setFieldValue(
+				LastSessionRecorderHelperUtil.class,
+				"_lastSessionRecorderHelper", lastSessionRecorderHelper);
+		}
+
+		Assert.assertFalse(companyIds.toString(), companyIds.isEmpty());
+
+		Assert.assertEquals(
+			companyIds.toString(), _defaultCompanyId, (long)companyIds.get(0));
 	}
 
 	@Test

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -334,18 +334,16 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 					companyId)) {
 
 			if (PropsValues.DATABASE_PARTITION_ENABLED) {
-				try {
-					return TransactionInvokerUtil.invoke(
-						_transactionConfig, callable);
-				}
-				finally {
+				Company addedCompany = TransactionInvokerUtil.invoke(
+					_transactionConfig, callable);
 
-					// Commit callbacks must flush before this scope restores
-					// the previous company, or they would execute against
-					// the default partition
+				// Commit callbacks must flush before this scope restores the
+				// previous company, or they would execute against the
+				// caller's partition
 
-					LastSessionRecorderHelperUtil.syncLastSessionState(false);
-				}
+				LastSessionRecorderHelperUtil.syncLastSessionState(false);
+
+				return addedCompany;
 			}
 
 			return callable.call();

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -109,6 +109,7 @@ import com.liferay.portal.kernel.service.persistence.PortletPersistence;
 import com.liferay.portal.kernel.service.persistence.RolePersistence;
 import com.liferay.portal.kernel.service.persistence.UserPersistence;
 import com.liferay.portal.kernel.service.persistence.VirtualHostPersistence;
+import com.liferay.portal.kernel.spring.orm.LastSessionRecorderHelperUtil;
 import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.transaction.TransactionConfig;
@@ -333,8 +334,18 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 					companyId)) {
 
 			if (PropsValues.DATABASE_PARTITION_ENABLED) {
-				return TransactionInvokerUtil.invoke(
-					_transactionConfig, callable);
+				try {
+					return TransactionInvokerUtil.invoke(
+						_transactionConfig, callable);
+				}
+				finally {
+
+					// Commit callbacks must flush before this scope restores
+					// the previous company, or they would execute against
+					// the default partition
+
+					LastSessionRecorderHelperUtil.syncLastSessionState(false);
+				}
 			}
 
 			return callable.call();

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -329,6 +329,14 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 			return updatedCompany;
 		};
 
+		if (PropsValues.DATABASE_PARTITION_ENABLED) {
+
+			// Pending writes must flush before this scope applies the new
+			// company, or they would execute against its partition
+
+			LastSessionRecorderHelperUtil.syncLastSessionState(false);
+		}
+
 		try (SafeCloseable safeCloseable =
 				CompanyThreadLocal.setRawCompanyIdWithSafeCloseable(
 					companyId)) {

--- a/portal-kernel/src/com/liferay/portal/kernel/service/CompanyLocalService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/CompanyLocalService.java
@@ -606,4 +606,4 @@ public interface CompanyLocalService
 		boolean strangersVerify, boolean siteLogo);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-728683316
+// LIFERAY-SERVICE-BUILDER-HASH:247372254


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100569

Carries the fix authored by @jorgediaz-lr and the test authored by @IstvanD, originally reviewed at shuyangzhou/liferay-portal#12408, plus three follow-up commits.

## What Is Being Fixed

With `database.partition.enabled=true`, creating a virtual instance fails with `org.hibernate.StaleStateException` on `update Layout`. The company row and its partition exist, but the company is left incomplete and stray `ResourcePermission` rows are left in the caller's partition. It was failing roughly 90 tests in the `ci:test:db-partition` suite.

`addCompany` opens the new company's scope with `setRawCompanyIdWithSafeCloseable`, which by contract performs no session sync, and runs the creation through `TransactionInvokerUtil.invoke`. `checkCompany` registers the site initializers as a commit callback, so they run after the inner transaction commits, by which point Spring has resumed the caller's session. Their `Layout` update joins that session and stays pending. `TransactionCallbackUtil._wrapCallable` takes its same-company shortcut, correctly, because it changes no scope. The raw scope then restores without syncing, and the pending update executes at the request-scoped commit. Statement routing resolves the partition from the live company thread local when each statement is prepared, so the update goes to the caller's partition, where that `plid` never existed, and zero rows match.

## How It Is Being Fixed

`addCompany` flushes on both sides of its company id swap.

The restoring side flushes after `TransactionInvokerUtil.invoke` returns, so the commit callbacks' pending writes execute while the new company is still applied. It runs on the success path rather than from a `finally`, because on the failure path the inner transaction has rolled back and its rollback discarded the commit callbacks that produce those writes, and a throwable from the flush would replace the throwable that actually failed the creation.

The opening side flushes before the swap. Pending writes the caller still held would otherwise cross into the new company's scope, where the `REQUIRES_NEW` transaction's created-event syncs the session Spring recorded before suspending it — the caller's — and inserts those rows into the new company's partition.

LPS-185647 (16725810aae0e) established the flush on both sides of a company id swap and applied it to `setCompanyId` and `setCompanyIdWithSafeCloseable`, but not to the initializing variant this method uses, which LPS-108239 (6b3e95bf02c9c) added so company creation could set the id without the default user lookup `setCompanyId` performed at the time. That lookup became lazy in LPS-194715 and was removed in LPD-1721. The restoring side stayed covered until LPD-88080 (c97cbc50e9b32) replaced the deferred release from LPS-129502 (fc42860ea36d1) with a plain try-with-resources; the opening side was never covered.

## Testing

`CompanyLocalServiceDBPartitionTest` gains two tests. One asserts the company creation leaves no rows in the caller's partition, covering the restoring side. The other asserts the flush itself for the opening side, which leaves no residue to look for unless the caller happens to hold pending writes: it records the company each full session sync runs under and requires the first to be the caller's company.

Verified on CI at shuyangzhou/liferay-portal#12429. `ci:test:db-partition` build 507564923 returned 327 passed and 1 failed, the failure being the `ScheduleWebContentChangesWithDBPartitioningActivatedAcrossVariousCompanies` Poshi locator flake that is red on plain master nightlies (builds 338 through 348) since 2026-07-29 and that passed 2 of 3 retries here. `ci:test:relevant` build 507566021 returned 94 failures, each reproduced on a clean-master baseline.

## PR Check

**pr-check: PASS** — tested on `bf2a09541ea5c774e2ab0316fde2e3e2cf9e1791`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Transaction Usage | PASS |
| Full Portal Build | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

Source Format reported one `BNDBreakingChangeCommitMessageCheck` violation against `modules/apps/batch-engine/batch-engine-api/bnd.bnd`. It traces to a commit outside this branch that is present only on the local master used for the run, and this branch changes no batch-engine file, so it is an artifact of that local state rather than a finding against these commits.

<!-- pr-check {"result": "success", "sha": "bf2a09541ea5c774e2ab0316fde2e3e2cf9e1791"} -->
