### PR TITLE
LPD-102871 Tolerate releasing a resource whose registration is gone

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/lifecycle/SafeReleaseInstanceResourceProvider.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/lifecycle/SafeReleaseInstanceResourceProvider.java
@@ -5,8 +5,11 @@
 
 package com.liferay.portal.vulcan.internal.jaxrs.lifecycle;
 
-import java.util.HashSet;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.cxf.jaxrs.lifecycle.ResourceProvider;
 import org.apache.cxf.message.Message;
@@ -43,11 +46,28 @@ public class SafeReleaseInstanceResourceProvider implements ResourceProvider {
 	@Override
 	public void releaseInstance(Message message, Object object) {
 		if (_instances.remove(object)) {
-			_resourceProvider.releaseInstance(message, object);
+			try {
+				_resourceProvider.releaseInstance(message, object);
+			}
+			catch (IllegalArgumentException illegalArgumentException) {
+
+				// The service registration backing this instance was
+				// unregistered while the request was in flight, so there is
+				// nothing left to release the instance to, and the instance
+				// is abandoned to garbage collection. Rethrowing would
+				// replace the response the request already produced.
+
+				if (_log.isDebugEnabled()) {
+					_log.debug(illegalArgumentException);
+				}
+			}
 		}
 	}
 
-	private final Set<Object> _instances = new HashSet<>();
+	private static final Log _log = LogFactoryUtil.getLog(
+		SafeReleaseInstanceResourceProvider.class);
+
+	private final Set<Object> _instances = ConcurrentHashMap.newKeySet();
 	private final ResourceProvider _resourceProvider;
 
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/test/java/com/liferay/portal/vulcan/internal/jaxrs/lifecycle/SafeReleaseInstanceResourceProviderTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/test/java/com/liferay/portal/vulcan/internal/jaxrs/lifecycle/SafeReleaseInstanceResourceProviderTest.java
@@ -1,0 +1,142 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.vulcan.internal.jaxrs.lifecycle;
+
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
+import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.cxf.jaxrs.lifecycle.ResourceProvider;
+import org.apache.cxf.message.Message;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Shuyang Zhou
+ */
+public class SafeReleaseInstanceResourceProviderTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testReleaseInstanceIgnoresUnknownInstance() {
+		AtomicInteger releaseCounter = new AtomicInteger();
+
+		SafeReleaseInstanceResourceProvider
+			safeReleaseInstanceResourceProvider =
+				new SafeReleaseInstanceResourceProvider(
+					new TestResourceProvider(null, releaseCounter));
+
+		safeReleaseInstanceResourceProvider.releaseInstance(null, new Object());
+
+		Assert.assertEquals(0, releaseCounter.get());
+	}
+
+	@Test
+	public void testReleaseInstanceReleasesOnce() {
+		AtomicInteger releaseCounter = new AtomicInteger();
+
+		SafeReleaseInstanceResourceProvider
+			safeReleaseInstanceResourceProvider =
+				new SafeReleaseInstanceResourceProvider(
+					new TestResourceProvider(null, releaseCounter));
+
+		Object instance = safeReleaseInstanceResourceProvider.getInstance(null);
+
+		safeReleaseInstanceResourceProvider.releaseInstance(null, instance);
+		safeReleaseInstanceResourceProvider.releaseInstance(null, instance);
+
+		Assert.assertEquals(1, releaseCounter.get());
+	}
+
+	@Test
+	public void testReleaseInstanceToleratesUnregisteredRegistration() {
+		IllegalArgumentException illegalArgumentException =
+			new IllegalArgumentException(
+				"The service parameter was not provided by this object");
+
+		AtomicInteger releaseCounter = new AtomicInteger();
+
+		SafeReleaseInstanceResourceProvider
+			safeReleaseInstanceResourceProvider =
+				new SafeReleaseInstanceResourceProvider(
+					new TestResourceProvider(
+						illegalArgumentException, releaseCounter));
+
+		Object instance = safeReleaseInstanceResourceProvider.getInstance(null);
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				SafeReleaseInstanceResourceProvider.class.getName(),
+				LoggerTestUtil.DEBUG)) {
+
+			safeReleaseInstanceResourceProvider.releaseInstance(null, instance);
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
+
+			LogEntry logEntry = logEntries.get(0);
+
+			Assert.assertEquals(
+				"The service parameter was not provided by this object",
+				logEntry.getMessage());
+			Assert.assertSame(
+				illegalArgumentException, logEntry.getThrowable());
+		}
+
+		Assert.assertEquals(1, releaseCounter.get());
+	}
+
+	private static class TestResourceProvider implements ResourceProvider {
+
+		public TestResourceProvider(
+			IllegalArgumentException illegalArgumentException,
+			AtomicInteger releaseCounter) {
+
+			_illegalArgumentException = illegalArgumentException;
+			_releaseCounter = releaseCounter;
+		}
+
+		@Override
+		public Object getInstance(Message message) {
+			return new Object();
+		}
+
+		@Override
+		public Class<?> getResourceClass() {
+			return Object.class;
+		}
+
+		@Override
+		public boolean isSingleton() {
+			return false;
+		}
+
+		@Override
+		public void releaseInstance(Message message, Object object) {
+			_releaseCounter.incrementAndGet();
+
+			if (_illegalArgumentException != null) {
+				throw _illegalArgumentException;
+			}
+		}
+
+		private final IllegalArgumentException _illegalArgumentException;
+		private final AtomicInteger _releaseCounter;
+
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102871

## What Is Being Fixed

REST requests intermittently fail with `400 {"title":"The service parameter was not provided by this object","type":"IllegalArgumentException"}` — Equinox's `SERVICE_OBJECTS_UNGET_ARGUMENT_EXCEPTION` escaping into the response pipeline. A JAX-RS request obtains its prototype resource through the OSGi `ServiceObjects` of the resource's registration and releases it when the response is written; when the registration is unregistered by another thread in between (e.g., an object definition redeploying while a request another client abandoned is still executing), Equinox refuses the release, and the IAE mapper renders the framework condition as a client error, replacing whatever the request actually produced. Nothing logs it.

Captured stack: `ServiceObjectsImpl.ungetService:137 ← aries PrototypeServiceReferenceResourceProvider.releaseInstance ← vulcan SafeReleaseInstanceResourceProvider.releaseInstance` (response phase). Forced object-definition churn beside concurrent requests reproduces it at will (10 and 16 refusals per ~19.5k posts); a strictly sequential client never hits it (0/150 create→delete→post rounds), proving the churn synchronous and the refusal purely a cross-thread overlap. Refused requests never reached their resource method.

Root cause: born incomplete. `9c38b9a19c070` (LPD-21871, "Always releasing the resource") guards double-release but not the registration being torn out from under an in-flight request, and mutated its `HashSet` from concurrent request threads from the start.

## How It Is Being Fixed

`releaseInstance` tolerates the refusal — the registration is gone, there is nothing left to release the instance to, so it is abandoned to GC and logged at debug. `_instances` becomes a concurrent set. New unit test asserts release-once, unknown-instance, and the tolerated refusal including the debug log entry in detail via LogCapture (message + same throwable).

Empirical before/after on a live bundle at identical churn load: 10 and 16 failures per run → **0 / 19,585**.

## PR Check

| Validation | Result |
|---|---|
| Source Format | ✅ passed |
| Per-Module Compile (deploy) | ✅ passed |
| Java Unit (portal-vulcan-impl) | ✅ passed |
| Baseline | ✅ passed (internal package, no exported API change) |

<!-- pr-check {"result": "success", "sha": "fe5f98733a0b6878b311387eadad79b38a042476"} -->
