### PR TITLE
LPD-102246 Use the object definition's real class name for the form reference

### DIFF
--- a/modules/apps/object/object-test/src/testFunctional/macros/json/JSONObject.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/json/JSONObject.macro
@@ -1155,6 +1155,41 @@ definition {
 	}
 
 	@summary = "Default summary"
+	macro getObjectClassName(objectName = null, virtualHost = null, token = null) {
+		if (isSet(virtualHost)) {
+			if (!(isSet(port))) {
+				var port = 8080;
+			}
+
+			var portalURL = "http://${virtualHost}:${port}";
+		}
+		else {
+			var portalURL = JSONCompany.getPortalURL();
+		}
+
+		if (!(isSet(userEmailAddress))) {
+			var userEmailAddress = "test@liferay.com";
+		}
+
+		if (!(isSet(userPassword))) {
+			var userPassword = PropsUtil.get("default.admin.password");
+		}
+
+		var curl = '''
+			${portalURL}/o/object-admin/v1.0/object-definitions?filter=name%20eq%20%27${objectName}%27 \
+				-u ${userEmailAddress}:${userPassword}
+		''';
+
+		if (isSet(token)) {
+			var curl = StringUtil.add(${curl}, " -H 'Authorization: Bearer ${token}'", "");
+		}
+
+		var objectClassName = JSONCurlUtil.get(${curl}, "$.items[?(@['name'] == '${objectName}')]['className']");
+
+		return ${objectClassName};
+	}
+
+	@summary = "Default summary"
 	macro getObjectDefinition(objectName = null) {
 		Variables.assertDefined(parameterList = ${objectName});
 

--- a/modules/apps/object/object-test/src/testFunctional/macros/json/JSONObjectContentPage.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/json/JSONObjectContentPage.macro
@@ -8,7 +8,7 @@ definition {
 			var submittedEntryStatus = 0;
 		}
 
-		var objectDefinitionId = JSONObject.getObjectId(objectName = ${objectName});
+		var objectClassName = JSONObject.getObjectClassName(objectName = ${objectName});
 		var portalURL = JSONCompany.getPortalURL();
 		var siteId = JSONGroupAPI._getSiteIdByGroupKey(groupName = ${groupName});
 		var userLoginInfo = JSONUtil2.formatJSONUser();
@@ -26,7 +26,7 @@ definition {
 									"definition": {
 										"formConfig": {
 											"formReference": {
-												"className": "com.liferay.object.model.ObjectDefinition#${objectDefinitionId}",
+												"className": "${objectClassName}",
 												"classType": 0
 											},
 											"formType": "simple"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102246

Follow up to the first iteration of this ticket, which is already on master as `aabf6d6c14d73d9777757dde37b9054762ab5724`. That commit replaced the drag and drop with an API built page, which was the right move and is kept. This corrects the one thing it got wrong, so `CheckWorkflowNotTriggeredForDraftEntry` still fails on master today.

## What Is Being Fixed

The macro builds the form container page with a synthesized form reference class name:

```
"className": "com.liferay.object.model.ObjectDefinition#${objectDefinitionId}"
```

That follows the usual `Model#id` convention, but an object definition's class name is not derived from its id. `ObjectDefinitionUtil.generateRandomClassName` appends a random four character suffix to the prefix, and `ObjectDefinitionLocalServiceImpl` loops until that random name is unique, so the real name looks like `com.liferay.object.model.ObjectDefinition#G0C7`. The info item form provider is registered under that name.

Nothing rejects the synthesized name. The headless request accepts it and the page is created, so the failure is silent: the provider is never found and the published page renders the form container with no input fields. The test then dies much later at `ObjectWorkflow.testcase:80`, typing into an input that was never rendered, which reads like a timing flake and is not one. No amount of waiting or reloading can help.

## How It Is Being Fixed

Ask the backend for the class name instead of constructing it. A new `JSONObject.getObjectClassName` macro, mirroring the existing `getObjectId`, reads it from the object admin API and the page definition passes it through.

## Testing

Local A B is deterministic: with the id based name the published page renders zero inputs; with the real class name the text field and the submit button render every time.

CI confirms it on two runs sharing base `7d35cbedf` in the same hour. The run without this commit failed `CheckWorkflowNotTriggeredForDraftEntry` on the functional axis; the run with it passed the same test on the same axis.

Poshi validation passes.

## PR Check

**pr-check: PASS** — tested on `1aa4530a8631584fdd4a41aa347e30f2ad3b604a`

| Validation | Result |
| --- | --- |
| Poshi Syntax | PASS |

The diff is two Poshi macro files. Their formatting is unchanged from the source formatter run that produced them.

<!-- pr-check {"result": "success", "sha": "1aa4530a8631584fdd4a41aa347e30f2ad3b604a"} -->
