### PR TITLE
LPD-102849 Return the reload the layout save schedules to its caller

### DIFF
--- a/modules/test/playwright/pages/object-web/object-layout/ObjectLayoutsPage.ts
+++ b/modules/test/playwright/pages/object-web/object-layout/ObjectLayoutsPage.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {FrameLocator, Locator, Page} from '@playwright/test';
+import {FrameLocator, Locator, Page, expect} from '@playwright/test';
 
 import {ViewObjectDefinitionsPage} from '../ViewObjectDefinitionsPage';
 
@@ -247,6 +247,37 @@ export class ObjectLayoutsPage {
 		);
 
 		await this.layoutsTabItem.click();
+	}
+
+	/**
+	 * Saves the layout and returns the reload the save schedules on the
+	 * parent window, which fires about a third of a second after the save's
+	 * own request answers. The caller must await it before its next
+	 * navigation, or the reload lands on whatever runs next and cancels it.
+	 * Ten seconds is generous headroom for that timer and fails loud, rather
+	 * than quietly at the default half minute. The promise is deliberately
+	 * not swallowed: if the save ever stops reloading, the wait fails and
+	 * says so.
+	 */
+	async saveObjectLayoutReturningReload() {
+		const reload = this.page.waitForNavigation({
+			timeout: 10000,
+			waitUntil: 'load',
+		});
+
+		const saveButton = this.iframeLocator
+			.getByRole('button', {name: 'Save'})
+			.first();
+
+		await expect(saveButton).toBeVisible();
+
+		await saveButton.dispatchEvent('click');
+
+		// Wrapped, because awaiting this method would otherwise flatten the
+		// promise and wait for the reload here, which is what the caller is
+		// being given the chance to avoid.
+
+		return {reload};
 	}
 
 	async openObjectLayoutConfiguration(objectLayoutName: string) {

--- a/modules/test/playwright/tests/object-web/relationship/objectRelationship.spec.ts
+++ b/modules/test/playwright/tests/object-web/relationship/objectRelationship.spec.ts
@@ -2797,21 +2797,8 @@ test.describe('Manage object relationships with system objects', () => {
 			);
 			await objectLayoutsPage.setObjectLayoutAsDefault();
 
-			const saveButton = page
-				.frameLocator('iframe')
-				.getByRole('button', {name: 'Save'})
-				.first();
-
-			await expect(saveButton).toBeVisible();
-
-			const layoutSavedPromise = page.waitForResponse(
-				(response) =>
-					response.url().includes('/object-layouts/') &&
-					response.request().method() === 'PUT'
-			);
-
-			await saveButton.dispatchEvent('click');
-			await layoutSavedPromise;
+			const {reload} =
+				await objectLayoutsPage.saveObjectLayoutReturningReload();
 
 			const restPath = `c/${objectDefinition.name.toLowerCase()}s`;
 
@@ -2824,6 +2811,11 @@ test.describe('Manage object relationships with system objects', () => {
 				{[textFieldName]: 'Entry B'},
 				restPath
 			);
+
+			// The layout save's reload has had the entry seeding to land in;
+			// consume it before the first navigation.
+
+			await reload;
 
 			const relateEntryToBothUsers = async (entryLabel: string) => {
 				await viewObjectEntriesPage.goto(objectEntriesClassName);
@@ -3335,18 +3327,10 @@ test.describe('Manage object relationship entries', () => {
 						'Relationship'
 					);
 
-					const saveButton = objectLayoutsPage.iframeLocator
-						.getByRole('button', {name: 'Save'})
-						.first();
+					const {reload} =
+						await objectLayoutsPage.saveObjectLayoutReturningReload();
 
-					await expect(saveButton).toBeVisible();
-
-					await saveButton.dispatchEvent('click');
-
-					await waitForAlert(
-						page,
-						'Success:The object layout was updated successfully'
-					);
+					await reload;
 				};
 
 				await setupLayout(objectDefinition1, 'textField');
@@ -3857,12 +3841,8 @@ test.describe('Manage object relationship entries', () => {
 			);
 			await objectLayoutsPage.setObjectLayoutAsDefault();
 
-			const saveButton = objectLayoutsPage.iframeLocator
-				.getByRole('button', {name: 'Save'})
-				.first();
-
-			await expect(saveButton).toBeVisible();
-			await saveButton.dispatchEvent('click');
+			const {reload} =
+				await objectLayoutsPage.saveObjectLayoutReturningReload();
 
 			const restPath = `c/${objectDefinition.name.toLowerCase()}s`;
 
@@ -3898,6 +3878,11 @@ test.describe('Manage object relationship entries', () => {
 				await expect(relationshipTab).toBeVisible();
 				await relationshipTab.click();
 			};
+
+			// The layout save's reload has had the entry seeding to land in;
+			// consume it before the first navigation.
+
+			await reload;
 
 			await openEntryRelationshipTab('Entry Test A');
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102849

## What Is Being Fixed

Playwright tests that save an object layout and then navigate fail intermittently on CI with `page.goto: ... interrupted by another navigation to ...screenNavigationCategoryKey=layouts`. Saving a layout answers, shows its success toast, and only then schedules the parent window's reload, about a third of a second later (measured locally). The tests returned at the click or waited on the save's request or alert — all of which resolve before the reload is even scheduled — so the reload stayed pending and landed on whichever navigation ran next, cancelling it.

Root cause: born waiting on the wrong signal. `6178dc43bf5dd` (LPD-82349) and its sibling migrations wrote save-then-navigate with at most the request or alert awaited, and the reload has been scheduled after the answer since `2c605fe504724` (LPS-158503) set its current timing.

## How It Is Being Fixed

The save now lives in a page method, `saveObjectLayoutReturningReload()`, that registers the wait for the reload before clicking and returns the promise wrapped, so each caller awaits it right before its next navigation — work that does not navigate, like seeding entries over the API, still overlaps the reload. The wait is deliberately not swallowed: if the save ever stops reloading, it fails loudly, with ten seconds of headroom rather than the quiet half-minute default. Three sites are converted here; the remaining sites in the spec follow separately so this stays reviewable.

Testing: the three converted tests pass together locally. A local A/B with an identical navigation-delay amplifier on both arms was null (control passed with the amplifier provably engaged) — the failure needs CI-interleaving timing. The CI hammer at shrunk scope ran both arms clean at attempt level (24/24 each), passing the treatment gate this class can offer; the positive evidence is the observed victims' signatures on runs without the fix, with full-scope accumulation ongoing.

## PR Check

| Validation | Result |
|---|---|
| Source Format | ✅ passed |

Only Source Format fires for this Playwright-only diff (no Java, no `bnd.bnd`/`packageinfo`/Gradle changes).

<!-- pr-check {"result": "success", "sha": "f8e0798a4f1f7f0afd25c15c2890a834d9ad67bf"} -->
