### PR TITLE
LPD-102983 Give the Address relationship test its own folder

### DIFF
--- a/modules/test/playwright/tests/object-web/relationship/objectRelationship.spec.ts
+++ b/modules/test/playwright/tests/object-web/relationship/objectRelationship.spec.ts
@@ -42,8 +42,12 @@ test.describe('Manage object relationships through Model Builder', () => {
 			apiHelpers,
 			modelBuilderDiagramPage,
 			page,
-			viewObjectDefinitionsPage,
 		}) => {
+			const objectFolder =
+				await apiHelpers.objectAdmin.postRandomObjectFolder();
+
+			apiHelpers.data.push({id: objectFolder.id, type: 'objectFolder'});
+
 			const objectDefinitionAPIClient =
 				await apiHelpers.buildRestClient(ObjectDefinitionAPI);
 
@@ -57,6 +61,8 @@ test.describe('Manage object relationships through Model Builder', () => {
 					},
 					name: 'Address',
 					objectFields: [],
+					objectFolderExternalReferenceCode:
+						objectFolder.externalReferenceCode,
 					pluralLabel: {
 						en_US: 'Custom Postal Addresses',
 					},
@@ -72,17 +78,22 @@ test.describe('Manage object relationships through Model Builder', () => {
 				type: 'objectDefinition',
 			});
 
-			const {body: commerceOrderDefinition} =
-				await objectDefinitionAPIClient.getObjectDefinitionByExternalReferenceCode(
-					'L_COMMERCE_ORDER'
-				);
+			const partnerObjectDefinition =
+				await apiHelpers.objectAdmin.postRandomObjectDefinition({
+					objectFolderExternalReferenceCode:
+						objectFolder.externalReferenceCode,
+					status: {code: 0},
+				});
+
+			apiHelpers.data.push({
+				id: partnerObjectDefinition.id,
+				type: 'objectDefinition',
+			});
 
 			await test.step('navigate to model builder and display all nodes', async () => {
-				await viewObjectDefinitionsPage.goto();
-
-				await viewObjectDefinitionsPage.openObjectFolder('Default');
-
-				await viewObjectDefinitionsPage.viewInModelBuilderButton.click();
+				await modelBuilderDiagramPage.goto({
+					objectFolderName: objectFolder.name,
+				});
 
 				await modelBuilderDiagramPage.toggleSidebarsButton.click();
 
@@ -92,7 +103,7 @@ test.describe('Manage object relationships through Model Builder', () => {
 			await test.step('assert that creating a relationship with a custom object named Address as the source node is allowed', async () => {
 				await modelBuilderDiagramPage.connectObjectDefinitionsNodeHandles(
 					customPostalAddressDefinition.id,
-					commerceOrderDefinition.id
+					partnerObjectDefinition.id
 				);
 
 				expect(
@@ -104,7 +115,7 @@ test.describe('Manage object relationships through Model Builder', () => {
 				await page.getByRole('button', {name: 'Cancel'}).click();
 
 				await modelBuilderDiagramPage.connectObjectDefinitionsNodeHandles(
-					commerceOrderDefinition.id,
+					partnerObjectDefinition.id,
 					customPostalAddressDefinition.id
 				);
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102983

## What Is Being Fixed

`allows to create relationship with a custom object named Address` intermittently times out dragging the relationship handles: the test opened the shared Default folder, whose node count depends on what earlier tests left behind; the canvas transform zooms to fit them all, so where the target handle lands is a per-run lottery — and when it lands bottom-left it sits under the minimap, a fixed overlay that swallows pointer events (`react-flow__minimap ... intercepts pointer events`), retrying until the budget dies.

Root cause: born this way — `9a90eeceefaf0` (LPD-85191) wrote the test against the shared Default folder from creation, so its geometry has always depended on suite leftovers.

## How It Is Being Fixed

The test creates its own folder and a custom partner definition and opens the model builder on that folder (the sibling connect tests' shape). With exactly two nodes the transform is determined and both handles land far from the overlay — the lottery is removed, not re-rolled. The LPD-51156 regression guard is unchanged: it keys on the postal-address table name on either end of the drag, which a custom partner exercises exactly as the system object did.

## PR Check

| Validation | Result |
|---|---|
| Source Format | ✅ passed |
| Local target (fresh + whole-set sweep + shared-site batch) | ✅ passed |
| Full-batch aggregate rides (AGG21–24), target quiet | ✅ passed |

<!-- pr-check {"result": "success", "sha": "bb398a14625a9f9bb4e6d34d64196b14c8748404"} -->
