### PR TITLE
LPD-102846 Hand the field save's navigation to the step that cannot race it

### DIFF
--- a/modules/test/playwright/pages/object-web/object-fields/ObjectFieldsPage.ts
+++ b/modules/test/playwright/pages/object-web/object-fields/ObjectFieldsPage.ts
@@ -252,6 +252,33 @@ export class ObjectFieldsPage {
 		await waitForPageToBeLoaded(this.page);
 	}
 
+	/**
+	 * Saves the field and hands back the navigation the save starts. The
+	 * success message renders before that navigation commits, so a caller that
+	 * cannot tolerate it in flight, such as one that asks for another address
+	 * next, awaits the returned promise at the point it needs it. Ten seconds
+	 * is generous headroom for that navigation and fails loud, rather than
+	 * quietly at the default half minute.
+	 *
+	 * The caller must await it. The promise is deliberately not swallowed: if
+	 * the save ever stops navigating, the wait fails and says so, rather than
+	 * passing quietly and leaving the collision it guards against unguarded.
+	 */
+	async saveObjectFieldReturningNavigation() {
+		const navigation = this.page.waitForNavigation({
+			timeout: 10000,
+			waitUntil: 'load',
+		});
+
+		await this.editFieldSaveButton.click();
+
+		// Wrapped, because awaiting this method would otherwise flatten the
+		// promise and wait for the navigation here, which is what the caller is
+		// being given the chance to avoid.
+
+		return {navigation};
+	}
+
 	async selectDefaultValue(value: string) {
 		await this.selectOptionButton.click();
 

--- a/modules/test/playwright/tests/object-web/entry/objectEntry.spec.ts
+++ b/modules/test/playwright/tests/object-web/entry/objectEntry.spec.ts
@@ -4554,12 +4554,8 @@ test.describe('Manage object entries through View Object Entries', () => {
 			.getByPlaceholder('Create an expression.')
 			.fill(textFieldName);
 
-		await objectFieldsPage.editFieldSaveButton.click();
-
-		await waitForAlert(
-			page,
-			'Success:The object field was updated successfully'
-		);
+		const {navigation} =
+			await objectFieldsPage.saveObjectFieldReturningNavigation();
 
 		const applicationName =
 			'c/' + objectDefinition.name.toLowerCase() + 's';
@@ -4570,6 +4566,11 @@ test.describe('Manage object entries through View Object Entries', () => {
 			{[textFieldName]: firstItemName},
 			applicationName
 		);
+
+		// The save's navigation has had the entry seeding to land in; consume
+		// it before the next address is asked for, or the two collide.
+
+		await navigation;
 
 		await viewObjectEntriesPage.goto(objectDefinition.className);
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102846

## What Is Being Fixed

The Playwright test `can set picklist default value via expression builder` fails intermittently on CI when it navigates to the entries view after saving the object field: `page.goto: ... interrupted by another navigation to ...screenNavigationCategoryKey=fields`. Saving an object field renders its success alert when the save request answers, then navigates the page back to the fields tab — the test clicked save, saw the alert, seeded an entry over the API, and asked for the entries view, colliding with the save's still-pending navigation. The alert never protected anything: it renders before the navigation commits.

Root cause: born this way. `5354f141444bf` (LPD-85191, "Create entry playwright subproject") added the test saving the field and navigating onward with nothing consuming the save's navigation.

## How It Is Being Fixed

A new `ObjectFieldsPage.saveObjectFieldReturningNavigation()` registers the wait for the save's navigation before clicking and hands the promise back wrapped, so the caller consumes it where it needs it — the same producer-owns-its-navigation design as the layout save family. The wait is deliberately not swallowed (a save that stops navigating fails loud), with ten seconds of headroom rather than the quiet half-minute default. The test consumes the navigation after its API seeding, before the next address; the alert wait goes away with the click it belonged to. The other callers of the save button are untouched — they do not ask for another address next and have nothing to protect.

Testing: the producer behavior was verified by instrument (a GET of the control-panel address recorded right after the save answered). No local A/B exists for this class — the failure needs CI-interleaving timing, and the local amplified control for the same leftover-navigation family was null with the amplifier provably engaged. The run without the fix failed with the exact signature; the target passes on the current master base after rebasing and the fix rides the current full-scope aggregate for accumulation.

## PR Check

| Validation | Result |
|---|---|
| Source Format | ✅ passed |

Only Source Format fires for this Playwright-only diff (no Java, no `bnd.bnd`/`packageinfo`/Gradle changes).

<!-- pr-check {"result": "success", "sha": "811323159df8d5d12e27cc8f0bbb38d4e701069d"} -->
