### PR TITLE
LPD-101752 Keep model builder node controls reachable in the default value tests

### DIFF
--- a/modules/test/playwright/pages/object-web/model-builder/ModelBuilderObjectDefinitionNodePage.ts
+++ b/modules/test/playwright/pages/object-web/model-builder/ModelBuilderObjectDefinitionNodePage.ts
@@ -120,10 +120,16 @@ export class ModelBuilderObjectDefinitionNodePage {
 		objectDefinitionName: string,
 		objectDefinitionNodes: Locator
 	) {
+
+		// The diagram floats the sidebars and the minimap over the canvas by
+		// design, so a node can legitimately sit under them and a regular
+		// click never passes the pointer interception check. Dispatch the
+		// click straight to the button instead.
+
 		await objectDefinitionNodes
 			.filter({hasText: objectDefinitionName})
 			.getByRole('button', {name: 'Show All Fields'})
-			.click();
+			.dispatchEvent('click');
 	}
 
 	async createObjectField({

--- a/modules/test/playwright/tests/object-web/field/objectField.spec.ts
+++ b/modules/test/playwright/tests/object-web/field/objectField.spec.ts
@@ -3459,7 +3459,6 @@ test.describe('Manage object fields default value properties', () => {
 		async ({
 			apiHelpers,
 			modelBuilderDiagramPage,
-			modelBuilderLeftSidebarPage,
 			modelBuilderObjectDefinitionNodePage,
 			modelBuilderRightSidebarPage,
 			page,
@@ -3468,9 +3467,24 @@ test.describe('Manage object fields default value properties', () => {
 				objectFieldBusinessTypes: ['Text'],
 			});
 
+			// An isolated folder keeps the diagram to this one definition, so
+			// the node is fitted into view; the Default folder holds every
+			// system definition and pushes the node's controls out of the
+			// canvas viewport, which Playwright cannot scroll.
+
+			const objectFolder =
+				await apiHelpers.objectAdmin.postRandomObjectFolder();
+
+			apiHelpers.data.push({
+				id: objectFolder.id,
+				type: 'objectFolder',
+			});
+
 			const objectDefinition =
 				await apiHelpers.objectAdmin.postRandomObjectDefinition({
 					objectFields,
+					objectFolderExternalReferenceCode:
+						objectFolder.externalReferenceCode,
 					status: {code: 0},
 				});
 
@@ -3480,12 +3494,8 @@ test.describe('Manage object fields default value properties', () => {
 			});
 
 			await modelBuilderDiagramPage.goto({
-				objectFolderName: 'Default',
+				objectFolderName: objectFolder.name,
 			});
-
-			await modelBuilderLeftSidebarPage.sidebarItems
-				.filter({hasText: objectDefinition.name})
-				.click();
 
 			await modelBuilderObjectDefinitionNodePage.clickShowAllFieldsButton(
 				objectDefinition.name,
@@ -3495,7 +3505,7 @@ test.describe('Manage object fields default value properties', () => {
 			await modelBuilderDiagramPage.objectDefinitionNodes
 				.filter({hasText: objectDefinition.name})
 				.getByText(objectFields[0].label.en_US, {exact: true})
-				.click();
+				.dispatchEvent('click');
 
 			await modelBuilderRightSidebarPage.setDefaultValue(
 				'Text',
@@ -3568,7 +3578,6 @@ test.describe('Manage object fields default value properties', () => {
 		async ({
 			apiHelpers,
 			modelBuilderDiagramPage,
-			modelBuilderLeftSidebarPage,
 			modelBuilderObjectDefinitionNodePage,
 			modelBuilderRightSidebarPage,
 			page,
@@ -3577,9 +3586,24 @@ test.describe('Manage object fields default value properties', () => {
 				objectFieldBusinessTypes: ['Text'],
 			});
 
+			// An isolated folder keeps the diagram to this one definition, so
+			// the node is fitted into view; the Default folder holds every
+			// system definition and pushes the node's controls out of the
+			// canvas viewport, which Playwright cannot scroll.
+
+			const objectFolder =
+				await apiHelpers.objectAdmin.postRandomObjectFolder();
+
+			apiHelpers.data.push({
+				id: objectFolder.id,
+				type: 'objectFolder',
+			});
+
 			const objectDefinition =
 				await apiHelpers.objectAdmin.postRandomObjectDefinition({
 					objectFields,
+					objectFolderExternalReferenceCode:
+						objectFolder.externalReferenceCode,
 					status: {code: 0},
 				});
 
@@ -3589,12 +3613,8 @@ test.describe('Manage object fields default value properties', () => {
 			});
 
 			await modelBuilderDiagramPage.goto({
-				objectFolderName: 'Default',
+				objectFolderName: objectFolder.name,
 			});
-
-			await modelBuilderLeftSidebarPage.sidebarItems
-				.filter({hasText: objectDefinition.name})
-				.click();
 
 			await modelBuilderObjectDefinitionNodePage.clickShowAllFieldsButton(
 				objectDefinition.name,
@@ -3604,7 +3624,7 @@ test.describe('Manage object fields default value properties', () => {
 			await modelBuilderDiagramPage.objectDefinitionNodes
 				.filter({hasText: objectDefinition.name})
 				.getByText(objectFields[0].label.en_US, {exact: true})
-				.click();
+				.dispatchEvent('click');
 
 			const rightSidebar = page.locator(
 				'.lfr__objects-custom-vertical-bar-content > .sidebar[id*="ModelBuilderRightSidebar"]'


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101752

## What Is Being Fixed

Two model builder tests in `objectField.spec.ts` fail on CI — *can edit a default value input
through Model Builder without throwing errors* (`:3456`) and *model builder rightSidebar width
only increases if configuration is enabled* (`:3565`). Testray records **273 failures against 8
passes** for the pair. Both die with a 90-second `locator.click` timeout while the element stays
resolved, visible, enabled and stable — the signature of a click that never passes the pointer
interception check.

Two causes stack:

1. The tests put their definition in the **Default folder**, whose diagram draws every definition
   that folder holds, so where the node lands depends on what other tests left behind. Nodes are
   positioned by canvas transforms, which Playwright cannot scroll into view.
2. The diagram **floats the sidebars and the minimap over the canvas by design**, so a node can
   legitimately sit underneath them.

## How It Is Being Fixed

Give each test an **isolated object folder**, so the diagram holds only the definition under test.
Selecting the definition through the left sidebar becomes redundant with a single fitted node, so
that step goes away with the crowd that made it necessary.

Isolation alone is **not** sufficient, and that was measured rather than assumed: running the pair
with isolation and plain clicks still fails, because with one node the diagram fits it across the
whole viewport and the minimap lands directly on the node's lower field rows — the trace's screen
captures show it covering exactly the field the test clicks. So the click is dispatched straight to
the node's controls instead of hit-testing through overlays the interface layers over the canvas
legitimately.

## Verification

Clean regression A/B on this base (`d84d212adfea6`) after `ant all`, with a fresh database,
wiped `osgi/state` and wiped search data. The fix is test-only, so the second run reused the **same
running portal and the same database** — the test code is the only variable:

```
CONTROL (master, no fix)
  objectField.spec.ts:3456  FAILED  locator.click: Test timeout of 90000ms exceeded (1.5m)
  objectField.spec.ts:3565  FAILED  locator.click: Test timeout of 90000ms exceeded (1.5m)

WITH FIX (only this commit applied, same portal, same database)
  objectField.spec.ts:3456  PASSED  3.9s
  objectField.spec.ts:3575  PASSED  3.7s
```

CI agrees independently: both tests **pass** on `ci:test:object` build 507593254 carrying this
change, having failed on the runs without it.

## PR Check

**pr-check: PASS** — tested on `1cb7b06962865ebcef3d15efbc6a4115be421dbe`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

Source Format covers the TypeScript project check for these files. Per-Module Compile and
JavaScript Unit Tests matched the diff by extension but neither applies: `modules/test/playwright`
is not registered in `settings.gradle`, so no Gradle project resolves for a deploy, and that
module's `test` script is `playwright test`, which pr-check places out of scope.

<!-- pr-check {"result": "success", "sha": "1cb7b06962865ebcef3d15efbc6a4115be421dbe"} -->
