### PR TITLE
LPD-102549 Key each selected multiple select label by its value

### DIFF
--- a/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/Select/MultipleSelect.tsx
+++ b/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/Select/MultipleSelect.tsx
@@ -97,11 +97,16 @@ export function MultipleSelect({
 	useEffect(() => {
 		const multiSelectOptions = [] as LabelValueObject[];
 
+		// The multi select keys each selected label by its value, so a label
+		// carried on its own leaves every key undefined, and React discards and
+		// rebuilds the whole row on each change.
+
 		(options as MultiSelectItem[]).forEach(({children}) => {
-			return children.forEach(({checked, label}) => {
+			return children.forEach(({checked, label, value}) => {
 				if (checked) {
 					multiSelectOptions.push({
 						label,
+						value,
 					});
 				}
 			});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102549

## What Is Being Fixed

Every selected label in the object multiple select is handed the same React key, so React discards and rebuilds the whole label row on each change. Selecting the eight workflow statuses in an object view filter emitted seventy duplicate key warnings per run:

```
Encountered two children with the same key, `clay-id-11-label-undefined-span`.
```

Clay keys a selected label by the value its locator reads, falling back to the item id, and its default locator is `{id: 'key', label: 'label', value: 'value'}`. `MultipleSelect` pushed each selected label carrying nothing but its text, so both reads came back `undefined`.

The remount detaches whatever the user is interacting with, which is how this surfaced: a side panel Save button that reported visible, enabled, unobscured and inside the viewport, yet was not attached to the DOM by the time it was clicked.

## How It Is Being Fixed

Carry the value the option already holds.

## Testing

Seventy duplicate key warnings per run before the change and none after, six runs each way with identical counts.

`MultipleSelect` from `object-js-components-web` is consumed only inside `object-web`, by `ModalAddFilter`, `ObjectValidation/UniqueCompositeKey` and `StateManager/StateDefinition`. The change was checked for regressions on four axes:

| Check | Result |
| --- | --- |
| `ci:test:object` | green, 5163 passed and 0 failed |
| `ci:test:frontend` with and without the change | identical, 3638 passed and 26 failed both ways, 25 of the 26 failures shared and all pre-existing on master |
| `js-unit` and `modules-unit`, which run this component's own tests | identical, 400 and 92 passing both ways |
| twelve alternating local runs of `objectValidation` | one failure without the change, none with it |

## PR Check

**pr-check: PASS** — tested on `1dcdb5cf0fc6b147fe6d5c32f0c8f6282260bfd2`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "1dcdb5cf0fc6b147fe6d5c32f0c8f6282260bfd2"} -->
