### PR TITLE
LPD-102939 Own the attachment download before reading the mail it sends

### DIFF
--- a/modules/test/playwright/tests/object-web/action/objectAction.spec.ts
+++ b/modules/test/playwright/tests/object-web/action/objectAction.spec.ts
@@ -352,7 +352,18 @@ test('can send notification email via download action', async ({
 		.getByRole('button', {name: 'Search'})
 		.waitFor({state: 'visible'});
 
+	// The queue entry is written inside the download request, before its
+	// first response byte, so a finished download means the entry is there.
+	// A bare click resolves on dispatch with the request still in flight, so
+	// own the download to its end before reading the queue.
+
+	const downloadPromise = page.waitForEvent('download');
+
 	await viewObjectEntriesPage.page.getByText('sampleFile.txt').click();
+
+	const download = await downloadPromise;
+
+	await expect(download.failure()).resolves.toBeNull();
 
 	// Verify if the email was sent
 
@@ -360,6 +371,8 @@ test('can send notification email via download action', async ({
 		await apiHelpers.notification.getNotificationQueueEntriesPage(
 			senderEmail
 		);
+
+	expect(notificationQueueEntries.items.length).toBeTruthy();
 
 	const notificationQueueEntriesId = notificationQueueEntries.items.map(
 		(item: any) => item.id
@@ -371,8 +384,6 @@ test('can send notification email via download action', async ({
 			type: 'notificationQueueEntry',
 		});
 	}
-
-	expect(notificationQueueEntries.items.length).toBeTruthy();
 });
 
 test(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102939

## What Is Being Fixed

The most frequent flake on the object playwright list: `can send notification email via download action` intermittently reports no mail was sent (9/9 full-scope runs hit without a fix aboard, 0/5 with one). The attachment download click is not awaited to any response signal — a click resolves on dispatch — so the download request is still in flight when the test reads the notification queue on the next line. The queue entry is written **inside** that request, before its first response byte (trigger fires synchronously during routing: `VirtualHostFilter.isDocumentFriendlyURL` → `WebServerServlet.hasFiles` → synchronous `object_entry_attachment_download` destination → `addNotificationQueueEntry`) — verified by pausing a listener on that destination for 30s and watching the download's first byte arrive 30s late while thread dumps held the worker inside that chain. The single read raced the whole request; CI showed it losing by 175ms.

Root cause: born this way — `ef4a4feb357d5` (LPD-27321) migrated the Poshi test as an unawaited click + single immediate read; `ae751422a870a` (LPD-85191) carried it into the action subproject.

## How It Is Being Fixed

The test owns the download it starts: the wait is registered before the click, the download is consumed to its end, then a single queue read runs. A finished download is sequenced after the queue write, so the read cannot race it — the race is removed structurally, no polling.

## PR Check

| Validation | Result |
|---|---|
| Source Format | ✅ passed |
| Local target (4/4 runs incl. ×3 repeat-each, first-ask read every time) | ✅ passed |

<!-- pr-check {"result": "success", "sha": "5bdcf52217d508c14a8bef03474771b7c2ef8ab9"} -->
