### PR TITLE
LPD-102618 Correct the claim that ant all baselines nothing

### DIFF
--- a/.claude/skills/pr-check/validations/baseline.md
+++ b/.claude/skills/pr-check/validations/baseline.md
@@ -16,7 +16,7 @@ Do not narrow it to the branch diff. The comparison target is resolved from Nexu
 (cd "${REPO_ROOT}" && ant baseline-all)
 ```
 
-Leave `baseline.all.ant.projects` at its default of `true`. Passing `false` drops the seven top level Ant projects — `portal-kernel`, `portal-impl`, `portal-test`, `util-bridges`, `util-java`, `util-slf4j`, and `util-taglib` — from the run. **Full Portal Build** is not a reason to pass it: `ant all` is `clean` plus `compile` plus `deploy` and baselines nothing. The target builds each of those jars itself before baselining it, so there is no build to arrange first.
+Leave `baseline.all.ant.projects` at its default of `true`. Passing `false` drops the seven top level Ant projects — `portal-kernel`, `portal-impl`, `portal-test`, `util-bridges`, `util-java`, `util-slf4j`, and `util-taglib` — from the run. Pass it only when **Full Portal Build** ran in this same pr-check: `ant all` starts with `clean`, so each of those jars is rebuilt, and the `jar` target baselines it on the way through.
 
 Two prerequisites:
 

--- a/modules/apps/site/site-pim-site-initializer-test-util/bnd.bnd
+++ b/modules/apps/site/site-pim-site-initializer-test-util/bnd.bnd
@@ -1,4 +1,4 @@
 Bundle-Name: Liferay Site PIM Site Initializer Test Utilities
 Bundle-SymbolicName: com.liferay.site.pim.site.initializer.test.util
-Bundle-Version: 1.0.2
+Bundle-Version: 1.1.0
 Export-Package: com.liferay.site.pim.site.initializer.test.util

--- a/modules/apps/site/site-pim-site-initializer-test-util/src/main/resources/com/liferay/site/pim/site/initializer/test/util/packageinfo
+++ b/modules/apps/site/site-pim-site-initializer-test-util/src/main/resources/com/liferay/site/pim/site/initializer/test/util/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102618

Follow-up to #180237, correcting one paragraph in the baseline validation.

## What Is Being Fixed

`766f55d826e032a4423ff844ff03db2af2afba18` states that **Full Portal Build** is not a reason to pass `baseline.all.ant.projects=false`, because `ant all` "is `clean` plus `compile` plus `deploy` and baselines nothing." `ant all` does baseline the seven top level Ant projects.

## How It Is Being Fixed

The baseline runs inside the `jar` target rather than at the top level, which is why it is not visible in `ant all` itself:

- `build-common-java.xml:117` — `jar` runs `<gradle-execute task="baseline" />` unless `baseline.jar.report.level` is `off`.
- `build.properties:16` — that property defaults to `persist`.
- `build-common-java.xml:59` — `deploy` depends on `jar`, and root `deploy` calls all seven (`build.xml:479-488`).
- `ant all` begins with `clean`, so `jar.uptodate` cannot skip it.

Observed directly:

```
$ cd util-slf4j && rm -f util-slf4j.jar && ant jar
compile:
init-jar:
build-common-java.jar:
[beanshell] Executing Gradle task: baseline
     [exec] > Task :baseline
     [exec] BUILD SUCCESSFUL in 681ms
jar:
```

The wording keeps the simplified `ant baseline-all` command and the list of the seven projects; only the claim about `ant all` changes.

Based on `brianchandotcom/master` rather than `upstream/master`, since the commit being corrected has not synced upstream yet.

## Semantic Versioning

The second commit is a bump this branch did not cause. `com.liferay.site.pim.site.initializer.test.util` needs `1.0.0` to `1.1.0` (`VERSION INCREASE REQUIRED`, MINOR) because `4c24409903b82` added `PIMBaseSKUTestUtil` without bumping the package. The baseline validation repairs and commits minor bumps, so it is carried here and called out.

## PR Check

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Baseline | PASS — finding above auto-fixed and committed; rerun clean |

<!-- pr-check {"result": "success", "sha": "bb283f993425ba0b2143c9cd4ea68b3bb6c80236"} -->
