### PR TITLE
LPD-X CI C02: lowered module packageinfo

### DIFF
--- a/.claude/skills/pr-check/validations/baseline.md
+++ b/.claude/skills/pr-check/validations/baseline.md
@@ -2,49 +2,122 @@
 
 ## Trigger
 
-An exported package API changed: Java under an `*-api` module, `portal-impl`, or `portal-kernel`, a `bnd.bnd` with an `Export-Package`, or a `packageinfo`. The bnd baseline task diffs the exported API against the last release and fails on a missing, excessive, or insufficient `Bundle-Version`/`packageinfo` bump. No drift check catches that, since the `bnd.bnd` carrying the bump never changes.
+Always. The bnd baseline task diffs each exported API against the last release and fails on a missing, excessive, or insufficient `Bundle-Version` or `packageinfo` bump.
+
+This validation used to run only against the branch diff, on the reasoning that an API cannot drift unless someone edits it. That reasoning is wrong, and it is the reason baseline breaks keep reaching master and failing every build until somebody notices. A bump falls due when the API is published, not when it is written, so the failing module is routinely one that the branch never touched:
+
+`site-cms-site-initializer-api` failed every build on master for a day. Its exported `util` package had gained `CMPLicenseUtil` and `CMSObjectEntryUtil` and been carried to `3.5.0`, while the published `4.5.0` artifact contained neither, and the release preparation had moved the bundle only to the micro step `4.5.1`. Every pull request that ran into it failed, and none of them had the module in its diff, so a diff-driven check stayed silent through all of them.
+
+Baselining the whole repository costs about thirty seconds and is quicker than baselining three changed modules one at a time, so there is nothing to buy by narrowing it.
 
 ## Match
 
-`^modules/.+-api/.+\.java$|^portal-kernel/src/.+\.java$|^portal-impl/src/.+\.java$|(^|/)bnd\.bnd$|(^|/)packageinfo$`
-
-## Selection
-
-The Nexus baseline task runs on `*-api` modules whose `bnd.bnd` declares `Export-Package` (the task does nothing otherwise) and whose `Bundle-Version` is above `1.0.0` (baseline is skipped below that). It also runs on `portal-impl` and `portal-kernel`. Both apply the `BaselinePlugin` through `modules/build-portal.gradle` and resolve as standalone Gradle projects, so the same task baselines their Ant-built jars. The local version check below is the no-network fallback and covers the same paths.
+`.`
 
 ## Command
 
-### Module Task
-
-Run the Nexus baseline task per selected `*-api` module, with its directory converted to a Gradle project path:
-
 ```bash
-("${REPO_ROOT}/gradlew" \
-	--project-dir "${REPO_ROOT}/modules" \
-	-Dbaseline.ignoreFailures=true \
-	:<path>:baseline)
+(cd "${REPO_ROOT}" && ANT_OPTS="-Xmx2560m" ant baseline-all -Dbaseline.all.ant.projects=<true|false>)
 ```
 
-A nonempty `modules/<module>/build/reports/baseline/baseline.log` is a FAIL. An empty log is a PASS. The task builds the module jar and resolves the last released artifact from Nexus, so it requires network access.
+Pass `false` only when **Full Portal Build** ran in this same pr-check. That property decides whether the seven top level Ant projects are baselined here, and `ant all` has already baselined them on its way through, from its `jar` target. Otherwise leave the property alone, since it defaults to `true`. Skipping them when nothing else has baselined them is the one setting that loses coverage without saying so, which is why it is not the default, and why jarring them again costs five seconds rather than an argument.
 
-### Portal Impl and Portal Kernel
+One Gradle invocation covers every module. The target collects each `modules` bnd.bnd declaring `Export-Package`, converts its directory to a Gradle project path, and names all of them explicitly, because asking Gradle for `baseline` across the tree makes it configure every module to find the task, which costs far more than the baselining. The top level Ant projects run alongside it, each being its own Gradle build.
 
-Both run as standalone Gradle projects that apply the `BaselinePlugin`. The task baselines the Ant-built jar in the project directory, so build that jar with `ant jar` first, then run the baseline task (substitute `portal-kernel` for the kernel side):
+One prerequisite, which does not announce itself when missing: each baseline resolves the last released artifact from Nexus, so the run needs network access. Use the local check below when there is none.
+
+The jar used to be a second prerequisite. The top level Ant projects are baselined against the jar in their project directory, and the baseline task does not build it, so the target jars each one it is asked to baseline. Relying on the build validations for it was not enough. They do produce it (`ant all` through its `deploy` target and `ant compile install-portal-snapshots` directly, both reaching `install-portal-snapshot`, which depends on `jar`), but they fire only on a `portal-*`, `util-*`, or `modules` diff, while this validation fires on everything. A documentation or Poshi only branch would otherwise reach this point with whatever jar happened to be on disk. Jarring costs about five seconds against already compiled classes, spent in parallel with the modules.
+
+It also makes the run settle. The repair is written to the source `packageinfo` while the comparison reads the jar, so leaving the jar alone means the next run reads the same old version back out of it and reports the same finding again, without end. The target deletes each `baseline.log` it is about to regenerate for the same reason: the baseline task writes that file on a finding and never removes it, so a log left by an earlier run outlives the repair and reports a failure that no longer exists.
+
+What jarring does not fix is a stale `.class`. Build output that does not correspond to the checked out source deserves more suspicion than a missing jar, because it misleads in both directions and looks like nothing. A worktree holding output from another branch reported six findings against an untouched master, two of them major and one a removed package, and not one was real. Five were the stale `packageinfo` inside the jar. The sixth outlived even a rebuilt jar: an orphaned `.class` from the other branch, whose source does not exist on master, packaged because the compile it belonged to looked up to date. It read as an added class in an exported package and asked for a minor bump, and no `git status` shows such a file, since it is build output rather than source. The same staleness suppresses findings just as easily, since a jar carrying a version that the source has not got matches baseline's own suggestion and reports nothing. Only a clean build clears this, which is what `ant all` does and `ant compile install-portal-snapshots` does not. Treat a finding against a project you have not cleanly built on this branch as unproven.
+
+Both invocations run quiet, which takes the run from roughly thirty nine thousand lines to forty. Nothing is lost by it. Baseline reports every finding on standard output, which Gradle logs at its QUIET level, and a failing module raises at ERROR, so both survive; what quiet drops is the one lifecycle line each of the three thousand tasks emits to say it did nothing. A run that finds something still prints the whole report, ending in `Semantic versioning is incorrect`. Do not restore the default level to bring findings back, because none are missing.
+
+## Interpretation
+
+The exit code does not carry the result on its own, because the baseline task repairs what it finds. `Baseline.updateBundleVersion` writes the suggested version into `bnd.bnd`, and `Baseline.generatePackageInfo` writes a `packageinfo` holding the suggested version, or deletes it when the package is gone. The first run rewrites the tree and every run after it passes. **Read `git status`, not just the exit code.** (`syncVersions`, which the baseline task is `finalizedBy`, is not what repairs the version; it only pushes the resulting `Bundle-Version` out into JS files.)
+
+Baseline has five warnings, and they do not all reach the tree in the same shape:
+
+| Warning | What Lands in the Tree |
+| --- | --- |
+| `VERSION INCREASE REQUIRED` | version raised |
+| `VERSION INCREASE SUGGESTED` | version raised |
+| `EXCESSIVE VERSION INCREASE` | version **lowered** |
+| `PACKAGE ADDED, MISSING PACKAGEINFO` | **new, untracked** packageinfo |
+| `PACKAGE REMOVED` | packageinfo **deleted** |
+
+All five concern the version of an exported package, the one recorded in its `packageinfo`. `Bundle-Version` is not among them. It is raised when it fails to cover the packages beneath it and is otherwise left alone, so a `Bundle-Version` inflated past what its packages need draws no warning and no repair: the run reports nothing and passes. That case reaches this validation only through the classification below, which reads the number out of `bnd.bnd` and calls it a major bump, so do not treat a passing run as evidence the bundle version is right.
+
+Only the first two arrive as an ordinary pair of version lines. A bare diff of those lines cannot tell the rest apart: it drops the filename, renders an addition or a deletion as a lone unpaired line, and reads a lowering as a routine bump. List each file with both of its versions instead:
 
 ```bash
-(cd "${REPO_ROOT}/portal-impl" && ant jar)
+version() {
+	sed -nE 's/^(Bundle-Version:[[:space:]]*|version[[:space:]]+)//p' | head -1
+}
 
-("${REPO_ROOT}/gradlew" \
-	--project-dir "${REPO_ROOT}/portal-impl" \
-	-Dbaseline.ignoreFailures=true \
-	baseline)
+git status --porcelain -uall -- '*bnd.bnd' '*packageinfo' |
+while read -r status path; do
+	case "${status}" in
+	D)    old=$(git show "HEAD:${path}" | version) ; new="<removed>" ;;
+	'??') old="<added>" ; new=$(version < "${path}") ;;
+	*)    old=$(git show "HEAD:${path}" | version) ; new=$(version < "${path}") ;;
+	esac
+
+	printf '%s\t%s\t%s\n' "${old:-<none>}" "${new:-<none>}" "${path}"
+done
 ```
 
-A nonempty `baseline-reports/portal-impl.log` is a FAIL. Like the module task, it resolves the last released artifact from Nexus, so it needs network access.
+Two details in that loop are load bearing.
 
-### Local Version Check
+`-uall` makes a newly written packageinfo visible even where `status.showUntrackedFiles` is set to `no`. That is a reasonable setting to carry on a tree this size, and under it the same command reports nothing whatsoever (the file is untracked), so the finding disappears in silence rather than as an error. The pathspec is not a substitute. It does stop git collapsing an untracked directory into its parent, but it does not override that setting.
 
-This needs no network and reports an advisory note, never a PASS or FAIL.
+Removal is read from git's status letter rather than from an empty file. Inferring it from a missing version line instead conflates a deleted file with an unreadable one, and the two do occur together: the baseline task rewrites `bnd.bnd` by truncating and storing, so a file read inside that window yields no version line and would be reported as a removed package. `<none>` keeps that case distinct, since it means the file could not be read, which is a defect in the run to repeat, never a finding to act on.
+
+Classify each row, comparing segments as numbers so that `9.5.1` to `10.0.0` counts as a rise and `1.9.0` to `1.10.0` does not:
+
+- Identical versions are not a finding.
+- The first segment rises: **major**.
+- The second or third rises: **minor** or **micro**.
+- Any segment falls: **lowered**.
+- `<added>`: a newly exported package.
+- `<removed>`: an exported package is gone.
+- `<none>` on either side: the file held no version line. Repeat the run rather than classifying it.
+
+## Autocommit
+
+Split on the classification, because the three outcomes carry different obligations.
+
+**Minor or micro only.** Stage the version files and commit them, resolving `<TICKET>` from the branch name the way [commit.md](../../../rules/commit.md) does:
+
+```bash
+paths=$(git status --porcelain -uall -- '*bnd.bnd' '*packageinfo' | cut -c4-)
+
+[ -n "${paths}" ] && printf '%s\n' "${paths}" | git add --pathspec-from-file=-
+
+git commit --message "${TICKET} Semantic versioning"
+```
+
+Two shorter spellings of that are both wrong. Handing the same two globs straight to `git add` is fatal whenever one of them matches nothing, which is the commonest bump of all, a lone `Bundle-Version`: `git add` stops on `pathspec '*packageinfo' did not match any files` and stages neither. Piping `git status` directly into `git add` fails differently and only sometimes, because the two run concurrently and both want `index.lock`, `git status` taking it to write the index it just refreshed. Measured at six runs in twelve. Collect the paths first, then stage them.
+
+An added API owes a bump and nothing else, so there is no decision for the developer to make and no reason to hold the repository inconsistent while they apply it by hand.
+
+A bump owed to a package that this branch never touched commits under this branch's ticket as well. The ticket that published the API cannot be resolved from the tree, and the alternative is to leave master failing every build until somebody notices, which is the incident above. Report it, though, since the pull request now carries a semantic versioning fix that its author did not write.
+
+**Major, lowered, or removed.** Do not commit. Fail this validation and report each one with its file and both versions. All three carry a decision that is the developer's to make, and each is a breaking change wearing a different disguise:
+
+- A **major** bump means an exported API was removed or changed incompatibly. It needs a breaking change section in the commit message and a deliberate reckoning with the consumers it breaks.
+- A **lowered** version is `EXCESSIVE VERSION INCREASE`: the branch claimed more than it delivered, or the number was already published. Committing it retracts a version that consumers may already resolve against.
+- A **removed** packageinfo is `PACKAGE REMOVED`, the most breaking outcome of the five, and the one that looks least like anything. It arrives as a bare file deletion carrying no new version at all, so a check that reads version numbers sees nothing to object to.
+
+**A newly exported package.** Report it and leave it uncommitted. The file is the developer's own new API surface and belongs in the commit that adds the package, not under a semantic versioning title.
+
+When several appear in one run, the run fails on the strictest, and every safe bump stays uncommitted with it so the whole set is reviewed together.
+
+## Local Version Check
+
+This needs no network and reports an advisory note, never a PASS or FAIL. Use it when the baseline run above cannot reach Nexus.
 
 Look at each changed `.java` under an `*-api` module's `src/main/java`, `portal-impl/src`, or `portal-kernel/src`. When its diff adds or removes a `public` or `protected` line, the exported API changed, so the version should be bumped too. The bump shows up in the diff as a changed `packageinfo`, or a changed `bnd.bnd` `Bundle-Version` for an `*-api` module. If neither changed, flag the package, since the API changed but the version did not.
 
@@ -53,9 +126,11 @@ Flag a lowered `packageinfo` or `Bundle-Version` that has no matching `public` o
 ## Checklist
 
 ```
-- [ ] (One subitem per exporting module:) Baseline <module path>
+- [ ] Baseline
 ```
 
 ## Time Estimate
 
