### PR TITLE
LPD-100147 Backfill FragmentEntryLink configuration for OOTB renderers

### DIFF
--- a/modules/apps/fragment/fragment-service/bnd.bnd
+++ b/modules/apps/fragment/fragment-service/bnd.bnd
@@ -5,6 +5,6 @@ Import-Package:\
 	com.liferay.fragment.util.comparator,\
 	\
 	*
-Liferay-Require-SchemaVersion: 4.0.0
+Liferay-Require-SchemaVersion: 4.1.0
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/registry/FragmentServiceUpgradeStepRegistrator.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/registry/FragmentServiceUpgradeStepRegistrator.java
@@ -15,6 +15,7 @@ import com.liferay.fragment.internal.upgrade.v2_4_0.FragmentEntryLinkUpgradeProc
 import com.liferay.fragment.internal.upgrade.v3_0_1.BrowserSnifferFragmentEntryTemplateUpgradeProcess;
 import com.liferay.fragment.internal.upgrade.v3_0_2.FragmentEntryHTMLUpgradeProcess;
 import com.liferay.fragment.internal.upgrade.v4_0_0.FragmentEntryVersionUpgradeProcess;
+import com.liferay.fragment.internal.upgrade.v4_1_0.FragmentEntryLinkConfigurationUpgradeProcess;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
 import com.liferay.portal.kernel.json.JSONFactory;
@@ -284,6 +285,10 @@ public class FragmentServiceUpgradeStepRegistrator
 			"3.0.2", "4.0.0",
 			new FragmentEntryVersionUpgradeProcess(
 				_companyLocalService, _configurationProvider));
+
+		registry.register(
+			"4.0.0", "4.1.0",
+			new FragmentEntryLinkConfigurationUpgradeProcess());
 	}
 
 	@Reference

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/v4_1_0/FragmentEntryLinkConfigurationUpgradeProcess.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/v4_1_0/FragmentEntryLinkConfigurationUpgradeProcess.java
@@ -1,0 +1,70 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.fragment.internal.upgrade.v4_1_0;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.StringUtil;
+
+import java.sql.PreparedStatement;
+
+import java.util.Map;
+
+/**
+ * @author Lourdes Fernández Besada
+ */
+public class FragmentEntryLinkConfigurationUpgradeProcess
+	extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		try (PreparedStatement preparedStatement =
+				AutoBatchPreparedStatementUtil.autoBatch(
+					connection,
+					StringBundler.concat(
+						"update FragmentEntryLink set configuration = ? where ",
+						"rendererKey = ? and (configuration is null or ",
+						"configuration = '' or configuration = '{}' or ",
+						"configuration = '[]')"))) {
+
+			Map<String, String> rendererKeyResourceNames = HashMapBuilder.put(
+				"com.liferay.fragment.internal.renderer." +
+					"ContentFlagsFragmentRenderer",
+				"dependencies/content_flags_configuration.json"
+			).put(
+				"com.liferay.fragment.internal.renderer." +
+					"ContentObjectFragmentRenderer",
+				"dependencies/content_object_configuration.json"
+			).put(
+				"com.liferay.fragment.internal.renderer." +
+					"ContentRatingsFragmentRenderer",
+				"dependencies/content_ratings_configuration.json"
+			).put(
+				"com.liferay.fragment.renderer.menu.display.internal." +
+					"MenuDisplayFragmentRenderer",
+				"dependencies/menu_display_configuration.json"
+			).build();
+
+			for (Map.Entry<String, String> entry :
+					rendererKeyResourceNames.entrySet()) {
+
+				preparedStatement.setString(
+					1,
+					StringUtil.read(
+						FragmentEntryLinkConfigurationUpgradeProcess.class.
+							getResourceAsStream(entry.getValue())));
+				preparedStatement.setString(2, entry.getKey());
+
+				preparedStatement.addBatch();
+			}
+
+			preparedStatement.executeBatch();
+		}
+	}
+
+}

--- a/modules/apps/fragment/fragment-service/src/main/resources/com/liferay/fragment/internal/upgrade/v4_1_0/dependencies/content_flags_configuration.json
+++ b/modules/apps/fragment/fragment-service/src/main/resources/com/liferay/fragment/internal/upgrade/v4_1_0/dependencies/content_flags_configuration.json
@@ -1,0 +1,18 @@
+{
+	"fieldSets": [
+		{
+			"fields": [
+				{
+					"label": "content",
+					"name": "itemSelector",
+					"type": "itemSelector"
+				},
+				{
+					"label": "message",
+					"name": "message",
+					"type": "text"
+				}
+			]
+		}
+	]
+}

