### PR TITLE
LPD-102323 Target the visible collect button in the document library toolbar

### DIFF
--- a/modules/apps/digital-signature/digital-signature-test/src/testFunctional/paths/DigitalSignatureDM.path
+++ b/modules/apps/digital-signature/digital-signature-test/src/testFunctional/paths/DigitalSignatureDM.path
@@ -17,7 +17,7 @@
 </tr>
 <tr>
 	<td>DIGITAL_SIGNATURE_COLLECT_BUTTON</td>
-	<td>//button[contains(@title, 'Collect Digital Signature')] | //button[contains(@title, 'Collect Digital Signature')]//*[contains(@class, 'lexicon-icon-signature')]</td>
+	<td>//button[contains(@class, 'inline')][.//*[name()='svg'][contains(@class, 'lexicon-icon-signature')]]</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102323

## What Is Being Fixed

DigitalSignatureDM#CanCollectDigitalSignatureByButton and CanGetMultipleSignaturesByButton failed with ElementNotInteractableException (the Collect button has no size and location). `DIGITAL_SIGNATURE_COLLECT_BUTTON` located the button by its `title`, but the DL management toolbar renders each quick action twice: an icon-only button that carries the title but is `d-lg-none` (hidden at CI viewports), and a wide icon+text button that is visible there but renders no `title`. So the locator could only ever match the hidden zero-size button.

## How It Is Being Fixed

Relocate to the wide button by class + signature icon: `//button[contains(@class, 'inline')][.//*[name()='svg'][contains(@class, 'lexicon-icon-signature')]]` — the shape the LPS-203725 cleanup (53b492711562c) gave Icon#MOVE_TO_RECYCLE_BIN when the dual-button markup became unconditional; that cleanup missed DigitalSignatureDM.path.

## PR Check

**pr-check: PASS** — tested on `5195defc187b4399bb0c418c2cf8d8fd473b2b34`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Poshi Syntax | PASS |

<!-- pr-check {"result":"success","sha":"5195defc187b4399bb0c418c2cf8d8fd473b2b34"} -->
