### PR TITLE
LPD-102996 Scope the sign in submit to the sign in form

### DIFF
--- a/modules/test/playwright/utils/performLogin.ts
+++ b/modules/test/playwright/utils/performLogin.ts
@@ -76,7 +76,18 @@ async function performLogin(
 	await page.getByLabel('Password').fill(password);
 	await page.getByLabel('Remember Me').setChecked(rememberMe);
 
-	await page.getByRole('button', {name: 'Sign In'}).last().click();
+	// Two buttons on the page carry the name Sign In, the personal bar
+	// trigger and the prompt's own submit, and the prompt can re-render under
+	// the click: a pick by ordinal that is re-resolved in that window matches
+	// the only survivor, the trigger, which submits nothing. Scoped to the
+	// sign in form, the pick can only ever resolve to the submit, and the
+	// click's own wait for it to be enabled is the form's readiness signal,
+	// because the script that enables it attaches the submit handler first.
+
+	await page
+		.locator('form.sign-in-form')
+		.getByRole('button', {name: 'Sign In'})
+		.click();
 
 	await expect(page.getByLabel(`${name} ${surname}`)).toBeVisible({
 		timeout: 30 * 1000,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102996

## What Is Being Fixed

`performLogin` intermittently spends 30s waiting for a personal-bar label that never changes, failing whichever test signed in at that moment. The helper picked the submit as `.last()` of the buttons named Sign In — two carry that name (the personal-bar trigger and the prompt's own submit), and the prompt is an inline panel that can re-render under the click: the pick resolves to the submit, the submit detaches in the re-render window, and the **re-resolved** pick matches the only survivor — the trigger, which submits nothing. Live-probe-verified topology: trigger first in DOM order, submit second, inside `form.sign-in-form`.

Root cause: got broken later — `d191bd9b94269` (LPD-64256) replaced LPD-31008's containment (`1b9999c50e7c7`) with the bare ordinal pick.

## How It Is Being Fixed

Scope the pick to `form.sign-in-form`, whose only Sign In button is the real one — no re-resolution can land on the trigger. Nothing else is needed: the submit renders disabled and the inline script that enables it attaches the form's submit handler **first**, so the click's own wait-for-enabled consumes the form's readiness signal — an enabled button is a wired button, and a landed click always submits. The 30s label wait is unchanged; no retry loop.

## PR Check

| Validation | Result |
|---|---|
| Source Format | ✅ passed |
| tsc + live-markup probe + UI-login flows on final bytes | ✅ passed |
| Full-batch aggregate rides (AGG20–24), no login-loss faces | ✅ passed |

<!-- pr-check {"result": "success", "sha": "e668a79ecf40f594912b2fbd89d1a541fa8dca9a"} -->