--- a/modules/apps/fragment/fragment-service/src/main/resources/com/liferay/fragment/internal/upgrade/v4_1_0/dependencies/content_object_configuration.json
+++ b/modules/apps/fragment/fragment-service/src/main/resources/com/liferay/fragment/internal/upgrade/v4_1_0/dependencies/content_object_configuration.json
@@ -1,0 +1,17 @@
+{
+	"fieldSets": [
+		{
+			"fields": [
+				{
+					"label": "item",
+					"name": "itemSelector",
+					"type": "itemSelector",
+					"typeOptions": {
+						"enableSelectTemplate": true
+					}
+				}
+			],
+			"label": "Content Display Options"
+		}
+	]
+}

--- a/modules/apps/fragment/fragment-service/src/main/resources/com/liferay/fragment/internal/upgrade/v4_1_0/dependencies/content_ratings_configuration.json
+++ b/modules/apps/fragment/fragment-service/src/main/resources/com/liferay/fragment/internal/upgrade/v4_1_0/dependencies/content_ratings_configuration.json
@@ -1,0 +1,13 @@
+{
+	"fieldSets": [
+		{
+			"fields": [
+				{
+					"label": "content",
+					"name": "itemSelector",
+					"type": "itemSelector"
+				}
+			]
+		}
+	]
+}

