### PR TITLE
LPD-102724 Keep the side panel open for a modal it owns

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/side_panel/SidePanel.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/side_panel/SidePanel.js
@@ -127,9 +127,20 @@ export default class SidePanel extends React.Component {
 	}
 
 	handleKeyupEvent(even) {
+
+		// This handler is bound to the panel iframe's window as well as to the
+		// top one, so an Escape raised inside the panel arrives here. A modal
+		// opened by the panel's own content belongs to the iframe's document,
+		// where the check below against the top document cannot see it, and the
+		// panel would close under a modal the user is still working in, taking
+		// every unsaved edit with it. Ask the document the event came from too.
+
+		const eventDocument = even.view?.document ?? even.target?.ownerDocument;
+
 		if (
 			even.keyCode !== 27 ||
-			window.top.document.querySelector('.modal-content')
+			window.top.document.querySelector('.modal-content') ||
+			eventDocument?.querySelector('.modal-content')
 		) {
 			return;
 		}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102724

## What Is Being Fixed

Pressing Escape inside a Frontend Data Set side panel closes the whole panel, even while a modal opened by the panel's own content is on screen. The user loses the panel and every unsaved edit in it.

Reaching this takes nothing unusual. In the Objects view designer, opening Filters, clicking New Filter, picking a field and a value, and then pressing Escape to dismiss the still-open value dropdown closes the entire panel — the half-built filter, the selected fields and the Mark as Default setting all go with it. Escape is the ordinary gesture for dismissing a dropdown, so no deliberate attempt to close anything is involved.

`SidePanel.handleKeyupEvent` is bound to the panel iframe's window as well as to the top window, so an Escape raised inside the panel reaches it. The handler already declines to close when a modal is open, but it looks for that modal in the top document only, and a modal belonging to the panel's own content is rendered into the iframe's document. Measured with the filter modal open, the top document matches zero `.modal-content` nodes while the panel iframe's document matches one.

The flaw dates to `6fe2c973dd4ce` (LPS-114698), which added the component and gave it both halves at once: the listener on the iframe window and the modal check against the top document. Nothing exercised the gap until a modal was rendered inside the panel's own iframe, which the object view designer and its filter modal did in `c2c24884df22d` and `360ace6026b30`.

## How It Is Being Fixed

The handler now also asks the document the event came from, alongside the top document, before deciding to close. `even.view?.document` is the window the event was raised in; `even.target?.ownerDocument` covers synthetic events that do not set `view`.

The guard only ever returns earlier than it did before, so it can withhold a close that should not have happened and cannot cause one that should.

Verified by a manual A/B on a running bundle, with the JavaScript served over HTTP checked in both directions to confirm which build was live. On the unpatched build the steps above close the whole panel, observable as the panel's content iframe URL changing from the view designer URL to `about:blank`. On the patched build the same steps close only the dropdown, leaving the modal and the panel open.

## Why Are There No Tests?

The change repairs two existing Playwright tests that exercise this path, `objectView` "can edit a filter in custom view" and "can filter entries by status in custom view". Both drive the filter modal and press Escape on the value dropdown, so the regression is already covered by the suite rather than needing a new test.

## PR Check

**pr-check: PASS** — tested SHA `c887f166417c63d904c47c845e6e864ad6d74d0f`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Baseline | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Test | PASS |

Source Format ran with `-Dvalidate.commit.messages=true` and left the tree clean. Baseline reported no version warnings and rewrote nothing. Per-Module Compile ran `ant compile install-portal-snapshots` then deployed `frontend-data-set-web`. The module's Jest suite passed 22 of 22 files, 246 tests.

Integration Test Compile, Java Unit, Cross-Module Compile and Transaction Usage did not fire; the diff is a single `.js` file.

<!-- pr-check {"result": "success", "sha": "c887f166417c63d904c47c845e6e864ad6d74d0f"} -->