-~30 sec - 1 min per module. The local version check is instant.
+~30 sec for the whole repository, measured repeatedly between 26 and 30 sec, on a warm Gradle daemon whose module jars are already built.
+
+Two things move that number, and neither is the Ant heap. Ant only orchestrates here; the work belongs to the Gradle daemon in its own JVM, and raising `ANT_OPTS` from 2.5 GB to 4 GB was measured as no change at all. What costs is a run that has to rebuild jars before it can baseline them, the ordinary case right after a branch change, at around 45 sec; and a cold Gradle daemon, at around 80 sec. Gradle starts a second daemon rather than waiting when the one already up is busy or was given different JVM arguments, so an unexplained slow run is worth checking against the daemon list before it is read as the target being slow.

--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -9247,178 +9247,6 @@ information. Make sure to commit in all format-javadoc results.
 		<run-modules-integration-test database.type="sqlserver" database.version="2022" />
 	</target>
 
-	<target name="modules-semantic-versioning">
-		<propertycopy from="app.server.${app.server.type}.version" name="app.server.version" />
-
-		<run-batch-test>
-			<test-action>
-				<loadresource property="modules.baseline.task.groups">
-					<filterchain>
-						<tokenfilter>
-							<replaceregex flags="g" pattern="(\S+ ){${test.module.groups.size}}" replace="\0," />
-						</tokenfilter>
-					</filterchain>
-					<propertyresource name="modules.test.class.group" />
-				</loadresource>
-
-				<get-gradle-module-dir-task-names gradle.task.names="${modules.baseline.task.groups}" />
-
-				<for delimiter="|" list="${gradle.module.dir.task.names}" param="gradle.module.dir.task.name" trim="true">
-					<sequential>
-						<local name="gradle.module.dir" />
-						<local name="gradle.task.name" />
-
-						<propertyregex
-							input="@{gradle.module.dir.task.name}"
-							override="true"
-							property="gradle.module.dir"
-							regexp="([^=]+)=([^=]+)"
-							replace="\1"
-						/>
-
-						<propertyregex
-							input="@{gradle.module.dir.task.name}"
-							override="true"
-							property="gradle.task.name"
-							regexp="([^=]+)=([^=]+)"
-							replace="\2"
-						/>
-
-						<execute-gradle-task gradle.task.module.dir="${gradle.module.dir}" gradle.task.name="${gradle.task.name}">
-							<action>
-								<gradle-execute dir="${gradle.module.dir}" forcedcacheenabled="false" task="${gradle.task.name}">
-									<arg value="--continue" />
-									<arg value="--parallel" />
-									<arg value="-Dbaseline.ignoreFailures=true" />
-								</gradle-execute>
-							</action>
-							<action-fail>
-								<local name="baseline.log.files.content" />
-
-								<beanshell>
-									<![CDATA[
-										import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
-
-										File projectDir = new File(project.getProperty("project.dir"));
-
-										File baseDir = new File(projectDir, project.getProperty("gradle.module.dir"));
-
-										StringBuilder sb = new StringBuilder();
-
-										for (File baselineFile : JenkinsResultsParserUtil.findFiles(baseDir, "baseline.log")) {
-											sb.append("\n> ");
-											sb.append(JenkinsResultsParserUtil.getPathRelativeTo(baselineFile, projectDir));
-											sb.append("\n\n");
-											sb.append(JenkinsResultsParserUtil.read(baselineFile));
-											sb.append("\n");
-										}
-
-										if (sb.length() > 0) {
-											project.setProperty("baseline.log.files.content", sb.toString());
-										}
-									]]>
-								</beanshell>
-
-								<if>
-									<isset property="baseline.log.files.content" />
-									<then>
-										<generate-backend-batch-junit-report-gradle-task
-											gradle.task.failure.count="1"
-											gradle.task.failure.message="${gradle.module.dir} failed semantic versioning. Please check the logs for details."
-											gradle.task.failure.stacktrace="${baseline.log.files.content}"
-											gradle.task.module.dir="${gradle.module.dir}"
-											gradle.task.name="${gradle.task.name}"
-											gradle.task.start.time="${gradle.task.start.time}"
-										/>
-									</then>
-								</if>
-							</action-fail>
-						</execute-gradle-task>
-					</sequential>
-				</for>
-
-				<echo>Checking for baseline log files.</echo>
-
-				<gradle-execute dir="modules/test/semantic-versioning-test" task="test">
-					<arg value="-Dmodules.test.class.group=${modules.test.class.group}" />
-					<arg value="-Dproject.dir=${project.dir}" />
-				</gradle-execute>
-
-				<echo>Check for baseline log files completed.</echo>
-			</test-action>
-
-			<test-set-up>
-				<fail message="Please set the property ${modules.test.class.group}" unless="modules.test.class.group" />
-
-				<if>
-					<and>
-						<or>
-							<available file="liferay-portal-bundle-${app.server.type}.tar.gz" />
-							<available file="liferay-portal-bundle-${app.server.type}-${app.server.version}.tar.gz" />
-						</or>
-						<available file="liferay-portal-source.tar.gz" />
-					</and>
-					<then>
-						<local name="bundle.src.file.name" />
-
-						<condition else="liferay-portal-bundle-${app.server.type}.tar.gz" property="bundle.src.file.name" value="liferay-portal-bundle-${app.server.type}-${app.server.version}.tar.gz">
-							<available file="liferay-portal-bundle-${app.server.type}-${app.server.version}.tar.gz" />
-						</condition>
-
-						<execute>
-							tar --extract --gzip --file=${bundle.src.file.name}
-						</execute>
-
-						<antcall inheritAll="false" target="compile" />
-
-						<antcall inheritAll="false" target="install-portal-snapshots" />
-
-						<echo>tar --extract --file=liferay-portal-source.tar.gz modules/core/portal-bootstrap/build/system.packages.extra.mf --gzip --to-stdout --verbose > modules/core/portal-bootstrap/system.packages.extra.mf</echo>
-
-						<execute>
-							<![CDATA[
-								mkdir -p modules/core/portal-bootstrap
-
-								tar --extract --file=liferay-portal-source.tar.gz modules/core/portal-bootstrap/build/system.packages.extra.mf --gzip --to-stdout --verbose > modules/core/portal-bootstrap/system.packages.extra.mf
-							]]>
-						</execute>
-
-						<echo>tar -zxvf liferay-portal-source.tar.gz --wildcards '*.profile-dxp.properties'</echo>
-
-						<trycatch property="tar.failure">
-							<try>
-								<execute>
-									<![CDATA[
-										tar -zxvf liferay-portal-source.tar.gz --wildcards '*.profile-dxp.properties'
-									]]>
-								</execute>
-							</try>
-							<catch>
-								<echo>${tar.failure}</echo>
-							</catch>
-						</trycatch>
-					</then>
-					<else>
-						<prepare-test-build />
-					</else>
-				</if>
-
-				<echo>Deleting stale baseline log files.</echo>
-
-				<for param="log.file">
-					<fileset
-						dir="${project.dir}"
-					>
-						<include name="modules/**/baseline.log" />
-					</fileset>
-					<sequential>
-						<delete file="@{log.file}" />
-					</sequential>
-				</for>
-			</test-set-up>
-		</run-batch-test>
-	</target>
-
 	<target name="modules-unit">
 		<run-batch-test>
 			<test-action>
