### PR TITLE
LPD-102997 Wait for the alert the personal data delete and anonymize render

### DIFF
--- a/modules/test/playwright/tests/object-web/entry/objectPersonalData.spec.ts
+++ b/modules/test/playwright/tests/object-web/entry/objectPersonalData.spec.ts
@@ -13,6 +13,7 @@ import {objectPagesTest} from '../../../fixtures/objectPagesTest';
 import {usersAndOrganizationsPagesTest} from '../../../fixtures/usersAndOrganizationsPagesTest';
 import {getRandomInt} from '../../../utils/getRandomInt';
 import {performUserSwitch, userData} from '../../../utils/performLogin';
+import {waitForAlert} from '../../../utils/waitForAlert';
 import {generateObjectFields} from '../utils/generateObjectFields';
 
 const test = mergeTests(
@@ -264,6 +265,14 @@ test('can delete object entries via personal data management', async ({
 	await personalDataErasurePage.allSelectedButton.click();
 
 	await personalDataErasurePage.deleteMenuItem.click();
+
+	// The delete confirmation submits its form through a loader that only
+	// queues the submission, so the click resolves while the delete has not
+	// been sent yet, and navigating away here kills it before it commits.
+	// The success alert renders after the delete's own redirect, so waiting
+	// for it proves the delete reached the server.
+
+	await waitForAlert(page);
 
 	await usersAndOrganizationsPage.goToUsers(true);
 

--- a/modules/test/playwright/tests/object-web/entry/objectPersonalData.spec.ts
+++ b/modules/test/playwright/tests/object-web/entry/objectPersonalData.spec.ts
@@ -110,6 +110,14 @@ test('can anonymize object entries', async ({
 
 	await personalDataErasurePage.anonymizeButton.click();
 
+	// The anonymize confirmation submits through the same queued form
+	// submission as the delete, so leaving for the users list here can kill
+	// it before it commits. The success alerts render after its redirect, one
+	// per anonymized application, so waiting for the first proves the
+	// anonymize reached the server.
+
+	await waitForAlert(page, undefined, {first: true});
+
 	await usersAndOrganizationsPage.goToUsers();
 
 	await usersAndOrganizationsPage.filterUsers('inactive');


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102997

## What Is Being Fixed

The personal-data erasure tests intermittently assert against operations that never happened: the delete test finds the entry still present at its final check (`Received: visible`), the anonymize test finds entries unanonymized — long after every intermediate step passed. Both flows confirm and submit through a loader that only **queues** the form submission, so the click resolves while nothing has left the browser; the tests navigated away on the next line, tearing the page down and killing the queued submit. The user-deactivate happened on an earlier request, so everything downstream still worked and the failure surfaced only at the end.

Root cause: delete — `2fd92549062ae` (LPD-80345, Poshi migration) created click-then-navigate, `d644aaf8d0d0d` (LPD-82347) moved the delete onto the queued submission the navigation kills; anonymize — born the same way in the same migration.

## How It Is Being Fixed

Wait for the success alert before leaving — it renders after the operation's own redirect, so it is the roundtrip's completion signal (the settle point sibling flows already use). No retry loop. The anonymize renders one alert per anonymized application, so only the first is waited on.

## PR Check

| Validation | Result |
|---|---|
| Source Format | ✅ passed |
| Local: both targets together on final bytes + tier runs | ✅ passed |
| Full-batch aggregate rides (AGG20v2–24), targets quiet | ✅ passed |

<!-- pr-check {"result": "success", "sha": "1783ab3699ec66a009a9b658c32ad58e4c25148c"} -->
