### PR TITLE
LPD-102547 Reach the workflow configuration tab by address in objectWorkflow

### DIFF
--- a/modules/test/playwright/pages/portal-workflow-kaleo-designer-web/ConfigurationTabPage.ts
+++ b/modules/test/playwright/pages/portal-workflow-kaleo-designer-web/ConfigurationTabPage.ts
@@ -9,6 +9,9 @@ import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
 import {waitForAlert} from '../../utils/waitForAlert';
 import {ProcessBuilderPage} from './ProcessBuilderPage';
 
+const WORKFLOW_NAMESPACE =
+	'_com_liferay_portal_workflow_web_portlet_ControlPanelWorkflowPortlet_';
+
 export class ConfigurationTabPage {
 	readonly configurationTabLink: Locator;
 	readonly page: Page;
@@ -31,24 +34,36 @@ export class ConfigurationTabPage {
 		);
 	}
 
-	private async clickAssetTypeEditButton(assetType: string) {
+	async searchAssetType(assetType: string) {
 
-		// Callers reach this tab either through goTo, which waits for the tab's
-		// own address, or by clicking the tab link themselves and continuing
-		// straight into an assignment. Until that navigation lands, the tab the
-		// caller came from is still on screen, and its management bar carries
-		// its own enabled search form, so a submit sent in that window filters
-		// that other table and leaves this one empty for good. Wait for the
-		// address before touching the search form.
+		// The tab a caller arrives from stays on screen until its navigation
+		// lands, and it carries its own search form, so a submit sent in that
+		// window filters the other table and navigates away from this tab for
+		// good. Ask for the tab and the keywords in one address instead: the
+		// table is rendered already filtered, with no form to race.
 
-		await this.page.waitForURL((url) =>
-			url.href.includes('=configuration')
+		// Object definitions are registered as workflow asset types for the
+		// instance, so they are listed by the instance wide control panel and
+		// not by a site scoped one.
+
+		await this.page.goto(
+			'/group/control_panel/manage' +
+				'?p_p_id=com_liferay_portal_workflow_web_portlet_ControlPanelWorkflowPortlet' +
+				`&${WORKFLOW_NAMESPACE}tab=configuration` +
+				`&${WORKFLOW_NAMESPACE}keywords=${encodeURIComponent(assetType)}`
 		);
+
+		await this.page.waitForLoadState('networkidle');
+	}
+
+	private async clickAssetTypeEditButton(assetType: string) {
 
 		// The table lists every workflow enabled asset type in the instance and
 		// pages at twenty rows, which leaves a generated object definition on the
 		// boundary of the first page. Filter by name so the lookup does not
 		// depend on how many asset types the instance happens to hold.
+
+		await this.searchAssetType(assetType);
 
 		const editButton = this.page
 			.getByRole('row')
@@ -59,24 +74,6 @@ export class ConfigurationTabPage {
 				}),
 			})
 			.getByRole('button', {name: 'Edit'});
-
-		// The search submit button is served disabled and the toolbar's script
-		// enables it only once it runs. It is the form's default button, and a
-		// form whose default button is disabled ignores Enter, so wait for the
-		// button itself before submitting. No load state can stand in for it:
-		// the tab arrives through a single page application navigation, after
-		// which load and networkidle resolve while the button is still
-		// disabled.
-
-		await expect(
-			this.page.locator('.management-bar button[type="submit"]')
-		).toBeEnabled();
-
-		const searchInput = this.page.getByPlaceholder('Search for');
-
-		await searchInput.fill(assetType);
-
-		await searchInput.press('Enter');
 
 		await expect(editButton).toBeVisible();
 

