### PR TITLE
LPD-98189 Derive the language override creator from the principal

### DIFF
--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
@@ -1446,31 +1446,110 @@ public class BatchEnginePortletDataHandlerTest {
 	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-49852"))
 	@Test
 	public void testExportImportLanguageOverrides() throws Exception {
-		Group group = _stagingGroupHelper.fetchCompanyGroup(
-			TestPropsValues.getCompanyId());
+		PLOEntry ploEntry1 = _addPLOEntry(TestPropsValues.getUserId(), "en_US");
+		PLOEntry ploEntry2 = _addPLOEntry(TestPropsValues.getUserId(), "en_CA");
 
-		PLOEntry ploEntry1 = _addPLOEntry("en_US");
-		PLOEntry ploEntry2 = _addPLOEntry("en_CA");
-
-		File larFile = new ExportImportExecutor(
-		).withGroupId(
-			group.getGroupId()
-		).withIncludeLanguageOverrides(
-		).executeExport();
+		File larFile = _exportLanguageOverrides();
 
 		_ploEntryLocalService.deletePLOEntry(ploEntry1);
 		_ploEntryLocalService.deletePLOEntry(ploEntry2);
 
-		new ExportImportExecutor(
-		).withGroupId(
-			group.getGroupId()
-		).withIncludeLanguageOverrides(
-		).withLARFile(
-			larFile
-		).executeImport();
+		_importLanguageOverrides(larFile, null);
 
-		_assertPLOEntry(ploEntry1);
-		_assertPLOEntry(ploEntry2);
+		_assertPLOEntry(ploEntry1, TestPropsValues.getUserId());
+		_assertPLOEntry(ploEntry2, TestPropsValues.getUserId());
+	}
+
+	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-49852"))
+	@Test
+	public void testExportImportLanguageOverridesWithAlwaysCurrentUser()
+		throws Exception {
+
+		User user = UserTestUtil.addUser();
+
+		_users.add(user);
+
+		PLOEntry ploEntry = _addPLOEntry(user.getUserId(), "en_US");
+
+		File larFile = _exportLanguageOverrides();
+
+		_ploEntryLocalService.deletePLOEntry(ploEntry);
+
+		_importLanguageOverrides(
+			larFile, UserIdStrategy.ALWAYS_CURRENT_USER_ID);
+
+		_assertPLOEntry(ploEntry, TestPropsValues.getUserId());
+	}
+
+	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-49852"))
+	@Test
+	public void testExportImportLanguageOverridesWithDifferentExistingCreator()
+		throws Exception {
+
+		User user1 = UserTestUtil.addUser();
+
+		_users.add(user1);
+
+		PLOEntry ploEntry = _addPLOEntry(user1.getUserId(), "en_US");
+
+		File larFile = _exportLanguageOverrides();
+
+		_ploEntryLocalService.deletePLOEntry(ploEntry);
+
+		User user2 = UserTestUtil.addUser();
+
+		_users.add(user2);
+
+		_ploEntryLocalService.addOrUpdatePLOEntry(
+			ploEntry.getExternalReferenceCode(), TestPropsValues.getCompanyId(),
+			user2.getUserId(), ploEntry.getKey(), ploEntry.getLanguageId(),
+			RandomTestUtil.randomString());
+
+		_importLanguageOverrides(larFile, UserIdStrategy.CURRENT_USER_ID);
+
+		_assertPLOEntry(ploEntry, user2.getUserId());
+	}
+
+	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-49852"))
+	@Test
+	public void testExportImportLanguageOverridesWithExistingOriginalCreator()
+		throws Exception {
+
+		User user = UserTestUtil.addUser();
+
+		_users.add(user);
+
+		PLOEntry ploEntry = _addPLOEntry(user.getUserId(), "en_US");
+
+		File larFile = _exportLanguageOverrides();
+
+		_ploEntryLocalService.deletePLOEntry(ploEntry);
+
+		_importLanguageOverrides(larFile, UserIdStrategy.CURRENT_USER_ID);
+
+		_assertPLOEntry(ploEntry, user.getUserId());
+	}
+
+	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-49852"))
+	@Test
+	public void testExportImportLanguageOverridesWithMissingOriginalCreator()
+		throws Exception {
+
+		User user = UserTestUtil.addUser();
+
+		_users.add(user);
+
+		PLOEntry ploEntry = _addPLOEntry(user.getUserId(), "en_US");
+
+		File larFile = _exportLanguageOverrides();
+
+		_ploEntryLocalService.deletePLOEntry(ploEntry);
+
+		_userLocalService.deleteUser(user);
+
+		_importLanguageOverrides(larFile, UserIdStrategy.CURRENT_USER_ID);
+
+		_assertPLOEntry(ploEntry, TestPropsValues.getUserId());
 	}
 
 	@Test
@@ -3056,11 +3135,13 @@ public class BatchEnginePortletDataHandlerTest {
 		return objectFields;
 	}
 
-	private PLOEntry _addPLOEntry(String languageId) throws Exception {
+	private PLOEntry _addPLOEntry(long userId, String languageId)
+		throws Exception {
+
 		return _ploEntryLocalService.addOrUpdatePLOEntry(
 			RandomTestUtil.randomString(), TestPropsValues.getCompanyId(),
-			TestPropsValues.getUserId(), RandomTestUtil.randomString(),
-			languageId, RandomTestUtil.randomString());
+			userId, RandomTestUtil.randomString(), languageId,
+			RandomTestUtil.randomString());
 	}
 
 	private ObjectEntry _addSystemObjectEntry(ObjectDefinition objectDefinition)
@@ -3314,7 +3395,9 @@ public class BatchEnginePortletDataHandlerTest {
 		}
 	}
 
