### PR TITLE
LPD-102844 Wait for the entry the relationship picker relates

### DIFF
--- a/modules/test/playwright/tests/object-web/relationship/objectRelationship.spec.ts
+++ b/modules/test/playwright/tests/object-web/relationship/objectRelationship.spec.ts
@@ -3911,6 +3911,19 @@ test.describe('Manage object relationship entries', () => {
 			await expect(relationshipEntry).toBeVisible();
 			await relationshipEntry.click();
 
+			// Selecting relates the entry and closes the picker, and the
+			// relating is still in flight when the click resolves. The next step
+			// asks for another address, which tears down the frame the request
+			// belongs to and cancels it, so the relationship is never made and
+			// the row below never arrives. Wait for the picker to go and the
+			// relationship to show.
+
+			await expect(page.locator('iframe[title="Select"]')).toBeHidden();
+
+			await expect(
+				page.getByRole('row').filter({hasText: 'Entry Test B'}).first()
+			).toBeVisible();
+
 			await openEntryRelationshipTab('Entry Test A');
 
 			await expect(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102844

## What Is Being Fixed

The Playwright test `can see related entries on Relationship tab` fails intermittently on CI at its final assertion: after relating Entry Test B to Entry Test A through the Select picker and reopening the Relationship tab, the related row never appears — `getByRole('row').filter({hasText: 'Entry Test B'})` times out on `<element(s) not found>`.

Root cause: born this way. Selecting an entry in the picker posts the relate from inside the picker iframe and dismisses the picker while the write is still in flight; the test immediately navigates to reopen the entry, tearing down the frame before the request is dispatched, so the relationship is never made. `6178dc43bf5dd` (LPD-82349) migrated the test with the picker click followed immediately by the next navigation and nothing consuming the relate; `46afd26f1bef5` later moved and retitled it unchanged. This is the last known unowned picker site in this spec, after LPD-102718, LPD-102725, and LPD-102843.

## How It Is Being Fixed

After the picker click, the test waits for the picker iframe to be gone and for the related row to be on screen in the current document — the visible confirmation a careful user waits for — before asking for the next address. The later assertion after reopening the tab is unchanged and still tests persistence across a full reload. Same ownership shape as the shipped siblings; explicit waits on the effect's own signals, no retries, no timers.

Testing: local A/B is null for this target (passes both arms locally; the relate is invisible to request interception, so no honest amplifier exists) — the mechanism is proven by the bidirectional sibling in this spec, which separated 0/6 vs 6/6 locally with the identical fix shape. On CI every run carrying the fix is clean: shrunk hammer ×8 clean, two full-scope aggregates clean with it aboard, against one recorded natural failure without it. Revalidated on the current master base after rebasing.

## PR Check

| Validation | Result |
|---|---|
| Source Format | ✅ passed |

Only Source Format fires for this Playwright-spec-only diff (no Java, no `bnd.bnd`/`packageinfo`/Gradle changes).

<!-- pr-check {"result": "success", "sha": "0a2d09073e9cfc2d50d47545956b9c843ef946f3"} -->
