### PR TITLE
LPD-102447 Sort the Salesforce entries view by create date so new rows stay on page one

### DIFF
--- a/modules/test/playwright/tests/object-web/salesforce/objectSalesforce.spec.ts
+++ b/modules/test/playwright/tests/object-web/salesforce/objectSalesforce.spec.ts
@@ -3,7 +3,10 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {ObjectDefinitionAPI} from '@liferay/object-admin-rest-client-js';
+import {
+	ObjectDefinitionAPI,
+	ObjectViewAPI,
+} from '@liferay/object-admin-rest-client-js';
 import {expect, mergeTests} from '@playwright/test';
 
 import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
@@ -112,6 +115,23 @@ test('Assert CRUD with created custom object using Salesforce storage type', asy
 		type: 'objectDefinition',
 	});
 
+	const objectViewAPIClient = await apiHelpers.buildRestClient(ObjectViewAPI);
+
+	await objectViewAPIClient.postObjectDefinitionObjectView(
+		objectDefinition.id,
+		{
+			defaultObjectView: true,
+			name: {en_US: getRandomString()},
+			objectViewColumns: [
+				{objectFieldName: objectFields[0].name, priority: 0},
+				{objectFieldName: 'createDate', priority: 1},
+			],
+			objectViewSortColumns: [
+				{objectFieldName: 'createDate', priority: 0, sortOrder: 'desc'},
+			],
+		}
+	);
+
 	const objectFieldValue = getRandomString();
 	const objectFieldUpdatedValue = getRandomString();
 
@@ -134,12 +154,15 @@ test('Assert CRUD with created custom object using Salesforce storage type', asy
 
 	await test.step('Read Object Entry', async () => {
 		await expect(
-			page.getByRole('cell', {name: objectFieldValue})
+			page.getByRole('cell', {exact: true, name: objectFieldValue})
 		).toBeVisible();
 	});
 
 	await test.step('Update Object Entry', async () => {
-		await page.getByRole('button', {name: 'Actions'}).last().click();
+		await page
+			.getByRole('row', {name: objectFieldValue})
+			.getByRole('button', {name: 'Actions'})
+			.click();
 		await page.getByRole('menuitem', {name: 'View'}).click();
 
 		await viewObjectEntriesPage.fillObjectEntry({
@@ -153,19 +176,22 @@ test('Assert CRUD with created custom object using Salesforce storage type', asy
 		await viewObjectEntriesPage.backButton.click();
 
 		await expect(
-			page.getByRole('cell', {name: objectFieldUpdatedValue})
+			page.getByRole('cell', {exact: true, name: objectFieldUpdatedValue})
 		).toBeVisible();
 	});
 
 	await test.step('Delete Object Entry', async () => {
-		await viewObjectEntriesPage.frontendDatasetActions.last().click();
+		await page
+			.getByRole('row', {name: objectFieldUpdatedValue})
+			.getByRole('button', {name: 'Actions'})
+			.click();
 		await viewObjectEntriesPage.frontendDatasetDeleteAction.click();
 		await viewObjectEntriesPage.deletionConfirmationModal
 			.getByRole('button', {name: 'Delete'})
 			.click();
 
 		await expect(
-			page.getByRole('cell', {name: objectFieldUpdatedValue})
+			page.getByRole('cell', {exact: true, name: objectFieldUpdatedValue})
 		).toBeAttached({attached: false});
 	});
 });
@@ -211,6 +237,23 @@ test('Assert CRUD with created custom object using Salesforce storage type in fo
 		type: 'objectDefinition',
 	});
 
+	const objectViewAPIClient = await apiHelpers.buildRestClient(ObjectViewAPI);
+
+	await objectViewAPIClient.postObjectDefinitionObjectView(
+		objectDefinition.id,
+		{
+			defaultObjectView: true,
+			name: {en_US: getRandomString()},
+			objectViewColumns: [
+				{objectFieldName: objectFields[0].name, priority: 0},
+				{objectFieldName: 'createDate', priority: 1},
+			],
+			objectViewSortColumns: [
+				{objectFieldName: 'createDate', priority: 0, sortOrder: 'desc'},
+			],
+		}
+	);
+
 	const formId = getRandomString();
 
 	const layout = await apiHelpers.headlessDelivery.createSitePage({
@@ -252,17 +295,24 @@ test('Assert CRUD with created custom object using Salesforce storage type in fo
 	await test.step('Read Object Entry in object admin', async () => {
 		await viewObjectEntriesPage.goto(objectDefinition.className);
 
-		await expect(page.getByRole('cell', {name: entryValue})).toBeVisible();
+		await expect(
+			page.getByRole('cell', {exact: true, name: entryValue})
+		).toBeVisible();
 	});
 
 	await test.step('Delete Object Entry', async () => {
-		await viewObjectEntriesPage.frontendDatasetActions.last().click();
+		await page
+			.getByRole('row', {name: entryValue})
+			.getByRole('button', {name: 'Actions'})
+			.click();
 		await viewObjectEntriesPage.frontendDatasetDeleteAction.click();
 		await viewObjectEntriesPage.deletionConfirmationModal
 			.getByRole('button', {name: 'Delete'})
 			.click();
 
-		await expect(page.getByRole('cell', {name: entryValue})).toBeAttached({
+		await expect(
+			page.getByRole('cell', {exact: true, name: entryValue})
+		).toBeAttached({
 			attached: false,
 		});
 	});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102447

## What Is Being Fixed

The two Salesforce storage CRUD tests in `objectSalesforce.spec.ts` fail on CI at their read steps: the entry the test just created never appears in the entries list, and ninety seconds of reloading does not help.

The failure impersonated an external consistency problem — diagnostics proved the create request returns success while the list never shows the row. The real chain is inside the tests: they create no object view, so the entries dataset sends no sort, and `SalesforceObjectEntryManagerImpl` builds a `SELECT FIELDS(ALL)` query with no `ORDER BY` over a twenty-row first page. The Salesforce custom object is keyed by a constant external reference code, so every run of every branch shares one object that is never purged, and failed runs strand orphan rows in it. Once it grew past twenty rows, a new entry landed on an arbitrary page while the read step reloaded a first page that could never contain it.

Born fragile with the tests themselves: an unsorted first-page query over a shared, growing object could only pass while it held fewer than twenty rows.

## How It Is Being Fixed

Create a default object view sorted by create date descending before reading — the manager translates it to `ORDER BY CreatedDate DESC`, so the newest row is always first regardless of how much residue the shared object holds. Target the entry rows by their cell value instead of positional `last()`, since the sort moves new entries to the top, and match the title cell exactly, because the row's select checkbox and actions cells also carry the entry title in their accessible names.

## Testing

CI validated with same-day controls: the run carrying the fix passed the Salesforce project three out of three, and two independent full-batch runs the same day without the fix both failed the same two tests — ruling out the alternative that the shared Salesforce object had been purged below the page boundary.

## PR Check

**pr-check: PASS** — tested on `c741f631eb5cd238790c14949043ce65f6ab4d9e`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

The diff is a single Playwright spec. Prettier reports the file formatted, and `playwright test --list` enumerates both tests, so the file transpiles and nothing is silently dropped from the batch.

<!-- pr-check {"result": "success", "sha": "c741f631eb5cd238790c14949043ce65f6ab4d9e"} -->
