### PR TITLE
LPD-100186 Semantic versioning

### DIFF
--- a/modules/apps/site/site-cmp-site-initializer-test-util/bnd.bnd
+++ b/modules/apps/site/site-cmp-site-initializer-test-util/bnd.bnd
@@ -1,4 +1,4 @@
 Bundle-Name: Liferay Site CMP Site Initializer Test Utilities
 Bundle-SymbolicName: com.liferay.site.cmp.site.initializer.test.util
-Bundle-Version: 2.0.1
+Bundle-Version: 2.1.0
 Export-Package: com.liferay.site.cmp.site.initializer.test.util

--- a/modules/apps/site/site-cmp-site-initializer-test-util/src/main/resources/com/liferay/site/cmp/site/initializer/test/util/packageinfo
+++ b/modules/apps/site/site-cmp-site-initializer-test-util/src/main/resources/com/liferay/site/cmp/site/initializer/test/util/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100186

## What Is Being Fixed

The modules-semantic-versioning batch fails on `site-cmp-site-initializer-test-util`: the exported `com.liferay.site.cmp.site.initializer.test.util` package has a MINOR API delta against the released 2.0.0 baseline with no version bump.

## How It Is Being Fixed

Root cause: `971d6867df4c8` (LPD-100186) added three public static methods to `CMPTestUtil` after the 2.0.0 artifact was released (`c46d206d63951`), without the matching bump. Bump the packageinfo and Bundle-Version to 2.1.0. Verified locally: the module's `baseline` Gradle task passes against the released 2.0.0 on Nexus.

## PR Check

**pr-check: PASS** — tested on `578da3c2e554986184d8401a8d4d1a676312c770`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Baseline | PASS |

<!-- pr-check {"result": "success", "sha": "578da3c2e554986184d8401a8d4d1a676312c770"} -->
