### PR TITLE
LPD-101755 Land on the requested page when a leftover navigation kills the open

### DIFF
--- a/modules/test/playwright/pages/object-web/ViewObjectDefinitionsPage.ts
+++ b/modules/test/playwright/pages/object-web/ViewObjectDefinitionsPage.ts
@@ -8,6 +8,7 @@ import {Locator, Page, Response, expect} from '@playwright/test';
 import {readFile} from 'fs/promises';
 import path from 'path';
 
+import {gotoWithRetry} from '../../utils/gotoWithRetry';
 import {PORTLET_URLS} from '../../utils/portletUrls';
 import {getTempDir} from '../../utils/temp';
 import {waitForAlert} from '../../utils/waitForAlert';
@@ -198,7 +199,8 @@ export class ViewObjectDefinitionsPage {
 	};
 
 	async goto(siteUrl?: Site['friendlyUrlPath']) {
-		await this.page.goto(
+		await gotoWithRetry(
+			this.page,
 			`/group${siteUrl || '/guest'}${PORTLET_URLS.objects}`,
 			{waitUntil: 'load'}
 		);

--- a/modules/test/playwright/pages/object-web/object-entries/ViewObjectEntriesPage.ts
+++ b/modules/test/playwright/pages/object-web/object-entries/ViewObjectEntriesPage.ts
@@ -15,6 +15,7 @@ import {
 	type SupportedBusinessType,
 	isFillableBusinessType,
 } from '../../../tests/object-web/utils/generateObjectEntry';
+import {gotoWithRetry} from '../../../utils/gotoWithRetry';
 import {PORTLET_URLS} from '../../../utils/portletUrls';
 
 export class ViewObjectEntriesPage {
@@ -264,7 +265,8 @@ export class ViewObjectEntriesPage {
 		const [_, objectDefinitionClassNameSuffix] =
 			objectDefinitionClassName.split('#');
 
-		await this.page.goto(
+		await gotoWithRetry(
+			this.page,
 			`/${regionalCode}/group${siteUrl ?? '/guest'}${
 				PORTLET_URLS.objects
 			}_${objectDefinitionClassNameSuffix}`,

--- a/modules/test/playwright/utils/gotoWithRetry.ts
+++ b/modules/test/playwright/utils/gotoWithRetry.ts
@@ -1,0 +1,39 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Page} from '@playwright/test';
+
+/**
+ * Navigates like page.goto, surviving a navigation left pending by an earlier
+ * step. An action whose success signal renders before its navigation commits,
+ * like saving an object layout, leaves that navigation in flight, and when it
+ * lands during a later goto the browser reports the goto as aborted or
+ * interrupted even though nothing is wrong with the address. Let the pending
+ * navigation land and go again: unlike settling for whatever page won, the
+ * retry ends on the address the caller asked for.
+ */
+export async function gotoWithRetry(
+	page: Page,
+	url: string,
+	options?: Parameters<Page['goto']>[1]
+) {
+	try {
+		return await page.goto(url, options);
+	}
+	catch (error) {
+		const message = String(error.message);
+
+		if (
+			!message.includes('interrupted by another navigation') &&
+			!message.includes('net::ERR_ABORTED')
+		) {
+			throw error;
+		}
+
+		await page.waitForLoadState();
+
+		return await page.goto(url, options);
+	}
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101755

## What Is Being Fixed

Opening the object definitions or object entries page intermittently dies on continuous integration at an address that is perfectly valid:

```
Error: page.goto: net::ERR_ABORTED at .../control_panel/manage?p_p_id=com_liferay_object_web_internal_object_definitions_portlet_ObjectDefinitionsPortlet
```

The same failure also appears in its other wording, `Navigation to ... interrupted by another navigation`. An earlier step leaves a navigation in flight — an action whose success signal renders before the navigation it triggers commits, such as saving the object layout configuration side panel — and when that navigation lands during the next open, the browser aborts one of the two.

## How It Is Being Fixed

`gotoWithRetry` lets the pending navigation settle and issues the open again. Retrying rather than tolerating the interruption is the point: settling for whichever page won would let a wrong page leak into the steps that follow, while the retry ends on the address the caller asked for.

Every occurrence collected from continuous integration aborts on the object definitions portlet, which is the address the two patched opens produce, across the relationship, layout, entry and workflow suites. `ObjectLayoutsPage.goto` reaches the same open by delegation, which is why layout tests fail on it without navigating themselves.

## Verification

- **Deterministic local reproduction.** Delaying document loads three seconds and firing a navigation from inside the page without awaiting it makes the open fail with the exact error above without the change, and pass with it. Normal timing passes either way.
- **Isolated continuous integration run.** Run as a single commit on its own branch, the signature stops appearing. The branch immediately before it, carrying a different change, still reports it.
- **Concurrent control.** Routines that build plain master, and so never carry this change, keep reporting the signature over the same days the fixed branch stays clean — so the change, not a quieter run environment, accounts for the difference.
- The test that failed in the isolated control run, `objectLayout.spec.ts:884`, passes locally with this change.

This masks rather than removes the race: a retry cannot prove the interruption stopped happening. `PORTLET_URLS.modelBuilder` and the remaining raw `page.goto` calls in object-web are still unprotected and are left for follow-up.

## PR Check

**pr-check: PASS** — tested on `9c6b663088237174eecff456bdbff9054ddd3ffe`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Spec Resolution (985 files, 5116 tests) | PASS |

Diff is three TypeScript files under `modules/test/playwright`. The module declares a `test` script, but it runs the Playwright suite itself, which is out of pr-check scope; spec resolution via `playwright test --list` is the compile gate that applies. No Java, `bnd.bnd`, `packageinfo`, or Gradle change, so Baseline, Per-Module Compile, Integration Test Compile and the Java validations do not fire.

<!-- pr-check {"result": "success", "sha": "9c6b663088237174eecff456bdbff9054ddd3ffe"} -->