-	private void _assertPLOEntry(PLOEntry ploEntry) throws Exception {
+	private void _assertPLOEntry(PLOEntry ploEntry, long userId)
+		throws Exception {
+
 		PLOEntry importedPLOEntry =
 			_ploEntryLocalService.getPLOEntryByExternalReferenceCode(
 				ploEntry.getExternalReferenceCode(),
@@ -3324,7 +3407,7 @@ public class BatchEnginePortletDataHandlerTest {
 		Assert.assertEquals(
 			ploEntry.getLanguageId(), importedPLOEntry.getLanguageId());
 		Assert.assertEquals(ploEntry.getValue(), importedPLOEntry.getValue());
-		Assert.assertEquals(ploEntry.getUserId(), importedPLOEntry.getUserId());
+		Assert.assertEquals(userId, importedPLOEntry.getUserId());
 	}
 
 	private void _deleteObjectEntries(ObjectEntry... objectEntries)
@@ -3349,6 +3432,14 @@ public class BatchEnginePortletDataHandlerTest {
 				_dlFileEntryLocalService.deleteFileEntry(fileEntryId);
 			}
 		}
+	}
+
+	private File _exportLanguageOverrides() throws Exception {
+		return new ExportImportExecutor(
+		).withGroupId(
+			_getCompanyGroupId()
+		).withIncludeLanguageOverrides(
+		).executeExport();
 	}
 
 	private JSONArray _getClassExternalReferenceCodesJSONArray(
@@ -3378,6 +3469,13 @@ public class BatchEnginePortletDataHandlerTest {
 					throw new RuntimeException(exception);
 				});
 		}
+	}
+
+	private long _getCompanyGroupId() throws Exception {
+		Group group = _stagingGroupHelper.fetchCompanyGroup(
+			TestPropsValues.getCompanyId());
+
+		return group.getGroupId();
 	}
 
 	private JSONArray _getExportedObjectEntriesJSONArray(
@@ -3588,6 +3686,20 @@ public class BatchEnginePortletDataHandlerTest {
 
 		return _dlURLHelper.getPreviewURL(
 			fileEntryFriendlyURL, group.getFriendlyURL());
+	}
+
+	private void _importLanguageOverrides(File larFile, String userIdStrategy)
+		throws Exception {
+
+		new ExportImportExecutor(
+		).withGroupId(
+			_getCompanyGroupId()
+		).withIncludeLanguageOverrides(
+		).withLARFile(
+			larFile
+		).withUserIdStrategy(
+			userIdStrategy
+		).executeImport();
 	}
 
 	private SafeCloseable _register(

--- a/modules/apps/headless/headless-admin-language-override/headless-admin-language-override-impl/src/main/java/com/liferay/headless/admin/language/override/internal/resource/v1_0/LanguageOverrideResourceImpl.java
+++ b/modules/apps/headless/headless-admin-language-override/headless-admin-language-override-impl/src/main/java/com/liferay/headless/admin/language/override/internal/resource/v1_0/LanguageOverrideResourceImpl.java
@@ -149,8 +149,8 @@ public class LanguageOverrideResourceImpl
 		return _toLanguageOverride(
 			_ploEntryService.addOrUpdatePLOEntry(
 				languageOverride.getExternalReferenceCode(),
-				contextUser.getUserId(), languageOverride.getKey(),
-				languageOverride.getLanguageId(), languageOverride.getValue()));
+				languageOverride.getKey(), languageOverride.getLanguageId(),
+				languageOverride.getValue()));
 	}
 
 	@Override