--- a/modules/apps/fragment/fragment-service/src/main/resources/com/liferay/fragment/internal/upgrade/v4_1_0/dependencies/menu_display_configuration.json
+++ b/modules/apps/fragment/fragment-service/src/main/resources/com/liferay/fragment/internal/upgrade/v4_1_0/dependencies/menu_display_configuration.json
@@ -1,0 +1,147 @@
+{
+	"fieldSets": [
+		{
+			"fields": [
+				{
+					"description": "",
+					"label": "Source",
+					"name": "source",
+					"type": "navigationMenuSelector"
+				},
+				{
+					"defaultValue": "horizontal",
+					"description": "",
+					"label": "Display Style",
+					"name": "displayStyle",
+					"type": "select",
+					"typeOptions": {
+						"validValues": [
+							{
+								"label": "Horizontal",
+								"value": "horizontal"
+							},
+							{
+								"label": "Stacked",
+								"value": "stacked"
+							}
+						]
+					}
+				},
+				{
+					"defaultValue": "-1",
+					"description": "",
+					"label": "Sublevels",
+					"name": "sublevels",
+					"type": "select",
+					"typeOptions": {
+						"validValues": [
+							{
+								"label": "All",
+								"value": "-1"
+							},
+							{
+								"label": "0",
+								"value": "0"
+							},
+							{
+								"label": "1",
+								"value": "1"
+							},
+							{
+								"label": "2",
+								"value": "2"
+							},
+							{
+								"label": "3",
+								"value": "3"
+							},
+							{
+								"label": "4",
+								"value": "4"
+							},
+							{
+								"label": "5",
+								"value": "5"
+							},
+							{
+								"label": "6",
+								"value": "6"
+							},
+							{
+								"label": "7",
+								"value": "7"
+							},
+							{
+								"label": "8",
+								"value": "8"
+							},
+							{
+								"label": "9",
+								"value": "9"
+							},
+							{
+								"label": "10",
+								"value": "10"
+							},
+							{
+								"label": "11",
+								"value": "11"
+							},
+							{
+								"label": "12",
+								"value": "12"
+							},
+							{
+								"label": "13",
+								"value": "13"
+							},
+							{
+								"label": "14",
+								"value": "14"
+							},
+							{
+								"label": "15",
+								"value": "15"
+							},
+							{
+								"label": "17",
+								"value": "17"
+							},
+							{
+								"label": "18",
+								"value": "18"
+							},
+							{
+								"label": "19",
+								"value": "19"
+							},
+							{
+								"label": "20",
+								"value": "20"
+							}
+						]
+					}
+				}
+			],
+			"label": "Menu Display Options"
+		},
+		{
+			"configurationRole": "style",
+			"fields": [
+				{
+					"description": "",
+					"label": "Hovered Item Color",
+					"name": "hoveredItemColor",
+					"type": "colorPicker"
+				},
+				{
+					"description": "",
+					"label": "Selected Item Color",
+					"name": "selectedItemColor",
+					"type": "colorPicker"
+				}
+			],
+			"label": "Menu Display Options"
+		}
+	]
+}

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/upgrade/v4_1_0/test/FragmentEntryLinkConfigurationUpgradeProcessTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/upgrade/v4_1_0/test/FragmentEntryLinkConfigurationUpgradeProcessTest.java
@@ -1,0 +1,212 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.fragment.internal.upgrade.v4_1_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.fragment.model.FragmentEntryLink;
+import com.liferay.fragment.renderer.FragmentRenderer;
+import com.liferay.fragment.renderer.FragmentRendererRegistry;
+import com.liferay.fragment.service.FragmentEntryLinkLocalService;
+import com.liferay.layout.test.util.ContentLayoutTestUtil;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.cache.MultiVMPool;
+import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.kernel.dao.orm.EntityCache;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
+import com.liferay.segments.service.SegmentsExperienceLocalService;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Lourdes Fernández Besada
+ */
+@RunWith(Arquillian.class)
+public class FragmentEntryLinkConfigurationUpgradeProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		Layout layout = LayoutTestUtil.addTypeContentLayout(_group);
+
+		_draftLayout = layout.fetchDraftLayout();
+
+		_segmentsExperienceId =
+			_segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
+				_draftLayout.getPlid());
+	}
+
+	@Test
+	@TestInfo("LPD-100147")
+	public void testUpgrade() throws Exception {
+		UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
+			_upgradeStepRegistrator,
+			"FragmentEntryLinkConfigurationUpgradeProcess");
+
+		Class<?> clazz = upgradeProcess.getClass();
+
+		Map<Long, String> expectedConfigurations = new HashMap<>();
+
+		Map<String, String> rendererKeyResourceNames = HashMapBuilder.put(
+			"com.liferay.fragment.internal.renderer." +
+				"ContentFlagsFragmentRenderer",
+			"dependencies/content_flags_configuration.json"
+		).put(
+			"com.liferay.fragment.internal.renderer." +
+				"ContentObjectFragmentRenderer",
+			"dependencies/content_object_configuration.json"
+		).put(
+			"com.liferay.fragment.internal.renderer." +
+				"ContentRatingsFragmentRenderer",
+			"dependencies/content_ratings_configuration.json"
+		).put(
+			"com.liferay.fragment.renderer.menu.display.internal." +
+				"MenuDisplayFragmentRenderer",
+			"dependencies/menu_display_configuration.json"
+		).build();
+
+		for (Map.Entry<String, String> entry :
+				rendererKeyResourceNames.entrySet()) {
+
+			FragmentRenderer fragmentRenderer =
+				_fragmentRendererRegistry.getFragmentRenderer(entry.getKey());
+
+			FragmentEntryLink backfilledFragmentEntryLink =
+				ContentLayoutTestUtil.addFragmentEntryLinkToLayout(
+					StringPool.BLANK, fragmentRenderer, _draftLayout, null, 0,
+					_segmentsExperienceId);
+			FragmentEntryLink preservedFragmentEntryLink =
+				ContentLayoutTestUtil.addFragmentEntryLinkToLayout(
+					StringPool.BLANK, fragmentRenderer, _draftLayout, null, 1,
+					_segmentsExperienceId);
+
+			_nullifyConfiguration(
+				backfilledFragmentEntryLink.getFragmentEntryLinkId());
+
+			expectedConfigurations.put(
+				backfilledFragmentEntryLink.getFragmentEntryLinkId(),
+				StringUtil.read(clazz.getResourceAsStream(entry.getValue())));
+			expectedConfigurations.put(
+				preservedFragmentEntryLink.getFragmentEntryLinkId(),
+				preservedFragmentEntryLink.getConfiguration());
+		}
+
+		FragmentRenderer collectionFilterFragmentRenderer =
+			_fragmentRendererRegistry.getFragmentRenderer(
+				"com.liferay.fragment.renderer.collection.filter.internal." +
+					"CollectionFilterFragmentRenderer");
+
+		FragmentEntryLink nullifiedFragmentEntryLink =
+			ContentLayoutTestUtil.addFragmentEntryLinkToLayout(
+				StringPool.BLANK, collectionFilterFragmentRenderer,
+				_draftLayout, null, 0, _segmentsExperienceId);
+		FragmentEntryLink unmodifiedFragmentEntryLink =
+			ContentLayoutTestUtil.addFragmentEntryLinkToLayout(
+				StringPool.BLANK, collectionFilterFragmentRenderer,
+				_draftLayout, null, 1, _segmentsExperienceId);
+
+		_nullifyConfiguration(
+			nullifiedFragmentEntryLink.getFragmentEntryLinkId());
+
+		expectedConfigurations.put(
+			nullifiedFragmentEntryLink.getFragmentEntryLinkId(),
+			StringPool.BLANK);
+		expectedConfigurations.put(
+			unmodifiedFragmentEntryLink.getFragmentEntryLinkId(),
+			unmodifiedFragmentEntryLink.getConfiguration());
+
+		upgradeProcess.upgrade();
+
+		_entityCache.clearCache();
+		_multiVMPool.clear();
+
+		for (Map.Entry<Long, String> entry :
+				expectedConfigurations.entrySet()) {
+
+			FragmentEntryLink fragmentEntryLink =
+				_fragmentEntryLinkLocalService.getFragmentEntryLink(
+					entry.getKey());
+
+			Assert.assertEquals(
+				entry.getValue(), fragmentEntryLink.getConfiguration());
+		}
+	}
+
+	private void _nullifyConfiguration(long fragmentEntryLinkId)
+		throws Exception {
+
+		try (Connection connection = DataAccess.getConnection();
+
+			PreparedStatement preparedStatement = connection.prepareStatement(
+				"update FragmentEntryLink set configuration = null where " +
+					"fragmentEntryLinkId = ?")) {
+
+			preparedStatement.setLong(1, fragmentEntryLinkId);
+
+			preparedStatement.executeUpdate();
+		}
+	}
+
+	private Layout _draftLayout;
+
+	@Inject
+	private EntityCache _entityCache;
+
+	@Inject
+	private FragmentEntryLinkLocalService _fragmentEntryLinkLocalService;
+
+	@Inject
+	private FragmentRendererRegistry _fragmentRendererRegistry;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private MultiVMPool _multiVMPool;
+
+	private long _segmentsExperienceId;
+
+	@Inject
+	private SegmentsExperienceLocalService _segmentsExperienceLocalService;
+
+	@Inject(
+		filter = "(&(component.name=com.liferay.fragment.internal.upgrade.registry.FragmentServiceUpgradeStepRegistrator))"
+	)
+	private UpgradeStepRegistrator _upgradeStepRegistrator;
+
+}


