### PR TITLE
LPD-102617 Wait for the object to save before restoring the account title field

### DIFF
--- a/modules/test/playwright/tests/object-web/main/systemObjectAccount.spec.ts
+++ b/modules/test/playwright/tests/object-web/main/systemObjectAccount.spec.ts
@@ -15,6 +15,7 @@ import {loginTest} from '../../../fixtures/loginTest';
 import {objectPagesTest} from '../../../fixtures/objectPagesTest';
 import {getRandomInt} from '../../../utils/getRandomInt';
 import {performUserSwitch, userData} from '../../../utils/performLogin';
+import {waitForAlert} from '../../../utils/waitForAlert';
 import {generateObjectFields} from '../utils/generateObjectFields';
 
 const test = mergeTests(
@@ -745,7 +746,7 @@ test('edit title field on system account', async ({
 
 		await page.getByRole('button', {name: 'Save'}).click();
 
-		await page.waitForLoadState('networkidle');
+		await waitForAlert(page, 'The object was saved successfully.');
 
 		await expect(titleFieldGroup.getByRole('combobox')).toHaveText(/Type/);
 
@@ -755,7 +756,7 @@ test('edit title field on system account', async ({
 
 		await page.getByRole('button', {name: 'Save'}).click();
 
-		await page.waitForLoadState('networkidle');
+		await waitForAlert(page, 'The object was saved successfully.');
 	}
 	finally {
 		await objectDefinitionAPIClient.patchObjectDefinition(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102617

## What Is Being Fixed

`object-web/main/systemObjectAccount.spec.ts` "edit title field on system account" fails about one run in five on CI — 20 of the last 100 recorded results, all with the same signature, and most of them on runs that are not mine (nightlies, other engineers' pull requests, frozen release branches):

```
Error: HTTP Error 500: . {
  "status" : "INTERNAL_SERVER_ERROR",
  "title" : "Internal Server Error"
}
    at ObjectDefinitionAPI.patchObjectDefinitionWithContentType (ObjectDefinitionAPI.ts:347:11)
    at systemObjectAccount.spec.ts:761:3
```

The test drives two saves through the UI, then restores the title field over REST in a `finally` block. Between the last Save click and that write it waits on network idle, which returns before the click's request reaches the wire — the first save held that wait two seconds, the second released it in a tenth of one. The cleanup write then goes out while the browser is still saving, and both write the same object definition row.

## How It Is Being Fixed

Wait for the save alert instead of network idle. The alert appears only once the save response has come back, so the save has finished before the cleanup asks for anything.

## Evidence

CI archives no portal log for playwright axes, so the server side came from a local reproduction (~5 failures in 6 with the title field restored first). The server throws an optimistic lock failure, and a ledger of every write to that row — recording the version each carries and the thread it runs on — pinned the collision:

```
write t=...428485 thread=exec-8 mvccVersion=345
done  t=...428487 thread=exec-8 mvccVersion=345
write t=...428497 thread=exec-8 mvccVersion=346
done  t=...428497 thread=exec-8 mvccVersion=346
write t=...428498 thread=exec-9 mvccVersion=345   <- fails
```

Two threads, so two requests: the browser's save and the test's cleanup. The cleanup read the row at version 345 and writes it **one millisecond** after the save moved it to 346. The window is wider than a single write because saving an object definition writes the row **twice** — once for the definition, once to put the title field back, about twelve milliseconds apart — and the cleanup reads before the first and writes after the second.

With the fix, the same ledger shows the cleanup starting nearly three hundred milliseconds after the save finished, versions advancing one by one, and no write reusing a version it did not read: **120 writes, zero conflicts**.

| arm | runs | failed |
| --- | --- | --- |
| before | 60 | **50** |
| after | 20 | **0** |

The test also passed on a full `ci:test:object` run.

## Out Of Scope

Two backend gaps found while investigating are deliberately left out and deserve their own tickets:

- An optimistic lock failure across requests answers with a bare `500` instead of a conflict status, because no problem mapper matches it. It also logs at ERROR, which `PortalLogAssertorTest` fails on.
- The patch endpoint offers clients no version token with which to detect a lost update.

## PR Check

| Validation | Result |
| --- | --- |
| Source Format (`format-source-current-branch`) | SUCCESS |
| ESLint (changed spec) | clean |
| Playwright (the changed test) | 20/20 |

Other validations do not fire: the diff is a single `.ts` spec, with no Java, `bnd.bnd`, `packageinfo`, `.gradle`, service or REST descriptor change. `@liferay/playwright`'s `test` script is `playwright test`, not Jest, so the JavaScript unit validation resolves to running the spec itself.
