### PR TITLE
LPD-101393 Attach system data masks to MCP profiles in any boot order

### DIFF
--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/model/listener/DataMaskObjectEntryModelListener.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/model/listener/DataMaskObjectEntryModelListener.java
@@ -219,9 +219,8 @@ public class DataMaskObjectEntryModelListener
 		int maxExecutionOrder = 0;
 
 		if (!valuesList.isEmpty()) {
-			maxExecutionOrder = Math.max(
-				maxExecutionOrder,
-				MapUtil.getInteger(valuesList.get(0), "executionOrder"));
+			maxExecutionOrder = MapUtil.getInteger(
+				valuesList.get(0), "executionOrder");
 		}
 
 		_objectEntryLocalService.addObjectEntry(

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/model/listener/DataMaskObjectEntryModelListener.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/model/listener/DataMaskObjectEntryModelListener.java
@@ -6,12 +6,15 @@
 package com.liferay.mcp.server.rest.internal.model.listener;
 
 import com.liferay.mcp.server.rest.internal.constants.MCPServerConstants;
+import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.model.listener.RelevantObjectEntryModelListener;
+import com.liferay.object.rest.filter.factory.FilterFactory;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.ModelListenerException;
@@ -19,6 +22,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.BaseModelListener;
+import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.MapUtil;
@@ -77,77 +81,15 @@ public class DataMaskObjectEntryModelListener
 			return;
 		}
 
-		String externalReferenceCode = objectEntry.getExternalReferenceCode();
-
-		List<ObjectEntry> mcpServerProfileDataMaskObjectEntries =
-			_objectEntryLocalService.getObjectEntries(
-				0,
-				mcpServerProfileDataMaskObjectDefinition.
-					getObjectDefinitionId(),
-				QueryUtil.ALL_POS, QueryUtil.ALL_POS);
-
 		for (ObjectEntry mcpServerProfileObjectEntry :
 				_objectEntryLocalService.getObjectEntries(
 					0, mcpServerProfileObjectDefinition.getObjectDefinitionId(),
 					QueryUtil.ALL_POS, QueryUtil.ALL_POS)) {
 
-			String mcpServerProfileExternalReferenceCode =
-				mcpServerProfileObjectEntry.getExternalReferenceCode();
-
-			boolean linked = false;
-			int maxExecutionOrder = 0;
-
-			for (ObjectEntry mcpServerProfileDataMaskObjectEntry :
-					mcpServerProfileDataMaskObjectEntries) {
-
-				Map<String, Serializable> mcpServerProfileDataMaskValues =
-					mcpServerProfileDataMaskObjectEntry.getValues();
-
-				if (!Objects.equals(
-						mcpServerProfileDataMaskValues.get(
-							"mcpServerProfileExternalReferenceCode"),
-						mcpServerProfileExternalReferenceCode)) {
-
-					continue;
-				}
-
-				if (Objects.equals(
-						mcpServerProfileDataMaskValues.get(
-							"dataMaskExternalReferenceCode"),
-						externalReferenceCode)) {
-
-					linked = true;
-
-					break;
-				}
-
-				maxExecutionOrder = Math.max(
-					maxExecutionOrder,
-					MapUtil.getInteger(
-						mcpServerProfileDataMaskValues, "executionOrder"));
-			}
-
-			if (linked) {
-				continue;
-			}
-
 			try {
-				_objectEntryLocalService.addObjectEntry(
-					0, objectEntry.getUserId(),
-					mcpServerProfileDataMaskObjectDefinition.
-						getObjectDefinitionId(),
-					ObjectEntryFolderConstants.
-						PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
-					null,
-					HashMapBuilder.<String, Serializable>put(
-						"dataMaskExternalReferenceCode", externalReferenceCode
-					).put(
-						"executionOrder", maxExecutionOrder + 1
-					).put(
-						"mcpServerProfileExternalReferenceCode",
-						mcpServerProfileExternalReferenceCode
-					).build(),
-					new ServiceContext());
+				_addMCPServerProfileDataMaskObjectEntry(
+					objectEntry, mcpServerProfileDataMaskObjectDefinition,
+					mcpServerProfileObjectEntry);
 			}
 			catch (PortalException portalException) {
 				if (_log.isWarnEnabled()) {
@@ -179,25 +121,32 @@ public class DataMaskObjectEntryModelListener
 
 		String externalReferenceCode = objectEntry.getExternalReferenceCode();
 
-		for (ObjectEntry mcpServerProfileDataMaskObjectEntry :
-				_objectEntryLocalService.getObjectEntries(
-					0, objectDefinition.getObjectDefinitionId(),
-					QueryUtil.ALL_POS, QueryUtil.ALL_POS)) {
+		List<Long> primaryKeys = null;
 
-			Map<String, Serializable> values =
-				mcpServerProfileDataMaskObjectEntry.getValues();
+		try {
+			primaryKeys = _objectEntryLocalService.getPrimaryKeys(
+				new Long[] {0L}, objectEntry.getCompanyId(),
+				objectEntry.getUserId(),
+				objectDefinition.getObjectDefinitionId(),
+				_filterFactory.create(
+					StringBundler.concat(
+						"dataMaskExternalReferenceCode eq '",
+						externalReferenceCode, "'"),
+					objectDefinition),
+				false, null, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+		}
+		catch (PortalException portalException) {
+			throw new ModelListenerException(portalException);
+		}
 
-			if (!Objects.equals(
-					values.get("dataMaskExternalReferenceCode"),
-					externalReferenceCode)) {
-
-				continue;
-			}
-
+		for (long primaryKey : primaryKeys) {
 			try {
+				ObjectEntry mcpServerProfileDataMaskObjectEntry =
+					_objectEntryLocalService.getObjectEntry(primaryKey);
+
 				Map<String, Serializable> newValues =
 					HashMapBuilder.<String, Serializable>putAll(
-						values
+						mcpServerProfileDataMaskObjectEntry.getValues()
 					).put(
 						"deleteReason", "Data mask was deleted."
 					).build();
@@ -218,9 +167,7 @@ public class DataMaskObjectEntryModelListener
 				if (_log.isWarnEnabled()) {
 					_log.warn(
 						StringBundler.concat(
-							"Unable to delete profile data mask ",
-							mcpServerProfileDataMaskObjectEntry.
-								getObjectEntryId(),
+							"Unable to delete profile data mask ", primaryKey,
 							" for data mask ", externalReferenceCode),
 						portalException);
 				}
@@ -228,8 +175,77 @@ public class DataMaskObjectEntryModelListener
 		}
 	}
 
+	private void _addMCPServerProfileDataMaskObjectEntry(
+			ObjectEntry dataMaskObjectEntry,
+			ObjectDefinition mcpServerProfileDataMaskObjectDefinition,
+			ObjectEntry mcpServerProfileObjectEntry)
+		throws PortalException {
+
+		long companyId = dataMaskObjectEntry.getCompanyId();
+		long userId = dataMaskObjectEntry.getUserId();
+		long objectDefinitionId =
+			mcpServerProfileDataMaskObjectDefinition.getObjectDefinitionId();
+		String dataMaskExternalReferenceCode =
+			dataMaskObjectEntry.getExternalReferenceCode();
+		String mcpServerProfileExternalReferenceCode =
+			mcpServerProfileObjectEntry.getExternalReferenceCode();
+
+		int count = _objectEntryLocalService.getValuesListCount(
+			new Long[] {0L}, companyId, userId, objectDefinitionId,
+			_filterFactory.create(
+				StringBundler.concat(
+					"(dataMaskExternalReferenceCode eq '",
+					dataMaskExternalReferenceCode,
+					"') and (mcpServerProfileExternalReferenceCode eq '",
+					mcpServerProfileExternalReferenceCode, "')"),
+				mcpServerProfileDataMaskObjectDefinition),
+			false, null);
+
+		if (count > 0) {
+			return;
+		}
+
+		List<Map<String, Serializable>> valuesList =
+			_objectEntryLocalService.getValuesList(
+				0, companyId, userId, objectDefinitionId,
+				_filterFactory.create(
+					StringBundler.concat(
+						"mcpServerProfileExternalReferenceCode eq '",
+						mcpServerProfileExternalReferenceCode, "'"),
+					mcpServerProfileDataMaskObjectDefinition),
+				null, 0, 1,
+				new Sort[] {new Sort("executionOrder", Sort.INT_TYPE, true)});
+
+		int maxExecutionOrder = 0;
+
+		if (!valuesList.isEmpty()) {
+			maxExecutionOrder = Math.max(
+				maxExecutionOrder,
+				MapUtil.getInteger(valuesList.get(0), "executionOrder"));
+		}
+
+		_objectEntryLocalService.addObjectEntry(
+			0, userId, objectDefinitionId,
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			null,
+			HashMapBuilder.<String, Serializable>put(
+				"dataMaskExternalReferenceCode", dataMaskExternalReferenceCode
+			).put(
+				"executionOrder", maxExecutionOrder + 1
+			).put(
+				"mcpServerProfileExternalReferenceCode",
+				mcpServerProfileExternalReferenceCode
+			).build(),
+			new ServiceContext());
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		DataMaskObjectEntryModelListener.class);
+
+	@Reference(
+		target = "(filter.factory.key=" + ObjectDefinitionConstants.STORAGE_TYPE_DEFAULT + ")"
+	)
+	private FilterFactory<Predicate> _filterFactory;
 
 	@Reference
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/model/listener/DataMaskObjectEntryModelListener.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/model/listener/DataMaskObjectEntryModelListener.java
@@ -6,6 +6,7 @@
 package com.liferay.mcp.server.rest.internal.model.listener;
 
 import com.liferay.mcp.server.rest.internal.constants.MCPServerConstants;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.model.listener.RelevantObjectEntryModelListener;
@@ -20,9 +21,11 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.MapUtil;
 
 import java.io.Serializable;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -40,6 +43,123 @@ public class DataMaskObjectEntryModelListener
 	@Override
 	public String getObjectDefinitionExternalReferenceCode() {
 		return MCPServerConstants.EXTERNAL_REFERENCE_CODE_DATA_MASK;
+	}
+
+	@Override
+	public void onAfterCreate(ObjectEntry objectEntry)
+		throws ModelListenerException {
+
+		Map<String, Serializable> values = objectEntry.getValues();
+
+		if (!Objects.equals(values.get("maskType"), "system")) {
+			return;
+		}
+
+		long companyId = objectEntry.getCompanyId();
+
+		ObjectDefinition mcpServerProfileObjectDefinition =
+			_objectDefinitionLocalService.
+				fetchObjectDefinitionByExternalReferenceCode(
+					MCPServerConstants.
+						EXTERNAL_REFERENCE_CODE_MCP_SERVER_PROFILE,
+					companyId);
+
+		ObjectDefinition mcpServerProfileDataMaskObjectDefinition =
+			_objectDefinitionLocalService.
+				fetchObjectDefinitionByExternalReferenceCode(
+					MCPServerConstants.
+						EXTERNAL_REFERENCE_CODE_MCP_SERVER_PROFILE_DATA_MASK,
+					companyId);
+
+		if ((mcpServerProfileObjectDefinition == null) ||
+			(mcpServerProfileDataMaskObjectDefinition == null)) {
+
+			return;
+		}
+
+		String externalReferenceCode = objectEntry.getExternalReferenceCode();
+
+		List<ObjectEntry> mcpServerProfileDataMaskObjectEntries =
+			_objectEntryLocalService.getObjectEntries(
+				0,
+				mcpServerProfileDataMaskObjectDefinition.
+					getObjectDefinitionId(),
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+
+		for (ObjectEntry mcpServerProfileObjectEntry :
+				_objectEntryLocalService.getObjectEntries(
+					0, mcpServerProfileObjectDefinition.getObjectDefinitionId(),
+					QueryUtil.ALL_POS, QueryUtil.ALL_POS)) {
+
+			String mcpServerProfileExternalReferenceCode =
+				mcpServerProfileObjectEntry.getExternalReferenceCode();
+
+			boolean linked = false;
+			int maxExecutionOrder = 0;
+
+			for (ObjectEntry mcpServerProfileDataMaskObjectEntry :
+					mcpServerProfileDataMaskObjectEntries) {
+
+				Map<String, Serializable> mcpServerProfileDataMaskValues =
+					mcpServerProfileDataMaskObjectEntry.getValues();
+
+				if (!Objects.equals(
+						mcpServerProfileDataMaskValues.get(
+							"mcpServerProfileExternalReferenceCode"),
+						mcpServerProfileExternalReferenceCode)) {
+
+					continue;
+				}
+
+				if (Objects.equals(
+						mcpServerProfileDataMaskValues.get(
+							"dataMaskExternalReferenceCode"),
+						externalReferenceCode)) {
+
+					linked = true;
+
+					break;
+				}
+
+				maxExecutionOrder = Math.max(
+					maxExecutionOrder,
+					MapUtil.getInteger(
+						mcpServerProfileDataMaskValues, "executionOrder"));
+			}
+
+			if (linked) {
+				continue;
+			}
+
+			try {
+				_objectEntryLocalService.addObjectEntry(
+					0, objectEntry.getUserId(),
+					mcpServerProfileDataMaskObjectDefinition.
+						getObjectDefinitionId(),
+					ObjectEntryFolderConstants.
+						PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+					null,
+					HashMapBuilder.<String, Serializable>put(
+						"dataMaskExternalReferenceCode", externalReferenceCode
+					).put(
+						"executionOrder", maxExecutionOrder + 1
+					).put(
+						"mcpServerProfileExternalReferenceCode",
+						mcpServerProfileExternalReferenceCode
+					).build(),
+					new ServiceContext());
+			}
+			catch (PortalException portalException) {
+				if (_log.isWarnEnabled()) {
+					_log.warn(
+						StringBundler.concat(
+							"Unable to attach system mask \"",
+							values.get("name"), "\" to profile ",
+							mcpServerProfileObjectEntry.getObjectEntryId()),
+						portalException);
+				}
+			}
+		}
 	}
 
 	@Override

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/model/listener/DataMaskObjectEntryModelListener.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/model/listener/DataMaskObjectEntryModelListener.java
@@ -182,13 +182,13 @@ public class DataMaskObjectEntryModelListener
 		throws PortalException {
 
 		long companyId = dataMaskObjectEntry.getCompanyId();
-		long userId = dataMaskObjectEntry.getUserId();
-		long objectDefinitionId =
-			mcpServerProfileDataMaskObjectDefinition.getObjectDefinitionId();
 		String dataMaskExternalReferenceCode =
 			dataMaskObjectEntry.getExternalReferenceCode();
 		String mcpServerProfileExternalReferenceCode =
 			mcpServerProfileObjectEntry.getExternalReferenceCode();
+		long objectDefinitionId =
+			mcpServerProfileDataMaskObjectDefinition.getObjectDefinitionId();
+		long userId = dataMaskObjectEntry.getUserId();
 
 		int count = _objectEntryLocalService.getValuesListCount(
 			new Long[] {0L}, companyId, userId, objectDefinitionId,

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/upgrade/MCPProfileDataMaskUpgradeProcess.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/upgrade/MCPProfileDataMaskUpgradeProcess.java
@@ -51,143 +51,146 @@ public class MCPProfileDataMaskUpgradeProcess extends UpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		_companyLocalService.forEachCompanyId(this::_upgradeCompany);
-	}
+		_companyLocalService.forEachCompanyId(
+			companyId -> {
+				ObjectDefinition dataMaskObjectDefinition =
+					_objectDefinitionLocalService.
+						fetchObjectDefinitionByExternalReferenceCode(
+							MCPServerConstants.
+								EXTERNAL_REFERENCE_CODE_DATA_MASK,
+							companyId);
 
-	private List<ObjectEntry> _getSystemDataMaskObjectEntries(
-			ObjectDefinition dataMaskObjectDefinition)
-		throws Exception {
-
-		return TransformUtil.transform(
-			_objectEntryLocalService.getPrimaryKeys(
-				new Long[] {0L}, dataMaskObjectDefinition.getCompanyId(),
-				dataMaskObjectDefinition.getUserId(),
-				dataMaskObjectDefinition.getObjectDefinitionId(),
-				_filterFactory.create(
-					"maskType eq 'system'", dataMaskObjectDefinition),
-				false, null, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
-				new Sort[] {new Sort("id", Sort.LONG_TYPE, false)}),
-			_objectEntryLocalService::getObjectEntry);
-	}
-
-	private void _upgradeCompany(long companyId) throws Exception {
-		ObjectDefinition dataMaskObjectDefinition =
-			_objectDefinitionLocalService.
-				fetchObjectDefinitionByExternalReferenceCode(
-					MCPServerConstants.EXTERNAL_REFERENCE_CODE_DATA_MASK,
-					companyId);
-
-		if (dataMaskObjectDefinition == null) {
-			return;
-		}
-
-		List<ObjectEntry> systemDataMaskObjectEntries =
-			_getSystemDataMaskObjectEntries(dataMaskObjectDefinition);
-
-		if (systemDataMaskObjectEntries.isEmpty()) {
-			return;
-		}
-
-		ObjectDefinition mcpServerProfileDataMaskObjectDefinition =
-			_objectDefinitionLocalService.
-				fetchObjectDefinitionByExternalReferenceCode(
-					MCPServerConstants.
-						EXTERNAL_REFERENCE_CODE_MCP_SERVER_PROFILE_DATA_MASK,
-					companyId);
-
-		if (mcpServerProfileDataMaskObjectDefinition == null) {
-			return;
-		}
-
-		Map<String, Set<String>> dataMaskExternalReferenceCodesMap =
-			new HashMap<>();
-		Map<String, Integer> maxExecutionOrders = new HashMap<>();
-
-		for (Map<String, Serializable> values :
-				_objectEntryLocalService.getValuesList(
-					0, companyId,
-					mcpServerProfileDataMaskObjectDefinition.getUserId(),
-					mcpServerProfileDataMaskObjectDefinition.
-						getObjectDefinitionId(),
-					null, null, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null)) {
-
-			String mcpServerProfileExternalReferenceCode = GetterUtil.getString(
-				values.get("mcpServerProfileExternalReferenceCode"));
-
-			Set<String> dataMaskExternalReferenceCodes =
-				dataMaskExternalReferenceCodesMap.computeIfAbsent(
-					mcpServerProfileExternalReferenceCode,
-					externalReferenceCode -> new HashSet<>());
-
-			dataMaskExternalReferenceCodes.add(
-				GetterUtil.getString(
-					values.get("dataMaskExternalReferenceCode")));
-
-			maxExecutionOrders.merge(
-				mcpServerProfileExternalReferenceCode,
-				MapUtil.getInteger(values, "executionOrder"), Math::max);
-		}
-
-		ObjectDefinition mcpServerProfileObjectDefinition =
-			_objectDefinitionLocalService.
-				fetchObjectDefinitionByExternalReferenceCode(
-					MCPServerConstants.
-						EXTERNAL_REFERENCE_CODE_MCP_SERVER_PROFILE,
-					companyId);
-
-		if (mcpServerProfileObjectDefinition == null) {
-			return;
-		}
-
-		for (ObjectEntry mcpServerProfileObjectEntry :
-				_objectEntryLocalService.getObjectEntries(
-					0, mcpServerProfileObjectDefinition.getObjectDefinitionId(),
-					QueryUtil.ALL_POS, QueryUtil.ALL_POS)) {
-
-			String mcpServerProfileExternalReferenceCode =
-				mcpServerProfileObjectEntry.getExternalReferenceCode();
-
-			Set<String> dataMaskExternalReferenceCodes =
-				dataMaskExternalReferenceCodesMap.getOrDefault(
-					mcpServerProfileExternalReferenceCode,
-					Collections.emptySet());
-
-			int executionOrder = maxExecutionOrders.getOrDefault(
-				mcpServerProfileExternalReferenceCode, 0);
-
-			for (ObjectEntry systemDataMaskObjectEntry :
-					systemDataMaskObjectEntries) {
-
-				String dataMaskExternalReferenceCode =
-					systemDataMaskObjectEntry.getExternalReferenceCode();
-
-				if (dataMaskExternalReferenceCodes.contains(
-						dataMaskExternalReferenceCode)) {
-
-					continue;
+				if (dataMaskObjectDefinition == null) {
+					return;
 				}
 
-				executionOrder++;
+				List<ObjectEntry> systemDataMaskObjectEntries =
+					TransformUtil.transform(
+						_objectEntryLocalService.getPrimaryKeys(
+							new Long[] {0L},
+							dataMaskObjectDefinition.getCompanyId(),
+							dataMaskObjectDefinition.getUserId(),
+							dataMaskObjectDefinition.getObjectDefinitionId(),
+							_filterFactory.create(
+								"maskType eq 'system'",
+								dataMaskObjectDefinition),
+							false, null, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+							new Sort[] {new Sort("id", Sort.LONG_TYPE, false)}),
+						_objectEntryLocalService::getObjectEntry);
 
-				_objectEntryLocalService.addObjectEntry(
-					0, systemDataMaskObjectEntry.getUserId(),
-					mcpServerProfileDataMaskObjectDefinition.
-						getObjectDefinitionId(),
-					ObjectEntryFolderConstants.
-						PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
-					null,
-					HashMapBuilder.<String, Serializable>put(
-						"dataMaskExternalReferenceCode",
-						dataMaskExternalReferenceCode
-					).put(
-						"executionOrder", executionOrder
-					).put(
-						"mcpServerProfileExternalReferenceCode",
-						mcpServerProfileExternalReferenceCode
-					).build(),
-					new ServiceContext());
-			}
-		}
+				if (systemDataMaskObjectEntries.isEmpty()) {
+					return;
+				}
+
+				ObjectDefinition mcpServerProfileDataMaskObjectDefinition =
+					_objectDefinitionLocalService.
+						fetchObjectDefinitionByExternalReferenceCode(
+							MCPServerConstants.
+								EXTERNAL_REFERENCE_CODE_MCP_SERVER_PROFILE_DATA_MASK,
+							companyId);
+
+				if (mcpServerProfileDataMaskObjectDefinition == null) {
+					return;
+				}
+
+				Map<String, Set<String>> dataMaskExternalReferenceCodesMap =
+					new HashMap<>();
+				Map<String, Integer> maxExecutionOrders = new HashMap<>();
+
+				for (Map<String, Serializable> values :
+						_objectEntryLocalService.getValuesList(
+							0, companyId,
+							mcpServerProfileDataMaskObjectDefinition.
+								getUserId(),
+							mcpServerProfileDataMaskObjectDefinition.
+								getObjectDefinitionId(),
+							null, null, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+							null)) {
+
+					String mcpServerProfileExternalReferenceCode =
+						GetterUtil.getString(
+							values.get(
+								"mcpServerProfileExternalReferenceCode"));
+
+					Set<String> dataMaskExternalReferenceCodes =
+						dataMaskExternalReferenceCodesMap.computeIfAbsent(
+							mcpServerProfileExternalReferenceCode,
+							externalReferenceCode -> new HashSet<>());
+
+					dataMaskExternalReferenceCodes.add(
+						GetterUtil.getString(
+							values.get("dataMaskExternalReferenceCode")));
+
+					maxExecutionOrders.merge(
+						mcpServerProfileExternalReferenceCode,
+						MapUtil.getInteger(values, "executionOrder"),
+						Math::max);
+				}
+
+				ObjectDefinition mcpServerProfileObjectDefinition =
+					_objectDefinitionLocalService.
+						fetchObjectDefinitionByExternalReferenceCode(
+							MCPServerConstants.
+								EXTERNAL_REFERENCE_CODE_MCP_SERVER_PROFILE,
+							companyId);
+
+				if (mcpServerProfileObjectDefinition == null) {
+					return;
+				}
+
+				for (ObjectEntry mcpServerProfileObjectEntry :
+						_objectEntryLocalService.getObjectEntries(
+							0,
+							mcpServerProfileObjectDefinition.
+								getObjectDefinitionId(),
+							QueryUtil.ALL_POS, QueryUtil.ALL_POS)) {
+
+					String mcpServerProfileExternalReferenceCode =
+						mcpServerProfileObjectEntry.getExternalReferenceCode();
+
+					Set<String> dataMaskExternalReferenceCodes =
+						dataMaskExternalReferenceCodesMap.getOrDefault(
+							mcpServerProfileExternalReferenceCode,
+							Collections.emptySet());
+
+					int executionOrder = maxExecutionOrders.getOrDefault(
+						mcpServerProfileExternalReferenceCode, 0);
+
+					for (ObjectEntry systemDataMaskObjectEntry :
+							systemDataMaskObjectEntries) {
+
+						String dataMaskExternalReferenceCode =
+							systemDataMaskObjectEntry.
+								getExternalReferenceCode();
+
+						if (dataMaskExternalReferenceCodes.contains(
+								dataMaskExternalReferenceCode)) {
+
+							continue;
+						}
+
+						executionOrder++;
+
+						_objectEntryLocalService.addObjectEntry(
+							0, systemDataMaskObjectEntry.getUserId(),
+							mcpServerProfileDataMaskObjectDefinition.
+								getObjectDefinitionId(),
+							ObjectEntryFolderConstants.
+								PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+							null,
+							HashMapBuilder.<String, Serializable>put(
+								"dataMaskExternalReferenceCode",
+								dataMaskExternalReferenceCode
+							).put(
+								"executionOrder", executionOrder
+							).put(
+								"mcpServerProfileExternalReferenceCode",
+								mcpServerProfileExternalReferenceCode
+							).build(),
+							new ServiceContext());
+					}
+				}
+			});
 	}
 
 	private final CompanyLocalService _companyLocalService;

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/upgrade/MCPProfileDataMaskUpgradeProcess.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/upgrade/MCPProfileDataMaskUpgradeProcess.java
@@ -12,8 +12,10 @@ import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.rest.filter.factory.FilterFactory;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
@@ -23,7 +25,6 @@ import com.liferay.portal.kernel.util.MapUtil;
 
 import java.io.Serializable;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -57,24 +58,16 @@ public class MCPProfileDataMaskUpgradeProcess extends UpgradeProcess {
 			ObjectDefinition dataMaskObjectDefinition)
 		throws Exception {
 
-		List<ObjectEntry> systemDataMaskObjectEntries = new ArrayList<>();
-
-		List<Long> primaryKeys = _objectEntryLocalService.getPrimaryKeys(
-			new Long[] {0L}, dataMaskObjectDefinition.getCompanyId(),
-			dataMaskObjectDefinition.getUserId(),
-			dataMaskObjectDefinition.getObjectDefinitionId(),
-			_filterFactory.create(
-				"maskType eq 'system'", dataMaskObjectDefinition),
-			false, null, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
-
-		Collections.sort(primaryKeys);
-
-		for (long primaryKey : primaryKeys) {
-			systemDataMaskObjectEntries.add(
-				_objectEntryLocalService.getObjectEntry(primaryKey));
-		}
-
-		return systemDataMaskObjectEntries;
+		return TransformUtil.transform(
+			_objectEntryLocalService.getPrimaryKeys(
+				new Long[] {0L}, dataMaskObjectDefinition.getCompanyId(),
+				dataMaskObjectDefinition.getUserId(),
+				dataMaskObjectDefinition.getObjectDefinitionId(),
+				_filterFactory.create(
+					"maskType eq 'system'", dataMaskObjectDefinition),
+				false, null, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+				new Sort[] {new Sort("id", Sort.LONG_TYPE, false)}),
+			_objectEntryLocalService::getObjectEntry);
 	}
 
 	private void _upgradeCompany(long companyId) throws Exception {

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/upgrade/MCPProfileDataMaskUpgradeProcess.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/upgrade/MCPProfileDataMaskUpgradeProcess.java
@@ -1,0 +1,200 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.mcp.server.rest.internal.upgrade;
+
+import com.liferay.mcp.server.rest.internal.constants.MCPServerConstants;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.rest.filter.factory.FilterFactory;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.petra.sql.dsl.expression.Predicate;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.MapUtil;
+
+import java.io.Serializable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author Alberto Javier Moreno Lage
+ */
+public class MCPProfileDataMaskUpgradeProcess extends UpgradeProcess {
+
+	public MCPProfileDataMaskUpgradeProcess(
+		CompanyLocalService companyLocalService,
+		FilterFactory<Predicate> filterFactory,
+		ObjectDefinitionLocalService objectDefinitionLocalService,
+		ObjectEntryLocalService objectEntryLocalService) {
+
+		_companyLocalService = companyLocalService;
+		_filterFactory = filterFactory;
+		_objectDefinitionLocalService = objectDefinitionLocalService;
+		_objectEntryLocalService = objectEntryLocalService;
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		_companyLocalService.forEachCompanyId(this::_upgradeCompany);
+	}
+
+	private List<ObjectEntry> _getSystemDataMaskObjectEntries(
+			ObjectDefinition dataMaskObjectDefinition)
+		throws Exception {
+
+		List<ObjectEntry> systemDataMaskObjectEntries = new ArrayList<>();
+
+		List<Long> primaryKeys = _objectEntryLocalService.getPrimaryKeys(
+			new Long[] {0L}, dataMaskObjectDefinition.getCompanyId(),
+			dataMaskObjectDefinition.getUserId(),
+			dataMaskObjectDefinition.getObjectDefinitionId(),
+			_filterFactory.create(
+				"maskType eq 'system'", dataMaskObjectDefinition),
+			false, null, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+
+		Collections.sort(primaryKeys);
+
+		for (long primaryKey : primaryKeys) {
+			systemDataMaskObjectEntries.add(
+				_objectEntryLocalService.getObjectEntry(primaryKey));
+		}
+
+		return systemDataMaskObjectEntries;
+	}
+
+	private void _upgradeCompany(long companyId) throws Exception {
+		ObjectDefinition dataMaskObjectDefinition =
+			_objectDefinitionLocalService.
+				fetchObjectDefinitionByExternalReferenceCode(
+					MCPServerConstants.EXTERNAL_REFERENCE_CODE_DATA_MASK,
+					companyId);
+
+		ObjectDefinition mcpServerProfileDataMaskObjectDefinition =
+			_objectDefinitionLocalService.
+				fetchObjectDefinitionByExternalReferenceCode(
+					MCPServerConstants.
+						EXTERNAL_REFERENCE_CODE_MCP_SERVER_PROFILE_DATA_MASK,
+					companyId);
+
+		ObjectDefinition mcpServerProfileObjectDefinition =
+			_objectDefinitionLocalService.
+				fetchObjectDefinitionByExternalReferenceCode(
+					MCPServerConstants.
+						EXTERNAL_REFERENCE_CODE_MCP_SERVER_PROFILE,
+					companyId);
+
+		if ((dataMaskObjectDefinition == null) ||
+			(mcpServerProfileDataMaskObjectDefinition == null) ||
+			(mcpServerProfileObjectDefinition == null)) {
+
+			return;
+		}
+
+		List<ObjectEntry> systemDataMaskObjectEntries =
+			_getSystemDataMaskObjectEntries(dataMaskObjectDefinition);
+
+		if (systemDataMaskObjectEntries.isEmpty()) {
+			return;
+		}
+
+		Map<String, Set<String>> dataMaskExternalReferenceCodesMap =
+			new HashMap<>();
+		Map<String, Integer> maxExecutionOrders = new HashMap<>();
+
+		for (Map<String, Serializable> values :
+				_objectEntryLocalService.getValuesList(
+					0, companyId,
+					mcpServerProfileDataMaskObjectDefinition.getUserId(),
+					mcpServerProfileDataMaskObjectDefinition.
+						getObjectDefinitionId(),
+					null, null, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null)) {
+
+			String mcpServerProfileExternalReferenceCode = GetterUtil.getString(
+				values.get("mcpServerProfileExternalReferenceCode"));
+
+			Set<String> dataMaskExternalReferenceCodes =
+				dataMaskExternalReferenceCodesMap.computeIfAbsent(
+					mcpServerProfileExternalReferenceCode,
+					externalReferenceCode -> new HashSet<>());
+
+			dataMaskExternalReferenceCodes.add(
+				GetterUtil.getString(
+					values.get("dataMaskExternalReferenceCode")));
+
+			maxExecutionOrders.merge(
+				mcpServerProfileExternalReferenceCode,
+				MapUtil.getInteger(values, "executionOrder"), Math::max);
+		}
+
+		for (ObjectEntry mcpServerProfileObjectEntry :
+				_objectEntryLocalService.getObjectEntries(
+					0, mcpServerProfileObjectDefinition.getObjectDefinitionId(),
+					QueryUtil.ALL_POS, QueryUtil.ALL_POS)) {
+
+			String mcpServerProfileExternalReferenceCode =
+				mcpServerProfileObjectEntry.getExternalReferenceCode();
+
+			Set<String> dataMaskExternalReferenceCodes =
+				dataMaskExternalReferenceCodesMap.getOrDefault(
+					mcpServerProfileExternalReferenceCode,
+					Collections.emptySet());
+
+			int executionOrder = maxExecutionOrders.getOrDefault(
+				mcpServerProfileExternalReferenceCode, 0);
+
+			for (ObjectEntry systemDataMaskObjectEntry :
+					systemDataMaskObjectEntries) {
+
+				String dataMaskExternalReferenceCode =
+					systemDataMaskObjectEntry.getExternalReferenceCode();
+
+				if (dataMaskExternalReferenceCodes.contains(
+						dataMaskExternalReferenceCode)) {
+
+					continue;
+				}
+
+				executionOrder++;
+
+				_objectEntryLocalService.addObjectEntry(
+					0, systemDataMaskObjectEntry.getUserId(),
+					mcpServerProfileDataMaskObjectDefinition.
+						getObjectDefinitionId(),
+					ObjectEntryFolderConstants.
+						PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+					null,
+					HashMapBuilder.<String, Serializable>put(
+						"dataMaskExternalReferenceCode",
+						dataMaskExternalReferenceCode
+					).put(
+						"executionOrder", executionOrder
+					).put(
+						"mcpServerProfileExternalReferenceCode",
+						mcpServerProfileExternalReferenceCode
+					).build(),
+					new ServiceContext());
+			}
+		}
+	}
+
+	private final CompanyLocalService _companyLocalService;
+	private final FilterFactory<Predicate> _filterFactory;
+	private final ObjectDefinitionLocalService _objectDefinitionLocalService;
+	private final ObjectEntryLocalService _objectEntryLocalService;
+
+}

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/upgrade/MCPProfileDataMaskUpgradeProcess.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/upgrade/MCPProfileDataMaskUpgradeProcess.java
@@ -84,6 +84,10 @@ public class MCPProfileDataMaskUpgradeProcess extends UpgradeProcess {
 					MCPServerConstants.EXTERNAL_REFERENCE_CODE_DATA_MASK,
 					companyId);
 
+		if (dataMaskObjectDefinition == null) {
+			return;
+		}
+
 		List<ObjectEntry> systemDataMaskObjectEntries =
 			_getSystemDataMaskObjectEntries(dataMaskObjectDefinition);
 
@@ -97,6 +101,10 @@ public class MCPProfileDataMaskUpgradeProcess extends UpgradeProcess {
 					MCPServerConstants.
 						EXTERNAL_REFERENCE_CODE_MCP_SERVER_PROFILE_DATA_MASK,
 					companyId);
+
+		if (mcpServerProfileDataMaskObjectDefinition == null) {
+			return;
+		}
 
 		Map<String, Set<String>> dataMaskExternalReferenceCodesMap =
 			new HashMap<>();
@@ -133,6 +141,10 @@ public class MCPProfileDataMaskUpgradeProcess extends UpgradeProcess {
 					MCPServerConstants.
 						EXTERNAL_REFERENCE_CODE_MCP_SERVER_PROFILE,
 					companyId);
+
+		if (mcpServerProfileObjectDefinition == null) {
+			return;
+		}
 
 		for (ObjectEntry mcpServerProfileObjectEntry :
 				_objectEntryLocalService.getObjectEntries(

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/upgrade/MCPProfileDataMaskUpgradeProcess.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/upgrade/MCPProfileDataMaskUpgradeProcess.java
@@ -84,33 +84,19 @@ public class MCPProfileDataMaskUpgradeProcess extends UpgradeProcess {
 					MCPServerConstants.EXTERNAL_REFERENCE_CODE_DATA_MASK,
 					companyId);
 
-		ObjectDefinition mcpServerProfileDataMaskObjectDefinition =
-			_objectDefinitionLocalService.
-				fetchObjectDefinitionByExternalReferenceCode(
-					MCPServerConstants.
-						EXTERNAL_REFERENCE_CODE_MCP_SERVER_PROFILE_DATA_MASK,
-					companyId);
-
-		ObjectDefinition mcpServerProfileObjectDefinition =
-			_objectDefinitionLocalService.
-				fetchObjectDefinitionByExternalReferenceCode(
-					MCPServerConstants.
-						EXTERNAL_REFERENCE_CODE_MCP_SERVER_PROFILE,
-					companyId);
-
-		if ((dataMaskObjectDefinition == null) ||
-			(mcpServerProfileDataMaskObjectDefinition == null) ||
-			(mcpServerProfileObjectDefinition == null)) {
-
-			return;
-		}
-
 		List<ObjectEntry> systemDataMaskObjectEntries =
 			_getSystemDataMaskObjectEntries(dataMaskObjectDefinition);
 
 		if (systemDataMaskObjectEntries.isEmpty()) {
 			return;
 		}
+
+		ObjectDefinition mcpServerProfileDataMaskObjectDefinition =
+			_objectDefinitionLocalService.
+				fetchObjectDefinitionByExternalReferenceCode(
+					MCPServerConstants.
+						EXTERNAL_REFERENCE_CODE_MCP_SERVER_PROFILE_DATA_MASK,
+					companyId);
 
 		Map<String, Set<String>> dataMaskExternalReferenceCodesMap =
 			new HashMap<>();
@@ -140,6 +126,13 @@ public class MCPProfileDataMaskUpgradeProcess extends UpgradeProcess {
 				mcpServerProfileExternalReferenceCode,
 				MapUtil.getInteger(values, "executionOrder"), Math::max);
 		}
+
+		ObjectDefinition mcpServerProfileObjectDefinition =
+			_objectDefinitionLocalService.
+				fetchObjectDefinitionByExternalReferenceCode(
+					MCPServerConstants.
+						EXTERNAL_REFERENCE_CODE_MCP_SERVER_PROFILE,
+					companyId);
 
 		for (ObjectEntry mcpServerProfileObjectEntry :
 				_objectEntryLocalService.getObjectEntries(

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/upgrade/registry/MCPServerRestUpgradeStepRegistrator.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/upgrade/registry/MCPServerRestUpgradeStepRegistrator.java
@@ -6,12 +6,16 @@
 package com.liferay.mcp.server.rest.internal.upgrade.registry;
 
 import com.liferay.list.type.service.ListTypeDefinitionLocalService;
+import com.liferay.mcp.server.rest.internal.upgrade.MCPProfileDataMaskUpgradeProcess;
 import com.liferay.mcp.server.rest.internal.upgrade.MCPPromptUpgradeProcess;
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.rest.filter.factory.FilterFactory;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.service.ObjectFieldSettingLocalService;
 import com.liferay.object.service.ObjectValidationRuleLocalService;
+import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 
@@ -36,10 +40,21 @@ public class MCPServerRestUpgradeStepRegistrator
 				_objectDefinitionLocalService, _objectEntryLocalService,
 				_objectFieldLocalService, _objectFieldSettingLocalService,
 				_objectValidationRuleLocalService));
+
+		registry.register(
+			"1.0.0", "1.1.0",
+			new MCPProfileDataMaskUpgradeProcess(
+				_companyLocalService, _filterFactory,
+				_objectDefinitionLocalService, _objectEntryLocalService));
 	}
 
 	@Reference
 	private CompanyLocalService _companyLocalService;
+
+	@Reference(
+		target = "(filter.factory.key=" + ObjectDefinitionConstants.STORAGE_TYPE_DEFAULT + ")"
+	)
+	private FilterFactory<Predicate> _filterFactory;
 
 	@Reference
 	private ListTypeDefinitionLocalService _listTypeDefinitionLocalService;

--- a/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/internal/model/listener/test/DataMaskObjectEntryModelListenerTest.java
+++ b/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/internal/model/listener/test/DataMaskObjectEntryModelListenerTest.java
@@ -7,9 +7,12 @@ package com.liferay.mcp.server.rest.internal.model.listener.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.mcp.server.rest.test.util.MCPServerTestUtil;
+import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.portal.configuration.test.util.ConfigurationTemporarySwapper;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
@@ -17,10 +20,18 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.io.Serializable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -44,6 +55,42 @@ public class DataMaskObjectEntryModelListenerTest {
 	@Before
 	public void setUp() {
 		MCPServerTestUtil.processBatchEngineUnits();
+	}
+
+	@Test
+	public void testOnAfterCreate() throws Exception {
+		ObjectEntry defaultMCPServerProfileObjectEntry =
+			MCPServerTestUtil.fetchMCPServerProfileObjectEntry("default");
+
+		String defaultMCPServerProfileExternalReferenceCode =
+			defaultMCPServerProfileObjectEntry.getExternalReferenceCode();
+
+		int mcpServerProfileDataMasksCount =
+			_getMCPServerProfileDataMaskObjectEntriesSize(
+				defaultMCPServerProfileExternalReferenceCode);
+
+		MCPServerTestUtil.addDataMaskObjectEntry(
+			"\\d{4}", RandomTestUtil.randomString(), "[REDACTED]");
+
+		Assert.assertEquals(
+			mcpServerProfileDataMasksCount,
+			_getMCPServerProfileDataMaskObjectEntriesSize(
+				defaultMCPServerProfileExternalReferenceCode));
+
+		String dataMaskExternalReferenceCode = RandomTestUtil.randomString();
+
+		ObjectEntry systemDataMaskObjectEntry =
+			MCPServerTestUtil.addSystemDataMaskObjectEntry(
+				"\\d{4}", dataMaskExternalReferenceCode,
+				RandomTestUtil.randomString(), "[REDACTED]");
+
+		Assert.assertEquals(
+			mcpServerProfileDataMasksCount + 1,
+			_getExecutionOrder(
+				dataMaskExternalReferenceCode,
+				defaultMCPServerProfileExternalReferenceCode));
+
+		_deleteSystemDataMaskObjectEntry(systemDataMaskObjectEntry);
 	}
 
 	@Test
@@ -99,6 +146,92 @@ public class DataMaskObjectEntryModelListenerTest {
 					mcpServerProfileDataMaskObjectEntry.getObjectEntryId()));
 		}
 	}
+
+	private void _deleteSystemDataMaskObjectEntry(ObjectEntry objectEntry)
+		throws Exception {
+
+		PermissionChecker originalPermissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		try {
+			PermissionThreadLocal.setPermissionChecker(
+				PermissionCheckerFactoryUtil.create(TestPropsValues.getUser()));
+
+			MCPServerTestUtil.deleteSystemDataMaskObjectEntry(objectEntry);
+		}
+		finally {
+			PermissionThreadLocal.setPermissionChecker(
+				originalPermissionChecker);
+		}
+	}
+
+	private int _getExecutionOrder(
+			String dataMaskExternalReferenceCode,
+			String mcpServerProfileExternalReferenceCode)
+		throws Exception {
+
+		for (ObjectEntry mcpServerProfileDataMaskObjectEntry :
+				_getMCPServerProfileDataMaskObjectEntries(
+					mcpServerProfileExternalReferenceCode)) {
+
+			Map<String, Serializable> values =
+				mcpServerProfileDataMaskObjectEntry.getValues();
+
+			if (Objects.equals(
+					dataMaskExternalReferenceCode,
+					values.get("dataMaskExternalReferenceCode"))) {
+
+				return MapUtil.getInteger(values, "executionOrder");
+			}
+		}
+
+		return -1;
+	}
+
+	private List<ObjectEntry> _getMCPServerProfileDataMaskObjectEntries(
+			String mcpServerProfileExternalReferenceCode)
+		throws Exception {
+
+		List<ObjectEntry> mcpServerProfileDataMaskObjectEntries =
+			new ArrayList<>();
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.
+				fetchObjectDefinitionByExternalReferenceCode(
+					"L_MCP_SERVER_PROFILE_DATA_MASK",
+					TestPropsValues.getCompanyId());
+
+		for (ObjectEntry objectEntry :
+				_objectEntryLocalService.getObjectEntries(
+					0, objectDefinition.getObjectDefinitionId(),
+					QueryUtil.ALL_POS, QueryUtil.ALL_POS)) {
+
+			Map<String, Serializable> values = objectEntry.getValues();
+
+			if (Objects.equals(
+					mcpServerProfileExternalReferenceCode,
+					values.get("mcpServerProfileExternalReferenceCode"))) {
+
+				mcpServerProfileDataMaskObjectEntries.add(objectEntry);
+			}
+		}
+
+		return mcpServerProfileDataMaskObjectEntries;
+	}
+
+	private int _getMCPServerProfileDataMaskObjectEntriesSize(
+			String mcpServerProfileExternalReferenceCode)
+		throws Exception {
+
+		List<ObjectEntry> mcpServerProfileDataMaskObjectEntries =
+			_getMCPServerProfileDataMaskObjectEntries(
+				mcpServerProfileExternalReferenceCode);
+
+		return mcpServerProfileDataMaskObjectEntries.size();
+	}
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
 
 	@Inject
 	private ObjectEntryLocalService _objectEntryLocalService;

--- a/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/internal/model/listener/test/DataMaskObjectEntryModelListenerTest.java
+++ b/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/internal/model/listener/test/DataMaskObjectEntryModelListenerTest.java
@@ -7,31 +7,23 @@ package com.liferay.mcp.server.rest.internal.model.listener.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.mcp.server.rest.test.util.MCPServerTestUtil;
-import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
-import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.portal.configuration.test.util.ConfigurationTemporarySwapper;
-import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
-import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
-import java.io.Serializable;
-
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.Objects;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -65,17 +57,24 @@ public class DataMaskObjectEntryModelListenerTest {
 		String defaultMCPServerProfileExternalReferenceCode =
 			defaultMCPServerProfileObjectEntry.getExternalReferenceCode();
 
-		int mcpServerProfileDataMasksCount =
-			_getMCPServerProfileDataMaskObjectEntriesSize(
+		List<ObjectEntry> mcpServerProfileDataMaskObjectEntries =
+			MCPServerTestUtil.getMCPServerProfileDataMaskObjectEntries(
 				defaultMCPServerProfileExternalReferenceCode);
 
-		MCPServerTestUtil.addDataMaskObjectEntry(
+		int mcpServerProfileDataMasksCount =
+			mcpServerProfileDataMaskObjectEntries.size();
+
+		_customDataMaskObjectEntry = MCPServerTestUtil.addDataMaskObjectEntry(
 			"\\d{4}", RandomTestUtil.randomString(), "[REDACTED]");
 
+		mcpServerProfileDataMaskObjectEntries =
+			MCPServerTestUtil.getMCPServerProfileDataMaskObjectEntries(
+				defaultMCPServerProfileExternalReferenceCode);
+
 		Assert.assertEquals(
+			mcpServerProfileDataMaskObjectEntries.toString(),
 			mcpServerProfileDataMasksCount,
-			_getMCPServerProfileDataMaskObjectEntriesSize(
-				defaultMCPServerProfileExternalReferenceCode));
+			mcpServerProfileDataMaskObjectEntries.size());
 
 		String dataMaskExternalReferenceCode = RandomTestUtil.randomString();
 
@@ -84,13 +83,16 @@ public class DataMaskObjectEntryModelListenerTest {
 				"\\d{4}", dataMaskExternalReferenceCode,
 				RandomTestUtil.randomString(), "[REDACTED]");
 
-		Assert.assertEquals(
-			mcpServerProfileDataMasksCount + 1,
-			_getExecutionOrder(
-				dataMaskExternalReferenceCode,
-				defaultMCPServerProfileExternalReferenceCode));
-
-		_deleteSystemDataMaskObjectEntry(systemDataMaskObjectEntry);
+		try {
+			Assert.assertEquals(
+				mcpServerProfileDataMasksCount + 1,
+				MCPServerTestUtil.getMCPServerProfileDataMaskExecutionOrder(
+					dataMaskExternalReferenceCode,
+					defaultMCPServerProfileExternalReferenceCode));
+		}
+		finally {
+			_deleteSystemDataMaskObjectEntry(systemDataMaskObjectEntry);
+		}
 	}
 
 	@Test
@@ -165,73 +167,8 @@ public class DataMaskObjectEntryModelListenerTest {
 		}
 	}
 
-	private int _getExecutionOrder(
-			String dataMaskExternalReferenceCode,
-			String mcpServerProfileExternalReferenceCode)
-		throws Exception {
-
-		for (ObjectEntry mcpServerProfileDataMaskObjectEntry :
-				_getMCPServerProfileDataMaskObjectEntries(
-					mcpServerProfileExternalReferenceCode)) {
-
-			Map<String, Serializable> values =
-				mcpServerProfileDataMaskObjectEntry.getValues();
-
-			if (Objects.equals(
-					dataMaskExternalReferenceCode,
-					values.get("dataMaskExternalReferenceCode"))) {
-
-				return MapUtil.getInteger(values, "executionOrder");
-			}
-		}
-
-		return -1;
-	}
-
-	private List<ObjectEntry> _getMCPServerProfileDataMaskObjectEntries(
-			String mcpServerProfileExternalReferenceCode)
-		throws Exception {
-
-		List<ObjectEntry> mcpServerProfileDataMaskObjectEntries =
-			new ArrayList<>();
-
-		ObjectDefinition objectDefinition =
-			_objectDefinitionLocalService.
-				fetchObjectDefinitionByExternalReferenceCode(
-					"L_MCP_SERVER_PROFILE_DATA_MASK",
-					TestPropsValues.getCompanyId());
-
-		for (ObjectEntry objectEntry :
-				_objectEntryLocalService.getObjectEntries(
-					0, objectDefinition.getObjectDefinitionId(),
-					QueryUtil.ALL_POS, QueryUtil.ALL_POS)) {
-
-			Map<String, Serializable> values = objectEntry.getValues();
-
-			if (Objects.equals(
-					mcpServerProfileExternalReferenceCode,
-					values.get("mcpServerProfileExternalReferenceCode"))) {
-
-				mcpServerProfileDataMaskObjectEntries.add(objectEntry);
-			}
-		}
-
-		return mcpServerProfileDataMaskObjectEntries;
-	}
-
-	private int _getMCPServerProfileDataMaskObjectEntriesSize(
-			String mcpServerProfileExternalReferenceCode)
-		throws Exception {
-
-		List<ObjectEntry> mcpServerProfileDataMaskObjectEntries =
-			_getMCPServerProfileDataMaskObjectEntries(
-				mcpServerProfileExternalReferenceCode);
-
-		return mcpServerProfileDataMaskObjectEntries.size();
-	}
-
-	@Inject
-	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+	@DeleteAfterTestRun
+	private ObjectEntry _customDataMaskObjectEntry;
 
 	@Inject
 	private ObjectEntryLocalService _objectEntryLocalService;

--- a/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/internal/model/listener/test/MCPServerProfileObjectEntryModelListenerTest.java
+++ b/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/internal/model/listener/test/MCPServerProfileObjectEntryModelListenerTest.java
@@ -7,12 +7,9 @@ package com.liferay.mcp.server.rest.internal.model.listener.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.mcp.server.rest.test.util.MCPServerTestUtil;
-import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
-import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.portal.configuration.test.util.ConfigurationTemporarySwapper;
-import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
@@ -28,10 +25,8 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.io.Serializable;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -76,7 +71,7 @@ public class MCPServerProfileObjectEntryModelListenerTest {
 				"mcp-server-profiles getMCPServerProfilesPage");
 
 		List<ObjectEntry> mcpServerProfileDataMaskObjectEntries =
-			_getMCPServerProfileDataMaskObjectEntries(
+			MCPServerTestUtil.getMCPServerProfileDataMaskObjectEntries(
 				mcpServerProfileObjectEntry.getExternalReferenceCode());
 
 		Assert.assertEquals(
@@ -160,43 +155,12 @@ public class MCPServerProfileObjectEntryModelListenerTest {
 		}
 	}
 
-	private List<ObjectEntry> _getMCPServerProfileDataMaskObjectEntries(
-			String mcpServerProfileExternalReferenceCode)
-		throws Exception {
-
-		List<ObjectEntry> mcpServerProfileDataMaskObjectEntries =
-			new ArrayList<>();
-
-		ObjectDefinition objectDefinition =
-			_objectDefinitionLocalService.
-				fetchObjectDefinitionByExternalReferenceCode(
-					"L_MCP_SERVER_PROFILE_DATA_MASK",
-					TestPropsValues.getCompanyId());
-
-		for (ObjectEntry objectEntry :
-				_objectEntryLocalService.getObjectEntries(
-					0, objectDefinition.getObjectDefinitionId(),
-					QueryUtil.ALL_POS, QueryUtil.ALL_POS)) {
-
-			Map<String, Serializable> values = objectEntry.getValues();
-
-			if (Objects.equals(
-					mcpServerProfileExternalReferenceCode,
-					values.get("mcpServerProfileExternalReferenceCode"))) {
-
-				mcpServerProfileDataMaskObjectEntries.add(objectEntry);
-			}
-		}
-
-		return mcpServerProfileDataMaskObjectEntries;
-	}
-
 	private int _getMCPServerProfileDataMasksCount(
 			String mcpServerProfileExternalReferenceCode)
 		throws Exception {
 
 		List<ObjectEntry> mcpServerProfileDataMaskObjectEntries =
-			_getMCPServerProfileDataMaskObjectEntries(
+			MCPServerTestUtil.getMCPServerProfileDataMaskObjectEntries(
 				mcpServerProfileExternalReferenceCode);
 
 		return mcpServerProfileDataMaskObjectEntries.size();
@@ -208,9 +172,6 @@ public class MCPServerProfileObjectEntryModelListenerTest {
 		"L_DATA_MASK_NATIONAL_ID_BSN", "L_DATA_MASK_NATIONAL_ID_DNI_NIF",
 		"L_DATA_MASK_NATIONAL_ID_SSN", "L_DATA_MASK_PHONE_NUMBER"
 	};
-
-	@Inject
-	private ObjectDefinitionLocalService _objectDefinitionLocalService;
 
 	@Inject
 	private ObjectEntryLocalService _objectEntryLocalService;

--- a/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/internal/model/listener/test/MCPServerProfileObjectEntryModelListenerTest.java
+++ b/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/internal/model/listener/test/MCPServerProfileObjectEntryModelListenerTest.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
@@ -27,6 +28,8 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.io.Serializable;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -60,19 +63,39 @@ public class MCPServerProfileObjectEntryModelListenerTest {
 			MCPServerTestUtil.fetchMCPServerProfileObjectEntry("default");
 
 		Assert.assertEquals(
-			_SYSTEM_MASK_COUNT,
+			_SYSTEM_DATA_MASK_EXTERNAL_REFERENCE_CODES.length,
 			_getMCPServerProfileDataMasksCount(
 				mcpServerProfileObjectEntry.getExternalReferenceCode()));
+
+		MCPServerTestUtil.addDataMaskObjectEntry(
+			"\\d{4}", RandomTestUtil.randomString(), "[REDACTED]");
 
 		mcpServerProfileObjectEntry =
 			MCPServerTestUtil.addMCPServerProfileObjectEntry(
 				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 				"mcp-server-profiles getMCPServerProfilesPage");
 
+		List<ObjectEntry> mcpServerProfileDataMaskObjectEntries =
+			_getMCPServerProfileDataMaskObjectEntries(
+				mcpServerProfileObjectEntry.getExternalReferenceCode());
+
 		Assert.assertEquals(
-			_SYSTEM_MASK_COUNT,
-			_getMCPServerProfileDataMasksCount(
-				mcpServerProfileObjectEntry.getExternalReferenceCode()));
+			mcpServerProfileDataMaskObjectEntries.toString(),
+			_SYSTEM_DATA_MASK_EXTERNAL_REFERENCE_CODES.length,
+			mcpServerProfileDataMaskObjectEntries.size());
+
+		for (ObjectEntry mcpServerProfileDataMaskObjectEntry :
+				mcpServerProfileDataMaskObjectEntries) {
+
+			Map<String, Serializable> values =
+				mcpServerProfileDataMaskObjectEntry.getValues();
+
+			int executionOrder = MapUtil.getInteger(values, "executionOrder");
+
+			Assert.assertEquals(
+				_SYSTEM_DATA_MASK_EXTERNAL_REFERENCE_CODES[executionOrder - 1],
+				values.get("dataMaskExternalReferenceCode"));
+		}
 	}
 
 	@Test
@@ -86,7 +109,7 @@ public class MCPServerProfileObjectEntryModelListenerTest {
 			mcpServerProfileObjectEntry.getExternalReferenceCode();
 
 		Assert.assertEquals(
-			_SYSTEM_MASK_COUNT,
+			_SYSTEM_DATA_MASK_EXTERNAL_REFERENCE_CODES.length,
 			_getMCPServerProfileDataMasksCount(
 				mcpServerProfileObjectEntryExternalReferenceCode));
 
@@ -137,38 +160,54 @@ public class MCPServerProfileObjectEntryModelListenerTest {
 		}
 	}
 
-	private int _getMCPServerProfileDataMasksCount(
+	private List<ObjectEntry> _getMCPServerProfileDataMaskObjectEntries(
 			String mcpServerProfileExternalReferenceCode)
 		throws Exception {
 
-		int count = 0;
+		List<ObjectEntry> mcpServerProfileDataMaskObjectEntries =
+			new ArrayList<>();
 
-		ObjectDefinition profileDataMaskObjectDefinition =
+		ObjectDefinition objectDefinition =
 			_objectDefinitionLocalService.
 				fetchObjectDefinitionByExternalReferenceCode(
 					"L_MCP_SERVER_PROFILE_DATA_MASK",
 					TestPropsValues.getCompanyId());
 
-		for (ObjectEntry profileDataMaskObjectEntry :
+		for (ObjectEntry objectEntry :
 				_objectEntryLocalService.getObjectEntries(
-					0, profileDataMaskObjectDefinition.getObjectDefinitionId(),
+					0, objectDefinition.getObjectDefinitionId(),
 					QueryUtil.ALL_POS, QueryUtil.ALL_POS)) {
 
-			Map<String, Serializable> values =
-				profileDataMaskObjectEntry.getValues();
+			Map<String, Serializable> values = objectEntry.getValues();
 
 			if (Objects.equals(
 					mcpServerProfileExternalReferenceCode,
 					values.get("mcpServerProfileExternalReferenceCode"))) {
 
-				count++;
+				mcpServerProfileDataMaskObjectEntries.add(objectEntry);
 			}
 		}
 
-		return count;
+		return mcpServerProfileDataMaskObjectEntries;
 	}
 
-	private static final int _SYSTEM_MASK_COUNT = 9;
+	private int _getMCPServerProfileDataMasksCount(
+			String mcpServerProfileExternalReferenceCode)
+		throws Exception {
+
+		List<ObjectEntry> mcpServerProfileDataMaskObjectEntries =
+			_getMCPServerProfileDataMaskObjectEntries(
+				mcpServerProfileExternalReferenceCode);
+
+		return mcpServerProfileDataMaskObjectEntries.size();
+	}
+
+	private static final String[] _SYSTEM_DATA_MASK_EXTERNAL_REFERENCE_CODES = {
+		"L_DATA_MASK_IBAN", "L_DATA_MASK_CREDIT_CARD_NUMBER",
+		"L_DATA_MASK_EMAIL_ADDRESS", "L_DATA_MASK_IPV4", "L_DATA_MASK_IPV6",
+		"L_DATA_MASK_NATIONAL_ID_BSN", "L_DATA_MASK_NATIONAL_ID_DNI_NIF",
+		"L_DATA_MASK_NATIONAL_ID_SSN", "L_DATA_MASK_PHONE_NUMBER"
+	};
 
 	@Inject
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;

--- a/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/internal/upgrade/test/MCPProfileDataMaskUpgradeProcessTest.java
+++ b/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/internal/upgrade/test/MCPProfileDataMaskUpgradeProcessTest.java
@@ -7,17 +7,15 @@ package com.liferay.mcp.server.rest.internal.upgrade.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.mcp.server.rest.test.util.MCPServerTestUtil;
-import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
-import com.liferay.object.service.ObjectDefinitionLocalService;
-import com.liferay.object.service.ObjectEntryLocalService;
-import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
-import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.upgrade.UpgradeStep;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
@@ -40,6 +38,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Alberto Javier Moreno Lage
  */
+@FeatureFlags(featureFlags = @FeatureFlag("LPD-63311"))
 @RunWith(Arquillian.class)
 public class MCPProfileDataMaskUpgradeProcessTest {
 
@@ -63,38 +62,74 @@ public class MCPProfileDataMaskUpgradeProcessTest {
 		String mcpServerProfileExternalReferenceCode =
 			_mcpServerProfileObjectEntry.getExternalReferenceCode();
 
-		for (ObjectEntry mcpServerProfileDataMaskObjectEntry :
-				_getMCPServerProfileDataMaskObjectEntries(
-					mcpServerProfileExternalReferenceCode)) {
-
-			MCPServerTestUtil.deleteMCPServerProfileDataMaskObjectEntry(
-				"Deleted by test.", mcpServerProfileDataMaskObjectEntry);
-		}
+		_deleteMCPServerProfileDataMaskObjectEntries(
+			_SYSTEM_DATA_MASK_EXTERNAL_REFERENCE_CODES,
+			mcpServerProfileExternalReferenceCode);
 
 		List<ObjectEntry> mcpServerProfileDataMaskObjectEntries =
-			_getMCPServerProfileDataMaskObjectEntries(
+			MCPServerTestUtil.getMCPServerProfileDataMaskObjectEntries(
 				mcpServerProfileExternalReferenceCode);
 
 		Assert.assertEquals(
 			mcpServerProfileDataMaskObjectEntries.toString(), 0,
 			mcpServerProfileDataMaskObjectEntries.size());
 
+		ObjectEntry defaultMCPServerProfileObjectEntry =
+			MCPServerTestUtil.fetchMCPServerProfileObjectEntry("default");
+
 		UpgradeStep upgradeStep = _getUpgradeStep();
 
 		upgradeStep.upgrade();
 
 		_assertUpgrade(mcpServerProfileExternalReferenceCode);
+		_assertUpgrade(
+			defaultMCPServerProfileObjectEntry.getExternalReferenceCode());
 
 		upgradeStep.upgrade();
 
 		_assertUpgrade(mcpServerProfileExternalReferenceCode);
+		_assertUpgrade(
+			defaultMCPServerProfileObjectEntry.getExternalReferenceCode());
+
+		String[] dataMaskExternalReferenceCodes = {
+			"L_DATA_MASK_IBAN", "L_DATA_MASK_IPV4", "L_DATA_MASK_IPV6"
+		};
+
+		_deleteMCPServerProfileDataMaskObjectEntries(
+			dataMaskExternalReferenceCodes,
+			mcpServerProfileExternalReferenceCode);
+
+		upgradeStep.upgrade();
+
+		mcpServerProfileDataMaskObjectEntries =
+			MCPServerTestUtil.getMCPServerProfileDataMaskObjectEntries(
+				mcpServerProfileExternalReferenceCode);
+
+		Assert.assertEquals(
+			mcpServerProfileDataMaskObjectEntries.toString(),
+			_SYSTEM_DATA_MASK_EXTERNAL_REFERENCE_CODES.length,
+			mcpServerProfileDataMaskObjectEntries.size());
+
+		int executionOrder = _SYSTEM_DATA_MASK_EXTERNAL_REFERENCE_CODES.length;
+
+		for (String dataMaskExternalReferenceCode :
+				dataMaskExternalReferenceCodes) {
+
+			executionOrder++;
+
+			Assert.assertEquals(
+				executionOrder,
+				MCPServerTestUtil.getMCPServerProfileDataMaskExecutionOrder(
+					dataMaskExternalReferenceCode,
+					mcpServerProfileExternalReferenceCode));
+		}
 	}
 
 	private void _assertUpgrade(String mcpServerProfileExternalReferenceCode)
 		throws Exception {
 
 		List<ObjectEntry> mcpServerProfileDataMaskObjectEntries =
-			_getMCPServerProfileDataMaskObjectEntries(
+			MCPServerTestUtil.getMCPServerProfileDataMaskObjectEntries(
 				mcpServerProfileExternalReferenceCode);
 
 		Assert.assertEquals(
@@ -116,35 +151,25 @@ public class MCPProfileDataMaskUpgradeProcessTest {
 		}
 	}
 
-	private List<ObjectEntry> _getMCPServerProfileDataMaskObjectEntries(
+	private void _deleteMCPServerProfileDataMaskObjectEntries(
+			String[] dataMaskExternalReferenceCodes,
 			String mcpServerProfileExternalReferenceCode)
 		throws Exception {
 
-		List<ObjectEntry> mcpServerProfileDataMaskObjectEntries =
-			new ArrayList<>();
+		for (ObjectEntry mcpServerProfileDataMaskObjectEntry :
+				MCPServerTestUtil.getMCPServerProfileDataMaskObjectEntries(
+					mcpServerProfileExternalReferenceCode)) {
 
-		ObjectDefinition objectDefinition =
-			_objectDefinitionLocalService.
-				fetchObjectDefinitionByExternalReferenceCode(
-					"L_MCP_SERVER_PROFILE_DATA_MASK",
-					TestPropsValues.getCompanyId());
+			if (ArrayUtil.contains(
+					dataMaskExternalReferenceCodes,
+					MapUtil.getString(
+						mcpServerProfileDataMaskObjectEntry.getValues(),
+						"dataMaskExternalReferenceCode"))) {
 
-		for (ObjectEntry objectEntry :
-				_objectEntryLocalService.getObjectEntries(
-					0, objectDefinition.getObjectDefinitionId(),
-					QueryUtil.ALL_POS, QueryUtil.ALL_POS)) {
-
-			Map<String, Serializable> values = objectEntry.getValues();
-
-			if (Objects.equals(
-					mcpServerProfileExternalReferenceCode,
-					values.get("mcpServerProfileExternalReferenceCode"))) {
-
-				mcpServerProfileDataMaskObjectEntries.add(objectEntry);
+				MCPServerTestUtil.deleteMCPServerProfileDataMaskObjectEntry(
+					"Deleted by test.", mcpServerProfileDataMaskObjectEntry);
 			}
 		}
-
-		return mcpServerProfileDataMaskObjectEntries;
 	}
 
 	private UpgradeStep _getUpgradeStep() {
@@ -184,12 +209,6 @@ public class MCPProfileDataMaskUpgradeProcessTest {
 
 	@DeleteAfterTestRun
 	private ObjectEntry _mcpServerProfileObjectEntry;
-
-	@Inject
-	private ObjectDefinitionLocalService _objectDefinitionLocalService;
-
-	@Inject
-	private ObjectEntryLocalService _objectEntryLocalService;
 
 	@Inject(
 		filter = "component.name=com.liferay.mcp.server.rest.internal.upgrade.registry.MCPServerRestUpgradeStepRegistrator"

--- a/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/internal/upgrade/test/MCPProfileDataMaskUpgradeProcessTest.java
+++ b/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/internal/upgrade/test/MCPProfileDataMaskUpgradeProcessTest.java
@@ -1,0 +1,199 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.mcp.server.rest.internal.upgrade.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.mcp.server.rest.test.util.MCPServerTestUtil;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.upgrade.UpgradeStep;
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+
+import java.io.Serializable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Alberto Javier Moreno Lage
+ */
+@RunWith(Arquillian.class)
+public class MCPProfileDataMaskUpgradeProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() {
+		MCPServerTestUtil.processBatchEngineUnits();
+	}
+
+	@Test
+	public void testUpgrade() throws Exception {
+		_mcpServerProfileObjectEntry =
+			MCPServerTestUtil.addMCPServerProfileObjectEntry(
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+				"mcp-server-profiles getMCPServerProfilesPage");
+
+		String mcpServerProfileExternalReferenceCode =
+			_mcpServerProfileObjectEntry.getExternalReferenceCode();
+
+		for (ObjectEntry mcpServerProfileDataMaskObjectEntry :
+				_getMCPServerProfileDataMaskObjectEntries(
+					mcpServerProfileExternalReferenceCode)) {
+
+			MCPServerTestUtil.deleteMCPServerProfileDataMaskObjectEntry(
+				"Deleted by test.", mcpServerProfileDataMaskObjectEntry);
+		}
+
+		List<ObjectEntry> mcpServerProfileDataMaskObjectEntries =
+			_getMCPServerProfileDataMaskObjectEntries(
+				mcpServerProfileExternalReferenceCode);
+
+		Assert.assertEquals(
+			mcpServerProfileDataMaskObjectEntries.toString(), 0,
+			mcpServerProfileDataMaskObjectEntries.size());
+
+		UpgradeStep upgradeStep = _getUpgradeStep();
+
+		upgradeStep.upgrade();
+
+		_assertUpgrade(mcpServerProfileExternalReferenceCode);
+
+		upgradeStep.upgrade();
+
+		_assertUpgrade(mcpServerProfileExternalReferenceCode);
+	}
+
+	private void _assertUpgrade(String mcpServerProfileExternalReferenceCode)
+		throws Exception {
+
+		List<ObjectEntry> mcpServerProfileDataMaskObjectEntries =
+			_getMCPServerProfileDataMaskObjectEntries(
+				mcpServerProfileExternalReferenceCode);
+
+		Assert.assertEquals(
+			mcpServerProfileDataMaskObjectEntries.toString(),
+			_SYSTEM_DATA_MASK_EXTERNAL_REFERENCE_CODES.length,
+			mcpServerProfileDataMaskObjectEntries.size());
+
+		for (ObjectEntry mcpServerProfileDataMaskObjectEntry :
+				mcpServerProfileDataMaskObjectEntries) {
+
+			Map<String, Serializable> values =
+				mcpServerProfileDataMaskObjectEntry.getValues();
+
+			int executionOrder = MapUtil.getInteger(values, "executionOrder");
+
+			Assert.assertEquals(
+				_SYSTEM_DATA_MASK_EXTERNAL_REFERENCE_CODES[executionOrder - 1],
+				values.get("dataMaskExternalReferenceCode"));
+		}
+	}
+
+	private List<ObjectEntry> _getMCPServerProfileDataMaskObjectEntries(
+			String mcpServerProfileExternalReferenceCode)
+		throws Exception {
+
+		List<ObjectEntry> mcpServerProfileDataMaskObjectEntries =
+			new ArrayList<>();
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.
+				fetchObjectDefinitionByExternalReferenceCode(
+					"L_MCP_SERVER_PROFILE_DATA_MASK",
+					TestPropsValues.getCompanyId());
+
+		for (ObjectEntry objectEntry :
+				_objectEntryLocalService.getObjectEntries(
+					0, objectDefinition.getObjectDefinitionId(),
+					QueryUtil.ALL_POS, QueryUtil.ALL_POS)) {
+
+			Map<String, Serializable> values = objectEntry.getValues();
+
+			if (Objects.equals(
+					mcpServerProfileExternalReferenceCode,
+					values.get("mcpServerProfileExternalReferenceCode"))) {
+
+				mcpServerProfileDataMaskObjectEntries.add(objectEntry);
+			}
+		}
+
+		return mcpServerProfileDataMaskObjectEntries;
+	}
+
+	private UpgradeStep _getUpgradeStep() {
+		List<UpgradeStep> versionedUpgradeSteps = new ArrayList<>();
+
+		_upgradeStepRegistrator.register(
+			new UpgradeStepRegistrator.Registry() {
+
+				@Override
+				public void register(
+					String fromSchemaVersionString,
+					String toSchemaVersionString, UpgradeStep... upgradeSteps) {
+
+					if (Objects.equals(fromSchemaVersionString, "1.0.0") &&
+						Objects.equals(toSchemaVersionString, "1.1.0")) {
+
+						Collections.addAll(versionedUpgradeSteps, upgradeSteps);
+					}
+				}
+
+				@Override
+				public void registerReleaseCreationUpgradeSteps(
+					UpgradeStep... upgradeSteps) {
+				}
+
+			});
+
+		return versionedUpgradeSteps.get(0);
+	}
+
+	private static final String[] _SYSTEM_DATA_MASK_EXTERNAL_REFERENCE_CODES = {
+		"L_DATA_MASK_IBAN", "L_DATA_MASK_CREDIT_CARD_NUMBER",
+		"L_DATA_MASK_EMAIL_ADDRESS", "L_DATA_MASK_IPV4", "L_DATA_MASK_IPV6",
+		"L_DATA_MASK_NATIONAL_ID_BSN", "L_DATA_MASK_NATIONAL_ID_DNI_NIF",
+		"L_DATA_MASK_NATIONAL_ID_SSN", "L_DATA_MASK_PHONE_NUMBER"
+	};
+
+	@DeleteAfterTestRun
+	private ObjectEntry _mcpServerProfileObjectEntry;
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Inject
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Inject(
+		filter = "component.name=com.liferay.mcp.server.rest.internal.upgrade.registry.MCPServerRestUpgradeStepRegistrator"
+	)
+	private UpgradeStepRegistrator _upgradeStepRegistrator;
+
+}

--- a/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/test/util/MCPServerTestUtil.java
+++ b/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/test/util/MCPServerTestUtil.java
@@ -6,6 +6,7 @@
 package com.liferay.mcp.server.rest.test.util;
 
 import com.liferay.batch.engine.test.util.BatchEngineTestUtil;
+import com.liferay.batch.engine.unit.BatchEngineUnitThreadLocal;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
@@ -139,6 +140,46 @@ public class MCPServerTestUtil {
 			ServiceContextTestUtil.getServiceContext());
 	}
 
+	public static ObjectEntry addSystemDataMaskObjectEntry(
+			String detectionRegex, String externalReferenceCode, String name,
+			String replacementValue)
+		throws Exception {
+
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionLocalServiceUtil.
+				fetchObjectDefinitionByExternalReferenceCode(
+					"L_DATA_MASK", TestPropsValues.getCompanyId());
+
+		String fileName = BatchEngineUnitThreadLocal.getFileName();
+
+		BatchEngineUnitThreadLocal.setFileName(
+			"com.liferay.headless.data.mask.impl_test");
+
+		try {
+			return ObjectEntryLocalServiceUtil.addObjectEntry(
+				0, TestPropsValues.getUserId(),
+				objectDefinition.getObjectDefinitionId(),
+				ObjectEntryFolderConstants.
+					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+				null,
+				HashMapBuilder.<String, Serializable>put(
+					"detectionRegex", detectionRegex
+				).put(
+					"externalReferenceCode", externalReferenceCode
+				).put(
+					"maskType", "system"
+				).put(
+					"name", name
+				).put(
+					"replacementValue", replacementValue
+				).build(),
+				ServiceContextTestUtil.getServiceContext());
+		}
+		finally {
+			BatchEngineUnitThreadLocal.setFileName(fileName);
+		}
+	}
+
 	public static void deleteMCPServerProfileDataMaskObjectEntry(
 			String deleteReason, ObjectEntry objectEntry)
 		throws Exception {
@@ -154,6 +195,23 @@ public class MCPServerTestUtil {
 
 		ObjectEntryLocalServiceUtil.deleteObjectEntry(
 			objectEntry.getObjectEntryId());
+	}
+
+	public static void deleteSystemDataMaskObjectEntry(ObjectEntry objectEntry)
+		throws Exception {
+
+		String fileName = BatchEngineUnitThreadLocal.getFileName();
+
+		BatchEngineUnitThreadLocal.setFileName(
+			"com.liferay.headless.data.mask.impl_test");
+
+		try {
+			ObjectEntryLocalServiceUtil.deleteObjectEntry(
+				objectEntry.getObjectEntryId());
+		}
+		finally {
+			BatchEngineUnitThreadLocal.setFileName(fileName);
+		}
 	}
 
 	public static ObjectEntry fetchDataMaskObjectEntry(String name)

--- a/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/test/util/MCPServerTestUtil.java
+++ b/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/test/util/MCPServerTestUtil.java
@@ -17,14 +17,17 @@ import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.security.audit.event.generators.constants.EventTypes;
 import com.liferay.portal.security.audit.storage.model.AuditEvent;
 import com.liferay.portal.security.audit.storage.service.AuditEventLocalServiceUtil;
 
 import java.io.Serializable;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * @author Jose Luis Navarro
@@ -152,8 +155,7 @@ public class MCPServerTestUtil {
 
 		String fileName = BatchEngineUnitThreadLocal.getFileName();
 
-		BatchEngineUnitThreadLocal.setFileName(
-			"com.liferay.headless.data.mask.impl_test");
+		BatchEngineUnitThreadLocal.setFileName(_DATA_MASK_BATCH_FILE_NAME);
 
 		try {
 			return ObjectEntryLocalServiceUtil.addObjectEntry(
@@ -202,8 +204,7 @@ public class MCPServerTestUtil {
 
 		String fileName = BatchEngineUnitThreadLocal.getFileName();
 
-		BatchEngineUnitThreadLocal.setFileName(
-			"com.liferay.headless.data.mask.impl_test");
+		BatchEngineUnitThreadLocal.setFileName(_DATA_MASK_BATCH_FILE_NAME);
 
 		try {
 			ObjectEntryLocalServiceUtil.deleteObjectEntry(
@@ -249,17 +250,62 @@ public class MCPServerTestUtil {
 		);
 	}
 
+	public static int getMCPServerProfileDataMaskExecutionOrder(
+			String dataMaskExternalReferenceCode,
+			String mcpServerProfileExternalReferenceCode)
+		throws Exception {
+
+		for (ObjectEntry mcpServerProfileDataMaskObjectEntry :
+				getMCPServerProfileDataMaskObjectEntries(
+					mcpServerProfileExternalReferenceCode)) {
+
+			Map<String, Serializable> values =
+				mcpServerProfileDataMaskObjectEntry.getValues();
+
+			if (Objects.equals(
+					dataMaskExternalReferenceCode,
+					values.get("dataMaskExternalReferenceCode"))) {
+
+				return MapUtil.getInteger(values, "executionOrder");
+			}
+		}
+
+		return -1;
+	}
+
+	public static List<ObjectEntry> getMCPServerProfileDataMaskObjectEntries(
+			String mcpServerProfileExternalReferenceCode)
+		throws Exception {
+
+		List<ObjectEntry> mcpServerProfileDataMaskObjectEntries =
+			new ArrayList<>();
+
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionLocalServiceUtil.
+				fetchObjectDefinitionByExternalReferenceCode(
+					"L_MCP_SERVER_PROFILE_DATA_MASK",
+					TestPropsValues.getCompanyId());
+
+		for (ObjectEntry objectEntry :
+				ObjectEntryLocalServiceUtil.getObjectEntries(
+					0, objectDefinition.getObjectDefinitionId(),
+					QueryUtil.ALL_POS, QueryUtil.ALL_POS)) {
+
+			Map<String, Serializable> values = objectEntry.getValues();
+
+			if (Objects.equals(
+					mcpServerProfileExternalReferenceCode,
+					values.get("mcpServerProfileExternalReferenceCode"))) {
+
+				mcpServerProfileDataMaskObjectEntries.add(objectEntry);
+			}
+		}
+
+		return mcpServerProfileDataMaskObjectEntries;
+	}
+
 	public static void processBatchEngineUnits() {
-		String prefix = ".com.liferay.headless.data.mask.internal.batch.";
-
-		BatchEngineTestUtil.processBatchEngineUnits(
-			"com.liferay.headless.data.mask.impl", MCPServerTestUtil.class,
-			new String[] {
-				prefix + "01.list.type.definition",
-				prefix + "02.object.definition", prefix + "03.object.entry"
-			});
-
-		prefix = ".com.liferay.mcp.server.rest.internal.batch.";
+		String prefix = ".com.liferay.mcp.server.rest.internal.batch.";
 
 		BatchEngineTestUtil.processBatchEngineUnits(
 			"com.liferay.mcp.server.rest.impl", MCPServerTestUtil.class,
@@ -268,6 +314,15 @@ public class MCPServerTestUtil {
 				prefix + "01.object.definition",
 				prefix + "02.object.definition",
 				prefix + "03.object.definition", prefix + "04.object.entry"
+			});
+
+		prefix = ".com.liferay.headless.data.mask.internal.batch.";
+
+		BatchEngineTestUtil.processBatchEngineUnits(
+			"com.liferay.headless.data.mask.impl", MCPServerTestUtil.class,
+			new String[] {
+				prefix + "01.list.type.definition",
+				prefix + "02.object.definition", prefix + "03.object.entry"
 			});
 	}
 
@@ -299,5 +354,8 @@ public class MCPServerTestUtil {
 
 		return null;
 	}
+
+	private static final String _DATA_MASK_BATCH_FILE_NAME =
+		"com.liferay.headless.data.mask.impl_test";
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101393

## What Is Being Fixed

The `default` MCP server profile is served without the system data masks, so data that should be redacted passes through unmasked. Data masks are linked to profiles through join entries, and that link was only ever created in one direction: when a profile was created, the profile listener attached the system masks that existed at that moment. Two cases leave a profile with no masks. On a first deployment the MCP bundle creates the `default` profile before `headless-data-mask` creates the system masks, so nothing is attached. And a system mask shipped in a later release never reaches the profiles that already exist.

## How It Is Being Fixed

`DataMaskObjectEntryModelListener` now covers the opposite direction: creating a system mask attaches it to every existing profile, appending it after that profile's highest `executionOrder` and skipping any profile that already holds the pair, so a repeated run changes nothing. `MCPProfileDataMaskUpgradeProcess` backfills the existing data per company, building the profile-to-masks map in a single pass and creating only the missing links while continuing each profile's numbering. It exits early when the object definitions or the system masks are absent, so an instance that never installed data masks is untouched, and it is safe to re-run. The profile data mask lookup in `onBeforeRemove` also moved from an in-Java scan of every join entry to an OData filter pushed into the database.

Integration tests cover both directions and the upgrade — backfill, an idempotent second run, and re-append after masks are deleted — and the test batch order now mirrors the real bundle order, so the deployment scenario that produces the bug is exercised rather than assumed.

## PR Check

**pr-check: PASS** — tested on `096ec33d1e00ce9b59acf734c010d5feaf9e30bf`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "096ec33d1e00ce9b59acf734c010d5feaf9e30bf"} -->
