### PR TITLE
LPD-101757 Send workflow status filter values as the integers they are

### DIFF
--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/field/frontend/data/set/filter/ObjectEntryStatusSelectionFDSFilter.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/field/frontend/data/set/filter/ObjectEntryStatusSelectionFDSFilter.java
@@ -29,7 +29,7 @@ public class ObjectEntryStatusSelectionFDSFilter
 
 	@Override
 	public String getEntityFieldType() {
-		return FDSEntityFieldTypes.COLLECTION;
+		return FDSEntityFieldTypes.COLLECTION_INTEGER;
 	}
 
 	@Override


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101757

## What Is Being Fixed

Filtering an object entries view by workflow status returns no results, even when matching entries exist. The filter chip populates correctly with every chosen status, so the interface looks right, while the list below reads no results found.

The list is empty because the request behind it **failed**, not because nothing matched. The data set frontend renders a failed fetch and a genuinely empty result identically, which disguises a hard error as a legitimate answer.

The filter was serialized with quoted values against an integer field:

```
status/any(x:(x eq '0') or (x eq '2'))
```

The portal rejects a quoted literal against the integer status field with `Incompatible types`, the request dies with a 400, and the frontend draws an empty table. Verified against a running portal: the same filter with unquoted values returns the entry and quoted values return 400, for both the collection and the plain comparison forms.

## How It Is Being Fixed

The quoting is decided by the entity field type each filter declares about itself. In `SelectionFilter.tsx`, `COLLECTION_INTEGER` and `INTEGER` values are emitted as-is, while `COLLECTION`, `COLLECTION_STRING` and `STRING` values are wrapped in quotes. This filter declared the untyped `COLLECTION` while its values are workflow status integers, so every request it built was malformed.

Declaring `COLLECTION_INTEGER` puts it in the unquoted branch. Both constants produce the same `any` expression, so the structure of the query is unchanged — only the quoting differs.

## Root Cause

A missed migration. LPD-56706 (`ac9e8c1459a1e`, `0e2625bee62e2`) introduced the typed collection constants precisely so integer-valued collections could go unquoted, and every value-typed filter had to adopt them. This filter kept the untyped `COLLECTION` it had declared since `8d3c3441ad903` (LPS-158754) and was left behind.

## Verification

The two object view status filter tests cover this, and Testray holds no recorded pass for either — consistent with the filter never having worked.

A/B run by rebuilding and redeploying the module on each side and bouncing the server, with the reverted state confirmed in the compiled bytecode (`javap` showing `ldc "collection"`) so the control was real rather than nominal: the tests fail without the change and pass with it. Of the two, `objectView` `can edit a filter in custom view` is the clean control failure; the other test's control run died with `ERR_CONNECTION_RESET` when the portal went down mid-run, so it is not counted as evidence.

## PR Check

**pr-check: PASS** — tested on `3df2fbc2a19a7a8ea4410f2e7837671f9ebb6f45`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Baseline | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |

Baseline reports no differences and requires no version bump: the change is a method body, not a signature, so the exported `object-api` package is unaffected. For the same reason no consumer expansion applies — the diff contains no added, removed or changed `public`/`protected` member — so Cross-Module Compile has nothing beyond the module set already built. Integration Test Compile covers `object-test`, `object-rest-test` and `object-admin-rest-test`. Java Unit Tests does not fire: the changed class has no `src/test` counterpart.

<!-- pr-check {"result": "success", "sha": "3df2fbc2a19a7a8ea4410f2e7837671f9ebb6f45"} -->
