### PR TITLE
LPD-102479 Let the instance digital signature settings save under Always Override

### DIFF
--- a/modules/apps/digital-signature/digital-signature-web/src/main/resources/META-INF/resources/portal_settings/digital_signature.jsp
+++ b/modules/apps/digital-signature/digital-signature-web/src/main/resources/META-INF/resources/portal_settings/digital_signature.jsp
@@ -9,6 +9,8 @@
 
 <%
 DigitalSignatureConfiguration digitalSignatureConfiguration = (DigitalSignatureConfiguration)request.getAttribute(DigitalSignatureConfiguration.class.getName());
+
+boolean alwaysOverride = Objects.equals(digitalSignatureConfiguration.siteSettingsStrategy(), "always-override");
 %>
 
 <div class="row">
@@ -70,7 +72,7 @@ DigitalSignatureConfiguration digitalSignatureConfiguration = (DigitalSignatureC
 
 	<div class="form-group row">
 		<div class="col-md-6">
-			<aui:select label="environment" name="environment" required="<%= true %>" value="<%= digitalSignatureConfiguration.environment() %>">
+			<aui:select label="environment" name="environment" required="<%= !alwaysOverride %>" value="<%= digitalSignatureConfiguration.environment() %>">
 				<aui:option label="" value="" />
 
 				<%
@@ -106,13 +108,28 @@ DigitalSignatureConfiguration digitalSignatureConfiguration = (DigitalSignatureC
 			'<portlet:namespace />siteSettingsStrategy'
 		);
 
-		if (
-			digitalSignatureSiteSettingsStrategyElement.value === 'always-override'
-		) {
+		var alwaysOverride =
+			digitalSignatureSiteSettingsStrategyElement.value === 'always-override';
+
+		if (alwaysOverride) {
 			digitalSignatureProviderCredentialsElement.classList.add('hide');
 		}
 		else {
 			digitalSignatureProviderCredentialsElement.classList.remove('hide');
+		}
+
+		// The credentials are hidden when every site overrides them, but a hidden
+		// field is still validated, and its message renders inside the hidden
+		// block. Keep the rule in step with the block so the form can submit.
+
+		var form = Liferay.Form.get('<portlet:namespace />fm');
+
+		if (form) {
+			var rules = form.formValidator._getAttr('rules');
+
+			rules['<portlet:namespace />environment'] = {
+				required: !alwaysOverride,
+			};
 		}
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102479

## What Is Being Fixed

On Instance Settings → Digital Signature, choosing the "Always Override" site settings strategy makes the Save button silently do nothing. The strategy is never stored, so every site keeps inheriting the instance credentials and the Digital Signature fields on Site Settings stay disabled. An administrator on a fresh instance cannot enable the Always Override strategy at all.

Selecting "Always Override" hides the credentials block, but the `environment` select inside that block stays required. Liferay's form validator still validates hidden required fields, so it cancels the submit and renders the error inside the block it just hid. Driving the screen in a browser against a running bundle:

```
submit event -> defaultPrevented: true
error node   -> "The Environment field is required."   hiddenByAncestor: true
POSTs        -> []
```

`DigitalSignatureSiteSettings#CanEnableDigitalSignatureBySiteSettings` has failed on this since 2026-06-17, reporting a symptom two steps downstream:

```
java.lang.Exception: Element is not editable at "//input[contains(@name,'apiUsername')]"
	at DigitalSignature.enableDigitalSignature(DigitalSignature.macro:326)
	at DigitalSignatureSiteSettings.CanEnableDigitalSignatureBySiteSettings(...testcase:50)
```

The test only reaches that step because `SystemSettings.saveConfiguration()` asserts the success message with `VerifyElementPresent`, a soft assertion, so the missing message never fails the save step. The site screen is then correctly disabled, because the company scope strategy really was never saved.

**Root cause:** born broken in `d6c9fd8604481` (LPS-197949), which added the required `environment` select inside the credentials block that `304e0823631aa` (LPS-131427) had introduced the hiding for. Until then the hidden block held no required field, so hiding it was harmless.

## How It Is Being Fixed

Keep the validation rule in step with the block: the environment is required only while the credentials are on screen. The select renders required from the persisted strategy, and the existing `onchange` handler updates the validator rule when the strategy changes without a reload, using the same `Liferay.Form` rules idiom already used in `users-admin/.../common/edit_address.jsp`.

## Testing

Local A/B against a running bundle: before the fix the Save click produced zero POSTs and the submit was cancelled; after it, the save posts, persists `always-override`, and the Site Settings screen becomes editable. Walking the full test sequence confirmed `always-inherit` leaves the site screen correctly disabled and `always-override` leaves it editable.

CI A/B on the Digital Signature functional batch, same build parameters and the same `jenkins-results-parser` jar, with only this JSP changed:

| Run | Result |
| --- | --- |
| without the fix | 20 passed, 1 failed — failing exactly this test |
| with the fix | **21 passed, 0 failed** |

## PR Check

**pr-check: PASS** — tested on `e03641bc42f28534ead0a507cafcf96330b2b4c6`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "e03641bc42f28534ead0a507cafcf96330b2b4c6"} -->
