### PR TITLE
LPD-102456 Wait for the publish reload again in the client extension storage test

### DIFF
--- a/modules/test/playwright/tests/object-web/client-extension/objectClientExtension.spec.ts
+++ b/modules/test/playwright/tests/object-web/client-extension/objectClientExtension.spec.ts
@@ -139,9 +139,11 @@ test('Can create, read, update, and delete object entries that use the client ex
 
 	await editObjectDetailsPage.goToDetailsTab();
 
+	const publishReloadPromise = page.waitForEvent('domcontentloaded');
+
 	await editObjectDetailsPage.publishButton.click();
 
-	await page.waitForLoadState('domcontentloaded');
+	await publishReloadPromise;
 
 	// Create
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102456

Fixes a regression I introduced in LPD-102319.

## What Is Being Fixed

`objectClientExtension.spec.ts` "Can create, read, update, and delete object entries that use the client extension as a storage type" fails on CI: the Add button never renders and the click burns the full ninety-second budget on both the attempt and the retry.

Publishing an object definition is entirely client-side. The editor chains a save request and a publish request and only then reloads the page, so the click starts no navigation and the reload is the only signal that both landed.

LPD-102319 replaced `waitForEvent('domcontentloaded')` with `waitForLoadState('domcontentloaded')` at both call sites in this spec, but only the validation-save site was its target and its evidence. On the publish site the substitution is a no-op: `goToDetailsTab()` on the line above already awaits `networkidle`, so the state has long since been reached and the call returns immediately. That deleted the only barrier.

The test then navigates away, destroying the JS context. Because the publish request is chained after the save request resolves, losing that race means the publish is never issued at all and the definition stays a draft. Only publishing deploys the definition, and only that deployment registers the per-definition portlet the entries page addresses, so the page renders without the portlet and the Add button is never created.

## How It Is Being Fixed

Await the reload again, arming the wait before the click so the reload cannot land in the gap between clicking and waiting. That ordering also closes a latent flaw in the original code, which armed the wait after the click.

The second call site is deliberately untouched — `waitForLoadState` there is LPD-102319's real, CI-confirmed target.

## Testing

The failure signature is absent from all 327 prior results of this case and appears only on trees carrying the LPD-102319 commit; the last routine master run without it passed. CI validated on a full batch run with same-day controls: the run carrying this fix passed the test, and two independent runs the same day without it failed.

## PR Check

**pr-check: PASS** — tested on `849ca8fb6db2893eb922e727f8106314b8423fe7`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

The diff is a single Playwright spec. Prettier reports the file formatted, and `playwright test --list` enumerates all four tests, so the file transpiles and nothing is silently dropped from the batch.

<!-- pr-check {"result": "success", "sha": "849ca8fb6db2893eb922e727f8106314b8423fe7"} -->
