### PR TITLE
LRCI-8121 Use local URLs when invoking downstream Jenkins builds

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -3745,7 +3745,9 @@ public class JenkinsResultsParserUtil {
 				UrlReader.getResponseHeader(
 					"Location", getJenkinsHTTPAuthorization(),
 					HttpRequestMethod.POST, sb.toString(), requestHeaders,
-					timeout, combine(jenkinsJobURL, "/buildWithParameters")));
+					timeout,
+					combine(
+						getLocalURL(jenkinsJobURL), "/buildWithParameters")));
 		}
 		catch (IOException ioException) {
 			throw new RuntimeException(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-8121

## What Is Being Fixed

`JenkinsResultsParserUtil.invokeJenkinsBuild` posted to `/buildWithParameters` on the raw `jenkinsJobURL` it was handed. On a cloud CI node that URL is the public, externally routed address of the Jenkins master, so every downstream build invoke left the cluster and came back in through the public gateway instead of talking to the master directly.

## How It Is Being Fixed

The job URL is now passed through `getLocalURL` before `/buildWithParameters` is appended, matching how the rest of the utility resolves Jenkins addresses. On a cloud CI node `getLocalURL` rewrites the remote authority to its internal `http://<host>/` equivalent; everywhere else it returns the URL unchanged, so the behavior outside the cluster is identical.

## Why Are There No Tests?

This is a Jenkins-only infrastructure change. The build-invoke path is only exercisable against live Jenkins masters, and there is no unit-testable seam around it — `getLocalURL` itself is already covered by `JenkinsResultsParserUtilTest`.

## PR Check

**pr-check: PASS** — tested on `ef892a4e5e25ea5bd00faaadcf9945926fef2feb`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "ef892a4e5e25ea5bd00faaadcf9945926fef2feb"} -->
