### PR TITLE
LPD-102718 Wait for the relationship the entry picker relates

### DIFF
--- a/modules/test/playwright/tests/object-web/relationship/objectRelationship.spec.ts
+++ b/modules/test/playwright/tests/object-web/relationship/objectRelationship.spec.ts
@@ -4671,6 +4671,23 @@ test.describe('Manage object relationship entries', () => {
 					await expect(entry).toBeVisible();
 
 					await entry.click();
+
+					// Selecting relates the entry and closes the picker, and the
+					// relating is still in flight when the click resolves. The
+					// next step navigates away, so returning here lets that
+					// navigation race the save and the entry is never related.
+					// Wait for the picker to go and the row to appear.
+
+					await expect(
+						page.locator('iframe[title="Select"]')
+					).toBeHidden();
+
+					await expect(
+						page
+							.getByRole('row')
+							.filter({hasText: entryLabel})
+							.first()
+					).toBeVisible();
 				};
 
 				await openRelationshipTab(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102718

## What Is Being Fixed

`object-web/relationship` *"relates many entries from both objects in a many-to-many relationship"* fails about a third of the time. It was one of the two failures in the 2026-08-15 upstream baseline.

`selectRelationshipEntry` clicks an entry in the Select picker and returns. Selecting posts the relationship as a form submission from inside the picker iframe, so the write is still in flight when the click resolves. The helper does not navigate itself, but the test's next call does: `openRelationshipTab` opens with `viewObjectEntriesPage.goto`, and that navigation tears down the frame the post belongs to and cancels it. The relationship is never written.

The write is not merely late, it is dropped. In the CI trace of the many-to-many failure three relate posts appear, two answered `302` in ten and thirteen milliseconds, and one that never completes:

```
POST  -1   .../object_entries/edit_object_entry_related_model
           timings send=-1 wait=-1 receive=-1
POST  302  .../object_entries/edit_object_entry_related_model   12.6ms
POST  302  .../object_entries/edit_object_entry_related_model    9.7ms
```

A cancelled form post leaves nothing behind to finish later, so no amount of waiting recovers it. The trace shows Entry B related and Entry C lost, with the `goto` a hundred and thirty three milliseconds after the click, and the assertion that follows still finding no Entry C row fifteen seconds later:

```
458470.4  click "Entry C" in iframe[title="Select"]
458603.8  goto ...control_panel/manage
459954.1  expect row "Entry B"  ->  passes
460068.3  expect row "Entry C"  ->  not found, times out
```

## How It Is Being Fixed

Wait for the picker to close and the row to appear, so the helper does not hand back control until the entry it selected is actually related. The test pairs `selectRelationshipEntry` with `openRelationshipTab` three times, so the fix belongs in the shared helper rather than at any one navigation.

Root cause: born wrong. `e92e6aa20ce25` (LPD-90439, *"Add migrations"*) added both this test and the helper, with the helper already ending on a bare `entry.click` and nothing waiting for the relate it starts.

## Testing

Local A/B, forty runs on a freshly built bundle and database: without this change the test fails **six of twenty** with the reported signature, timing out after fifteen seconds waiting for the related row. With it, **zero of twenty**.

CI A/B, arms differing only by this commit, read from the axis `playwright-report` rather than the bot summary: the control fails the named test **four of twenty** and the treatment **zero of twenty**.

Re-run after rebasing onto current master and applying the source formatter: **ten of ten pass**.

## PR Check

**pr-check: PASS** — tested on `14618b1e2f0775ad10d4d92127ce709301221d0a`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Baseline | PASS |

Only these two validations matched the diff, whose single changed path is `modules/test/playwright/tests/object-web/relationship/objectRelationship.spec.ts`. Both declare **Match** `.`, so they always fire; every other validation requires a path this diff does not touch. Per-Module Compile does not fire because `modules/test/playwright` is not a deployable module — no `.lfrbuild-portal` marker, no `bnd.bnd` up its ancestor chain, its own standalone `settings.gradle`, and no `build.gradle` declares `project(":test:playwright")`. Integration Test Compile, Cross-Module Compile, Java Unit Tests and Transaction Usage all require a `.java` path.

Source Format covers both halves: the Ant formatter with commit message validation, which itself invokes `:portalYarnFormatCurrentBranch` for the changed TypeScript, applying Prettier and the TypeScript compiler.

<!-- pr-check {"result": "success", "sha": "14618b1e2f0775ad10d4d92127ce709301221d0a"} -->
