### PR TITLE
LPD-102974 Own the side panel rebuild the filter save starts

### DIFF
--- a/modules/test/playwright/pages/object-web/object-view/EditObjectViewPage.ts
+++ b/modules/test/playwright/pages/object-web/object-view/EditObjectViewPage.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {FrameLocator, Locator, Page} from '@playwright/test';
+import {FrameLocator, Locator, Page, expect} from '@playwright/test';
 
 export class EditObjectViewPage {
 	readonly addButton: Locator;
@@ -79,6 +79,19 @@ export class EditObjectViewPage {
 		}
 
 		await this.saveFilter.dispatchEvent('click');
+
+		if (filterValues) {
+
+			// Saving the filter rebuilds the side panel, and the rebuild is
+			// still in flight when the dispatch returns. A caller that clicks
+			// the view's own Save next binds a button that is torn out from
+			// under it, and retries against a panel that keeps rebuilding until
+			// the test times out. Wait for the filter form to go, which is what
+			// a saved filter produces. A filter with no value cannot save and
+			// keeps its form open to report that, so leave that case alone.
+
+			await expect(this.sidePanel.getByLabel('New Filter')).toBeHidden();
+		}
 	}
 
 	async addDefaultSort(columnName: string, sortOrder: string) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102974

## What Is Being Fixed

Two object view tests ("can filter entries by status in custom view", "can edit a filter in custom view") intermittently time out clicking the view's Save right after creating a filter: `createFilter` dispatches a click on the filter's Save and returns while the save's side-panel rebuild is still in flight, so the caller's next click binds a button the rebuild tears out from under it — `element was detached from the DOM, retrying` until the 90s budget dies.

Root cause: born wrong, reachable later — `c2aab41275aee` (LPD-27457) created createFilter ending on a bare dispatched click with nothing waiting for the save it starts; `e78eb387699c3` (LPD-82342) added the caller that clicks the view's Save immediately after.

## How It Is Being Fixed

The helper owns the rebuild it starts and finalizes it before returning: it waits for the filter form to be gone — the saved filter's own signal. A valueless filter cannot save and keeps its form open to report that, so that branch is deliberately untouched and the negative test relying on it still passes.

## PR Check

| Validation | Result |
|---|---|
| Source Format | ✅ passed |
| Local: 4 callers ×3 (12/12) + fresh 3/3 on final bytes | ✅ passed |
| Full-batch aggregate rides (AGG21–24), victims quiet | ✅ passed |

<!-- pr-check {"result": "success", "sha": "d6b790027cf541c83b9df697d1207ab98e968a78"} -->
