### PR TITLE
LPD-101753 Remove the X-Liferay-Transaction-Disabled header

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/container/request/filter/TransactionContainerRequestFilter.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/container/request/filter/TransactionContainerRequestFilter.java
@@ -13,7 +13,6 @@ import com.liferay.portal.kernel.transaction.Isolation;
 import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.TransactionDefinition;
 import com.liferay.portal.kernel.transaction.Transactional;
-import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.spring.transaction.TransactionAttributeAdapter;
 import com.liferay.portal.spring.transaction.TransactionAttributeBuilder;
 import com.liferay.portal.spring.transaction.TransactionExecutor;
@@ -60,22 +59,7 @@ public class TransactionContainerRequestFilter
 
 		TransactionAttributeAdapter transactionAttributeAdapter = null;
 
-		if (GetterUtil.getBoolean(
-				containerRequestContext.getHeaderString(
-					"X-Liferay-Transaction-Disabled"))) {
-
-			if (_log.isDebugEnabled()) {
-				_log.debug("Request level transaction wrapping is disabled");
-			}
-
-			// Not read only, because a request that disables wrapping may
-			// still write, and those writes reach the database only when the
-			// session flushes at commit
-
-			transactionAttributeAdapter =
-				_transactionDisabledTransactionAttributeAdapter;
-		}
-		else if (_writeMethodNames.contains(method)) {
+		if (_writeMethodNames.contains(method)) {
 			transactionAttributeAdapter = _writeTransactionAttributeAdapter;
 		}
 		else if (_readMethodNames.contains(method)) {
@@ -149,14 +133,6 @@ public class TransactionContainerRequestFilter
 				TransactionDefinition.TIMEOUT_DEFAULT,
 				new Class<?>[] {Exception.class}, new String[0],
 				new Class<?>[0], new String[0]));
-	private static final TransactionAttributeAdapter
-		_transactionDisabledTransactionAttributeAdapter =
-			new TransactionAttributeAdapter(
-				TransactionAttributeBuilder.build(
-					true, Isolation.DEFAULT, Propagation.SUPPORTS, false,
-					TransactionDefinition.TIMEOUT_DEFAULT,
-					new Class<?>[] {Exception.class}, new String[0],
-					new Class<?>[0], new String[0]));
 	private static final TransactionExecutor _transactionExecutor =
 		(TransactionExecutor)PortalBeanLocatorUtil.locate(
 			"transactionExecutor");

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/jaxrs/container/request/filter/test/TransactionContainerRequestFilterTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/jaxrs/container/request/filter/test/TransactionContainerRequestFilterTest.java
@@ -113,32 +113,8 @@ public class TransactionContainerRequestFilterTest {
 				"DELETE",
 				StringBundler.concat(
 					"http://localhost:", PortalUtil.getPortalServerPort(false),
-					"/o/test-vulcan/commit/", group.getGroupId()),
-				false));
+					"/o/test-vulcan/commit/", group.getGroupId())));
 		Assert.assertNull(GroupLocalServiceUtil.getGroup(group.getGroupId()));
-	}
-
-	@Test
-	public void testDeleteWithTransactionDisabledHeader() throws Exception {
-		Group group = GroupTestUtil.addGroup();
-
-		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
-				_CLASS_NAME_EXCEPTION_MAPPER, LoggerTestUtil.ERROR)) {
-
-			Assert.assertEquals(
-				500,
-				_getResponseCode(
-					"DELETE",
-					StringBundler.concat(
-						"http://localhost:",
-						PortalUtil.getPortalServerPort(false),
-						"/o/test-vulcan/rollback/", group.getGroupId(),
-						"?failInExceptionMapper=false"),
-					true));
-
-			Assert.assertNull(
-				GroupLocalServiceUtil.fetchGroup(group.getGroupId()));
-		}
 	}
 
 	@Test
@@ -149,20 +125,7 @@ public class TransactionContainerRequestFilterTest {
 				"GET",
 				StringBundler.concat(
 					"http://localhost:", PortalUtil.getPortalServerPort(false),
-					"/o/test-vulcan/read/", RandomTestUtil.randomLong()),
-				false));
-	}
-
-	@Test
-	public void testGetWithTransactionDisabledHeader() throws Exception {
-		Assert.assertEquals(
-			200,
-			_getResponseCode(
-				"GET",
-				StringBundler.concat(
-					"http://localhost:", PortalUtil.getPortalServerPort(false),
-					"/o/test-vulcan/read/", RandomTestUtil.randomLong()),
-				true));
+					"/o/test-vulcan/read/", RandomTestUtil.randomLong())));
 	}
 
 	@Test
