### PR TITLE
LPD-102825 Wait for the outcome the picklist import reaches

### DIFF
--- a/modules/test/playwright/tests/object-web/list-type-definition/listTypeDefinition.spec.ts
+++ b/modules/test/playwright/tests/object-web/list-type-definition/listTypeDefinition.spec.ts
@@ -92,7 +92,36 @@ async function importPicklistFromFile(
 
 	await expect(page.getByLabel('External Reference Code')).not.toBeEmpty();
 
+	// Clicking Import fires a reference code check and then either imports and
+	// reloads the page, or, when the reference code already exists, asks about
+	// overwriting instead. Returning at the click leaves that chain in flight,
+	// and the caller's next navigation cancels it, so the picklist is silently
+	// never imported. Wait for whichever outcome the click reaches: the reload
+	// only ever happens after the import commits, and the overwrite prompt is
+	// the caller's to answer.
+
+	const importNavigation = page.waitForNavigation({waitUntil: 'load'}).then(
+		() => 'imported',
+		() => null
+	);
+
+	const overwritePrompt = page
+		.getByRole('heading', {name: 'Update Existing Picklist'})
+		.waitFor({state: 'visible'})
+		.then(
+			() => 'prompted',
+			() => null
+		);
+
 	await page.getByRole('button', {exact: true, name: 'Import'}).click();
+
+	const outcome = await Promise.race([importNavigation, overwritePrompt]);
+
+	if (outcome === null) {
+		throw new Error(
+			'The import neither reloaded the page nor asked about overwriting'
+		);
+	}
 }
 
 test.describe('manage export/import of picklists', () => {
@@ -156,8 +185,6 @@ test.describe('manage export/import of picklists', () => {
 				filePath,
 				importedPicklistName
 			);
-
-			await page.waitForLoadState('networkidle');
 
 			await listTypeDefinitionPage.goto();
 
@@ -283,8 +310,6 @@ test.describe('manage export/import of picklists', () => {
 				importedPicklistName
 			);
 
-			await page.waitForLoadState('networkidle');
-
 			await listTypeDefinitionPage.goto();
 
 			const [importedListTypeDefinition] =
@@ -406,8 +431,6 @@ test.describe('manage export/import of picklists', () => {
 				filePath,
 				importedPicklistName
 			);
-
-			await page.waitForLoadState('networkidle');
 
 			await listTypeDefinitionPage.goto();
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102825

## What Is Being Fixed

The Playwright test `can add entry with picklist field imported (required or not)` fails intermittently on CI with `expect(received).toBeTruthy() / Received: undefined` when reading the imported picklist back over the API. The failure is retry masked — the retry passes, Testray imports PASSED — so the test shows a clean history while failing first attempts across CI runs.

`importPicklistFromFile` clicks Import and returns while the click's chain (reference-code check → import → page reload) is still in flight. The caller's next navigation cancels the chain, the picklist is silently never imported, and the API read returns nothing. The `networkidle` waits around the import never protected it: the document was already past network idle before the click, so they resolve immediately.

Root cause: born this way in 9cb2be5355904 (LPD-80345), which created the helper ending at the bare Import click; 2058c9ec4fe0a (LPD-87190) later fixed the helper's ambiguous locator, removing the hard failure and leaving this race as the remaining, retry-masked one.

## How It Is Being Fixed

The helper registers waits for the click's two legitimate outcomes before clicking — the reload (which only happens after the import commits) and the `Update Existing Picklist` prompt (duplicate reference code path) — and returns when whichever arrives, failing loudly when neither does. The dead `networkidle` waits are removed. All four tests sharing the helper pass together.

Testing: local A/B — unpatched 0/6 pass with the exact signature, patched 6/6. CI hammer at the same shrink — control flaked 1/10, treatment 20/20 clean. (A follow-up green run of the same head answered the test axis from Jenkins' build cache, so it is a record of the verdict, not additional executions.)

## PR Check

| Validation | Result |
|---|---|
| Source Format | ✅ passed |

Only Source Format fires for this Playwright-spec-only diff (no Java, no `bnd.bnd`/`packageinfo`/Gradle changes).

<!-- pr-check {"result": "success", "sha": "bc6f6ea0951277000ca426599a8543c1c8c13094"} -->
