### PR TITLE
LPD-101663 Publish a transaction executor for every resource request

### DIFF
--- a/modules/apps/cookies/cookies-api/bnd.bnd
+++ b/modules/apps/cookies/cookies-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Cookies API
 Bundle-SymbolicName: com.liferay.cookies.api
-Bundle-Version: 9.2.0
+Bundle-Version: 9.1.3
 Export-Package:\
 	com.liferay.cookies.configuration,\
 	com.liferay.cookies.configuration.banner,\

--- a/modules/apps/cookies/cookies-api/src/main/java/com/liferay/cookies/service/CookiesConsentPreferenceLocalService.java
+++ b/modules/apps/cookies/cookies-api/src/main/java/com/liferay/cookies/service/CookiesConsentPreferenceLocalService.java
@@ -211,10 +211,6 @@ public interface CookiesConsentPreferenceLocalService
 		long cookiesConsentPreferenceId);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CookiesConsentPreference fetchCookiesConsentPreference(
-		long userId, String domain, String name);
-
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public ActionableDynamicQuery getActionableDynamicQuery();
 
 	/**
@@ -294,4 +290,4 @@ public interface CookiesConsentPreferenceLocalService
 		CookiesConsentPreference cookiesConsentPreference);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1819426011
+// LIFERAY-SERVICE-BUILDER-HASH:-1885118937

--- a/modules/apps/cookies/cookies-api/src/main/java/com/liferay/cookies/service/CookiesConsentPreferenceLocalServiceUtil.java
+++ b/modules/apps/cookies/cookies-api/src/main/java/com/liferay/cookies/service/CookiesConsentPreferenceLocalServiceUtil.java
@@ -241,12 +241,6 @@ public class CookiesConsentPreferenceLocalServiceUtil {
 			cookiesConsentPreferenceId);
 	}
 
-	public static CookiesConsentPreference fetchCookiesConsentPreference(
-		long userId, String domain, String name) {
-
-		return getService().fetchCookiesConsentPreference(userId, domain, name);
-	}
-
 	public static com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery
 		getActionableDynamicQuery() {
 
@@ -359,4 +353,4 @@ public class CookiesConsentPreferenceLocalServiceUtil {
 			CookiesConsentPreferenceLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-949977715
+// LIFERAY-SERVICE-BUILDER-HASH:-1988590670

--- a/modules/apps/cookies/cookies-api/src/main/java/com/liferay/cookies/service/CookiesConsentPreferenceLocalServiceWrapper.java
+++ b/modules/apps/cookies/cookies-api/src/main/java/com/liferay/cookies/service/CookiesConsentPreferenceLocalServiceWrapper.java
@@ -275,14 +275,6 @@ public class CookiesConsentPreferenceLocalServiceWrapper
 	}
 
 	@Override
-	public com.liferay.cookies.model.CookiesConsentPreference
-		fetchCookiesConsentPreference(long userId, String domain, String name) {
-
-		return _cookiesConsentPreferenceLocalService.
-			fetchCookiesConsentPreference(userId, domain, name);
-	}
-
-	@Override
 	public com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery
 		getActionableDynamicQuery() {
 
@@ -426,4 +418,4 @@ public class CookiesConsentPreferenceLocalServiceWrapper
 		_cookiesConsentPreferenceLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1983608772
+// LIFERAY-SERVICE-BUILDER-HASH:-2076735159

--- a/modules/apps/cookies/cookies-api/src/main/resources/com/liferay/cookies/service/packageinfo
+++ b/modules/apps/cookies/cookies-api/src/main/resources/com/liferay/cookies/service/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 1.0.0

--- a/modules/apps/cookies/cookies-rest-impl/src/main/java/com/liferay/cookies/rest/internal/resource/v1_0/CookiesConsentPreferenceResourceImpl.java
+++ b/modules/apps/cookies/cookies-rest-impl/src/main/java/com/liferay/cookies/rest/internal/resource/v1_0/CookiesConsentPreferenceResourceImpl.java
@@ -9,6 +9,7 @@ import com.liferay.cookies.rest.dto.v1_0.CookiesConsentPreference;
 import com.liferay.cookies.rest.internal.dto.v1_0.util.CookiesConsentPreferenceUtil;
 import com.liferay.cookies.rest.resource.v1_0.CookiesConsentPreferenceResource;
 import com.liferay.cookies.service.CookiesConsentPreferenceLocalService;
+import com.liferay.cookies.service.persistence.CookiesConsentPreferencePersistence;
 import com.liferay.portal.kernel.exception.PortalException;
 
 import java.net.URI;
@@ -48,9 +49,8 @@ public class CookiesConsentPreferenceResourceImpl
 
 		com.liferay.cookies.model.CookiesConsentPreference
 			serviceBuilderCookiesConsentPreference =
-				_cookiesConsentPreferenceLocalService.
-					fetchCookiesConsentPreference(
-						contextUser.getUserId(), _getDomain(), name);
+				_cookiesConsentPreferencePersistence.fetchByU_D_N(
+					contextUser.getUserId(), _getDomain(), name);
 
 		if (serviceBuilderCookiesConsentPreference == null) {
 			return null;
@@ -67,11 +67,10 @@ public class CookiesConsentPreferenceResourceImpl
 
 		com.liferay.cookies.model.CookiesConsentPreference
 			serviceBuilderCookiesConsentPreference =
-				_cookiesConsentPreferenceLocalService.
-					fetchCookiesConsentPreference(
-						contextUser.getUserId(),
-						cookiesConsentPreference.getDomain(),
-						cookiesConsentPreference.getName());
+				_cookiesConsentPreferencePersistence.fetchByU_D_N(
+					contextUser.getUserId(),
+					cookiesConsentPreference.getDomain(),
+					cookiesConsentPreference.getName());
 
 		if (serviceBuilderCookiesConsentPreference != null) {
 			serviceBuilderCookiesConsentPreference.setExpirationDate(
@@ -80,9 +79,8 @@ public class CookiesConsentPreferenceResourceImpl
 				cookiesConsentPreference.getValue());
 
 			serviceBuilderCookiesConsentPreference =
-				_cookiesConsentPreferenceLocalService.
-					updateCookiesConsentPreference(
-						serviceBuilderCookiesConsentPreference);
+				_cookiesConsentPreferencePersistence.update(
+					serviceBuilderCookiesConsentPreference);
 		}
 		else {
 			serviceBuilderCookiesConsentPreference =
@@ -117,5 +115,9 @@ public class CookiesConsentPreferenceResourceImpl
 	@Reference
 	private CookiesConsentPreferenceLocalService
 		_cookiesConsentPreferenceLocalService;
+
+	@Reference
+	private CookiesConsentPreferencePersistence
+		_cookiesConsentPreferencePersistence;
 
 }

--- a/modules/apps/cookies/cookies-service/src/main/java/com/liferay/cookies/service/impl/CookiesConsentPreferenceLocalServiceImpl.java
+++ b/modules/apps/cookies/cookies-service/src/main/java/com/liferay/cookies/service/impl/CookiesConsentPreferenceLocalServiceImpl.java
@@ -29,7 +29,6 @@ import org.osgi.service.component.annotations.Reference;
 public class CookiesConsentPreferenceLocalServiceImpl
 	extends CookiesConsentPreferenceLocalServiceBaseImpl {
 
-	@Override
 	public CookiesConsentPreference addCookiesConsentPreference(
 			long userId, String domain, Date expirationDate, String name,
 			String value)
@@ -54,7 +53,6 @@ public class CookiesConsentPreferenceLocalServiceImpl
 			cookiesConsentPreference);
 	}
 
-	@Override
 	public void deleteCookiesConsentPreference(
 			long userId, String domain, String name)
 		throws PortalException {
@@ -62,25 +60,14 @@ public class CookiesConsentPreferenceLocalServiceImpl
 		cookiesConsentPreferencePersistence.removeByU_D_N(userId, domain, name);
 	}
 
-	@Override
 	public void deleteCookiesConsentPreferences(long userId) {
 		cookiesConsentPreferencePersistence.removeByUserId(userId);
 	}
 
-	@Override
 	public void deleteCookiesConsentPreferences(long userId, String domain) {
 		cookiesConsentPreferencePersistence.removeByU_D(userId, domain);
 	}
 
-	@Override
-	public CookiesConsentPreference fetchCookiesConsentPreference(
-		long userId, String domain, String name) {
-
-		return cookiesConsentPreferencePersistence.fetchByU_D_N(
-			userId, domain, name);
-	}
-
-	@Override
 	public CookiesConsentPreference getCookiesConsentPreference(
 			long userId, String domain, String name)
 		throws PortalException {
@@ -89,14 +76,12 @@ public class CookiesConsentPreferenceLocalServiceImpl
 			userId, domain, name);
 	}
 
-	@Override
 	public List<CookiesConsentPreference> getCookiesConsentPreferences(
 		long userId, String domain) {
 
 		return cookiesConsentPreferencePersistence.findByU_D(userId, domain);
 	}
 
-	@Override
 	public CookiesConsentPreference updateCookiesConsentPreference(
 		CookiesConsentPreference cookiesConsentPreference) {
 

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/container/request/filter/TransactionContainerRequestFilter.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/container/request/filter/TransactionContainerRequestFilter.java
@@ -9,6 +9,9 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.bean.PortalBeanLocatorUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.transaction.Isolation;
+import com.liferay.portal.kernel.transaction.Propagation;
+import com.liferay.portal.kernel.transaction.TransactionDefinition;
 import com.liferay.portal.kernel.transaction.Transactional;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.spring.transaction.TransactionAttributeAdapter;
@@ -49,39 +52,64 @@ public class TransactionContainerRequestFilter
 	public void filter(ContainerRequestContext containerRequestContext)
 		throws IOException {
 
+		String method = containerRequestContext.getMethod();
+
+		// Publishing a transaction executor is what lets the persistence layer
+		// open a session at all, so it happens for every request that reaches
+		// a resource method. Only the transaction attribute varies: a write
+		// wraps its work in one transaction, while a read, and a request that
+		// asks for transaction wrapping to be disabled, leave each service
+		// call to manage a transaction of its own
+
+		TransactionAttributeAdapter transactionAttributeAdapter = null;
+
 		if (GetterUtil.getBoolean(
 				containerRequestContext.getHeaderString(
 					"X-Liferay-Transaction-Disabled"))) {
 
 			if (_log.isDebugEnabled()) {
-				_log.debug("Transaction management is disabled");
+				_log.debug("Request level transaction wrapping is disabled");
 			}
 
+			// Not read only, because a request that disables transaction
+			// wrapping may still write, and a write that goes through the
+			// persistence layer alone only reaches the database when the
+			// session flushes at commit
+
+			transactionAttributeAdapter =
+				_transactionDisabledTransactionAttributeAdapter;
+		}
+		else if (_writeMethodNames.contains(method)) {
+			transactionAttributeAdapter = _writeTransactionAttributeAdapter;
+		}
+		else if (_readMethodNames.contains(method)) {
+
+			// Read only keeps the request scoped session in manual flush
+			// mode, so entities dirtied during a read are never flushed, and
+			// lets a read routed data source serve the request
+
+			transactionAttributeAdapter = _readTransactionAttributeAdapter;
+		}
+		else {
 			return;
 		}
 
-		if (_transactionRequiredMethodNames.contains(
-				containerRequestContext.getMethod())) {
+		Message message = PhaseInterceptorChain.getCurrentMessage();
 
-			Message message = PhaseInterceptorChain.getCurrentMessage();
+		InterceptorChain interceptorChain = message.getInterceptorChain();
 
-			InterceptorChain interceptorChain = message.getInterceptorChain();
+		TransactionCleanUpMessageObserver transactionCleanUpMessageObserver =
+			new TransactionCleanUpMessageObserver(
+				interceptorChain.getFaultObserver(),
+				transactionAttributeAdapter,
+				_transactionExecutor.start(transactionAttributeAdapter));
 
-			TransactionCleanUpMessageObserver
-				transactionCleanUpMessageObserver =
-					new TransactionCleanUpMessageObserver(
-						interceptorChain.getFaultObserver(),
-						_transactionExecutor.start(
-							_transactionAttributeAdapter));
+		containerRequestContext.setProperty(
+			VulcanConstants.TRANSACTION_CLEAN_UP_MESSAGE_OBSERVER,
+			transactionCleanUpMessageObserver);
 
-			containerRequestContext.setProperty(
-				VulcanConstants.TRANSACTION_CLEAN_UP_MESSAGE_OBSERVER,
-				transactionCleanUpMessageObserver);
-
-			interceptorChain.add(transactionCleanUpMessageObserver);
-			interceptorChain.setFaultObserver(
-				transactionCleanUpMessageObserver);
-		}
+		interceptorChain.add(transactionCleanUpMessageObserver);
+		interceptorChain.setFaultObserver(transactionCleanUpMessageObserver);
 	}
 
 	@Override
@@ -116,16 +144,33 @@ public class TransactionContainerRequestFilter
 	private static final Log _log = LogFactoryUtil.getLog(
 		TransactionContainerRequestFilter.class);
 
+	private static final Set<String> _readMethodNames = new HashSet<>(
+		Arrays.asList("GET", "HEAD"));
 	private static final TransactionAttributeAdapter
-		_transactionAttributeAdapter = new TransactionAttributeAdapter(
+		_readTransactionAttributeAdapter = new TransactionAttributeAdapter(
 			TransactionAttributeBuilder.build(
-				TransactionContainerRequestFilter.class.getAnnotation(
-					Transactional.class)));
+				true, Isolation.DEFAULT, Propagation.SUPPORTS, true,
+				TransactionDefinition.TIMEOUT_DEFAULT,
+				new Class<?>[] {Exception.class}, new String[0],
+				new Class<?>[0], new String[0]));
+	private static final TransactionAttributeAdapter
+		_transactionDisabledTransactionAttributeAdapter =
+			new TransactionAttributeAdapter(
+				TransactionAttributeBuilder.build(
+					true, Isolation.DEFAULT, Propagation.SUPPORTS, false,
+					TransactionDefinition.TIMEOUT_DEFAULT,
+					new Class<?>[] {Exception.class}, new String[0],
+					new Class<?>[0], new String[0]));
 	private static final TransactionExecutor _transactionExecutor =
 		(TransactionExecutor)PortalBeanLocatorUtil.locate(
 			"transactionExecutor");
-	private static final Set<String> _transactionRequiredMethodNames =
-		new HashSet<>(Arrays.asList("DELETE", "PATCH", "POST", "PUT"));
+	private static final Set<String> _writeMethodNames = new HashSet<>(
+		Arrays.asList("DELETE", "PATCH", "POST", "PUT"));
+	private static final TransactionAttributeAdapter
+		_writeTransactionAttributeAdapter = new TransactionAttributeAdapter(
+			TransactionAttributeBuilder.build(
+				TransactionContainerRequestFilter.class.getAnnotation(
+					Transactional.class)));
 
 	private static class TransactionCleanUpMessageObserver
 		extends AbstractPhaseInterceptor implements MessageObserver {
@@ -184,16 +229,19 @@ public class TransactionContainerRequestFilter
 
 		private TransactionCleanUpMessageObserver(
 			MessageObserver messageObserver,
+			TransactionAttributeAdapter transactionAttributeAdapter,
 			TransactionStatusAdapter transactionStatusAdapter) {
 
 			super(Phase.POST_INVOKE);
 
 			_messageObserver = messageObserver;
+			_transactionAttributeAdapter = transactionAttributeAdapter;
 			_transactionStatusAdapter = transactionStatusAdapter;
 		}
 
 		private boolean _complete;
 		private final MessageObserver _messageObserver;
+		private final TransactionAttributeAdapter _transactionAttributeAdapter;
 		private final TransactionStatusAdapter _transactionStatusAdapter;
 
 	}

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/jaxrs/container/request/filter/test/TransactionContainerRequestFilterTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/jaxrs/container/request/filter/test/TransactionContainerRequestFilterTest.java
@@ -10,7 +10,9 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.NoSuchGroupException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
+import com.liferay.portal.kernel.service.persistence.GroupUtil;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.test.log.LogCapture;
@@ -21,6 +23,7 @@ import com.liferay.portal.vulcan.jaxrs.exception.mapper.BaseExceptionMapper;
 import com.liferay.portal.vulcan.jaxrs.exception.mapper.Problem;
 
 import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.QueryParam;
@@ -107,10 +110,71 @@ public class TransactionContainerRequestFilterTest {
 		Assert.assertEquals(
 			204,
 			_getResponseCode(
+				"DELETE",
 				StringBundler.concat(
 					"http://localhost:", PortalUtil.getPortalServerPort(false),
-					"/o/test-vulcan/commit/", group.getGroupId())));
+					"/o/test-vulcan/commit/", group.getGroupId()),
+				false));
 		Assert.assertNull(GroupLocalServiceUtil.getGroup(group.getGroupId()));
+	}
+
+	@Test
+	public void testDeleteWithTransactionDisabledHeader() throws Exception {
+		Group group = GroupTestUtil.addGroup();
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				_CLASS_NAME_EXCEPTION_MAPPER, LoggerTestUtil.ERROR)) {
+
+			Assert.assertEquals(
+				500,
+				_getResponseCode(
+					"DELETE",
+					StringBundler.concat(
+						"http://localhost:",
+						PortalUtil.getPortalServerPort(false),
+						"/o/test-vulcan/rollback/", group.getGroupId(),
+						"?failInExceptionMapper=false"),
+					true));
+
+			Assert.assertNull(
+				GroupLocalServiceUtil.fetchGroup(group.getGroupId()));
+		}
+	}
+
+	@Test
+	public void testGet() throws Exception {
+		Assert.assertEquals(
+			200,
+			_getResponseCode(
+				"GET",
+				StringBundler.concat(
+					"http://localhost:", PortalUtil.getPortalServerPort(false),
+					"/o/test-vulcan/read/", RandomTestUtil.randomLong()),
+				false));
+	}
+
+	@Test
+	public void testGetWithTransactionDisabledHeader() throws Exception {
+		Assert.assertEquals(
+			200,
+			_getResponseCode(
+				"GET",
+				StringBundler.concat(
+					"http://localhost:", PortalUtil.getPortalServerPort(false),
+					"/o/test-vulcan/read/", RandomTestUtil.randomLong()),
+				true));
+	}
+
+	@Test
+	public void testHead() throws Exception {
+		Assert.assertEquals(
+			200,
+			_getResponseCode(
+				"HEAD",
+				StringBundler.concat(
+					"http://localhost:", PortalUtil.getPortalServerPort(false),
+					"/o/test-vulcan/read/", RandomTestUtil.randomLong()),
+				false));
 	}
 
 	@Test
@@ -123,11 +187,13 @@ public class TransactionContainerRequestFilterTest {
 			Assert.assertEquals(
 				500,
 				_getResponseCode(
+					"DELETE",
 					StringBundler.concat(
 						"http://localhost:",
 						PortalUtil.getPortalServerPort(false),
 						"/o/test-vulcan/rollback/", group.getGroupId(),
-						"?failInExceptionMapper=false")));
+						"?failInExceptionMapper=false"),
+					false));
 
 			Assert.assertNotNull(
 				GroupLocalServiceUtil.getGroup(group.getGroupId()));
@@ -135,11 +201,13 @@ public class TransactionContainerRequestFilterTest {
 			Assert.assertEquals(
 				500,
 				_getResponseCode(
+					"DELETE",
 					StringBundler.concat(
 						"http://localhost:",
 						PortalUtil.getPortalServerPort(false),
 						"/o/test-vulcan/rollback/", group.getGroupId(),
-						"?failInExceptionMapper=true")));
+						"?failInExceptionMapper=true"),
+					false));
 
 			Assert.assertNotNull(
 				GroupLocalServiceUtil.getGroup(group.getGroupId()));
@@ -159,6 +227,17 @@ public class TransactionContainerRequestFilterTest {
 			throws Exception {
 
 			GroupLocalServiceUtil.deleteGroup(siteId);
+		}
+
+		@GET
+		@Path("/read/{siteId}")
+		public String testRead(@PathParam("siteId") long siteId) {
+
+			// Calling the persistence layer directly, without the local
+			// service in between, is what makes this endpoint dependent on
+			// the transaction executor the filter publishes
+
+			return String.valueOf(GroupUtil.fetchByPrimaryKey(siteId));
 		}
 
 		@DELETE
@@ -208,11 +287,19 @@ public class TransactionContainerRequestFilterTest {
 
 	}
 
-	private int _getResponseCode(String urlString) throws IOException {
+	private int _getResponseCode(
+			String method, String urlString, boolean transactionDisabled)
+		throws IOException {
+
 		HttpURLConnection httpURLConnection =
 			(HttpURLConnection)URLConnectionUtil.createURLConnection(urlString);
 
-		httpURLConnection.setRequestMethod("DELETE");
+		httpURLConnection.setRequestMethod(method);
+
+		if (transactionDisabled) {
+			httpURLConnection.setRequestProperty(
+				"X-Liferay-Transaction-Disabled", "true");
+		}
 
 		return httpURLConnection.getResponseCode();
 	}

--- a/modules/apps/portal-vulcan/source-formatter-suppressions.xml
+++ b/modules/apps/portal-vulcan/source-formatter-suppressions.xml
@@ -3,5 +3,6 @@
 <suppressions>
 	<checkstyle>
 		<suppress checks="ParameterNameCheck" files="portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/list/type/ListEntry\.java" />
+		<suppress checks="PersistenceCallCheck" files="portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/jaxrs/container/request/filter/test/TransactionContainerRequestFilterTest\.java" />
 	</checkstyle>
 </suppressions>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101663

## What Is Being Fixed

`GET /o/cookies/v1.0/cookies-consent-preferences/by-name/{name}` returned `500` on every cache miss, so the Store Consent toggle on Account Settings > Data and Privacy never reflected a stored preference.

The cause is not in the cookies module. `TransactionContainerRequestFilter` started a transaction executor only for `DELETE`, `PATCH`, `POST`, and `PUT`, and returned before starting anything at all when a request carried `X-Liferay-Transaction-Disabled`. Every other path reached the resource method with an empty `TransactionExecutorThreadLocal`, so any resource touching the persistence layer directly died in `VerifySessionFactoryWrapper._verify` with `IllegalStateException: No current transaction executor`. A `GET` failed while the mirror image call on `PUT` succeeded, and because CXF dispatches `HEAD` onto the matching `GET` resource method, `HEAD` failed the same way.

Root cause: `c9c1021b96e70` ("LPS-93844 add transactioncontainerfilter") introduced the filter's transaction support covering only the four write verbs, and `37fc5409b1412` ("LPS-93844 TX") carried that restriction into `TransactionContainerRequestFilter` under its current name. Every later gap descends from that initial incomplete support, including the header early return that `25ae1d2211823` added in 2021. It stayed latent for as long as resources reached the database only through local services, which carry transaction attributes of their own; `9adcff3032709` made it visible by repointing the cookies consent resource straight at its persistence.

## How It Is Being Fixed

The filter now publishes a transaction executor for every request that reaches a resource method through the JAX-RS pipeline, and only the transaction attribute varies. A write keeps wrapping its work in one transaction. A read uses `SUPPORTS` with read only, which pushes `TransactionExecutorThreadLocal` without starting a transaction, keeps the request scoped session in manual flush mode, and lets deployments that split read and write data sources keep serving reads from the read data source. A request that disables transaction wrapping uses `SUPPORTS` without read only, because such a request may still write, and a write that goes through the persistence layer alone only reaches the database when the session flushes at commit.

Because the filter now covers the case the earlier attempt worked around, the three commits from that attempt are reverted here: they routed two cookies lookups through the local service only to borrow its transaction envelope, and the direct persistence calls are correct again. New integration tests pin the read and disabled header behavior; they fail on this branch with the filter commit dropped.

Two behavior changes worth knowing. A pooled connection acquired during a request is now held until the response commits instead of returning to the pool per call. `CTTransactionAdvice`'s null check of the current transaction executor no longer sees null on these paths, so a CTAware resource under a checked out publication reads publication data where it previously forced production mode, and a strict production write from such a resource fails instead of silently writing to production.

The GraphQL servlet invokes the same resource implementations outside the JAX-RS pipeline and still publishes no executor. That gap predates this pull request and needs its own change.

## Testing

`ci:test:relevant` ran green: `ci:test:stable` 11 of 11 jobs passed, `ci:test:relevant` 23 of 25, with no unique failures. The two failing jobs carry only failures shared with the upstream acceptance baseline at `9bc377c568ae2b1798194cc4c6436699870c6ced`, two of which have failed 12 of their last 12 runs. `RESTClientTemplateContextContributorTest` failing in `portal-vulcan-test` confirms that module ran, so the new tests in it ran and passed.

## PR Check

**pr-check: PASS** — tested on `4f2315b89f79d1cc1f023aa8edbe449e1657a262`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |
