### PR TITLE
LPD-98918 Semantic versioning

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-api/bnd.bnd
+++ b/modules/apps/site/site-cms-site-initializer-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Site CMS Site Initializer API
 Bundle-SymbolicName: com.liferay.site.cms.site.initializer.api
-Bundle-Version: 4.5.1
+Bundle-Version: 4.6.0
 Export-Package:\
 	com.liferay.site.cms.site.initializer.bulk.selection,\
 	com.liferay.site.cms.site.initializer.configuration,\


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98918

## What Is Being Fixed

Every build on master fails its baseline for `site-cms-site-initializer-api`:

```
Semantic versioning is incorrect while checking
  com.liferay.site.cms.site.initializer.api-4.5.1.jar against
  com.liferay.site.cms.site.initializer.api-4.5.0.jar
[Baseline Warning] Bundle Version Change Recommended: 4.6.0
```

Diffing the two jars, the source carries two classes the published artifact does not, and the exported `util` package differs with them:

```
com/liferay/site/cms/site/initializer/util/CMPLicenseUtil.class      (LPD-98918)
com/liferay/site/cms/site/initializer/util/CMSObjectEntryUtil.class  (LPD-100186)

published 4.5.0 : util version 3.4.0
source          : util version 3.5.0
```

## How This Came About

| | bundle | util |
| --- | --- | --- |
| `8e493109e29a5` LPD-97798, Aug 3 | 4.4.1 → **4.5.0** | 3.4.0 |
| `74b621da1b3dc` adds CMPLicenseUtil, Aug 7 | 4.5.0 | 3.4.0 |
| `5f0daee0255f5` LPD-98918 baseline, Aug 7 | 4.5.0 | 3.4.0 → **3.5.0** |
| `d38f712154708` release prep, Aug 12 | 4.5.0 → **4.5.1** | 3.5.0 |

The package bump on August 7 was correct as made: the bundle already stood at 4.5.0, a minor step over the released 4.4.x, so the added API was covered on both counts.

What the published 4.5.0 artifact contains is a different matter. It carries neither new class and still exports `util;version="3.4.0"`, so it was cut from a tree that predates them. Once the release preparation carried the source bundle to 4.5.1, the pending minor addition was left sitting behind a micro step, and the baseline correctly asks for 4.6.0.

So no single commit is at fault for skipping a bump. The mismatch is between what 4.5.0 was published as and what 4.5.0 had become in source.

## How It Is Being Fixed

Carry the bundle to 4.6.0, which is the version the baseline task itself recommends and the one its `syncVersions` step writes.

## Testing

`gradlew :apps:site:site-cms-site-initializer-api:baseline` fails on master and passes with this change.

## PR Check

**pr-check: PASS** — tested on `5eb2ac820a86407bae14fa6d6126966c56348d57`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Baseline | PASS |

<!-- pr-check {"result": "success", "sha": "5eb2ac820a86407bae14fa6d6126966c56348d57"} -->
