### PR TITLE
LPD-102994 Read the persisted relationship value, not the pre-save render

### DIFF
--- a/modules/test/playwright/tests/object-web/entry/objectEntry.spec.ts
+++ b/modules/test/playwright/tests/object-web/entry/objectEntry.spec.ts
@@ -5269,6 +5269,17 @@ test.describe('Manage object entries through View Object Entries', () => {
 
 			await expect(viewObjectEntriesPage.successMessage).toBeVisible();
 
+			// The save fires its toast before it navigates to the saved entry,
+			// and the remounted relationship field publishes an empty hidden
+			// input until its option fetch resolves, so a read taken here can
+			// see the render before the save or the field before its value.
+			// Land on the saved entry and reload so the read is the persisted
+			// value.
+
+			await page.waitForURL(/externalReferenceCode=/);
+
+			await page.reload();
+
 			const fieldContainer = page.locator(
 				'[data-field-name="r_objectRelationshipName_CProductId"]'
 			);
@@ -5288,6 +5299,17 @@ test.describe('Manage object entries through View Object Entries', () => {
 			await viewObjectEntriesPage.saveObjectEntryButton.click();
 
 			await expect(viewObjectEntriesPage.successMessage).toBeVisible();
+
+			// The save fires its toast before it navigates to the saved entry,
+			// and the remounted relationship field publishes an empty hidden
+			// input until its option fetch resolves, so a read taken here can
+			// see the render before the save or the field before its value.
+			// Land on the saved entry and reload so the read is the persisted
+			// value.
+
+			await page.waitForURL(/externalReferenceCode=/);
+
+			await page.reload();
 
 			await expect(relationshipInput).not.toHaveValue('');
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102994

## What Is Being Fixed

The commerce product versions test intermittently reads an empty relationship value (`received: ''`). It reads the relationship field's hidden input right after the success toast — but the save fires its toast **before** navigating to the saved entry (so the empty-value guard passes vacuously against the pre-save DOM), and the navigation then remounts the relationship field, which publishes an empty hidden input until its option fetch resolves. A read in either window sees a non-persisted value.

Root cause: `ce5c1b4824d32` (LPS-157898) switched the hidden input to the asynchronously fetched selection (opening the blank window); `be0a711e84a73` (LPD-65249) wrote the test reading straight off the toast; `d400d329c306c` (LPD-101216) added the guard where the pre-save render satisfies it.

## How It Is Being Fixed

After each save's toast, own the save's navigation (wait for the saved entry's address) and reload before reading — the value read is the persisted one both times. Not a retry: it makes the assertion mean what the test's title claims (database render, not client memory). The field's async fill keeps its loud failure path via the existing guard.

## PR Check

| Validation | Result |
|---|---|
| Source Format | ✅ passed |
| Local target (fresh + batch + tier sweep) | ✅ passed |
| Full-batch aggregate rides (AGG20–24), target quiet | ✅ passed |

<!-- pr-check {"result": "success", "sha": "e31f48005426140777f525c94f8dac9d25b8e3a8"} -->
