### PR TITLE
LPD-102867 Settle the details form before typing and own the tasks tab

### DIFF
--- a/modules/test/playwright/pages/object-web/object-details/EditObjectDetailsPage.ts
+++ b/modules/test/playwright/pages/object-web/object-details/EditObjectDetailsPage.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {Locator, Page} from '@playwright/test';
+import {Locator, Page, expect} from '@playwright/test';
 
 import {ViewObjectDefinitionsPage} from '../ViewObjectDefinitionsPage';
 
@@ -105,6 +105,15 @@ export class EditObjectDetailsPage {
 		await this.detailsTabItem.click();
 
 		await this.page.waitForLoadState('networkidle');
+	}
+
+	async waitForDetailsFormLoaded() {
+
+		// The form is interactive before its mount fetch lands, and the fetch
+		// merges the persisted definition over anything already typed. The
+		// toolbar buttons unlock only once that fetch is done, so wait there.
+
+		await expect(this.saveButton).toBeEnabled();
 	}
 
 	async saveObjectDefinition() {

--- a/modules/test/playwright/pages/portal-workflow-task-web/WorkflowTasksPage.ts
+++ b/modules/test/playwright/pages/portal-workflow-task-web/WorkflowTasksPage.ts
@@ -46,6 +46,14 @@ export class WorkflowTasksPage {
 		await this.goto(siteUrl);
 
 		await this.assignedToMyRolesLink.click();
+
+		// The tab is its own full navigation, so returning at the click hands
+		// the caller the list still on screen, whose rows go stale when the
+		// tab lands. Wait for the tab's address so the caller reads the tab.
+
+		await this.page.waitForURL(/tabs1=assigned-to-my-roles/);
+
+		await this.page.waitForLoadState();
 	}
 
 	async approve(articleTitle: string) {

--- a/modules/test/playwright/tests/object-web/main/objectDefinition.spec.ts
+++ b/modules/test/playwright/tests/object-web/main/objectDefinition.spec.ts
@@ -1177,6 +1177,8 @@ test.describe('Manage object definitions through View Object Definitions', () =>
 
 		await editObjectDetailsPage.goToDetailsTab();
 
+		await editObjectDetailsPage.waitForDetailsFormLoaded();
+
 		await editObjectDetailsPage.labelInput.fill(label);
 
 		await editObjectDetailsPage.publishButton.click();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102867

## What Is Being Fixed

Three Playwright tests fail intermittently on CI. `can save changes when publishing` types a new label, publishes behind a success alert, reloads — and reads back the persisted original label (`toHaveValue: expected UpdatedLabel..., received ObjectDefinition...`): the details form is interactive before its mount fetch lands, and the fetch merges the persisted definition over anything already typed. And two tests die after `goToAssignedToMyRoles`: the tab is its own full navigation, but the helper returned at the click, handing callers the outgoing list whose rows go stale as the tab lands (`friendly URL input is disabled...` clicks a row that is leaving; `Can preview entry information on My Workflow Tasks` spends its budget the same way).

Root cause: `2a21a6079b4ee` (LPS-162430, "Create ObjectDetails component") mounted the form live with a late merging fetch, and the tests typed and clicked into those windows from their creation; the tab helper is the campaign's unowned-navigation class.

## How It Is Being Fixed

`EditObjectDetailsPage.waitForDetailsFormLoaded()` waits on the toolbar's own signal — Save stays disabled until the fetch lands — and the typing test calls it before filling (a separate method, because the same tab is opened by read-only tests whose Save never enables). `goToAssignedToMyRoles` now waits for the tab's address and its load before returning.

Testing: all three victim tests pass on the rebased head. The typing clobber has no local A/B, with instrumented reasoning: three amplifier shapes were built and provably engaged, all null — the label input only becomes fillable after the definition fetch locally, so the runner's own actionability closes the pre-fetch window, and a straggling late fetch dies to the publish's reload, leaving an untunable window of tens of milliseconds. The fix rode a full-scope aggregate clean (562 expected / 0 unexpected), including all three victim tests.

## PR Check

| Validation | Result |
|---|---|
| Source Format | ✅ passed |

Only Source Format fires for this Playwright-only diff (no Java, no `bnd.bnd`/`packageinfo`/Gradle changes).

<!-- pr-check {"result": "success", "sha": "e17c1dffbb7c9ee3b97c122a85157b4e0f32ffee"} -->
