### PR TITLE
LPD-102548 Retry the reload after saving a groovy object validation

### DIFF
--- a/modules/test/playwright/tests/object-web/validation/objectValidation.spec.ts
+++ b/modules/test/playwright/tests/object-web/validation/objectValidation.spec.ts
@@ -1291,7 +1291,13 @@ test.describe('Object Groovy Validation', () => {
 			'Groovy'
 		);
 
-		await page.reload();
+		// Saving the validation leaves a navigation in flight that aborts the
+		// reload, and it lands after the page has otherwise gone quiet, so
+		// waiting for a load state does not avoid it. Retry the reload instead.
+
+		await expect(async () => {
+			await page.reload({timeout: 15000});
+		}).toPass({timeout: 60000});
 
 		await expect(page.getByRole('cell', {name: 'No'})).toBeVisible();
 	});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102548

## What Is Being Fixed

`objectValidation.spec.ts` "groovy validation is not active by default" failed about a fifth of the time on master with nothing changed, which is enough on its own to deny the object suite a clean run.

Saving the validation leaves a navigation in flight, and it lands after the page has otherwise gone quiet, so the reload that follows is aborted outright:

```
Error: page.reload: net::ERR_ABORTED; maybe frame was detached?
  - waiting for navigation until "load"
```

## How It Is Being Fixed

Retry the reload rather than trying to prevent the abort.

Waiting for a load state first was tried and measured, and it does not work: it gave two failures in ten runs, exactly the baseline rate, because the navigation arrives after the wait resolves. That negative result is recorded in the comment so the next reader does not repeat it.

## Testing

| | failures in ten runs |
| --- | --- |
| master | 2 |
| waiting for a load state | 2 |
| retrying the reload | **0** |

The aborted reload no longer appears in the output at all.

## PR Check

**pr-check: PASS** — tested on `d9a1942c79f9a444726363dbdd788365e671e42b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "d9a1942c79f9a444726363dbdd788365e671e42b"} -->
