### PR TITLE
Revert "LPD-93945 Update object-web Management Bar to use atlas-custom-properties"

### DIFF
--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/css/_management-toolbar.scss
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/css/_management-toolbar.scss
@@ -8,7 +8,7 @@
 
 	.data-set {
 		.management-bar-wrapper {
-			background-color: $white;
+			background-color: #fff;
 			top: calc(var(--control-menu-container-height, 56px) + 4rem + 48px);
 		}
 	}

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/css/main.scss
@@ -1,4 +1,5 @@
-@import '_atlas-custom-properties-variables';
+@import 'atlas-custom-properties/_variables';
+@import 'atlas-variables';
 
 @import 'management-toolbar';
 

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectField/ModalAddObjectField.scss
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectField/ModalAddObjectField.scss
@@ -1,12 +1,10 @@
-@import '_atlas-custom-properties-variables';
-
 .lfr-objects__modal-add-object-field-enable-translations-toggle {
 	display: flex;
 	gap: 10px;
 	margin-bottom: 20px;
 
 	&-icon {
-		color: $gray-500;
+		color: #a7a9bc;
 	}
 }
 

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectField/ObjectFieldFormBase.scss
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectField/ObjectFieldFormBase.scss
@@ -1,4 +1,4 @@
-@import '_atlas-custom-properties-variables';
+@import 'atlas-variables';
 
 .lfr-objects__object-field-form-base {
 	&-container {
@@ -18,7 +18,7 @@
 
 	&-mandatory-toggle {
 		align-items: center;
-		color: $gray-600;
+		color: #6b6c7e;
 		display: flex;
 		gap: 0.5rem;
 	}


### PR DESCRIPTION
@pat270 @JerryAdrianoo

## This unblocks `ant all`, and unblocks syncing from this origin to the Liferay upstream

`master` cannot build `object-web`. Because that failure lands in the bundle builder, **no `ci:test:object` axis runs at all** — the suite reports 4 jobs instead of 65 — so CI's stable testing cannot pass and **nothing is syncing from this origin to the Liferay upstream** while it stands. That is the reason this is worth landing ahead of anything else in it.

```
> Task :apps:object:object-web:packageRunBuild FAILED
Error: Can't find stylesheet to import.
1 │ @import '_atlas-custom-properties-variables';
```

## An incomplete revert

Two commits pass each other:

| Commit | Author | Landed | What |
| --- | --- | --- | --- |
| `84ab809f67e57` LPD-93945 | @pat270 | 2026-08-13 21:27 | object-web swaps three hardcoded colors for variables, reaching them through the flat wrapper `_atlas-custom-properties-variables` |
| `d4241309c8c10` Revert of LPD-92565 | @JerryAdrianoo | 2026-08-14 | deletes `clay-css/src/scss/_atlas-custom-properties{,-variables}.scss`, the files that wrapper is |

LPD-93945 landed **first** and took a dependency on the importable files LPD-92565 had added. The LPD-92565 revert series — 12+ commits withdrawing the whole feature — then removed them. Each individual `git revert` was faithful to its own commit, but the series did not account for the one consumer living **outside** LPD-92565. Three importers were left pointing at a deleted file:

- `object-web/.../css/main.scss`
- `object-web/.../ObjectField/ModalAddObjectField.scss`
- `object-web/.../ObjectField/ObjectFieldFormBase.scss`

## The fix is a plain `git revert`

```
git revert 84ab809f67e573d0729158e1186098daa6bb7c2c
```

No hand edits. LPD-93945 *is* "Update object-web Management Bar to use atlas-custom-properties" — an adoption of the very API being withdrawn — so reverting it whole is consistent with the rest of the series, and it applies cleanly. **LPD-93945 is a single commit**, so this reverts the entire ticket with nothing stranded behind it.

@pat270 — this puts the three hardcoded hex values back (`#fff`, `#a7a9bc`, `#6b6c7e`). When LPD-92565 returns, LPD-93945 can be re-applied unchanged.

## Why not restore the deleted wrappers instead

I tried that first; it is worse. The themes carry their own non-underscore `atlas-custom-properties.scss`, so putting the underscore partial back makes the import ambiguous and breaks two theme builds in exchange for fixing one module:

```
> Task :apps:frontend-theme:frontend-theme-classic:packageRunBuild FAILED
Error: It's not clear which file to import. Found:
  build/_css/clay/_atlas-custom-properties.scss
  build/_css/clay/atlas-custom-properties.scss
```

That is presumably why the revert deleted them.

## Note: the Gradle build cache hides this locally

`ant all` on a warm cache reports `packageRunBuild UP-TO-DATE` / `FROM-CACHE` and **succeeds**, even with the broken import in the tree — including with `--no-build-cache`. It only fails once the module's `build` directory is gone. That is why this is invisible to incremental local builds and fatal on CI, which builds cold every time. Confirmed on plain `master`:

```
# with modules/apps/object/object-web/build removed
> Task :apps:object:object-web:packageRunBuild FAILED
Error: Can't find stylesheet to import.   (x3, one per importer)
```

## Verification

| Check | Result |
| --- | --- |
| `ant all` | **BUILD SUCCESSFUL** (6m 8s) |
| Cold build, cache disabled — `object-web`, `frontend-theme-classic`, `frontend-theme-cms` | **BUILD SUCCESSFUL**, all three tasks actually executed |
| Source Format | `SUCCESS: Everything is correctly formatted` |
| Stranded importers remaining | 0 |
| Other modules affected | none — `LPD-94095`, the same hardcoded-colors work landed today, imports the canonical `atlas-custom-properties/_variables` and is unaffected |

Rebased on `9ef440f2588a3`.

## PR Check

| Validation | Result |
| --- | --- |
| Source Format | SUCCESS |
| Frontend build (`packageRunBuild`, cold, no cache) | SUCCESS — object-web + both themes |
| Full `ant all` | SUCCESS |
| Java compile / Baseline | not applicable — three `.scss` files, no Java and no exported API touched |