### PR DESCRIPTION
@lfbesada
@liferay-page-management

Original pull request comment:
https://liferay.atlassian.net/browse/LPD-100147

## What Is Being Fixed

`FragmentEntryLink` rows created before LPS-121751 landed have an empty `configuration` column. When those rows are pushed through Remote Staging publish after an upgrade, the layout export fails with `NoSuchClassNameException` because the receiving side cannot resolve the missing schema for the OOTB renderers.

## How It Is Being Fixed

A `4.0.0 → 4.1.0` upgrade step (`FragmentEntryLinkConfigurationUpgradeProcess`) backfills the `configuration` column for every OOTB renderer key that reached production before LPS-121751 — `ContentFlagsFragmentRenderer`, `ContentObjectFragmentRenderer`, `ContentRatingsFragmentRenderer`, and `MenuDisplayFragmentRenderer` — using the JSON shape each renderer exposed at the moment LPS-121751 started persisting the configuration on create (the same payload LPP-64968's manual Groovy backfill wrote for the same rows). Only rows whose `configuration` is `null`, empty, `{}`, or `[]` are touched, so any existing configuration survives. Replaying today's `getConfigurationJSONObject` output is deliberately avoided — it could introduce new fields, drop legacy ones, or rename existing ones, silently breaking `editableValues` that reference the pre-existing shape.

## PR Check

**pr-check: PASS** — tested on `4abc6fa5afcf89fbcd600d698ff11f3ebf0c1bab`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | PASS |

<!-- pr-check {"result": "success", "sha": "4abc6fa5afcf89fbcd600d698ff11f3ebf0c1bab"} -->
