### PR TITLE
LPD-102445 Drop the redundant workflow unassign from the active inactive test

### DIFF
--- a/modules/test/playwright/tests/object-web/entry/objectActiveInactive.spec.ts
+++ b/modules/test/playwright/tests/object-web/entry/objectActiveInactive.spec.ts
@@ -85,20 +85,4 @@ test('Verify that pending and completed Object entries with workflow are not dis
 	await metricsPage.chooseProcess('Single Approver');
 
 	await expect(page.getByText('0', {exact: true}).first()).toBeVisible();
-
-	// Reactivate the object and unassign workflow for cleanup
-
-	await viewObjectDefinitionsPage.goto();
-
-	await viewObjectDefinitionsPage.changeObjectActivateStatus(
-		objectDefinition.name
-	);
-
-	await globalMenuPage.goToApplications('Process Builder');
-
-	await configurationTabPage.configurationTabLink.click();
-
-	await configurationTabPage.unassignWorkflowFromAssetType(
-		objectDefinition.label['en_US']
-	);
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102445

## What Is Being Fixed

`objectActiveInactive.spec.ts` "Verify that pending and completed Object entries with workflow are not displayed on the Workflow Metrics page when inactivated" has failed intermittently since June and continuously since the master snapshot of 2026-07-18.

The assertion under test passes — in every captured run, in both attempts. What fails is the cleanup after it: the test reactivates the object, walks back to the Process Builder Configuration tab, and unassigns the workflow through the admin table. That table lists one row per registered workflow handler, pages at twenty rows, and toggles each row between a read view and an inline edit form, so on the second visit the object's row and its Edit button never resolve, and the test times out long after the behavior under test was proven.

## How It Is Being Fixed

Drop the cleanup block. It is redundant: the definition is registered with the data API helper, so it is deleted when the test ends, and `ObjectDefinitionLocalServiceImpl.deleteObjectDefinition` already deletes the definition's workflow definition links along with its resource permissions. Deletion has no active-state requirement, only a permission check, so the reactivation existed solely to serve the unassign and goes with it.

## Testing

Same-day CI A/B: the run carrying this change passed the object-web entry project three out of three, and an independent full-batch run on the same base without this change failed the test with the original signature. The fix deletes the failing step outright, so no race remains to sample.

## PR Check

**pr-check: PASS** — tested on `bebc7bd3e32f2b728ad7d2c7a82985918a01867a`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

The diff is a single Playwright spec, deletion only. Prettier reports the file formatted, and `playwright test --list` enumerates it, so the file transpiles and nothing is silently dropped from the batch.

<!-- pr-check {"result": "success", "sha": "bebc7bd3e32f2b728ad7d2c7a82985918a01867a"} -->