@@ -10293,51 +10121,48 @@ ${output.content}</echo>
 	</target>
 
 	<target name="semantic-versioning">
+		<propertycopy from="app.server.${app.server.type}.version" name="app.server.version" />
+
 		<run-batch-test>
 			<test-action>
-				<echo>Checking for baseline log files.</echo>
-
-				<var name="log.files" unset="true" />
-
-				<fileset
-					dir="${project.dir}"
-					id="log.files"
-				>
-					<include name="baseline-reports/*.log" />
-					<include name="modules/**/baseline.log" />
-				</fileset>
-
-				<pathconvert pathsep="," property="log.files" refid="log.files" />
-
-				<for list="${log.files}" param="log.file">
-					<sequential>
-						<print-file file.name="@{log.file}" />
-					</sequential>
-				</for>
-
-				<if>
-					<not>
-						<equals arg1="${log.files}" arg2="" />
-					</not>
-					<then>
-						<fail message="Semantic versioning is incorrect." />
-					</then>
-				</if>
-
-				<echo>Check for baseline log files completed.</echo>
+				<ant antfile="${project.dir}/build.xml" dir="${project.dir}" inheritall="false" target="baseline-all">
+					<property name="baseline.all.ant.projects" value="true" />
+					<property name="baseline.all.ignore.failures" value="true" />
+					<property name="baseline.all.report" value="true" />
+				</ant>
 			</test-action>
 
 			<test-set-up>
 				<if>
-					<available file="liferay-portal-source.tar.gz" />
+					<and>
+						<or>
+							<available file="liferay-portal-bundle-${app.server.type}.tar.gz" />
+							<available file="liferay-portal-bundle-${app.server.type}-${app.server.version}.tar.gz" />
+						</or>
+						<available file="liferay-portal-source.tar.gz" />
+					</and>
 					<then>
-						<echo>tar --extract --file=liferay-portal-source.tar.gz modules/core/portal-bootstrap/build/system.packages.extra.mf --gzip --verbose
-tar --extract --file=liferay-portal-source.tar.gz modules/core/portal-bootstrap/lib/biz.aQute.bnd.annotation.jar --gzip --verbose</echo>
+						<local name="bundle.src.file.name" />
+
+						<condition else="liferay-portal-bundle-${app.server.type}.tar.gz" property="bundle.src.file.name" value="liferay-portal-bundle-${app.server.type}-${app.server.version}.tar.gz">
+							<available file="liferay-portal-bundle-${app.server.type}-${app.server.version}.tar.gz" />
+						</condition>
+
+						<execute>
+							tar --extract --gzip --file=${bundle.src.file.name}
+						</execute>
+
+						<antcall inheritAll="false" target="compile" />
+
+						<antcall inheritAll="false" target="install-portal-snapshots" />
+
+						<echo>tar --extract --file=liferay-portal-source.tar.gz modules/core/portal-bootstrap/build/system.packages.extra.mf --gzip --to-stdout --verbose > modules/core/portal-bootstrap/system.packages.extra.mf</echo>
 
 						<execute>
 							<![CDATA[
-								tar --extract --file=liferay-portal-source.tar.gz modules/core/portal-bootstrap/build/system.packages.extra.mf --gzip --verbose
-								tar --extract --file=liferay-portal-source.tar.gz modules/core/portal-bootstrap/lib/biz.aQute.bnd.annotation.jar --gzip --verbose
+								mkdir -p modules/core/portal-bootstrap
+
+								tar --extract --file=liferay-portal-source.tar.gz modules/core/portal-bootstrap/build/system.packages.extra.mf --gzip --to-stdout --verbose > modules/core/portal-bootstrap/system.packages.extra.mf
 							]]>
 						</execute>
 
@@ -10356,6 +10181,9 @@ tar --extract --file=liferay-portal-source.tar.gz modules/core/portal-bootstrap/
 							</catch>
 						</trycatch>
 					</then>
+					<else>
+						<prepare-test-build />
+					</else>
 				</if>
 
 				<echo>Deleting stale baseline log files.</echo>
@@ -10364,28 +10192,12 @@ tar --extract --file=liferay-portal-source.tar.gz modules/core/portal-bootstrap/
 					<fileset
 						dir="${project.dir}"
 					>
-						<include name="baseline-reports/*.log" />
 						<include name="modules/**/baseline.log" />
 					</fileset>
 					<sequential>
 						<delete file="@{log.file}" />
 					</sequential>
 				</for>
-
-				<echo file="build.${user.name}.properties">baseline.jar.report.level=persist</echo>
-
-				<antcall inheritAll="false" target="compile" />
-
-				<antcall inheritAll="false" target="jar" />
-
-				<prepare-test-bundles unit="false" />
-
-				<antcall inheritAll="false" target="compile-test" />
-
-				<echo if:set="env.JENKINS_HOME">ANT_OPTS=${env.ANT_OPTS}</echo>
-
-				<antcall if:set="env.JENKINS_HOME" inheritAll="false" target="clean-up-db2-processes" />
-				<antcall if:set="env.JENKINS_HOME" inheritAll="false" target="clean-up-java-processes" />
 			</test-set-up>
 		</run-batch-test>
 	</target>

--- a/build.xml
+++ b/build.xml
@@ -181,6 +181,127 @@ testray.build.type=EE Development (@{to.branch.name})</echo>
 		<antcall target="deploy" />
 	</target>
 
