### PR TITLE
LPD-102320 Make the DocuSign request timeout configurable and trim the portlet envelope list

### DIFF
--- a/modules/apps/digital-signature/digital-signature-api/bnd.bnd
+++ b/modules/apps/digital-signature/digital-signature-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Digital Signature API
 Bundle-SymbolicName: com.liferay.digital.signature.api
-Bundle-Version: 4.0.4
+Bundle-Version: 4.1.0
 Export-Package:\
 	com.liferay.digital.signature.configuration,\
 	com.liferay.digital.signature.constants,\

--- a/modules/apps/digital-signature/digital-signature-api/bnd.bnd
+++ b/modules/apps/digital-signature/digital-signature-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Digital Signature API
 Bundle-SymbolicName: com.liferay.digital.signature.api
-Bundle-Version: 4.1.0
+Bundle-Version: 5.0.0
 Export-Package:\
 	com.liferay.digital.signature.configuration,\
 	com.liferay.digital.signature.constants,\

--- a/modules/apps/digital-signature/digital-signature-api/src/main/java/com/liferay/digital/signature/configuration/DigitalSignatureConfiguration.java
+++ b/modules/apps/digital-signature/digital-signature-api/src/main/java/com/liferay/digital/signature/configuration/DigitalSignatureConfiguration.java
@@ -9,6 +9,8 @@ import aQute.bnd.annotation.metatype.Meta;
 
 import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
 
+import org.osgi.annotation.versioning.ProviderType;
+
 /**
  * @author José Abelenda
  */
@@ -21,6 +23,7 @@ import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClass
 	localization = "content/Language",
 	name = "digital-signature-configuration-name"
 )
+@ProviderType
 public interface DigitalSignatureConfiguration {
 
 	public String accountBaseURI();
@@ -32,6 +35,9 @@ public interface DigitalSignatureConfiguration {
 	public boolean enabled();
 
 	public String environment();
+
+	@Meta.AD(deflt = "60000", required = false)
+	public int httpTimeout();
 
 	@Meta.AD(type = Meta.Type.Password)
 	public String integrationKey();

--- a/modules/apps/digital-signature/digital-signature-api/src/main/java/com/liferay/digital/signature/manager/DSEnvelopeManager.java
+++ b/modules/apps/digital-signature/digital-signature-api/src/main/java/com/liferay/digital/signature/manager/DSEnvelopeManager.java
@@ -31,12 +31,8 @@ public interface DSEnvelopeManager {
 		long companyId, long groupId, String dsEnvelopeId, String include);
 
 	public Page<DSEnvelope> getDSEnvelopesPage(
-		long companyId, long groupId, String fromDateString, String keywords,
-		String order, Pagination pagination, String status);
-
-	public Page<DSEnvelope> getDSEnvelopesPage(
-		long companyId, long groupId, String fromDateString, String keywords,
-		String order, Pagination pagination, String status,
-		boolean includeDocuments);
+		long companyId, long groupId, String fromDateString,
+		boolean includeDocuments, String keywords, String order,
+		Pagination pagination, String status);
 
 }

--- a/modules/apps/digital-signature/digital-signature-api/src/main/java/com/liferay/digital/signature/manager/DSEnvelopeManager.java
+++ b/modules/apps/digital-signature/digital-signature-api/src/main/java/com/liferay/digital/signature/manager/DSEnvelopeManager.java
@@ -34,4 +34,9 @@ public interface DSEnvelopeManager {
 		long companyId, long groupId, String fromDateString, String keywords,
 		String order, Pagination pagination, String status);
 
+	public Page<DSEnvelope> getDSEnvelopesPage(
+		long companyId, long groupId, String fromDateString, String keywords,
+		String order, Pagination pagination, String status,
+		boolean includeDocuments);
+
 }

--- a/modules/apps/digital-signature/digital-signature-api/src/main/resources/com/liferay/digital/signature/configuration/packageinfo
+++ b/modules/apps/digital-signature/digital-signature-api/src/main/resources/com/liferay/digital/signature/configuration/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.1
+version 2.1.0

--- a/modules/apps/digital-signature/digital-signature-api/src/main/resources/com/liferay/digital/signature/manager/packageinfo
+++ b/modules/apps/digital-signature/digital-signature-api/src/main/resources/com/liferay/digital/signature/manager/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 1.2.0

--- a/modules/apps/digital-signature/digital-signature-api/src/main/resources/com/liferay/digital/signature/manager/packageinfo
+++ b/modules/apps/digital-signature/digital-signature-api/src/main/resources/com/liferay/digital/signature/manager/packageinfo
@@ -1,1 +1,1 @@
-version 1.2.0
+version 2.0.0

