### PR TITLE
LPD-102826 Click the relationship count badge by its exact text

### DIFF
--- a/modules/test/playwright/tests/object-web/relationship/objectRelationship.spec.ts
+++ b/modules/test/playwright/tests/object-web/relationship/objectRelationship.spec.ts
@@ -257,15 +257,29 @@ test.describe('Manage object relationships through Model Builder', () => {
 			type: 'One to Many',
 		});
 
-		await page.waitForTimeout(500);
+		// The badge showing the relationship count is rebuilt from a refetch
+		// the second relationship's save schedules, so right after the save the
+		// diagram still shows the single relationship's edge. That edge's label
+		// is random digits, so filtering edges by the text 2 matches it whenever
+		// the label contains a 2, and the click opens the sidebar instead of the
+		// menu, which only a click on the badge itself renders. Match the badge
+		// by its exact text, which the label cannot equal, and wait for it: the
+		// badge appearing is the save's rebuild finishing.
 
-		await modelBuilderDiagramPage.clickObjectRelationshipEdge('2');
+		const manyRelationshipsEdge =
+			modelBuilderDiagramPage.objectRelationshipEdges.filter({
+				has: page.getByText('2', {exact: true}),
+			});
 
-		expect(
+		await expect(manyRelationshipsEdge).toBeVisible();
+
+		await manyRelationshipsEdge.click();
+
+		await expect(
 			page.getByRole('menuitem', {name: objectRelationship1Label})
 		).toBeVisible();
 
-		expect(
+		await expect(
 			page.getByRole('menuitem', {name: objectRelationship2Label})
 		).toBeVisible();
 	});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102826

## What Is Being Fixed

The Playwright test `can create multiple object relationships between the same objects` fails intermittently on CI when opening the many-relationships badge on a model builder diagram edge — the relationship menu items are not found (`objectRelationship.spec.ts:266`).

Root cause: born broken in a9975ee68a3da (LPD-26472), which added the test with three stacked hazards — a fixed 500ms sleep standing in for the second relationship's edge re-render, an edge locator matching the badge text `2` as a substring (so it can resolve against a stale edge before the re-render settles), and the two menu item assertions missing their `await`s, so failures surface late or at the wrong site.

## How It Is Being Fixed

The sleep and the substring match are replaced by an explicit wait on the precise state the click needs: the edge filtered by exact badge text `2` must be visible before the click, and after it each relationship's menu item must be visible, both awaited. No retries, no fixed timers.

Testing: local amplified A/B (identical render-delay amplifier on both arms, instrumented to prove engagement) — unpatched fails 13/24 pooled, patched clean. CI hammer at shrunk scope: the first pair separated (control flaked exactly this target, treatment clean at identical shrink); the final version re-ran 10/10 clean on CI, pooled CI control power one flake across 18 control repetitions.

## PR Check

| Validation | Result |
|---|---|
| Source Format | ✅ passed |

Only Source Format fires for this Playwright-spec-only diff (no Java, no `bnd.bnd`/`packageinfo`/Gradle changes).

<!-- pr-check {"result": "success", "sha": "27e3a0165e30e4bd866d4f57e2d0b198e8b77d98"} -->