@@ -162,9 +162,8 @@ public class LanguageOverrideResourceImpl
 
 		return _toLanguageOverride(
 			_ploEntryService.addOrUpdatePLOEntry(
-				externalReferenceCode, contextUser.getUserId(),
-				languageOverride.getKey(), languageOverride.getLanguageId(),
-				languageOverride.getValue()));
+				externalReferenceCode, languageOverride.getKey(),
+				languageOverride.getLanguageId(), languageOverride.getValue()));
 	}
 
 	private void _checkFeatureFlag() {

--- a/modules/apps/portal-language/portal-language-override-api/src/main/java/com/liferay/portal/language/override/service/PLOEntryService.java
+++ b/modules/apps/portal-language/portal-language-override-api/src/main/java/com/liferay/portal/language/override/service/PLOEntryService.java
@@ -49,8 +49,8 @@ public interface PLOEntryService extends BaseService {
 	 * Never modify this interface directly. Add custom service methods to <code>com.liferay.portal.language.override.service.impl.PLOEntryServiceImpl</code> and rerun ServiceBuilder to automatically copy the method declarations to this interface. Consume the plo entry remote service via injection or a <code>org.osgi.util.tracker.ServiceTracker</code>. Use {@link PLOEntryServiceUtil} if injection and service tracking are not available.
 	 */
 	public PLOEntry addOrUpdatePLOEntry(
-			String externalReferenceCode, long userId, String key,
-			String languageId, String value)
+			String externalReferenceCode, String key, String languageId,
+			String value)
 		throws PortalException;
 
 	public void deletePLOEntries(String key) throws PortalException;
@@ -101,4 +101,4 @@ public interface PLOEntryService extends BaseService {
 		throws PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1474791432
+// LIFERAY-SERVICE-BUILDER-HASH:-585008555

--- a/modules/apps/portal-language/portal-language-override-api/src/main/java/com/liferay/portal/language/override/service/PLOEntryServiceUtil.java
+++ b/modules/apps/portal-language/portal-language-override-api/src/main/java/com/liferay/portal/language/override/service/PLOEntryServiceUtil.java
@@ -33,12 +33,12 @@ public class PLOEntryServiceUtil {
 	 * Never modify this class directly. Add custom service methods to <code>com.liferay.portal.language.override.service.impl.PLOEntryServiceImpl</code> and rerun ServiceBuilder to regenerate this class.
 	 */
 	public static PLOEntry addOrUpdatePLOEntry(
-			String externalReferenceCode, long userId, String key,
-			String languageId, String value)
+			String externalReferenceCode, String key, String languageId,
+			String value)
 		throws PortalException {
 
 		return getService().addOrUpdatePLOEntry(
-			externalReferenceCode, userId, key, languageId, value);
+			externalReferenceCode, key, languageId, value);
 	}
 
 	public static void deletePLOEntries(String key) throws PortalException {
@@ -128,4 +128,4 @@ public class PLOEntryServiceUtil {
 		new Snapshot<>(PLOEntryServiceUtil.class, PLOEntryService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1999178910
+// LIFERAY-SERVICE-BUILDER-HASH:641191932

--- a/modules/apps/portal-language/portal-language-override-api/src/main/java/com/liferay/portal/language/override/service/PLOEntryServiceWrapper.java
+++ b/modules/apps/portal-language/portal-language-override-api/src/main/java/com/liferay/portal/language/override/service/PLOEntryServiceWrapper.java
@@ -28,12 +28,12 @@ public class PLOEntryServiceWrapper
 	@Override
 	public com.liferay.portal.language.override.model.PLOEntry
 			addOrUpdatePLOEntry(
-				String externalReferenceCode, long userId, String key,
-				String languageId, String value)
+				String externalReferenceCode, String key, String languageId,
+				String value)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _ploEntryService.addOrUpdatePLOEntry(
-			externalReferenceCode, userId, key, languageId, value);
+			externalReferenceCode, key, languageId, value);
 	}
 
 	@Override
@@ -156,4 +156,4 @@ public class PLOEntryServiceWrapper
 	private PLOEntryService _ploEntryService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:2080420053
+// LIFERAY-SERVICE-BUILDER-HASH:1221374787

--- a/modules/apps/portal-language/portal-language-override-service/src/main/java/com/liferay/portal/language/override/service/http/PLOEntryServiceHttp.java
+++ b/modules/apps/portal-language/portal-language-override-service/src/main/java/com/liferay/portal/language/override/service/http/PLOEntryServiceHttp.java
@@ -44,7 +44,7 @@ public class PLOEntryServiceHttp {
 	public static com.liferay.portal.language.override.model.PLOEntry
 			addOrUpdatePLOEntry(
 				HttpPrincipal httpPrincipal, String externalReferenceCode,
-				long userId, String key, String languageId, String value)
+				String key, String languageId, String value)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
@@ -53,8 +53,7 @@ public class PLOEntryServiceHttp {
 				_addOrUpdatePLOEntryParameterTypes0);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, externalReferenceCode, userId, key, languageId,
-				value);
+				methodKey, externalReferenceCode, key, languageId, value);
 
 			Object returnObj = null;
 
