### PR TITLE
LPD-102534 Scope element variation audience entry rel lookups by group

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/SaveLayoutPageTemplateStructureRelElementVariationMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/SaveLayoutPageTemplateStructureRelElementVariationMVCActionCommandTest.java
@@ -107,8 +107,8 @@ public class
 				layoutPageTemplateStructureRelElementVariations.get(0);
 
 		_assertAudienceEntryERCs(
-			externalReferenceCode,
-			Arrays.asList(audienceEntryERC1, audienceEntryERC2));
+			Arrays.asList(audienceEntryERC1, audienceEntryERC2),
+			externalReferenceCode, group.getGroupId());
 
 		Assert.assertTrue(
 			layoutPageTemplateStructureRelElementVariation.isActive());
@@ -168,8 +168,8 @@ public class
 			layoutPageTemplateStructureRelElementVariations.get(0);
 
 		_assertAudienceEntryERCs(
-			externalReferenceCode,
-			Collections.singletonList(updatedAudienceEntryERC));
+			Collections.singletonList(updatedAudienceEntryERC),
+			externalReferenceCode, group.getGroupId());
 
 		Assert.assertFalse(
 			layoutPageTemplateStructureRelElementVariation.isActive());
@@ -182,14 +182,15 @@ public class
 	}
 
 	private void _assertAudienceEntryERCs(
-		String externalReferenceCode, List<String> audienceEntryERCs) {
+		List<String> audienceEntryERCs, String externalReferenceCode,
+		long groupId) {
 
 		Collections.sort(audienceEntryERCs);
 
 		List<String> actualAudienceEntryERCs = TransformUtil.transform(
 			_layoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService.
 				getLayoutPageTemplateStructureRelElementVariationAudienceEntryRels(
-					externalReferenceCode),
+					groupId, externalReferenceCode),
 			LayoutPageTemplateStructureRelElementVariationAudienceEntryRel::
 				getAudienceEntryERC);
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/frontend/js/audiences/ElementVariationsProviderImpl.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/frontend/js/audiences/ElementVariationsProviderImpl.java
@@ -190,6 +190,8 @@ public class ElementVariationsProviderImpl
 					_layoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService.
 						getLayoutPageTemplateStructureRelElementVariationAudienceEntryRels(
 							layoutPageTemplateStructureRelElementVariation.
+								getGroupId(),
+							layoutPageTemplateStructureRelElementVariation.
 								getExternalReferenceCode())));
 
 		return StringBundler.concat(

--- a/modules/apps/layout/layout-page-template-api/bnd.bnd
+++ b/modules/apps/layout/layout-page-template-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Layout Page Template API
 Bundle-SymbolicName: com.liferay.layout.page.template.api
-Bundle-Version: 37.0.1
+Bundle-Version: 38.0.0
 Export-Package:\
 	com.liferay.layout.page.template.constants,\
 	com.liferay.layout.page.template.exception,\

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService.java
@@ -142,6 +142,7 @@ public interface
 
 	public void
 		deleteLayoutPageTemplateStructureRelElementVariationAudienceEntryRels(
+			long groupId,
 			String layoutPageTemplateStructureRelElementVariationERC);
 
 	public void
@@ -313,6 +314,7 @@ public interface
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<LayoutPageTemplateStructureRelElementVariationAudienceEntryRel>
 		getLayoutPageTemplateStructureRelElementVariationAudienceEntryRels(
+			long groupId,
 			String layoutPageTemplateStructureRelElementVariationERC);
 
 	/**
@@ -406,4 +408,4 @@ public interface
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1186327494
+// LIFERAY-SERVICE-BUILDER-HASH:-1459376752

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalServiceUtil.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalServiceUtil.java
@@ -142,11 +142,12 @@ public class
 
 	public static void
 		deleteLayoutPageTemplateStructureRelElementVariationAudienceEntryRels(
+			long groupId,
 			String layoutPageTemplateStructureRelElementVariationERC) {
 
 		getService().
 			deleteLayoutPageTemplateStructureRelElementVariationAudienceEntryRels(
-				layoutPageTemplateStructureRelElementVariationERC);
+				groupId, layoutPageTemplateStructureRelElementVariationERC);
 	}
 
 	public static void
@@ -379,11 +380,12 @@ public class
 	public static List
 		<LayoutPageTemplateStructureRelElementVariationAudienceEntryRel>
 			getLayoutPageTemplateStructureRelElementVariationAudienceEntryRels(
+				long groupId,
 				String layoutPageTemplateStructureRelElementVariationERC) {
 
 		return getService().
 			getLayoutPageTemplateStructureRelElementVariationAudienceEntryRels(
-				layoutPageTemplateStructureRelElementVariationERC);
+				groupId, layoutPageTemplateStructureRelElementVariationERC);
 	}
 
 	/**
@@ -490,4 +492,4 @@ public class
 				LayoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:310072702
+// LIFERAY-SERVICE-BUILDER-HASH:-576015336

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalServiceWrapper.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalServiceWrapper.java
@@ -148,11 +148,12 @@ public class
 	@Override
 	public void
 		deleteLayoutPageTemplateStructureRelElementVariationAudienceEntryRels(
+			long groupId,
 			String layoutPageTemplateStructureRelElementVariationERC) {
 
 		_layoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService.
 			deleteLayoutPageTemplateStructureRelElementVariationAudienceEntryRels(
-				layoutPageTemplateStructureRelElementVariationERC);
+				groupId, layoutPageTemplateStructureRelElementVariationERC);
 	}
 
 	@Override
@@ -424,11 +425,12 @@ public class
 	public java.util.List
 		<LayoutPageTemplateStructureRelElementVariationAudienceEntryRel>
 			getLayoutPageTemplateStructureRelElementVariationAudienceEntryRels(
+				long groupId,
 				String layoutPageTemplateStructureRelElementVariationERC) {
 
 		return _layoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService.
 			getLayoutPageTemplateStructureRelElementVariationAudienceEntryRels(
-				layoutPageTemplateStructureRelElementVariationERC);
+				groupId, layoutPageTemplateStructureRelElementVariationERC);
 	}
 
 	/**
@@ -587,4 +589,4 @@ public class
 			_layoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:220700058
+// LIFERAY-SERVICE-BUILDER-HASH:-1938393786

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/persistence/LayoutPageTemplateStructureRelElementVariationAudienceEntryRelPersistence.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/persistence/LayoutPageTemplateStructureRelElementVariationAudienceEntryRelPersistence.java
@@ -222,12 +222,13 @@ public interface
 	public int countByUuid_C(String uuid, long companyId);
 
 	/**
-	 * Returns an ordered range of all the layout page template structure rel element variation audience entry rels where layoutPageTemplateStructureRelElementVariationERC = &#63;.
+	 * Returns an ordered range of all the layout page template structure rel element variation audience entry rels where groupId = &#63; and layoutPageTemplateStructureRelElementVariationERC = &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateStructureRelElementVariationAudienceEntryRelModelImpl</code>.
 	 * </p>
 	 *
+	 * @param groupId the group ID
 	 * @param layoutPageTemplateStructureRelElementVariationERC the layout page template structure rel element variation erc
 	 * @param start the lower bound of the range of layout page template structure rel element variation audience entry rels
 	 * @param end the upper bound of the range of layout page template structure rel element variation audience entry rels (not inclusive)
@@ -237,7 +238,8 @@ public interface
 	 */
 	public java.util.List
 		<LayoutPageTemplateStructureRelElementVariationAudienceEntryRel>
-			findByLayoutPageTemplateStructureRelElementVariationERC(
+			findByG_LPTSREVERC(
+				long groupId,
 				String layoutPageTemplateStructureRelElementVariationERC,
 				int start, int end,
 				com.liferay.portal.kernel.util.OrderByComparator
@@ -246,15 +248,17 @@ public interface
 				boolean useFinderCache);
 
 	/**
-	 * Returns the first layout page template structure rel element variation audience entry rel in the ordered set where layoutPageTemplateStructureRelElementVariationERC = &#63;.
+	 * Returns the first layout page template structure rel element variation audience entry rel in the ordered set where groupId = &#63; and layoutPageTemplateStructureRelElementVariationERC = &#63;.
 	 *
+	 * @param groupId the group ID
 	 * @param layoutPageTemplateStructureRelElementVariationERC the layout page template structure rel element variation erc
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching layout page template structure rel element variation audience entry rel
 	 * @throws NoSuchPageTemplateStructureRelElementVariationAudienceEntryRelException if a matching layout page template structure rel element variation audience entry rel could not be found
 	 */
 	public LayoutPageTemplateStructureRelElementVariationAudienceEntryRel
-			findByLayoutPageTemplateStructureRelElementVariationERC_First(
+			findByG_LPTSREVERC_First(
+				long groupId,
 				String layoutPageTemplateStructureRelElementVariationERC,
 				com.liferay.portal.kernel.util.OrderByComparator
 					<LayoutPageTemplateStructureRelElementVariationAudienceEntryRel>
@@ -262,35 +266,39 @@ public interface
 		throws NoSuchPageTemplateStructureRelElementVariationAudienceEntryRelException;
 
 	/**
-	 * Returns the first layout page template structure rel element variation audience entry rel in the ordered set where layoutPageTemplateStructureRelElementVariationERC = &#63;.
+	 * Returns the first layout page template structure rel element variation audience entry rel in the ordered set where groupId = &#63; and layoutPageTemplateStructureRelElementVariationERC = &#63;.
 	 *
+	 * @param groupId the group ID
 	 * @param layoutPageTemplateStructureRelElementVariationERC the layout page template structure rel element variation erc
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching layout page template structure rel element variation audience entry rel, or <code>null</code> if a matching layout page template structure rel element variation audience entry rel could not be found
 	 */
 	public LayoutPageTemplateStructureRelElementVariationAudienceEntryRel
-		fetchByLayoutPageTemplateStructureRelElementVariationERC_First(
+		fetchByG_LPTSREVERC_First(
+			long groupId,
 			String layoutPageTemplateStructureRelElementVariationERC,
 			com.liferay.portal.kernel.util.OrderByComparator
 				<LayoutPageTemplateStructureRelElementVariationAudienceEntryRel>
 					orderByComparator);
 
 	/**
-	 * Removes all the layout page template structure rel element variation audience entry rels where layoutPageTemplateStructureRelElementVariationERC = &#63; from the database.
+	 * Removes all the layout page template structure rel element variation audience entry rels where groupId = &#63; and layoutPageTemplateStructureRelElementVariationERC = &#63; from the database.
 	 *
+	 * @param groupId the group ID
 	 * @param layoutPageTemplateStructureRelElementVariationERC the layout page template structure rel element variation erc
 	 */
-	public void removeByLayoutPageTemplateStructureRelElementVariationERC(
-		String layoutPageTemplateStructureRelElementVariationERC);
+	public void removeByG_LPTSREVERC(
+		long groupId, String layoutPageTemplateStructureRelElementVariationERC);
 
 	/**
-	 * Returns the number of layout page template structure rel element variation audience entry rels where layoutPageTemplateStructureRelElementVariationERC = &#63;.
+	 * Returns the number of layout page template structure rel element variation audience entry rels where groupId = &#63; and layoutPageTemplateStructureRelElementVariationERC = &#63;.
 	 *
+	 * @param groupId the group ID
 	 * @param layoutPageTemplateStructureRelElementVariationERC the layout page template structure rel element variation erc
 	 * @return the number of matching layout page template structure rel element variation audience entry rels
 	 */
-	public int countByLayoutPageTemplateStructureRelElementVariationERC(
-		String layoutPageTemplateStructureRelElementVariationERC);
+	public int countByG_LPTSREVERC(
+		long groupId, String layoutPageTemplateStructureRelElementVariationERC);
 
 	/**
 	 * Returns an ordered range of all the layout page template structure rel element variation audience entry rels where companyId = &#63; and audienceEntryERC = &#63;.
@@ -612,29 +620,32 @@ public interface
 	}
 
 	/**
-	 * Returns all the layout page template structure rel element variation audience entry rels where layoutPageTemplateStructureRelElementVariationERC = &#63;.
+	 * Returns all the layout page template structure rel element variation audience entry rels where groupId = &#63; and layoutPageTemplateStructureRelElementVariationERC = &#63;.
 	 *
+	 * @param groupId the group ID
 	 * @param layoutPageTemplateStructureRelElementVariationERC the layout page template structure rel element variation erc
 	 * @return the matching layout page template structure rel element variation audience entry rels
 	 */
 	public default java.util.List
 		<LayoutPageTemplateStructureRelElementVariationAudienceEntryRel>
-			findByLayoutPageTemplateStructureRelElementVariationERC(
+			findByG_LPTSREVERC(
+				long groupId,
 				String layoutPageTemplateStructureRelElementVariationERC) {
 
-		return findByLayoutPageTemplateStructureRelElementVariationERC(
-			layoutPageTemplateStructureRelElementVariationERC,
+		return findByG_LPTSREVERC(
+			groupId, layoutPageTemplateStructureRelElementVariationERC,
 			com.liferay.portal.kernel.dao.orm.QueryUtil.ALL_POS,
 			com.liferay.portal.kernel.dao.orm.QueryUtil.ALL_POS, null, true);
 	}
 
 	/**
-	 * Returns a range of all the layout page template structure rel element variation audience entry rels where layoutPageTemplateStructureRelElementVariationERC = &#63;.
+	 * Returns a range of all the layout page template structure rel element variation audience entry rels where groupId = &#63; and layoutPageTemplateStructureRelElementVariationERC = &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateStructureRelElementVariationAudienceEntryRelModelImpl</code>.
 	 * </p>
 	 *
+	 * @param groupId the group ID
 	 * @param layoutPageTemplateStructureRelElementVariationERC the layout page template structure rel element variation erc
 	 * @param start the lower bound of the range of layout page template structure rel element variation audience entry rels
 	 * @param end the upper bound of the range of layout page template structure rel element variation audience entry rels (not inclusive)
@@ -642,22 +653,24 @@ public interface
 	 */
 	public default java.util.List
 		<LayoutPageTemplateStructureRelElementVariationAudienceEntryRel>
-			findByLayoutPageTemplateStructureRelElementVariationERC(
+			findByG_LPTSREVERC(
+				long groupId,
 				String layoutPageTemplateStructureRelElementVariationERC,
 				int start, int end) {
 
-		return findByLayoutPageTemplateStructureRelElementVariationERC(
-			layoutPageTemplateStructureRelElementVariationERC, start, end, null,
-			true);
+		return findByG_LPTSREVERC(
+			groupId, layoutPageTemplateStructureRelElementVariationERC, start,
+			end, null, true);
 	}
 
 	/**
-	 * Returns an ordered range of all the layout page template structure rel element variation audience entry rels where layoutPageTemplateStructureRelElementVariationERC = &#63;.
+	 * Returns an ordered range of all the layout page template structure rel element variation audience entry rels where groupId = &#63; and layoutPageTemplateStructureRelElementVariationERC = &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateStructureRelElementVariationAudienceEntryRelModelImpl</code>.
 	 * </p>
 	 *
+	 * @param groupId the group ID
 	 * @param layoutPageTemplateStructureRelElementVariationERC the layout page template structure rel element variation erc
 	 * @param start the lower bound of the range of layout page template structure rel element variation audience entry rels
 	 * @param end the upper bound of the range of layout page template structure rel element variation audience entry rels (not inclusive)
@@ -666,16 +679,17 @@ public interface
 	 */
 	public default java.util.List
 		<LayoutPageTemplateStructureRelElementVariationAudienceEntryRel>
-			findByLayoutPageTemplateStructureRelElementVariationERC(
+			findByG_LPTSREVERC(
+				long groupId,
 				String layoutPageTemplateStructureRelElementVariationERC,
 				int start, int end,
 				com.liferay.portal.kernel.util.OrderByComparator
 					<LayoutPageTemplateStructureRelElementVariationAudienceEntryRel>
 						orderByComparator) {
 
-		return findByLayoutPageTemplateStructureRelElementVariationERC(
-			layoutPageTemplateStructureRelElementVariationERC, start, end,
-			orderByComparator, true);
+		return findByG_LPTSREVERC(
+			groupId, layoutPageTemplateStructureRelElementVariationERC, start,
+			end, orderByComparator, true);
 	}
 
 	/**
@@ -744,4 +758,4 @@ public interface
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1258272629
+// LIFERAY-SERVICE-BUILDER-HASH:-1926635571

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/persistence/LayoutPageTemplateStructureRelElementVariationAudienceEntryRelUtil.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/persistence/LayoutPageTemplateStructureRelElementVariationAudienceEntryRelUtil.java
@@ -386,12 +386,13 @@ public class
 	}
 
 	/**
-	 * Returns an ordered range of all the layout page template structure rel element variation audience entry rels where layoutPageTemplateStructureRelElementVariationERC = &#63;.
+	 * Returns an ordered range of all the layout page template structure rel element variation audience entry rels where groupId = &#63; and layoutPageTemplateStructureRelElementVariationERC = &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateStructureRelElementVariationAudienceEntryRelModelImpl</code>.
 	 * </p>
 	 *
+	 * @param groupId the group ID
 	 * @param layoutPageTemplateStructureRelElementVariationERC the layout page template structure rel element variation erc
 	 * @param start the lower bound of the range of layout page template structure rel element variation audience entry rels
 	 * @param end the upper bound of the range of layout page template structure rel element variation audience entry rels (not inclusive)
@@ -401,7 +402,8 @@ public class
 	 */
 	public static List
 		<LayoutPageTemplateStructureRelElementVariationAudienceEntryRel>
-			findByLayoutPageTemplateStructureRelElementVariationERC(
+			findByG_LPTSREVERC(
+				long groupId,
 				String layoutPageTemplateStructureRelElementVariationERC,
 				int start, int end,
 				OrderByComparator
@@ -409,22 +411,23 @@ public class
 						orderByComparator,
 				boolean useFinderCache) {
 
-		return getPersistence().
-			findByLayoutPageTemplateStructureRelElementVariationERC(
-				layoutPageTemplateStructureRelElementVariationERC, start, end,
-				orderByComparator, useFinderCache);
+		return getPersistence().findByG_LPTSREVERC(
+			groupId, layoutPageTemplateStructureRelElementVariationERC, start,
+			end, orderByComparator, useFinderCache);
 	}
 
 	/**
-	 * Returns the first layout page template structure rel element variation audience entry rel in the ordered set where layoutPageTemplateStructureRelElementVariationERC = &#63;.
+	 * Returns the first layout page template structure rel element variation audience entry rel in the ordered set where groupId = &#63; and layoutPageTemplateStructureRelElementVariationERC = &#63;.
 	 *
+	 * @param groupId the group ID
 	 * @param layoutPageTemplateStructureRelElementVariationERC the layout page template structure rel element variation erc
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching layout page template structure rel element variation audience entry rel
 	 * @throws NoSuchPageTemplateStructureRelElementVariationAudienceEntryRelException if a matching layout page template structure rel element variation audience entry rel could not be found
 	 */
 	public static LayoutPageTemplateStructureRelElementVariationAudienceEntryRel
-			findByLayoutPageTemplateStructureRelElementVariationERC_First(
+			findByG_LPTSREVERC_First(
+				long groupId,
 				String layoutPageTemplateStructureRelElementVariationERC,
 				OrderByComparator
 					<LayoutPageTemplateStructureRelElementVariationAudienceEntryRel>
@@ -432,58 +435,59 @@ public class
 		throws com.liferay.layout.page.template.exception.
 			NoSuchPageTemplateStructureRelElementVariationAudienceEntryRelException {
 
-		return getPersistence().
-			findByLayoutPageTemplateStructureRelElementVariationERC_First(
-				layoutPageTemplateStructureRelElementVariationERC,
-				orderByComparator);
+		return getPersistence().findByG_LPTSREVERC_First(
+			groupId, layoutPageTemplateStructureRelElementVariationERC,
+			orderByComparator);
 	}
 
 	/**
-	 * Returns the first layout page template structure rel element variation audience entry rel in the ordered set where layoutPageTemplateStructureRelElementVariationERC = &#63;.
+	 * Returns the first layout page template structure rel element variation audience entry rel in the ordered set where groupId = &#63; and layoutPageTemplateStructureRelElementVariationERC = &#63;.
 	 *
+	 * @param groupId the group ID
 	 * @param layoutPageTemplateStructureRelElementVariationERC the layout page template structure rel element variation erc
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching layout page template structure rel element variation audience entry rel, or <code>null</code> if a matching layout page template structure rel element variation audience entry rel could not be found
 	 */
 	public static LayoutPageTemplateStructureRelElementVariationAudienceEntryRel
-		fetchByLayoutPageTemplateStructureRelElementVariationERC_First(
+		fetchByG_LPTSREVERC_First(
+			long groupId,
 			String layoutPageTemplateStructureRelElementVariationERC,
 			OrderByComparator
 				<LayoutPageTemplateStructureRelElementVariationAudienceEntryRel>
 					orderByComparator) {
 
-		return getPersistence().
-			fetchByLayoutPageTemplateStructureRelElementVariationERC_First(
-				layoutPageTemplateStructureRelElementVariationERC,
-				orderByComparator);
+		return getPersistence().fetchByG_LPTSREVERC_First(
+			groupId, layoutPageTemplateStructureRelElementVariationERC,
+			orderByComparator);
 	}
 
 	/**
-	 * Removes all the layout page template structure rel element variation audience entry rels where layoutPageTemplateStructureRelElementVariationERC = &#63; from the database.
+	 * Removes all the layout page template structure rel element variation audience entry rels where groupId = &#63; and layoutPageTemplateStructureRelElementVariationERC = &#63; from the database.
 	 *
+	 * @param groupId the group ID
 	 * @param layoutPageTemplateStructureRelElementVariationERC the layout page template structure rel element variation erc
 	 */
-	public static void
-		removeByLayoutPageTemplateStructureRelElementVariationERC(
-			String layoutPageTemplateStructureRelElementVariationERC) {
+	public static void removeByG_LPTSREVERC(
+		long groupId,
+		String layoutPageTemplateStructureRelElementVariationERC) {
 
-		getPersistence().
-			removeByLayoutPageTemplateStructureRelElementVariationERC(
-				layoutPageTemplateStructureRelElementVariationERC);
+		getPersistence().removeByG_LPTSREVERC(
+			groupId, layoutPageTemplateStructureRelElementVariationERC);
 	}
 
 	/**
-	 * Returns the number of layout page template structure rel element variation audience entry rels where layoutPageTemplateStructureRelElementVariationERC = &#63;.
+	 * Returns the number of layout page template structure rel element variation audience entry rels where groupId = &#63; and layoutPageTemplateStructureRelElementVariationERC = &#63;.
 	 *
+	 * @param groupId the group ID
 	 * @param layoutPageTemplateStructureRelElementVariationERC the layout page template structure rel element variation erc
 	 * @return the number of matching layout page template structure rel element variation audience entry rels
 	 */
-	public static int countByLayoutPageTemplateStructureRelElementVariationERC(
+	public static int countByG_LPTSREVERC(
+		long groupId,
 		String layoutPageTemplateStructureRelElementVariationERC) {
 
-		return getPersistence().
-			countByLayoutPageTemplateStructureRelElementVariationERC(
-				layoutPageTemplateStructureRelElementVariationERC);
+		return getPersistence().countByG_LPTSREVERC(
+			groupId, layoutPageTemplateStructureRelElementVariationERC);
 	}
 
 	/**
@@ -856,28 +860,30 @@ public class
 	}
 
 	/**
-	 * Returns all the layout page template structure rel element variation audience entry rels where layoutPageTemplateStructureRelElementVariationERC = &#63;.
+	 * Returns all the layout page template structure rel element variation audience entry rels where groupId = &#63; and layoutPageTemplateStructureRelElementVariationERC = &#63;.
 	 *
+	 * @param groupId the group ID
 	 * @param layoutPageTemplateStructureRelElementVariationERC the layout page template structure rel element variation erc
 	 * @return the matching layout page template structure rel element variation audience entry rels
 	 */
 	public static List
 		<LayoutPageTemplateStructureRelElementVariationAudienceEntryRel>
-			findByLayoutPageTemplateStructureRelElementVariationERC(
+			findByG_LPTSREVERC(
+				long groupId,
 				String layoutPageTemplateStructureRelElementVariationERC) {
 
-		return getPersistence().
-			findByLayoutPageTemplateStructureRelElementVariationERC(
-				layoutPageTemplateStructureRelElementVariationERC);
+		return getPersistence().findByG_LPTSREVERC(
+			groupId, layoutPageTemplateStructureRelElementVariationERC);
 	}
 
 	/**
-	 * Returns a range of all the layout page template structure rel element variation audience entry rels where layoutPageTemplateStructureRelElementVariationERC = &#63;.
+	 * Returns a range of all the layout page template structure rel element variation audience entry rels where groupId = &#63; and layoutPageTemplateStructureRelElementVariationERC = &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateStructureRelElementVariationAudienceEntryRelModelImpl</code>.
 	 * </p>
 	 *
+	 * @param groupId the group ID
 	 * @param layoutPageTemplateStructureRelElementVariationERC the layout page template structure rel element variation erc
 	 * @param start the lower bound of the range of layout page template structure rel element variation audience entry rels
 	 * @param end the upper bound of the range of layout page template structure rel element variation audience entry rels (not inclusive)
@@ -885,22 +891,24 @@ public class
 	 */
 	public static List
 		<LayoutPageTemplateStructureRelElementVariationAudienceEntryRel>
-			findByLayoutPageTemplateStructureRelElementVariationERC(
+			findByG_LPTSREVERC(
+				long groupId,
 				String layoutPageTemplateStructureRelElementVariationERC,
 				int start, int end) {
 
-		return getPersistence().
-			findByLayoutPageTemplateStructureRelElementVariationERC(
-				layoutPageTemplateStructureRelElementVariationERC, start, end);
+		return getPersistence().findByG_LPTSREVERC(
+			groupId, layoutPageTemplateStructureRelElementVariationERC, start,
+			end);
 	}
 
 	/**
-	 * Returns an ordered range of all the layout page template structure rel element variation audience entry rels where layoutPageTemplateStructureRelElementVariationERC = &#63;.
+	 * Returns an ordered range of all the layout page template structure rel element variation audience entry rels where groupId = &#63; and layoutPageTemplateStructureRelElementVariationERC = &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateStructureRelElementVariationAudienceEntryRelModelImpl</code>.
 	 * </p>
 	 *
+	 * @param groupId the group ID
 	 * @param layoutPageTemplateStructureRelElementVariationERC the layout page template structure rel element variation erc
 	 * @param start the lower bound of the range of layout page template structure rel element variation audience entry rels
 	 * @param end the upper bound of the range of layout page template structure rel element variation audience entry rels (not inclusive)
@@ -909,17 +917,17 @@ public class
 	 */
 	public static List
 		<LayoutPageTemplateStructureRelElementVariationAudienceEntryRel>
-			findByLayoutPageTemplateStructureRelElementVariationERC(
+			findByG_LPTSREVERC(
+				long groupId,
 				String layoutPageTemplateStructureRelElementVariationERC,
 				int start, int end,
 				OrderByComparator
 					<LayoutPageTemplateStructureRelElementVariationAudienceEntryRel>
 						orderByComparator) {
 
-		return getPersistence().
-			findByLayoutPageTemplateStructureRelElementVariationERC(
-				layoutPageTemplateStructureRelElementVariationERC, start, end,
-				orderByComparator);
+		return getPersistence().findByG_LPTSREVERC(
+			groupId, layoutPageTemplateStructureRelElementVariationERC, start,
+			end, orderByComparator);
 	}
 
 	/**
@@ -1003,4 +1011,4 @@ public class
 			_persistence;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-540601816
+// LIFERAY-SERVICE-BUILDER-HASH:15988496

--- a/modules/apps/layout/layout-page-template-api/src/main/resources/com/liferay/layout/page/template/service/packageinfo
+++ b/modules/apps/layout/layout-page-template-api/src/main/resources/com/liferay/layout/page/template/service/packageinfo
@@ -1,1 +1,1 @@
-version 18.0.0
+version 19.0.0

--- a/modules/apps/layout/layout-page-template-api/src/main/resources/com/liferay/layout/page/template/service/persistence/packageinfo
+++ b/modules/apps/layout/layout-page-template-api/src/main/resources/com/liferay/layout/page/template/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 9.2.0
+version 10.0.0

--- a/modules/apps/layout/layout-page-template-service/service.xml
+++ b/modules/apps/layout/layout-page-template-service/service.xml
@@ -398,7 +398,8 @@
 
 		<!-- Finder methods -->
 
-		<finder name="LayoutPageTemplateStructureRelElementVariationERC" return-type="Collection">
+		<finder name="G_LPTSREVERC" return-type="Collection">
+			<finder-column name="groupId" />
 			<finder-column name="layoutPageTemplateStructureRelElementVariationERC" />
 		</finder>
 		<finder name="C_AEERC" return-type="Collection">

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/model/impl/LayoutPageTemplateStructureRelElementVariationImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/model/impl/LayoutPageTemplateStructureRelElementVariationImpl.java
@@ -24,7 +24,7 @@ public class LayoutPageTemplateStructureRelElementVariationImpl
 			_audienceEntryERCs = TransformUtil.transform(
 				LayoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalServiceUtil.
 					getLayoutPageTemplateStructureRelElementVariationAudienceEntryRels(
-						getExternalReferenceCode()),
+						getGroupId(), getExternalReferenceCode()),
 				LayoutPageTemplateStructureRelElementVariationAudienceEntryRel::
 					getAudienceEntryERC);
 

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalServiceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalServiceImpl.java
@@ -70,11 +70,12 @@ public class
 	@Override
 	public void
 		deleteLayoutPageTemplateStructureRelElementVariationAudienceEntryRels(
+			long groupId,
 			String layoutPageTemplateStructureRelElementVariationERC) {
 
 		layoutPageTemplateStructureRelElementVariationAudienceEntryRelPersistence.
-			removeByLayoutPageTemplateStructureRelElementVariationERC(
-				layoutPageTemplateStructureRelElementVariationERC);
+			removeByG_LPTSREVERC(
+				groupId, layoutPageTemplateStructureRelElementVariationERC);
 	}
 
 	@Override
@@ -89,11 +90,12 @@ public class
 	@Override
 	public List<LayoutPageTemplateStructureRelElementVariationAudienceEntryRel>
 		getLayoutPageTemplateStructureRelElementVariationAudienceEntryRels(
+			long groupId,
 			String layoutPageTemplateStructureRelElementVariationERC) {
 
 		return layoutPageTemplateStructureRelElementVariationAudienceEntryRelPersistence.
-			findByLayoutPageTemplateStructureRelElementVariationERC(
-				layoutPageTemplateStructureRelElementVariationERC);
+			findByG_LPTSREVERC(
+				groupId, layoutPageTemplateStructureRelElementVariationERC);
 	}
 
 	@Reference

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateStructureRelElementVariationLocalServiceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateStructureRelElementVariationLocalServiceImpl.java
@@ -103,7 +103,7 @@ public class LayoutPageTemplateStructureRelElementVariationLocalServiceImpl
 
 		_layoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService.
 			deleteLayoutPageTemplateStructureRelElementVariationAudienceEntryRels(
-				externalReferenceCode);
+				groupId, externalReferenceCode);
 
 		for (String audienceEntryERC : audienceEntryERCs) {
 			if (Validator.isNull(audienceEntryERC)) {
@@ -134,7 +134,7 @@ public class LayoutPageTemplateStructureRelElementVariationLocalServiceImpl
 
 			_layoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService.
 				deleteLayoutPageTemplateStructureRelElementVariationAudienceEntryRels(
-					externalReferenceCode);
+					groupId, externalReferenceCode);
 		}
 	}
 
@@ -156,6 +156,7 @@ public class LayoutPageTemplateStructureRelElementVariationLocalServiceImpl
 
 			_layoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService.
 				deleteLayoutPageTemplateStructureRelElementVariationAudienceEntryRels(
+					layoutPageTemplateStructureRelElementVariation.getGroupId(),
 					layoutPageTemplateStructureRelElementVariation.
 						getExternalReferenceCode());
 		}
@@ -264,6 +265,8 @@ public class LayoutPageTemplateStructureRelElementVariationLocalServiceImpl
 				layoutPageTemplateStructureRelElementVariationAudienceEntryRels =
 					_layoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService.
 						getLayoutPageTemplateStructureRelElementVariationAudienceEntryRels(
+							layoutPageTemplateStructureRelElementVariation.
+								getGroupId(),
 							existingExternalReferenceCode);
 
 			for (LayoutPageTemplateStructureRelElementVariationAudienceEntryRel

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/persistence/impl/LayoutPageTemplateStructureRelElementVariationAudienceEntryRelPersistenceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/persistence/impl/LayoutPageTemplateStructureRelElementVariationAudienceEntryRelPersistenceImpl.java
@@ -370,15 +370,16 @@ public class
 	private CollectionPersistenceFinder
 		<LayoutPageTemplateStructureRelElementVariationAudienceEntryRel,
 		 NoSuchPageTemplateStructureRelElementVariationAudienceEntryRelException>
-			_collectionPersistenceFinderByLayoutPageTemplateStructureRelElementVariationERC;
+			_collectionPersistenceFinderByG_LPTSREVERC;
 
 	/**
-	 * Returns an ordered range of all the layout page template structure rel element variation audience entry rels where layoutPageTemplateStructureRelElementVariationERC = &#63;.
+	 * Returns an ordered range of all the layout page template structure rel element variation audience entry rels where groupId = &#63; and layoutPageTemplateStructureRelElementVariationERC = &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>LayoutPageTemplateStructureRelElementVariationAudienceEntryRelModelImpl</code>.
 	 * </p>
 	 *
+	 * @param groupId the group ID
 	 * @param layoutPageTemplateStructureRelElementVariationERC the layout page template structure rel element variation erc
 	 * @param start the lower bound of the range of layout page template structure rel element variation audience entry rels
 	 * @param end the upper bound of the range of layout page template structure rel element variation audience entry rels (not inclusive)
@@ -388,7 +389,8 @@ public class
 	 */
 	@Override
 	public List<LayoutPageTemplateStructureRelElementVariationAudienceEntryRel>
-		findByLayoutPageTemplateStructureRelElementVariationERC(
+		findByG_LPTSREVERC(
+			long groupId,
 			String layoutPageTemplateStructureRelElementVariationERC, int start,
 			int end,
 			OrderByComparator
@@ -396,18 +398,18 @@ public class
 					orderByComparator,
 			boolean useFinderCache) {
 
-		return _collectionPersistenceFinderByLayoutPageTemplateStructureRelElementVariationERC.
-			find(
-				finderCache,
-				new Object[] {
-					layoutPageTemplateStructureRelElementVariationERC
-				},
-				start, end, orderByComparator, useFinderCache);
+		return _collectionPersistenceFinderByG_LPTSREVERC.find(
+			finderCache,
+			new Object[] {
+				groupId, layoutPageTemplateStructureRelElementVariationERC
+			},
+			start, end, orderByComparator, useFinderCache);
 	}
 
 	/**
-	 * Returns the first layout page template structure rel element variation audience entry rel in the ordered set where layoutPageTemplateStructureRelElementVariationERC = &#63;.
+	 * Returns the first layout page template structure rel element variation audience entry rel in the ordered set where groupId = &#63; and layoutPageTemplateStructureRelElementVariationERC = &#63;.
 	 *
+	 * @param groupId the group ID
 	 * @param layoutPageTemplateStructureRelElementVariationERC the layout page template structure rel element variation erc
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching layout page template structure rel element variation audience entry rel
@@ -415,79 +417,82 @@ public class
 	 */
 	@Override
 	public LayoutPageTemplateStructureRelElementVariationAudienceEntryRel
-			findByLayoutPageTemplateStructureRelElementVariationERC_First(
+			findByG_LPTSREVERC_First(
+				long groupId,
 				String layoutPageTemplateStructureRelElementVariationERC,
 				OrderByComparator
 					<LayoutPageTemplateStructureRelElementVariationAudienceEntryRel>
 						orderByComparator)
 		throws NoSuchPageTemplateStructureRelElementVariationAudienceEntryRelException {
 
-		return _collectionPersistenceFinderByLayoutPageTemplateStructureRelElementVariationERC.
-			findFirst(
-				finderCache,
-				new Object[] {
-					layoutPageTemplateStructureRelElementVariationERC
-				},
-				orderByComparator);
+		return _collectionPersistenceFinderByG_LPTSREVERC.findFirst(
+			finderCache,
+			new Object[] {
+				groupId, layoutPageTemplateStructureRelElementVariationERC
+			},
+			orderByComparator);
 	}
 
 	/**
-	 * Returns the first layout page template structure rel element variation audience entry rel in the ordered set where layoutPageTemplateStructureRelElementVariationERC = &#63;.
+	 * Returns the first layout page template structure rel element variation audience entry rel in the ordered set where groupId = &#63; and layoutPageTemplateStructureRelElementVariationERC = &#63;.
 	 *
+	 * @param groupId the group ID
 	 * @param layoutPageTemplateStructureRelElementVariationERC the layout page template structure rel element variation erc
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching layout page template structure rel element variation audience entry rel, or <code>null</code> if a matching layout page template structure rel element variation audience entry rel could not be found
 	 */
 	@Override
 	public LayoutPageTemplateStructureRelElementVariationAudienceEntryRel
-		fetchByLayoutPageTemplateStructureRelElementVariationERC_First(
+		fetchByG_LPTSREVERC_First(
+			long groupId,
 			String layoutPageTemplateStructureRelElementVariationERC,
 			OrderByComparator
 				<LayoutPageTemplateStructureRelElementVariationAudienceEntryRel>
 					orderByComparator) {
 
-		return _collectionPersistenceFinderByLayoutPageTemplateStructureRelElementVariationERC.
-			fetchFirst(
-				finderCache,
-				new Object[] {
-					layoutPageTemplateStructureRelElementVariationERC
-				},
-				orderByComparator);
+		return _collectionPersistenceFinderByG_LPTSREVERC.fetchFirst(
+			finderCache,
+			new Object[] {
+				groupId, layoutPageTemplateStructureRelElementVariationERC
+			},
+			orderByComparator);
 	}
 
 	/**
-	 * Removes all the layout page template structure rel element variation audience entry rels where layoutPageTemplateStructureRelElementVariationERC = &#63; from the database.
+	 * Removes all the layout page template structure rel element variation audience entry rels where groupId = &#63; and layoutPageTemplateStructureRelElementVariationERC = &#63; from the database.
 	 *
+	 * @param groupId the group ID
 	 * @param layoutPageTemplateStructureRelElementVariationERC the layout page template structure rel element variation erc
 	 */
 	@Override
-	public void removeByLayoutPageTemplateStructureRelElementVariationERC(
+	public void removeByG_LPTSREVERC(
+		long groupId,
 		String layoutPageTemplateStructureRelElementVariationERC) {
 
-		_collectionPersistenceFinderByLayoutPageTemplateStructureRelElementVariationERC.
-			remove(
-				finderCache,
-				new Object[] {
-					layoutPageTemplateStructureRelElementVariationERC
-				});
+		_collectionPersistenceFinderByG_LPTSREVERC.remove(
+			finderCache,
+			new Object[] {
+				groupId, layoutPageTemplateStructureRelElementVariationERC
+			});
 	}
 
 	/**
-	 * Returns the number of layout page template structure rel element variation audience entry rels where layoutPageTemplateStructureRelElementVariationERC = &#63;.
+	 * Returns the number of layout page template structure rel element variation audience entry rels where groupId = &#63; and layoutPageTemplateStructureRelElementVariationERC = &#63;.
 	 *
+	 * @param groupId the group ID
 	 * @param layoutPageTemplateStructureRelElementVariationERC the layout page template structure rel element variation erc
 	 * @return the number of matching layout page template structure rel element variation audience entry rels
 	 */
 	@Override
-	public int countByLayoutPageTemplateStructureRelElementVariationERC(
+	public int countByG_LPTSREVERC(
+		long groupId,
 		String layoutPageTemplateStructureRelElementVariationERC) {
 
-		return _collectionPersistenceFinderByLayoutPageTemplateStructureRelElementVariationERC.
-			count(
-				finderCache,
-				new Object[] {
-					layoutPageTemplateStructureRelElementVariationERC
-				});
+		return _collectionPersistenceFinderByG_LPTSREVERC.count(
+			finderCache,
+			new Object[] {
+				groupId, layoutPageTemplateStructureRelElementVariationERC
+			});
 	}
 
 	private CollectionPersistenceFinder
@@ -1243,34 +1248,40 @@ public class
 					LayoutPageTemplateStructureRelElementVariationAudienceEntryRel::
 						getCompanyId));
 
-		_collectionPersistenceFinderByLayoutPageTemplateStructureRelElementVariationERC =
+		_collectionPersistenceFinderByG_LPTSREVERC =
 			new CollectionPersistenceFinder<>(
 				this,
 				new FinderPath(
 					FINDER_CLASS_NAME_LIST_WITH_PAGINATION,
-					"findByLayoutPageTemplateStructureRelElementVariationERC",
+					"findByG_LPTSREVERC",
 					new String[] {
-						String.class.getName(), Integer.class.getName(),
-						Integer.class.getName(),
+						Long.class.getName(), String.class.getName(),
+						Integer.class.getName(), Integer.class.getName(),
 						OrderByComparator.class.getName()
 					},
-					new String[] {"lptsRelElementVariationERC"}, true),
+					new String[] {"groupId", "lptsRelElementVariationERC"},
+					true),
 				new FinderPath(
 					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"findByLayoutPageTemplateStructureRelElementVariationERC",
-					new String[] {String.class.getName()},
-					new String[] {"lptsRelElementVariationERC"}, 0, 1, true,
-					null),
+					"findByG_LPTSREVERC",
+					new String[] {Long.class.getName(), String.class.getName()},
+					new String[] {"groupId", "lptsRelElementVariationERC"}, 0,
+					2, true, null),
 				new FinderPath(
 					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByLayoutPageTemplateStructureRelElementVariationERC",
-					new String[] {String.class.getName()},
-					new String[] {"lptsRelElementVariationERC"}, 0, 1, false,
-					null),
+					"countByG_LPTSREVERC",
+					new String[] {Long.class.getName(), String.class.getName()},
+					new String[] {"groupId", "lptsRelElementVariationERC"}, 0,
+					2, false, null),
 				_SQL_SELECT_LAYOUTPAGETEMPLATESTRUCTURERELELEMENTVARIATIONAUDIENCEENTRYREL_WHERE,
 				_SQL_COUNT_LAYOUTPAGETEMPLATESTRUCTURERELELEMENTVARIATIONAUDIENCEENTRYREL_WHERE,
 				LayoutPageTemplateStructureRelElementVariationAudienceEntryRelModelImpl.ORDER_BY_JPQL,
 				_ENTITY_ALIAS_PREFIX, "", "", null,
+				new FinderColumn<>(
+					"layoutPageTemplateStructureRelElementVariationAudienceEntryRel.",
+					"groupId", FinderColumn.Type.LONG, "=", true, true,
+					LayoutPageTemplateStructureRelElementVariationAudienceEntryRel::
+						getGroupId),
 				new FinderColumn<>(
 					"layoutPageTemplateStructureRelElementVariationAudienceEntryRel.",
 					"layoutPageTemplateStructureRelElementVariationERC",
@@ -1419,4 +1430,4 @@ public class
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-507220576
+// LIFERAY-SERVICE-BUILDER-HASH:-392900454

--- a/modules/apps/layout/layout-page-template-service/src/main/resources/META-INF/sql/indexes.sql
+++ b/modules/apps/layout/layout-page-template-service/src/main/resources/META-INF/sql/indexes.sql
@@ -1,6 +1,6 @@
 create index IX_11CEFB3 on LPTSREVAudienceEntryRel (companyId, audienceEntryERC[$COLUMN_LENGTH:75$]);
 create unique index IX_BB3F862 on LPTSREVAudienceEntryRel (groupId, externalReferenceCode[$COLUMN_LENGTH:75$], ctCollectionId);
-create index IX_3530024E on LPTSREVAudienceEntryRel (lptsRelElementVariationERC[$COLUMN_LENGTH:75$]);
+create index IX_BFC958B6 on LPTSREVAudienceEntryRel (groupId, lptsRelElementVariationERC[$COLUMN_LENGTH:75$]);
 create unique index IX_B988F085 on LPTSREVAudienceEntryRel (uuid_[$COLUMN_LENGTH:75$], groupId, ctCollectionId);
 
 create unique index IX_D4E7D564 on LPTSRelElementVariation (groupId, externalReferenceCode[$COLUMN_LENGTH:75$], ctCollectionId);

--- a/modules/apps/layout/layout-page-template-service/src/main/resources/service.properties
+++ b/modules/apps/layout/layout-page-template-service/src/main/resources/service.properties
@@ -13,5 +13,5 @@
 ##
 
     build.namespace=com.liferay.layout.page.template.service
-    build.number=13
-    build.date=1784195813192
+    build.number=14
+    build.date=1786624366316

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/model/listener/test/AudiencesEntryModelListenerTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/model/listener/test/AudiencesEntryModelListenerTest.java
@@ -82,7 +82,7 @@ public class AudiencesEntryModelListenerTest {
 			layoutPageTemplateStructureRelElementVariationAudienceEntryRels =
 				_layoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService.
 					getLayoutPageTemplateStructureRelElementVariationAudienceEntryRels(
-						externalReferenceCode);
+						_group.getGroupId(), externalReferenceCode);
 
 		Assert.assertEquals(
 			layoutPageTemplateStructureRelElementVariationAudienceEntryRels.
@@ -97,7 +97,7 @@ public class AudiencesEntryModelListenerTest {
 		layoutPageTemplateStructureRelElementVariationAudienceEntryRels =
 			_layoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService.
 				getLayoutPageTemplateStructureRelElementVariationAudienceEntryRels(
-					externalReferenceCode);
+					_group.getGroupId(), externalReferenceCode);
 
 		Assert.assertEquals(
 			layoutPageTemplateStructureRelElementVariationAudienceEntryRels.

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/model/listener/test/SegmentsExperienceModelListenerTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/model/listener/test/SegmentsExperienceModelListenerTest.java
@@ -190,7 +190,7 @@ public class SegmentsExperienceModelListenerTest {
 			layoutPageTemplateStructureRelElementVariationAudienceEntryRels =
 				_layoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService.
 					getLayoutPageTemplateStructureRelElementVariationAudienceEntryRels(
-						externalReferenceCode);
+						_group.getGroupId(), externalReferenceCode);
 
 		Assert.assertEquals(
 			layoutPageTemplateStructureRelElementVariationAudienceEntryRels.

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/persistence/test/LayoutPageTemplateStructureRelElementVariationAudienceEntryRelPersistenceTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/persistence/test/LayoutPageTemplateStructureRelElementVariationAudienceEntryRelPersistenceTest.java
@@ -317,17 +317,12 @@ public class
 	}
 
 	@Test
-	public void testCountByLayoutPageTemplateStructureRelElementVariationERC()
-		throws Exception {
+	public void testCountByG_LPTSREVERC() throws Exception {
+		_persistence.countByG_LPTSREVERC(RandomTestUtil.nextLong(), "");
 
-		_persistence.countByLayoutPageTemplateStructureRelElementVariationERC(
-			"");
+		_persistence.countByG_LPTSREVERC(0L, "null");
 
-		_persistence.countByLayoutPageTemplateStructureRelElementVariationERC(
-			"null");
-
-		_persistence.countByLayoutPageTemplateStructureRelElementVariationERC(
-			(String)null);
+		_persistence.countByG_LPTSREVERC(0L, (String)null);
 	}
 
 	@Test
@@ -865,4 +860,4 @@ public class
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1976310929
+// LIFERAY-SERVICE-BUILDER-HASH:330975690

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/test/LayoutPageTemplateStructureRelElementVariationLocalServiceTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/test/LayoutPageTemplateStructureRelElementVariationLocalServiceTest.java
@@ -9,6 +9,8 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.layout.page.template.exception.DuplicateLayoutPageTemplateStructureRelElementVariationAudienceEntryRelException;
 import com.liferay.layout.page.template.exception.LayoutPageTemplateStructureRelElementVariationTargetElementException;
 import com.liferay.layout.page.template.model.LayoutPageTemplateStructureRelElementVariation;
+import com.liferay.layout.page.template.model.LayoutPageTemplateStructureRelElementVariationAudienceEntryRel;
+import com.liferay.layout.page.template.service.LayoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService;
 import com.liferay.layout.page.template.service.LayoutPageTemplateStructureRelElementVariationLocalService;
 import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.portal.kernel.model.Group;
@@ -63,6 +65,71 @@ public class LayoutPageTemplateStructureRelElementVariationLocalServiceTest {
 		_testAddOrUpdateLayoutPageTemplateStructureRelElementVariationWithDuplicateAudienceEntryERCs();
 		_testAddOrUpdateLayoutPageTemplateStructureRelElementVariationWithSameAudienceEntryERCForDifferentSegmentsExperience();
 		_testAddOrUpdateLayoutPageTemplateStructureRelElementVariationWithSameAudienceEntryERCForDifferentTargetElement();
+	}
+
+	@Test
+	public void testDeleteLayoutPageTemplateStructureRelElementVariation()
+		throws Exception {
+
+		String audienceEntryERC = RandomTestUtil.randomString();
+		String externalReferenceCode = RandomTestUtil.randomString();
+
+		_addLayoutPageTemplateStructureRelElementVariation(
+			audienceEntryERC, externalReferenceCode, _group);
+
+		Group group = GroupTestUtil.addGroup();
+
+		_addLayoutPageTemplateStructureRelElementVariation(
+			RandomTestUtil.randomString(), externalReferenceCode, group);
+
+		_layoutPageTemplateStructureRelElementVariationLocalService.
+			deleteLayoutPageTemplateStructureRelElementVariation(
+				externalReferenceCode, group.getGroupId());
+
+		List<LayoutPageTemplateStructureRelElementVariationAudienceEntryRel>
+			layoutPageTemplateStructureRelElementVariationAudienceEntryRels =
+				_layoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService.
+					getLayoutPageTemplateStructureRelElementVariationAudienceEntryRels(
+						_group.getGroupId(), externalReferenceCode);
+
+		Assert.assertEquals(
+			layoutPageTemplateStructureRelElementVariationAudienceEntryRels.
+				toString(),
+			1,
+			layoutPageTemplateStructureRelElementVariationAudienceEntryRels.
+				size());
+
+		LayoutPageTemplateStructureRelElementVariationAudienceEntryRel
+			layoutPageTemplateStructureRelElementVariationAudienceEntryRel =
+				layoutPageTemplateStructureRelElementVariationAudienceEntryRels.
+					get(0);
+
+		Assert.assertEquals(
+			audienceEntryERC,
+			layoutPageTemplateStructureRelElementVariationAudienceEntryRel.
+				getAudienceEntryERC());
+	}
+
+	private void _addLayoutPageTemplateStructureRelElementVariation(
+			String audienceEntryERC, String externalReferenceCode, Group group)
+		throws Exception {
+
+		Layout layout = LayoutTestUtil.addTypeContentLayout(group);
+
+		_layoutPageTemplateStructureRelElementVariationLocalService.
+			addOrUpdateLayoutPageTemplateStructureRelElementVariation(
+				externalReferenceCode, TestPropsValues.getUserId(),
+				group.getGroupId(), RandomTestUtil.randomBoolean(),
+				RandomTestUtil.randomString(),
+				Collections.singletonMap(
+					LocaleUtil.US, RandomTestUtil.randomString()),
+				Collections.singletonMap(
+					LocaleUtil.US, RandomTestUtil.randomString()),
+				RandomTestUtil.randomString(), layout.getPlid(),
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+				new String[] {audienceEntryERC},
+				ServiceContextTestUtil.getServiceContext(
+					group, TestPropsValues.getUserId()));
 	}
 
 	private void _testAddOrUpdateLayoutPageTemplateStructureRelElementVariationWithDuplicateAudienceEntryERCForTargetElement()
@@ -231,6 +298,11 @@ public class LayoutPageTemplateStructureRelElementVariationLocalServiceTest {
 	}
 
 	private Group _group;
+
+	@Inject
+	private
+		LayoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService
+			_layoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService;
 
 	@Inject
 	private LayoutPageTemplateStructureRelElementVariationLocalService


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102534

## What Is Being Fixed

`LayoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService` looked up the audience entry rels of an element variation by the variation's external reference code alone. That code is only unique per site, since the entity is declared `external-reference-code="group"` and the generated unique finder is `fetchByERC_G(externalReferenceCode, groupId)`. Both the read and the delete therefore matched rows in every site, and the code is client supplied, `SaveLayoutPageTemplateStructureRelElementVariationMVCActionCommand` reads it straight from the request payload, so two sites can easily hold the same value.

Writes were the damaging half. `addOrUpdateLayoutPageTemplateStructureRelElementVariation` deletes the rels for the code and re-adds the ones passed in, so editing a variation in one site silently wiped another site's audience assignments. `deleteLayoutPageTemplateStructureRelElementVariation` and `deleteLayoutPageTemplateStructureRelElementVariations` deleted across sites the same way. Reads returned the union of both sites' rows, which reached the rendered page through `ElementVariationsProviderImpl`, the page editor through `getAudienceEntryERCs`, and the duplicate-target validation in `_validate`.

## How It Is Being Fixed

The `LayoutPageTemplateStructureRelElementVariationERC` finder is replaced with `G_LPTSREVERC` on `groupId` and the variation code, matching the key the entity is actually unique on. Both service methods take the group and use it, and every caller passes it: the four in `LayoutPageTemplateStructureRelElementVariationLocalServiceImpl`, the model's `getAudienceEntryERCs`, and `ElementVariationsProviderImpl`. Each caller already had the group in hand, so nothing needed threading through new plumbing.

Removing the old methods is a breaking API change, so `layout-page-template-api` goes to 38.0.0 with the two `packageinfo` bumps, documented in the `# breaking` block on the buildService commit. The audience-entry side of the service is untouched: `deleteLayoutPageTemplateStructureRelElementVariationAudienceEntryRelsByAudienceEntryERC` already keys on `companyId` plus the audience code, which is correct, since audience external reference codes are company scoped. The segments counterpart, `SegmentsExperienceAudienceEntryRelLocalService`, was already group scoped and needed no change.

The test creates variations with the same external reference code in two sites, deletes one, and asserts the other's rel survives with its own audience. It was verified to fail on the old behavior with `expected:<1> but was:<0>` before the fix.

## PR Check

**pr-check: PASS** — tested on `0536f6dd397a90f3053b5d058c1ca7f4eac6f587`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "0536f6dd397a90f3053b5d058c1ca7f4eac6f587"} -->