--- a/modules/test/playwright/tests/object-web/workflow/objectWorkflow.spec.ts
+++ b/modules/test/playwright/tests/object-web/workflow/objectWorkflow.spec.ts
@@ -188,7 +188,6 @@ test(
 	async ({
 		apiHelpers,
 		configurationTabPage,
-		globalMenuPage,
 		page,
 		viewObjectDefinitionsPage,
 	}) => {
@@ -202,47 +201,32 @@ test(
 			type: 'objectDefinition',
 		});
 
-		await globalMenuPage.goToApplications('Process Builder');
+		const label = objectDefinition.label['en_US'];
 
-		await configurationTabPage.configurationTabLink.click();
+		// What this test asserts is whether the object is listed, so reach the
+		// filtered Configuration tab by address. Walking the global menu adds
+		// two navigations that are torn down and rebuilt while the object
+		// definition redeploys, and neither of them is under test here.
 
-		await expect(
-			page.getByRole('row', {
-				name: objectDefinition.label['en_US'],
-			})
-		).toBeVisible();
+		await configurationTabPage.searchAssetType(label);
 
-		await viewObjectDefinitionsPage.goto();
-
-		await viewObjectDefinitionsPage.changeObjectActivateStatus(
-			objectDefinition.label['en_US']
-		);
-
-		await globalMenuPage.goToApplications('Process Builder');
-
-		await configurationTabPage.configurationTabLink.click();
-
-		await expect(
-			page.getByRole('row', {
-				name: objectDefinition.label['en_US'],
-			})
-		).toBeHidden();
+		await expect(page.getByRole('row', {name: label})).toBeVisible();
 
 		await viewObjectDefinitionsPage.goto();
 
-		await viewObjectDefinitionsPage.changeObjectActivateStatus(
-			objectDefinition.label['en_US']
-		);
+		await viewObjectDefinitionsPage.changeObjectActivateStatus(label);
 
-		await globalMenuPage.goToApplications('Process Builder');
+		await configurationTabPage.searchAssetType(label);
 
-		await configurationTabPage.configurationTabLink.click();
+		await expect(page.getByRole('row', {name: label})).toBeHidden();
 
-		await expect(
-			page.getByRole('row', {
-				name: objectDefinition.label['en_US'],
-			})
-		).toBeVisible();
+		await viewObjectDefinitionsPage.goto();
+
+		await viewObjectDefinitionsPage.changeObjectActivateStatus(label);
+
+		await configurationTabPage.searchAssetType(label);
+
+		await expect(page.getByRole('row', {name: label})).toBeVisible();
 	}
 );
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102547

## What Is Being Fixed

`objectWorkflow.spec.ts` "Verify that the Object is displayed on the Workflow Process Builder page" failed about a fifth of the time, always on the pass that follows reactivating the object definition. The initial and deactivated passes never failed once in fifteen runs.

`ConfigurationTabPage.searchAssetType` waited for the tab's address, then typed into the management bar search and pressed Enter. Until the configuration tab's navigation lands, the tab the caller came from is still on screen with its own management bar, so the submit filters that other table and navigates away from the configuration tab. The assertion then runs against the wrong tab.

Instrumenting the failure showed the object definition already active in the backend, the Configuration link present, and the address carrying no tab at all:

```
definition = {"active":true,"status":0}
atFailure  = {rows:1, tabLinks:1, url:"...ControlPanelWorkflowPortlet&p_p_lifecycle=0"}
```

## How It Is Being Fixed

Ask for the tab and the keywords in one address, so the table arrives already filtered with no form to race, and drop the global menu walk the test does not assert. Object definitions are registered as workflow asset types for the instance, so the listing comes from the instance wide control panel rather than a site scoped one.

## Testing

Forty five consecutive local runs pass, against twenty four of thirty before. Two full green `ci:test:object` runs include this change.

`searchAssetType` is shared by twelve specs through `assignWorkflowToAssetType`, so it was checked for regressions against `portal-workflow-task-web`: three failures on master, two with this change.

## PR Check

**pr-check: PASS** — tested on `ca4a1a48f4782e70be8d875433b9203c8446e770`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "ca4a1a48f4782e70be8d875433b9203c8446e770"} -->
