### PR TITLE
LPD-102434 Page Collection Providers via the nav link href to keep the tab

### DIFF
--- a/modules/test/playwright/tests/object-web/main/objectDefinition.spec.ts
+++ b/modules/test/playwright/tests/object-web/main/objectDefinition.spec.ts
@@ -2786,6 +2786,19 @@ test.describe('Manage object definitions through Page Templates', () => {
 				type: 'objectDefinition',
 			});
 
+			await collectionsPage.goto(site.friendlyUrlPath);
+
+			await page.goto(
+				(await page
+					.getByRole('link', {name: 'Collection Providers'})
+					.getAttribute('href')) +
+					'&_com_liferay_asset_list_web_portlet_AssetListPortlet_delta=200'
+			);
+
+			await expect(
+				page.getByText(objectDefinition.name).first()
+			).toBeVisible();
+
 			await viewObjectDefinitionsPage.goto();
 
 			await viewObjectDefinitionsPage.changeObjectActivateStatus(
@@ -2794,9 +2807,12 @@ test.describe('Manage object definitions through Page Templates', () => {
 
 			await collectionsPage.goto(site.friendlyUrlPath);
 
-			await page
-				.getByRole('link', {name: 'Collection Providers'})
-				.click();
+			await page.goto(
+				(await page
+					.getByRole('link', {name: 'Collection Providers'})
+					.getAttribute('href')) +
+					'&_com_liferay_asset_list_web_portlet_AssetListPortlet_delta=200'
+			);
 
 			await expect(
 				page.getByText(objectDefinition.name).first()
@@ -2810,9 +2826,12 @@ test.describe('Manage object definitions through Page Templates', () => {
 
 			await collectionsPage.goto(site.friendlyUrlPath);
 
-			await page
-				.getByRole('link', {name: 'Collection Providers'})
-				.click();
+			await page.goto(
+				(await page
+					.getByRole('link', {name: 'Collection Providers'})
+					.getAttribute('href')) +
+					'&_com_liferay_asset_list_web_portlet_AssetListPortlet_delta=200'
+			);
 
 			await expect(
 				page.getByText(objectDefinition.name).first()


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102434

## What Is Being Fixed

`objectDefinition.spec.ts` "verify that the Object visibility in Collection Providers changes according to activation status" fails on its reactivation leg, and has never passed under CI load.

The Collection Providers tab is a search container paginated at twenty rows, sorted alphabetically, with no search form. Under CI load, concurrent tests register enough info collection providers that the generated `ObjectDefinition<n>` falls off the first page, so the row is absent and the assertion fails however long it waits — reloading re-reads the same first page.

The deactivation leg was passing vacuously: `toBeHidden` succeeded whether the provider was genuinely unregistered or merely pushed onto a later page, so half the test proved nothing.

The product is not at fault. Reactivation re-registers the info collection provider synchronously through `deployObjectDefinition`, and the tab reads the live registry.

Born page-one dependent in `1d7f6863b26f6dea7497ce17b4bc5d1b6f6fbb32`, which repointed the assertion from the display page template menu, where every collection provider renders, to the Collection Providers tab, and added the reactivation leg that fails.

## How It Is Being Fixed

Take the page size base from the Collection Providers link's own `href`, which carries the tab selection parameter, and append a large delta so every visit renders the full list regardless of how many providers the instance holds. Building the URL from the current address instead would append the parameter to the wrong tab.

Also assert the row is visible before deactivating, so the sequence is visible, hidden, visible and the hidden leg becomes meaningful.

## Testing

Verified on CI in two independent full-load object runs on base `7d35cbedf`; `object-web.main` passed in both. One of those runs carried this change as the only difference against master, where the test was chronically failing.

## PR Check

**pr-check: PASS** — tested on `23b1bfc8d3391e71075bb105185097785e792e63`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

The diff is a single Playwright spec. Prettier reports the file formatted, and `playwright test --list` enumerates all 43 tests in it, confirming the file transpiles and no test is silently dropped from the batch.

<!-- pr-check {"result": "success", "sha": "23b1bfc8d3391e71075bb105185097785e792e63"} -->
