### PR TITLE
LPD-102929 Own the activate toggle's settle, save answer and scheduled reload

### DIFF
--- a/modules/test/playwright/pages/object-web/ViewObjectDefinitionsPage.ts
+++ b/modules/test/playwright/pages/object-web/ViewObjectDefinitionsPage.ts
@@ -93,9 +93,28 @@ export class ViewObjectDefinitionsPage {
 	async changeObjectActivateStatus(objectDefinitionName: string) {
 		await this.clickEditObjectDefinitionLink(objectDefinitionName);
 
-		await this.page.getByRole('switch', {name: 'Activate Object'}).click();
+		const saveButton = this.page.getByRole('button', {name: 'Save'});
 
-		await this.page.getByRole('button', {name: 'Save'}).click();
+		const toggle = this.page.getByRole('switch', {
+			name: 'Activate Object',
+		});
+
+		// The details form mounts with an enabled Activate Object toggle
+		// before the object definition has been fetched, and the fetch
+		// overwrites whatever the toggle holds by then, so a flip made too
+		// early is silently undone and saved away as a success. Save stays
+		// disabled until the fetch lands, so wait there, then flip the settled
+		// value and check the flip survived.
+
+		await expect(saveButton).toBeEnabled();
+
+		const toggled = await toggle.isChecked();
+
+		await toggle.click();
+
+		await expect(toggle).toBeChecked({checked: !toggled});
+
+		await saveButton.click();
 
 		await waitForAlert(
 			this.page,

--- a/modules/test/playwright/pages/object-web/ViewObjectDefinitionsPage.ts
+++ b/modules/test/playwright/pages/object-web/ViewObjectDefinitionsPage.ts
@@ -11,7 +11,6 @@ import path from 'path';
 import {gotoWithRetry} from '../../utils/gotoWithRetry';
 import {PORTLET_URLS} from '../../utils/portletUrls';
 import {getTempDir} from '../../utils/temp';
-import {waitForAlert} from '../../utils/waitForAlert';
 import {waitForSearchToBeReady} from '../../utils/waitForSearchToBeReady';
 
 export class ViewObjectDefinitionsPage {
@@ -114,12 +113,36 @@ export class ViewObjectDefinitionsPage {
 
 		await expect(toggle).toBeChecked({checked: !toggled});
 
+		// The save answers with its PUT, shows its toast, and only then
+		// schedules a page reload a second later, so neither the click nor
+		// the toast says the work is done. Wait for the save's own answer,
+		// then consume the reload it schedules, so the caller's next
+		// navigation cannot collide with it. Ten seconds is generous headroom
+		// for that timer and fails loud, rather than quietly at the default
+		// half minute.
+
+		const saveResponse = this.page.waitForResponse(
+			(response) =>
+				response
+					.url()
+					.includes(
+						'/o/object-admin/v1.0/object-definitions/by-external-reference-code/'
+					) && response.request().method() === 'PUT'
+		);
+
+		// The reload is waited on through the page's load event, which fires
+		// once per real document load: the same-document navigation the
+		// portlet fires around the save does not fire it, and the redirect
+		// the reload answers with first collapses into the one load of the
+		// final address.
+
+		const reload = this.page.waitForEvent('load', {timeout: 10000});
+
 		await saveButton.click();
 
-		await waitForAlert(
-			this.page,
-			`Success:The object was saved successfully.`
-		);
+		await saveResponse;
+
+		await reload;
 	}
 
 	async clickEditObjectDefinitionLink(

--- a/modules/test/playwright/tests/object-web/main/objectDefinition.spec.ts
+++ b/modules/test/playwright/tests/object-web/main/objectDefinition.spec.ts
@@ -2414,7 +2414,7 @@ test.describe('Manage object definitions through View Object Definitions', () =>
 				objectDefinition.name
 			);
 
-			expect(
+			await expect(
 				page.getByRole('switch', {name: 'Activate Object'})
 			).not.toBeChecked();
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102929

## What Is Being Fixed

Intermittent object-suite failures around object activation. Two windows in the shared `changeObjectActivateStatus` helper: (1) the details form mounts with an enabled Activate Object toggle before the definition fetch lands, and the fetch overwrites the form values — a flip made in that window is silently undone and saved away behind a success alert; (2) the save answers its PUT and shows its toast, then schedules a page reload ~1s later — the helper returned while that reload was in flight, and the caller's next navigation collided with it (the Workflow Process Builder signature). The ownership shift also exposed a floating `expect` downstream, written without `await` (broken by `28ccf18079d84`, which converted a synchronous `expect(await isChecked()).toBeFalsy()` to the web-first form without the await it requires).

## How It Is Being Fixed

Wait for Save to enable (the fetch's own signal), flip the settled value and assert the flip survived; register waits for the save's PUT answer (URL + method matched) and the page `load` event before clicking, and consume both before returning — `load` fires once per real document load, so the portlet's same-document navigation does not satisfy it and the reload's redirect collapses into the one final load. The exposed assertion gets its `await`.

Evidence: amplified CI pair separated at attempt level — control (settle only) failed 3/3 amplified Process Builder reps on the reload collision; treatment (settle + ownership) ran the identical amplifier 6/6 clean. Rode three full-batch aggregate runs with all covered targets quiet; each target passes locally on the final bytes.

## PR Check

| Validation | Result |
|---|---|
| Source Format | ✅ passed |
| Local targets (toggle, await-fix, reactivate walk) | ✅ passed |

<!-- pr-check {"result": "success", "sha": "cefad52d11d96f70437f79c54a71b70715b32b91"} -->