@@ -538,9 +537,7 @@ public class PLOEntryServiceHttp {
 	private static Log _log = LogFactoryUtil.getLog(PLOEntryServiceHttp.class);
 
 	private static final Class<?>[] _addOrUpdatePLOEntryParameterTypes0 =
-		new Class[] {
-			String.class, long.class, String.class, String.class, String.class
-		};
+		new Class[] {String.class, String.class, String.class, String.class};
 	private static final Class<?>[] _deletePLOEntriesParameterTypes1 =
 		new Class[] {String.class};
 	private static final Class<?>[] _deletePLOEntryParameterTypes2 =
@@ -575,4 +572,4 @@ public class PLOEntryServiceHttp {
 		new Class[] {String.class, java.util.Map.class};
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:651918052
+// LIFERAY-SERVICE-BUILDER-HASH:-136216899

--- a/modules/apps/portal-language/portal-language-override-service/src/main/java/com/liferay/portal/language/override/service/impl/PLOEntryServiceImpl.java
+++ b/modules/apps/portal-language/portal-language-override-service/src/main/java/com/liferay/portal/language/override/service/impl/PLOEntryServiceImpl.java
@@ -38,8 +38,8 @@ public class PLOEntryServiceImpl extends PLOEntryServiceBaseImpl {
 
 	@Override
 	public PLOEntry addOrUpdatePLOEntry(
-			String externalReferenceCode, long userId, String key,
-			String languageId, String value)
+			String externalReferenceCode, String key, String languageId,
+			String value)
 		throws PortalException {
 
 		PermissionChecker permissionChecker = getPermissionChecker();
@@ -47,13 +47,9 @@ public class PLOEntryServiceImpl extends PLOEntryServiceBaseImpl {
 		PortalPermissionUtil.check(
 			permissionChecker, PLOActionKeys.MANAGE_LANGUAGE_OVERRIDES);
 
-		if (userId <= 0) {
-			userId = permissionChecker.getUserId();
-		}
-
 		return ploEntryLocalService.addOrUpdatePLOEntry(
-			externalReferenceCode, permissionChecker.getCompanyId(), userId,
-			key, languageId, value);
+			externalReferenceCode, permissionChecker.getCompanyId(),
+			getUserId(), key, languageId, value);
 	}
 
 	@Override
@@ -181,8 +177,8 @@ public class PLOEntryServiceImpl extends PLOEntryServiceBaseImpl {
 			permissionChecker, PLOActionKeys.MANAGE_LANGUAGE_OVERRIDES);
 
 		ploEntryLocalService.importPLOEntries(
-			permissionChecker.getCompanyId(), permissionChecker.getUserId(),
-			languageId, properties);
+			permissionChecker.getCompanyId(), getUserId(), languageId,
+			properties);
 	}
 
 	@Override