+	<target name="baseline-all">
+		<property name="baseline.all.ant.projects" value="true" />
+		<property name="baseline.all.ignore.failures" value="false" />
+		<property name="baseline.all.report" value="false" />
+
+		<fileset
+			dir="${project.dir}/modules"
+			id="baseline.all.bnd.files"
+		>
+			<include name="**/bnd.bnd" />
+			<exclude name="**/.*/**" />
+			<exclude name="**/_node-scripts/**" />
+			<exclude name="**/build/**" />
+			<exclude name="**/node_modules/**" />
+			<exclude name="**/node_modules_cache/**" />
+			<exclude name="sdk/**" />
+			<exclude name="test/**" />
+			<exclude name="third-party/**" />
+			<exclude name="util/**" />
+			<contains text="Export-Package:" />
+		</fileset>
+
+		<pathconvert pathsep=" " property="baseline.all.dirs" refid="baseline.all.bnd.files">
+			<regexpmapper from="^.*/modules/(.*)/bnd\.bnd$" handledirsep="true" to="\1" />
+		</pathconvert>
+
+		<for delimiter=" " list="${baseline.all.dirs}" param="baseline.all.dir">
+			<sequential>
+				<delete file="${project.dir}/modules/@{baseline.all.dir}/build/reports/baseline/baseline.log" quiet="true" />
+			</sequential>
+		</for>
+
+		<propertyregex
+			global="true"
+			input="${baseline.all.dirs}"
+			override="true"
+			property="baseline.all.tasks"
+			regexp="/"
+			replace=":"
+		/>
+
+		<propertyregex
+			global="true"
+			input="${baseline.all.tasks}"
+			override="true"
+			property="baseline.all.tasks"
+			regexp="([^ ]+)"
+			replace=":\1:baseline"
+		/>
+
+		<parallel threadCount="2">
+			<sequential>
+				<if>
+					<equals arg1="${baseline.all.ant.projects}" arg2="true" />
+					<then>
+						<delete quiet="true">
+							<fileset
+								dir="${project.dir}/baseline-reports"
+								erroronmissingdir="false"
+								includes="*.log"
+							/>
+						</delete>
+
+						<for list="portal-kernel,portal-impl,portal-test,util-bridges,util-java,util-slf4j,util-taglib" param="baseline.all.project.dir">
+							<sequential>
+								<ant antfile="${project.dir}/@{baseline.all.project.dir}/build.xml" dir="${project.dir}/@{baseline.all.project.dir}" inheritall="false" target="jar" />
+
+								<gradle-execute dir="${project.dir}/@{baseline.all.project.dir}" failonerror="false" forcedcacheenabled="false" stacktrace="false" task="baseline">
+									<arg value="--quiet" />
+									<arg value="-Dbaseline.ignoreFailures=${baseline.all.ignore.failures}" />
+								</gradle-execute>
+							</sequential>
+						</for>
+
+						<fileset
+							dir="${project.dir}/baseline-reports"
+							erroronmissingdir="false"
+							id="baseline.all.log.files"
+							includes="*.log"
+						/>
+
+						<pathconvert pathsep="," property="baseline.all.log.files" refid="baseline.all.log.files" setonempty="false" />
+
+						<if>
+							<isset property="baseline.all.log.files" />
+							<then>
+								<concat>
+									<fileset
+										dir="${project.dir}/baseline-reports"
+										includes="*.log"
+									/>
+								</concat>
+
+								<fail message="Semantic versioning is incorrect." />
+							</then>
+						</if>
+					</then>
+				</if>
+			</sequential>
+			<sequential>
+				<gradle-execute dir="${project.dir}/modules" forcedcacheenabled="false" stacktrace="false" task="">
+					<arg value="--continue" />
+					<arg value="--parallel" />
+					<arg value="--quiet" />
+					<arg line="${baseline.all.tasks}" />
+					<arg value="-Dbaseline.ignoreFailures=${baseline.all.ignore.failures}" />
+				</gradle-execute>
+			</sequential>
+		</parallel>
+
+		<if>
+			<equals arg1="${baseline.all.report}" arg2="true" />
+			<then>
+				<gradle-execute dir="${project.dir}/modules/test/semantic-versioning-test" forcedcacheenabled="false" stacktrace="false" task="test">
+					<arg value="-Dmodules.test.class.group=${baseline.all.tasks}" />
+					<arg value="-Dproject.dir=${project.dir}" />
+				</gradle-execute>
+			</then>
+		</if>
+	</target>
+
 	<target name="baseline-current-branch">
 		<java
 			classname="com.liferay.portal.tools.GitUtil"

--- a/modules/apps/account/account-api/src/main/resources/com/liferay/account/service/packageinfo
+++ b/modules/apps/account/account-api/src/main/resources/com/liferay/account/service/packageinfo
@@ -1,1 +1,1 @@
-version 17.1.0
+version 17.0.0

--- a/modules/apps/site/site-cms-site-initializer-api/bnd.bnd
+++ b/modules/apps/site/site-cms-site-initializer-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Site CMS Site Initializer API
 Bundle-SymbolicName: com.liferay.site.cms.site.initializer.api
-Bundle-Version: 4.5.1
+Bundle-Version: 4.6.0
 Export-Package:\
 	com.liferay.site.cms.site.initializer.bulk.selection,\
 	com.liferay.site.cms.site.initializer.configuration,\

--- a/test.properties
+++ b/test.properties
@@ -629,8 +629,8 @@
     modules.excludes[modules-compile]=\
         third-party/**
 
-    #modules.excludes[modules-semantic-versioning]=
     #modules.excludes[rest-builder]=
+    #modules.excludes[semantic-versioning]=
     #modules.excludes[service-builder]=
 
     #modules.excludes.dxp=
@@ -645,17 +645,17 @@
 
     #modules.includes[modules-compile]=
 
-    modules.includes[modules-semantic-versioning]=\
-        apps/**,\
-        core/**,\
-        dxp/apps/**
-
     modules.includes[rest-builder]=\
         apps/**,\
         core/**,\
         dxp/apps/**,\
         test/**,\
         util/**
+
+    modules.includes[semantic-versioning]=\
+        apps/**,\
+        core/**,\
+        dxp/apps/**
 
     modules.includes[service-builder]=\
         apps/**,\
@@ -664,21 +664,21 @@
         test/**,\
         util/**
 
-    modules.includes.private[modules-semantic-versioning]=\
-        ${modules.includes[modules-semantic-versioning]},\
-        dxp/apps/**
-
     modules.includes.private[rest-builder]=\
         ${modules.includes[rest-builder]},\
+        dxp/apps/**
+
+    modules.includes.private[semantic-versioning]=\
+        ${modules.includes[semantic-versioning]},\
         dxp/apps/**
 
     modules.includes.private[service-builder]=\
         ${modules.includes[service-builder]},\
         dxp/apps/**
 
-    modules.includes.public[modules-semantic-versioning]=${modules.includes[modules-semantic-versioning]}
-
     modules.includes.public[rest-builder]=${modules.includes[rest-builder]}
+
+    modules.includes.public[semantic-versioning]=${modules.includes[semantic-versioning]}
 
     modules.includes.public[service-builder]=${modules.includes[service-builder]}
 
@@ -855,7 +855,6 @@
         ${modules.excludes[js-unit][stable]}
 
     relevant.batch.names.whitelist=\
-        (?:modules-|)semantic-versioning,\
         (?:modules-|js-|)unit(?:-opensearch2|-remote-elasticsearch|_stable|),\
         (?:rest|service)-builder,\
         build-iw,\
@@ -864,6 +863,7 @@
         modules-compile,\
         modules-integration-.*,\
         playwright-.*,\
+        semantic-versioning,\
         workspaces-compile
 
     relevant.engine.enabled=true
@@ -873,7 +873,6 @@
         default-modules-unit-rule,\
         default-unit-rule,\
         modules-compile-rule,\
-        modules-semantic-versioning-rule,\
         playwright-compile-rule,\
         playwright-setup-rule,\
         rest-builder-rule,\
@@ -906,7 +905,6 @@
         modules-integration-opensearch2-mysql84,\
         modules-integration-postgresql163,\
         modules-integration-remote-elasticsearch-mysql84,\
-        modules-semantic-versioning,\
         modules-unit,\
         playwright-js-tomcat101-hypersonic20,\
         playwright-js-tomcat101-postgresql163,\
@@ -974,14 +972,6 @@
     test.batch.names[modules-compile-rule][relevant]=modules-compile
 
     #
-    # Modules Semantic Versioning Rule
-    #
-
-    modified.files.includes[modules-semantic-versioning-rule][relevant]=modules/**
-
-    test.batch.names[modules-semantic-versioning-rule][relevant]=modules-semantic-versioning
-
-    #
     # Playwright Compile Rule
     #
 
@@ -1014,8 +1004,6 @@
     #
     # Semantic Versioning Rule
     #
-
-    modified.files.excludes[semantic-versioning-rule][relevant]=modules/**
 
     modified.files.includes[semantic-versioning-rule][relevant]=**
 
@@ -1429,6 +1417,7 @@
     test.batch.axis.count[playwright-js-tomcat101*]=1
     test.batch.axis.count[rest-builder]=1
     test.batch.axis.count[rest-builder-and-service-builder]=1
+    test.batch.axis.count[semantic-versioning]=1
     test.batch.axis.count[service-builder]=1
     test.batch.axis.count[tck]=1
     test.batch.axis.max.size[functional-*]=7
@@ -1437,12 +1426,10 @@
     test.batch.axis.max.size[modules-integration-project-templates-jdk17_zulu]=5
     test.batch.axis.max.size[modules-integration-project-templates-jdk21_zulu]=5
     test.batch.axis.max.size[modules-integration-*]=20
-    test.batch.axis.max.size[modules-semantic-versioning]=50
     test.batch.axis.max.size[modules-unit*]=100
     test.batch.axis.max.size[modules-unit-project-templates]=25
     test.batch.axis.max.size[modules-unit-project-templates-jdk17_zulu]=15
     test.batch.axis.max.size[modules-unit-project-templates-jdk21_zulu]=15
-    test.batch.axis.max.size[semantic-versioning]=50
     test.batch.axis.max.size[tck]=50
     test.batch.axis.max.size[unit*]=5000
 
@@ -1654,7 +1641,6 @@
         central-requirements,\
         javadoc-test,\
         js-unit,\
-        modules-semantic-versioning,\
         playwright-compile,\
         portal-frontend-js-lint,\
         poshi-validation,\
@@ -2531,7 +2517,6 @@
         lpkg-persistence-postgresql163,\
         lpkg-startup-postgresql163,\
         modules-integration-postgresql163,\
-        modules-semantic-versioning,\
         modules-unit,\
         modules-unit-opensearch2,\
         #patching-tool-postgresql163,\
@@ -2575,9 +2560,9 @@
 
     modules.includes[js-unit][analytics-cloud-upstream]=${analytics.cloud.upstream.testing.modules}
 
-    modules.includes[modules-semantic-versioning][analytics-cloud-upstream]=${analytics.cloud.upstream.testing.modules}
+    modules.includes[semantic-versioning][analytics-cloud-upstream]=${analytics.cloud.upstream.testing.modules}
 
-    modules.includes.public[modules-semantic-versioning][analytics-cloud-upstream]=${analytics.cloud.upstream.testing.modules}
+    modules.includes.public[semantic-versioning][analytics-cloud-upstream]=${analytics.cloud.upstream.testing.modules}
 
     playwright.projects.includes[playwright-js-tomcat101-postgresql163][analytics-cloud-upstream]=\
         analytics-client-js.main,\
@@ -2606,9 +2591,9 @@
     test.batch.names[analytics-cloud-upstream]=\
         js-unit,\
         modules-integration-postgresql163,\
-        modules-semantic-versioning,\
         modules-unit,\
-        playwright-js-tomcat101-postgresql163
+        playwright-js-tomcat101-postgresql163,\
+        semantic-versioning
 
     test.batch.osb.asah.github.url[analytics-cloud-upstream]=https://github.com/liferay/com-liferay-osb-asah-private/tree/7.0.x
 
@@ -2682,7 +2667,6 @@
         functional-tomcat101-mysql84,\
         js-unit,\
         modules-integration-postgresql163,\
-        modules-semantic-versioning,\
         modules-unit,\
         semantic-versioning,\
         unit
@@ -2716,12 +2700,12 @@
         modules-integration-postgresql153,\
         modules-integration-postgresql163,\
         modules-integration-sqlserver2019,\
-        modules-semantic-versioning,\
         modules-unit,\
         release-osgi-state-exploded-test-mysql84,\
         release-osgi-state-lpkg-change-directory-test-mysql84,\
         release-osgi-state-lpkg-test-mysql84,\
         rest-builder,\
+        semantic-versioning,\
         service-builder,\
         source-format,\
         unit
@@ -2840,7 +2824,7 @@
         dxp/apps/portal-workflow/**,\
         dxp/apps/portal-workflow-kaleo-forms/**
 
-    modules.excludes[modules-semantic-versioning][bpm]=\
+    modules.excludes[semantic-versioning][bpm]=\
         apps/portal-security/portal-security-antisamy,\
         apps/portal-security/portal-security-api,\
         apps/portal-security/portal-security-auth-verifier,\
@@ -2864,9 +2848,9 @@
         ${bpm.testing.modules},\
         apps/site/site-cmp-site-initializer
 
-    modules.includes[modules-semantic-versioning][bpm]=${bpm.testing.modules}
+    modules.includes[semantic-versioning][bpm]=${bpm.testing.modules}
 
-    modules.includes.public[modules-semantic-versioning][bpm]=${bpm.testing.modules}
+    modules.includes.public[semantic-versioning][bpm]=${bpm.testing.modules}
 
     playwright.test.project[playwright-js-tomcat101-*][bpm]=\
         ${object.playwright.projects},\
@@ -2908,9 +2892,9 @@
         functional-upgrade-tomcat101-sqlserver2017,\
         js-unit,\
         modules-integration-postgresql163,\
-        modules-semantic-versioning,\
         modules-unit,\
         playwright-js-tomcat101-postgresql163,\
+        semantic-versioning,\
         unit
 
     test.batch.run.property.query[functional-tomcat101-*][bpm]=\
@@ -2965,7 +2949,6 @@
         functional-upgrade-tomcat101-postgresql163,\
         js-unit,\
         modules-integration-postgresql163,\
-        modules-semantic-versioning,\
         modules-unit,\
         playwright-js-tomcat101-postgresql163,\
         semantic-versioning,\
@@ -3251,21 +3234,21 @@
         apps/asset/asset-display-page-*/**,\
         apps/asset/asset-list-*/**
 
-    modules.excludes.public[modules-semantic-versioning][content-management]=\
+    modules.excludes.public[semantic-versioning][content-management]=\
         apps/asset/asset-display-page-api,\
         apps/asset/asset-display-page-item-selector-api,\
         apps/asset/asset-list-api
 
     modules.includes[js-unit][content-management]=${content.management.testing.modules}
 
-    modules.includes[modules-semantic-versioning][content-management]=${content.management.testing.modules}
+    modules.includes[semantic-versioning][content-management]=${content.management.testing.modules}
 
-    modules.includes.private[modules-semantic-versioning][content-management]=\
+    modules.includes.private[semantic-versioning][content-management]=\
         dxp/apps/document-library-opener/**,\
         dxp/apps/sharepoint-rest/**,\
         dxp/apps/sharepoint-soap/**
 
-    modules.includes.public[modules-semantic-versioning][content-management]=${content.management.testing.modules}
+    modules.includes.public[semantic-versioning][content-management]=${content.management.testing.modules}
 
     playwright.projects.includes[playwright-js-tomcat101-*][content-management]=${content.management.playwright.projects}
 
@@ -3323,7 +3306,6 @@
         functional-tomcat101-postgresql163,\
         js-unit,\
         modules-integration-postgresql163,\
-        modules-semantic-versioning,\
         modules-unit,\
         playwright-js-tomcat101-postgresql163,\
         semantic-versioning
@@ -3397,10 +3379,10 @@
     modules.includes[js-unit][cookies]=\
         apps/cookies/**
 
-    modules.includes[modules-semantic-versioning][cookies]=\
+    modules.includes[semantic-versioning][cookies]=\
         apps/cookies/**
 
-    modules.includes.public[modules-semantic-versioning][cookies]=\
+    modules.includes.public[semantic-versioning][cookies]=\
         apps/cookies/**
 
     playwright.projects.includes[playwright-js-tomcat101-postgresql163][cookies]=\
@@ -3506,7 +3488,6 @@
         functional-upgrade-tomcat101-postgresql163,\
         js-unit,\
         modules-integration-postgresql163,\
-        modules-semantic-versioning,\
         modules-unit,\
         semantic-versioning,\
         unit
@@ -3727,7 +3708,6 @@
         functional-upgrade-tomcat101-mysql84,\
         js-unit,\
         modules-integration-postgresql163,\
-        modules-semantic-versioning,\
         modules-unit,\
         semantic-versioning,\
         unit
@@ -3864,8 +3844,8 @@
     test.batch.names[external-document-repositories]=\
         functional-tomcat101-mysql84,\
         modules-integration-postgresql163,\
-        modules-semantic-versioning,\
-        modules-unit
+        modules-unit,\
+        semantic-versioning
 
     test.batch.run.property.query[functional-tomcat101-mysql84][external-document-repositories]=\
         (testray.main.component.name == "External Document Repositories")
@@ -4545,7 +4525,6 @@
         functional-tomcat101-postgresql163,\
         js-unit,\
         modules-integration-postgresql163,\
-        modules-semantic-versioning,\
         modules-unit,\
         playwright-js-tomcat101-postgresql163,\
         semantic-versioning,\
@@ -4688,10 +4667,10 @@
     modules.includes[js-unit][ldap]=\
         apps/portal-security/portal-security-ldap*/**
 
