### PR TITLE
LPD-102982 Mark the layout as default from the pane the checkbox lives on

### DIFF
--- a/modules/test/playwright/tests/object-web/layout/objectLayout.spec.ts
+++ b/modules/test/playwright/tests/object-web/layout/objectLayout.spec.ts
@@ -796,11 +796,9 @@ test.describe('Manage custom layouts through object layout tab', () => {
 
 			await objectLayoutsPage.openObjectLayoutConfiguration(layoutName);
 
-			await objectLayoutsPage.layoutTab.click();
+			await objectLayoutsPage.setObjectLayoutAsDefault();
 
-			await objectLayoutsPage.iframeLocator
-				.getByLabel('Mark as Default')
-				.click();
+			await objectLayoutsPage.layoutTab.click();
 
 			await objectLayoutsPage.createObjectLayoutTab('Field Tab');
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102982

## What Is Being Fixed

`can see label when creating Relationship Tab` intermittently times out on CI clicking Mark as Default (`145 × element is not visible`, hit point on the panel container). The test switches to the Layout pane and then clicks a checkbox that exists only on the Info pane — it only ever passed inside the ~150ms window Clay's TabPane keeps the outgoing pane laid out while fading (display block at opacity 0, which Playwright counts visible). CI load stretches the gap past the window; the pane flips to display none and the checkbox stays invisible for the rest of the budget. A real user cannot hit this — they click the checkbox while looking at the pane it lives on.

Root cause: born this way — the LPD-82349 Poshi migration (`6178dc43bf5dd` and siblings, final shape `ed95809e5ff6c`) wrote the click against the Layout pane from creation; Clay's fade has always kept the outgoing pane Playwright-visible.

## How It Is Being Fixed

Reorder onto the established helper: `setObjectLayoutAsDefault()` first (activates the Info pane before touching its checkbox — the arriving pane cannot race the fade), then switch to the Layout pane for the tab work. Spec-only, no waits or retries added.

## PR Check

| Validation | Result |
|---|---|
| Source Format | ✅ passed |
| Local target (fresh on final bytes + whole-set sweep) | ✅ passed |
| Full-batch aggregate rides (AGG21–24), target quiet | ✅ passed |

<!-- pr-check {"result": "success", "sha": "73f1a123a55d60123b61825fb206c08ba11f4f9a"} -->
