### PR TITLE
LPD-102620 Draw a free class name for the object test system objects

### DIFF
--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/util/ObjectDefinitionTestUtil.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/util/ObjectDefinitionTestUtil.java
@@ -6,7 +6,6 @@
 package com.liferay.object.admin.rest.resource.v1_0.test.util;
 
 import com.liferay.object.constants.ObjectDefinitionConstants;
-import com.liferay.object.definition.util.ObjectDefinitionUtil;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -58,11 +57,12 @@ public class ObjectDefinitionTestUtil {
 		return ObjectDefinitionLocalServiceUtil.addSystemObjectDefinition(
 			"L_" + StringUtil.toLowerCase(RandomTestUtil.randomString()),
 			TestPropsValues.getUserId(), 0,
-			ObjectDefinitionUtil.generateRandomClassName(), null, true, false,
-			true, false, false, false, false, false, false, false, null,
-			LocalizedMapUtil.getLocalizedMap(value), true, "Test", null, null,
-			null, null, LocalizedMapUtil.getLocalizedMap(value), true,
-			ObjectDefinitionConstants.SCOPE_COMPANY, null, 1, 0,
+			com.liferay.object.test.util.ObjectDefinitionTestUtil.
+				getUniqueRandomClassName(),
+			null, true, false, true, false, false, false, false, false, false,
+			false, null, LocalizedMapUtil.getLocalizedMap(value), true, "Test",
+			null, null, null, null, LocalizedMapUtil.getLocalizedMap(value),
+			true, ObjectDefinitionConstants.SCOPE_COMPANY, null, 1, 0,
 			Collections.emptyList(), Collections.emptyList(),
 			Collections.emptyList());
 	}

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/util/ObjectDefinitionUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/util/ObjectDefinitionUtil.java
@@ -16,7 +16,6 @@ import com.liferay.portal.events.StartupHelperUtil;
 import com.liferay.portal.kernel.portlet.FriendlyURLResolver;
 import com.liferay.portal.kernel.portlet.FriendlyURLResolverRegistryUtil;
 import com.liferay.portal.kernel.portlet.constants.FriendlyURLResolverConstants;
-import com.liferay.portal.kernel.security.RandomUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.PortalRunMode;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -28,20 +27,6 @@ import java.util.Map;
  * @author Alejandro Tardín
  */
 public class ObjectDefinitionUtil {
-
-	public static String generateRandomClassName() {
-		StringBuilder sb = new StringBuilder();
-
-		sb.append(
-			ObjectDefinitionConstants.
-				CLASS_NAME_PREFIX_CUSTOM_OBJECT_DEFINITION);
-		sb.append(StringUtil.toUpperCase(StringUtil.randomId(1)));
-		sb.append(RandomUtil.nextInt(10));
-		sb.append(StringUtil.toUpperCase(StringUtil.randomId(1)));
-		sb.append(RandomUtil.nextInt(10));
-
-		return sb.toString();
-	}
 
 	public static String getItemClassName(ObjectDefinition objectDefinition) {
 		if (objectDefinition.isSystem()) {

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/definition/util/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/definition/util/packageinfo
@@ -1,1 +1,1 @@
-version 3.5.0
+version 4.0.0

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -154,6 +154,7 @@ import com.liferay.portal.kernel.portlet.FriendlyURLResolver;
 import com.liferay.portal.kernel.portlet.FriendlyURLResolverRegistryUtil;
 import com.liferay.portal.kernel.search.Indexable;
 import com.liferay.portal.kernel.search.IndexableType;
+import com.liferay.portal.kernel.security.RandomUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.permission.ResourceActions;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
@@ -1220,7 +1221,7 @@ public class ObjectDefinitionLocalServiceImpl
 		ObjectDefinition objectDefinition =
 			objectDefinitionPersistence.findByPrimaryKey(objectDefinitionId);
 
-		String className = _getClassName(
+		String className = _getUniqueClassName(
 			objectDefinition.getClassName(), objectDefinition.isModifiable(),
 			objectDefinition.isSystem());
 
@@ -1591,7 +1592,7 @@ public class ObjectDefinitionLocalServiceImpl
 		objectDefinition.setActive(
 			_isUnmodifiableSystemObject(modifiable, system));
 		objectDefinition.setClassName(
-			_getClassName(className, modifiable, system));
+			_getUniqueClassName(className, modifiable, system));
 		objectDefinition.setDBTableName(dbTableName);
 		objectDefinition.setEnableCategorization(enableCategorization);
 		objectDefinition.setEnableComments(enableComments);
@@ -2278,31 +2279,6 @@ public class ObjectDefinitionLocalServiceImpl
 		runSQL("DROP_TABLE_IF_EXISTS(" + dbTableName + ")");
 	}
 
-	private String _getClassName(
-		String className, boolean modifiable, boolean system) {
-
-		if (_isUnmodifiableSystemObject(modifiable, system)) {
-			return className;
-		}
-
-		if (Validator.isNotNull(className)) {
-			int count = _getObjectDefinitionsCountByClassName(className);
-
-			if (count == 0) {
-				return className;
-			}
-		}
-
-		while (true) {
-			String randomClassName =
-				ObjectDefinitionUtil.generateRandomClassName();
-
-			if (_getObjectDefinitionsCountByClassName(randomClassName) == 0) {
-				return randomClassName;
-			}
-		}
-	}
-
 	private Set<Long> _getClassNameIds(String className) {
 		Set<Long> classNameIds = new HashSet<>();
 
@@ -2443,6 +2419,36 @@ public class ObjectDefinitionLocalServiceImpl
 		}
 
 		return "c_" + pkObjectFieldName;
+	}
+
+	private String _getUniqueClassName(
+		String className, boolean modifiable, boolean system) {
+
+		if (_isUnmodifiableSystemObject(modifiable, system)) {
+			return className;
+		}
+
+		if (Validator.isNotNull(className)) {
+			int count = _getObjectDefinitionsCountByClassName(className);
+
+			if (count == 0) {
+				return className;
+			}
+		}
+
+		while (true) {
+			String randomClassName = StringBundler.concat(
+				ObjectDefinitionConstants.
+					CLASS_NAME_PREFIX_CUSTOM_OBJECT_DEFINITION,
+				StringUtil.toUpperCase(StringUtil.randomId(1)),
+				RandomUtil.nextInt(10),
+				StringUtil.toUpperCase(StringUtil.randomId(1)),
+				RandomUtil.nextInt(10));
+
+			if (_getObjectDefinitionsCountByClassName(randomClassName) == 0) {
+				return randomClassName;
+			}
+		}
 	}
 
 	private <E extends Exception> void _handleException(
@@ -2823,7 +2829,7 @@ public class ObjectDefinitionLocalServiceImpl
 
 		if (Validator.isNull(oldClassName)) {
 			objectDefinition.setClassName(
-				_getClassName(
+				_getUniqueClassName(
 					className, objectDefinition.isModifiable(),
 					objectDefinition.isSystem()));
 		}

--- a/modules/apps/object/object-test-util/src/main/java/com/liferay/object/test/util/ObjectDefinitionTestUtil.java
+++ b/modules/apps/object/object-test-util/src/main/java/com/liferay/object/test/util/ObjectDefinitionTestUtil.java
@@ -7,14 +7,15 @@ package com.liferay.object.test.util;
 
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectFieldConstants;
-import com.liferay.object.definition.util.ObjectDefinitionUtil;
 import com.liferay.object.field.builder.TextObjectFieldBuilder;
 import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.WorkflowDefinitionLink;
 import com.liferay.portal.kernel.portlet.constants.FriendlyURLResolverConstants;
+import com.liferay.portal.kernel.security.RandomUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -133,13 +134,12 @@ public class ObjectDefinitionTestUtil {
 		throws Exception {
 
 		return ObjectDefinitionLocalServiceUtil.addSystemObjectDefinition(
-			null, userId, 0, ObjectDefinitionUtil.generateRandomClassName(),
-			dbTableName, true, false, true, false, true, false, false, false,
-			false, false, null, labelMap, true, name, null, null,
-			pkObjectFieldDBColumnName, pkObjectFieldName, pluralLabelMap, false,
-			scope, titleObjectFieldName, version,
-			WorkflowConstants.STATUS_DRAFT, Collections.emptyList(),
-			objectFields, Collections.emptyList());
+			null, userId, 0, getUniqueRandomClassName(), dbTableName, true,
+			false, true, false, true, false, false, false, false, false, null,
+			labelMap, true, name, null, null, pkObjectFieldDBColumnName,
+			pkObjectFieldName, pluralLabelMap, false, scope,
+			titleObjectFieldName, version, WorkflowConstants.STATUS_DRAFT,
+			Collections.emptyList(), objectFields, Collections.emptyList());
 	}
 
 	public static ObjectDefinition addUnmodifiableSystemObjectDefinition(
@@ -166,6 +166,32 @@ public class ObjectDefinitionTestUtil {
 
 	public static String getRandomName() {
 		return "A" + RandomTestUtil.randomString();
+	}
+
+	public static String getUniqueRandomClassName() throws Exception {
+
+		// Draw until the name is free, as
+		// ObjectDefinitionLocalServiceImpl._getUniqueClassName does, so a
+		// generated name does not conflict with one already taken.
+
+		while (true) {
+			String className = StringBundler.concat(
+				ObjectDefinitionConstants.
+					CLASS_NAME_PREFIX_CUSTOM_OBJECT_DEFINITION,
+				StringUtil.toUpperCase(StringUtil.randomId(1)),
+				RandomUtil.nextInt(10),
+				StringUtil.toUpperCase(StringUtil.randomId(1)),
+				RandomUtil.nextInt(10));
+
+			ObjectDefinition objectDefinition =
+				ObjectDefinitionLocalServiceUtil.
+					fetchObjectDefinitionByClassName(
+						TestPropsValues.getCompanyId(), className);
+
+			if (objectDefinition == null) {
+				return className;
+			}
+		}
 	}
 
 	public static ObjectDefinition publishObjectDefinition() throws Exception {

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
@@ -34,7 +34,6 @@ import com.liferay.object.constants.ObjectFieldSettingConstants;
 import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.object.constants.ObjectRelationshipConstants;
 import com.liferay.object.definition.setting.builder.ObjectDefinitionSettingBuilder;
-import com.liferay.object.definition.util.ObjectDefinitionUtil;
 import com.liferay.object.definition.util.ObjectDefinitionValidationThreadLocal;
 import com.liferay.object.exception.DuplicateObjectDefinitionExternalReferenceCodeException;
 import com.liferay.object.exception.NoSuchObjectDefinitionException;
@@ -2087,7 +2086,7 @@ public class ObjectDefinitionLocalServiceTest {
 		objectDefinition =
 			_objectDefinitionLocalService.addSystemObjectDefinition(
 				null, TestPropsValues.getUserId(), 0,
-				ObjectDefinitionUtil.generateRandomClassName(), null, true,
+				ObjectDefinitionTestUtil.getUniqueRandomClassName(), null, true,
 				false, true, false, true, false, false, false, false, false,
 				null, RandomTestUtil.randomLocaleStringMap(), true, "Test",
 				null, null, null, null, RandomTestUtil.randomLocaleStringMap(),
@@ -5215,7 +5214,7 @@ public class ObjectDefinitionLocalServiceTest {
 		ObjectDefinition objectDefinition =
 			ObjectDefinitionLocalServiceUtil.addSystemObjectDefinition(
 				null, TestPropsValues.getUserId(), 0,
-				ObjectDefinitionUtil.generateRandomClassName(), null,
+				ObjectDefinitionTestUtil.getUniqueRandomClassName(), null,
 				enableCategorization, false, true, false, true, false, true,
 				false, false, false, null,
 				RandomTestUtil.randomLocaleStringMap(), true, "Test", null,

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionServiceTest.java
@@ -11,7 +11,6 @@ import com.liferay.object.constants.ObjectConstants;
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.constants.ObjectFolderConstants;
-import com.liferay.object.definition.util.ObjectDefinitionUtil;
 import com.liferay.object.field.builder.TextObjectFieldBuilder;
 import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.model.ObjectDefinition;
@@ -528,9 +527,9 @@ public class ObjectDefinitionServiceTest {
 
 			_objectDefinitionService.addSystemObjectDefinition(
 				RandomTestUtil.randomString(), user.getUserId(), objectFolderId,
-				ObjectDefinitionUtil.generateRandomClassName(), true, false,
-				true, false, true, false, false, false, false, false, null,
-				RandomTestUtil.randomLocaleStringMap(),
+				ObjectDefinitionTestUtil.getUniqueRandomClassName(), true,
+				false, true, false, true, false, false, false, false, false,
+				null, RandomTestUtil.randomLocaleStringMap(),
 				ObjectDefinitionTestUtil.
 					getRandomModifiableSystemObjectDefinitionName(),
 				null, null, RandomTestUtil.randomLocaleStringMap(), false,

--- a/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/service/test/CMPPermissionsObjectDefinitionLocalServiceWrapperTest.java
+++ b/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/service/test/CMPPermissionsObjectDefinitionLocalServiceWrapperTest.java
@@ -10,13 +10,13 @@ import com.liferay.depot.constants.DepotRolesConstants;
 import com.liferay.object.constants.ObjectActionKeys;
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectFieldConstants;
-import com.liferay.object.definition.util.ObjectDefinitionUtil;
 import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectFolder;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
 import com.liferay.object.service.ObjectFolderLocalService;
+import com.liferay.object.test.util.ObjectDefinitionTestUtil;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.Role;
@@ -98,7 +98,7 @@ public class CMPPermissionsObjectDefinitionLocalServiceWrapperTest {
 			ObjectDefinitionLocalServiceUtil.addSystemObjectDefinition(
 				null, TestPropsValues.getUserId(),
 				objectFolder.getObjectFolderId(),
-				ObjectDefinitionUtil.generateRandomClassName(), null, true,
+				ObjectDefinitionTestUtil.getUniqueRandomClassName(), null, true,
 				false, true, false, true, false, false, false, false, false,
 				null,
 				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/info/item/provider/test/ObjectEntryInfoItemFriendlyURLProviderTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/info/item/provider/test/ObjectEntryInfoItemFriendlyURLProviderTest.java
@@ -17,7 +17,6 @@ import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.object.definition.setting.builder.ObjectDefinitionSettingBuilder;
-import com.liferay.object.definition.util.ObjectDefinitionUtil;
 import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
@@ -25,6 +24,7 @@ import com.liferay.object.model.ObjectFolder;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectFolderLocalService;
+import com.liferay.object.test.util.ObjectDefinitionTestUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.LanguageUtil;
@@ -89,7 +89,7 @@ public class ObjectEntryInfoItemFriendlyURLProviderTest {
 			_objectDefinitionLocalService.addSystemObjectDefinition(
 				null, TestPropsValues.getUserId(),
 				objectFolder.getObjectFolderId(),
-				ObjectDefinitionUtil.generateRandomClassName(), null, true,
+				ObjectDefinitionTestUtil.getUniqueRandomClassName(), null, true,
 				false, true, false, true, false, false, false, false, false,
 				null,
 				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/service/test/ObjectEntryLocalServiceTest.java
@@ -20,7 +20,6 @@ import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.object.definition.setting.builder.ObjectDefinitionSettingBuilder;
-import com.liferay.object.definition.util.ObjectDefinitionUtil;
 import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
@@ -31,6 +30,7 @@ import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
 import com.liferay.object.service.ObjectEntryFolderLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectFolderLocalService;
+import com.liferay.object.test.util.ObjectDefinitionTestUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
@@ -117,7 +117,7 @@ public class ObjectEntryLocalServiceTest {
 			_objectDefinitionLocalService.addSystemObjectDefinition(
 				null, TestPropsValues.getUserId(),
 				objectFolder.getObjectFolderId(),
-				ObjectDefinitionUtil.generateRandomClassName(), null, true,
+				ObjectDefinitionTestUtil.getUniqueRandomClassName(), null, true,
 				false, true, false, true, false, false, false, false, false,
 				null,
 				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
@@ -190,7 +190,7 @@ public class ObjectEntryLocalServiceTest {
 			ObjectDefinitionLocalServiceUtil.addSystemObjectDefinition(
 				null, TestPropsValues.getUserId(),
 				objectFolder.getObjectFolderId(),
-				ObjectDefinitionUtil.generateRandomClassName(), null, true,
+				ObjectDefinitionTestUtil.getUniqueRandomClassName(), null, true,
 				false, true, false, true, false, false, false, false, false,
 				null,
 				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102620

Resend of #180241 with the rename you asked for: `getRandomClassName` is now `getUniqueRandomClassName`, and the service side private it mirrors, `_getClassName`, is now `_getUniqueClassName`.

## What Is Being Fixed

Tests that add a modifiable system object definition draw the class name from `ObjectDefinitionUtil.generateRandomClassName` and use whatever comes back. The name is four characters wide over a namespace of 67,600, and the batch engine units hold a handful of those names for good — 13 in the company a CI run builds — so a draw eventually lands on one and the service rejects it:

```
testAddSystemObjectRelationship: com.liferay.object.exception.ObjectDefinitionClassNameException$MustNotBeDuplicate:
Duplicate class name com.liferay.object.model.ObjectDefinition#E8D0
```

`#E8D0` is `NecessaryCookieEntry`, hardcoded in the cookies batch data that every portal applies. The add sits in a `@Before` hook, so it surfaces as a failure of whichever test happened to be running.

`_validateClassName` rejects a supplied duplicate **before** reaching `_getUniqueClassName`, the code that would draw again — so an unlucky draw is fatal rather than retried.

**Root cause:** `c020387c9aef7` ("LPD-73421 Provide the class name when creating a modifiable system object in tests") replaced a `null` class name with the draw. A `null` one had been safe, because the service then named the object itself and re-rolled until it found one free.

## How It Is Being Fixed

Three commits:

1. **All eight test call sites** ask `ObjectDefinitionTestUtil.getUniqueRandomClassName`, which draws until the name is free the way the service does, looking in the company the tests run in to match the check that rejects the duplicate. Covers `object-test-util`, `object-admin-rest-test`, `object-test`, and both site-initializer test modules.
2. **`generateRandomClassName` is removed** from the exported `ObjectDefinitionUtil` and inlined into its one legitimate caller, `ObjectDefinitionLocalServiceImpl._getUniqueClassName`, so a future test cannot reach for an unchecked name.
3. **Semantic versioning** — that removal is breaking, so `com.liferay.object.definition.util` goes 3.5.0 → 4.0.0.

The four-character shape is kept rather than widened past a collision: the class name and portlet id patterns in `ObjectDefinitionClassNameProcessorImpl` match exactly four characters when rewriting references to a definition, so a longer name would leave tests exercising a definition those patterns cannot see.

## Evidence

Proven on CI with a throwaway test before writing the fix: the CI company holds **13** four-character class names, supplying one throws `MustNotBeDuplicate`, and a free name is accepted. The local company holds 28.

An earlier diagnostic of mine reported **zero** held names on both CI and locally, which nearly refuted the root cause. That was a broken instrument — it asked `getObjectDefinitions(companyId, STATUS_ANY)`, and that finder matches the status exactly while `STATUS_ANY` is `-1`, so it matched nothing.

## Testing

On a freshly rebuilt environment — database dropped and recreated, `osgi/state` wiped, Elasticsearch and document library data wiped, Tomcat `work`/`temp` wiped, portal booted from scratch:

| suite | result |
| --- | --- |
| `ObjectRelationshipLocalServiceTest` + `ObjectDefinitionServiceTest` | **19/19** |
| `ObjectEntryLocalServiceTest` + `ObjectEntryInfoItemFriendlyURLProviderTest` (site-cms) | **5/5** |

Counts read from the JUnit XML rather than the Gradle exit code: `object-test` writes its results to `object-test/test-results/integration/`, and the task reports `BUILD SUCCESSFUL` regardless of what is in there.

All affected modules compile, including the nine that import the bumped package, and `baseline` accepts the major bump.

## PR Check

| Validation | Result |
| --- | --- |
| Source Format | see note |
| Baseline (`object-api`) | SUCCESS — accepts 4.0.0 |
| Per-module compile | SUCCESS (api, service, test-util) |
| Integration test compile | SUCCESS (object-test, object-admin-rest-test, site-cms/cmp-site-initializer-test) |
| Cross-module compile | SUCCESS — all 9 importers of `com.liferay.object.definition.util` |

**Source Format note.** `ant format-source-current-branch` **passes fully** on this branch up to and including commit 2 (`SUCCESS: Everything is correctly formatted`). With the `packageinfo` commit it aborts with a `ConcurrentModificationException` inside the formatter itself:

```
at com.liferay.source.formatter.check.BaseBreakingChangesCheck._checkCommitMessages(BaseBreakingChangesCheck.java:225)
at com.liferay.source.formatter.check.BaseBreakingChangesCheck.checkMajorVersionBump(BaseBreakingChangesCheck.java:134)
at com.liferay.source.formatter.check.PackageinfoBreakingChangeCommitMessageCheck.doProcess(...)
```

`_checkCommitMessages` mutates the shared list returned by `getCurrentBranchCommitMessages()` via `iterator.remove()`, and SF runs file checks in parallel. That is a formatter bug, not a formatting violation in this branch — verified by isolating the commit. It is tracked separately.