-    modules.includes[modules-semantic-versioning][ldap]=\
+    modules.includes[semantic-versioning][ldap]=\
         apps/portal-security/portal-security-ldap*/**
 
-    modules.includes.public[modules-semantic-versioning][ldap]=\
+    modules.includes.public[semantic-versioning][ldap]=\
         apps/portal-security/portal-security-ldap*/**
 
     playwright.projects.includes[playwright-js-tomcat101-postgresql163][ldap]=\
@@ -4764,10 +4743,10 @@
     modules.includes[js-unit][mfa]=\
         dxp/apps/multi-factor-authentication/**
 
-    modules.includes[modules-semantic-versioning][mfa]=\
+    modules.includes[semantic-versioning][mfa]=\
         dxp/apps/multi-factor-authentication/**
 
-    modules.includes.public[modules-semantic-versioning][mfa]=\
+    modules.includes.public[semantic-versioning][mfa]=\
         dxp/apps/multi-factor-authentication/**
 
     playwright.projects.includes[playwright-js-tomcat101-postgresql163][mfa]=\
@@ -4799,11 +4778,11 @@
         apps/oauth-client/**,\
         apps/oauth2-provider/**
 
-    modules.includes[modules-semantic-versioning][oauth2]=\
+    modules.includes[semantic-versioning][oauth2]=\
         apps/oauth-client/**,\
         apps/oauth2-provider/**
 
-    modules.includes.public[modules-semantic-versioning][oauth2]=\
+    modules.includes.public[semantic-versioning][oauth2]=\
         apps/oauth-client/**,\
         apps/oauth2-provider/**
 
@@ -4872,7 +4851,6 @@
         functional-upgrade-tomcat101-sqlserver2019,\
         js-unit,\
         modules-integration-postgresql163,\
-        modules-semantic-versioning,\
         modules-unit,\
         playwright-js-tomcat101-postgresql163,\
         semantic-versioning
@@ -4916,10 +4894,10 @@
     modules.includes[js-unit][oidc]=\
         apps/portal-security-sso/**
 
-    modules.includes[modules-semantic-versioning][oidc]=\
+    modules.includes[semantic-versioning][oidc]=\
         apps/portal-security-sso/**
 
-    modules.includes.public[modules-semantic-versioning][oidc]=\
+    modules.includes.public[semantic-versioning][oidc]=\
         apps/portal-security-sso/**
 
     playwright.projects.includes[playwright-js-tomcat101-postgresql163][oidc]=\
@@ -4941,17 +4919,17 @@
     # Page Management
     #
 
-    modules.excludes[modules-semantic-versioning][page-management]=\
+    modules.excludes[semantic-versioning][page-management]=\
         apps/layout/layout-set-prototype-web
 
-    modules.excludes.public[modules-semantic-versioning][page-management]=\
+    modules.excludes.public[semantic-versioning][page-management]=\
         apps/layout/layout-set-prototype-web
 
     modules.includes[js-unit][page-management]=${page.management.testing.modules}
 
-    modules.includes[modules-semantic-versioning][page-management]=${page.management.testing.modules}
+    modules.includes[semantic-versioning][page-management]=${page.management.testing.modules}
 
-    modules.includes.public[modules-semantic-versioning][page-management]=${page.management.testing.modules}
+    modules.includes.public[semantic-versioning][page-management]=${page.management.testing.modules}
 
     page.management.headless.admin.site.integration.tests=\
         **/headless/headless-admin-site/**/DisplayPageTemplateFolderResourceTest.java,\
@@ -5043,9 +5021,9 @@
     test.batch.names[page-management]=\
         js-unit,\
         modules-integration-postgresql163,\
-        modules-semantic-versioning,\
         modules-unit,\
-        playwright-js-tomcat101-postgresql163
+        playwright-js-tomcat101-postgresql163,\
+        semantic-versioning
 
     #
     # Page Management Playwright
@@ -5614,10 +5592,10 @@
     # Product Analytics
     #
 
