### PR TITLE
LPD-102865 Consume the layout save's reload at the eight remaining sites

### DIFF
--- a/modules/test/playwright/tests/object-web/relationship/objectRelationship.spec.ts
+++ b/modules/test/playwright/tests/object-web/relationship/objectRelationship.spec.ts
@@ -3516,16 +3516,8 @@ test.describe('Manage object relationship entries', () => {
 				'Relationship'
 			);
 
-			const saveButton = objectLayoutsPage.iframeLocator
-				.getByRole('button', {name: 'Save'})
-				.first();
-
-			await expect(saveButton).toBeVisible();
-			await saveButton.dispatchEvent('click');
-			await waitForAlert(
-				page,
-				'Success:The object layout was updated successfully'
-			);
+			const {reload} =
+				await objectLayoutsPage.saveObjectLayoutReturningReload();
 
 			const restPath1 = `c/${objectDefinition1.name.toLowerCase()}s`;
 			const restPath2 = `c/${objectDefinition2.name.toLowerCase()}s`;
@@ -3548,6 +3540,11 @@ test.describe('Manage object relationship entries', () => {
 					relatedExternalReferenceCode: entryB.externalReferenceCode,
 				}
 			);
+
+			// The layout save's reload has had the entry seeding to land in;
+			// consume it before the first navigation.
+
+			await reload;
 
 			const openObjectEntry = async (
 				className: string,
@@ -3681,17 +3678,8 @@ test.describe('Manage object relationship entries', () => {
 				'Relationship'
 			);
 
-			const saveButton = page
-				.frameLocator('iframe')
-				.getByRole('button', {name: 'Save'})
-				.first();
-
-			await expect(saveButton).toBeVisible();
-			await saveButton.dispatchEvent('click');
-			await waitForAlert(
-				page,
-				'Success:The object layout was updated successfully'
-			);
+			const {reload} =
+				await objectLayoutsPage.saveObjectLayoutReturningReload();
 
 			const restPath = `c/${objectDefinition.name.toLowerCase()}s`;
 
@@ -3704,6 +3692,11 @@ test.describe('Manage object relationship entries', () => {
 				{[textFieldName]: 'Entry B'},
 				restPath
 			);
+
+			// The layout save's reload has had the entry seeding to land in;
+			// consume it before the first navigation.
+
+			await reload;
 
 			const openEntryRelationshipTab = async (entryLabel: string) => {
 				await viewObjectEntriesPage.goto(objectDefinition.className);
@@ -4046,18 +4039,10 @@ test.describe('Manage object relationship entries', () => {
 					'Relationship'
 				);
 
-				const saveButton = objectLayoutsPage.iframeLocator
-					.getByRole('button', {name: 'Save'})
-					.first();
+				const {reload} =
+					await objectLayoutsPage.saveObjectLayoutReturningReload();
 
-				await expect(saveButton).toBeVisible();
-
-				await saveButton.dispatchEvent('click');
-
-				await waitForAlert(
-					page,
-					'Success:The object layout was updated successfully'
-				);
+				await reload;
 
 				restPath = `c/${objectDefinition.name.toLowerCase()}s`;
 			});
@@ -4206,17 +4191,8 @@ test.describe('Manage object relationship entries', () => {
 				'Relationship'
 			);
 
-			const saveButton = page
-				.frameLocator('iframe')
-				.getByRole('button', {name: 'Save'})
-				.first();
-
-			await expect(saveButton).toBeVisible();
-			await saveButton.dispatchEvent('click');
-			await waitForAlert(
-				page,
-				'Success:The object layout was updated successfully'
-			);
+			const {reload} =
+				await objectLayoutsPage.saveObjectLayoutReturningReload();
 
 			const restPath = `c/${objectDefinition.name.toLowerCase()}s`;
 
@@ -4224,6 +4200,11 @@ test.describe('Manage object relationship entries', () => {
 				{[textFieldName]: 'Entry Test'},
 				restPath
 			);
+
+			// The layout save's reload has had the entry seeding to land in;
+			// consume it before the first navigation.
+
+			await reload;
 
 			const openEntryRelationshipTab = async (entryLabel: string) => {
 				await viewObjectEntriesPage.goto(objectDefinition.className);
@@ -4406,18 +4387,10 @@ test.describe('Manage object relationship entries', () => {
 					'Relationship'
 				);
 
-				const saveButton = objectLayoutsPage.iframeLocator
-					.getByRole('button', {name: 'Save'})
-					.first();
+				const {reload} =
+					await objectLayoutsPage.saveObjectLayoutReturningReload();
 
-				await expect(saveButton).toBeVisible();
-
-				await saveButton.dispatchEvent('click');
-
-				await waitForAlert(
-					page,
-					'Success:The object layout was updated successfully'
-				);
+				await reload;
 			});
 
 			await test.step('create entries A and B and associate entry B to entry A', async () => {
@@ -4601,18 +4574,10 @@ test.describe('Manage object relationship entries', () => {
 						'Relationship'
 					);
 
-					const saveButton = objectLayoutsPage.iframeLocator
-						.getByRole('button', {name: 'Save'})
-						.first();
+					const {reload} =
+						await objectLayoutsPage.saveObjectLayoutReturningReload();
 
-					await expect(saveButton).toBeVisible();
-
-					await saveButton.dispatchEvent('click');
-
-					await waitForAlert(
-						page,
-						'Success:The object layout was updated successfully'
-					);
+					await reload;
 				};
 
 				await setupLayout(objectDefinition1, 'textField');
@@ -4944,18 +4909,10 @@ test.describe('Manage object relationship entries', () => {
 					'Relationship'
 				);
 
-				const saveButton = objectLayoutsPage.iframeLocator
-					.getByRole('button', {name: 'Save'})
-					.first();
+				const {reload} =
+					await objectLayoutsPage.saveObjectLayoutReturningReload();
 
-				await expect(saveButton).toBeVisible();
-
-				await saveButton.dispatchEvent('click');
-
-				await waitForAlert(
-					page,
-					'Success:The object layout was updated successfully'
-				);
+				await reload;
 			};
 
 			await setupLayout(objectDefinition1, 'textField');
@@ -5109,18 +5066,8 @@ test.describe('Manage object relationship entries', () => {
 				'Relationship'
 			);
 
-			const saveButton = objectLayoutsPage.iframeLocator
-				.getByRole('button', {name: 'Save'})
-				.first();
-
-			await expect(saveButton).toBeVisible();
-
-			await saveButton.dispatchEvent('click');
-
-			await waitForAlert(
-				page,
-				'Success:The object layout was updated successfully'
-			);
+			const {reload} =
+				await objectLayoutsPage.saveObjectLayoutReturningReload();
 
 			const applicationName1 = `c/${objectDefinition1.name.toLowerCase()}s`;
 
@@ -5128,6 +5075,11 @@ test.describe('Manage object relationship entries', () => {
 				{['textField']: 'Entry 1'},
 				applicationName1
 			);
+
+			// The layout save's reload has had the entry seeding to land in;
+			// consume it before the first navigation.
+
+			await reload;
 
 			const openEntry1Details = async () => {
 				await viewObjectEntriesPage.goto(objectDefinition1.className);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102865

## What Is Being Fixed

Playwright tests that save an object layout and then navigate fail intermittently on CI with `page.goto: ... interrupted by another navigation to ...screenNavigationCategoryKey=layouts`. LPD-102849 established the mechanism and converted three sites: the layout save answers, shows its toast, and only then schedules the parent window's reload ~⅓s later, so a test that returns at the click or the alert leaves the reload pending, and it lands on whatever navigates next. **Eight more sites in the relationship spec still clicked the save and waited only for the success alert.** Two of them are observed CI victims at attempt level — `can edit Many-to-Many relationship of Custom Object entries` (twice) and `can view object entry title in the relationship tab for self relationship` (once) — with the exact signature; the remaining six carry the identical bytes and the identical pending reload.

Root cause: born this way. The sites arrived with the Poshi→Playwright migrations (LPD-82349's move, LPD-90439's migrations and their siblings) already carrying the bare save-then-alert pattern; none ever consumed the scheduled reload.

## How It Is Being Fixed

Every remaining site saves through `saveObjectLayoutReturningReload()` and consumes the reload it returns: sites inside helpers and steps consume it before returning; the inline sites consume it after their API entry seeding, right before the first navigation, so the seeding still overlaps the reload. The alert wait goes away with the click it belonged to — the reload only happens after the save commits, so it is the stronger signal. Net −48 lines.

Testing: all eight affected tests pass together locally, revalidated after rebasing onto the merged LPD-102849. Evidence class inherited from LPD-102849: the local amplified control was null with the amplifier provably engaged (CI-interleaving-dependent class); the shrunk CI hammer ran both arms clean at attempt level (24/24 each); the positive evidence is the observed victims' signatures on runs without the fix, with full-scope aggregate accumulation carrying it since.

## PR Check

| Validation | Result |
|---|---|
| Source Format | ✅ passed |

Only Source Format fires for this Playwright-spec-only diff (no Java, no `bnd.bnd`/`packageinfo`/Gradle changes).

<!-- pr-check {"result": "success", "sha": "fb969ec757ff7b0f145cf5e930c0fffbb57a6553"} -->