--- a/modules/apps/digital-signature/digital-signature-impl/src/main/java/com/liferay/digital/signature/internal/http/DSHttp.java
+++ b/modules/apps/digital-signature/digital-signature-impl/src/main/java/com/liferay/digital/signature/internal/http/DSHttp.java
@@ -137,6 +137,7 @@ public class DSHttp {
 				"/restapi/v2.1/accounts/",
 				digitalSignatureConfiguration.apiAccountId(), "/", location));
 		options.setMethod(method);
+		options.setTimeout(digitalSignatureConfiguration.httpTimeout());
 
 		return _http.URLtoByteArray(options);
 	}

--- a/modules/apps/digital-signature/digital-signature-impl/src/main/java/com/liferay/digital/signature/internal/manager/DSEnvelopeManagerImpl.java
+++ b/modules/apps/digital-signature/digital-signature-impl/src/main/java/com/liferay/digital/signature/internal/manager/DSEnvelopeManagerImpl.java
@@ -123,19 +123,9 @@ public class DSEnvelopeManagerImpl implements DSEnvelopeManager {
 
 	@Override
 	public Page<DSEnvelope> getDSEnvelopesPage(
-		long companyId, long groupId, String fromDateString, String keywords,
-		String order, Pagination pagination, String status) {
-
-		return getDSEnvelopesPage(
-			companyId, groupId, fromDateString, keywords, order, pagination,
-			status, true);
-	}
-
-	@Override
-	public Page<DSEnvelope> getDSEnvelopesPage(
-		long companyId, long groupId, String fromDateString, String keywords,
-		String order, Pagination pagination, String status,
-		boolean includeDocuments) {
+		long companyId, long groupId, String fromDateString,
+		boolean includeDocuments, String keywords, String order,
+		Pagination pagination, String status) {
 
 		Matcher matcher = _pattern.matcher(GetterUtil.get(keywords, ""));
 

--- a/modules/apps/digital-signature/digital-signature-impl/src/main/java/com/liferay/digital/signature/internal/manager/DSEnvelopeManagerImpl.java
+++ b/modules/apps/digital-signature/digital-signature-impl/src/main/java/com/liferay/digital/signature/internal/manager/DSEnvelopeManagerImpl.java
@@ -126,6 +126,17 @@ public class DSEnvelopeManagerImpl implements DSEnvelopeManager {
 		long companyId, long groupId, String fromDateString, String keywords,
 		String order, Pagination pagination, String status) {
 
+		return getDSEnvelopesPage(
+			companyId, groupId, fromDateString, keywords, order, pagination,
+			status, true);
+	}
+
+	@Override
+	public Page<DSEnvelope> getDSEnvelopesPage(
+		long companyId, long groupId, String fromDateString, String keywords,
+		String order, Pagination pagination, String status,
+		boolean includeDocuments) {
+
 		Matcher matcher = _pattern.matcher(GetterUtil.get(keywords, ""));
 
 		if (matcher.matches()) {
@@ -143,9 +154,10 @@ public class DSEnvelopeManagerImpl implements DSEnvelopeManager {
 			"envelopes?count=", pagination.getPageSize(), "&from_date=",
 			GetterUtil.get(fromDateString, "2000-01-01"),
 			"&folder_types=sentitems&start_position=",
-			pagination.getStartPosition(),
-			"&include=custom_fields,documents,recipients&order=",
-			GetterUtil.get(order, ""));
+			pagination.getStartPosition(), "&include=",
+			includeDocuments ? "custom_fields,documents,recipients" :
+				"custom_fields,recipients",
+			"&order=", GetterUtil.get(order, ""));
 
 		if (!Validator.isBlank(keywords)) {
 			location += "&search_text=" + keywords;

--- a/modules/apps/digital-signature/digital-signature-rest-impl/src/main/java/com/liferay/digital/signature/rest/internal/resource/v1_0/DSEnvelopeResourceImpl.java
+++ b/modules/apps/digital-signature/digital-signature-rest-impl/src/main/java/com/liferay/digital/signature/rest/internal/resource/v1_0/DSEnvelopeResourceImpl.java
@@ -47,7 +47,7 @@ public class DSEnvelopeResourceImpl extends BaseDSEnvelopeResourceImpl {
 
 		Page<com.liferay.digital.signature.model.DSEnvelope> page =
 			_dsEnvelopeManager.getDSEnvelopesPage(
-				contextCompany.getCompanyId(), siteId, fromDate, keywords,
+				contextCompany.getCompanyId(), siteId, fromDate, true, keywords,
 				order, pagination, status);
 
 		return Page.of(

--- a/modules/apps/digital-signature/digital-signature-test/src/testIntegration/java/com/liferay/digital/signature/manager/test/DSEnvelopeManagerTest.java
+++ b/modules/apps/digital-signature/digital-signature-test/src/testIntegration/java/com/liferay/digital/signature/manager/test/DSEnvelopeManagerTest.java
@@ -337,7 +337,7 @@ public class DSEnvelopeManagerTest {
 
 		Page<DSEnvelope> page = _dsEnvelopeManager.getDSEnvelopesPage(
 			TestPropsValues.getCompanyId(), TestPropsValues.getGroupId(),
-			"2021-01-01", keywords, order, Pagination.of(1, 2), status);
+			"2021-01-01", true, keywords, order, Pagination.of(1, 2), status);
 
 		Assert.assertEquals(expectedTotalCount, page.getTotalCount());
 

--- a/modules/apps/digital-signature/digital-signature-web/src/main/java/com/liferay/digital/signature/web/internal/portlet/action/GetDSEnvelopesMVCResourceCommand.java
+++ b/modules/apps/digital-signature/digital-signature-web/src/main/java/com/liferay/digital/signature/web/internal/portlet/action/GetDSEnvelopesMVCResourceCommand.java
@@ -58,7 +58,7 @@ public class GetDSEnvelopesMVCResourceCommand extends BaseMVCResourceCommand {
 			Pagination.of(
 				ParamUtil.getInteger(resourceRequest, "page"),
 				ParamUtil.getInteger(resourceRequest, "pageSize")),
-			ParamUtil.getString(resourceRequest, "status"));
+			ParamUtil.getString(resourceRequest, "status"), false);
 
 		JSONPortletResponseUtil.writeJSON(
 			resourceRequest, resourceResponse, page.toString());

--- a/modules/apps/digital-signature/digital-signature-web/src/main/java/com/liferay/digital/signature/web/internal/portlet/action/GetDSEnvelopesMVCResourceCommand.java
+++ b/modules/apps/digital-signature/digital-signature-web/src/main/java/com/liferay/digital/signature/web/internal/portlet/action/GetDSEnvelopesMVCResourceCommand.java
@@ -49,6 +49,7 @@ public class GetDSEnvelopesMVCResourceCommand extends BaseMVCResourceCommand {
 		Page<DSEnvelope> page = _dsEnvelopeManager.getDSEnvelopesPage(
 			themeDisplay.getCompanyId(), themeDisplay.getSiteGroupId(),
 			ParamUtil.getString(resourceRequest, "from_date", "2000-01-01"),
+			false,
 			StringUtil.replace(
 				ParamUtil.getString(resourceRequest, "keywords"),
 				CharPool.SPACE, CharPool.PLUS),
@@ -58,7 +59,7 @@ public class GetDSEnvelopesMVCResourceCommand extends BaseMVCResourceCommand {
 			Pagination.of(
 				ParamUtil.getInteger(resourceRequest, "page"),
 				ParamUtil.getInteger(resourceRequest, "pageSize")),
-			ParamUtil.getString(resourceRequest, "status"), false);
+			ParamUtil.getString(resourceRequest, "status"));
 
 		JSONPortletResponseUtil.writeJSON(
 			resourceRequest, resourceResponse, page.toString());


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102320

Supersedes brianchandotcom#180085, carrying the full review feedback: includeDocuments is folded into the existing getDSEnvelopesPage (no overload) and sorted into the parameter list after fromDateString.

## What Is Being Fixed

Digital Signature envelope tests failed intermittently on CI with the success alert never appearing. The portal log showed `ERROR [PortletServlet] java.io.IOException: java.net.SocketTimeoutException: Read timed out` thrown from `DSHttp` calling the DocuSign envelope REST API. `DSHttp` set no timeout on its `Http.Options`, so every DocuSign call inherited the shared portal default of 10 seconds — too aggressive for an external SaaS returning rich envelope payloads. The OAuth token grant succeeds (locally verified with the CI credentials: token in 0.16s, envelope read HTTP 200 in 1.4s), so the timeouts are CI-side latency, not credentials. The envelope list also requested `include=custom_fields,documents,recipients` although the portlet list never reads documents — roughly a quarter of the payload discarded on every page.

## How It Is Being Fixed

Add an `httpTimeout` configuration attribute defaulting to 60 seconds and apply it to every `DSHttp` request; `DigitalSignatureConfiguration` is marked `@ProviderType` so the added attribute is a minor package change. Give `getDSEnvelopesPage` an `includeDocuments` parameter, sorted after `fromDateString`: the portlet's `GetDSEnvelopesMVCResourceCommand` passes `false` (its list never reads documents; downloads use the separate resource command), while the REST endpoint and the integration test pass `true`, unchanged in behavior. Replacing the old seven-argument signature is a breaking change on the internally consumed manager package, declared in the commit message with the corresponding major bump.

Confirm-no-regression run on the Digital Signature functional batch: the SocketTimeoutException class is gone from every envelope axis (zero portal errors, versus the PortletServlet ERROR on every control axis) and no new failure signature appeared.

## PR Check

**pr-check: PASS** — tested on `b1fe20a9e36308fddbb88d0d33ff4589c9bf0a99`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |

<!-- pr-check {"result":"success","sha":"b1fe20a9e36308fddbb88d0d33ff4589c9bf0a99"} -->
