### PR TITLE
LPD-102843 Wait for the entry the bidirectional picker relates

### DIFF
--- a/modules/test/playwright/tests/object-web/relationship/objectRelationship.spec.ts
+++ b/modules/test/playwright/tests/object-web/relationship/objectRelationship.spec.ts
@@ -3759,6 +3759,21 @@ test.describe('Manage object relationship entries', () => {
 
 				await expect(relationshipEntry).toBeVisible();
 				await relationshipEntry.click();
+
+				// Selecting relates the entry and closes the picker, and the
+				// relating is still in flight when the click resolves. The next
+				// step asks for another address, which tears down the frame the
+				// request belongs to and cancels it, so one of the two
+				// relationships is never made. Wait for the picker to go and
+				// the related row to show.
+
+				await expect(
+					page.locator('iframe[title="Select"]')
+				).toBeHidden();
+
+				await expect(
+					page.getByRole('row').filter({hasText: entryLabel}).first()
+				).toBeVisible();
 			};
 
 			await openEntryRelationshipTab('Entry A');


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102843

## What Is Being Fixed

The Playwright test `can relate two entries bidirectionally in a self-referencing One-to-Many relationship` fails intermittently on CI counting the related rows — it relates Entry A and Entry B to each other, expects each label twice in the table, and finds it once (`toHaveCount: Expected 2, Received: 1`). Seen at attempt level in three recent full-scope runs, including a hard failure on an aggregate run without this fix aboard.

Root cause: masked, then uncovered — both commits same day, same ticket (LPD-82349). `6178dc43bf5dd` migrated the Poshi test with a `waitForTimeout(1000)` after each picker selection, which happened to cover the write; `fd889e8e4915e` removed those sleeps without replacing them with a wait for what the sleep was accidentally protecting. The test's picker helper clicks an entry inside the Select picker iframe and returns while the relate POST is still in flight; the next step's navigation tears down the frame the request belongs to, and one of the two relates is silently dropped.

## How It Is Being Fixed

The helper now owns its outcome before returning — the same ownership LPD-102718 and LPD-102725 gave this spec's other picker helpers: it waits for the Select picker iframe to be hidden (the relate answered and the picker dismissed itself) and for the related row to be visible (the write observably landed). Explicit waits on the effect's own signals; no retries, no timers.

Testing: local A/B with natural separation (no amplifier needed) — unpatched 0/6 pass, all six with the exact signature, patched 6/6, interleaved blocks. CI: the hammer treatment ran the target ×8 clean at shrunk scope; the shrunk control did not reach this target's window, so CI power comes from full scope — an aggregate without the fix hard-failed the test, the next aggregate with it aboard ran clean. Revalidated on the current master base after rebasing.

## PR Check

| Validation | Result |
|---|---|
| Source Format | ✅ passed |

Only Source Format fires for this Playwright-spec-only diff (no Java, no `bnd.bnd`/`packageinfo`/Gradle changes).

<!-- pr-check {"result": "success", "sha": "f9c68ab8b359b1440bb10b5bdbaba45936fd1c9f"} -->
