### PR TITLE
LPD-102720 Put the system object's title field back the way it was found

### DIFF
--- a/modules/test/playwright/tests/object-web/main/objectDefinition.spec.ts
+++ b/modules/test/playwright/tests/object-web/main/objectDefinition.spec.ts
@@ -1247,6 +1247,11 @@ test.describe('Manage object definitions through View Object Definitions', () =>
 
 			await editObjectDetailsPage.goToDetailsTab();
 
+			const originalEntryTitleField =
+				(
+					await editObjectDetailsPage.entryTitleField.textContent()
+				)?.trim() ?? '';
+
 			await editObjectDetailsPage.entryTitleField.click();
 
 			await page
@@ -1262,6 +1267,23 @@ test.describe('Manage object definitions through View Object Definitions', () =>
 			await expect(editObjectDetailsPage.entryTitleField).toContainText(
 				'Screen Name'
 			);
+
+			// User is a system object shared by the whole run, so put its title
+			// field back the way it was found. Left on Screen Name, a later
+			// execution opens the dropdown with that option already selected and
+			// waits on it until the test times out, so the test can otherwise
+			// only pass once per environment.
+
+			await editObjectDetailsPage.entryTitleField.click();
+
+			await page
+				.getByRole('option', {
+					exact: true,
+					name: originalEntryTitleField,
+				})
+				.click();
+
+			await editObjectDetailsPage.saveObjectDefinition();
 		}
 	);
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102720

## What Is Being Fixed

The Playwright test `can set Title Field for a system object` points the `User`
object's Entry Title Field at Screen Name and never restores it. `User` is a
system object shared by every test in the run, so the change outlives the test
and the test can only pass once against a given environment.

A later execution opens the dropdown with Screen Name already selected. The
option is then no longer offered as something to pick, so the click waits on it
until the test's own ninety second budget runs out. On CI this reads as a bare
`Test timeout of 90000ms exceeded` with no failing assertion, at a step that
looks trivial — the step trace shows
`Click getByRole('option', { name: 'Screen Name' })` taking 85,861ms. It surfaces
under `repeatEach`, where the second and third repeats meet the state the first
left behind.

Root cause is `6178dc43bf5dd` (LPD-82349), which created the test in this form
while migrating it from Poshi. Its diff adds the test outright with no restore
step, so the flaw is as old as the Playwright version of the test.

The repository's cleanup convention did not catch it because that convention
covers creation, not mutation: objects created through `apiHelpers` are
registered and deleted automatically, but nothing records that a pre-existing
shared object was edited. This test creates nothing, so it registered nothing,
and still left the system altered.

## How It Is Being Fixed

Record the title field found on arrival and restore it at the end. The value is
captured rather than hardcoded, so the test stays correct if the product default
changes. That default is `givenName`, per
`UserSystemObjectDefinitionManager.getTitleObjectFieldName()`.

## PR Check

**Overall: PASS** — tested SHA `236de79dec35c359984c1e81c36bdf2fbbe4b487`

| Validation | Result |
| --- | --- |
| Source Format | PASS — `format-source-current-branch`, including the TypeScript project check |
| Per-Module Compile | Not applicable — `modules/test/playwright` has no `bnd.bnd` and no `.lfrbuild-portal`, so it deploys no runtime bundle. The compile-equivalent for a `.ts` change is the TypeScript check, which Source Format ran. |
| JavaScript Unit Tests | Not applicable — the module declares no Jest suite (no jest config, no jest dependency); its `test` script is the Playwright runner itself. |

Behaviour was verified by running the test rather than by a unit suite. Locally,
four times in a row against one environment: pure `upstream/master` fails 4 of 4
in about 4.7 minutes of timeouts; with the fix it passes 4 of 4 in 27.6 seconds,
and the object definition is left reporting `titleObjectFieldName=givenName`. On
CI, an arm running `object-web.main` at `repeatEach: 4` returned 242 expected,
0 unexpected and 0 skipped — a complete run with nothing truncated — and the
target test 4 of 4 expected.

<!-- pr-check {"result": "success", "sha": "236de79dec35c359984c1e81c36bdf2fbbe4b487"} -->
