### PR TITLE
LPD-101756 Read the authentication token once per session instead of on every request

### DIFF
--- a/modules/test/playwright/helpers/ApiHelpers.ts
+++ b/modules/test/playwright/helpers/ApiHelpers.ts
@@ -9,7 +9,7 @@ import {
 	ObjectFolderAPI,
 	ObjectRelationshipAPI,
 } from '@liferay/object-admin-rest-client-js';
-import {Page} from '@playwright/test';
+import {BrowserContext, Page} from '@playwright/test';
 
 import {liferayConfig} from '../liferay.config';
 import {AnalyticsSettingsRestApiHelper} from './AnalyticsSettingsRestApiHelper';
@@ -105,8 +105,32 @@ interface RequestOptions<T> {
 	multipart?: {[key: string]: any};
 }
 
-async function getCSRFTokenHeader(page: Page) {
+const authTokens = new WeakMap<BrowserContext, string>();
+
+export function clearAuthToken(page: Page) {
+	authTokens.delete(page.context());
+}
+
+export async function readAuthToken(page: Page) {
+
+	// Read the token when the caller knows the page is settled, which is right
+	// after signing in, and keep it for the session it belongs to. Reading it
+	// while a request is being built instead is what fails: a navigation racing
+	// the evaluation destroys the execution context and kills it.
+
 	const authToken = await page.evaluate(() => Liferay.authToken);
+
+	authTokens.set(page.context(), authToken);
+
+	return authToken;
+}
+
+async function getCSRFTokenHeader(page: Page) {
+	let authToken = authTokens.get(page.context());
+
+	if (authToken === undefined) {
+		authToken = await readAuthToken(page);
+	}
 
 	return {
 		'x-csrf-token': authToken,
@@ -338,16 +362,51 @@ export class ApiHelpers {
 		return apiInstance;
 	}
 
+	private async _sendRequest(
+		method: 'delete' | 'get' | 'patch' | 'post' | 'put',
+		url: string,
+		options: {[key: string]: unknown} = {},
+		headers?: {[key: string]: string},
+		extraHeaders?: {[key: string]: string}
+	) {
+		const buildHeaders = async () =>
+			headers || {
+				...(await getHeader(this.page)),
+				...(extraHeaders || {}),
+			};
+
+		const response = await this.page.request[method](url, {
+			...options,
+			headers: await buildHeaders(),
+		});
+
+		if (headers || response.status() !== 403) {
+			return response;
+		}
+
+		// The token belongs to the session that was live when it was read, so
+		// a test that has signed in again since leaves it stale and the portal
+		// answers Forbidden. Read it again and retry once, rather than failing
+		// the caller with a Forbidden body it cannot interpret.
+
+		clearAuthToken(this.page);
+
+		return await this.page.request[method](url, {
+			...options,
+			headers: await buildHeaders(),
+		});
+	}
+
 	async postResponse<T>(
 		url: string,
 		{data, failOnStatusCode, headers, multipart}: RequestOptions<T> = {}
 	) {
-		return await this.page.request.post(url, {
-			data,
-			failOnStatusCode: failOnStatusCode || false,
-			headers: headers || (await getHeader(this.page)),
-			multipart,
-		});
+		return await this._sendRequest(
+			'post',
+			url,
+			{data, failOnStatusCode: failOnStatusCode || false, multipart},
+			headers
+		);
 	}
 
 	async post<T>(url: string, options: RequestOptions<T> = {}) {
@@ -374,10 +433,12 @@ export class ApiHelpers {
 		failOnStatusCode?: boolean,
 		headers?: {[key: string]: string}
 	) {
-		return await this.page.request.get(url, {
-			failOnStatusCode: failOnStatusCode || false,
-			headers: headers || (await getHeader(this.page)),
-		});
+		return await this._sendRequest(
+			'get',
+			url,
+			{failOnStatusCode: failOnStatusCode || false},
+			headers
+		);
 	}
 
 	async put<T>(url: string, options: RequestOptions<T> = {}) {
@@ -394,26 +455,25 @@ export class ApiHelpers {
 		url: string,
 		{data, failOnStatusCode, headers, multipart}: RequestOptions<T> = {}
 	) {
-		return await this.page.request.put(url, {
-			data,
-			failOnStatusCode: failOnStatusCode || false,
-			headers: headers || (await getHeader(this.page)),
-			multipart,
-		});
+		return await this._sendRequest(
+			'put',
+			url,
+			{data, failOnStatusCode: failOnStatusCode || false, multipart},
+			headers
+		);
 	}
 
 	async delete<T>(
 		url: string,
 		{data, failOnStatusCode, headers}: RequestOptions<T> = {}
 	) {
-		return this.page.request.delete(url, {
-			data,
-			failOnStatusCode: failOnStatusCode || false,
-			headers: {
-				...(await getHeader(this.page)),
-				...(headers || {}),
-			},
-		});
+		return this._sendRequest(
+			'delete',
+			url,
+			{data, failOnStatusCode: failOnStatusCode || false},
+			undefined,
+			headers
+		);
 	}
 
 	async get(
@@ -427,10 +487,7 @@ export class ApiHelpers {
 	}
 
 	async patch(url: string, data: DataObject) {
-		const response = await this.page.request.patch(url, {
-			data,
-			headers: await getHeader(this.page),
-		});
+		const response = await this._sendRequest('patch', url, {data});
 
 		const text = await response.text();
 
@@ -442,12 +499,16 @@ export class ApiHelpers {
 	}
 
 	async patchRequestOptions<T>(url: string, options: RequestOptions<T> = {}) {
-		const response = await this.page.request.patch(url, {
-			data: options.data,
-			failOnStatusCode: options.failOnStatusCode || false,
-			headers: options.headers || (await getHeader(this.page)),
-			multipart: options.multipart,
-		});
+		const response = await this._sendRequest(
+			'patch',
+			url,
+			{
+				data: options.data,
+				failOnStatusCode: options.failOnStatusCode || false,
+				multipart: options.multipart,
+			},
+			options.headers
+		);
 
 		const text = await response.text();
 

--- a/modules/test/playwright/utils/performLogin.ts
+++ b/modules/test/playwright/utils/performLogin.ts
@@ -5,7 +5,7 @@
 
 import {Cookie, Page, expect} from '@playwright/test';
 
-import {getHeader} from '../helpers/ApiHelpers';
+import {clearAuthToken, getHeader, readAuthToken} from '../helpers/ApiHelpers';
 import {liferayConfig} from '../liferay.config';
 import {faroConfig} from '../tests/osb-faro-web/main/faro.config';
 
@@ -82,6 +82,8 @@ async function performLogin(
 		timeout: 30 * 1000,
 	});
 
+	await readAuthToken(page);
+
 	return await page.context().cookies();
 }
 
@@ -103,6 +105,11 @@ export async function performLoginViaApi({
 	try {
 		await page.goto(loginUrl);
 
+		// Signing in replaces the session, so drop the token held for the one
+		// being left behind before the request that replaces it.
+
+		clearAuthToken(page);
+
 		const url = `${loginUrl}/c/portal/login`;
 
 		await expect
@@ -120,6 +127,11 @@ export async function performLoginViaApi({
 			.toBe(200);
 
 		await page.goto(loginUrl);
+
+		// The page has settled on the signed in session, so this is the moment
+		// to read the token every later request will carry.
+
+		await readAuthToken(page);
 	}
 	catch (error) {
 		error.message = `Login via API failed\n\n${error.message}`;
@@ -144,6 +156,11 @@ export async function performAnalyticsCloudLoginViaApi(
 	try {
 		await page.goto(loginUrl);
 
+		// Signing in replaces the session, so drop the token held for the one
+		// being left behind before the request that replaces it.
+
+		clearAuthToken(page);
+
 		const url = `${loginUrl}/c/portal/login`;
 
 		await expect
@@ -161,6 +178,11 @@ export async function performAnalyticsCloudLoginViaApi(
 			.toBe(200);
 
 		await page.goto(loginUrl);
+
+		// The page has settled on the signed in session, so this is the moment
+		// to read the token every later request will carry.
+
+		await readAuthToken(page);
 	}
 	catch (error) {
 		error.message = `Analytics Cloud login via API failed\n\n${error.message}`;
@@ -175,6 +197,8 @@ export async function performLogout(page: Page) {
 	await page.goto('/c/portal/logout');
 
 	await page.waitForURL((url) => !url.pathname.endsWith('/c/portal/logout'));
+
+	clearAuthToken(page);
 }
 
 export async function performUserSwitch(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101756

## What Is Being Fixed

Every API helper builds its request by reading `Liferay.authToken` out of the page through a single evaluation. When a navigation is in flight at that moment the execution context is destroyed and the evaluation dies, failing the test on infrastructure rather than on anything under test:

```
Error: page.evaluate: Execution context was destroyed, most likely because of a navigation
   at ../helpers/ApiHelpers.ts:109

  108 | async function getCSRFTokenHeader(page: Page) {
> 109 | 	const authToken = await page.evaluate(() => Liferay.authToken);
```

The object relationship suite hits it repeatedly, because its steps drive the interface and then set data up through the API, so a step that saves a layout is followed immediately by one that creates entries.

Settling the page before the evaluation does not help: that wait resolves against the document that is about to be replaced and returns in under a millisecond.

## How It Is Being Fixed

Nothing about the token requires reading it while a request is being built. It belongs to the session rather than to the page — every portal page serves the same value, and it changes only when the session does. Read it once, right after signing in where the caller knows the page has settled, and keep it for the session it belongs to. There is then no evaluation left to race.

The sign in, sign out and user switch helpers drop the token, and a request that still comes back Forbidden reads it again and retries once, so a session replaced by a path that does not go through those helpers recovers instead of surfacing an unreadable Forbidden body far from its cause.

## Verification

Deterministic local A/B against the real helpers — start a navigation, do not await it, call an API helper immediately. Five runs of ten iterations per side:

| Probe | Without the change | With the change |
| --- | --- | --- |
| Race amplifier | **0 passed / 5 failed** | **5 passed / 0 failed** |
| Session replaced behind the cache | pass | pass |
| `objectRelationship` Many-to-Many (the case that carried this on CI) | pass | pass |

Without the change it fails every run, at the exact line the change removes and with the error above. The session-replacement probe passes on both sides, which is the point: it confirms the retry guard covers the paths that bypass the helpers, so the cache introduces no new failure mode.

**Continuous integration cannot adjudicate this change**, and should not be read as supporting it. The signature stopped appearing on routines that build plain master, and so never carry this change, over the same days it stopped appearing on the branch carrying it — so a clean run here is not evidence either way. The reproduction above is what establishes the effect.

## PR Check

**pr-check: PASS** — tested on `0f542e7be56b01a65133b8ecee906eafe6570d3b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Spec Resolution (985 files, 5116 tests) | PASS |

Diff is two TypeScript files under `modules/test/playwright`. The module declares a `test` script, but it runs the Playwright suite itself, which is out of pr-check scope; spec resolution via `playwright test --list` is the compile gate that applies. No Java, `bnd.bnd`, `packageinfo`, or Gradle change, so Baseline, Per-Module Compile, Integration Test Compile and the Java validations do not fire.

<!-- pr-check {"result": "success", "sha": "0f542e7be56b01a65133b8ecee906eafe6570d3b"} -->
