### PR TITLE
LPD-102725 Wait for the user the relationship picker relates

### DIFF
--- a/modules/test/playwright/tests/object-web/relationship/objectRelationship.spec.ts
+++ b/modules/test/playwright/tests/object-web/relationship/objectRelationship.spec.ts
@@ -3118,6 +3118,17 @@ test.describe('Manage object relationships with system objects', () => {
 				await relationshipTab.click();
 			};
 
+			const getRelatedUserRow = (userAccount: TUserAccount) =>
+				page
+					.getByRole('row')
+					.filter({
+						hasText: new RegExp(
+							`${userAccount.givenName}|${userAccount.id}`,
+							'i'
+						),
+					})
+					.first();
+
 			const selectExistingRelationshipEntry = async (
 				userAccount: TUserAccount
 			) => {
@@ -3130,18 +3141,19 @@ test.describe('Manage object relationships with system objects', () => {
 
 				await expect(relationshipEntry).toBeVisible();
 				await relationshipEntry.click();
-			};
 
-			const getRelatedUserRow = (userAccount: TUserAccount) =>
-				page
-					.getByRole('row')
-					.filter({
-						hasText: new RegExp(
-							`${userAccount.givenName}|${userAccount.id}`,
-							'i'
-						),
-					})
-					.first();
+				// Selecting relates the user and closes the picker, and the
+				// relating is still in flight when the click resolves. The next
+				// step opens the tab with a goto, which tears down the frame the
+				// post belongs to and cancels it. Wait for the picker to go and
+				// the row to appear.
+
+				await expect(
+					page.locator('iframe[title="Select"]')
+				).toBeHidden();
+
+				await expect(getRelatedUserRow(userAccount)).toBeVisible();
+			};
 
 			for (const entryLabel of ['Entry A', 'Entry B']) {
 				await openEntryRelationshipTab(entryLabel);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102725

## What Is Being Fixed

The Playwright test "can relate Many-to-Many Custom Object entry with System Object entries" fails intermittently on CI, timing out on the assertion that a related user's row is visible:

```
Error: Timed out 15000ms waiting for expect(locator).toBeVisible()
Locator: getByRole('row').filter({hasText: /User8038009710|41216/i}).first()
Expected: visible
Received: <element(s) not found>
```

The row is absent rather than late, so the relationship was never persisted.

The local helper `selectExistingRelationshipEntry` clicks a user in the Select picker and returns immediately. Selecting posts the relationship from inside the picker iframe, so the write is still in flight when the click resolves. The next step, `openEntryRelationshipTab`, navigates with `viewObjectEntriesPage.goto`, and that navigation tears down the frame the post belongs to and cancels it.

The hazard was masked and then uncovered on the same day under LPD-82349: `46afd26f1bef5` added this code with an `await page.waitForTimeout(1000)` after the click, which covered the write, and `fd889e8e4915e` removed that sleep without replacing it with a wait for the relate.

## How It Is Being Fixed

The helper now waits for the picker iframe to be hidden and for the selected user's row to appear before returning, so it does not hand back control until the user it selected is actually related. `getRelatedUserRow` moves above the helper so the helper can use it.

This is the same anti-pattern LPD-102718 fixed on the neighbouring entry picker in the same spec file. The two helpers are distinct — one takes a `TUserAccount`, the other an entry label — and the changes do not overlap; this branch rebases cleanly over that commit.

Blast radius is one test. The helper is a `const` local to its describe block with two call sites, and both already assert exactly what the fix hoists earlier.

## Why Are There No Tests?

The change is itself a test fix. It repairs an existing Playwright test rather than adding behavior.

## PR Check

**pr-check: PASS** — tested SHA `c5ad6e05b81cb008241f0f9f2bb8d886881f1c80`

| Validation | Result |
| --- | --- |
| Source Format | PASS — `format-source-current-branch` with `validate.commit.messages`, including the TypeScript check; tree clean after |
| Baseline | PASS — `ant baseline-all`, no version warnings, tree unchanged |
| Per-Module Compile | Not applicable — `modules/test/playwright` has no `bnd.bnd` and no `.lfrbuild-portal`, so it deploys no runtime bundle. The compile-equivalent for a `.ts` change is the TypeScript check, which Source Format ran. |
| JavaScript Unit Test | Not applicable — the module declares no Jest suite (no jest dependency, no jest config); its `test` script is the Playwright runner itself. |

Behaviour was verified by running the test. Under a local amplifier on one environment, unpatched fails 0 of 20 and patched passes 20 of 20.

<!-- pr-check {"result": "success", "sha": "c5ad6e05b81cb008241f0f9f2bb8d886881f1c80"} -->
