### PR TITLE
LPD-102718 Run the JavaScript formatter as part of pr-check Source Format

### DIFF
--- a/.claude/skills/format-source/SKILL.md
+++ b/.claude/skills/format-source/SKILL.md
@@ -21,9 +21,17 @@ Run across the entire codebase:
 cd <repo-root>/portal-impl && ant format-source-current-branch
 ```
 
+Run for JavaScript, TypeScript, and CSS:
+
+```bash
+cd <repo-root>/modules && <gradlew> :portalYarnFormatCurrentBranch
+```
+
 `ant format-source-current-branch` only inspects committed files, so run it after creating the commit, and amend any formatter changes or fixes into that commit.
 
-In both cases, if there are issues to be fixed, the formatter will list them. Fix them.
+`:portalYarnFormatCurrentBranch` is the only command that type-checks TypeScript. Invoke it by its absolute task path; the bare name configures every subproject and fails on any JDK other than 17.
+
+In every case, if there are issues to be fixed, the formatter will list them. Fix them.
 
 In addition to the automatic formatter, there is a set of manual rules that the formatter does not catch. The full workflow is to run the formatter, apply the manual rules, then rerun the formatter to clean up any fallout from the manual edits. When a manual rule conflicts with the automatic formatter, the formatter wins; leave the formatted code as it stands.
 

--- a/.claude/skills/pr-check/validations/source-format.md
+++ b/.claude/skills/pr-check/validations/source-format.md
@@ -17,6 +17,14 @@ Run the SDK setup, then run the source formatter in `current-branch` mode:
 (cd "${REPO_ROOT}/portal-impl" && ANT_OPTS="-Xmx2560m" ant format-source-current-branch -Dvalidate.commit.messages=true)
 ```
 
+When the branch changes any `.css`, `.js`, `.jsx`, `.scss`, `.ts`, or `.tsx` file, also run the JavaScript formatter:
+
+```bash
+(cd "${REPO_ROOT}/modules" && ../gradlew :portalYarnFormatCurrentBranch)
+```
+
+Both commands must pass.
+
 ## Autocommit
 
 When `git status --porcelain` is nonempty after the formatter (fixable subset applied to the working tree), stage all changes (`git add --all`) and create a commit titled `<TICKET> SF`.
@@ -28,6 +36,10 @@ Unfixable violations exit nonzero and fail this validation; surface them from th
 ## Notes
 
 Run **after** all drift validations so the formatter sees the regenerated tree.
+
+The Ant formatter does not type-check TypeScript. Only the JavaScript formatter does.
+
+Invoke the JavaScript formatter by its absolute task path. The bare name configures every subproject and fails on any JDK other than 17.
 
 ## Time Estimate
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102718

## What Is Being Fixed

The **Source Format** validation runs only the Ant Java formatter. A branch that changes JavaScript, TypeScript, or CSS therefore reports PASS without Prettier or the TypeScript compiler ever running. The string `portalYarn` has never appeared anywhere under `.claude` before this commit.

This is not theoretical. LPD-102717 was closed out on that basis and carried a TypeScript error:

```
(89,7) (error TS2365) Operator '+' cannot be applied to types 'string | number' and 'number'.
```

It went through the full pr-check with a `.ts` file in the diff and no validation flagged it. No other validation covers this: `javascript-unit-test` runs `npm test`, which is Jest, and Jest transpiles without type-checking; `per-module-compile` matches `.ts` paths but operates on the deploy set, and `modules/test/playwright` is not a deployable module.

`prettier --check` is not a substitute either — it reported *"All matched files use Prettier code style!"* on the file carrying the error above, because it checks formatting and does not type-check.

## How It Is Being Fixed

`source-format.md` runs the JavaScript formatter when the branch changes a `.css`, `.js`, `.jsx`, `.scss`, `.ts`, or `.tsx` file, and both commands must pass. `format-source/SKILL.md` gains the same command.

The formatter is invoked by its absolute task path. Gradle resolves an unqualified task name against the root project **and every subproject**, so the bare name configures the whole tree, including `modules/third-party/jakarta-faces`, which throws unless the JDK is exactly 17. That happens at configuration — `--dry-run` fails identically — so the run formats nothing while reporting what looks like an unrelated toolchain problem. The absolute path configures only the root project.

Root cause: born wrong, in two places that each assumed the other covered it. `d297ef35bfc1a` (LPD-86965, *"Add format-source skill"*) documented the Ant and `formatSource` commands and never the JavaScript formatter. `d2e9f59d10fe8` (LRCI-7395, *"Restructure pr-check skill into a checklist of validations"*) created `source-format.md` delegating to that skill, and later revisions inlined the Ant command it documented.

## Testing

Nine local test cases, each asserting one property of the added command. Every fixture was removed afterwards and none is committed.

| Test | Question | Result |
| --- | --- | --- |
| T1 | Does the absolute path lose coverage vs the bare name? | Identical 5-task graph under JDK 17 |
| T2 | Catches a committed TypeScript error? | Exit 1, file and line named |
| T3 | Passes a type-correct file? | Exit 0 |
| T4 | Auto-fix blast radius? | Exactly 1 file, no collateral |
| T5 | Java-only branch? | Exit 0 in 14 s, 0 files modified |
| T6 | Error outside the branch diff? | Caught; the whole project is checked |
| T6c | Untracked new file? | Caught |
| T8 | `.scss` file? | Reformatted, exit 0 |
| T9 | `.js` file? | Reformatted, exit 0 |

T5 matters because this validation's **Match** is `.`, so it fires on every pull request. On a branch with no JavaScript change the command is a 14-second no-op that modifies nothing.

T4 matters because the validation autocommits with `git add --all`. The formatter rewrites only the files it was given, so the autocommit captures nothing extra.

T1 is the safety proof for the absolute path: both invocations resolve to the same five root-project tasks, so scoping the path removes a failure mode without removing work.

The first attempt at T6 was discarded — its fixture never applied, which made a vacuous pass look like a real one. Rerun with an assertion that the fixture landed, it produced the opposite result.

## PR Check

**pr-check: PASS** — tested on `4539fc3d85cacda73b1b9b94d136003387b94584`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Baseline | PASS |

Only these two validations matched the diff. Both declare **Match** `.`, so they always fire; every other validation requires a path this diff does not touch, since the two changed files are under `.claude/skills/`. Source Format was run in both halves, including the JavaScript half this commit adds, which reports `Formatting 2 files` and passes.

<!-- pr-check {"result": "success", "sha": "4539fc3d85cacda73b1b9b94d136003387b94584"} -->
