### PR TITLE
LPD-96888 Let Hibernate reconcile a sequence increment size mismatch

### DIFF
--- a/modules/util/portal-tools-service-builder-test-sequence-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/sequence/service/test/SequenceEntryLocalServiceTest.java
+++ b/modules/util/portal-tools-service-builder-test-sequence-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/sequence/service/test/SequenceEntryLocalServiceTest.java
@@ -6,15 +6,23 @@
 package com.liferay.portal.tools.service.builder.test.sequence.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.db.DBType;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Release;
+import com.liferay.portal.kernel.service.ReleaseLocalServiceUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.AssumeTestRule;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.tools.service.builder.test.sequence.service.SequenceEntryLocalService;
 
+import java.io.IOException;
 import java.io.InputStream;
+
+import java.sql.SQLException;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -51,6 +59,10 @@ public class SequenceEntryLocalServiceTest {
 
 	@BeforeClass
 	public static void setUpClass() throws Exception {
+		_dropSequenceEntryTables();
+
+		_deleteRelease();
+
 		Bundle bundle = FrameworkUtil.getBundle(
 			SequenceEntryLocalServiceTest.class);
 
@@ -73,6 +85,10 @@ public class SequenceEntryLocalServiceTest {
 	@AfterClass
 	public static void tearDownClass() throws Exception {
 		_bundle.uninstall();
+
+		_dropSequenceEntryTables();
+
+		_deleteRelease();
 	}
 
 	@Test
@@ -81,6 +97,36 @@ public class SequenceEntryLocalServiceTest {
 			_sequenceEntryLocalService.addSequenceEntry(
 				_sequenceEntryLocalService.createSequenceEntry(0)));
 	}
+
+	private static void _deleteRelease() {
+		Release release = ReleaseLocalServiceUtil.fetchRelease(
+			"com.liferay.portal.tools.service.builder.test.sequence.service");
+
+		if (release != null) {
+			ReleaseLocalServiceUtil.deleteRelease(release);
+		}
+	}
+
+	private static void _dropSequenceEntryTables() {
+		_runSQL("drop table SequenceEntry");
+		_runSQL("drop sequence id_sequence");
+	}
+
+	private static void _runSQL(String sql) {
+		try {
+			DB db = DBManagerUtil.getDB();
+
+			db.runSQL(sql);
+		}
+		catch (IOException | SQLException exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		SequenceEntryLocalServiceTest.class);
 
 	private static Bundle _bundle;
 

--- a/modules/util/portal-tools-service-builder-test-sequence-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/sequence/service/test/SequenceEntryLocalServiceTest.java
+++ b/modules/util/portal-tools-service-builder-test-sequence-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/sequence/service/test/SequenceEntryLocalServiceTest.java
@@ -17,6 +17,7 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.AssumeTestRule;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.tools.service.builder.test.sequence.model.SequenceEntry;
 import com.liferay.portal.tools.service.builder.test.sequence.service.SequenceEntryLocalService;
 
 import java.io.IOException;
@@ -93,9 +94,21 @@ public class SequenceEntryLocalServiceTest {
 
 	@Test
 	public void testAddSequenceEntry() {
-		Assert.assertNotNull(
-			_sequenceEntryLocalService.addSequenceEntry(
-				_sequenceEntryLocalService.createSequenceEntry(0)));
+		Assert.assertNotNull(_addSequenceEntry());
+	}
+
+	@Test
+	public void testAddSequenceEntryIncrementsPrimaryKeyByOne() {
+		SequenceEntry sequenceEntry1 = _addSequenceEntry();
+		SequenceEntry sequenceEntry2 = _addSequenceEntry();
+		SequenceEntry sequenceEntry3 = _addSequenceEntry();
+
+		Assert.assertEquals(
+			sequenceEntry1.getSequenceEntryId() + 1,
+			sequenceEntry2.getSequenceEntryId());
+		Assert.assertEquals(
+			sequenceEntry2.getSequenceEntryId() + 1,
+			sequenceEntry3.getSequenceEntryId());
 	}
 
 	private static void _deleteRelease() {
@@ -123,6 +136,11 @@ public class SequenceEntryLocalServiceTest {
 				_log.debug(exception);
 			}
 		}
+	}
+
+	private SequenceEntry _addSequenceEntry() {
+		return _sequenceEntryLocalService.addSequenceEntry(
+			_sequenceEntryLocalService.createSequenceEntry(0));
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/portal-impl/src/com/liferay/portal/spring/hibernate/PortalHibernateConfiguration.java
+++ b/portal-impl/src/com/liferay/portal/spring/hibernate/PortalHibernateConfiguration.java
@@ -109,6 +109,8 @@ public class PortalHibernateConfiguration
 		properties.setProperty(
 			"hibernate.current_session_context_class",
 			PortalCurrentSessionContext.class.getName());
+		properties.setProperty(
+			"hibernate.id.sequence.increment_size_mismatch_strategy", "FIX");
 
 		if (Validator.isNull(PropsValues.HIBERNATE_DIALECT)) {
 			Class<?> clazz = dialect.getClass();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96888

## What Is Being Fixed

The database defaults a sequence to an increment of 1, and Hibernate 5 defaults a sequence generator's increment size to 1 as well, so a Service Builder mapping and the sequence created by the generated `sequences.sql` agree by coincidence. Hibernate 7 changed that default to 50 and validates the mapping against the sequence it finds, so the session factory refuses to build: "The increment size of the [id_sequence] sequence is set to [50] in the entity mapping but the mapped database sequence increment size is [1]".

## How It Is Being Fixed

`PortalHibernateConfiguration` sets `hibernate.id.sequence.increment_size_mismatch_strategy` to `FIX`, which asks Hibernate to take the increment size from the database rather than from the mapping. Every module session factory inherits it, so no mapping has to be edited.

`SequenceEntryLocalServiceTest` pins the behavior by adding three entries and asserting their primary keys are consecutive, which only holds while the mapping increment matches the sequence increment. On Hibernate 5 the assertion passes either way, so on master it stands as a guard rather than a reproduction — the mismatch is unreachable there because `NullSchemaNameResolver` makes Hibernate 5 skip the sequence check entirely.

The test installs its own service bundle, whose schema creation never drops what it created, so it also cleans the database on both sides of the run. `_dropSequenceEntryTables` drops the table and the sequence and `_deleteRelease` removes the `Release` row; all three have to go together, because `ReleaseManagerImpl` decides whether to create the schema from that row. This addresses the review comment on #180001 — the previous single `_deleteSequenceEntrySchema` used `delete` for DDL and said `schema` for a table and a sequence, and it mixed a DDL drop with an entity delete. Splitting it follows `CleanServiceBuilderCommand`, which separates `_dropTable` from `_deleteReleaseRows` for exactly this operation.

## PR Check

**pr-check: PASS** — tested on `b1b5f8b48de2fc6f2c40fc9006e4cde3174a5f2c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Full Portal Build | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

`SequenceEntryLocalServiceTest` was additionally run twice back to back against a persistent local PostgreSQL database. Both runs pass and the table, the sequence, and the `Release` row are absent afterwards, which is the property the cleanup exists to guarantee.

<!-- pr-check {"result": "success", "sha": "b1b5f8b48de2fc6f2c40fc9006e4cde3174a5f2c"} -->
