### PR TITLE
LPD-102681 Keep the list reload when the object side panel closes

### DIFF
--- a/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/SidePanelContent.tsx
+++ b/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/SidePanelContent.tsx
@@ -19,9 +19,9 @@ export function closeSidePanel() {
 export function saveAndReload() {
 	const parentWindow = Liferay.Util.getOpener();
 
-	closeSidePanel();
-
 	setTimeout(() => {
+		closeSidePanel();
+
 		parentWindow.location.reload();
 	}, 300);
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102681

## What Is Being Fixed

Saving an object side panel refreshes the list behind it by reloading the parent window, and nothing else does — the data set refreshes from a submit handler, and the object panels save through an `onClick` instead, so the reload is the only path.

The reload is scheduled 300 ms out, **after** the panel has already been asked to close, and the timer belongs to the frame that closing tears down. When the teardown lands first the reload is lost for good and the list keeps the old name. A user who saves and looks at the list sees stale data; `objectLayout:823` reads the list and fails.

The teardown waits for the first `transitionend` to reach the panel, and the panel transitions over 500 ms, so the 300 ms timer usually wins. It only has to lose once — and **`transitionend` bubbles**, so any descendant that finishes sooner ends the wait early.

A diagnostic run on CI caught it in the act across twelve executions: eleven reported `reloads=1`, and the one failure reported

```
reloads=0 newName=false te=5595:loader:opacity
```

A loader finished its opacity transition first, bubbled up, and closed the panel inside the timer window.

**Root cause:** `2c605fe504724` ("LPS-158503 Reduce time to save and reload object side panels") moved `closeSidePanel` back out of the timeout while cutting the delay from 1500 ms to 300 ms. That undid `f9d40ce92473e` ("LPS-147590 Close sidebar and reload list"), which had put the two in one task six days earlier for exactly this reason, and restored the shape `dcfca6f3abac8` introduced. Shrinking the delay also shrank the margin.

## How It Is Being Fixed

Issue the close and the reload from one task, so the reload no longer depends on the frame outliving a timer.

```diff
 export function saveAndReload() {
 	const parentWindow = Liferay.Util.getOpener();

-	closeSidePanel();
-
 	setTimeout(() => {
+		closeSidePanel();
+
 		parentWindow.location.reload();
 	}, 300);
 }
```

## Testing

Shortening the panel transition to 1 ms makes the loss deterministic and pins both halves.

| arm | result |
| --- | --- |
| without this change, amplified | **0/8** — reload lost, fails exactly as reported |
| with this change, amplified | **8/8** |
| with this change, shipped transition | 6/6 |
| re-verified on a rebuilt clean environment, no feature flags | **10/10** |
| CI | green in the sweep run that carried it |

The change was confirmed present in the deployed jar rather than assumed.

**One alternative rejected:** owning the timer on the parent window (`parentWindow.setTimeout`) looks like it should work and does not — the callback still belongs to the frame being torn down, and 6/6 amplified runs lose the reload anyway. That is why the fix moves the work rather than the timer.

## PR Check

| Validation | Result |
| --- | --- |
| Source Format | SUCCESS — `SUCCESS: Everything is correctly formatted` |
| Prettier | SUCCESS |
| Local A/B under a deterministic amplifier | 0/8 → 8/8 |
| Clean-environment re-verification | 10/10 |
| Baseline / Java compile | not applicable — one `.tsx` file, no Java and no exported API touched |
