### PR TITLE
LPD-95020 Return typed error responses for widget instances

### DIFF
--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/rest-openapi.yaml
@@ -9051,6 +9051,12 @@ paths:
                                 items:
                                     $ref: "#/components/schemas/WidgetPageWidgetInstance"
                                 type: array
+                400:
+                    description:
+                        "The request is invalid. For example, the site page is not a widget page."
+                404:
+                    description:
+                        "The requested site page could not be found."
             # @review
             tags: ["WidgetPageWidgetInstance"]
         post:
@@ -9098,6 +9104,12 @@ paths:
                         application/xml:
                             schema:
                                 $ref: "#/components/schemas/WidgetPageWidgetInstance"
+                400:
+                    description:
+                        "The request is invalid. For example, the site page is not a widget page, the parent section does not exist, or the widget could not be added to the site page."
+                404:
+                    description:
+                        "The requested site page could not be found."
             # @review
             tags: ["WidgetPageWidgetInstance"]
     "/sites/{siteExternalReferenceCode}/site-pages/{sitePageExternalReferenceCode}/widget-instances/{widgetInstanceExternalReferenceCode}":
@@ -9127,6 +9139,12 @@ paths:
                     content:
                         application/json: {}
                         application/xml: {}
+                400:
+                    description:
+                        "The request is invalid. For example, the site page is not a widget page."
+                404:
+                    description:
+                        "The requested site page or widget instance could not be found."
             tags: ["WidgetPageWidgetInstance"]
         get:
             # @review
@@ -9170,6 +9188,12 @@ paths:
                         application/xml:
                             schema:
                                 $ref: "#/components/schemas/WidgetPageWidgetInstance"
+                400:
+                    description:
+                        "The request is invalid. For example, the site page is not a widget page."
+                404:
+                    description:
+                        "The requested site page or widget instance could not be found."
             tags: ["WidgetPageWidgetInstance"]
         patch:
             # @review
@@ -9221,6 +9245,12 @@ paths:
                         application/xml:
                             schema:
                                 $ref: "#/components/schemas/WidgetPageWidgetInstance"
+                400:
+                    description:
+                        "The request is invalid. For example, the site page is not a widget page or the parent section does not exist."
+                404:
+                    description:
+                        "The requested site page or widget instance could not be found."
             tags: ["WidgetPageWidgetInstance"]
         put:
             # @review
@@ -9272,6 +9302,12 @@ paths:
                         application/xml:
                             schema:
                                 $ref: "#/components/schemas/WidgetPageWidgetInstance"
+                400:
+                    description:
+                        "The request is invalid. For example, the site page is not a widget page, the parent section does not exist, or the widget could not be added to the site page."
+                404:
+                    description:
+                        "The requested site page could not be found."
             tags: ["WidgetPageWidgetInstance"]
     "/sites/{siteExternalReferenceCode}/style-books":
         get:

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/WidgetPageWidgetInstanceResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/WidgetPageWidgetInstanceResourceImpl.java
@@ -11,14 +11,14 @@ import com.liferay.headless.admin.site.internal.resource.v1_0.util.LayoutUtil;
 import com.liferay.headless.admin.site.resource.v1_0.WidgetPageWidgetInstanceResource;
 import com.liferay.headless.common.spi.util.GroupUtil;
 import com.liferay.petra.string.StringBundler;
-import com.liferay.portal.kernel.exception.NoSuchPortletException;
-import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.NoSuchLayoutException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.model.Layout;
-import com.liferay.portal.kernel.model.LayoutType;
+import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.LayoutTypePortlet;
 import com.liferay.portal.kernel.portlet.PortletIdCodec;
 import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
@@ -27,6 +27,9 @@ import com.liferay.portal.vulcan.pagination.Page;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.tags.Tags;
 
+import jakarta.ws.rs.NotFoundException;
+
+import java.util.List;
 import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
@@ -58,21 +61,8 @@ public class WidgetPageWidgetInstanceResourceImpl
 			throw new UnsupportedOperationException();
 		}
 
-		Layout layout = _layoutLocalService.fetchLayoutByExternalReferenceCode(
-			sitePageExternalReferenceCode,
-			GroupUtil.getGroupId(
-				false, contextCompany.getCompanyId(),
-				siteExternalReferenceCode));
-
-		if (layout == null) {
-			throw new UnsupportedOperationException();
-		}
-
-		LayoutType layoutType = layout.getLayoutType();
-
-		if (!(layoutType instanceof LayoutTypePortlet)) {
-			throw new UnsupportedOperationException();
-		}
+		Layout layout = _getTypePortletLayout(
+			siteExternalReferenceCode, sitePageExternalReferenceCode);
 
 		LayoutTypePortlet layoutTypePortlet =
 			(LayoutTypePortlet)layout.getLayoutType();
@@ -80,7 +70,11 @@ public class WidgetPageWidgetInstanceResourceImpl
 		if (!layoutTypePortlet.hasPortletId(
 				widgetInstanceExternalReferenceCode)) {
 
-			throw new NoSuchPortletException();
+			throw new NotFoundException(
+				StringBundler.concat(
+					"No widget instance with external reference code \"",
+					widgetInstanceExternalReferenceCode,
+					"\" exists in this site page"));
 		}
 
 		layoutTypePortlet.removePortletId(
@@ -104,21 +98,8 @@ public class WidgetPageWidgetInstanceResourceImpl
 			throw new UnsupportedOperationException();
 		}
 
-		Layout layout = _layoutLocalService.fetchLayoutByExternalReferenceCode(
-			sitePageExternalReferenceCode,
-			GroupUtil.getGroupId(
-				false, contextCompany.getCompanyId(),
-				siteExternalReferenceCode));
-
-		if (layout == null) {
-			throw new UnsupportedOperationException();
-		}
-
-		LayoutType layoutType = layout.getLayoutType();
-
-		if (!(layoutType instanceof LayoutTypePortlet)) {
-			throw new UnsupportedOperationException();
-		}
+		Layout layout = _getTypePortletLayout(
+			siteExternalReferenceCode, sitePageExternalReferenceCode);
 
 		LayoutTypePortlet layoutTypePortlet =
 			(LayoutTypePortlet)layout.getLayoutType();
@@ -126,7 +107,11 @@ public class WidgetPageWidgetInstanceResourceImpl
 		if (!layoutTypePortlet.hasPortletId(
 				widgetInstanceExternalReferenceCode)) {
 
-			throw new NoSuchPortletException();
+			throw new NotFoundException(
+				StringBundler.concat(
+					"No widget instance with external reference code \"",
+					widgetInstanceExternalReferenceCode,
+					"\" exists in this site page"));
 		}
 
 		return _toWidgetPageWidgetInstance(
@@ -145,21 +130,8 @@ public class WidgetPageWidgetInstanceResourceImpl
 			throw new UnsupportedOperationException();
 		}
 
-		Layout layout = _layoutLocalService.fetchLayoutByExternalReferenceCode(
-			sitePageExternalReferenceCode,
-			GroupUtil.getGroupId(
-				false, contextCompany.getCompanyId(),
-				siteExternalReferenceCode));
-
-		if (layout == null) {
-			throw new UnsupportedOperationException();
-		}
-
-		LayoutType layoutType = layout.getLayoutType();
-
-		if (!(layoutType instanceof LayoutTypePortlet)) {
-			throw new UnsupportedOperationException();
-		}
+		Layout layout = _getTypePortletLayout(
+			siteExternalReferenceCode, sitePageExternalReferenceCode);
 
 		LayoutTypePortlet layoutTypePortlet =
 			(LayoutTypePortlet)layout.getLayoutType();
@@ -190,21 +162,11 @@ public class WidgetPageWidgetInstanceResourceImpl
 			throw new UnsupportedOperationException();
 		}
 
-		Layout layout = _layoutLocalService.fetchLayoutByExternalReferenceCode(
-			sitePageExternalReferenceCode,
-			GroupUtil.getGroupId(
-				false, contextCompany.getCompanyId(),
-				siteExternalReferenceCode));
+		Layout layout = _getTypePortletLayout(
+			siteExternalReferenceCode, sitePageExternalReferenceCode);
 
-		if (layout == null) {
-			throw new UnsupportedOperationException();
-		}
-
-		LayoutType layoutType = layout.getLayoutType();
-
-		if (!(layoutType instanceof LayoutTypePortlet)) {
-			throw new UnsupportedOperationException();
-		}
+		_validateParentSectionId(
+			layout, widgetPageWidgetInstance.getParentSectionId());
 
 		String portletId = PortletIdCodec.encode(
 			widgetPageWidgetInstance.getWidgetName(),
@@ -229,21 +191,11 @@ public class WidgetPageWidgetInstanceResourceImpl
 			throw new UnsupportedOperationException();
 		}
 
-		Layout layout = _layoutLocalService.fetchLayoutByExternalReferenceCode(
-			sitePageExternalReferenceCode,
-			GroupUtil.getGroupId(
-				false, contextCompany.getCompanyId(),
-				siteExternalReferenceCode));
+		Layout layout = _getTypePortletLayout(
+			siteExternalReferenceCode, sitePageExternalReferenceCode);
 
-		if (layout == null) {
-			throw new UnsupportedOperationException();
-		}
-
-		LayoutType layoutType = layout.getLayoutType();
-
-		if (!(layoutType instanceof LayoutTypePortlet)) {
-			throw new UnsupportedOperationException();
-		}
+		_validateParentSectionId(
+			layout, widgetPageWidgetInstance.getParentSectionId());
 
 		LayoutTypePortlet layoutTypePortlet =
 			(LayoutTypePortlet)layout.getLayoutType();
@@ -289,10 +241,11 @@ public class WidgetPageWidgetInstanceResourceImpl
 			contextUser.getUserId(), portletId, columnId, position);
 
 		if (addedPortletId == null) {
-			throw new PortalException(
+			throw new IllegalArgumentException(
 				StringBundler.concat(
-					"Portlet ", portletId, " cannot be added to layout ",
-					layout.getPlid(), " by user ", contextUser.getUserId()));
+					"The widget ", portletId,
+					" could not be added to the site page ",
+					layout.getExternalReferenceCode()));
 		}
 
 		layout = _layoutLocalService.updateTypeSettings(
@@ -300,6 +253,33 @@ public class WidgetPageWidgetInstanceResourceImpl
 			layout.getTypeSettings());
 
 		return _toWidgetPageWidgetInstance(layout, addedPortletId);
+	}
+
+	private Layout _getTypePortletLayout(
+			String siteExternalReferenceCode,
+			String sitePageExternalReferenceCode)
+		throws Exception {
+
+		Layout layout = _layoutLocalService.fetchLayoutByExternalReferenceCode(
+			sitePageExternalReferenceCode,
+			GroupUtil.getGroupId(
+				false, contextCompany.getCompanyId(),
+				siteExternalReferenceCode));
+
+		if (layout == null) {
+			throw new NoSuchLayoutException(
+				StringBundler.concat(
+					"No site page exists with the external reference code \"",
+					sitePageExternalReferenceCode, "\""));
+		}
+
+		if (!Objects.equals(layout.getType(), LayoutConstants.TYPE_PORTLET)) {
+			throw new IllegalArgumentException(
+				"The site page with external reference code \"" +
+					sitePageExternalReferenceCode + "\" is not a widget page");
+		}
+
+		return layout;
 	}
 
 	private WidgetPageWidgetInstance _toWidgetPageWidgetInstance(
@@ -323,6 +303,25 @@ public class WidgetPageWidgetInstanceResourceImpl
 				contextHttpServletRequest, layout.getPlid(), contextUriInfo,
 				contextUser),
 			layout, portletId);
+	}
+
+	private void _validateParentSectionId(
+		Layout layout, String parentSectionId) {
+
+		if (Validator.isNull(parentSectionId)) {
+			return;
+		}
+
+		LayoutTypePortlet layoutTypePortlet =
+			(LayoutTypePortlet)layout.getLayoutType();
+
+		List<String> columns = layoutTypePortlet.getColumns();
+
+		if (!columns.contains(parentSectionId)) {
+			throw new IllegalArgumentException(
+				"The widget page section " + parentSectionId +
+					" does not exist");
+		}
 	}
 
 	@Reference

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/WidgetPageWidgetInstanceResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/WidgetPageWidgetInstanceResourceTest.java
@@ -11,6 +11,8 @@ import com.liferay.headless.admin.site.client.dto.v1_0.BasicWidgetPageWidgetInst
 import com.liferay.headless.admin.site.client.dto.v1_0.WidgetPageWidgetInstance;
 import com.liferay.headless.admin.site.client.problem.Problem;
 import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.function.UnsafeRunnable;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutTypePortlet;
 import com.liferay.portal.kernel.portlet.PortletIdCodec;
@@ -76,19 +78,13 @@ public class WidgetPageWidgetInstanceResourceTest
 
 		Assert.assertFalse(layoutTypePortlet.hasPortletId(portletId));
 
-		try {
-			widgetPageWidgetInstanceResource.deleteSiteSitePageWidgetInstance(
-				testGroup.getExternalReferenceCode(),
-				_layout.getExternalReferenceCode(), portletId);
-
-			Assert.fail();
-		}
-		catch (Problem.ProblemException problemException) {
-			Problem problem = problemException.getProblem();
-
-			Assert.assertEquals("NOT_FOUND", problem.getStatus());
-			Assert.assertNull(problem.getTitle());
-		}
+		_assertProblemException(
+			"NOT_FOUND", null,
+			() ->
+				widgetPageWidgetInstanceResource.
+					deleteSiteSitePageWidgetInstance(
+						testGroup.getExternalReferenceCode(),
+						_layout.getExternalReferenceCode(), portletId));
 	}
 
 	@Override
@@ -110,20 +106,20 @@ public class WidgetPageWidgetInstanceResourceTest
 		assertEquals(postWidgetPageWidgetInstance, getWidgetPageWidgetInstance);
 		assertValid(getWidgetPageWidgetInstance);
 
-		try {
-			widgetPageWidgetInstanceResource.getSiteSitePageWidgetInstance(
-				testGroup.getExternalReferenceCode(),
-				_layout.getExternalReferenceCode(),
-				RandomTestUtil.randomString());
+		String widgetInstanceExternalReferenceCode =
+			RandomTestUtil.randomString();
 
-			Assert.fail();
-		}
-		catch (Problem.ProblemException problemException) {
-			Problem problem = problemException.getProblem();
+		_assertProblemException(
+			"NOT_FOUND", null,
+			() ->
+				widgetPageWidgetInstanceResource.getSiteSitePageWidgetInstance(
+					testGroup.getExternalReferenceCode(),
+					_layout.getExternalReferenceCode(),
+					widgetInstanceExternalReferenceCode));
 
-			Assert.assertEquals("NOT_FOUND", problem.getStatus());
-			Assert.assertNull(problem.getTitle());
-		}
+		_testGetSiteSitePageWidgetInstanceWithContentPage();
+
+		_testGetSiteSitePageWidgetInstanceWithNonexistentSitePage();
 	}
 
 	@Override
@@ -147,21 +143,18 @@ public class WidgetPageWidgetInstanceResourceTest
 			postWidgetPageWidgetInstance, patchWidgetPageWidgetInstance);
 		assertValid(patchWidgetPageWidgetInstance);
 
-		try {
-			widgetPageWidgetInstanceResource.patchSiteSitePageWidgetInstance(
-				testGroup.getExternalReferenceCode(),
-				_layout.getExternalReferenceCode(),
-				RandomTestUtil.randomString(),
-				randomWidgetPageWidgetInstance());
+		String widgetInstanceExternalReferenceCode =
+			RandomTestUtil.randomString();
 
-			Assert.fail();
-		}
-		catch (Problem.ProblemException problemException) {
-			Problem problem = problemException.getProblem();
-
-			Assert.assertEquals("NOT_FOUND", problem.getStatus());
-			Assert.assertNull(problem.getTitle());
-		}
+		_assertProblemException(
+			"NOT_FOUND", null,
+			() ->
+				widgetPageWidgetInstanceResource.
+					patchSiteSitePageWidgetInstance(
+						testGroup.getExternalReferenceCode(),
+						_layout.getExternalReferenceCode(),
+						widgetInstanceExternalReferenceCode,
+						randomWidgetPageWidgetInstance()));
 	}
 
 	@Override
@@ -177,6 +170,10 @@ public class WidgetPageWidgetInstanceResourceTest
 		assertEquals(
 			randomWidgetPageWidgetInstance, postWidgetPageWidgetInstance);
 		assertValid(postWidgetPageWidgetInstance);
+
+		_testPostSiteSitePageWidgetInstanceWithNonexistentParentSectionId();
+
+		_testPostSiteSitePageWidgetInstanceWithUnregisteredWidget();
 	}
 
 	@Override
@@ -197,6 +194,8 @@ public class WidgetPageWidgetInstanceResourceTest
 
 		assertEquals(widgetPageWidgetInstance, putWidgetPageWidgetInstance);
 		assertValid(putWidgetPageWidgetInstance);
+
+		_testPutSiteSitePageWidgetInstanceWithNonexistentParentSectionId();
 	}
 
 	@Override
@@ -269,6 +268,129 @@ public class WidgetPageWidgetInstanceResourceTest
 		return widgetPageWidgetInstanceResource.postSiteSitePageWidgetInstance(
 			testGroup.getExternalReferenceCode(),
 			_layout.getExternalReferenceCode(), widgetPageWidgetInstance);
+	}
+
+	private void _assertProblemException(
+			String expectedStatus, String expectedTitle,
+			UnsafeRunnable<Exception> unsafeRunnable)
+		throws Exception {
+
+		try {
+			unsafeRunnable.run();
+
+			Assert.fail();
+		}
+		catch (Problem.ProblemException problemException) {
+			Problem problem = problemException.getProblem();
+
+			Assert.assertEquals(expectedStatus, problem.getStatus());
+			Assert.assertEquals(expectedTitle, problem.getTitle());
+		}
+	}
+
+	private void _testGetSiteSitePageWidgetInstanceWithContentPage()
+		throws Exception {
+
+		Layout layout = LayoutTestUtil.addTypeContentLayout(testGroup);
+
+		_assertProblemException(
+			"BAD_REQUEST",
+			"The site page with external reference code \"" +
+				layout.getExternalReferenceCode() + "\" is not a widget page",
+			() ->
+				widgetPageWidgetInstanceResource.getSiteSitePageWidgetInstance(
+					testGroup.getExternalReferenceCode(),
+					layout.getExternalReferenceCode(),
+					RandomTestUtil.randomString()));
+	}
+
+	private void _testGetSiteSitePageWidgetInstanceWithNonexistentSitePage()
+		throws Exception {
+
+		String sitePageExternalReferenceCode = RandomTestUtil.randomString();
+
+		_assertProblemException(
+			"NOT_FOUND", null,
+			() ->
+				widgetPageWidgetInstanceResource.getSiteSitePageWidgetInstance(
+					testGroup.getExternalReferenceCode(),
+					sitePageExternalReferenceCode,
+					RandomTestUtil.randomString()));
+	}
+
+	private void _testPostSiteSitePageWidgetInstanceWithNonexistentParentSectionId()
+		throws Exception {
+
+		WidgetPageWidgetInstance widgetPageWidgetInstance =
+			randomWidgetPageWidgetInstance();
+
+		String parentSectionId = RandomTestUtil.randomString();
+
+		widgetPageWidgetInstance.setParentSectionId(parentSectionId);
+
+		_assertProblemException(
+			"BAD_REQUEST",
+			"The widget page section " + parentSectionId + " does not exist",
+			() ->
+				widgetPageWidgetInstanceResource.postSiteSitePageWidgetInstance(
+					testGroup.getExternalReferenceCode(),
+					_layout.getExternalReferenceCode(),
+					widgetPageWidgetInstance));
+	}
+
+	private void _testPostSiteSitePageWidgetInstanceWithUnregisteredWidget()
+		throws Exception {
+
+		String widgetInstanceId = RandomTestUtil.randomString();
+		String widgetName = "com_liferay_test_FakePortlet";
+
+		WidgetPageWidgetInstance widgetPageWidgetInstance =
+			new BasicWidgetPageWidgetInstance();
+
+		widgetPageWidgetInstance.setParentSectionId("column-1");
+		widgetPageWidgetInstance.setPosition(0);
+		widgetPageWidgetInstance.setType(
+			WidgetPageWidgetInstance.Type.BASIC_WIDGET_PAGE_WIDGET_INSTANCE);
+		widgetPageWidgetInstance.setWidgetInstanceId(widgetInstanceId);
+		widgetPageWidgetInstance.setWidgetName(widgetName);
+
+		_assertProblemException(
+			"BAD_REQUEST",
+			StringBundler.concat(
+				"The widget ",
+				PortletIdCodec.encode(widgetName, widgetInstanceId),
+				" could not be added to the site page ",
+				_layout.getExternalReferenceCode()),
+			() ->
+				widgetPageWidgetInstanceResource.postSiteSitePageWidgetInstance(
+					testGroup.getExternalReferenceCode(),
+					_layout.getExternalReferenceCode(),
+					widgetPageWidgetInstance));
+	}
+
+	private void _testPutSiteSitePageWidgetInstanceWithNonexistentParentSectionId()
+		throws Exception {
+
+		WidgetPageWidgetInstance widgetPageWidgetInstance =
+			testPostSiteSitePageWidgetInstance_addWidgetPageWidgetInstance(
+				randomWidgetPageWidgetInstance());
+
+		String portletId = PortletIdCodec.encode(
+			widgetPageWidgetInstance.getWidgetName(),
+			widgetPageWidgetInstance.getWidgetInstanceId());
+
+		String parentSectionId = RandomTestUtil.randomString();
+
+		widgetPageWidgetInstance.setParentSectionId(parentSectionId);
+
+		_assertProblemException(
+			"BAD_REQUEST",
+			"The widget page section " + parentSectionId + " does not exist",
+			() ->
+				widgetPageWidgetInstanceResource.putSiteSitePageWidgetInstance(
+					testGroup.getExternalReferenceCode(),
+					_layout.getExternalReferenceCode(), portletId,
+					widgetPageWidgetInstance));
 	}
 
 	private Layout _layout;

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/WidgetPageWidgetInstanceResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/WidgetPageWidgetInstanceResourceTest.java
@@ -53,148 +53,38 @@ public class WidgetPageWidgetInstanceResourceTest
 	@Override
 	@Test
 	public void testDeleteSiteSitePageWidgetInstance() throws Exception {
-		WidgetPageWidgetInstance widgetPageWidgetInstance =
-			testPostSiteSitePageWidgetInstance_addWidgetPageWidgetInstance(
-				randomWidgetPageWidgetInstance());
-
-		_layout = _layoutLocalService.fetchLayout(_layout.getPlid());
-
-		LayoutTypePortlet layoutTypePortlet =
-			(LayoutTypePortlet)_layout.getLayoutType();
-
-		String portletId = PortletIdCodec.encode(
-			widgetPageWidgetInstance.getWidgetName(),
-			widgetPageWidgetInstance.getWidgetInstanceId());
-
-		Assert.assertTrue(layoutTypePortlet.hasPortletId(portletId));
-
-		widgetPageWidgetInstanceResource.deleteSiteSitePageWidgetInstance(
-			testGroup.getExternalReferenceCode(),
-			_layout.getExternalReferenceCode(), portletId);
-
-		_layout = _layoutLocalService.fetchLayout(_layout.getPlid());
-
-		layoutTypePortlet = (LayoutTypePortlet)_layout.getLayoutType();
-
-		Assert.assertFalse(layoutTypePortlet.hasPortletId(portletId));
-
-		_assertProblemException(
-			"NOT_FOUND", null,
-			() ->
-				widgetPageWidgetInstanceResource.
-					deleteSiteSitePageWidgetInstance(
-						testGroup.getExternalReferenceCode(),
-						_layout.getExternalReferenceCode(), portletId));
+		_testDeleteSiteSitePageWidgetInstance();
+		_testDeleteSiteSitePageWidgetInstanceWithNonexistentWidgetInstance();
 	}
 
 	@Override
 	@Test
 	public void testGetSiteSitePageWidgetInstance() throws Exception {
-		WidgetPageWidgetInstance postWidgetPageWidgetInstance =
-			testPostSiteSitePageWidgetInstance_addWidgetPageWidgetInstance(
-				randomWidgetPageWidgetInstance());
-
-		String portletId = PortletIdCodec.encode(
-			postWidgetPageWidgetInstance.getWidgetName(),
-			postWidgetPageWidgetInstance.getWidgetInstanceId());
-
-		WidgetPageWidgetInstance getWidgetPageWidgetInstance =
-			widgetPageWidgetInstanceResource.getSiteSitePageWidgetInstance(
-				testGroup.getExternalReferenceCode(),
-				_layout.getExternalReferenceCode(), portletId);
-
-		assertEquals(postWidgetPageWidgetInstance, getWidgetPageWidgetInstance);
-		assertValid(getWidgetPageWidgetInstance);
-
-		String widgetInstanceExternalReferenceCode =
-			RandomTestUtil.randomString();
-
-		_assertProblemException(
-			"NOT_FOUND", null,
-			() ->
-				widgetPageWidgetInstanceResource.getSiteSitePageWidgetInstance(
-					testGroup.getExternalReferenceCode(),
-					_layout.getExternalReferenceCode(),
-					widgetInstanceExternalReferenceCode));
-
+		_testGetSiteSitePageWidgetInstance();
 		_testGetSiteSitePageWidgetInstanceWithContentPage();
-
 		_testGetSiteSitePageWidgetInstanceWithNonexistentSitePage();
+		_testGetSiteSitePageWidgetInstanceWithNonexistentWidgetInstance();
 	}
 
 	@Override
 	@Test
 	public void testPatchSiteSitePageWidgetInstance() throws Exception {
-		WidgetPageWidgetInstance postWidgetPageWidgetInstance =
-			testPostSiteSitePageWidgetInstance_addWidgetPageWidgetInstance(
-				randomWidgetPageWidgetInstance());
-
-		String portletId = PortletIdCodec.encode(
-			postWidgetPageWidgetInstance.getWidgetName(),
-			postWidgetPageWidgetInstance.getWidgetInstanceId());
-
-		WidgetPageWidgetInstance patchWidgetPageWidgetInstance =
-			widgetPageWidgetInstanceResource.patchSiteSitePageWidgetInstance(
-				testGroup.getExternalReferenceCode(),
-				_layout.getExternalReferenceCode(), portletId,
-				postWidgetPageWidgetInstance);
-
-		assertEquals(
-			postWidgetPageWidgetInstance, patchWidgetPageWidgetInstance);
-		assertValid(patchWidgetPageWidgetInstance);
-
-		String widgetInstanceExternalReferenceCode =
-			RandomTestUtil.randomString();
-
-		_assertProblemException(
-			"NOT_FOUND", null,
-			() ->
-				widgetPageWidgetInstanceResource.
-					patchSiteSitePageWidgetInstance(
-						testGroup.getExternalReferenceCode(),
-						_layout.getExternalReferenceCode(),
-						widgetInstanceExternalReferenceCode,
-						randomWidgetPageWidgetInstance()));
+		_testPatchSiteSitePageWidgetInstance();
+		_testPatchSiteSitePageWidgetInstanceWithNonexistentWidgetInstance();
 	}
 
 	@Override
 	@Test
 	public void testPostSiteSitePageWidgetInstance() throws Exception {
-		WidgetPageWidgetInstance randomWidgetPageWidgetInstance =
-			randomWidgetPageWidgetInstance();
-
-		WidgetPageWidgetInstance postWidgetPageWidgetInstance =
-			testPostSiteSitePageWidgetInstance_addWidgetPageWidgetInstance(
-				randomWidgetPageWidgetInstance);
-
-		assertEquals(
-			randomWidgetPageWidgetInstance, postWidgetPageWidgetInstance);
-		assertValid(postWidgetPageWidgetInstance);
-
+		_testPostSiteSitePageWidgetInstance();
 		_testPostSiteSitePageWidgetInstanceWithNonexistentParentSectionId();
-
 		_testPostSiteSitePageWidgetInstanceWithUnregisteredWidget();
 	}
 
 	@Override
 	@Test
 	public void testPutSiteSitePageWidgetInstance() throws Exception {
-		WidgetPageWidgetInstance widgetPageWidgetInstance =
-			randomWidgetPageWidgetInstance();
-
-		String portletId = PortletIdCodec.encode(
-			widgetPageWidgetInstance.getWidgetName(),
-			widgetPageWidgetInstance.getWidgetInstanceId());
-
-		WidgetPageWidgetInstance putWidgetPageWidgetInstance =
-			widgetPageWidgetInstanceResource.putSiteSitePageWidgetInstance(
-				testGroup.getExternalReferenceCode(),
-				_layout.getExternalReferenceCode(), portletId,
-				widgetPageWidgetInstance);
-
-		assertEquals(widgetPageWidgetInstance, putWidgetPageWidgetInstance);
-		assertValid(putWidgetPageWidgetInstance);
-
+		_testPutSiteSitePageWidgetInstance();
 		_testPutSiteSitePageWidgetInstanceWithNonexistentParentSectionId();
 	}
 
@@ -288,6 +178,67 @@ public class WidgetPageWidgetInstanceResourceTest
 		}
 	}
 
+	private void _testDeleteSiteSitePageWidgetInstance() throws Exception {
+		WidgetPageWidgetInstance widgetPageWidgetInstance =
+			testPostSiteSitePageWidgetInstance_addWidgetPageWidgetInstance(
+				randomWidgetPageWidgetInstance());
+
+		_layout = _layoutLocalService.fetchLayout(_layout.getPlid());
+
+		LayoutTypePortlet layoutTypePortlet =
+			(LayoutTypePortlet)_layout.getLayoutType();
+
+		String portletId = PortletIdCodec.encode(
+			widgetPageWidgetInstance.getWidgetName(),
+			widgetPageWidgetInstance.getWidgetInstanceId());
+
+		Assert.assertTrue(layoutTypePortlet.hasPortletId(portletId));
+
+		widgetPageWidgetInstanceResource.deleteSiteSitePageWidgetInstance(
+			testGroup.getExternalReferenceCode(),
+			_layout.getExternalReferenceCode(), portletId);
+
+		_layout = _layoutLocalService.fetchLayout(_layout.getPlid());
+
+		layoutTypePortlet = (LayoutTypePortlet)_layout.getLayoutType();
+
+		Assert.assertFalse(layoutTypePortlet.hasPortletId(portletId));
+	}
+
+	private void _testDeleteSiteSitePageWidgetInstanceWithNonexistentWidgetInstance()
+		throws Exception {
+
+		String widgetInstanceExternalReferenceCode =
+			RandomTestUtil.randomString();
+
+		_assertProblemException(
+			"NOT_FOUND", null,
+			() ->
+				widgetPageWidgetInstanceResource.
+					deleteSiteSitePageWidgetInstance(
+						testGroup.getExternalReferenceCode(),
+						_layout.getExternalReferenceCode(),
+						widgetInstanceExternalReferenceCode));
+	}
+
+	private void _testGetSiteSitePageWidgetInstance() throws Exception {
+		WidgetPageWidgetInstance postWidgetPageWidgetInstance =
+			testPostSiteSitePageWidgetInstance_addWidgetPageWidgetInstance(
+				randomWidgetPageWidgetInstance());
+
+		String portletId = PortletIdCodec.encode(
+			postWidgetPageWidgetInstance.getWidgetName(),
+			postWidgetPageWidgetInstance.getWidgetInstanceId());
+
+		WidgetPageWidgetInstance getWidgetPageWidgetInstance =
+			widgetPageWidgetInstanceResource.getSiteSitePageWidgetInstance(
+				testGroup.getExternalReferenceCode(),
+				_layout.getExternalReferenceCode(), portletId);
+
+		assertEquals(postWidgetPageWidgetInstance, getWidgetPageWidgetInstance);
+		assertValid(getWidgetPageWidgetInstance);
+	}
+
 	private void _testGetSiteSitePageWidgetInstanceWithContentPage()
 		throws Exception {
 
@@ -316,6 +267,71 @@ public class WidgetPageWidgetInstanceResourceTest
 					testGroup.getExternalReferenceCode(),
 					sitePageExternalReferenceCode,
 					RandomTestUtil.randomString()));
+	}
+
+	private void _testGetSiteSitePageWidgetInstanceWithNonexistentWidgetInstance()
+		throws Exception {
+
+		String widgetInstanceExternalReferenceCode =
+			RandomTestUtil.randomString();
+
+		_assertProblemException(
+			"NOT_FOUND", null,
+			() ->
+				widgetPageWidgetInstanceResource.getSiteSitePageWidgetInstance(
+					testGroup.getExternalReferenceCode(),
+					_layout.getExternalReferenceCode(),
+					widgetInstanceExternalReferenceCode));
+	}
+
+	private void _testPatchSiteSitePageWidgetInstance() throws Exception {
+		WidgetPageWidgetInstance postWidgetPageWidgetInstance =
+			testPostSiteSitePageWidgetInstance_addWidgetPageWidgetInstance(
+				randomWidgetPageWidgetInstance());
+
+		String portletId = PortletIdCodec.encode(
+			postWidgetPageWidgetInstance.getWidgetName(),
+			postWidgetPageWidgetInstance.getWidgetInstanceId());
+
+		WidgetPageWidgetInstance patchWidgetPageWidgetInstance =
+			widgetPageWidgetInstanceResource.patchSiteSitePageWidgetInstance(
+				testGroup.getExternalReferenceCode(),
+				_layout.getExternalReferenceCode(), portletId,
+				postWidgetPageWidgetInstance);
+
+		assertEquals(
+			postWidgetPageWidgetInstance, patchWidgetPageWidgetInstance);
+		assertValid(patchWidgetPageWidgetInstance);
+	}
+
+	private void _testPatchSiteSitePageWidgetInstanceWithNonexistentWidgetInstance()
+		throws Exception {
+
+		String widgetInstanceExternalReferenceCode =
+			RandomTestUtil.randomString();
+
+		_assertProblemException(
+			"NOT_FOUND", null,
+			() ->
+				widgetPageWidgetInstanceResource.
+					patchSiteSitePageWidgetInstance(
+						testGroup.getExternalReferenceCode(),
+						_layout.getExternalReferenceCode(),
+						widgetInstanceExternalReferenceCode,
+						randomWidgetPageWidgetInstance()));
+	}
+
+	private void _testPostSiteSitePageWidgetInstance() throws Exception {
+		WidgetPageWidgetInstance randomWidgetPageWidgetInstance =
+			randomWidgetPageWidgetInstance();
+
+		WidgetPageWidgetInstance postWidgetPageWidgetInstance =
+			testPostSiteSitePageWidgetInstance_addWidgetPageWidgetInstance(
+				randomWidgetPageWidgetInstance);
+
+		assertEquals(
+			randomWidgetPageWidgetInstance, postWidgetPageWidgetInstance);
+		assertValid(postWidgetPageWidgetInstance);
 	}
 
 	private void _testPostSiteSitePageWidgetInstanceWithNonexistentParentSectionId()
@@ -366,6 +382,24 @@ public class WidgetPageWidgetInstanceResourceTest
 					testGroup.getExternalReferenceCode(),
 					_layout.getExternalReferenceCode(),
 					widgetPageWidgetInstance));
+	}
+
+	private void _testPutSiteSitePageWidgetInstance() throws Exception {
+		WidgetPageWidgetInstance widgetPageWidgetInstance =
+			randomWidgetPageWidgetInstance();
+
+		String portletId = PortletIdCodec.encode(
+			widgetPageWidgetInstance.getWidgetName(),
+			widgetPageWidgetInstance.getWidgetInstanceId());
+
+		WidgetPageWidgetInstance putWidgetPageWidgetInstance =
+			widgetPageWidgetInstanceResource.putSiteSitePageWidgetInstance(
+				testGroup.getExternalReferenceCode(),
+				_layout.getExternalReferenceCode(), portletId,
+				widgetPageWidgetInstance);
+
+		assertEquals(widgetPageWidgetInstance, putWidgetPageWidgetInstance);
+		assertValid(putWidgetPageWidgetInstance);
 	}
 
 	private void _testPutSiteSitePageWidgetInstanceWithNonexistentParentSectionId()

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/WidgetPageWidgetInstanceResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/WidgetPageWidgetInstanceResourceTest.java
@@ -70,6 +70,7 @@ public class WidgetPageWidgetInstanceResourceTest
 	@Test
 	public void testPatchSiteSitePageWidgetInstance() throws Exception {
 		_testPatchSiteSitePageWidgetInstance();
+		_testPatchSiteSitePageWidgetInstanceWithNonexistentParentSectionId();
 		_testPatchSiteSitePageWidgetInstanceWithNonexistentWidgetInstance();
 	}
 
@@ -86,6 +87,7 @@ public class WidgetPageWidgetInstanceResourceTest
 	public void testPutSiteSitePageWidgetInstance() throws Exception {
 		_testPutSiteSitePageWidgetInstance();
 		_testPutSiteSitePageWidgetInstanceWithNonexistentParentSectionId();
+		_testPutSiteSitePageWidgetInstanceWithUnregisteredWidget();
 	}
 
 	@Override
@@ -304,6 +306,32 @@ public class WidgetPageWidgetInstanceResourceTest
 		assertValid(patchWidgetPageWidgetInstance);
 	}
 
+	private void _testPatchSiteSitePageWidgetInstanceWithNonexistentParentSectionId()
+		throws Exception {
+
+		WidgetPageWidgetInstance widgetPageWidgetInstance =
+			testPostSiteSitePageWidgetInstance_addWidgetPageWidgetInstance(
+				randomWidgetPageWidgetInstance());
+
+		String portletId = PortletIdCodec.encode(
+			widgetPageWidgetInstance.getWidgetName(),
+			widgetPageWidgetInstance.getWidgetInstanceId());
+
+		String parentSectionId = RandomTestUtil.randomString();
+
+		widgetPageWidgetInstance.setParentSectionId(parentSectionId);
+
+		_assertProblemException(
+			"BAD_REQUEST",
+			"The widget page section " + parentSectionId + " does not exist",
+			() ->
+				widgetPageWidgetInstanceResource.
+					patchSiteSitePageWidgetInstance(
+						testGroup.getExternalReferenceCode(),
+						_layout.getExternalReferenceCode(), portletId,
+						widgetPageWidgetInstance));
+	}
+
 	private void _testPatchSiteSitePageWidgetInstanceWithNonexistentWidgetInstance()
 		throws Exception {
 
@@ -420,6 +448,37 @@ public class WidgetPageWidgetInstanceResourceTest
 		_assertProblemException(
 			"BAD_REQUEST",
 			"The widget page section " + parentSectionId + " does not exist",
+			() ->
+				widgetPageWidgetInstanceResource.putSiteSitePageWidgetInstance(
+					testGroup.getExternalReferenceCode(),
+					_layout.getExternalReferenceCode(), portletId,
+					widgetPageWidgetInstance));
+	}
+
+	private void _testPutSiteSitePageWidgetInstanceWithUnregisteredWidget()
+		throws Exception {
+
+		String widgetInstanceId = RandomTestUtil.randomString();
+		String widgetName = "com_liferay_test_FakePortlet";
+
+		WidgetPageWidgetInstance widgetPageWidgetInstance =
+			new BasicWidgetPageWidgetInstance();
+
+		widgetPageWidgetInstance.setParentSectionId("column-1");
+		widgetPageWidgetInstance.setPosition(0);
+		widgetPageWidgetInstance.setType(
+			WidgetPageWidgetInstance.Type.BASIC_WIDGET_PAGE_WIDGET_INSTANCE);
+		widgetPageWidgetInstance.setWidgetInstanceId(widgetInstanceId);
+		widgetPageWidgetInstance.setWidgetName(widgetName);
+
+		String portletId = PortletIdCodec.encode(widgetName, widgetInstanceId);
+
+		_assertProblemException(
+			"BAD_REQUEST",
+			StringBundler.concat(
+				"The widget ", portletId,
+				" could not be added to the site page ",
+				_layout.getExternalReferenceCode()),
 			() ->
 				widgetPageWidgetInstanceResource.putSiteSitePageWidgetInstance(
 					testGroup.getExternalReferenceCode(),


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95020

## What Is Being Fixed

The widget instance endpoints under `/sites/{siteExternalReferenceCode}/site-pages/{sitePageExternalReferenceCode}/widget-instances` answered every failure with an opaque error. A missing site page, a site page that is not a widget page, and a nonexistent parent section all raised a bare `UnsupportedOperationException`, which surfaces as a 500 and tells the caller nothing about what was wrong with the request. A widget that could not be added raised a `PortalException` whose message carried internal identifiers, the layout plid and the user id. A nonexistent widget instance raised `NoSuchPortletException`, which nothing translates for this API. None of these outcomes appeared in the OpenAPI contract, so a client had no way to anticipate them.

## How It Is Being Fixed

Each failure now maps to the status code that describes it. Resolving the layout moved into a single `_getTypePortletLayout` helper shared by all five operations, replacing the block every method repeated: a missing site page throws `NoSuchLayoutException` for a 404, and a site page whose type is not `portlet` throws `IllegalArgumentException` for a 400. A nonexistent widget instance throws `NotFoundException` rather than `NoSuchPortletException`. The failure to add a widget becomes an `IllegalArgumentException` whose message names the widget and the site page by external reference code instead of by plid and user id.

The write operations gained a `_validateParentSectionId` check, so a `parentSectionId` naming no column on the page fails with a 400 up front rather than being accepted silently.

The OpenAPI contract documents the 400 and 404 responses for all five operations, and the integration test asserts each one. The existing test methods were reorganized so that every `@Test` mirrors an operation, with each scenario in its own `_test` helper.

## PR Check

**pr-check: PASS** — tested on `3a645d71b2f71062a0fe4d1189bfb4fa1c191d80`

| Validation | Result |
| --- | --- |
| REST Builder | PASS |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "3a645d71b2f71062a0fe4d1189bfb4fa1c191d80"} -->
