### PR TITLE
LPD-102711 Wait for the reload the object action save starts

### DIFF
--- a/modules/test/playwright/pages/object-web/object-action/EditObjectActionPage.ts
+++ b/modules/test/playwright/pages/object-web/object-action/EditObjectActionPage.ts
@@ -65,6 +65,7 @@ export class EditObjectActionPage {
 			.getByText(
 				`Send email notifications in the guest user's preferred language.`
 			);
+		this.page = page;
 		this.viewObjectActionsPage = new ViewObjectActionsPage(page);
 	}
 
@@ -107,7 +108,15 @@ export class EditObjectActionPage {
 				.click();
 		}
 
-		await this.saveButton.click();
+		// Saving closes the side panel and reloads the parent from a timer, so
+		// the reload is still in flight when the click resolves. Leaving it
+		// pending lands it in whatever step runs next, replacing the page under
+		// that step. Wait for it here.
+
+		await Promise.all([
+			this.page.waitForNavigation(),
+			this.saveButton.click(),
+		]);
 	}
 
 	async chooseNotificationOption() {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102711

## What Is Being Fixed

`EditObjectActionPage.addNewAction` clicks Save in the object action side panel and returns. Saving closes the panel and reloads the parent window from a 300 ms timer that fires *after* the success is already on screen, so the reload is still in flight when the helper returns, and nothing in the page marks it pending. It lands in whichever step runs next and replaces the document under it.

That is the recorded failure of `object-web/notification/notification.spec.ts:187`, "Can send user notification to a regular role". Three steps after the save the test opens the profile menu and clicks Notifications. The CI Playwright trace shows the click resolving the correct link while the page went somewhere else:

```
93482.8  locator resolved to <a ...p_p_id=com_liferay_notifications_web_portlet_NotificationsPortlet
93551.5  waiting for"       ...p_p_id=com_liferay_object_web_internal_object_definitions_portlet_ObjectDefinitionsPortlet
93551.8  navigated to       ...ObjectDefinitionsPortlet
```

The leftover reload arrives 533 ms into the click. Playwright re-resolves the menu item on the page that replaced it, where no personal menu is open, and waits out the rest of the test. The menu, the dropdown and the menu items were never at fault — they were on a document that had been thrown away.

## How It Is Being Fixed

Wait for that navigation where it is started, so the helper owns the reload it causes instead of leaving it to land in a later step. The change also assigns `this.page`, which the class declares and the constructor never set.

Fixing the cause removed the need for a by-address rewrite of `NotificationsPage.goto` that an earlier attempt had added: the passing arm runs master's menu walk untouched. That shrank the change from four files to one and dropped two edits outside the object suite.

Root cause: born wrong. `4c1e084744c53` (LPD-27612) added `addNewAction` already ending in a bare Save click with nothing waiting for the reload that save starts. The 300 ms delay is older still, from `2c605fe504724` (LPS-158503, 2022-07-18), which predates the helper by nearly two years — so the helper was born into that timing and this was never a regression.

Two known sharp edges in the primitive are left for their own change, because every run of evidence below was gathered against `page.waitForNavigation`: an unpredicated `waitForNavigation` also resolves on same-document `history.pushState`/`replaceState`, which the Frontend Data Set on the parent page uses, and `waitForNavigation` is deprecated in the pinned Playwright 1.54.2. `page.waitForEvent('load')` addresses both and should be swapped in with its own A/B. Separately, a save that fails validation never navigates, so the wait now runs to the 90 s test timeout rather than failing fast.

## Testing

Local A/B, amplifier holds the reload's document request for 3 s so the loss is deterministic: without the change the test fails **3 of 3** runs with the reported signature, waiting on `.dropdown-menu.show` until the test times out. With it, **6 of 6** pass amplified and **4 of 4** unamplified.

CI A/B on shrunk arms, `object-web.notification` grepped to the failing test with `repeatEach: 20`, arms differing only by this commit: the control ran **39 of 42** jobs with "Can send user notification to a regular role" as its *unique* failure, and the treatment ran **42 of 42**.

`addNewAction` is shared by five call sites and those arms exercised one, so all five were then run with the change in place. Four pass 3 of 3 runs locally. The fifth, `objectClientExtension.spec.ts:226` "Can trigger object action as a client extension", cannot run in a local bundle at all — it selects `object-action-executor[function#liferay-sample-etc-spring-boot-object-action-1]`, which exists only once the sample Spring Boot client extension is deployed. It fails identically with and without this change (**control 3/3 fail, treatment 3/3 fail**) at a step seventeen lines before the line being changed.

## PR Check

**pr-check: PASS** — tested on `048413dbb5213edf602c61c1eb9f043965b3eeea`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Baseline | PASS |

Only these two validations matched the diff. The single changed path is `modules/test/playwright/pages/object-web/object-action/EditObjectActionPage.ts`. Per-Module Compile does not fire because `modules/test/playwright` is not a deployable module — it has no `.lfrbuild-portal` marker, no `bnd.bnd` anywhere up its ancestor chain, carries its own standalone `settings.gradle`, and no `build.gradle` in the repo declares `project(":test:playwright")`, so no `deploy` task exists for it. Integration Test Compile, Cross-Module Compile, Java Unit Tests and Transaction Usage all require a `.java` path. JavaScript Unit Tests requires the module's `package.json` to declare a `test` script.

<!-- pr-check {"result": "success", "sha": "048413dbb5213edf602c61c1eb9f043965b3eeea"} -->
