### PR TITLE
LPD-102673 Make the breaking change commit message cache thread safe

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/BaseBreakingChangesCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/BaseBreakingChangesCheck.java
@@ -17,7 +17,8 @@ import com.liferay.source.formatter.processor.SourceProcessor;
 
 import java.io.IOException;
 
-import java.util.Iterator;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -185,23 +186,29 @@ public abstract class BaseBreakingChangesCheck extends BaseFileCheck {
 		}
 	}
 
-	protected synchronized List<String> getCurrentBranchCommitMessages()
-		throws Exception {
+	protected List<String> getCurrentBranchCommitMessages() throws Exception {
 
-		if (_currentBranchCommitMessages != null) {
+		// The cache is static, so it is shared by every check that reads it and
+		// the lock has to be too. Hand back an unmodifiable view, since a
+		// caller that filters the cache in place corrupts it for everyone else.
+
+		synchronized (BaseBreakingChangesCheck.class) {
+			if (_currentBranchCommitMessages != null) {
+				return _currentBranchCommitMessages;
+			}
+
+			SourceProcessor sourceProcessor = getSourceProcessor();
+
+			SourceFormatterArgs sourceFormatterArgs =
+				sourceProcessor.getSourceFormatterArgs();
+
+			_currentBranchCommitMessages = Collections.unmodifiableList(
+				GitUtil.getCurrentBranchCommitMessages(
+					sourceFormatterArgs.getBaseDirName(),
+					sourceFormatterArgs.getGitWorkingBranchName()));
+
 			return _currentBranchCommitMessages;
 		}
-
-		SourceProcessor sourceProcessor = getSourceProcessor();
-
-		SourceFormatterArgs sourceFormatterArgs =
-			sourceProcessor.getSourceFormatterArgs();
-
-		_currentBranchCommitMessages = GitUtil.getCurrentBranchCommitMessages(
-			sourceFormatterArgs.getBaseDirName(),
-			sourceFormatterArgs.getGitWorkingBranchName());
-
-		return _currentBranchCommitMessages;
 	}
 
 	protected Pattern getVersionPattern() {
@@ -212,21 +219,17 @@ public abstract class BaseBreakingChangesCheck extends BaseFileCheck {
 			String fileName, String absolutePath, String additionalMessage)
 		throws Exception {
 
-		List<String> commitMessages = getCurrentBranchCommitMessages();
+		List<String> breakingChangeCommitMessages = new ArrayList<>();
 
-		Iterator<String> iterator = commitMessages.iterator();
-
-		while (iterator.hasNext()) {
-			String commitMessage = iterator.next();
-
+		for (String commitMessage : getCurrentBranchCommitMessages()) {
 			String[] parts = commitMessage.split(":", 2);
 
-			if (!parts[1].contains("# breaking")) {
-				iterator.remove();
+			if (parts[1].contains("# breaking")) {
+				breakingChangeCommitMessages.add(commitMessage);
 			}
 		}
 
-		if (commitMessages.isEmpty()) {
+		if (breakingChangeCommitMessages.isEmpty()) {
 			addMessage(
 				fileName,
 				"Incorrect commit message: Missing breaking change in commit " +
@@ -235,12 +238,8 @@ public abstract class BaseBreakingChangesCheck extends BaseFileCheck {
 			return;
 		}
 
-		for (String commitMessage : commitMessages) {
+		for (String commitMessage : breakingChangeCommitMessages) {
 			String[] parts = commitMessage.split(":", 2);
-
-			if (!parts[1].contains("# breaking")) {
-				continue;
-			}
 
 			String message =
 				"Incorrect commit message in SHA " + parts[0] + ": ";


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102673

@ling-alan-huang for awareness — you own `90d758decee2a`, the commit this traces back to.

## Scope: this is a thread safety fix, not a change to what the formatter checks

No rule the breaking change check enforces is altered, no check is added or removed, and no message wording changes. The check only stops being handed a corrupted list. A branch whose major bump genuinely carries no breaking change section is still reported exactly as before — verified at the same sixteen messages.

## What Is Being Fixed

Any branch that bumps a `packageinfo` or `bnd` major version can fail source formatting with either of two crashes, both from the same line of `BaseBreakingChangesCheck._checkCommitMessages`:

```
java.util.ConcurrentModificationException
  at java.base/java.util.ArrayList$Itr.remove(ArrayList.java:1071)
  at BaseBreakingChangesCheck._checkCommitMessages(BaseBreakingChangesCheck.java:225)

java.lang.NullPointerException: Cannot invoke "String.split(String, int)" because "commitMessage" is null
  at BaseBreakingChangesCheck._checkCommitMessages(BaseBreakingChangesCheck.java:222)
```

Caught while stabilizing the Objects tests, where it blocked `format-source-current-branch` on every semantic versioning commit.

Three defects sit in one method, all of them about how shared state is reached:

1. The check narrowed the commit messages to the ones carrying a breaking change by **removing the others through the iterator** — and the list it removed from is a `static` field shared by all three checks that read it (`packageinfo`, `bnd`, REST config `yml`). Two threads removing from one `ArrayList` either trip the comodification guard, or read the slot the shift just nulled, which is where the null commit message comes from.
2. The in-place pruning is unsafe **even on one thread**. The first caller strips the shared cache for good, so a later file sees a list with its non-breaking commits already gone — and once every commit has been removed, the cache is empty and every later major bump is told its breaking change is missing.
3. The lock the getter already took was an **instance** lock guarding a **static** field, so two different checks locked two different objects and it never excluded anything.

**Root cause:** the filtering itself is older than the bug and was correct when written — `_checkCommitMessages` called `GitUtil` directly, so each call got its own list. `90d758decee2a` ("LPD-100288 SF") added the static cache to avoid repeating the `git log`, which turned a safe local mutation into shared state corruption.

## How It Is Being Fixed

Collect the breaking change commit messages into a new list and leave the cache alone. Hand the cache back unmodifiable, so the next caller that tries to filter it in place fails instead of corrupting it quietly. Take the lock on the class rather than the instance.

One file, imports aside: `+26 / -27`.

## Testing

Reproducing it needs a specific shape, worth recording: one commit **without** a breaking change section (so the removal executes), one **with** (so the list is not emptied on the first pass, leaving the comodification window open), and enough major-bumped `packageinfo` files to put several threads in the check at once. A single non-breaking commit is stable by accident — every thread races to remove the same lone entry, the first wins, the list empties, and `hasNext()` closes the window.

| | crashes | behavior |
| --- | --- | --- |
| Before | **3 / 6 runs** | — |
| After | **0 / 8 runs** | unchanged; a genuinely missing breaking change section still reports 16 messages |

## PR Check

| Validation | Result |
| --- | --- |
| Source Format | SUCCESS |
| Per-module compile (`source-formatter:compileJava`) | SUCCESS |
| Reproduction A/B | 3/6 crashes → 0/8 |
| False-negative guard | SUCCESS — missing-section reporting unchanged |
| Baseline | not applicable — build tool, no exported portal API touched |
