### PR TITLE
LPD-102869 Wait for the autosave label the page editor now renders

### DIFF
--- a/modules/test/playwright/pages/layout-content-page-editor-web/PageEditorPage.ts
+++ b/modules/test/playwright/pages/layout-content-page-editor-web/PageEditorPage.ts
@@ -2228,7 +2228,9 @@ export class PageEditorPage {
 	}
 
 	async waitForChangesSaved({timeout}: {timeout?: number} = {}) {
-		await this.page.getByLabel('Saved', {exact: true}).waitFor({timeout});
+		await this.page
+			.getByLabel('Saved as Draft', {exact: true})
+			.waitFor({timeout});
 
 		await this.page
 			.getByText(

--- a/modules/test/playwright/tests/layout-content-page-editor-web/fragments/fragmentConfiguration.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/fragments/fragmentConfiguration.spec.ts
@@ -1472,7 +1472,7 @@ test.describe('Styles Configuration', () => {
 
 		// Check Saved icon is not visible at the beggining
 
-		await expect(page.getByLabel('Saved')).not.toBeVisible();
+		await expect(page.getByLabel('Saved as Draft')).not.toBeVisible();
 
 		// Change Margin Top with custom value and check change is applied
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102869

## What Is Being Fixed

The page editor smoke test fails on every upstream master run (test-portal-testsuite-upstream builds 1559+), timing out waiting for the autosave indicator: `waiting for getByLabel('Saved', { exact: true })`. Every Playwright test that saves a page through the shared `waitForChangesSaved` helper will fail the same way on the next full suite run.

Root cause: got broken. `db23748edfc47` (LPD-102756, "Refer to the draft in the autosave tooltips") renamed the indicator's aria-label from `saved` to `saved-as-draft` in `NetworkStatusBar.js`; its test adaptations covered the Jest unit tests only, leaving the shared Playwright helper waiting for the old label — and a negative assertion on the same label in `fragmentConfiguration.spec.ts` vacuous (matching nothing, passing without testing).

## How It Is Being Fixed

`waitForChangesSaved` waits for `Saved as Draft`; the negative assertion checks the same new label so it keeps its meaning.

Testing: validated end to end against the renamed frontend — the current page editor and language modules deployed to a local bundle first reproduced the exact timeout with the old label, and a page-editor test that saves through the helper passes 3/3 with the fix.

## PR Check

| Validation | Result |
|---|---|
| Source Format | ✅ passed |

Only Source Format fires for this Playwright-only diff.

<!-- pr-check {"result": "success", "sha": "98f907c5d51ab90af7ea3836d7ff79ece6d60027"} -->
