### PR TITLE
LPD-101393 Name the data mask count after the entries it counts

### DIFF
--- a/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/internal/model/listener/test/DataMaskObjectEntryModelListenerTest.java
+++ b/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/internal/model/listener/test/DataMaskObjectEntryModelListenerTest.java
@@ -61,7 +61,7 @@ public class DataMaskObjectEntryModelListenerTest {
 			MCPServerTestUtil.getMCPServerProfileDataMaskObjectEntries(
 				defaultMCPServerProfileExternalReferenceCode);
 
-		int mcpServerProfileDataMasksCount =
+		int mcpServerProfileDataMaskObjectEntriesCount =
 			mcpServerProfileDataMaskObjectEntries.size();
 
 		_customDataMaskObjectEntry = MCPServerTestUtil.addDataMaskObjectEntry(
@@ -73,7 +73,7 @@ public class DataMaskObjectEntryModelListenerTest {
 
 		Assert.assertEquals(
 			mcpServerProfileDataMaskObjectEntries.toString(),
-			mcpServerProfileDataMasksCount,
+			mcpServerProfileDataMaskObjectEntriesCount,
 			mcpServerProfileDataMaskObjectEntries.size());
 
 		String dataMaskExternalReferenceCode = RandomTestUtil.randomString();
@@ -85,7 +85,7 @@ public class DataMaskObjectEntryModelListenerTest {
 
 		try {
 			Assert.assertEquals(
-				mcpServerProfileDataMasksCount + 1,
+				mcpServerProfileDataMaskObjectEntriesCount + 1,
 				MCPServerTestUtil.getMCPServerProfileDataMaskExecutionOrder(
 					dataMaskExternalReferenceCode,
 					defaultMCPServerProfileExternalReferenceCode));


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101393

## What Is Being Fixed

Follow-up to #180334, which renamed `_getMCPServerProfileDataMasksCount` to `_getMCPServerProfileDataMaskObjectEntriesCount` in `MCPServerProfileObjectEntryModelListenerTest` and left its counterpart in `DataMaskObjectEntryModelListenerTest` behind. That local is still called `mcpServerProfileDataMasksCount`, so it names data masks while it actually holds the size of `mcpServerProfileDataMaskObjectEntries`, the profile's data mask join entries.

## How It Is Being Fixed

The local becomes `mcpServerProfileDataMaskObjectEntriesCount`, matching the list whose `size()` it holds and the naming the other listener test now uses.

## Why Are There No Tests?

The change is a local variable rename inside an existing integration test, with no production code and no behavior involved.

## PR Check

**pr-check: PASS** — tested on `698db5cd89979818f9b51c5eb44e2b262f4b9439`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "698db5cd89979818f9b51c5eb44e2b262f4b9439"} -->
