### PR TITLE
LPD-102969 Ask for the actions tab by address instead of walking the UI to it

### DIFF
--- a/modules/test/playwright/pages/object-web/object-action/ViewObjectActionsPage.ts
+++ b/modules/test/playwright/pages/object-web/object-action/ViewObjectActionsPage.ts
@@ -5,6 +5,8 @@
 
 import {Locator, Page} from '@playwright/test';
 
+import {gotoWithRetry} from '../../../utils/gotoWithRetry';
+import {PORTLET_URLS} from '../../../utils/portletUrls';
 import {ViewObjectDefinitionsPage} from '../ViewObjectDefinitionsPage';
 
 export class ViewObjectActionsPage {
@@ -12,6 +14,7 @@ export class ViewObjectActionsPage {
 	readonly addObjectActionButton: Locator;
 	readonly frontendDataSetItems: Locator;
 	readonly lastExecutionCell: Locator;
+	readonly page: Page;
 	readonly viewObjectDefinitionsPage: ViewObjectDefinitionsPage;
 
 	constructor(page: Page) {
@@ -21,7 +24,24 @@ export class ViewObjectActionsPage {
 			.first();
 		this.frontendDataSetItems = page.locator('div.table-list-title a');
 		this.lastExecutionCell = page.locator('.cell-status');
+		this.page = page;
 		this.viewObjectDefinitionsPage = new ViewObjectDefinitionsPage(page);
+	}
+
+	async gotoByObjectDefinitionId(objectDefinitionId: number) {
+
+		// The tab is asked for by address, so the page arrives freshly loaded
+		// and unscrolled, with every row below the sticky toolbar band
+		// instead of under it.
+
+		const portletId =
+			'com_liferay_object_web_internal_object_definitions_portlet_ObjectDefinitionsPortlet';
+
+		await gotoWithRetry(
+			this.page,
+			`/group/guest${PORTLET_URLS.objects}&p_p_lifecycle=0&_${portletId}_mvcRenderCommandName=%2Fobject_definitions%2Fedit_object_definition&_${portletId}_objectDefinitionId=${objectDefinitionId}&_${portletId}_screenNavigationCategoryKey=actions`,
+			{waitUntil: 'load'}
+		);
 	}
 
 	async goto(objectDefinitionLabel: string) {

--- a/modules/test/playwright/tests/object-web/action/objectAction.spec.ts
+++ b/modules/test/playwright/tests/object-web/action/objectAction.spec.ts
@@ -82,8 +82,8 @@ test.describe('Manage object actions through object actions tab', () => {
 			);
 		}
 
-		await viewObjectActionsPage.goto(
-			createdObjectDefinition.label['en_US']
+		await viewObjectActionsPage.gotoByObjectDefinitionId(
+			createdObjectDefinition.id
 		);
 
 		await viewObjectActionsPage.openObjectActionSidePanel();
@@ -169,8 +169,8 @@ test.describe('Manage object actions through object actions tab', () => {
 			type: 'notificationTemplate',
 		});
 
-		await viewObjectActionsPage.goto(
-			createdObjectDefinition.label['en_US']
+		await viewObjectActionsPage.gotoByObjectDefinitionId(
+			createdObjectDefinition.id
 		);
 
 		await editObjectActionPage.addNewAction({
@@ -230,8 +230,8 @@ test.describe('Manage object actions through object actions tab', () => {
 			type: 'notificationTemplate',
 		});
 
-		await viewObjectActionsPage.goto(
-			createdObjectDefinition.label['en_US']
+		await viewObjectActionsPage.gotoByObjectDefinitionId(
+			createdObjectDefinition.id
 		);
 
 		await editObjectActionPage.addNewAction({
@@ -451,7 +451,9 @@ test.describe('Object Action CRUD', () => {
 				type: 'objectDefinition',
 			});
 
-			await viewObjectActionsPage.goto(objectDefinition.label['en_US']);
+			await viewObjectActionsPage.gotoByObjectDefinitionId(
+				objectDefinition.id
+			);
 
 			await viewObjectActionsPage.openObjectActionSidePanel();
 
@@ -499,7 +501,9 @@ test.describe('Object Action CRUD', () => {
 
 			apiHelpers.data.push({id: objectAction.id, type: 'objectAction'});
 
-			await viewObjectActionsPage.goto(objectDefinition.label['en_US']);
+			await viewObjectActionsPage.gotoByObjectDefinitionId(
+				objectDefinition.id
+			);
 
 			await page.getByRole('link', {name: 'Action Label'}).click();
 
@@ -539,7 +543,9 @@ test.describe('Object Action CRUD', () => {
 				type: 'objectDefinition',
 			});
 
-			await viewObjectActionsPage.goto(objectDefinition.label['en_US']);
+			await viewObjectActionsPage.gotoByObjectDefinitionId(
+				objectDefinition.id
+			);
 
 			await viewObjectActionsPage.openObjectActionSidePanel();
 
@@ -605,7 +611,9 @@ test.describe('Object Action CRUD', () => {
 				}
 			);
 
-			await viewObjectActionsPage.goto(objectDefinition.label['en_US']);
+			await viewObjectActionsPage.gotoByObjectDefinitionId(
+				objectDefinition.id
+			);
 
 			await expect(
 				page.getByRole('link', {name: 'Action Label'})
@@ -657,7 +665,9 @@ test.describe('Object Action CRUD', () => {
 
 			apiHelpers.data.push({id: objectAction.id, type: 'objectAction'});
 
-			await viewObjectActionsPage.goto(objectDefinition.label['en_US']);
+			await viewObjectActionsPage.gotoByObjectDefinitionId(
+				objectDefinition.id
+			);
 
 			await expect(page.getByRole('cell', {name: 'No'})).toBeVisible();
 
@@ -783,7 +793,9 @@ test.describe('Object Action CRUD', () => {
 
 			apiHelpers.data.push({id: objectAction2.id, type: 'objectAction'});
 
-			await viewObjectActionsPage.goto(objectDefinition.label['en_US']);
+			await viewObjectActionsPage.gotoByObjectDefinitionId(
+				objectDefinition.id
+			);
 
 			await expect(
 				page.getByRole('link', {name: 'Action Label 1'})
@@ -841,7 +853,9 @@ test.describe('Object Action CRUD', () => {
 
 			apiHelpers.data.push({id: objectAction.id, type: 'objectAction'});
 
-			await viewObjectActionsPage.goto(objectDefinition.label['en_US']);
+			await viewObjectActionsPage.gotoByObjectDefinitionId(
+				objectDefinition.id
+			);
 
 			await test.step('Update the action name', async () => {
 				await page.getByRole('link', {name: 'Action Label'}).click();
@@ -896,7 +910,9 @@ test.describe('Object Action Conditions and Triggers', () => {
 				type: 'objectDefinition',
 			});
 
-			await viewObjectActionsPage.goto(objectDefinition.label['en_US']);
+			await viewObjectActionsPage.gotoByObjectDefinitionId(
+				objectDefinition.id
+			);
 
 			await viewObjectActionsPage.openObjectActionSidePanel();
 
@@ -979,7 +995,9 @@ test.describe('Object Action Conditions and Triggers', () => {
 
 			apiHelpers.data.push({id: objectAction.id, type: 'objectAction'});
 
-			await viewObjectActionsPage.goto(objectDefinition.label['en_US']);
+			await viewObjectActionsPage.gotoByObjectDefinitionId(
+				objectDefinition.id
+			);
 
 			await page.getByRole('link', {name: 'Custom Action'}).click();
 
@@ -1197,7 +1215,9 @@ test.describe('Object Action Conditions and Triggers', () => {
 				applicationName
 			);
 
-			await viewObjectActionsPage.goto(objectDefinition.label['en_US']);
+			await viewObjectActionsPage.gotoByObjectDefinitionId(
+				objectDefinition.id
+			);
 
 			await expect(
 				page.getByRole('link', {name: 'Action Label'})
@@ -1775,7 +1795,9 @@ test.describe('Object Action Required Field Validation', () => {
 				type: 'objectDefinition',
 			});
 
-			await viewObjectActionsPage.goto(objectDefinition.label['en_US']);
+			await viewObjectActionsPage.gotoByObjectDefinitionId(
+				objectDefinition.id
+			);
 
 			await viewObjectActionsPage.openObjectActionSidePanel();
 
@@ -1803,7 +1825,9 @@ test.describe('Object Action Required Field Validation', () => {
 				type: 'objectDefinition',
 			});
 
-			await viewObjectActionsPage.goto(objectDefinition.label['en_US']);
+			await viewObjectActionsPage.gotoByObjectDefinitionId(
+				objectDefinition.id
+			);
 
 			await viewObjectActionsPage.openObjectActionSidePanel();
 
@@ -1851,7 +1875,9 @@ test.describe('Object Action Required Field Validation', () => {
 				type: 'objectDefinition',
 			});
 
-			await viewObjectActionsPage.goto(objectDefinition.label['en_US']);
+			await viewObjectActionsPage.gotoByObjectDefinitionId(
+				objectDefinition.id
+			);
 
 			await viewObjectActionsPage.openObjectActionSidePanel();
 
@@ -1886,7 +1912,9 @@ test.describe('Object Action Required Field Validation', () => {
 				type: 'objectDefinition',
 			});
 
-			await viewObjectActionsPage.goto(objectDefinition.label['en_US']);
+			await viewObjectActionsPage.gotoByObjectDefinitionId(
+				objectDefinition.id
+			);
 
 			await viewObjectActionsPage.openObjectActionSidePanel();
 
@@ -1925,7 +1953,9 @@ test.describe('Object Action Required Field Validation', () => {
 				type: 'objectDefinition',
 			});
 
-			await viewObjectActionsPage.goto(objectDefinition.label['en_US']);
+			await viewObjectActionsPage.gotoByObjectDefinitionId(
+				objectDefinition.id
+			);
 
 			await viewObjectActionsPage.openObjectActionSidePanel();
 
@@ -1975,7 +2005,9 @@ test.describe('Object Action Required Field Validation', () => {
 				type: 'objectDefinition',
 			});
 
-			await viewObjectActionsPage.goto(objectDefinition.label['en_US']);
+			await viewObjectActionsPage.gotoByObjectDefinitionId(
+				objectDefinition.id
+			);
 
 			await viewObjectActionsPage.openObjectActionSidePanel();
 
@@ -2887,8 +2919,8 @@ ObjectEntryLocalServiceUtil.updateObjectEntry(objectEntry.getUserId(), id, 0L, v
 			// execution status reflects 'Success'.
 
 			await expect(async () => {
-				await viewObjectActionsPage.goto(
-					objectDefinition.label!['en_US']
+				await viewObjectActionsPage.gotoByObjectDefinitionId(
+					objectDefinition.id
 				);
 
 				await expect(

--- a/modules/test/playwright/tests/object-web/action/objectAction.spec.ts
+++ b/modules/test/playwright/tests/object-web/action/objectAction.spec.ts
@@ -710,7 +710,9 @@ test.describe('Object Action CRUD', () => {
 
 			apiHelpers.data.push({id: objectAction.id, type: 'objectAction'});
 
-			await viewObjectActionsPage.goto(objectDefinition.label['en_US']);
+			await viewObjectActionsPage.gotoByObjectDefinitionId(
+				objectDefinition.id
+			);
 
 			await expect(page.getByRole('cell', {name: 'Yes'})).toBeVisible();
 

--- a/modules/test/playwright/tests/object-web/notification/notification.spec.ts
+++ b/modules/test/playwright/tests/object-web/notification/notification.spec.ts
@@ -259,7 +259,9 @@ test(
 			type: 'objectDefinition',
 		});
 
-		await viewObjectActionsPage.goto(objectDefinition.label['en_US']);
+		await viewObjectActionsPage.gotoByObjectDefinitionId(
+			objectDefinition.id
+		);
 
 		await editObjectActionPage.addNewAction({
 			notificationTemplateName,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102969

## What Is Being Fixed

`Can inactivate an object action` intermittently times out on CI clicking the action's row link: the sticky management toolbar intercepts the click point and keeps it through every retry (166 attempts over 83.8s in the captured trace, page unchanged at timeout). The test reached the actions tab by walking the UI — list → definition → Actions tab — three in-document SPA swaps; under CI load the swap can assemble the page wrong and latch there (trace screenshot: toolbar painted on the table, single row a sliver beneath it, tab strip below the table, page unscrollable — so no retry can free the point). A settled page provably cannot reach the state (row 91px clear, maxScroll 0), and a validated frame-sampling probe saw 0/989 covered frames across the swap locally even at 20× CPU throttle — the failure needs the loaded-CI assembly race, hence flaky there, invisible locally.

Root cause: born this way — `eceb80f24e088` (LPD-82334) shaped the test around the label walk from creation; the sticky band has owned that viewport slice all along.

## How It Is Being Fixed

The page object gains `gotoByObjectDefinitionId`: the actions tab is asked for by address — one fresh document load instead of three in-document swaps — so the page arrives properly assembled, unscrolled, rows below the band, no navigation left in flight. Commit 1 converts the failing test; commit 2 sweeps the remaining 21 id-holding callers. Label-only callers (commerce system objects, upgrade fixture) keep the walk.

## PR Check

| Validation | Result |
|---|---|
| Source Format | ✅ passed |
| Local target + converted-caller sweeps | ✅ passed |
| Full-batch aggregate rides (AGG21–24), covered targets quiet | ✅ passed |

<!-- pr-check {"result": "success", "sha": "a07766e8f9119a05eed2ee2ce92e1710da67fecc"} -->
