### PR TITLE
LPD-101758 Open notifications from the dropdown the profile click just opened

### DIFF
--- a/modules/test/playwright/tests/notifications-web/main/pages/NotificationsPage.ts
+++ b/modules/test/playwright/tests/notifications-web/main/pages/NotificationsPage.ts
@@ -57,6 +57,14 @@ export class NotificationsPage {
 
 	async goto(userName: string = 'Test Test') {
 		await this.page.getByLabel(`${userName} User Profile`).click();
-		await this.page.getByRole('menuitem', {name: 'Notifications'}).click();
+
+		// The control panel sidebar can hold a menu item also named
+		// Notifications, the push notifications portlet's entry, so stay
+		// inside the dropdown this click just opened.
+
+		await this.page
+			.locator('.dropdown-menu.show')
+			.getByRole('menuitem', {name: 'Notifications'})
+			.click();
 	}
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101758

## What Is Being Fixed

`object-web/notification/notification.spec.ts` "Can send user notification to a regular role" intermittently fails on continuous integration:

```
Error: strict mode violation: getByRole('menuitem', { name: 'Notifications' }) resolved to 2 elements
```

The shared notifications page object opens the user's notifications by clicking the profile picture and then clicking the **Notifications** item in the dropdown that opens. The old code searched the whole document for any menu item named Notifications.

The second element is the control panel sidebar's entry for the push notifications portlet. It matches for two reasons: Playwright's role-name matching is **substring** by default ("Push Notifications" contains "Notifications"), and the sidebar renders every panel application link with `role="menuitem"`. The colliding element was dumped from a live portal and matches the CI error exactly:

```json
{"cls":"nav-link collapsed","hidden":true,"role":"menuitem","text":"Push Notifications"}
```

The intermittency is ambient page state, not timing: role queries skip accessibility-hidden elements, so the sidebar entry only competes when the product menu is **expanded** — a persisted per-user preference toggled as a side effect by whatever ran earlier in the session.

## How It Is Being Fixed

Scope the click to `.dropdown-menu.show` — the dropdown the profile click just opened, which is where the intended entry lives by definition. The sidebar entry is rendered in a different container and can never be inside that dropdown, so two elements can never match again, by construction.

## Root Cause

Born broken in `302962a4432bb` (LPD-39468), the page object's first version, which already clicked the menu item name unscoped. The collision had been possible for years by then: the sidebar has rendered panel application links with the menuitem role since `9af2824bd47fb` (LPS-56910, 2015), carried through `fc515a06fae17` (LPS-169065, 2022) into today's markup, and the push notifications entry has been in that sidebar since `f59dab30db468` (LPS-53795, 2015).

## Verification

- **Direct measurement** on a live portal carrying the push notifications portlet, product menu expanded: unscoped query → **2 elements**; scoped query → **1**.
- A full run of the test with the fix reverted reproduced the exact CI error verbatim.
- **All four callers** of the changed method exercised with the fix: the failing test passes repeatedly (6/6 plus 3/3 with the collider armed), the users-admin caller passes including its non-default `userName` argument, and the e2e-cms-dxp workflow caller passes end to end. The remaining e2e-cms-dxp caller is blocked locally by an unrelated environment failure before it reaches this method; its call shape is identical to the verified one.

## PR Check

**pr-check: PASS** — tested on `5c2bd40269dbf0861bec2c8c67cbc40355d6d8e8`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Spec Resolution (985 files, 5116 tests) | PASS |

Diff is one TypeScript file under `modules/test/playwright`. The module's `test` script runs the Playwright suite itself, which is out of pr-check scope; spec resolution via `playwright test --list` is the compile gate that applies. No Java, `bnd.bnd`, `packageinfo`, or Gradle change, so the Java validations do not fire.

<!-- pr-check {"result": "success", "sha": "5c2bd40269dbf0861bec2c8c67cbc40355d6d8e8"} -->
