### PR TITLE
LPD-102185 Skip portlet messages when there is no portlet render request

### DIFF
--- a/portal-web/docroot/html/taglib/theme/portlet_messages/page.jsp
+++ b/portal-web/docroot/html/taglib/theme/portlet_messages/page.jsp
@@ -59,40 +59,42 @@ Portlet portlet = (Portlet)request.getAttribute("liferay-theme:portlet-messages:
 	</c:if>
 </c:if>
 
-<c:if test='<%= MultiSessionMessages.contains(renderRequest, "requestProcessed") && !MultiSessionMessages.contains(renderRequest, portlet.getPortletId() + SessionMessages.KEY_SUFFIX_HIDE_DEFAULT_SUCCESS_MESSAGE) %>'>
+<c:if test="<%= renderRequest != null %>">
+	<c:if test='<%= MultiSessionMessages.contains(renderRequest, "requestProcessed") && !MultiSessionMessages.contains(renderRequest, portlet.getPortletId() + SessionMessages.KEY_SUFFIX_HIDE_DEFAULT_SUCCESS_MESSAGE) %>'>
 
-	<%
-	String successMessage = (String)MultiSessionMessages.get(renderRequest, "requestProcessed");
-	%>
+		<%
+		String successMessage = (String)MultiSessionMessages.get(renderRequest, "requestProcessed");
+		%>
 
-	<liferay-util:buffer
-		var="successHTML"
-	>
-		<c:choose>
-			<c:when test='<%= Validator.isNotNull(successMessage) && !successMessage.equals("request_processed") %>'>
-				<%= HtmlUtil.escape(successMessage) %>
-			</c:when>
-			<c:otherwise>
-				<liferay-ui:message key="your-request-completed-successfully" />
-			</c:otherwise>
-		</c:choose>
+		<liferay-util:buffer
+			var="successHTML"
+		>
+			<c:choose>
+				<c:when test='<%= Validator.isNotNull(successMessage) && !successMessage.equals("request_processed") %>'>
+					<%= HtmlUtil.escape(successMessage) %>
+				</c:when>
+				<c:otherwise>
+					<liferay-ui:message key="your-request-completed-successfully" />
+				</c:otherwise>
+			</c:choose>
 
-		<c:if test="<%= themeDisplay.isStatePopUp() && MultiSessionMessages.contains(renderRequest, portlet.getPortletId() + SessionMessages.KEY_SUFFIX_CLOSE_REDIRECT) %>">
+			<c:if test="<%= themeDisplay.isStatePopUp() && MultiSessionMessages.contains(renderRequest, portlet.getPortletId() + SessionMessages.KEY_SUFFIX_CLOSE_REDIRECT) %>">
 
-			<%
-			String taglibMessage = "class=\"lfr-hide-dialog\" href=\"javascript:void(0);\"";
-			%>
+				<%
+				String taglibMessage = "class=\"lfr-hide-dialog\" href=\"javascript:void(0);\"";
+				%>
 
-			<liferay-ui:message arguments="<%= taglibMessage %>" key="the-page-will-be-refreshed-when-you-close-this-dialog.alternatively-you-can-hide-this-dialog-x" translateArguments="<%= false %>" />
-		</c:if>
-	</liferay-util:buffer>
+				<liferay-ui:message arguments="<%= taglibMessage %>" key="the-page-will-be-refreshed-when-you-close-this-dialog.alternatively-you-can-hide-this-dialog-x" translateArguments="<%= false %>" />
+			</c:if>
+		</liferay-util:buffer>
 
-	<liferay-ui:success key="requestProcessed" message="<%= successHTML %>" />
-</c:if>
+		<liferay-ui:success key="requestProcessed" message="<%= successHTML %>" />
+	</c:if>
 
-<liferay-ui:success key="<%= portlet.getPortletId() + SessionMessages.KEY_SUFFIX_UPDATED_CONFIGURATION %>" message="you-have-successfully-updated-the-setup" />
-<liferay-ui:success key="<%= portlet.getPortletId() + SessionMessages.KEY_SUFFIX_UPDATED_PREFERENCES %>" message="you-have-successfully-updated-your-preferences" />
+	<liferay-ui:success key="<%= portlet.getPortletId() + SessionMessages.KEY_SUFFIX_UPDATED_CONFIGURATION %>" message="you-have-successfully-updated-the-setup" />
+	<liferay-ui:success key="<%= portlet.getPortletId() + SessionMessages.KEY_SUFFIX_UPDATED_PREFERENCES %>" message="you-have-successfully-updated-your-preferences" />
 
-<c:if test="<%= !MultiSessionErrors.isHideDefaultErrorMessage(renderRequest, portlet.getPortletId()) %>">
-	<liferay-ui:error embed="<%= false %>" />
+	<c:if test="<%= !MultiSessionErrors.isHideDefaultErrorMessage(renderRequest, portlet.getPortletId()) %>">
+		<liferay-ui:error embed="<%= false %>" />
+	</c:if>
 </c:if>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102185

## What Is Being Fixed

Every object CI run's startup log carries a JasperException wrapping a NullPointerException from the portlet messages taglib page, which trips portal log scanning. Three CI axis consoles show the identical chain: the first request to `/` during the startup window ends in a silent 500, Tomcat renders the themed error page, and `portlet_messages/page.jsp` dereferences `renderRequest` — null outside a portlet render request — failing in `SessionMessages` via `PortalUtil.getHttpServletRequest(null)`. The page has dereferenced `renderRequest` without a guard since it was extracted into the taglib in LPS-67657.

## How It Is Being Fixed

Guard the message block on `renderRequest`, matching the taglib `init.jsp`, which already null-guards the same portlet request attributes. Without a portlet render request there are no portlet session messages to show, so skipping the block preserves behavior. A CI run with the guard boots through the same startup window with a startup log free of the JasperException and of any other error (three control consoles without the guard each carry it); the run's Playwright project passed 23 of 23, with the guarded page compiling and serving on every portal page view.

## PR Check

**pr-check: PASS** — tested on `e27a5643928e6bf2033a8435776bd5b9139db616`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "e27a5643928e6bf2033a8435776bd5b9139db616"} -->
