### PR TITLE
LPD-102243 Retry the asset type edit click until the workflow select shows

### DIFF
--- a/modules/test/playwright/pages/portal-workflow-kaleo-designer-web/ConfigurationTabPage.ts
+++ b/modules/test/playwright/pages/portal-workflow-kaleo-designer-web/ConfigurationTabPage.ts
@@ -5,6 +5,7 @@
 
 import {Locator, Page, expect} from '@playwright/test';
 
+import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
 import {waitForAlert} from '../../utils/waitForAlert';
 import {ProcessBuilderPage} from './ProcessBuilderPage';
 
@@ -79,7 +80,15 @@ export class ConfigurationTabPage {
 
 		await expect(editButton).toBeVisible();
 
-		await editButton.click();
+		// The edit button swaps the row into its inline edit form. A click
+		// fired before the row's script is wired gets swallowed, leaving the
+		// workflow definition select present but hidden, so retry the click
+		// until the select is visible.
+
+		await clickAndExpectToBeVisible({
+			target: this.getAssignWorkflowDropdown(assetType),
+			trigger: editButton,
+		});
 	}
 
 	private async clickAssetTypeSaveButton(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102243

## What Is Being Fixed

`ConfigurationTabPage.assignWorkflowToAssetType` clicked the asset type row's edit button once and then selected the workflow definition. A click fired before the row's script is wired gets swallowed: the inline edit form never opens, the workflow definition select stays present but hidden, and `selectOption` times out after retrying against a hidden element for the whole test timeout. This is a chronic flake across the object suite wherever a test assigns a workflow (for example `objectWorkflow` line 549 and `objectEntry` line 1663).

## How It Is Being Fixed

Replace the bare `editButton.click()` with `clickAndExpectToBeVisible`, passing the workflow definition select as the target, so a swallowed click is retried until the inline edit form opens and the select becomes visible. The single click dates to the page object's creation in LPD-25960 (df099ab16c0a5); LPD-101364 later hardened the search step of the same method but left the edit click bare.

## PR Check

**pr-check: PASS** — tested on `a59aabdd665af5c4a6fc8b855b08dc07f79260ed`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result":"success","sha":"a59aabdd665af5c4a6fc8b855b08dc07f79260ed"} -->
