### PR TITLE
LPD-102246 Build the draft entry form container page through the API

### DIFF
--- a/modules/apps/object/object-test/src/testFunctional/macros/json/JSONObjectContentPage.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/json/JSONObjectContentPage.macro
@@ -1,0 +1,76 @@
+definition {
+
+	@summary = "Default summary"
+	macro addObjectFormContainerPageViaAPI(groupName = null, layoutName = null, objectFieldName = null, objectName = null, submittedEntryStatus = null) {
+		Variables.assertDefined(parameterList = "${groupName},${layoutName},${objectFieldName},${objectName}");
+
+		if (!(isSet(submittedEntryStatus))) {
+			var submittedEntryStatus = 0;
+		}
+
+		var objectDefinitionId = JSONObject.getObjectId(objectName = ${objectName});
+		var portalURL = JSONCompany.getPortalURL();
+		var siteId = JSONGroupAPI._getSiteIdByGroupKey(groupName = ${groupName});
+		var userLoginInfo = JSONUtil2.formatJSONUser();
+
+		var curl = '''
+			${portalURL}/o/headless-delivery/v1.0/sites/${siteId}/site-pages \
+				-H 'Content-Type: application/json' \
+				-u ${userLoginInfo} \
+				-d '{
+					"pageDefinition": {
+						"pageElement": {
+							"id": "root",
+							"pageElements": [
+								{
+									"definition": {
+										"formConfig": {
+											"formReference": {
+												"className": "com.liferay.object.model.ObjectDefinition#${objectDefinitionId}",
+												"classType": 0
+											},
+											"formType": "simple"
+										}
+									},
+									"id": "form-container",
+									"pageElements": [
+										{
+											"definition": {
+												"fragment": {
+													"key": "INPUTS-text-input"
+												},
+												"fragmentConfig": {
+													"inputFieldId": "ObjectField_${objectFieldName}"
+												}
+											},
+											"id": "text-input",
+											"type": "Fragment"
+										},
+										{
+											"definition": {
+												"fragment": {
+													"key": "INPUTS-submit-button"
+												},
+												"fragmentConfig": {
+													"submittedEntryStatus": "${submittedEntryStatus}",
+													"type": "submit"
+												}
+											},
+											"id": "submit-button",
+											"type": "Fragment"
+										}
+									],
+									"type": "Form"
+								}
+							],
+							"type": "Root"
+						}
+					},
+					"title": "${layoutName}"
+				}'
+		''';
+
+		JSONCurlUtil.post(${curl});
+	}
+
+}

--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectWorkflow.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectWorkflow.testcase
@@ -24,6 +24,8 @@ definition {
 	@description = "LPS-181663 - Verify when a user creates an object entry and saves it as a draft, the workflow related to that object definition is not triggered"
 	@priority = 4
 	test CheckWorkflowNotTriggeredForDraftEntry {
+		property custom.properties = "feature.flag.LPS-178052=true";
+
 		task ("Given a custom object definition scoped by site") {
 			ObjectAdmin.addObjectViaAPI(
 				labelName = "Custom Object 197509",
@@ -54,32 +56,12 @@ definition {
 		}
 
 		task ("and Given a mapped form container on a content page") {
-			JSONLayout.addPublicLayout(
+			JSONObjectContentPage.addObjectFormContainerPageViaAPI(
 				groupName = "Guest",
 				layoutName = "Object Page",
-				type = "content");
-
-			ContentPagesNavigator.openEditContentPage(
-				pageName = "Object Page",
-				siteName = "Guest");
-
-			PageEditor.addFragment(
-				collectionName = "Form Components",
-				fragmentName = "Form Container");
-
-			PageEditor.mapFormContainerToObject(contentType = "Custom Object 197509");
-
-			Click.javaScriptClick(
-				index = 1,
-				key_fragmentName = "Form Button",
-				locator1 = "Fragment#FRAGMENT_LABEL");
-
-			Select(
-				key_fieldLabel = "Submitted Entry Status",
-				locator1 = "Select#GENERIC_SELECT_FIELD",
-				value1 = "Draft");
-
-			PageEditor.publish();
+				objectFieldName = "textField",
+				objectName = "CustomObject197509",
+				submittedEntryStatus = 2);
 		}
 
 		task ("and Given a workflow is set for that object definition") {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102246

## What Is Being Fixed

`CheckWorkflowNotTriggeredForDraftEntry` dragged the Form Container fragment into a content page with `Simulate.dragAndDrop`, whose synthetic untrusted events no longer reach the page editor's HTML5 drag backend, so the container never lands and the test dies looking for it.

## How It Is Being Fixed

Build the page through `POST /o/headless-delivery/v1.0/sites/{siteId}/site-pages` with an embedded page definition instead: a Form structure item referencing the object definition plus the contributed text input and submit button fragments, with the submit button configured to save entries as drafts. The import publishes the layout directly, so the page editor is bypassed entirely and the guest submission flow under test is unchanged. The endpoint sits behind the LPS-178052 development feature flag, enabled per test through custom.properties, matching the existing object tests that enable the same flag.

## PR Check

**pr-check: PASS** — tested on `c222f0df2889a6bc069fcaff480b7e34185a97b2`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Poshi Syntax | PASS |

<!-- pr-check {"result":"success","sha":"c222f0df2889a6bc069fcaff480b7e34185a97b2"} -->
