### PR TITLE
LPD-102319 Wait for load state instead of the next domcontentloaded event

### DIFF
--- a/modules/test/playwright/tests/object-web/client-extension/objectClientExtension.spec.ts
+++ b/modules/test/playwright/tests/object-web/client-extension/objectClientExtension.spec.ts
@@ -141,7 +141,7 @@ test('Can create, read, update, and delete object entries that use the client ex
 
 	await editObjectDetailsPage.publishButton.click();
 
-	await page.waitForEvent('domcontentloaded');
+	await page.waitForLoadState('domcontentloaded');
 
 	// Create
 
@@ -298,7 +298,7 @@ test('Can trigger object validation as a client extension', async ({
 
 	await editObjectValidationPage.saveObjectValidationButton.click();
 
-	await page.waitForEvent('domcontentloaded');
+	await page.waitForLoadState('domcontentloaded');
 
 	await viewObjectEntriesPage.goto(objectDefinition.className);
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102319

## What Is Being Fixed

Two objectClientExtension Playwright tests clicked Save or Publish and then called `page.waitForEvent('domcontentloaded')`, which waits for the NEXT such event. When the resulting reload completes before the wait is armed, the event never fires again and the test hangs until the 90 second timeout — the `objectClientExtension.spec.ts:267` flake. The race punishes fast responses, which is why it was intermittent.

## How It Is Being Fixed

Replace both call sites with `page.waitForLoadState('domcontentloaded')`, which checks the already-reached state and returns immediately in the race while still waiting when a load is genuinely in flight. The subsequent explicit navigation provides the real synchronization, so no waiting is lost. Both calls date to the subproject's creation in LPD-85191 (bf387c0ac7801). Verified on CI with the test repeated 15 times, retries disabled: 3 out of 3 jobs passed, all repeats green.

## PR Check

**pr-check: PASS** — tested on `f25b01eda7bbd27a8417965c7f6e210369e35434`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result":"success","sha":"f25b01eda7bbd27a8417965c7f6e210369e35434"} -->