-    modules.includes[modules-semantic-versioning][product-analytics]=\
+    modules.includes[semantic-versioning][product-analytics]=\
         apps/product-analytics/**
 
-    modules.includes.public[modules-semantic-versioning][product-analytics]=\
+    modules.includes.public[semantic-versioning][product-analytics]=\
         apps/product-analytics/**
 
     playwright.projects.includes[playwright-js-tomcat101-postgresql163][product-analytics]=\
@@ -5644,10 +5622,10 @@
     # Publications
     #
 
-    modules.includes[modules-semantic-versioning][publications]=\
+    modules.includes[semantic-versioning][publications]=\
         apps/change-tracking/**
 
-    modules.includes.public[modules-semantic-versioning][publications]=\
+    modules.includes.public[semantic-versioning][publications]=\
         apps/change-tracking/**
 
     playwright.projects.includes[playwright-js-tomcat101-*][publications]=\
@@ -5671,7 +5649,6 @@
         functional-upgrade-tomcat101-postgresql163,\
         functional-upgrade-tomcat101-sqlserver2019,\
         modules-integration-postgresql163,\
-        modules-semantic-versioning,\
         modules-unit,\
         playwright-js-tomcat101-postgresql163,\
         semantic-versioning
@@ -5892,7 +5869,6 @@
         functional-tomcat101-mysql84,\
         js-unit,\
         modules-integration-postgresql163,\
-        modules-semantic-versioning,\
         modules-unit,\
         semantic-versioning,\
         unit
@@ -5911,10 +5887,10 @@
     modules.includes[js-unit][saml]=\
         dxp/apps/saml/**
 
-    modules.includes[modules-semantic-versioning][saml]=\
+    modules.includes[semantic-versioning][saml]=\
         dxp/apps/saml/**
 
-    modules.includes.public[modules-semantic-versioning][saml]=\
+    modules.includes.public[semantic-versioning][saml]=\
         dxp/apps/saml/**
 
     playwright.projects.includes[playwright-js-tomcat101-postgresql163][saml]=\
@@ -5938,10 +5914,10 @@
     modules.includes[js-unit][scim]=\
         dxp/apps/scim/**
 
-    modules.includes[modules-semantic-versioning][scim]=\
+    modules.includes[semantic-versioning][scim]=\
         dxp/apps/scim/**
 
-    modules.includes.public[modules-semantic-versioning][scim]=\
+    modules.includes.public[semantic-versioning][scim]=\
         dxp/apps/scim/**
 
     playwright.projects.includes[playwright-js-tomcat101-postgresql163][scim]=\
@@ -6188,7 +6164,6 @@
         functional-wildfly300-postgresql155,\
         js-unit,\
         modules-integration-postgresql163,\
-        modules-semantic-versioning,\
         modules-unit,\
         playwright-js-tomcat101-postgresql163,\
         semantic-versioning,\
@@ -6298,7 +6273,6 @@
         functional-upgrade-tomcat101-mysql84,\
         js-unit,\
         modules-integration-postgresql163,\
-        modules-semantic-versioning,\
         modules-unit,\
         semantic-versioning,\
         unit
@@ -6814,14 +6788,14 @@
     modules.excludes[js-unit][site-management]=\
         apps/site/site-cms-site-initializer/**
 
-    modules.excludes.public[modules-semantic-versioning][site-management]=\
+    modules.excludes.public[semantic-versioning][site-management]=\
         apps/site-navigation/site-navigation-language-api
 
     modules.includes[js-unit][site-management]=${site.management.testing.modules}
 
-    modules.includes[modules-semantic-versioning][site-management]=${site.management.testing.modules}
+    modules.includes[semantic-versioning][site-management]=${site.management.testing.modules}
 
-    modules.includes.public[modules-semantic-versioning][site-management]=${site.management.testing.modules}
+    modules.includes.public[semantic-versioning][site-management]=${site.management.testing.modules}
 
     playwright.projects.includes[playwright-js-tomcat101-*][site-management]=\
         friendly-url-web.main,\
@@ -6867,7 +6841,6 @@
     test.batch.names[site-management]=\
         js-unit,\
         modules-integration-postgresql163,\
-        modules-semantic-versioning,\
         modules-unit,\
         playwright-js-tomcat101-postgresql163,\
         semantic-versioning
@@ -7058,9 +7031,9 @@
 
     modules.includes[js-unit][um]=${um.testing.modules}
 
-    modules.includes[modules-semantic-versioning][um]=${um.testing.modules}
+    modules.includes[semantic-versioning][um]=${um.testing.modules}
 
-    modules.includes.public[modules-semantic-versioning][um]=${um.testing.modules}
+    modules.includes.public[semantic-versioning][um]=${um.testing.modules}
 
     playwright.projects.includes[playwright-js-tomcat101-*][um]=${um.playwright.projects}
 
@@ -7102,7 +7075,6 @@
         functional-tomcat101-postgresql163,\
         js-unit,\
         modules-integration-postgresql163,\
-        modules-semantic-versioning,\
         modules-unit,\
         playwright-js-tomcat101-postgresql163,\
         semantic-versioning,\
@@ -7569,7 +7541,6 @@
         lpkg-startup-mysql80,\
         modules-integration-db-partition-postgresql163,\
         modules-integration-postgresql163,\
-        modules-semantic-versioning,\
         modules-unit,\
         playwright-js-tomcat101-postgresql163,\
         portal-license-smoke-mysql84,\
@@ -7743,7 +7714,6 @@
         functional-upgrade-tomcat101-postgresql163,\
         js-unit,\
         modules-integration-postgresql163,\
-        modules-semantic-versioning,\
         modules-unit,\
         playwright-js-tomcat101-postgresql163,\
         semantic-versioning,\
@@ -8027,7 +7997,6 @@
     testray.component.name[lpkg-*]=LPKG
     testray.component.name[modules-compile*]=Modules Compile
     testray.component.name[modules-integration*]=Modules Integration
-    testray.component.name[modules-semantic-versioning*]=Modules Semantic Versioning
     testray.component.name[modules-unit*]=Modules Unit
     testray.component.name[patching-tool*]=Patching Tool
     testray.component.name[playwright-compile*]=Playwright Compile
@@ -8473,7 +8442,6 @@
         JS Unit,\
         Modules Compile,\
         Modules Integration,\
-        Modules Semantic Versioning,\
         Modules Unit,\
         Playwright,\
         Playwright Compile,\

--- a/test.properties
+++ b/test.properties
@@ -868,20 +868,7 @@
 
     relevant.engine.enabled=true
 
-    relevant.rule.names=\
-        default-modules-integration-rule,\
-        default-modules-unit-rule,\
-        default-unit-rule,\
-        modules-compile-rule,\
-        playwright-compile-rule,\
-        playwright-setup-rule,\
-        rest-builder-rule,\
-        semantic-versioning-rule,\
-        service-builder-rule,\
-        stable-rule,\
-        staging-playwright-rule,\
-        staging-rule,\
-        workspaces-rule
+    relevant.rule.names=semantic-versioning-rule
 
     test.batch.class.names.excludes[unit][relevant]=\
         ${test.batch.class.names.excludes}


### PR DESCRIPTION
CI verification of the reworked `semantic-versioning` batch. **Not for merge.**

The batch is shrunk to itself (`relevant.rule.names=semantic-versioning-rule`), so a run
executes semantic versioning and nothing else.

**Expected:** red, and only `account-api`'s case fails while every other passes

Base of the series: the batch now calls `ant baseline-all` once instead of one Gradle
invocation per app directory, and the portal batch is folded in, taking five jobs to one.
