### PR TITLE
LPD-102458 Isolate the boolean default value node from the shared model builder folder

### DIFF
--- a/modules/test/playwright/tests/object-web/field/objectField.spec.ts
+++ b/modules/test/playwright/tests/object-web/field/objectField.spec.ts
@@ -2789,7 +2789,6 @@ test.describe('Manage object fields default value properties', () => {
 		async ({
 			apiHelpers,
 			modelBuilderDiagramPage,
-			modelBuilderLeftSidebarPage,
 			modelBuilderObjectDefinitionNodePage,
 			modelBuilderRightSidebarPage,
 			page,
@@ -2801,6 +2800,8 @@ test.describe('Manage object fields default value properties', () => {
 
 			let objectName: string;
 
+			let objectFolderName: string;
+
 			await test.step('create object with boolean field', async () => {
 				const objectFields = generateObjectFields({
 					objectFieldBusinessTypes: ['Boolean'],
@@ -2808,9 +2809,26 @@ test.describe('Manage object fields default value properties', () => {
 
 				booleanFieldName = objectFields[0].label['en_US'];
 
+				// An isolated folder keeps the diagram to this one definition, so
+				// the node is fitted into view; the Default folder holds every
+				// system definition and pushes the node's controls under the
+				// right sidebar, which Playwright cannot scroll away.
+
+				const objectFolder =
+					await apiHelpers.objectAdmin.postRandomObjectFolder();
+
+				apiHelpers.data.push({
+					id: objectFolder.id,
+					type: 'objectFolder',
+				});
+
+				objectFolderName = objectFolder.name;
+
 				const objectDefinition =
 					await apiHelpers.objectAdmin.postRandomObjectDefinition({
 						objectFields,
+						objectFolderExternalReferenceCode:
+							objectFolder.externalReferenceCode,
 						status: {code: 0},
 					});
 
@@ -2826,12 +2844,8 @@ test.describe('Manage object fields default value properties', () => {
 
 			await test.step('set default value to false for boolean field and check in object entry', async () => {
 				await modelBuilderDiagramPage.goto({
-					objectFolderName: 'Default',
+					objectFolderName,
 				});
-
-				await modelBuilderLeftSidebarPage.sidebarItems
-					.filter({hasText: objectName})
-					.click();
 
 				await modelBuilderObjectDefinitionNodePage.clickShowAllFieldsButton(
 					objectName,
@@ -2841,7 +2855,7 @@ test.describe('Manage object fields default value properties', () => {
 				await modelBuilderDiagramPage.objectDefinitionNodes
 					.filter({hasText: objectName})
 					.getByText('Boolean', {exact: true})
-					.click();
+					.dispatchEvent('click');
 
 				await modelBuilderRightSidebarPage.setDefaultValue(
 					'Boolean',
@@ -2859,12 +2873,8 @@ test.describe('Manage object fields default value properties', () => {
 
 			await test.step('set default value to true for boolean field and check in object entry', async () => {
 				await modelBuilderDiagramPage.goto({
-					objectFolderName: 'Default',
+					objectFolderName,
 				});
-
-				await modelBuilderLeftSidebarPage.sidebarItems
-					.filter({hasText: objectName})
-					.click();
 
 				await modelBuilderObjectDefinitionNodePage.clickShowAllFieldsButton(
 					objectName,
@@ -2874,7 +2884,7 @@ test.describe('Manage object fields default value properties', () => {
 				await modelBuilderDiagramPage.objectDefinitionNodes
 					.filter({hasText: objectName})
 					.getByText('Boolean', {exact: true})
-					.click();
+					.dispatchEvent('click');
 
 				await modelBuilderRightSidebarPage.setDefaultValue(
 					'Boolean',
@@ -2890,12 +2900,8 @@ test.describe('Manage object fields default value properties', () => {
 
 			await test.step('untoggle default value for boolean field and check in object entry', async () => {
 				await modelBuilderDiagramPage.goto({
-					objectFolderName: 'Default',
+					objectFolderName,
 				});
-
-				await modelBuilderLeftSidebarPage.sidebarItems
-					.filter({hasText: objectName})
-					.click();
 
 				await modelBuilderObjectDefinitionNodePage.clickShowAllFieldsButton(
 					objectName,
@@ -2905,7 +2911,7 @@ test.describe('Manage object fields default value properties', () => {
 				await modelBuilderDiagramPage.objectDefinitionNodes
 					.filter({hasText: objectName})
 					.getByText('Boolean', {exact: true})
-					.click();
+					.dispatchEvent('click');
 
 				await modelBuilderRightSidebarPage.advancedTab.click();
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102458

## What Is Being Fixed

`objectField.spec.ts` "can create, update, and delete default value for boolean field through Model Builder" times out clicking the Boolean field row inside the object's node. The call log shows the click retrying about fifty times, blocked by a Clay slideout panel that sits on top of the row. It fails on the upstream nightly as well, so it is not branch specific.

Three things combine:

The test drew its definition in the shared Default folder, alongside every other definition on the instance. Node position is decided purely by canvas transforms, and the diagram passes no `fitView`, so which slot the node lands in depends on what else the folder happens to hold. Playwright can neither scroll nor pan a canvas.

The test's own left-sidebar click made that worse rather than better. It was there to centre the node, but it dispatches the selection that opens the object definition details panel — at five hundred pixels the widest overlay in the application — covering the right side of the canvas. The step meant to make the node reachable is what buries it.

A plain click hit-tests, so Playwright refuses to click through the overlay and retries until the timeout.

## How It Is Being Fixed

Create the definition in its own folder, so the diagram holds a single node that is fitted into view regardless of instance state. Delete the left-sidebar click, which is no longer needed to find the node and was the thing opening the panel, and drop the now-unused fixture. Dispatch the field row click, since the sidebars and the minimap float over the canvas by design; this matches the show-all-fields helper, which already dispatches.

This is the recipe LPD-101752 already applied to the two structurally identical siblings in the same describe block, copied rather than reinvented. The folder is registered with the data API helper, so the fixture deletes it.

## Root Cause

Born broken in LPD-70980, the commit that created the test, written against the shared folder with plain clicks on transform-positioned controls six months after LPD-55897 widened the details panel to five hundred pixels. No product change since; the positioning code and the sidebar wiring are old and untouched. LPD-101752 missed this third test because reporting shows it as untested rather than as a failure, so it never appeared in the failure list.

## Testing

CI validated on a full batch run with same-day controls: the test passed with this change, and two independent runs the same day without it failed.

## PR Check

**pr-check: PASS** — tested on `e68843c71481543c5684bec129d1b78ef9ae80b8`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

The diff is a single Playwright spec. Prettier reports the file formatted, and `playwright test --list` enumerates all fifty-one tests, so the file transpiles and nothing is silently dropped from the batch.

<!-- pr-check {"result": "success", "sha": "e68843c71481543c5684bec129d1b78ef9ae80b8"} -->
