### PR TITLE
LPD-102542 Remove the stray link end tag from the stylesheet includes

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/java/com/liferay/frontend/js/aui/web/internal/servlet/taglib/AUITopHeadCSSDynamicInclude.java
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/java/com/liferay/frontend/js/aui/web/internal/servlet/taglib/AUITopHeadCSSDynamicInclude.java
@@ -50,7 +50,7 @@ public class AUITopHeadCSSDynamicInclude extends BaseDynamicInclude {
 		printWriter.print(
 			ContentSecurityPolicyNonceProviderUtil.getNonceAttribute(
 				httpServletRequest));
-		printWriter.print(" rel=\"stylesheet\"></link>\n");
+		printWriter.print(" rel=\"stylesheet\">\n");
 	}
 
 	@Override

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/test/java/com/liferay/frontend/js/aui/web/internal/servlet/taglib/AUITopHeadCSSDynamicIncludeTest.java
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/test/java/com/liferay/frontend/js/aui/web/internal/servlet/taglib/AUITopHeadCSSDynamicIncludeTest.java
@@ -1,0 +1,97 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.frontend.js.aui.web.internal.servlet.taglib;
+
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.portal.url.builder.AbsolutePortalURLBuilder;
+import com.liferay.portal.url.builder.AbsolutePortalURLBuilderFactory;
+import com.liferay.portal.url.builder.WebContextStylesheetAbsolutePortalURLBuilder;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * @author Georgel Pop
+ */
+public class AUITopHeadCSSDynamicIncludeTest {
+
+	@ClassRule
+	public static LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	@TestInfo("LPD-102542")
+	public void testInclude() throws Exception {
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+		MockHttpServletResponse mockHttpServletResponse =
+			new MockHttpServletResponse();
+
+		AUITopHeadCSSDynamicInclude auiTopHeadCSSDynamicInclude =
+			new AUITopHeadCSSDynamicInclude();
+
+		String href = RandomTestUtil.randomString();
+
+		ReflectionTestUtil.setFieldValue(
+			auiTopHeadCSSDynamicInclude, "_absolutePortalURLBuilderFactory",
+			_getAbsolutePortalURLBuilderFactory(href, mockHttpServletRequest));
+
+		auiTopHeadCSSDynamicInclude.include(
+			mockHttpServletRequest, mockHttpServletResponse,
+			"/html/common/themes/top_head.jsp#post");
+
+		Assert.assertEquals(
+			"<link data-senna-track=\"permanent\" href=\"" + href +
+				"\" rel=\"stylesheet\">\n",
+			mockHttpServletResponse.getContentAsString());
+	}
+
+	private AbsolutePortalURLBuilderFactory _getAbsolutePortalURLBuilderFactory(
+		String href, MockHttpServletRequest mockHttpServletRequest) {
+
+		AbsolutePortalURLBuilderFactory absolutePortalURLBuilderFactory =
+			Mockito.mock(AbsolutePortalURLBuilderFactory.class);
+
+		WebContextStylesheetAbsolutePortalURLBuilder
+			webContextStylesheetAbsolutePortalURLBuilder = Mockito.mock(
+				WebContextStylesheetAbsolutePortalURLBuilder.class);
+
+		Mockito.when(
+			webContextStylesheetAbsolutePortalURLBuilder.build()
+		).thenReturn(
+			href
+		);
+
+		AbsolutePortalURLBuilder absolutePortalURLBuilder = Mockito.mock(
+			AbsolutePortalURLBuilder.class);
+
+		Mockito.when(
+			absolutePortalURLBuilder.forWebContextStylesheet(
+				"frontend-js-aui-web", "/alloy_ui.css")
+		).thenReturn(
+			webContextStylesheetAbsolutePortalURLBuilder
+		);
+
+		Mockito.when(
+			absolutePortalURLBuilderFactory.getAbsolutePortalURLBuilder(
+				mockHttpServletRequest)
+		).thenReturn(
+			absolutePortalURLBuilder
+		);
+
+		return absolutePortalURLBuilderFactory;
+	}
+
+}

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/test/java/com/liferay/frontend/js/aui/web/internal/servlet/taglib/AUITopHeadCSSDynamicIncludeTest.java
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/test/java/com/liferay/frontend/js/aui/web/internal/servlet/taglib/AUITopHeadCSSDynamicIncludeTest.java
@@ -34,19 +34,18 @@ public class AUITopHeadCSSDynamicIncludeTest {
 	@Test
 	@TestInfo("LPD-102542")
 	public void testInclude() throws Exception {
-		MockHttpServletRequest mockHttpServletRequest =
-			new MockHttpServletRequest();
-		MockHttpServletResponse mockHttpServletResponse =
-			new MockHttpServletResponse();
-
 		AUITopHeadCSSDynamicInclude auiTopHeadCSSDynamicInclude =
 			new AUITopHeadCSSDynamicInclude();
-
 		String href = RandomTestUtil.randomString();
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
 
 		ReflectionTestUtil.setFieldValue(
 			auiTopHeadCSSDynamicInclude, "_absolutePortalURLBuilderFactory",
 			_getAbsolutePortalURLBuilderFactory(href, mockHttpServletRequest));
+
+		MockHttpServletResponse mockHttpServletResponse =
+			new MockHttpServletResponse();
 
 		auiTopHeadCSSDynamicInclude.include(
 			mockHttpServletRequest, mockHttpServletResponse,

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/test/java/com/liferay/frontend/js/aui/web/internal/servlet/taglib/AUITopHeadCSSDynamicIncludeTest.java
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/test/java/com/liferay/frontend/js/aui/web/internal/servlet/taglib/AUITopHeadCSSDynamicIncludeTest.java
@@ -5,6 +5,7 @@
 
 package com.liferay.frontend.js.aui.web.internal.servlet.taglib;
 
+import com.liferay.portal.kernel.servlet.taglib.DynamicInclude;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -55,6 +56,24 @@ public class AUITopHeadCSSDynamicIncludeTest {
 			"<link data-senna-track=\"permanent\" href=\"" + href +
 				"\" rel=\"stylesheet\">\n",
 			mockHttpServletResponse.getContentAsString());
+	}
+
+	@Test
+	@TestInfo("LPD-102542")
+	public void testRegister() {
+		AUITopHeadCSSDynamicInclude auiTopHeadCSSDynamicInclude =
+			new AUITopHeadCSSDynamicInclude();
+
+		DynamicInclude.DynamicIncludeRegistry dynamicIncludeRegistry =
+			Mockito.mock(DynamicInclude.DynamicIncludeRegistry.class);
+
+		auiTopHeadCSSDynamicInclude.register(dynamicIncludeRegistry);
+
+		Mockito.verify(
+			dynamicIncludeRegistry
+		).register(
+			"/html/common/themes/top_head.jsp#post"
+		);
 	}
 
 	private AbsolutePortalURLBuilderFactory _getAbsolutePortalURLBuilderFactory(

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/StylesheetTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/StylesheetTag.java
@@ -67,7 +67,7 @@ public class StylesheetTag extends AttributesTagSupport {
 		sb.append(
 			ContentSecurityPolicyNonceProviderUtil.getNonceAttribute(
 				httpServletRequest));
-		sb.append(" rel=\"stylesheet\" type=\"text/css\"></link>");
+		sb.append(" rel=\"stylesheet\" type=\"text/css\">");
 
 		outputData.addDataSB(_getOutputKey(), WebKeys.PAGE_TOP, sb);
 

--- a/modules/apps/frontend-taglib/frontend-taglib/src/test/java/com/liferay/frontend/taglib/servlet/taglib/StylesheetTagTest.java
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/test/java/com/liferay/frontend/taglib/servlet/taglib/StylesheetTagTest.java
@@ -52,17 +52,16 @@ public class StylesheetTagTest {
 	@Test
 	@TestInfo("LPD-102542")
 	public void testDoEndTag() throws Exception {
-		MockHttpServletRequest mockHttpServletRequest =
-			new MockHttpServletRequest();
+		StylesheetTag stylesheetTag = new StylesheetTag();
 
 		String bundleSymbolicName = RandomTestUtil.randomString();
 		String css = RandomTestUtil.randomString();
 		String href = RandomTestUtil.randomString();
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
 
 		_setUpServicesProvider(
 			bundleSymbolicName, css, href, mockHttpServletRequest);
-
-		StylesheetTag stylesheetTag = new StylesheetTag();
 
 		stylesheetTag.setBundle(bundleSymbolicName);
 		stylesheetTag.setCss(css);
@@ -86,12 +85,9 @@ public class StylesheetTagTest {
 		String bundleSymbolicName, String css, String href,
 		MockHttpServletRequest mockHttpServletRequest) {
 
-		AbsolutePortalURLBuilderFactory absolutePortalURLBuilderFactory =
-			Mockito.mock(AbsolutePortalURLBuilderFactory.class);
+		Bundle bundle = Mockito.mock(Bundle.class);
 
 		String webContextPath = RandomTestUtil.randomString();
-
-		Bundle bundle = Mockito.mock(Bundle.class);
 
 		Mockito.when(
 			bundle.getHeaders(StringPool.BLANK)
@@ -125,6 +121,9 @@ public class StylesheetTagTest {
 		).thenReturn(
 			webContextStylesheetAbsolutePortalURLBuilder
 		);
+
+		AbsolutePortalURLBuilderFactory absolutePortalURLBuilderFactory =
+			Mockito.mock(AbsolutePortalURLBuilderFactory.class);
 
 		Mockito.when(
 			absolutePortalURLBuilderFactory.getAbsolutePortalURLBuilder(

--- a/modules/apps/frontend-taglib/frontend-taglib/src/test/java/com/liferay/frontend/taglib/servlet/taglib/StylesheetTagTest.java
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/test/java/com/liferay/frontend/taglib/servlet/taglib/StylesheetTagTest.java
@@ -1,0 +1,146 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.frontend.taglib.servlet.taglib;
+
+import com.liferay.frontend.taglib.internal.util.ServicesProvider;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.servlet.taglib.util.OutputData;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.portal.url.builder.AbsolutePortalURLBuilder;
+import com.liferay.portal.url.builder.AbsolutePortalURLBuilderFactory;
+import com.liferay.portal.url.builder.WebContextStylesheetAbsolutePortalURLBuilder;
+
+import jakarta.servlet.jsp.tagext.Tag;
+
+import java.util.Collections;
+import java.util.Hashtable;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import org.osgi.framework.Bundle;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockPageContext;
+import org.springframework.mock.web.MockServletContext;
+
+/**
+ * @author Georgel Pop
+ */
+public class StylesheetTagTest {
+
+	@ClassRule
+	public static LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@After
+	public void tearDown() {
+		_servicesProviderMockedStatic.close();
+	}
+
+	@Test
+	@TestInfo("LPD-102542")
+	public void testDoEndTag() throws Exception {
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		String bundleSymbolicName = RandomTestUtil.randomString();
+		String css = RandomTestUtil.randomString();
+		String href = RandomTestUtil.randomString();
+
+		_setUpServicesProvider(
+			bundleSymbolicName, css, href, mockHttpServletRequest);
+
+		StylesheetTag stylesheetTag = new StylesheetTag();
+
+		stylesheetTag.setBundle(bundleSymbolicName);
+		stylesheetTag.setCss(css);
+		stylesheetTag.setPageContext(
+			new MockPageContext(
+				new MockServletContext(), mockHttpServletRequest));
+
+		Assert.assertEquals(Tag.EVAL_PAGE, stylesheetTag.doEndTag());
+
+		OutputData outputData = (OutputData)mockHttpServletRequest.getAttribute(
+			WebKeys.OUTPUT_DATA);
+
+		Assert.assertEquals(
+			"<link href=\"" + href + "\" rel=\"stylesheet\" type=\"text/css\">",
+			String.valueOf(
+				outputData.getDataSB(
+					bundleSymbolicName + "/" + css, WebKeys.PAGE_TOP)));
+	}
+
+	private void _setUpServicesProvider(
+		String bundleSymbolicName, String css, String href,
+		MockHttpServletRequest mockHttpServletRequest) {
+
+		AbsolutePortalURLBuilderFactory absolutePortalURLBuilderFactory =
+			Mockito.mock(AbsolutePortalURLBuilderFactory.class);
+
+		String webContextPath = RandomTestUtil.randomString();
+
+		Bundle bundle = Mockito.mock(Bundle.class);
+
+		Mockito.when(
+			bundle.getHeaders(StringPool.BLANK)
+		).thenReturn(
+			new Hashtable<>(
+				Collections.singletonMap("Web-ContextPath", webContextPath))
+		);
+
+		_servicesProviderMockedStatic.when(
+			ServicesProvider::getBundleMap
+		).thenReturn(
+			Collections.singletonMap(bundleSymbolicName, bundle)
+		);
+
+		WebContextStylesheetAbsolutePortalURLBuilder
+			webContextStylesheetAbsolutePortalURLBuilder = Mockito.mock(
+				WebContextStylesheetAbsolutePortalURLBuilder.class);
+
+		Mockito.when(
+			webContextStylesheetAbsolutePortalURLBuilder.build()
+		).thenReturn(
+			href
+		);
+
+		AbsolutePortalURLBuilder absolutePortalURLBuilder = Mockito.mock(
+			AbsolutePortalURLBuilder.class);
+
+		Mockito.when(
+			absolutePortalURLBuilder.forWebContextStylesheet(
+				webContextPath, css)
+		).thenReturn(
+			webContextStylesheetAbsolutePortalURLBuilder
+		);
+
+		Mockito.when(
+			absolutePortalURLBuilderFactory.getAbsolutePortalURLBuilder(
+				mockHttpServletRequest)
+		).thenReturn(
+			absolutePortalURLBuilder
+		);
+
+		_servicesProviderMockedStatic.when(
+			ServicesProvider::getAbsolutePortalURLBuilderFactory
+		).thenReturn(
+			absolutePortalURLBuilderFactory
+		);
+	}
+
+	private final MockedStatic<ServicesProvider> _servicesProviderMockedStatic =
+		Mockito.mockStatic(ServicesProvider.class);
+
+}

--- a/modules/apps/portlet-dependency-factory/portlet-dependency-factory-impl/src/main/java/com/liferay/portlet/dependency/factory/internal/PortletDependencyImpl.java
+++ b/modules/apps/portlet-dependency-factory/portlet-dependency-factory-impl/src/main/java/com/liferay/portlet/dependency/factory/internal/PortletDependencyImpl.java
@@ -96,7 +96,7 @@ public class PortletDependencyImpl implements PortletDependency {
 				sb.append(
 					ContentSecurityPolicyNonceProviderUtil.getNonceAttribute(
 						null));
-				sb.append(" type=\"text/css\"></link>");
+				sb.append(" type=\"text/css\">");
 			}
 			else if (_type == Type.JAVASCRIPT) {
 				sb.append("<script");

--- a/modules/apps/portlet-dependency-factory/portlet-dependency-factory-impl/src/test/java/com/liferay/portlet/dependency/factory/internal/PortletDependencyImplTest.java
+++ b/modules/apps/portlet-dependency-factory/portlet-dependency-factory-impl/src/test/java/com/liferay/portlet/dependency/factory/internal/PortletDependencyImplTest.java
@@ -1,0 +1,85 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portlet.dependency.factory.internal;
+
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.portal.url.builder.AbsolutePortalURLBuilder;
+import com.liferay.portal.url.builder.PortletDependencyAbsolutePortalURLBuilder;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Georgel Pop
+ */
+public class PortletDependencyImplTest {
+
+	@ClassRule
+	public static LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	@TestInfo("LPD-102542")
+	public void testToStringBundler() {
+		AbsolutePortalURLBuilder absolutePortalURLBuilder = Mockito.mock(
+			AbsolutePortalURLBuilder.class);
+
+		PortletDependencyImpl portletDependencyImpl = new PortletDependencyImpl(
+			"main.css", null, null, null, absolutePortalURLBuilder);
+
+		String cssURL = RandomTestUtil.randomString();
+
+		_setUpAbsolutePortalURLBuilder(
+			absolutePortalURLBuilder, portletDependencyImpl, cssURL);
+
+		Assert.assertEquals(
+			"<link href=\"" + cssURL + "\" type=\"text/css\">",
+			String.valueOf(portletDependencyImpl.toStringBundler()));
+
+		portletDependencyImpl = new PortletDependencyImpl(
+			"main.js", null, null, null, absolutePortalURLBuilder);
+
+		String javaScriptURL = RandomTestUtil.randomString();
+
+		_setUpAbsolutePortalURLBuilder(
+			absolutePortalURLBuilder, portletDependencyImpl, javaScriptURL);
+
+		Assert.assertEquals(
+			"<script src=\"" + javaScriptURL +
+				"\" type=\"text/javascript\"></script>",
+			String.valueOf(portletDependencyImpl.toStringBundler()));
+	}
+
+	private void _setUpAbsolutePortalURLBuilder(
+		AbsolutePortalURLBuilder absolutePortalURLBuilder,
+		PortletDependencyImpl portletDependencyImpl, String url) {
+
+		PortletDependencyAbsolutePortalURLBuilder
+			portletDependencyAbsolutePortalURLBuilder = Mockito.mock(
+				PortletDependencyAbsolutePortalURLBuilder.class);
+
+		Mockito.when(
+			portletDependencyAbsolutePortalURLBuilder.build()
+		).thenReturn(
+			url
+		);
+
+		Mockito.when(
+			absolutePortalURLBuilder.forPortletDependency(
+				portletDependencyImpl, PropsValues.PORTLET_DEPENDENCY_CSS_URN,
+				PropsValues.PORTLET_DEPENDENCY_JAVASCRIPT_URN)
+		).thenReturn(
+			portletDependencyAbsolutePortalURLBuilder
+		);
+	}
+
+}

--- a/modules/apps/portlet-dependency-factory/portlet-dependency-factory-impl/src/test/java/com/liferay/portlet/dependency/factory/internal/PortletDependencyImplTest.java
+++ b/modules/apps/portlet-dependency-factory/portlet-dependency-factory-impl/src/test/java/com/liferay/portlet/dependency/factory/internal/PortletDependencyImplTest.java
@@ -33,30 +33,20 @@ public class PortletDependencyImplTest {
 		AbsolutePortalURLBuilder absolutePortalURLBuilder = Mockito.mock(
 			AbsolutePortalURLBuilder.class);
 
-		PortletDependencyImpl portletDependencyImpl = new PortletDependencyImpl(
-			"main.css", null, null, null, absolutePortalURLBuilder);
-
 		String cssURL = RandomTestUtil.randomString();
 
-		_setUpAbsolutePortalURLBuilder(
-			absolutePortalURLBuilder, portletDependencyImpl, cssURL);
-
-		Assert.assertEquals(
+		_testToStringBundler(
+			absolutePortalURLBuilder,
 			"<link href=\"" + cssURL + "\" type=\"text/css\">",
-			String.valueOf(portletDependencyImpl.toStringBundler()));
-
-		portletDependencyImpl = new PortletDependencyImpl(
-			"main.js", null, null, null, absolutePortalURLBuilder);
+			RandomTestUtil.randomString() + ".css", cssURL);
 
 		String javaScriptURL = RandomTestUtil.randomString();
 
-		_setUpAbsolutePortalURLBuilder(
-			absolutePortalURLBuilder, portletDependencyImpl, javaScriptURL);
-
-		Assert.assertEquals(
+		_testToStringBundler(
+			absolutePortalURLBuilder,
 			"<script src=\"" + javaScriptURL +
 				"\" type=\"text/javascript\"></script>",
-			String.valueOf(portletDependencyImpl.toStringBundler()));
+			RandomTestUtil.randomString() + ".js", javaScriptURL);
 	}
 
 	private void _setUpAbsolutePortalURLBuilder(
@@ -80,6 +70,21 @@ public class PortletDependencyImplTest {
 		).thenReturn(
 			portletDependencyAbsolutePortalURLBuilder
 		);
+	}
+
+	private void _testToStringBundler(
+		AbsolutePortalURLBuilder absolutePortalURLBuilder,
+		String expectedMarkup, String fileName, String url) {
+
+		PortletDependencyImpl portletDependencyImpl = new PortletDependencyImpl(
+			fileName, null, null, null, absolutePortalURLBuilder);
+
+		_setUpAbsolutePortalURLBuilder(
+			absolutePortalURLBuilder, portletDependencyImpl, url);
+
+		Assert.assertEquals(
+			expectedMarkup,
+			String.valueOf(portletDependencyImpl.toStringBundler()));
 	}
 
 }

--- a/modules/apps/portlet-dependency-factory/portlet-dependency-factory-impl/src/test/java/com/liferay/portlet/dependency/factory/internal/PortletDependencyImplTest.java
+++ b/modules/apps/portlet-dependency-factory/portlet-dependency-factory-impl/src/test/java/com/liferay/portlet/dependency/factory/internal/PortletDependencyImplTest.java
@@ -5,6 +5,7 @@
 
 package com.liferay.portlet.dependency.factory.internal;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.PropsValues;
@@ -47,6 +48,10 @@ public class PortletDependencyImplTest {
 			"<script src=\"" + javaScriptURL +
 				"\" type=\"text/javascript\"></script>",
 			RandomTestUtil.randomString() + ".js", javaScriptURL);
+
+		_testToStringBundlerWithMarkup(absolutePortalURLBuilder);
+
+		_testToStringBundlerWithUnknownType(absolutePortalURLBuilder);
 	}
 
 	private void _setUpAbsolutePortalURLBuilder(
@@ -84,6 +89,35 @@ public class PortletDependencyImplTest {
 
 		Assert.assertEquals(
 			expectedMarkup,
+			String.valueOf(portletDependencyImpl.toStringBundler()));
+	}
+
+	private void _testToStringBundlerWithMarkup(
+		AbsolutePortalURLBuilder absolutePortalURLBuilder) {
+
+		String markup = RandomTestUtil.randomString();
+
+		PortletDependencyImpl portletDependencyImpl = new PortletDependencyImpl(
+			null, null, null, markup, absolutePortalURLBuilder);
+
+		Assert.assertEquals(
+			markup, String.valueOf(portletDependencyImpl.toStringBundler()));
+	}
+
+	private void _testToStringBundlerWithUnknownType(
+		AbsolutePortalURLBuilder absolutePortalURLBuilder) {
+
+		String name = RandomTestUtil.randomString();
+		String scope = RandomTestUtil.randomString();
+		String version = RandomTestUtil.randomString();
+
+		PortletDependencyImpl portletDependencyImpl = new PortletDependencyImpl(
+			name, scope, version, null, absolutePortalURLBuilder);
+
+		Assert.assertEquals(
+			StringBundler.concat(
+				"<!-- Unknown portlet resource dependency type name=\"", name,
+				"\" scope=\"", scope, "\" version=\"", version, "\" -->"),
 			String.valueOf(portletDependencyImpl.toStringBundler()));
 	}
 


### PR DESCRIPTION
[LPD-102542](https://liferay.atlassian.net/browse/LPD-102542)

Three classes write a `</link>` end tag after a `<link>` element. `<link>` is a void element, so it has no end tag, and the W3C validator reports each one as `Stray end tag "link"`. This surfaced in an STQC markup and accessibility audit of a customer site running DXP.

Only one of the three is visible on an ordinary page. `AUITopHeadCSSDynamicInclude` writes the `alloy_ui.css` link into every page head, which is why the audit reported exactly one stray tag and not three; `StylesheetTag` and `PortletDependencyImpl` fire only for pages that use them. Verified again against a local bundle on this head: the guest home page renders no `</link>` at all, and all 24 `<link>` elements are still there.

Each writer gets a unit test, and each was confirmed to fail on master and pass with the fix: `AUITopHeadCSSDynamicIncludeTest.testInclude`, `StylesheetTagTest.testDoEndTag`, and `PortletDependencyImplTest.testToStringBundler`. `frontend-js-aui-web` and `portlet-dependency-factory-impl` had no `src/test` before this; neither needed a `build.gradle` change to get one.

Previous pull: https://github.com/brianchandotcom/liferay-portal/pull/180260

The declaration ordering you flagged there is fixed, and I went past it rather than only applying your two hunks. Locals that feed one call are now declared in that call's argument order, a local first used later moves down to its use, the returned mock stays first while the rest of a mock chain interleaves with its stubs, and the two helpers differ only where the presence of a returned wrapper makes them differ. Where the source formatter refuses a layout, it wins: `MissingEmptyLineCheck` and `ReturnVariableDeclarationAsUsedCheck` dictate the blank lines in `PortletDependencyImplTest` and in both `_get`/`_setUp` helpers.

Beyond the ordering, this head also adds `AUITopHeadCSSDynamicIncludeTest.testRegister` to match the sibling `ScopedCSSVariablesTopHeadDynamicIncludeTest`, covers the two remaining `toStringBundler` outcomes (the unknown dependency type and the preset markup short circuit), asserts `Tag.EVAL_PAGE` from `StylesheetTag.doEndTag` so a `SKIP_PAGE` regression cannot pass, stubs `bundle.getHeaders(StringPool.BLANK)` exactly as the class under test calls it, and randomizes the dependency file names whose prefix no assertion reads.

This comes to you directly rather than through another `ci:forward` because the frontend team review already happened on the fork pull, https://github.com/liferay-frontend/liferay-portal/pull/5676, which @izaera forwarded. CODEOWNERS gives `modules/apps/frontend-js/` and `modules/apps/frontend-taglib/` to @liferay-frontend, and `modules/apps/portlet-dependency-factory/` has no owner listed at all, which is worth knowing separately.

**pr-check: PASS** — tested on `906c091e8511e7d6fd12c7e2b57aed7c94408efc`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |
