### PR TITLE
LPD-102457 Return to the top frame when saving the object side panel

### DIFF
--- a/modules/apps/object/object-test/src/testFunctional/macros/ObjectAdmin.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/ObjectAdmin.macro
@@ -1340,7 +1340,7 @@ definition {
 
 		if (isSet(click)) {
 			if ((${click} == "save") && (${notRefreshAttribute} == "true")) {
-				Button.clickSave();
+				ObjectAdmin.saveSidePanel();
 
 				WaitForElementNotPresent(locator1 = "ObjectAdmin#SIDE_PANEL");
 			}

--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectFields.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectFields.testcase
@@ -631,7 +631,7 @@ definition {
 				fieldList = "Custom Decimal Field 1,Custom Decimal Field 2,Custom Formula Field",
 				tabName = "Tab Test");
 
-			Button.clickSave();
+			ObjectAdmin.saveSidePanel();
 		}
 
 		task ("When the value of the fields is added") {
@@ -1195,7 +1195,7 @@ definition {
 				locator1 = "ObjectAdmin#LAYOUT_BASIC_INFO_NAME_FIELD",
 				value1 = "Layout Updated");
 
-			Button.clickSave();
+			ObjectAdmin.saveSidePanel();
 		}
 
 		task ("Then the Layout can be updated") {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102457

## What Is Being Fixed

`ObjectFields#CanCreateActionWithCustomFieldInSystemObjects` and `CanManageFormulaFieldWithLayout` fail with a signature that reads like the page never loaded:

```
org.openqa.selenium.TimeoutException: Expected condition failed:
  waiting for presence of element located by: By.xpath: //body
  (tried for 5 second(s) with 500 milliseconds interval)
    at Button.clickSave(Button.macro:137)
```

It is not that. Setup, fixtures, navigation and every UI step up to the save succeed.

`Button.clickSave()` clicks Save and then reinitializes the Liferay event log through a script evaluation, and Poshi's driver waits a fixed five seconds for `//body` before any script evaluation. Both call sites run inside the object side-panel iframe, and saving closes the panel and destroys that iframe, so the script evaluates against a document that no longer exists and times out exactly five seconds later. The click itself worked; the test dies on the bookkeeping after it.

## How It Is Being Fixed

Call `ObjectAdmin.saveSidePanel()` instead, which clicks Save, returns to the top frame, waits for the parent to load, and only then reinitializes the log. It is not a new helper — it is already the idiom at ten sites in this same test file.

This also repairs an assertion: the `WaitForElementNotPresent(ObjectAdmin#SIDE_PANEL)` that follows the action save was evaluating inside the iframe, where the panel locator can never match, so it was passing without checking anything. Returning to the top frame makes it a real assertion.

Three sites are changed, not two: the two failing tests plus `CanUpdateLayoutInSystemObject`, which has the identical latent pattern of an explicit `SelectFrame` followed by `Button.clickSave()`.

`Button.macro` is deliberately untouched. `clickSave` has correct semantics for top-document saves and is used portal-wide; the defect is calling it from inside a panel that the save destroys.

## Root Cause

Neither the tests nor the helper changed to cause this. The trailing script call has been part of `Button.clickSave` since LRQA-58578 in 2020, and the fixed five-second `//body` wait since POSHI-241 in 2022. The save became fatal in the 2026-02-25 to 2026-02-26 window, the same boundary already documented in LPD-101459 for the sibling tests, whose commit names the system feature flag delivery as the nearest candidate without claiming it verified. I make no stronger claim here either.

## Testing

CI validated on a full batch run with same-day controls: both tests passed with this change, and independent runs the same day without it failed with the original signature. Poshi syntax validation passes.

## PR Check

**pr-check: PASS** — tested on `86dcf15b9c51413ec74f5a9ff6574644bcec95f4`

| Validation | Result |
| --- | --- |
| Poshi Syntax | PASS |

The diff is two Poshi files, three one-line call swaps.

<!-- pr-check {"result": "success", "sha": "86dcf15b9c51413ec74f5a9ff6574644bcec95f4"} -->
