### PR TITLE
LPD-102976 Read the global menu's state from its trigger, not its contents

### DIFF
--- a/modules/test/playwright/pages/product-navigation-applications-menu/GlobalMenuPage.ts
+++ b/modules/test/playwright/pages/product-navigation-applications-menu/GlobalMenuPage.ts
@@ -131,21 +131,45 @@ export class GlobalMenuPage {
 			name: categoryName,
 		});
 
+		// aria-expanded is the trigger's own open state, so it reads true as
+		// soon as the menu opens, even while the category list is still
+		// loading. Reading the list's contents instead reads "closed" for
+		// that whole load and re-clicks the trigger, which toggles the menu
+		// shut again. The pair may still start over: a caller's earlier step
+		// can have a navigation in flight, and when it lands it replaces the
+		// document and takes the open menu with it. That navigation belongs
+		// to the caller and cannot be waited on from here, so the fresh
+		// document gets asked again.
+
 		await expect(async () => {
-			if (!(await this.categoriesList.isVisible())) {
+			if (
+				(await this.globalMenuButton.getAttribute('aria-expanded', {
+					timeout: 5000,
+				})) !== 'true'
+			) {
 				await this.globalMenuButton.click();
+
+				// Five seconds a look, so the loop asks again often instead
+				// of staring out the default before the next ask.
+
+				await expect(this.globalMenuButton).toHaveAttribute(
+					'aria-expanded',
+					'true',
+					{timeout: 5000}
+				);
 			}
 
-			await expect(menuItem).toBeVisible({timeout: 2000});
+			await expect(menuItem).toBeVisible({timeout: 5000});
 
-			const isActive = (
-				(await menuItem.getAttribute('class', {timeout: 2000})) || ''
-			).includes('active');
+			// The menu marks the category that owns the current page with
+			// aria-current, and an item already marked needs no navigation.
 
-			if (!isActive) {
-				await menuItem.click();
-
-				await expect(this.categoriesList).toBeHidden({timeout: 2000});
+			if (
+				(await menuItem.getAttribute('aria-current', {
+					timeout: 5000,
+				})) !== 'page'
+			) {
+				await menuItem.click({timeout: 5000});
 			}
 		}).toPass();
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102976

## What Is Being Fixed

`GlobalMenuPage.goTo` intermittently spends the whole 90s budget inside its `toPass`, failing whichever test walked the global menu. Two independent modes: (1) the open-check read the category *list's* visibility — the list renders empty (no box) while the menu's data loads, so the check read "closed" for the whole load and re-clicked the trigger, a **toggle**, flipping the menu open/shut for as long as the data took; (2) a caller's still-in-flight navigation can replace the document mid-round, and the round's later reads and click carried no timeouts (project sets no action timeout), so one broken round starved on the vanished element for the rest of the budget.

Root cause: got broken by `e075af461a372` (LPD-95507, "Remove flakyness of the global menu") — it replaced the trigger's `aria-expanded` read with the list-visibility read, cut the looks to 2s, and left the round's later reads without timeouts.

## How It Is Being Fixed

The open state comes from the trigger's own `aria-expanded` (true the moment the menu opens, data or no data), so a pass clicks the trigger at most once. The category item is clicked unless `aria-current="page"` already marks it as owning the current page. Every read/click inside the pass carries a 5s look, so a round broken by a document swap fails fast and the pass asks the fresh document — that navigation belongs to the caller and cannot be owned from inside the helper. The arrival wait after the loop is unchanged.

## PR Check

| Validation | Result |
|---|---|
| Source Format | ✅ passed |
| Local amplified A/B (anonymize flow): 1/4 fail before → 4/4 pass after, + fresh 2/2 | ✅ passed |
| Full-batch aggregate rides (AGG21–24), no menu-attributed failures | ✅ passed |

<!-- pr-check {"result": "success", "sha": "529f9340bf8ffe1c0e78601753a5445d27b428a7"} -->
