### PR TITLE
LPD-102721 Wait for the management toolbar search to accept Enter

### DIFF
--- a/modules/test/playwright/pages/object-web/ViewObjectDefinitionsPage.ts
+++ b/modules/test/playwright/pages/object-web/ViewObjectDefinitionsPage.ts
@@ -12,6 +12,7 @@ import {gotoWithRetry} from '../../utils/gotoWithRetry';
 import {PORTLET_URLS} from '../../utils/portletUrls';
 import {getTempDir} from '../../utils/temp';
 import {waitForAlert} from '../../utils/waitForAlert';
+import {waitForSearchToBeReady} from '../../utils/waitForSearchToBeReady';
 
 export class ViewObjectDefinitionsPage {
 	readonly actionsButton: Locator;
@@ -114,6 +115,8 @@ export class ViewObjectDefinitionsPage {
 
 		await input.fill(objectDefinitionLabel);
 
+		await waitForSearchToBeReady(this.page);
+
 		await this.page.keyboard.press('Enter');
 
 		await this.page
@@ -163,6 +166,8 @@ export class ViewObjectDefinitionsPage {
 		await this.goto();
 
 		await this.searchInput.fill(objectDefinitionLabel);
+
+		await waitForSearchToBeReady(this.page);
 
 		await this.page.keyboard.press('Enter');
 

--- a/modules/test/playwright/tests/object-web/field/objectField.spec.ts
+++ b/modules/test/playwright/tests/object-web/field/objectField.spec.ts
@@ -22,6 +22,7 @@ import {ObjectFieldsPage} from '../../../pages/object-web/object-fields/ObjectFi
 import {getRandomInt} from '../../../utils/getRandomInt';
 import getRandomString from '../../../utils/getRandomString';
 import {waitForAlert} from '../../../utils/waitForAlert';
+import {waitForSearchToBeReady} from '../../../utils/waitForSearchToBeReady';
 import {AsyncArray} from '../utils/AsyncArray';
 import {generateObjectFields} from '../utils/generateObjectFields';
 import {postListTypeDefinitionListTypeEntries} from '../utils/postListTypeDefinitionListTypeEntries';
@@ -2513,6 +2514,9 @@ test.describe('Create Object Fields', () => {
 			.getByRole('search')
 			.getByRole('searchbox', {name: 'Search'})
 			.fill('Cancel Field');
+
+		await waitForSearchToBeReady(page);
+
 		await page.keyboard.press('Enter');
 
 		await expect(page.getByText('No Results Found')).toBeVisible();

--- a/modules/test/playwright/utils/waitForSearchToBeReady.ts
+++ b/modules/test/playwright/utils/waitForSearchToBeReady.ts
@@ -1,0 +1,25 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Page, expect} from '@playwright/test';
+
+/**
+ * Waits until the management toolbar's search accepts Enter.
+ *
+ * The server ships the search form's default submit button disabled, and a form
+ * whose default button is disabled skips implicit submission entirely, so Enter
+ * produces no submit event and no request. The typed text simply sits there, the
+ * listing is never filtered, and an assertion about the filtered result fails
+ * against unfiltered content. The button is enabled once the client script runs,
+ * which is what this waits for.
+ *
+ * A load state is not enough on its own: after an SPA navigation the document
+ * has already fired load while the swapped-in markup is still inert.
+ */
+export async function waitForSearchToBeReady(page: Page) {
+	await expect(
+		page.locator('.management-bar button[type="submit"]')
+	).toBeEnabled();
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102721

## What Is Being Fixed

The Playwright test `Verify it is possible to cancel the creation of a custom
object field` cancels a field, then types into the management toolbar search,
presses Enter, and asserts that `No Results Found` appears.

Enter does nothing when pressed before the toolbar has hydrated. The server ships
the search form's default submit button `disabled`, and per the HTML
specification a form whose default button is disabled **skips implicit
submission entirely** — no submit event, no request. The typed text sits in the
box, the listing is never filtered, and the assertion is made against a listing
that still holds every field.

Waiting on a load state does not cover it: after a single page navigation the
document has already fired `load` while the markup swapped in is still inert.

Root cause is `7967fe3545d3e` (LPS-193661, 2023-08-22), *"Disabling search button
during page loading, because clicking that button when the page is not fully
rendered causes unexpected errors"*. Its diff adds
`const [searchDisabled, setSearchDisabled] = useState(true)` and changes the
button from `disabled={disabled}` to `disabled={searchDisabled}`, so it ships
disabled and is enabled only once the client script runs. That deliberately
blocked premature *clicks*; it unintentionally also blocked *Enter*, which was
never the intent.

## How It Is Being Fixed

A new `waitForSearchToBeReady` waits for `.management-bar button[type="submit"]`
to become enabled. That button is the form's default button and is exactly one
element in both states, with `disabled` going from `true` to `false` when the
script runs, so it is the correct readiness signal — label-independent and
feature-flag-independent.

It is applied in the failing test and in the two shared
`ViewObjectDefinitionsPage` helpers that reach a definition by label. Those sit
on the path of most object tests, including every caller that edits or exports a
definition by label, so gating them covers considerably more than the one test
that exposed the problem.

## PR Check

**Overall: PASS** — tested SHA `a9ea98cfb9408ac26bd8d16abd86ffcd802ea7b5`

| Validation | Result |
| --- | --- |
| Source Format | PASS — `format-source-current-branch` over 3 files, including the TypeScript project check |
| Per-Module Compile | Not applicable — `modules/test/playwright` has no `bnd.bnd` and no `.lfrbuild-portal`, so it deploys no runtime bundle. The compile-equivalent for a `.ts` change is the TypeScript check, which Source Format ran. |
| JavaScript Unit Tests | Not applicable — the module declares no Jest suite (no jest config, no jest dependency); its `test` script is the Playwright runner itself. |

Behaviour was verified by running the tests. Locally the target passes 6 of 6 at
`repeatEach: 6`, with no-harm checks on `object-web.main` (2 passed) and the
export/import 100-fields test (1 passed). On CI, an arm over `field`,
`export-import` and `list-type-definition` at `repeatEach: 6` returned the target
**6 of 6 expected** out of 574 expected overall, and the `listTypeDefinition`
translated-picklist test — a separate CI-only failure — passed **12 of 12**.

For completeness: that arm's job verdict was a failure, from one unrelated test,
`Can create an object entry of an object definition with 100 fields of all types
after export and import`. The arm branches from `upstream/master` and so does not
carry the import-ordering fix that test needs; it fails there for a separate and
already-diagnosed reason.

<!-- pr-check {"result": "success", "sha": "a9ea98cfb9408ac26bd8d16abd86ffcd802ea7b5"} -->
