### PR TITLE
LPD-101869 Report the object-web tests that sit in a nested describe

### DIFF
--- a/modules/test/playwright/tests/object-web/content-page-integration/objectContentPageIntegration.spec.ts
+++ b/modules/test/playwright/tests/object-web/content-page-integration/objectContentPageIntegration.spec.ts
@@ -1310,6 +1310,7 @@ test.describe('Display Page', () => {
 		}
 	);
 
+});
 	test.describe('Information Template', () => {
 		let contentPageName: string;
 		let informationTemplateName: string;
@@ -1472,6 +1473,7 @@ test.describe('Display Page', () => {
 			});
 		});
 	});
+test.describe('Display Page', () => {
 
 	test('verify if the object entries are displayed when selecting to preview an object entry on a page template', async ({
 		apiHelpers,

--- a/modules/test/playwright/tests/object-web/content-page-integration/objectContentPageIntegration.spec.ts
+++ b/modules/test/playwright/tests/object-web/content-page-integration/objectContentPageIntegration.spec.ts
@@ -1310,171 +1310,6 @@ test.describe('Display Page', () => {
 		}
 	);
 
-});
-	test.describe('Information Template', () => {
-		let contentPageName: string;
-		let informationTemplateName: string;
-
-		test.afterEach(async ({pagesAdminPage, templatesPage}) => {
-			if (contentPageName) {
-				await pagesAdminPage.goto();
-
-				await pagesAdminPage.deletePage(contentPageName);
-
-				contentPageName = '';
-			}
-
-			if (informationTemplateName) {
-				await templatesPage.goto();
-
-				await templatesPage.deleteInformationTemplate(
-					informationTemplateName
-				);
-
-				informationTemplateName = '';
-			}
-		});
-
-		test('verify it is possible to create a information template with an object as an item type and see its entries', async ({
-			apiHelpers,
-			page,
-			pageEditorPage,
-			pagesAdminPage,
-			templatesPage,
-		}) => {
-			const {listTypeDefinition, listTypeEntries} =
-				await postListTypeDefinitionListTypeEntries({
-					apiHelpers,
-				});
-
-			const objectFields = generateObjectFields({
-				listTypeDefinitionExternalReferenceCode:
-					listTypeDefinition.externalReferenceCode,
-				objectFieldBusinessTypes: [
-					'Boolean',
-					'Decimal',
-					'Integer',
-					'LongText',
-					'Picklist',
-					'Text',
-				],
-			});
-
-			apiHelpers.data.push({
-				id: listTypeDefinition.id,
-				type: 'listTypeDefinition',
-			});
-
-			const objectDefinition =
-				await apiHelpers.objectAdmin.postRandomObjectDefinition({
-					objectFields,
-					status: {code: 0},
-				});
-
-			apiHelpers.data.push({
-				id: objectDefinition.id,
-				type: 'objectDefinition',
-			});
-
-			const {objectEntry: objectEntryValues} =
-				await generateObjectEntryValues({
-					listTypeEntries: listTypeEntries.map(
-						(listTypeEntry) => listTypeEntry.name
-					),
-					objectEntryFormat: 'API',
-					objectFields,
-				});
-
-			const applicationName =
-				'c/' + objectDefinition.name.toLowerCase() + 's';
-
-			const objectEntry = await apiHelpers.objectEntry.postObjectEntry(
-				objectEntryValues,
-				applicationName
-			);
-
-			informationTemplateName = 'Object Template' + getRandomInt();
-
-			await test.step('create information template and add object fields', async () => {
-				await templatesPage.goto();
-
-				await templatesPage.createInformationTemplate({
-					itemType: objectDefinition.label['en_US'],
-					name: informationTemplateName,
-				});
-
-				for (const objectField of objectFields) {
-					await page
-						.getByRole('button', {name: objectField.label['en_US']})
-						.click();
-				}
-
-				await templatesPage.saveTemplate(informationTemplateName);
-			});
-
-			contentPageName = getRandomString();
-
-			await test.step('create page template with HTML element linked to the informationTemplateName', async () => {
-				await pagesAdminPage.goto();
-
-				await pagesAdminPage.createNewPage({
-					name: contentPageName,
-				});
-
-				await pagesAdminPage.editPage(contentPageName);
-
-				await pageEditorPage.addFragment('Basic Components', 'HTML');
-
-				const htmlFragmentId =
-					await pageEditorPage.getFragmentId('HTML');
-
-				await pageEditorPage.selectEditable(
-					htmlFragmentId,
-					'element-html'
-				);
-
-				await pageEditorPage.setMappedItem({
-					entity: objectDefinition.label['en_US'],
-					entry: objectEntry.id.toString(),
-					entryLocator: page
-						.frameLocator('iframe[title="Select"]')
-						.getByText(objectEntry.id.toString())
-						.first(),
-					field: informationTemplateName,
-				});
-
-				await pageEditorPage.waitForChangesSaved();
-
-				await pageEditorPage.publishPage();
-			});
-
-			await test.step('go to created page and assert object entries', async () => {
-				await page.goto(`/web/guest/${contentPageName}`);
-
-				const entries = Object.values(objectEntryValues)
-					.map((value) => {
-						if (typeof value === 'boolean') {
-							return value ? 'Yes' : 'No';
-						}
-
-						if (
-							typeof value === 'object' &&
-							value !== null &&
-							'key' in (value as object)
-						) {
-							return (value as {key: string}).key;
-						}
-
-						return String(value);
-					})
-					.join(' ');
-
-				await expect(page.getByText(entries)).toBeVisible();
-			});
-		});
-	});
-test.describe('Display Page', () => {
-
 	test('verify if the object entries are displayed when selecting to preview an object entry on a page template', async ({
 		apiHelpers,
 		displayPageTemplatesPage,
@@ -1637,6 +1472,165 @@ test.describe('Display Page', () => {
 		await displayPageTemplatesPage.goto();
 
 		await displayPageTemplatesPage.deleteTemplate(objectDefinitionLabel);
+	});
+});
+
+test.describe('Information Template', () => {
+	let contentPageName: string;
+	let informationTemplateName: string;
+
+	test.afterEach(async ({pagesAdminPage, templatesPage}) => {
+		if (contentPageName) {
+			await pagesAdminPage.goto();
+
+			await pagesAdminPage.deletePage(contentPageName);
+
+			contentPageName = '';
+		}
+
+		if (informationTemplateName) {
+			await templatesPage.goto();
+
+			await templatesPage.deleteInformationTemplate(
+				informationTemplateName
+			);
+
+			informationTemplateName = '';
+		}
+	});
+
+	test('verify it is possible to create a information template with an object as an item type and see its entries', async ({
+		apiHelpers,
+		page,
+		pageEditorPage,
+		pagesAdminPage,
+		templatesPage,
+	}) => {
+		const {listTypeDefinition, listTypeEntries} =
+			await postListTypeDefinitionListTypeEntries({
+				apiHelpers,
+			});
+
+		const objectFields = generateObjectFields({
+			listTypeDefinitionExternalReferenceCode:
+				listTypeDefinition.externalReferenceCode,
+			objectFieldBusinessTypes: [
+				'Boolean',
+				'Decimal',
+				'Integer',
+				'LongText',
+				'Picklist',
+				'Text',
+			],
+		});
+
+		apiHelpers.data.push({
+			id: listTypeDefinition.id,
+			type: 'listTypeDefinition',
+		});
+
+		const objectDefinition =
+			await apiHelpers.objectAdmin.postRandomObjectDefinition({
+				objectFields,
+				status: {code: 0},
+			});
+
+		apiHelpers.data.push({
+			id: objectDefinition.id,
+			type: 'objectDefinition',
+		});
+
+		const {objectEntry: objectEntryValues} =
+			await generateObjectEntryValues({
+				listTypeEntries: listTypeEntries.map(
+					(listTypeEntry) => listTypeEntry.name
+				),
+				objectEntryFormat: 'API',
+				objectFields,
+			});
+
+		const applicationName =
+			'c/' + objectDefinition.name.toLowerCase() + 's';
+
+		const objectEntry = await apiHelpers.objectEntry.postObjectEntry(
+			objectEntryValues,
+			applicationName
+		);
+
+		informationTemplateName = 'Object Template' + getRandomInt();
+
+		await test.step('create information template and add object fields', async () => {
+			await templatesPage.goto();
+
+			await templatesPage.createInformationTemplate({
+				itemType: objectDefinition.label['en_US'],
+				name: informationTemplateName,
+			});
+
+			for (const objectField of objectFields) {
+				await page
+					.getByRole('button', {name: objectField.label['en_US']})
+					.click();
+			}
+
+			await templatesPage.saveTemplate(informationTemplateName);
+		});
+
+		contentPageName = getRandomString();
+
+		await test.step('create page template with HTML element linked to the informationTemplateName', async () => {
+			await pagesAdminPage.goto();
+
+			await pagesAdminPage.createNewPage({
+				name: contentPageName,
+			});
+
+			await pagesAdminPage.editPage(contentPageName);
+
+			await pageEditorPage.addFragment('Basic Components', 'HTML');
+
+			const htmlFragmentId = await pageEditorPage.getFragmentId('HTML');
+
+			await pageEditorPage.selectEditable(htmlFragmentId, 'element-html');
+
+			await pageEditorPage.setMappedItem({
+				entity: objectDefinition.label['en_US'],
+				entry: objectEntry.id.toString(),
+				entryLocator: page
+					.frameLocator('iframe[title="Select"]')
+					.getByText(objectEntry.id.toString())
+					.first(),
+				field: informationTemplateName,
+			});
+
+			await pageEditorPage.waitForChangesSaved();
+
+			await pageEditorPage.publishPage();
+		});
+
+		await test.step('go to created page and assert object entries', async () => {
+			await page.goto(`/web/guest/${contentPageName}`);
+
+			const entries = Object.values(objectEntryValues)
+				.map((value) => {
+					if (typeof value === 'boolean') {
+						return value ? 'Yes' : 'No';
+					}
+
+					if (
+						typeof value === 'object' &&
+						value !== null &&
+						'key' in (value as object)
+					) {
+						return (value as {key: string}).key;
+					}
+
+					return String(value);
+				})
+				.join(' ');
+
+			await expect(page.getByText(entries)).toBeVisible();
+		});
 	});
 });
 

--- a/modules/test/playwright/tests/object-web/field/objectField.spec.ts
+++ b/modules/test/playwright/tests/object-web/field/objectField.spec.ts
@@ -2360,441 +2360,427 @@ test.describe('Manage objectFields through Objects Admin UI', () => {
 			})
 		).toBeVisible();
 	});
-
 });
-	test.describe('Create Object Fields', () => {
-		let createdObjectDefinition: ObjectDefinition;
-		let createdObjectField: ObjectField;
 
-		test.beforeEach(async ({apiHelpers, objectFieldsPage}) => {
-			const objectFields = generateObjectFields({
-				objectFieldBusinessTypes: ['Text'],
-			});
+test.describe('Create Object Fields', () => {
+	let createdObjectDefinition: ObjectDefinition;
+	let createdObjectField: ObjectField;
 
-			const objectDefinition =
-				await apiHelpers.objectAdmin.postRandomObjectDefinition({
-					objectFields,
-					status: {code: 2},
-				});
-
-			apiHelpers.data.push({
-				id: objectDefinition.id,
-				type: 'objectDefinition',
-			});
-
-			createdObjectDefinition = objectDefinition;
-			createdObjectField = objectFields[0];
-
-			await objectFieldsPage.goto(objectDefinition.label['en_US']);
+	test.beforeEach(async ({apiHelpers, objectFieldsPage}) => {
+		const objectFields = generateObjectFields({
+			objectFieldBusinessTypes: ['Text'],
 		});
 
-		async function assertSearchableProperties(
-			objectFieldsPage: ObjectFieldsPage,
-			visible: boolean
-		) {
-			await expect(
-				objectFieldsPage.iframeLocator.getByRole('radio', {
-					name: 'Keyword',
-				})
-			).toBeVisible({visible});
-			await expect(
-				objectFieldsPage.iframeLocator.getByText('Language')
-			).toBeVisible({visible});
-			await expect(
-				objectFieldsPage.iframeLocator.getByRole('radio', {
-					name: 'Text',
-				})
-			).toBeVisible({visible});
-		}
-
-		test('Verify it is not possible to add a custom object field when required properties are missing', async ({
-			objectFieldsPage,
-			page,
-		}) => {
-			await objectFieldsPage.addObjectFieldButton.click();
-
-			await test.step('Verify required error is shown three times when Label, Name and Type are blank', async () => {
-				await objectFieldsPage.saveButton.click();
-
-				await expect(page.getByText('Required')).toHaveCount(3);
+		const objectDefinition =
+			await apiHelpers.objectAdmin.postRandomObjectDefinition({
+				objectFields,
+				status: {code: 2},
 			});
 
-			await test.step('Verify required error is shown two times after filling the Name', async () => {
-				await objectFieldsPage.objectFieldNameInput.fill('testField');
-
-				await objectFieldsPage.saveButton.click();
-
-				await expect(page.getByText('Required')).toHaveCount(2);
-			});
-
-			await test.step('Verify required error is shown one time after filling the Label', async () => {
-				await objectFieldsPage.objectFieldLabelInput.fill('Test Field');
-
-				await objectFieldsPage.saveButton.click();
-
-				await expect(page.getByText('Required')).toHaveCount(1);
-			});
-
-			await test.step('Verify required error is shown for the picklist when the Type is changed to Picklist', async () => {
-				await objectFieldsPage.objectFieldOptionsDropdown.click();
-				await page
-					.getByRole('option', {exact: true, name: 'Picklist'})
-					.click();
-
-				await objectFieldsPage.saveButton.click();
-
-				await expect(page.getByText('Required')).toHaveCount(1);
-			});
+		apiHelpers.data.push({
+			id: objectDefinition.id,
+			type: 'objectDefinition',
 		});
 
-		test('Verify it is not possible to add custom object field with invalid name', async ({
-			objectFieldsPage,
-			page,
-		}) => {
-			await test.step('Verify that Name is autofilled when Label is filled', async () => {
-				await objectFieldsPage.addObjectFieldButton.click();
+		createdObjectDefinition = objectDefinition;
+		createdObjectField = objectFields[0];
 
-				await objectFieldsPage.objectFieldLabelInput.fill('Test Field');
+		await objectFieldsPage.goto(objectDefinition.label['en_US']);
+	});
 
-				await expect(objectFieldsPage.objectFieldNameInput).toHaveValue(
-					'testField'
-				);
-			});
+	async function assertSearchableProperties(
+		objectFieldsPage: ObjectFieldsPage,
+		visible: boolean
+	) {
+		await expect(
+			objectFieldsPage.iframeLocator.getByRole('radio', {
+				name: 'Keyword',
+			})
+		).toBeVisible({visible});
+		await expect(
+			objectFieldsPage.iframeLocator.getByText('Language')
+		).toBeVisible({visible});
+		await expect(
+			objectFieldsPage.iframeLocator.getByRole('radio', {
+				name: 'Text',
+			})
+		).toBeVisible({visible});
+	}
 
-			await test.step('Verify it is not possible to save Name with special characters', async () => {
-				await objectFieldsPage.objectFieldNameInput.fill(
-					'Field@Special!'
-				);
+	test('Verify it is not possible to add a custom object field when required properties are missing', async ({
+		objectFieldsPage,
+		page,
+	}) => {
+		await objectFieldsPage.addObjectFieldButton.click();
 
-				await objectFieldsPage.objectFieldOptionsDropdown.click();
-				await page
-					.getByRole('option', {exact: true, name: 'Text'})
-					.click();
+		await test.step('Verify required error is shown three times when Label, Name and Type are blank', async () => {
+			await objectFieldsPage.saveButton.click();
 
-				await objectFieldsPage.saveButton.click();
-
-				await expect(
-					page.getByText('Name must only contain letters and digits.')
-				).toBeVisible();
-			});
-
-			await test.step('Verify it is not possible to save Name that begin with uppercase letter', async () => {
-				await objectFieldsPage.objectFieldNameInput.fill(
-					'FieldUpperCase'
-				);
-
-				await objectFieldsPage.saveButton.click();
-
-				await expect(
-					page.getByText(
-						'The first character of a name must be a lowercase letter.'
-					)
-				).toBeVisible();
-			});
-
-			await test.step('Verify it is not possible to save Duplicated name', async () => {
-				await objectFieldsPage.objectFieldNameInput.fill(
-					createdObjectField.name
-				);
-
-				await objectFieldsPage.saveButton.click();
-
-				await expect(
-					page.getByText(
-						'This name is already in use. Try another one.'
-					)
-				).toBeVisible();
-			});
+			await expect(page.getByText('Required')).toHaveCount(3);
 		});
 
-		test('Verify it is possible to cancel the creation of a custom object field', async ({
-			objectFieldsPage,
-			page,
-		}) => {
-			await objectFieldsPage.addObjectFieldButton.click();
+		await test.step('Verify required error is shown two times after filling the Name', async () => {
+			await objectFieldsPage.objectFieldNameInput.fill('testField');
 
-			await objectFieldsPage.objectFieldLabelInput.fill('Cancel Field');
+			await objectFieldsPage.saveButton.click();
 
-			await page.getByRole('button', {name: 'Cancel'}).click();
+			await expect(page.getByText('Required')).toHaveCount(2);
+		});
 
+		await test.step('Verify required error is shown one time after filling the Label', async () => {
+			await objectFieldsPage.objectFieldLabelInput.fill('Test Field');
+
+			await objectFieldsPage.saveButton.click();
+
+			await expect(page.getByText('Required')).toHaveCount(1);
+		});
+
+		await test.step('Verify required error is shown for the picklist when the Type is changed to Picklist', async () => {
+			await objectFieldsPage.objectFieldOptionsDropdown.click();
 			await page
-				.getByRole('search')
-				.getByRole('searchbox', {name: 'Search'})
-				.fill('Cancel Field');
-			await page.keyboard.press('Enter');
+				.getByRole('option', {exact: true, name: 'Picklist'})
+				.click();
 
-			await expect(page.getByText('No Results Found')).toBeVisible();
+			await objectFieldsPage.saveButton.click();
+
+			await expect(page.getByText('Required')).toHaveCount(1);
+		});
+	});
+
+	test('Verify it is not possible to add custom object field with invalid name', async ({
+		objectFieldsPage,
+		page,
+	}) => {
+		await test.step('Verify that Name is autofilled when Label is filled', async () => {
+			await objectFieldsPage.addObjectFieldButton.click();
+
+			await objectFieldsPage.objectFieldLabelInput.fill('Test Field');
+
+			await expect(objectFieldsPage.objectFieldNameInput).toHaveValue(
+				'testField'
+			);
 		});
 
-		test('Verify it is possible to delete a custom object field depending on the object state', async ({
-			apiHelpers,
-			objectFieldsPage,
-			page,
-		}) => {
-			await test.step('Verify it is possible to delete the only custom object field before the object is published', async () => {
-				await objectFieldsPage.deleteObjectField(false, -1);
+		await test.step('Verify it is not possible to save Name with special characters', async () => {
+			await objectFieldsPage.objectFieldNameInput.fill('Field@Special!');
+
+			await objectFieldsPage.objectFieldOptionsDropdown.click();
+			await page.getByRole('option', {exact: true, name: 'Text'}).click();
+
+			await objectFieldsPage.saveButton.click();
+
+			await expect(
+				page.getByText('Name must only contain letters and digits.')
+			).toBeVisible();
+		});
+
+		await test.step('Verify it is not possible to save Name that begin with uppercase letter', async () => {
+			await objectFieldsPage.objectFieldNameInput.fill('FieldUpperCase');
+
+			await objectFieldsPage.saveButton.click();
+
+			await expect(
+				page.getByText(
+					'The first character of a name must be a lowercase letter.'
+				)
+			).toBeVisible();
+		});
+
+		await test.step('Verify it is not possible to save Duplicated name', async () => {
+			await objectFieldsPage.objectFieldNameInput.fill(
+				createdObjectField.name
+			);
+
+			await objectFieldsPage.saveButton.click();
+
+			await expect(
+				page.getByText('This name is already in use. Try another one.')
+			).toBeVisible();
+		});
+	});
+
+	test('Verify it is possible to cancel the creation of a custom object field', async ({
+		objectFieldsPage,
+		page,
+	}) => {
+		await objectFieldsPage.addObjectFieldButton.click();
+
+		await objectFieldsPage.objectFieldLabelInput.fill('Cancel Field');
+
+		await page.getByRole('button', {name: 'Cancel'}).click();
+
+		await page
+			.getByRole('search')
+			.getByRole('searchbox', {name: 'Search'})
+			.fill('Cancel Field');
+		await page.keyboard.press('Enter');
+
+		await expect(page.getByText('No Results Found')).toBeVisible();
+	});
+
+	test('Verify it is possible to delete a custom object field depending on the object state', async ({
+		apiHelpers,
+		objectFieldsPage,
+		page,
+	}) => {
+		await test.step('Verify it is possible to delete the only custom object field before the object is published', async () => {
+			await objectFieldsPage.deleteObjectField(false, -1);
+		});
+
+		await test.step('Verify it is not possible to delete the only custom object field after the object is published', async () => {
+			await objectFieldsPage.addObjectField({
+				objectFieldBusinessType: 'Text',
+				objectFieldLabel: 'Text1',
 			});
 
-			await test.step('Verify it is not possible to delete the only custom object field after the object is published', async () => {
-				await objectFieldsPage.addObjectField({
-					objectFieldBusinessType: 'Text',
-					objectFieldLabel: 'Text1',
-				});
-
-				await apiHelpers.objectAdmin.postObjectDefinitionPublish({
-					objectDefinitionId: createdObjectDefinition.id,
-				});
-
-				await objectFieldsPage.deleteObjectField(false, -1);
-
-				await expect(
-					page.getByText('Deletion Not Allowed')
-				).toBeVisible();
-				await expect(
-					page.getByText(
-						`The object field "Text1" cannot be deleted because it is the only custom object field of the published object definition.`
-					)
-				).toBeVisible();
-
-				await page.getByRole('button', {name: 'Done'}).click();
+			await apiHelpers.objectAdmin.postObjectDefinitionPublish({
+				objectDefinitionId: createdObjectDefinition.id,
 			});
 
-			await test.step('Verify it is possible to delete a custom object field when it is not the only one after the object is published', async () => {
-				await objectFieldsPage.addObjectField({
-					objectFieldBusinessType: 'Text',
-					objectFieldLabel: 'Text2',
-				});
+			await objectFieldsPage.deleteObjectField(false, -1);
 
-				await objectFieldsPage.deleteObjectField(true, -1);
+			await expect(page.getByText('Deletion Not Allowed')).toBeVisible();
+			await expect(
+				page.getByText(
+					`The object field "Text1" cannot be deleted because it is the only custom object field of the published object definition.`
+				)
+			).toBeVisible();
+
+			await page.getByRole('button', {name: 'Done'}).click();
+		});
+
+		await test.step('Verify it is possible to delete a custom object field when it is not the only one after the object is published', async () => {
+			await objectFieldsPage.addObjectField({
+				objectFieldBusinessType: 'Text',
+				objectFieldLabel: 'Text2',
+			});
+
+			await objectFieldsPage.deleteObjectField(true, -1);
+
+			await expect(
+				page.getByRole('row').filter({hasText: 'Text1'})
+			).toBeVisible();
+			await expect(
+				page.getByRole('row').filter({hasText: 'Text2'})
+			).toBeHidden();
+		});
+	});
+
+	test('Verify it is possible to update field properties depending on the object state', async ({
+		apiHelpers,
+		objectFieldsPage,
+		page,
+	}) => {
+		await test.step('Before the object is published', async () => {
+			await test.step('Update Label with translation', async () => {
+				await objectFieldsPage.openObjectField(
+					createdObjectField.label!['en_US']
+				);
+
+				await objectFieldsPage.iframeLocator
+					.getByLabel('Label')
+					.fill('Updated Label');
+
+				await objectFieldsPage.iframeLocator
+					.getByTitle('en_US')
+					.click();
+				await objectFieldsPage.iframeLocator
+					.getByRole('option', {name: 'pt_BR'})
+					.click();
+
+				await objectFieldsPage.iframeLocator
+					.getByLabel('Label')
+					.fill('Rótulo Atualizado');
+			});
+
+			await test.step('Verify that Keyword, Language, and Text fields are not visible for non-searchable Text field', async () => {
+				await assertSearchableProperties(objectFieldsPage, false);
+			});
+
+			await test.step('Update Mandatory, Name and Searchable', async () => {
+				await objectFieldsPage.iframeLocator
+					.getByRole('switch', {name: 'Mandatory'})
+					.check();
+				await objectFieldsPage.iframeLocator
+					.locator('input[name="name"]')
+					.fill('updatedName');
+				await objectFieldsPage.iframeLocator
+					.getByRole('switch', {name: 'Searchable'})
+					.check();
+			});
+
+			await test.step('Verify that Keyword, Language, and Text fields are visible for searchable Text field', async () => {
+				await assertSearchableProperties(objectFieldsPage, true);
+			});
+
+			await test.step('Update type to Integer', async () => {
+				await objectFieldsPage.iframeLocator
+					.getByRole('combobox', {name: 'Type'})
+					.click();
+				await objectFieldsPage.iframeLocator
+					.getByRole('option', {exact: true, name: 'Integer'})
+					.click();
+			});
+
+			await test.step('Verify that Keyword, Language, and Text fields are not visible for searchable Integer field', async () => {
+				await assertSearchableProperties(objectFieldsPage, false);
+			});
+
+			await objectFieldsPage.editFieldSaveButton.click();
+
+			await waitForAlert(
+				page,
+				'The object field was updated successfully'
+			);
+
+			await test.step('Verify that Label and Type columns are displayed for the updated field', async () => {
+				await page
+					.getByRole('search')
+					.getByRole('searchbox', {name: 'Search'})
+					.fill('Updated Label');
+				await page.keyboard.press('Enter');
 
 				await expect(
-					page.getByRole('row').filter({hasText: 'Text1'})
+					page
+						.getByRole('row')
+						.filter({hasText: 'Updated Label'})
+						.getByText('Integer')
 				).toBeVisible();
+			});
+
+			await test.step('Verify that translated Label is updated', async () => {
+				await objectFieldsPage.openObjectField('Updated Label');
+
+				await objectFieldsPage.iframeLocator
+					.getByTitle('en_US')
+					.click();
+				await objectFieldsPage.iframeLocator
+					.getByRole('option', {name: 'pt_BR'})
+					.click();
+
 				await expect(
-					page.getByRole('row').filter({hasText: 'Text2'})
-				).toBeHidden();
+					objectFieldsPage.iframeLocator.getByLabel('Label')
+				).toHaveValue('Rótulo Atualizado');
+			});
+
+			await test.step('Verify that Mandatory, Name, Searchable and Type are updated', async () => {
+				await expect(
+					objectFieldsPage.iframeLocator.getByRole('switch', {
+						name: 'Mandatory',
+					})
+				).toBeChecked();
+				await expect(
+					objectFieldsPage.iframeLocator.locator('input[name="name"]')
+				).toHaveValue('updatedName');
+				await expect(
+					objectFieldsPage.iframeLocator.getByRole('switch', {
+						name: 'Searchable',
+					})
+				).toBeChecked();
+				await expect(
+					objectFieldsPage.iframeLocator.getByRole('combobox', {
+						name: 'Type',
+					})
+				).toHaveText('Integer');
 			});
 		});
 
-		test('Verify it is possible to update field properties depending on the object state', async ({
-			apiHelpers,
-			objectFieldsPage,
-			page,
-		}) => {
-			await test.step('Before the object is published', async () => {
-				await test.step('Update Label with translation', async () => {
-					await objectFieldsPage.openObjectField(
-						createdObjectField.label!['en_US']
-					);
-
-					await objectFieldsPage.iframeLocator
-						.getByLabel('Label')
-						.fill('Updated Label');
-
-					await objectFieldsPage.iframeLocator
-						.getByTitle('en_US')
-						.click();
-					await objectFieldsPage.iframeLocator
-						.getByRole('option', {name: 'pt_BR'})
-						.click();
-
-					await objectFieldsPage.iframeLocator
-						.getByLabel('Label')
-						.fill('Rótulo Atualizado');
-				});
-
-				await test.step('Verify that Keyword, Language, and Text fields are not visible for non-searchable Text field', async () => {
-					await assertSearchableProperties(objectFieldsPage, false);
-				});
-
-				await test.step('Update Mandatory, Name and Searchable', async () => {
-					await objectFieldsPage.iframeLocator
-						.getByRole('switch', {name: 'Mandatory'})
-						.check();
-					await objectFieldsPage.iframeLocator
-						.locator('input[name="name"]')
-						.fill('updatedName');
-					await objectFieldsPage.iframeLocator
-						.getByRole('switch', {name: 'Searchable'})
-						.check();
-				});
-
-				await test.step('Verify that Keyword, Language, and Text fields are visible for searchable Text field', async () => {
-					await assertSearchableProperties(objectFieldsPage, true);
-				});
-
-				await test.step('Update type to Integer', async () => {
-					await objectFieldsPage.iframeLocator
-						.getByRole('combobox', {name: 'Type'})
-						.click();
-					await objectFieldsPage.iframeLocator
-						.getByRole('option', {exact: true, name: 'Integer'})
-						.click();
-				});
-
-				await test.step('Verify that Keyword, Language, and Text fields are not visible for searchable Integer field', async () => {
-					await assertSearchableProperties(objectFieldsPage, false);
-				});
-
-				await objectFieldsPage.editFieldSaveButton.click();
-
-				await waitForAlert(
-					page,
-					'The object field was updated successfully'
-				);
-
-				await test.step('Verify that Label and Type columns are displayed for the updated field', async () => {
-					await page
-						.getByRole('search')
-						.getByRole('searchbox', {name: 'Search'})
-						.fill('Updated Label');
-					await page.keyboard.press('Enter');
-
-					await expect(
-						page
-							.getByRole('row')
-							.filter({hasText: 'Updated Label'})
-							.getByText('Integer')
-					).toBeVisible();
-				});
-
-				await test.step('Verify that translated Label is updated', async () => {
-					await objectFieldsPage.openObjectField('Updated Label');
-
-					await objectFieldsPage.iframeLocator
-						.getByTitle('en_US')
-						.click();
-					await objectFieldsPage.iframeLocator
-						.getByRole('option', {name: 'pt_BR'})
-						.click();
-
-					await expect(
-						objectFieldsPage.iframeLocator.getByLabel('Label')
-					).toHaveValue('Rótulo Atualizado');
-				});
-
-				await test.step('Verify that Mandatory, Name, Searchable and Type are updated', async () => {
-					await expect(
-						objectFieldsPage.iframeLocator.getByRole('switch', {
-							name: 'Mandatory',
-						})
-					).toBeChecked();
-					await expect(
-						objectFieldsPage.iframeLocator.locator(
-							'input[name="name"]'
-						)
-					).toHaveValue('updatedName');
-					await expect(
-						objectFieldsPage.iframeLocator.getByRole('switch', {
-							name: 'Searchable',
-						})
-					).toBeChecked();
-					await expect(
-						objectFieldsPage.iframeLocator.getByRole('combobox', {
-							name: 'Type',
-						})
-					).toHaveText('Integer');
-				});
+		await test.step('After the object is published', async () => {
+			await apiHelpers.objectAdmin.postObjectDefinitionPublish({
+				objectDefinitionId: createdObjectDefinition.id,
 			});
 
-			await test.step('After the object is published', async () => {
-				await apiHelpers.objectAdmin.postObjectDefinitionPublish({
-					objectDefinitionId: createdObjectDefinition.id,
-				});
+			await page.reload();
 
-				await page.reload();
+			await test.step('Update Label with translation', async () => {
+				await objectFieldsPage.openObjectField('Updated Label');
 
-				await test.step('Update Label with translation', async () => {
-					await objectFieldsPage.openObjectField('Updated Label');
+				await objectFieldsPage.iframeLocator
+					.getByLabel('Label')
+					.fill('New Updated Label');
 
-					await objectFieldsPage.iframeLocator
-						.getByLabel('Label')
-						.fill('New Updated Label');
+				await objectFieldsPage.iframeLocator
+					.getByTitle('en_US')
+					.click();
+				await objectFieldsPage.iframeLocator
+					.getByRole('option', {name: 'pt_BR'})
+					.click();
 
-					await objectFieldsPage.iframeLocator
-						.getByTitle('en_US')
-						.click();
-					await objectFieldsPage.iframeLocator
-						.getByRole('option', {name: 'pt_BR'})
-						.click();
+				await objectFieldsPage.iframeLocator
+					.getByLabel('Label')
+					.fill('Novo Rótulo Atualizado');
+			});
 
-					await objectFieldsPage.iframeLocator
-						.getByLabel('Label')
-						.fill('Novo Rótulo Atualizado');
-				});
+			await test.step('Uncheck Mandatory and Searchable fields', async () => {
+				await objectFieldsPage.iframeLocator
+					.getByRole('switch', {name: 'Mandatory'})
+					.uncheck();
+				await objectFieldsPage.iframeLocator
+					.getByRole('switch', {name: 'Searchable'})
+					.uncheck();
+			});
 
-				await test.step('Uncheck Mandatory and Searchable fields', async () => {
-					await objectFieldsPage.iframeLocator
-						.getByRole('switch', {name: 'Mandatory'})
-						.uncheck();
-					await objectFieldsPage.iframeLocator
-						.getByRole('switch', {name: 'Searchable'})
-						.uncheck();
-				});
+			await test.step('Verify it is not possible to update Name and Type fields', async () => {
+				await expect(
+					objectFieldsPage.iframeLocator.locator('input[name="name"]')
+				).toBeDisabled();
+				await expect(
+					objectFieldsPage.iframeLocator.getByRole('combobox', {
+						name: 'Type',
+					})
+				).toBeDisabled();
+			});
 
-				await test.step('Verify it is not possible to update Name and Type fields', async () => {
-					await expect(
-						objectFieldsPage.iframeLocator.locator(
-							'input[name="name"]'
-						)
-					).toBeDisabled();
-					await expect(
-						objectFieldsPage.iframeLocator.getByRole('combobox', {
-							name: 'Type',
-						})
-					).toBeDisabled();
-				});
+			await objectFieldsPage.editFieldSaveButton.click();
 
-				await objectFieldsPage.editFieldSaveButton.click();
+			await waitForAlert(
+				page,
+				'The object field was updated successfully'
+			);
 
-				await waitForAlert(
-					page,
-					'The object field was updated successfully'
-				);
+			await test.step('Verify that translated Label is updated', async () => {
+				await objectFieldsPage.openObjectField('New Updated Label');
 
-				await test.step('Verify that translated Label is updated', async () => {
-					await objectFieldsPage.openObjectField('New Updated Label');
+				await objectFieldsPage.iframeLocator
+					.getByTitle('en_US')
+					.click();
+				await objectFieldsPage.iframeLocator
+					.getByRole('option', {name: 'pt_BR'})
+					.click();
 
-					await objectFieldsPage.iframeLocator
-						.getByTitle('en_US')
-						.click();
-					await objectFieldsPage.iframeLocator
-						.getByRole('option', {name: 'pt_BR'})
-						.click();
+				await expect(
+					objectFieldsPage.iframeLocator.getByLabel('Label')
+				).toHaveValue('Novo Rótulo Atualizado');
+			});
 
-					await expect(
-						objectFieldsPage.iframeLocator.getByLabel('Label')
-					).toHaveValue('Novo Rótulo Atualizado');
-				});
+			await test.step('Verify that Mandatory is unchecked and disabled', async () => {
+				await expect(
+					objectFieldsPage.iframeLocator.getByRole('switch', {
+						name: 'Mandatory',
+					})
+				).not.toBeChecked();
+				await expect(
+					objectFieldsPage.iframeLocator.getByRole('switch', {
+						name: 'Mandatory',
+					})
+				).toBeDisabled();
+			});
 
-				await test.step('Verify that Mandatory is unchecked and disabled', async () => {
-					await expect(
-						objectFieldsPage.iframeLocator.getByRole('switch', {
-							name: 'Mandatory',
-						})
-					).not.toBeChecked();
-					await expect(
-						objectFieldsPage.iframeLocator.getByRole('switch', {
-							name: 'Mandatory',
-						})
-					).toBeDisabled();
-				});
-
-				await test.step('Verify that Searchable is unchecked', async () => {
-					await expect(
-						objectFieldsPage.iframeLocator.getByRole('switch', {
-							name: 'Searchable',
-						})
-					).not.toBeChecked();
-					await expect(
-						objectFieldsPage.iframeLocator.getByRole('switch', {
-							name: 'Searchable',
-						})
-					).toBeEnabled();
-				});
+			await test.step('Verify that Searchable is unchecked', async () => {
+				await expect(
+					objectFieldsPage.iframeLocator.getByRole('switch', {
+						name: 'Searchable',
+					})
+				).not.toBeChecked();
+				await expect(
+					objectFieldsPage.iframeLocator.getByRole('switch', {
+						name: 'Searchable',
+					})
+				).toBeEnabled();
 			});
 		});
 	});
+});
 
 test.describe('Manage object fields default value properties', () => {
 	test(

--- a/modules/test/playwright/tests/object-web/field/objectField.spec.ts
+++ b/modules/test/playwright/tests/object-web/field/objectField.spec.ts
@@ -2361,6 +2361,7 @@ test.describe('Manage objectFields through Objects Admin UI', () => {
 		).toBeVisible();
 	});
 
+});
 	test.describe('Create Object Fields', () => {
 		let createdObjectDefinition: ObjectDefinition;
 		let createdObjectField: ObjectField;
@@ -2794,7 +2795,6 @@ test.describe('Manage objectFields through Objects Admin UI', () => {
 			});
 		});
 	});
-});
 
 test.describe('Manage object fields default value properties', () => {
 	test(

--- a/modules/test/playwright/tests/object-web/hierarchy/objectDefinitionHierarchy.spec.ts
+++ b/modules/test/playwright/tests/object-web/hierarchy/objectDefinitionHierarchy.spec.ts
@@ -628,190 +628,7 @@ test.describe('Manage root model elements through View Object Entries', () => {
 	});
 });
 
-	test.describe('Disable inheritance modal flows', () => {
-
-		// Inheritance edges with linked entries cannot be PUT edge=false until
-		// the entries are gone, and apiHelpers cannot delete an edge=true
-		// relationship. Delete the parent entry here so the cascade clears the
-		// linked child, then PUT edge=false on the relationships so the
-		// automatic apiHelpers cleanup chain stays unblocked.
-
-		let parentApplicationName = '';
-		let parentEntryId: number | undefined;
-		let relationshipsForCleanup: ObjectRelationship[] = [];
-
-		test.afterEach(async ({apiHelpers}) => {
-			if (parentEntryId !== undefined && parentApplicationName) {
-				await apiHelpers.delete(
-					`${apiHelpers.baseUrl}${parentApplicationName}/${parentEntryId}`
-				);
-			}
-
-			for (const objectRelationship of relationshipsForCleanup) {
-				await apiHelpers.objectAdmin.patchObjectRelationshipEdge(
-					objectRelationship,
-					false
-				);
-			}
-
-			parentApplicationName = '';
-			parentEntryId = undefined;
-			relationshipsForCleanup = [];
-		});
-
-		test('shows modal with warning message before disabling inheritance', async ({
-			apiHelpers,
-			objectRelationshipsPage,
-		}) => {
-			const parent =
-				await apiHelpers.objectAdmin.postRandomObjectDefinition({
-					status: {code: 0},
-				});
-
-			const child =
-				await apiHelpers.objectAdmin.postRandomObjectDefinition({
-					status: {code: 0},
-				});
-
-			pushToApiHelpersData(
-				apiHelpers,
-				[parent.id!, child.id!],
-				'objectDefinition'
-			);
-
-			const relationship =
-				await apiHelpers.objectAdmin.postObjectDefinitionInheritanceRelationship(
-					parent,
-					child
-				);
-
-			relationshipsForCleanup = [relationship];
-
-			apiHelpers.data.push({
-				id: relationship.id!,
-				type: 'objectRelationship',
-			});
-
-			await objectRelationshipsPage.goto(parent.label!['en_US']);
-
-			await objectRelationshipsPage.actionsButton.click();
-
-			await objectRelationshipsPage.editObjectRelationshipOption.click();
-
-			await objectRelationshipsPage.inheritanceCheckbox.click();
-
-			await expect(
-				objectRelationshipsPage.inheritanceModalHeader
-			).toBeVisible();
-
-			await expect(
-				objectRelationshipsPage.inheritanceModalConfirmationMessage
-			).toBeVisible();
-		});
-
-		test(
-			'shows modal blocking disabling inheritance when entries would be orphaned',
-			{tag: '@LPD-89021'},
-			async ({apiHelpers, objectRelationshipsPage}) => {
-
-				// Build a child with two inheritance parents and standalone=false
-
-				const parent1 =
-					await apiHelpers.objectAdmin.postRandomObjectDefinition({
-						status: {code: 0},
-					});
-
-				const parent2 =
-					await apiHelpers.objectAdmin.postRandomObjectDefinition({
-						status: {code: 0},
-					});
-
-				const child =
-					await apiHelpers.objectAdmin.postRandomObjectDefinition({
-						status: {code: 0},
-					});
-
-				pushToApiHelpersData(
-					apiHelpers,
-					[parent1.id!, parent2.id!, child.id!],
-					'objectDefinition'
-				);
-
-				const relationship1 =
-					await apiHelpers.objectAdmin.postObjectDefinitionInheritanceRelationship(
-						parent1,
-						child
-					);
-
-				const relationship2 =
-					await apiHelpers.objectAdmin.postObjectDefinitionInheritanceRelationship(
-						parent2,
-						child
-					);
-
-				relationshipsForCleanup = [relationship1, relationship2];
-
-				apiHelpers.data.push(
-					{id: relationship1.id!, type: 'objectRelationship'},
-					{id: relationship2.id!, type: 'objectRelationship'}
-				);
-
-				await apiHelpers.objectAdmin.patchObjectDefinitionSetting(
-					child.id!,
-					'allowStandaloneObjectEntry',
-					'false'
-				);
-
-				// Create a child entry linked under parent1
-
-				parentApplicationName = parent1.restContextPath!.replace(
-					/^\/o\//,
-					''
-				);
-
-				const parentEntry =
-					await apiHelpers.objectEntry.postObjectEntry(
-						{textField: 'parent-' + getRandomInt()},
-						parentApplicationName
-					);
-
-				parentEntryId = parentEntry.id;
-
-				await apiHelpers.post(
-					`${apiHelpers.baseUrl}${parentApplicationName}/${parentEntry.id}/${relationship1.name}`,
-					{data: {textField: 'linked-' + getRandomInt()}}
-				);
-
-				// Open Edit relationship and uncheck inheritance
-
-				await objectRelationshipsPage.goto(parent1.label!['en_US']);
-
-				await objectRelationshipsPage.actionsButton.click();
-
-				await objectRelationshipsPage.editObjectRelationshipOption.click();
-
-				await objectRelationshipsPage.inheritanceCheckbox.click();
-
-				// Block modal fires directly from the pre-check (no warning step)
-
-				await expect(
-					objectRelationshipsPage.disableInheritanceNotAllowedModalHeader
-				).toBeVisible();
-
-				await expect(
-					objectRelationshipsPage.disableInheritanceNotAllowedModalBody
-				).toBeVisible();
-
-				await objectRelationshipsPage.disableInheritanceNotAllowedModalDoneButton.click();
-
-				await expect(
-					objectRelationshipsPage.disableInheritanceNotAllowedModalHeader
-				).toBeHidden();
-			}
-		);
-	});
 test.describe('Manage root models elements through Objects Admin', () => {
-
 	test('cannot delete an object definition with inheritance enabled on its relationship', async ({
 		apiHelpers,
 		page,
@@ -1703,6 +1520,186 @@ test.describe('Manage root models elements through Objects Admin', () => {
 			}
 		}
 	});
+});
+
+test.describe('Disable inheritance modal flows', () => {
+
+	// Inheritance edges with linked entries cannot be PUT edge=false until
+	// the entries are gone, and apiHelpers cannot delete an edge=true
+	// relationship. Delete the parent entry here so the cascade clears the
+	// linked child, then PUT edge=false on the relationships so the
+	// automatic apiHelpers cleanup chain stays unblocked.
+
+	let parentApplicationName = '';
+	let parentEntryId: number | undefined;
+	let relationshipsForCleanup: ObjectRelationship[] = [];
+
+	test.afterEach(async ({apiHelpers}) => {
+		if (parentEntryId !== undefined && parentApplicationName) {
+			await apiHelpers.delete(
+				`${apiHelpers.baseUrl}${parentApplicationName}/${parentEntryId}`
+			);
+		}
+
+		for (const objectRelationship of relationshipsForCleanup) {
+			await apiHelpers.objectAdmin.patchObjectRelationshipEdge(
+				objectRelationship,
+				false
+			);
+		}
+
+		parentApplicationName = '';
+		parentEntryId = undefined;
+		relationshipsForCleanup = [];
+	});
+
+	test('shows modal with warning message before disabling inheritance', async ({
+		apiHelpers,
+		objectRelationshipsPage,
+	}) => {
+		const parent = await apiHelpers.objectAdmin.postRandomObjectDefinition({
+			status: {code: 0},
+		});
+
+		const child = await apiHelpers.objectAdmin.postRandomObjectDefinition({
+			status: {code: 0},
+		});
+
+		pushToApiHelpersData(
+			apiHelpers,
+			[parent.id!, child.id!],
+			'objectDefinition'
+		);
+
+		const relationship =
+			await apiHelpers.objectAdmin.postObjectDefinitionInheritanceRelationship(
+				parent,
+				child
+			);
+
+		relationshipsForCleanup = [relationship];
+
+		apiHelpers.data.push({
+			id: relationship.id!,
+			type: 'objectRelationship',
+		});
+
+		await objectRelationshipsPage.goto(parent.label!['en_US']);
+
+		await objectRelationshipsPage.actionsButton.click();
+
+		await objectRelationshipsPage.editObjectRelationshipOption.click();
+
+		await objectRelationshipsPage.inheritanceCheckbox.click();
+
+		await expect(
+			objectRelationshipsPage.inheritanceModalHeader
+		).toBeVisible();
+
+		await expect(
+			objectRelationshipsPage.inheritanceModalConfirmationMessage
+		).toBeVisible();
+	});
+
+	test(
+		'shows modal blocking disabling inheritance when entries would be orphaned',
+		{tag: '@LPD-89021'},
+		async ({apiHelpers, objectRelationshipsPage}) => {
+
+			// Build a child with two inheritance parents and standalone=false
+
+			const parent1 =
+				await apiHelpers.objectAdmin.postRandomObjectDefinition({
+					status: {code: 0},
+				});
+
+			const parent2 =
+				await apiHelpers.objectAdmin.postRandomObjectDefinition({
+					status: {code: 0},
+				});
+
+			const child =
+				await apiHelpers.objectAdmin.postRandomObjectDefinition({
+					status: {code: 0},
+				});
+
+			pushToApiHelpersData(
+				apiHelpers,
+				[parent1.id!, parent2.id!, child.id!],
+				'objectDefinition'
+			);
+
+			const relationship1 =
+				await apiHelpers.objectAdmin.postObjectDefinitionInheritanceRelationship(
+					parent1,
+					child
+				);
+
+			const relationship2 =
+				await apiHelpers.objectAdmin.postObjectDefinitionInheritanceRelationship(
+					parent2,
+					child
+				);
+
+			relationshipsForCleanup = [relationship1, relationship2];
+
+			apiHelpers.data.push(
+				{id: relationship1.id!, type: 'objectRelationship'},
+				{id: relationship2.id!, type: 'objectRelationship'}
+			);
+
+			await apiHelpers.objectAdmin.patchObjectDefinitionSetting(
+				child.id!,
+				'allowStandaloneObjectEntry',
+				'false'
+			);
+
+			// Create a child entry linked under parent1
+
+			parentApplicationName = parent1.restContextPath!.replace(
+				/^\/o\//,
+				''
+			);
+
+			const parentEntry = await apiHelpers.objectEntry.postObjectEntry(
+				{textField: 'parent-' + getRandomInt()},
+				parentApplicationName
+			);
+
+			parentEntryId = parentEntry.id;
+
+			await apiHelpers.post(
+				`${apiHelpers.baseUrl}${parentApplicationName}/${parentEntry.id}/${relationship1.name}`,
+				{data: {textField: 'linked-' + getRandomInt()}}
+			);
+
+			// Open Edit relationship and uncheck inheritance
+
+			await objectRelationshipsPage.goto(parent1.label!['en_US']);
+
+			await objectRelationshipsPage.actionsButton.click();
+
+			await objectRelationshipsPage.editObjectRelationshipOption.click();
+
+			await objectRelationshipsPage.inheritanceCheckbox.click();
+
+			// Block modal fires directly from the pre-check (no warning step)
+
+			await expect(
+				objectRelationshipsPage.disableInheritanceNotAllowedModalHeader
+			).toBeVisible();
+
+			await expect(
+				objectRelationshipsPage.disableInheritanceNotAllowedModalBody
+			).toBeVisible();
+
+			await objectRelationshipsPage.disableInheritanceNotAllowedModalDoneButton.click();
+
+			await expect(
+				objectRelationshipsPage.disableInheritanceNotAllowedModalHeader
+			).toBeHidden();
+		}
+	);
 });
 
 test.describe('Manage root models elements through Model Builder', () => {

--- a/modules/test/playwright/tests/object-web/hierarchy/objectDefinitionHierarchy.spec.ts
+++ b/modules/test/playwright/tests/object-web/hierarchy/objectDefinitionHierarchy.spec.ts
@@ -628,7 +628,6 @@ test.describe('Manage root model elements through View Object Entries', () => {
 	});
 });
 
-test.describe('Manage root models elements through Objects Admin', () => {
 	test.describe('Disable inheritance modal flows', () => {
 
 		// Inheritance edges with linked entries cannot be PUT edge=false until
@@ -811,6 +810,7 @@ test.describe('Manage root models elements through Objects Admin', () => {
 			}
 		);
 	});
+test.describe('Manage root models elements through Objects Admin', () => {
 
 	test('cannot delete an object definition with inheritance enabled on its relationship', async ({
 		apiHelpers,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101869

## What Is Being Fixed

Eight object-web Playwright tests have never reported a real result on CI. They are recorded as **"Unable to run test on CI"** and stored as **untested** (not passed, not failed) — the suite has carried them as permanent non-results while nobody could tell if they pass. They are exactly the tests that sit in a describe **nested inside another describe**: five in objectField's *Create Object Fields*, two in objectDefinitionHierarchy's *Disable inheritance modal flows*, one in objectContentPageIntegration's *Information Template*.

CI computes a doubly-nested test's name two ways that disagree:

```
discovery (run-list): Information Template › verify …          (innermost describe only)
reporter  (results):  Display Page › Information Template › verify …   (full path)
```

They are compared for **string equality**, never match, and the case falls into the branch that emits the marker. Single nesting produces the same one-level name on both sides, so only double nesting breaks.

## How It Is Being Fixed

Move each of the three describes out to the top level, so a test's path holds one describe again. Each describe moves **whole**, so its own `beforeEach`/`afterEach` stays scoped to exactly its tests — no test changes what it runs. The registered case name is unchanged (discovery already used the innermost describe), so the existing cases keep their identity and simply start matching.

**Two commits, for review:**
- **Move the doubly-nested describes to the top level** — changes only the describe **braces** to un-nest the three groups in place. 4 insertions / 2 deletions; the blocks do not move or reformat. This is the whole functional change.
- **Reindent and settle the hoisted describes into place** — reindent + prettier reflow + relocation to final position. **Formatting only, no functional change; the diff is large but purely whitespace/brace/reflow — safe to skip.**

## Root Cause

Born mismatched in `531d5537efa21` (LRCI-4594), which attached one level of describe title on a walk that `e578efcc3c2c5` (LRCI-4121) had already made recursive without accumulating ancestors, carried forward by `b9b37f6f4e86c` (LRCI-6310). The eight tests met it when nested: `2c4d482c34b36` (LPD-85450), `8d6aa9489cbeb` (LPD-89021), `dc995c1c9f927` (LPD-82692).

## Verification

Case history on CI: each of the eight cases flips from **untested** ("Unable to run test on CI") to **passed** on the branch carrying the change, while the same cases on routines that build plain master — and so never carry it — remain untested over the same period.

## PR Check

**pr-check: PASS** — tested on `80764bf97799a65acbf3fab428b1c0f6a380b02a`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Spec Resolution (986 files, 5119 tests) | PASS |

Diff is three TypeScript files under `modules/test/playwright`. The module's `test` script runs the Playwright suite itself (out of pr-check scope); spec resolution via `playwright test --list` plus prettier is the applicable gate. No Java, `bnd.bnd`, `packageinfo`, or Gradle change.

<!-- pr-check {"result": "success", "sha": "80764bf97799a65acbf3fab428b1c0f6a380b02a"} -->
