### PR TITLE
LPD-102717 Give a multiselect picklist two different entries

### DIFF
--- a/modules/test/playwright/tests/object-web/utils/generateObjectEntry.ts
+++ b/modules/test/playwright/tests/object-web/utils/generateObjectEntry.ts
@@ -53,10 +53,7 @@ function generateObjectEntryValue({
 }) {
 	const listTypeEntriesRandomLength1 = listTypeEntriesName
 		? Math.floor(Math.random() * listTypeEntriesName.length)
-		: '';
-	const listTypeEntriesRandomLength2 = listTypeEntriesName
-		? Math.floor(Math.random() * listTypeEntriesName.length)
-		: '';
+		: 0;
 
 	switch (objectFieldBusinessType) {
 		case 'Assignee':
@@ -78,9 +75,20 @@ function generateObjectEntryValue({
 		case 'LongText':
 			return getRandomString();
 		case 'MultiselectPicklist':
+
+			// The two entries were drawn independently, so on a short list they
+			// were often the same one. Selecting one entry twice is not a
+			// multiselect: the second selection lands on an option that is
+			// already selected, which the admin theme renders pointer
+			// transparent, and the click never arrives. Which two entries they
+			// are does not matter, so take the one after the first.
+
 			return [
 				listTypeEntriesName[listTypeEntriesRandomLength1],
-				listTypeEntriesName[listTypeEntriesRandomLength2],
+				listTypeEntriesName[
+					(listTypeEntriesRandomLength1 + 1) %
+						listTypeEntriesName.length
+				],
 			];
 		case 'Picklist':
 			return {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102717

## What Is Being Fixed

`object-web/export-import` *"Can create an object entry of an object definition with 100 fields of all types after export and import"* fails about a third of the time. It was one of the two failures in the 2026-08-15 upstream baseline.

`generateObjectEntryValues` drew the two `MultiselectPicklist` entries with two independent random indexes into the same list, so on a three-entry list they collide about a third of the time and the generated entry is the same value twice. `fillObjectFields` selects one option per value, so a duplicated value selects the same option twice.

The second selection lands on an option that is already selected, which carries `dropdown-item active`. The admin theme renders that pointer-transparent through LPD-71471 `868a5cf` and LPD-85958 `22d21804`, so `document.elementFromPoint` at the option's own centre returns the list item wrapping it, the click never arrives, and Playwright retries until the test times out.

The CI trace shows the field opened and `review` selected twice, 500 ms apart, the second hanging for 63 s:

```
264640.2  click [data-field-name="multiselectpicklist..."] .form-control
265025.7  click option "review"
265268.1  click [data-field-name="multiselectpicklist..."] .form-control
265401.0  click option "review"   ->  times out
```

Measured at the moment of failure, with the list open and one matching option inside the viewport, the hit test at the option's own centre returns the wrapping list item:

```
{"matches":1,"ownExpanded":"true","optRect":"277,507 724x35",
 "topAtCentre":"LI.","scrollY":5952,"viewport":"1280x720"}
```

## How It Is Being Fixed

The test needs two different entries and does not care which, so take the one after the first and let it wrap. The second random index has no other reader and goes with it.

The index fell back to an empty string when there was no list, which typed it as a string or a number and made the wrap arithmetic illegal. Nothing reads the index except a subscript into that same absent list, which throws whatever the index is, so the fallback is now zero and the type is honest.

Root cause: born wrong. `67ae09b6c4965` (LPD-54630, *"Isolate and simplify functions"*) created `generateObjectEntryValue` already returning two independently drawn indexes for a multiselect. `daf66ddac96d6` renamed them and `ba52d132c4985` moved the file, neither changing the shape.

## Testing

Local A/B, interleaved so environment drift hits both arms equally, two runs on a clean environment: **control 7 of 20 fail, treatment 0 of 20**.

CI A/B, `object-web.export-import` at `repeatEach: 8`, **224 executions per arm**, arms differing only by this commit: the control fails the target test **4 times** and the treatment has **no failure at all**. The control's Playwright axis went UNSTABLE while the bundle built successfully, so the failure is a real test failure rather than infrastructure.

The final commit was re-run locally after the type correction: **10 of 10 pass**.

Three earlier hypotheses were disproven by measurement before this one: `dispatchEvent` on the wrong branch had no effect, `dispatchEvent` on the right branch had no effect (6/10 vs 4/10), and waiting for `aria-expanded` made the test fail 12 of 12.

## PR Check

**pr-check: PASS** — tested on `d2598e49803b9cce7a5a99fdb1eb82c34542ffd1`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Baseline | PASS |

Only these two validations matched the diff, whose single changed path is `modules/test/playwright/tests/object-web/utils/generateObjectEntry.ts`. Per-Module Compile does not fire because `modules/test/playwright` is not a deployable module — no `.lfrbuild-portal` marker, no `bnd.bnd` up its ancestor chain, its own standalone `settings.gradle`, and no `build.gradle` declares `project(":test:playwright")`. Integration Test Compile, Cross-Module Compile, Java Unit Tests and Transaction Usage all require a `.java` path.

Source Format covers both halves: the Java formatter with commit-message validation, and `:portalYarnFormatCurrentBranch`, which runs Prettier and the TypeScript checks over the changed file.

<!-- pr-check {"result": "success", "sha": "d2598e49803b9cce7a5a99fdb1eb82c34542ffd1"} -->