@@ -173,8 +136,7 @@ public class TransactionContainerRequestFilterTest {
 				"HEAD",
 				StringBundler.concat(
 					"http://localhost:", PortalUtil.getPortalServerPort(false),
-					"/o/test-vulcan/read/", RandomTestUtil.randomLong()),
-				false));
+					"/o/test-vulcan/read/", RandomTestUtil.randomLong())));
 	}
 
 	@Test
@@ -192,8 +154,7 @@ public class TransactionContainerRequestFilterTest {
 						"http://localhost:",
 						PortalUtil.getPortalServerPort(false),
 						"/o/test-vulcan/rollback/", group.getGroupId(),
-						"?failInExceptionMapper=false"),
-					false));
+						"?failInExceptionMapper=false")));
 
 			Assert.assertNotNull(
 				GroupLocalServiceUtil.getGroup(group.getGroupId()));
@@ -206,8 +167,7 @@ public class TransactionContainerRequestFilterTest {
 						"http://localhost:",
 						PortalUtil.getPortalServerPort(false),
 						"/o/test-vulcan/rollback/", group.getGroupId(),
-						"?failInExceptionMapper=true"),
-					false));
+						"?failInExceptionMapper=true")));
 
 			Assert.assertNotNull(
 				GroupLocalServiceUtil.getGroup(group.getGroupId()));
@@ -286,19 +246,13 @@ public class TransactionContainerRequestFilterTest {
 
 	}
 
-	private int _getResponseCode(
-			String method, String urlString, boolean transactionDisabled)
+	private int _getResponseCode(String method, String urlString)
 		throws IOException {
 
 		HttpURLConnection httpURLConnection =
 			(HttpURLConnection)URLConnectionUtil.createURLConnection(urlString);
 
 		httpURLConnection.setRequestMethod(method);
-
-		if (transactionDisabled) {
-			httpURLConnection.setRequestProperty(
-				"X-Liferay-Transaction-Disabled", "true");
-		}
 
 		return httpURLConnection.getResponseCode();
 	}

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/node/AIHubAgentNodeExecutor.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/node/AIHubAgentNodeExecutor.java
@@ -168,7 +168,6 @@ public class AIHubAgentNodeExecutor extends BaseNodeExecutor {
 		options.addHeader(
 			"Liferay-AI-Hub-Cell-On-Behalf-Of",
 			authorizationTokenJSONObject.getString("userToken"));
-		options.addHeader("X-Liferay-Transaction-Disabled", "true");
 
 		Map<String, String> kaleoNodeSettingValues = new HashMap<>();
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101753

@gabrielwas

**This is one half of a two sided change. Its AI Hub cell counterpart must be merged and live on every reachable cell before this pull request lands.** Counterpart: https://github.com/brianchandotcom/liferay-portal-ee/pull/49964

## What Is Being Fixed

`X-Liferay-Transaction-Disabled` let a caller ask the receiving portal not to wrap its request in a single transaction. It existed because `TransactionContainerRequestFilter` chooses a transaction attribute from the HTTP verb alone, and a verb cannot express that a resource hands work to another thread and then waits for it, which is the property that actually matters. A resource with that requirement therefore had it asserted from the outside, by every caller, across a service boundary, and interpreted by a different deployment's filter.

The only endpoint that needed it is the AI Hub cell's agent instance resource, which now suspends the ambient transaction itself, so the requirement is declared where it is known rather than carried in a request header. The only producer of the header was the AI Hub agent workflow node, which no longer needs to send it.

## How It Is Being Fixed

Remove the three references: the producer in `AIHubAgentNodeExecutor`, the branch in `TransactionContainerRequestFilter` that consumed it along with the transaction attribute it selected, and the two tests that pinned it. The read and write coverage in `TransactionContainerRequestFilterTest` is unchanged.

This does not close the gap that motivated the header. A resource still cannot declare its own transaction attribute the way a Service Builder service does, and the filter still chooses by verb. Teaching the filter to read a resource method's `Transactional` annotation, the way `TransactionInterceptor` already reads a service method's, would let every resource state its own requirement and is the change this leaves room for.

## PR Check

**pr-check: PASS** — tested on `d2fe10b8ffd03ababff593ab6ba27cca3c662761`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |
