### PR TITLE
LPD-102121 Scope the objectValidation search to the management toolbar

### DIFF
--- a/modules/test/playwright/tests/object-web/validation/objectValidation.spec.ts
+++ b/modules/test/playwright/tests/object-web/validation/objectValidation.spec.ts
@@ -207,11 +207,9 @@ test.describe('Object Expression Builder Validation', () => {
 	}) => {
 		await objectValidationsPage.viewObjectDefinitionsPage.goto();
 
-		await page.getByPlaceholder('Search').fill('User');
-
-		await page.keyboard.press('Enter');
-
-		await page.getByRole('link', {exact: true, name: 'User'}).click();
+		await objectValidationsPage.viewObjectDefinitionsPage.clickEditObjectDefinitionLink(
+			'User'
+		);
 
 		await objectValidationsPage.validationTabItem.click();
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102121

## What Is Being Fixed

The object-web "expression builder validation on a system object" Playwright test (`object-web/validation/objectValidation.spec.ts`) is a chronic flake — it intermittently fails with a Playwright strict-mode violation when it types into the object definitions search.

## How It Is Being Fixed

The test filled `page.getByPlaceholder('Search')`, an unscoped locator added when the validation subproject was created in LPD-85191 (`5e31926d7b7a7`). Right after the `goto()` to the object definitions page, that locator can match more than one "Search" input, so strict mode fails the fill. Reuse `ViewObjectDefinitionsPage.clickEditObjectDefinitionLink`, which scopes the search to the `.management-bar` toolbar and performs the same fill, Enter, and result click. Verified on CI: the whole `object-web.validation` project passed (23/23) with the fix, versus the strict-mode failure without it.

## PR Check

**pr-check: PASS** — tested on `7cb1fe2286d15d40f54db6dd3f1e64a983d45723`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "7cb1fe2286d15d40f54db6dd3f1e64a983d45723"} -->