@@ -195,8 +191,8 @@ public class PLOEntryServiceImpl extends PLOEntryServiceBaseImpl {
 			permissionChecker, PLOActionKeys.MANAGE_LANGUAGE_OVERRIDES);
 
 		ploEntryLocalService.setPLOEntries(
-			permissionChecker.getCompanyId(), permissionChecker.getUserId(),
-			key, localizationMap);
+			permissionChecker.getCompanyId(), getUserId(), key,
+			localizationMap);
 	}
 
 }

--- a/modules/apps/portal-language/portal-language-override-test/src/testIntegration/java/com/liferay/portal/language/override/service/test/PLOEntryServiceTest.java
+++ b/modules/apps/portal-language/portal-language-override-test/src/testIntegration/java/com/liferay/portal/language/override/service/test/PLOEntryServiceTest.java
@@ -7,6 +7,7 @@ package com.liferay.portal.language.override.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
@@ -37,13 +38,22 @@ public class PLOEntryServiceTest {
 
 	@Test
 	public void testAddOrUpdatePLOEntry() throws Exception {
+		String name = PrincipalThreadLocal.getName();
+
 		User user = UserTestUtil.addUser();
 
-		PLOEntry ploEntry = _ploEntryService.addOrUpdatePLOEntry(
-			null, user.getUserId(), RandomTestUtil.randomString(), "en_US",
-			RandomTestUtil.randomString());
+		PrincipalThreadLocal.setName(user.getUserId());
 
-		Assert.assertEquals(user.getUserId(), ploEntry.getUserId());
+		try {
+			PLOEntry ploEntry = _ploEntryService.addOrUpdatePLOEntry(
+				null, RandomTestUtil.randomString(), "en_US",
+				RandomTestUtil.randomString());
+
+			Assert.assertEquals(user.getUserId(), ploEntry.getUserId());
+		}
+		finally {
+			PrincipalThreadLocal.setName(name);
+		}
 	}
 
 	@Inject

--- a/modules/apps/portal-language/portal-language-rest-impl/src/main/java/com/liferay/portal/language/rest/internal/resource/v1_0/MessageResourceImpl.java
+++ b/modules/apps/portal-language/portal-language-rest-impl/src/main/java/com/liferay/portal/language/rest/internal/resource/v1_0/MessageResourceImpl.java
@@ -179,8 +179,8 @@ public class MessageResourceImpl extends BaseMessageResourceImpl {
 		throws PortalException {
 
 		PLOEntry ploEntry = _ploEntryService.addOrUpdatePLOEntry(
-			null, contextUser.getUserId(), message.getKey(),
-			message.getLanguageId(), message.getValue());
+			null, message.getKey(), message.getLanguageId(),
+			message.getValue());
 
 		message.setKey(ploEntry::getKey);
 		message.setLanguageId(ploEntry::getLanguageId);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98189

## What Is Being Fixed

Batch import preserves the original creator of a language override by swapping only the principal and the resource's context user for each item; the permission checker stays bound to the importing user for the whole run. `PLOEntryServiceImpl#addOrUpdatePLOEntry` read the creator from the permission checker, so the original creator was discarded and every imported entry was attributed to the importing user.

The first attempt at this fixed it by adding a caller supplied `userId` to the remote service. That was a breaking signature change, and it let any caller holding `MANAGE_LANGUAGE_OVERRIDES` attribute an entry to an arbitrary user.

The integration coverage did not catch the regression either. The test created the entries with the same user that ran the import and never set a user ID strategy, so the creator assertion held whether or not the creator was preserved, and the strategy that preserves it never ran.

## How It Is Being Fixed

The remote service derives the creator from the principal through `getUserId()`, which is what batch import swaps per item, and the `userId` parameter is dropped from `PLOEntryService#addOrUpdatePLOEntry`, restoring the previous signature.

The test now creates the entries under a separate user and covers each user ID strategy, including the case where the original creator is missing from the target and the importing user is expected to take over, and the case where the target already holds the entry under a different creator that has to survive the update. The export and import calls are shared through helpers, since the user ID strategy and the state of the target are the only meaningful differences between the tests.