### PR TITLE
LRCI-8036 Escape exactly what a properties reader unescapes

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -104,7 +104,6 @@ import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
 import org.apache.commons.lang3.ObjectUtils;
-import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -5740,8 +5739,7 @@ public class JenkinsResultsParserUtil {
 			sb.append("=");
 
 			sb.append(
-				StringEscapeUtils.escapeJava(
-					getProperty(properties, propertyName)));
+				_escapePropertiesValue(getProperty(properties, propertyName)));
 
 			sb.append("\n");
 		}
@@ -6127,6 +6125,33 @@ public class JenkinsResultsParserUtil {
 
 	private static String _combineCommandArgs(String... args) {
 		return join(" ", args);
+	}
+
+	private static String _escapePropertiesValue(String value) {
+		if (value == null) {
+			return null;
+		}
+
+		StringBuilder sb = new StringBuilder(value.length());
+
+		for (int i = 0; i < value.length(); i++) {
+			char c = value.charAt(i);
+
+			if (c == '\\') {
+				sb.append("\\\\");
+			}
+			else if (c == '\n') {
+				sb.append("\\n");
+			}
+			else if (c == '\r') {
+				sb.append("\\r");
+			}
+			else {
+				sb.append(c);
+			}
+		}
+
+		return sb.toString();
 	}
 
 	private static void _executeCommandService(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -5738,7 +5738,10 @@ public class JenkinsResultsParserUtil {
 		for (String propertyName : propertyNames) {
 			sb.append(propertyName);
 			sb.append("=");
-			sb.append(getProperty(properties, propertyName));
+
+			sb.append(
+				StringEscapeUtils.escapeJava(
+					getProperty(properties, propertyName)));
 
 			sb.append("\n");
 		}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -104,6 +104,7 @@ import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
 import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-8036

cc @michaelhashimoto

## What Is Being Fixed

`JenkinsResultsParserUtil.writePropertiesFile` writes values raw, and every consumer reads these files back through `java.util.Properties.load`, which ends a value at its first unescaped line break. A multi-line value therefore truncates to its first line. The DocuSign rsa private key arrived as exactly its thirty-one character BEGIN header, the PEM parse failed on the missing end marker, the JWT was never signed, and DocuSign answered 401 to every request — which took down all nine DocuSign round-trip Poshi tests in every `ci:test:object` and `ci:test:bpm` run since the parser jar built from `9eba7c0902c8ca0ffeb0ecba7e497e276863cb47` deployed to the CI controllers on 2026-08-10.

## How It Is Being Fixed

Two reverts restore the writer's escaping, and the fix commit then scopes it to the three characters `Properties.load` unescapes: backslash, line feed, carriage return. Both `escapeJava` and this minimal form survive a properties loader unchanged — this is not a correctness difference on that path. The difference is in the file itself, where `escapeJava` additionally rewrites quotation marks and every non-ASCII character into unicode escapes, which is the wider escaping the original change set out to remove. Values containing none of the three characters are written byte-identically to the current code.

## Testing

Verified end-to-end on CI: a controller run with a parser jar built from this branch (test-1-41 `test-portal-acceptance-pullrequest(master)` build 52, run with a matching `liferay-jenkins-ee` branch) delivered the key intact — structural probe read length 1674, 27 lines, both PEM markers, zero literal escape residue, versus the broken feed's 31-character single line — the token grant produced a 939-character access token, DocuSign returned 200 with the account's 39 envelopes, envelope creation returned 201 with real envelope ids, and the previously failing round-trip tests passed. The two failures in that run are independent of this change: one fails before any DocuSign call on a pre-existing site-settings screen defect, and one hit DocuSign sandbox latency exceeding the configured HTTP timeout, with a later identical request succeeding in under four seconds.

A local round trip through this writer and a properties loader reproduces the truncation exactly, and only when the escaping is absent; a twelve-case matrix (PEM keys, backslash paths, pre-escaped text, unicode, quotes, tabs) round-trips unchanged.

## PR Check

**pr-check: PASS** — tested on `e8f5c61d62abf689cd22d85c0850ff824f1587ba`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |

`ant format-source-current-branch` passes against the branch base, and `modules/test/jenkins-results-parser` compiles.

<!-- pr-check {"result": "success", "sha": "e8f5c61d62abf689cd22d85c0850ff824f1587ba"} -->
