### PR TITLE
LPD-102998 Draw every relationship name through one collision-checked util

### DIFF
--- a/modules/test/playwright/tests/object-web/entry/objectEntry.spec.ts
+++ b/modules/test/playwright/tests/object-web/entry/objectEntry.spec.ts
@@ -50,6 +50,7 @@ import {
 import {createFile, deleteFile} from '../utils/fileHelpers';
 import {generateObjectEntryValues} from '../utils/generateObjectEntry';
 import {generateObjectFields} from '../utils/generateObjectFields';
+import {getFreshObjectRelationshipName} from '../utils/getFreshObjectRelationshipName';
 import evaluateKeepCheckingAfterFound from '../utils/keepCheckingAfterFound';
 import {pasteFile} from '../utils/pasteFile';
 import {postListTypeDefinitionListTypeEntries} from '../utils/postListTypeDefinitionListTypeEntries';
@@ -2700,7 +2701,14 @@ test.describe('Manage object entries through View Object Entries', () => {
 			objectDefinition2.externalReferenceCode!,
 			{
 				label: {en_US: 'Relationship'},
-				name: 'relationship' + Math.floor(Math.random() * 99),
+				name: await getFreshObjectRelationshipName(
+					apiHelpers,
+					[
+						objectDefinition2.externalReferenceCode!,
+						objectDefinition1.externalReferenceCode!,
+					],
+					'relationship'
+				),
 				objectDefinitionExternalReferenceCode2:
 					objectDefinition1.externalReferenceCode,
 				objectDefinitionId2: objectDefinition1.id,
@@ -3504,8 +3512,13 @@ test.describe('Manage object entries through View Object Entries', () => {
 
 		const objectRelationshipLabel =
 			'objectRelationshipLabel' + getRandomInt();
-		const objectRelationshipName =
-			'objectRelationshipName' + getRandomInt();
+		const objectRelationshipName = await getFreshObjectRelationshipName(
+			apiHelpers,
+			[
+				objectDefinition1.externalReferenceCode!,
+				objectDefinition2.externalReferenceCode!,
+			]
+		);
 
 		const objectRelationshipAPIClient = await apiHelpers.buildRestClient(
 			ObjectRelationshipAPI
@@ -3658,8 +3671,10 @@ test.describe('Manage object entries through View Object Entries', () => {
 			const objectRelationshipAPIClient =
 				await apiHelpers.buildRestClient(ObjectRelationshipAPI);
 
-			const objectRelationshipName =
-				'objectRelationshipName' + Math.floor(Math.random() * 99);
+			const objectRelationshipName = await getFreshObjectRelationshipName(
+				apiHelpers,
+				['L_USER', objectDefinition.externalReferenceCode!]
+			);
 
 			const {body: objectRelationship} =
 				await objectRelationshipAPIClient.postObjectDefinitionByExternalReferenceCodeObjectRelationship(
@@ -3730,8 +3745,10 @@ test.describe('Manage object entries through View Object Entries', () => {
 			const objectRelationshipAPIClient =
 				await apiHelpers.buildRestClient(ObjectRelationshipAPI);
 
-			const objectRelationshipName =
-				'objectRelationshipName' + Math.floor(Math.random() * 99);
+			const objectRelationshipName = await getFreshObjectRelationshipName(
+				apiHelpers,
+				['L_USER', objectDefinition.externalReferenceCode!]
+			);
 
 			const {body: objectRelationship} =
 				await objectRelationshipAPIClient.postObjectDefinitionByExternalReferenceCodeObjectRelationship(
@@ -3862,7 +3879,10 @@ test.describe('Manage object entries through View Object Entries', () => {
 					label: {
 						en_US: 'objectRelationshipLabel' + getRandomInt(),
 					},
-					name: 'objectRelationshipName' + getRandomInt(),
+					name: await getFreshObjectRelationshipName(apiHelpers, [
+						'L_ACCOUNT',
+						objectDefinition.externalReferenceCode!,
+					]),
 					objectDefinitionExternalReferenceCode1: 'L_ACCOUNT',
 					objectDefinitionExternalReferenceCode2:
 						objectDefinition.externalReferenceCode,
@@ -4041,7 +4061,10 @@ test.describe('Manage object entries through View Object Entries', () => {
 						label: {
 							en_US: 'objectRelationshipLabel' + getRandomInt(),
 						},
-						name: 'objectRelationshipName' + getRandomInt(),
+						name: await getFreshObjectRelationshipName(apiHelpers, [
+							'L_ORGANIZATION',
+							objectDefinition.externalReferenceCode!,
+						]),
 						objectDefinitionExternalReferenceCode1:
 							'L_ORGANIZATION',
 						objectDefinitionExternalReferenceCode2:
@@ -4194,7 +4217,10 @@ test.describe('Manage object entries through View Object Entries', () => {
 						label: {
 							en_US: 'objectRelationshipLabel' + getRandomInt(),
 						},
-						name: 'objectRelationshipName' + getRandomInt(),
+						name: await getFreshObjectRelationshipName(apiHelpers, [
+							'L_ORGANIZATION',
+							objectDefinition.externalReferenceCode!,
+						]),
 						objectDefinitionExternalReferenceCode1:
 							'L_ORGANIZATION',
 						objectDefinitionExternalReferenceCode2:
@@ -4664,8 +4690,13 @@ test.describe('Manage object entries through View Object Entries', () => {
 
 		const objectRelationshipLabel =
 			'objectRelationshipLabel' + getRandomInt();
-		const objectRelationshipName =
-			'objectRelationshipName' + Math.floor(Math.random() * 99);
+		const objectRelationshipName = await getFreshObjectRelationshipName(
+			apiHelpers,
+			[
+				objectDefinition1.externalReferenceCode!,
+				objectDefinition2.externalReferenceCode!,
+			]
+		);
 
 		const objectRelationshipAPIClient = await apiHelpers.buildRestClient(
 			ObjectRelationshipAPI
@@ -5948,7 +5979,10 @@ test.describe('Manage object entries through View Object Entries', () => {
 				label: {
 					en_US: 'objectRelationshipLabel' + getRandomInt(),
 				},
-				name: 'objectRelationshipName' + getRandomInt(),
+				name: await getFreshObjectRelationshipName(apiHelpers, [
+					'L_ACCOUNT',
+					objectDefinition.externalReferenceCode!,
+				]),
 				objectDefinitionExternalReferenceCode1: 'L_ACCOUNT',
 				objectDefinitionExternalReferenceCode2:
 					objectDefinition.externalReferenceCode,

--- a/modules/test/playwright/tests/object-web/entry/objectEntryLocalized.spec.ts
+++ b/modules/test/playwright/tests/object-web/entry/objectEntryLocalized.spec.ts
@@ -27,6 +27,7 @@ import getRandomString from '../../../utils/getRandomString';
 import {waitForAlert} from '../../../utils/waitForAlert';
 import {journalPagesTest} from '../../journal-web/main/fixtures/journalPagesTest';
 import {generateObjectFields} from '../utils/generateObjectFields';
+import {getFreshObjectRelationshipName} from '../utils/getFreshObjectRelationshipName';
 import {postListTypeDefinitionListTypeEntries} from '../utils/postListTypeDefinitionListTypeEntries';
 
 export const test = mergeTests(
@@ -1594,8 +1595,13 @@ test.describe('Manage object entries through Page Templates', () => {
 
 		const objectRelationshipLabel =
 			'objectRelationshipLabel' + getRandomInt();
-		const objectRelationshipName =
-			'objectRelationshipName' + Math.floor(Math.random() * 99);
+		const objectRelationshipName = await getFreshObjectRelationshipName(
+			apiHelpers,
+			[
+				objectDefinition1.externalReferenceCode,
+				objectDefinition2.externalReferenceCode!,
+			]
+		);
 
 		const objectRelationshipAPIClient = await apiHelpers.buildRestClient(
 			ObjectRelationshipAPI

--- a/modules/test/playwright/tests/object-web/field/objectField.spec.ts
+++ b/modules/test/playwright/tests/object-web/field/objectField.spec.ts
@@ -25,6 +25,7 @@ import {waitForAlert} from '../../../utils/waitForAlert';
 import {waitForSearchToBeReady} from '../../../utils/waitForSearchToBeReady';
 import {AsyncArray} from '../utils/AsyncArray';
 import {generateObjectFields} from '../utils/generateObjectFields';
+import {getFreshObjectRelationshipName} from '../utils/getFreshObjectRelationshipName';
 import {postListTypeDefinitionListTypeEntries} from '../utils/postListTypeDefinitionListTypeEntries';
 
 const test = mergeTests(
@@ -1195,9 +1196,10 @@ test.describe('Manage objectFields through Objects Admin UI', () => {
 					label: {
 						en_US: 'objectRelationshipLabel' + getRandomInt(),
 					},
-					name:
-						'objectRelationshipName' +
-						Math.floor(Math.random() * 99),
+					name: await getFreshObjectRelationshipName(apiHelpers, [
+						objectDefinition1.externalReferenceCode!,
+						objectDefinition2.externalReferenceCode!,
+					]),
 					objectDefinitionExternalReferenceCode1:
 						objectDefinition1.externalReferenceCode,
 					objectDefinitionExternalReferenceCode2:
@@ -1424,8 +1426,10 @@ test.describe('Manage objectFields through Objects Admin UI', () => {
 			ObjectRelationshipAPI
 		);
 
-		const objectRelationshipName =
-			'objectRelationshipName' + Math.floor(Math.random() * 99);
+		const objectRelationshipName = await getFreshObjectRelationshipName(
+			apiHelpers,
+			[objectDefinition.externalReferenceCode!]
+		);
 
 		await objectRelationshipAPIClient.postObjectDefinitionByExternalReferenceCodeObjectRelationship(
 			objectDefinition.externalReferenceCode!,
@@ -1544,8 +1548,11 @@ test.describe('Manage objectFields through Objects Admin UI', () => {
 			ObjectRelationshipAPI
 		);
 
-		const objectRelationship1 =
-			'objectRelationship' + Math.floor(Math.random() * 99);
+		const objectRelationship1 = await getFreshObjectRelationshipName(
+			apiHelpers,
+			[objectDefinition.externalReferenceCode!],
+			'objectRelationship'
+		);
 
 		await objectRelationshipAPIClient.postObjectDefinitionByExternalReferenceCodeObjectRelationship(
 			objectDefinition.externalReferenceCode!,
@@ -1560,8 +1567,14 @@ test.describe('Manage objectFields through Objects Admin UI', () => {
 			}
 		);
 
-		const objectRelationship2 =
-			'objectRelationship' + Math.floor(Math.random() * 99);
+		const objectRelationship2 = await getFreshObjectRelationshipName(
+			apiHelpers,
+			[
+				objectDefinition.externalReferenceCode!,
+				objectDefinition2.externalReferenceCode!,
+			],
+			'objectRelationship'
+		);
 
 		await objectRelationshipAPIClient.postObjectDefinitionByExternalReferenceCodeObjectRelationship(
 			objectDefinition.externalReferenceCode!,
@@ -1908,7 +1921,11 @@ test.describe('Manage objectFields through Objects Admin UI', () => {
 					'L_USER',
 					{
 						label: {en_US: relationshipLabel},
-						name: 'relationship' + getRandomInt(),
+						name: await getFreshObjectRelationshipName(
+							apiHelpers,
+							['L_USER', objectDefinition.externalReferenceCode!],
+							'relationship'
+						),
 						objectDefinitionExternalReferenceCode2:
 							objectDefinition.externalReferenceCode,
 						objectDefinitionId2: objectDefinition.id,
@@ -2148,9 +2165,10 @@ test.describe('Manage objectFields through Objects Admin UI', () => {
 					label: {
 						en_US: 'objectRelationshipLabel' + getRandomInt(),
 					},
-					name:
-						'objectRelationshipName' +
-						Math.floor(Math.random() * 99),
+					name: await getFreshObjectRelationshipName(apiHelpers, [
+						objectDefinition1.externalReferenceCode!,
+						objectDefinition2.externalReferenceCode!,
+					]),
 					objectDefinitionExternalReferenceCode1:
 						objectDefinition1.externalReferenceCode,
 					objectDefinitionExternalReferenceCode2:

--- a/modules/test/playwright/tests/object-web/hierarchy/objectDefinitionHierarchy.spec.ts
+++ b/modules/test/playwright/tests/object-web/hierarchy/objectDefinitionHierarchy.spec.ts
@@ -22,6 +22,7 @@ import performLogin, {
 } from '../../../utils/performLogin';
 import {pushToApiHelpersData} from '../../../utils/pushToApiHelpersData';
 import {waitForAlert} from '../../../utils/waitForAlert';
+import {getFreshObjectRelationshipName} from '../utils/getFreshObjectRelationshipName';
 
 export const test = mergeTests(
 	dataApiHelpersTest,
@@ -211,9 +212,10 @@ test.describe('Manage root model elements through View Object Entries', () => {
 						label: {
 							en_US: 'objectRelationshipLabel' + getRandomInt(),
 						},
-						name:
-							'objectRelationshipName' +
-							Math.floor(Math.random() * 99),
+						name: await getFreshObjectRelationshipName(apiHelpers, [
+							objectDefinition1.externalReferenceCode!,
+							objectDefinition2.externalReferenceCode!,
+						]),
 						objectDefinitionExternalReferenceCode1:
 							objectDefinition1.externalReferenceCode,
 						objectDefinitionExternalReferenceCode2:
@@ -419,9 +421,10 @@ test.describe('Manage root model elements through View Object Entries', () => {
 						label: {
 							en_US: 'objectRelationshipLabel' + getRandomInt(),
 						},
-						name:
-							'objectRelationshipName' +
-							Math.floor(Math.random() * 99),
+						name: await getFreshObjectRelationshipName(apiHelpers, [
+							'L_ACCOUNT',
+							objectDefinition1.externalReferenceCode!,
+						]),
 						objectDefinitionExternalReferenceCode1: 'L_ACCOUNT',
 						objectDefinitionExternalReferenceCode2:
 							objectDefinition1.externalReferenceCode,
@@ -447,9 +450,10 @@ test.describe('Manage root model elements through View Object Entries', () => {
 						label: {
 							en_US: 'objectRelationshipLabel' + getRandomInt(),
 						},
-						name:
-							'objectRelationshipName' +
-							Math.floor(Math.random() * 99),
+						name: await getFreshObjectRelationshipName(apiHelpers, [
+							objectDefinition1.externalReferenceCode!,
+							objectDefinition2.externalReferenceCode!,
+						]),
 						objectDefinitionExternalReferenceCode1:
 							objectDefinition1.externalReferenceCode,
 						objectDefinitionExternalReferenceCode2:
@@ -658,8 +662,13 @@ test.describe('Manage root models elements through Objects Admin', () => {
 
 			const objectRelationshipLabel =
 				'objectRelationshipLabel' + getRandomInt();
-			const objectRelationshipName =
-				'objectRelationshipName' + Math.floor(Math.random() * 99);
+			const objectRelationshipName = await getFreshObjectRelationshipName(
+				apiHelpers,
+				[
+					objectDefinition1.externalReferenceCode!,
+					objectDefinition2.externalReferenceCode!,
+				]
+			);
 
 			const objectRelationshipAPIClient =
 				await apiHelpers.buildRestClient(ObjectRelationshipAPI);
@@ -753,8 +762,13 @@ test.describe('Manage root models elements through Objects Admin', () => {
 
 			const objectRelationshipLabel =
 				'objectRelationshipLabel' + getRandomInt();
-			const objectRelationshipName =
-				'objectRelationshipName' + Math.floor(Math.random() * 99);
+			const objectRelationshipName = await getFreshObjectRelationshipName(
+				apiHelpers,
+				[
+					objectDefinition1.externalReferenceCode!,
+					objectDefinition2.externalReferenceCode!,
+				]
+			);
 
 			const objectRelationshipAPIClient =
 				await apiHelpers.buildRestClient(ObjectRelationshipAPI);
@@ -863,9 +877,10 @@ test.describe('Manage root models elements through Objects Admin', () => {
 						label: {
 							en_US: 'objectRelationshipACLabel' + getRandomInt(),
 						},
-						name:
-							'objectRelationshipACName' +
-							Math.floor(Math.random() * 99),
+						name: await getFreshObjectRelationshipName(apiHelpers, [
+							objectDefinitionA.externalReferenceCode!,
+							objectDefinitionC.externalReferenceCode!,
+						]),
 						objectDefinitionExternalReferenceCode1:
 							objectDefinitionA.externalReferenceCode,
 						objectDefinitionExternalReferenceCode2:
@@ -885,9 +900,10 @@ test.describe('Manage root models elements through Objects Admin', () => {
 						label: {
 							en_US: 'objectRelationshipBCLabel' + getRandomInt(),
 						},
-						name:
-							'objectRelationshipBCName' +
-							Math.floor(Math.random() * 99),
+						name: await getFreshObjectRelationshipName(apiHelpers, [
+							objectDefinitionB.externalReferenceCode!,
+							objectDefinitionC.externalReferenceCode!,
+						]),
 						objectDefinitionExternalReferenceCode1:
 							objectDefinitionB.externalReferenceCode,
 						objectDefinitionExternalReferenceCode2:
@@ -1020,9 +1036,14 @@ test.describe('Manage root models elements through Objects Admin', () => {
 						label: {
 							en_US: 'objectRelationship',
 						},
-						name:
-							'objectRelationship' +
-							Math.floor(Math.random() * 99),
+						name: await getFreshObjectRelationshipName(
+							apiHelpers,
+							[
+								parentObjectDefinition.externalReferenceCode!,
+								childObjectDefinition.externalReferenceCode!,
+							],
+							'objectRelationship'
+						),
 						objectDefinitionExternalReferenceCode1:
 							parentObjectDefinition.externalReferenceCode,
 						objectDefinitionExternalReferenceCode2:
@@ -1047,9 +1068,10 @@ test.describe('Manage root models elements through Objects Admin', () => {
 						label: {
 							en_US: 'inheritanceObjectRelationship',
 						},
-						name:
-							'articleObjectRelationship' +
-							Math.floor(Math.random() * 99),
+						name: await getFreshObjectRelationshipName(apiHelpers, [
+							parentObjectDefinition.externalReferenceCode!,
+							childObjectDefinition.externalReferenceCode!,
+						]),
 						objectDefinitionExternalReferenceCode1:
 							parentObjectDefinition.externalReferenceCode,
 						objectDefinitionExternalReferenceCode2:
@@ -1430,9 +1452,10 @@ test.describe('Manage root models elements through Objects Admin', () => {
 						label: {
 							en_US: 'objectRelationshipLabel' + getRandomInt(),
 						},
-						name:
-							'objectRelationshipName' +
-							Math.floor(Math.random() * 99),
+						name: await getFreshObjectRelationshipName(apiHelpers, [
+							objectDefinition1.externalReferenceCode!,
+							objectDefinition2.externalReferenceCode!,
+						]),
 						objectDefinitionExternalReferenceCode1:
 							objectDefinition1.externalReferenceCode,
 						objectDefinitionExternalReferenceCode2:
@@ -1452,9 +1475,10 @@ test.describe('Manage root models elements through Objects Admin', () => {
 						label: {
 							en_US: 'objectRelationshipLabel' + getRandomInt(),
 						},
-						name:
-							'objectRelationshipName' +
-							Math.floor(Math.random() * 99),
+						name: await getFreshObjectRelationshipName(apiHelpers, [
+							objectDefinition3.externalReferenceCode!,
+							objectDefinition2.externalReferenceCode!,
+						]),
 						objectDefinitionExternalReferenceCode1:
 							objectDefinition3.externalReferenceCode,
 						objectDefinitionExternalReferenceCode2:
@@ -1750,9 +1774,10 @@ test.describe('Manage root models elements through Model Builder', () => {
 					label: {
 						en_US: 'objectRelationshipLabel' + getRandomInt(),
 					},
-					name:
-						'objectRelationshipName' +
-						Math.floor(Math.random() * 99),
+					name: await getFreshObjectRelationshipName(apiHelpers, [
+						objectDefinition1.externalReferenceCode!,
+						objectDefinition2.externalReferenceCode!,
+					]),
 					objectDefinitionExternalReferenceCode1:
 						objectDefinition1.externalReferenceCode,
 					objectDefinitionExternalReferenceCode2:
@@ -1941,8 +1966,13 @@ test.describe('Manage root models elements through Model Builder', () => {
 
 			const objectRelationshipLabel =
 				'objectRelationshipLabel' + getRandomInt();
-			const objectRelationshipName =
-				'objectRelationshipName' + Math.floor(Math.random() * 99);
+			const objectRelationshipName = await getFreshObjectRelationshipName(
+				apiHelpers,
+				[
+					objectDefinition1.externalReferenceCode!,
+					objectDefinition2.externalReferenceCode!,
+				]
+			);
 
 			const objectRelationshipAPIClient =
 				await apiHelpers.buildRestClient(ObjectRelationshipAPI);

--- a/modules/test/playwright/tests/object-web/layout/objectLayout.spec.ts
+++ b/modules/test/playwright/tests/object-web/layout/objectLayout.spec.ts
@@ -21,6 +21,7 @@ import {performUserSwitch, userData} from '../../../utils/performLogin';
 import {waitForAlert} from '../../../utils/waitForAlert';
 import {generateObjectEntryValues} from '../utils/generateObjectEntry';
 import {generateObjectFields} from '../utils/generateObjectFields';
+import {getFreshObjectRelationshipName} from '../utils/getFreshObjectRelationshipName';
 import getRandomObjectFieldText from '../utils/getRandomObjectFieldText';
 
 export const test = mergeTests(
@@ -284,9 +285,13 @@ test.describe('Manage custom layouts through object layout tab', () => {
 				await apiHelpers.buildRestClient(ObjectRelationshipAPI);
 
 			const objectRelationshipName1 =
-				'objectRelationshipName' + Math.floor(Math.random() * 99);
+				await getFreshObjectRelationshipName(apiHelpers, [
+					objectDefinition.externalReferenceCode!,
+				]);
 			const objectRelationshipName2 =
-				'objectRelationshipName' + Math.floor(Math.random() * 99);
+				await getFreshObjectRelationshipName(apiHelpers, [
+					objectDefinition.externalReferenceCode!,
+				]);
 
 			const {body: objectRelationship1} =
 				await objectRelationshipAPIClient.postObjectDefinitionByExternalReferenceCodeObjectRelationship(
@@ -533,9 +538,10 @@ test.describe('Manage custom layouts through object layout tab', () => {
 					label: {
 						en_US: 'objectRelationshipLabel' + getRandomInt(),
 					},
-					name:
-						'objectRelationshipName' +
-						Math.floor(Math.random() * 99),
+					name: await getFreshObjectRelationshipName(apiHelpers, [
+						objectDefinition.externalReferenceCode!,
+						objectDefinition2.externalReferenceCode!,
+					]),
 					objectDefinitionExternalReferenceCode1:
 						objectDefinition.externalReferenceCode,
 					objectDefinitionExternalReferenceCode2:
@@ -909,7 +915,11 @@ test.describe('Manage custom layouts through object layout tab', () => {
 					label: {
 						en_US: 'Relationship' + getRandomInt(),
 					},
-					name: 'relationship' + getRandomInt(),
+					name: await getFreshObjectRelationshipName(
+						apiHelpers,
+						[objectDefinition.externalReferenceCode!],
+						'relationship'
+					),
 					objectDefinitionExternalReferenceCode1:
 						objectDefinition.externalReferenceCode,
 					objectDefinitionExternalReferenceCode2:
@@ -1364,7 +1374,11 @@ test.describe('Manage custom layouts through object layout tab', () => {
 					label: {
 						en_US: 'Relationship' + getRandomInt(),
 					},
-					name: 'relationship' + getRandomInt(),
+					name: await getFreshObjectRelationshipName(
+						apiHelpers,
+						[objectDefinition.externalReferenceCode!],
+						'relationship'
+					),
 					objectDefinitionExternalReferenceCode1:
 						objectDefinition.externalReferenceCode,
 					objectDefinitionExternalReferenceCode2:

--- a/modules/test/playwright/tests/object-web/main/objectDefinition.spec.ts
+++ b/modules/test/playwright/tests/object-web/main/objectDefinition.spec.ts
@@ -36,6 +36,7 @@ import getFragmentDefinition from '../../layout-content-page-editor-web/main/uti
 import getPageDefinition from '../../layout-content-page-editor-web/main/utils/getPageDefinition';
 import {localizationPagesTest} from '../../site-admin-web/main/fixtures/localizationPagesTest';
 import {generateObjectFields} from '../utils/generateObjectFields';
+import {getFreshObjectRelationshipName} from '../utils/getFreshObjectRelationshipName';
 
 const test = mergeTests(
 	collectionsPagesTest,
@@ -597,8 +598,13 @@ test.describe('Manage object definitions through Model Builder', () => {
 
 		const objectRelationshipLabel =
 			'objectRelationshipLabel' + getRandomInt();
-		const objectRelationshipName =
-			'objectRelationshipName' + Math.floor(Math.random() * 99);
+		const objectRelationshipName = await getFreshObjectRelationshipName(
+			apiHelpers,
+			[
+				objectDefinition1.externalReferenceCode!,
+				objectDefinition2.externalReferenceCode!,
+			]
+		);
 
 		const objectRelationshipAPIClient = await apiHelpers.buildRestClient(
 			ObjectRelationshipAPI
@@ -1119,7 +1125,10 @@ test.describe('Manage object definitions through View Object Definitions', () =>
 					label: {
 						en_US: 'objectRelationshipLabel' + getRandomInt(),
 					},
-					name: 'objectRelationshipName' + getRandomInt(),
+					name: await getFreshObjectRelationshipName(apiHelpers, [
+						'L_ACCOUNT',
+						objectDefinition.externalReferenceCode!,
+					]),
 					objectDefinitionExternalReferenceCode1: 'L_ACCOUNT',
 					objectDefinitionExternalReferenceCode2:
 						objectDefinition.externalReferenceCode,
@@ -1899,7 +1908,11 @@ test.describe('Manage object definitions through View Object Definitions', () =>
 					await apiHelpers.buildRestClient(ObjectRelationshipAPI);
 
 				relationshipLabel = 'Relationship';
-				relationshipName = 'relationship' + getRandomInt();
+				relationshipName = await getFreshObjectRelationshipName(
+					apiHelpers,
+					['L_ACCOUNT', objectDefinition.externalReferenceCode!],
+					'relationship'
+				);
 
 				await objectRelationshipAPIClient.postObjectDefinitionByExternalReferenceCodeObjectRelationship(
 					'L_ACCOUNT',

--- a/modules/test/playwright/tests/object-web/relationship/objectRelationship.spec.ts
+++ b/modules/test/playwright/tests/object-web/relationship/objectRelationship.spec.ts
@@ -22,6 +22,7 @@ import {getRandomInt} from '../../../utils/getRandomInt';
 import getRandomString from '../../../utils/getRandomString';
 import {waitForAlert} from '../../../utils/waitForAlert';
 import {generateObjectFields} from '../utils/generateObjectFields';
+import {getFreshObjectRelationshipName} from '../utils/getFreshObjectRelationshipName';
 
 export const test = mergeTests(
 	dataApiHelpersTest,
@@ -151,7 +152,10 @@ test.describe('Manage object relationships through Model Builder', () => {
 			label: {
 				en_US: 'objectRelationshipLabel' + getRandomInt(),
 			},
-			name: 'objectRelationshipName' + Math.floor(Math.random() * 99),
+			name: await getFreshObjectRelationshipName(apiHelpers, [
+				objectDefinition1.externalReferenceCode!,
+				objectDefinition2.externalReferenceCode!,
+			]),
 			objectDefinitionExternalReferenceCode1:
 				objectDefinition1.externalReferenceCode,
 			objectDefinitionExternalReferenceCode2:
@@ -333,8 +337,13 @@ test.describe('Manage object relationships through Model Builder', () => {
 
 		const objectRelationshipLabel =
 			'objectRelationshipLabel' + getRandomInt();
-		const objectRelationshipName =
-			'objectRelationshipName' + Math.floor(Math.random() * 99);
+		const objectRelationshipName = await getFreshObjectRelationshipName(
+			apiHelpers,
+			[
+				objectDefinition1.externalReferenceCode!,
+				objectDefinition2.externalReferenceCode!,
+			]
+		);
 
 		const objectRelationshipData: Partial<ObjectRelationship> = {
 			label: {
@@ -696,8 +705,10 @@ test.describe('Manage object relationships through Model Builder', () => {
 		];
 
 		for (const {label, type} of objectRelationshipDetails) {
-			const objectRelationshipName =
-				'objectRelationshipName' + Math.floor(Math.random() * 99);
+			const objectRelationshipName = await getFreshObjectRelationshipName(
+				apiHelpers,
+				[objectDefinition.externalReferenceCode!]
+			);
 			const objectRelationshipData: Partial<ObjectRelationship> = {
 				label: {
 					en_US: label,
@@ -798,8 +809,13 @@ test.describe('Manage object relationships through Model Builder', () => {
 
 		const objectRelationshipLabel =
 			'objectRelationshipLabel' + getRandomInt();
-		const objectRelationshipName =
-			'objectRelationshipName' + Math.floor(Math.random() * 99);
+		const objectRelationshipName = await getFreshObjectRelationshipName(
+			apiHelpers,
+			[
+				objectDefinition1.externalReferenceCode!,
+				objectDefinition2.externalReferenceCode!,
+			]
+		);
 
 		const objectRelationshipAPIClient = await apiHelpers.buildRestClient(
 			ObjectRelationshipAPI
@@ -916,8 +932,13 @@ test.describe('Manage object relationships through Model Builder', () => {
 
 		const objectRelationshipLabel =
 			'objectRelationshipLabel' + getRandomInt();
-		const objectRelationshipName =
-			'objectRelationshipName' + Math.floor(Math.random() * 99);
+		const objectRelationshipName = await getFreshObjectRelationshipName(
+			apiHelpers,
+			[
+				objectDefinition1.externalReferenceCode!,
+				objectDefinition2.externalReferenceCode!,
+			]
+		);
 
 		const objectRelationshipData: Partial<ObjectRelationship> = {
 			label: {
@@ -1026,9 +1047,10 @@ test.describe('Manage object relationships through Model Builder', () => {
 						label: {
 							en_US: 'objectRelationshipLabel' + getRandomInt(),
 						},
-						name:
-							'objectRelationshipName' +
-							Math.floor(Math.random() * 99),
+						name: await getFreshObjectRelationshipName(apiHelpers, [
+							objectDefinition1.externalReferenceCode!,
+							objectDefinition2.externalReferenceCode!,
+						]),
 						objectDefinitionExternalReferenceCode1:
 							objectDefinition1.externalReferenceCode,
 						objectDefinitionExternalReferenceCode2:
@@ -1116,8 +1138,13 @@ test.describe('Manage object relationships through Model Builder', () => {
 
 			const objectRelationshipLabel =
 				'objectRelationshipLabel' + getRandomInt();
-			const objectRelationshipName =
-				'objectRelationshipName' + Math.floor(Math.random() * 99);
+			const objectRelationshipName = await getFreshObjectRelationshipName(
+				apiHelpers,
+				[
+					objectDefinition1.externalReferenceCode!,
+					objectDefinition2.externalReferenceCode!,
+				]
+			);
 
 			const objectRelationshipAPIClient =
 				await apiHelpers.buildRestClient(ObjectRelationshipAPI);
@@ -1233,8 +1260,13 @@ test.describe('Manage object relationships through Model Builder', () => {
 
 		const objectRelationshipLabel =
 			'objectRelationshipLabel' + getRandomInt();
-		const objectRelationshipName =
-			'objectRelationshipName' + Math.floor(Math.random() * 99);
+		const objectRelationshipName = await getFreshObjectRelationshipName(
+			apiHelpers,
+			[
+				objectDefinition1.externalReferenceCode!,
+				objectDefinition2.externalReferenceCode!,
+			]
+		);
 
 		const objectRelationshipAPIClient = await apiHelpers.buildRestClient(
 			ObjectRelationshipAPI
@@ -1423,7 +1455,14 @@ test.describe('Manage object relationships through Objects Admin UI', () => {
 						'L_ACCOUNT',
 						{
 							label: {en_US: 'Relationship Account'},
-							name: 'relationshipAccount' + getRandomInt(),
+							name: await getFreshObjectRelationshipName(
+								apiHelpers,
+								[
+									'L_ACCOUNT',
+									objectDefinition.externalReferenceCode!,
+								],
+								'relationshipAccount'
+							),
 							objectDefinitionExternalReferenceCode1: 'L_ACCOUNT',
 							objectDefinitionExternalReferenceCode2:
 								objectDefinition.externalReferenceCode,
@@ -1595,7 +1634,10 @@ test.describe('Manage object relationships through Objects Admin UI', () => {
 			label: {
 				en_US: 'objectRelationshipLabel' + getRandomInt(),
 			},
-			name: 'objectRelationshipName' + Math.floor(Math.random() * 99),
+			name: await getFreshObjectRelationshipName(apiHelpers, [
+				'L_ACCOUNT',
+				objectDefinition.externalReferenceCode!,
+			]),
 			objectDefinitionExternalReferenceCode2:
 				objectDefinition.externalReferenceCode,
 			type: 'oneToMany',
@@ -1738,7 +1780,14 @@ test.describe('Manage object relationships through Objects Admin UI', () => {
 			});
 
 			const relationshipLabel = `Relationship${getRandomInt()}`;
-			const relationshipName = `relationship${getRandomInt()}`;
+			const relationshipName = await getFreshObjectRelationshipName(
+				apiHelpers,
+				[
+					objectDefinition1.externalReferenceCode!,
+					objectDefinition2.externalReferenceCode!,
+				],
+				'relationship'
+			);
 
 			await (
 				await apiHelpers.buildRestClient(ObjectRelationshipAPI)
@@ -1807,7 +1856,14 @@ test.describe('Manage object relationships through Objects Admin UI', () => {
 					objectDefinition1.externalReferenceCode,
 					{
 						label: {en_US: relationshipLabel},
-						name: `relationship${getRandomInt()}`,
+						name: await getFreshObjectRelationshipName(
+							apiHelpers,
+							[
+								objectDefinition1.externalReferenceCode!,
+								objectDefinition2.externalReferenceCode!,
+							],
+							'relationship'
+						),
 						objectDefinitionExternalReferenceCode2:
 							objectDefinition2.externalReferenceCode,
 						objectDefinitionId2: objectDefinition2.id,
@@ -1878,7 +1934,14 @@ test.describe('Manage object relationships through Objects Admin UI', () => {
 					objectDefinition1.externalReferenceCode,
 					{
 						label: {en_US: relationshipLabel},
-						name: `viewRelationship${getRandomInt()}`,
+						name: await getFreshObjectRelationshipName(
+							apiHelpers,
+							[
+								objectDefinition1.externalReferenceCode!,
+								objectDefinition2.externalReferenceCode!,
+							],
+							'viewRelationship'
+						),
 						objectDefinitionExternalReferenceCode2:
 							objectDefinition2.externalReferenceCode,
 						objectDefinitionId2: objectDefinition2.id,
@@ -1930,7 +1993,14 @@ test.describe('Manage object relationships through Objects Admin UI', () => {
 				await apiHelpers.buildRestClient(ObjectRelationshipAPI);
 
 			const relationshipLabel = `Relationship${getRandomInt()}`;
-			const relationshipName = `relationship${getRandomInt()}`;
+			const relationshipName = await getFreshObjectRelationshipName(
+				apiHelpers,
+				[
+					objectDefinition1.externalReferenceCode!,
+					objectDefinition2.externalReferenceCode!,
+				],
+				'relationship'
+			);
 
 			const {body: objectRelationship} =
 				await objectRelationshipAPIClient.postObjectDefinitionByExternalReferenceCodeObjectRelationship(
@@ -2034,7 +2104,11 @@ test.describe('Manage object relationships through Objects Admin UI', () => {
 					objectDefinition.externalReferenceCode,
 					{
 						label: {en_US: `Relationship${getRandomInt()}`},
-						name: `relationship${getRandomInt()}`,
+						name: await getFreshObjectRelationshipName(
+							apiHelpers,
+							[objectDefinition.externalReferenceCode!],
+							'relationship'
+						),
 						objectDefinitionExternalReferenceCode1:
 							objectDefinition.externalReferenceCode,
 						objectDefinitionExternalReferenceCode2:
@@ -2237,7 +2311,14 @@ test.describe('Manage object relationships through Objects Admin UI', () => {
 			const objectRelationshipAPIClient =
 				await apiHelpers.buildRestClient(ObjectRelationshipAPI);
 
-			const relationshipName = `relationship${getRandomInt()}`;
+			const relationshipName = await getFreshObjectRelationshipName(
+				apiHelpers,
+				[
+					objectDefinition1.externalReferenceCode!,
+					objectDefinition2.externalReferenceCode!,
+				],
+				'relationship'
+			);
 
 			await objectRelationshipAPIClient.postObjectDefinitionByExternalReferenceCodeObjectRelationship(
 				objectDefinition1.externalReferenceCode,
@@ -2442,7 +2523,14 @@ test.describe('Manage object relationships through Objects Admin UI', () => {
 					objectDefinition1.externalReferenceCode,
 					{
 						label: {en_US: `Relationship${getRandomInt()}`},
-						name: `relationship${getRandomInt()}`,
+						name: await getFreshObjectRelationshipName(
+							apiHelpers,
+							[
+								objectDefinition1.externalReferenceCode!,
+								objectDefinition2.externalReferenceCode!,
+							],
+							'relationship'
+						),
 						objectDefinitionExternalReferenceCode2:
 							objectDefinition2.externalReferenceCode,
 						objectDefinitionId2: objectDefinition2.id,
@@ -2558,7 +2646,14 @@ test.describe('Manage object relationships through Objects Admin UI', () => {
 					objectDefinition1.externalReferenceCode,
 					{
 						label: {en_US: `Relationship${getRandomInt()}`},
-						name: `relationship${getRandomInt()}`,
+						name: await getFreshObjectRelationshipName(
+							apiHelpers,
+							[
+								objectDefinition1.externalReferenceCode!,
+								objectDefinition2.externalReferenceCode!,
+							],
+							'relationship'
+						),
 						objectDefinitionExternalReferenceCode2:
 							objectDefinition2.externalReferenceCode,
 						objectDefinitionId2: objectDefinition2.id,
@@ -2629,7 +2724,14 @@ test.describe('Manage object relationships through Objects Admin UI', () => {
 				const objectRelationshipAPIClient =
 					await apiHelpers.buildRestClient(ObjectRelationshipAPI);
 
-				relationshipName = 'relationship' + getRandomInt();
+				relationshipName = await getFreshObjectRelationshipName(
+					apiHelpers,
+					[
+						objectDefinition1.externalReferenceCode!,
+						objectDefinition2.externalReferenceCode!,
+					],
+					'relationship'
+				);
 
 				await objectRelationshipAPIClient.postObjectDefinitionByExternalReferenceCodeObjectRelationship(
 					objectDefinition1.externalReferenceCode!,
@@ -2753,8 +2855,10 @@ test.describe('Manage object relationships with system objects', () => {
 			const objectRelationshipAPIClient =
 				await apiHelpers.buildRestClient(ObjectRelationshipAPI);
 
-			const objectRelationshipName =
-				'objectRelationshipName' + Math.floor(Math.random() * 99);
+			const objectRelationshipName = await getFreshObjectRelationshipName(
+				apiHelpers,
+				[objectDefinition.externalReferenceCode!, 'L_USER']
+			);
 
 			const {body: objectRelationship} =
 				await objectRelationshipAPIClient.postObjectDefinitionByExternalReferenceCodeObjectRelationship(
@@ -2935,7 +3039,11 @@ test.describe('Manage object relationships with system objects', () => {
 					await apiHelpers.buildRestClient(ObjectRelationshipAPI);
 
 				relationshipLabel = 'Relationship' + getRandomInt();
-				relationshipName = 'relationship' + getRandomInt();
+				relationshipName = await getFreshObjectRelationshipName(
+					apiHelpers,
+					['L_USER', objectDefinition.externalReferenceCode!],
+					'relationship'
+				);
 
 				const {body: objectRelationship} =
 					await objectRelationshipAPIClient.postObjectDefinitionByExternalReferenceCodeObjectRelationship(
@@ -3036,8 +3144,10 @@ test.describe('Manage object relationships with system objects', () => {
 			const objectRelationshipAPIClient =
 				await apiHelpers.buildRestClient(ObjectRelationshipAPI);
 
-			const objectRelationshipName =
-				'objectRelationshipName' + Math.floor(Math.random() * 99);
+			const objectRelationshipName = await getFreshObjectRelationshipName(
+				apiHelpers,
+				[objectDefinition.externalReferenceCode!, 'L_USER']
+			);
 
 			const {body: objectRelationship} =
 				await objectRelationshipAPIClient.postObjectDefinitionByExternalReferenceCodeObjectRelationship(
@@ -3209,7 +3319,11 @@ test.describe('Manage object relationships with system objects', () => {
 					'L_USER',
 					{
 						label: {en_US: relationshipLabel},
-						name: 'relationship' + getRandomInt(),
+						name: await getFreshObjectRelationshipName(
+							apiHelpers,
+							['L_USER', objectDefinition.externalReferenceCode!],
+							'relationship'
+						),
 						objectDefinitionExternalReferenceCode2:
 							objectDefinition.externalReferenceCode,
 						objectDefinitionId2: objectDefinition.id,
@@ -3290,7 +3404,14 @@ test.describe('Manage object relationship entries', () => {
 						objectDefinition1.externalReferenceCode,
 						{
 							label: {en_US: 'Relationship'},
-							name: 'relationship' + getRandomInt(),
+							name: await getFreshObjectRelationshipName(
+								apiHelpers,
+								[
+									objectDefinition1.externalReferenceCode!,
+									objectDefinition2.externalReferenceCode!,
+								],
+								'relationship'
+							),
 							objectDefinitionExternalReferenceCode1:
 								objectDefinition1.externalReferenceCode,
 							objectDefinitionExternalReferenceCode2:
@@ -3483,8 +3604,13 @@ test.describe('Manage object relationship entries', () => {
 			const objectRelationshipAPIClient =
 				await apiHelpers.buildRestClient(ObjectRelationshipAPI);
 
-			const objectRelationshipName =
-				'objectRelationshipName' + Math.floor(Math.random() * 99);
+			const objectRelationshipName = await getFreshObjectRelationshipName(
+				apiHelpers,
+				[
+					objectDefinition1.externalReferenceCode!,
+					objectDefinition2.externalReferenceCode!,
+				]
+			);
 
 			const {body: objectRelationship} =
 				await objectRelationshipAPIClient.postObjectDefinitionByExternalReferenceCodeObjectRelationship(
@@ -3642,8 +3768,10 @@ test.describe('Manage object relationship entries', () => {
 			const objectRelationshipAPIClient =
 				await apiHelpers.buildRestClient(ObjectRelationshipAPI);
 
-			const objectRelationshipName =
-				'objectRelationshipName' + Math.floor(Math.random() * 99);
+			const objectRelationshipName = await getFreshObjectRelationshipName(
+				apiHelpers,
+				[objectDefinition.externalReferenceCode!]
+			);
 
 			const {body: objectRelationship} =
 				await objectRelationshipAPIClient.postObjectDefinitionByExternalReferenceCodeObjectRelationship(
@@ -3819,8 +3947,10 @@ test.describe('Manage object relationship entries', () => {
 			const objectRelationshipAPIClient =
 				await apiHelpers.buildRestClient(ObjectRelationshipAPI);
 
-			const objectRelationshipName =
-				'objectRelationshipName' + Math.floor(Math.random() * 99);
+			const objectRelationshipName = await getFreshObjectRelationshipName(
+				apiHelpers,
+				[objectDefinition.externalReferenceCode!]
+			);
 
 			const {body: objectRelationship} =
 				await objectRelationshipAPIClient.postObjectDefinitionByExternalReferenceCodeObjectRelationship(
@@ -3965,7 +4095,11 @@ test.describe('Manage object relationship entries', () => {
 						objectDefinition.externalReferenceCode,
 						{
 							label: {en_US: 'Relationship'},
-							name: 'relationship' + getRandomInt(),
+							name: await getFreshObjectRelationshipName(
+								apiHelpers,
+								[objectDefinition.externalReferenceCode!],
+								'relationship'
+							),
 							objectDefinitionExternalReferenceCode1:
 								objectDefinition.externalReferenceCode,
 							objectDefinitionExternalReferenceCode2:
@@ -4038,7 +4172,11 @@ test.describe('Manage object relationship entries', () => {
 						objectDefinition.externalReferenceCode,
 						{
 							label: {en_US: 'Relationship'},
-							name: 'relationship' + getRandomInt(),
+							name: await getFreshObjectRelationshipName(
+								apiHelpers,
+								[objectDefinition.externalReferenceCode!],
+								'relationship'
+							),
 							objectDefinitionExternalReferenceCode1:
 								objectDefinition.externalReferenceCode,
 							objectDefinitionExternalReferenceCode2:
@@ -4300,8 +4438,10 @@ test.describe('Manage object relationship entries', () => {
 			const objectRelationshipAPIClient =
 				await apiHelpers.buildRestClient(ObjectRelationshipAPI);
 
-			const objectRelationshipName =
-				'objectRelationshipName' + Math.floor(Math.random() * 99);
+			const objectRelationshipName = await getFreshObjectRelationshipName(
+				apiHelpers,
+				[objectDefinition.externalReferenceCode!]
+			);
 
 			const {body: objectRelationship} =
 				await objectRelationshipAPIClient.postObjectDefinitionByExternalReferenceCodeObjectRelationship(
@@ -4386,7 +4526,14 @@ test.describe('Manage object relationship entries', () => {
 						{
 							deletionType: 'disassociate',
 							label: {en_US: 'Relationship'},
-							name: 'relationship' + getRandomInt(),
+							name: await getFreshObjectRelationshipName(
+								apiHelpers,
+								[
+									objectDefinition1.externalReferenceCode!,
+									objectDefinition2.externalReferenceCode!,
+								],
+								'relationship'
+							),
 							objectDefinitionExternalReferenceCode1:
 								objectDefinition1.externalReferenceCode,
 							objectDefinitionExternalReferenceCode2:
@@ -4546,7 +4693,14 @@ test.describe('Manage object relationship entries', () => {
 						objectDefinition1.externalReferenceCode,
 						{
 							label: {en_US: 'Relationship' + getRandomInt()},
-							name: 'relationship' + getRandomInt(),
+							name: await getFreshObjectRelationshipName(
+								apiHelpers,
+								[
+									objectDefinition1.externalReferenceCode!,
+									objectDefinition2.externalReferenceCode!,
+								],
+								'relationship'
+							),
 							objectDefinitionExternalReferenceCode1:
 								objectDefinition1.externalReferenceCode,
 							objectDefinitionExternalReferenceCode2:
@@ -4796,7 +4950,14 @@ test.describe('Manage object relationship entries', () => {
 					objectDefinition1.externalReferenceCode,
 					{
 						label: {en_US: 'Relationship' + getRandomInt()},
-						name: 'relationship' + getRandomInt(),
+						name: await getFreshObjectRelationshipName(
+							apiHelpers,
+							[
+								objectDefinition1.externalReferenceCode!,
+								objectDefinition2.externalReferenceCode!,
+							],
+							'relationship'
+						),
 						objectDefinitionExternalReferenceCode1:
 							objectDefinition1.externalReferenceCode,
 						objectDefinitionExternalReferenceCode2:
@@ -4904,7 +5065,14 @@ test.describe('Manage object relationship entries', () => {
 					objectDefinition1.externalReferenceCode,
 					{
 						label: {en_US: 'Relationship'},
-						name: 'relationship' + getRandomInt(),
+						name: await getFreshObjectRelationshipName(
+							apiHelpers,
+							[
+								objectDefinition1.externalReferenceCode!,
+								objectDefinition2.externalReferenceCode!,
+							],
+							'relationship'
+						),
 						objectDefinitionExternalReferenceCode1:
 							objectDefinition1.externalReferenceCode,
 						objectDefinitionExternalReferenceCode2:
@@ -5067,7 +5235,14 @@ test.describe('Manage object relationship entries', () => {
 					objectDefinition1.externalReferenceCode,
 					{
 						label: {en_US: 'Relationship'},
-						name: 'relationship' + getRandomInt(),
+						name: await getFreshObjectRelationshipName(
+							apiHelpers,
+							[
+								objectDefinition1.externalReferenceCode!,
+								objectDefinition2.externalReferenceCode!,
+							],
+							'relationship'
+						),
 						objectDefinitionExternalReferenceCode1:
 							objectDefinition1.externalReferenceCode,
 						objectDefinitionExternalReferenceCode2:
@@ -5280,8 +5455,10 @@ test.describe('View relationship hierarchy labels', () => {
 			const objectRelationshipAPIClient =
 				await apiHelpers.buildRestClient(ObjectRelationshipAPI);
 
-			const objectRelationshipName =
-				'objectRelationshipName' + Math.floor(Math.random() * 99);
+			const objectRelationshipName = await getFreshObjectRelationshipName(
+				apiHelpers,
+				[objectDefinition.externalReferenceCode!]
+			);
 
 			const {body: objectRelationship} =
 				await objectRelationshipAPIClient.postObjectDefinitionByExternalReferenceCodeObjectRelationship(

--- a/modules/test/playwright/tests/object-web/utils/getFreshObjectRelationshipName.ts
+++ b/modules/test/playwright/tests/object-web/utils/getFreshObjectRelationshipName.ts
@@ -1,0 +1,74 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {ObjectRelationshipAPI} from '@liferay/object-admin-rest-client-js';
+
+import {DataApiHelpers} from '../../../helpers/ApiHelpers';
+import {getRandomInt} from '../../../utils/getRandomInt';
+
+/**
+ * Returns a relationship name that is free on both definitions the
+ * relationship will connect. Relationship names are unique per definition, on
+ * both sides, because the reverse relationship carries the same name, and on
+ * a shared system definition the namespace also holds every other test's
+ * relationships and every leftover a crashed run left behind. The name is
+ * drawn from a ten digit space and each definition is asked whether it is
+ * taken, drawing again until it is not, so a collision with anything already
+ * persisted is impossible. Two callers drawing in the same moment can still
+ * race each other, and for that window the create's own duplicate refusal
+ * remains the arbiter, being the only atomic claim.
+ *
+ * Use this for every relationship name a test creates.
+ */
+export async function getFreshObjectRelationshipName(
+	apiHelpers: DataApiHelpers,
+	objectDefinitionExternalReferenceCodes: string[],
+	prefix: string = 'objectRelName'
+): Promise<string> {
+
+	// The name becomes part of a database column, so the validator holds it
+	// to a hard budget that the ten digits must fit inside as well.
+
+	if (prefix.length > 21) {
+		throw new Error(
+			`Prefix "${prefix}" is too long for a relationship name: the ` +
+				`ten digit draw needs the name to stay within thirty one ` +
+				`characters, so the prefix can hold at most twenty one`
+		);
+	}
+
+	const objectRelationshipAPIClient = await apiHelpers.buildRestClient(
+		ObjectRelationshipAPI
+	);
+
+	for (;;) {
+		const objectRelationshipName = prefix + getRandomInt();
+
+		let taken = false;
+
+		for (const externalReferenceCode of objectDefinitionExternalReferenceCodes) {
+			const {body} =
+				await objectRelationshipAPIClient.getObjectDefinitionByExternalReferenceCodeObjectRelationshipsPage(
+					externalReferenceCode,
+					undefined,
+					undefined,
+					undefined,
+					objectRelationshipName
+				);
+
+			if (
+				body.items?.some((item) => item.name === objectRelationshipName)
+			) {
+				taken = true;
+
+				break;
+			}
+		}
+
+		if (!taken) {
+			return objectRelationshipName;
+		}
+	}
+}

--- a/modules/test/playwright/tests/object-web/validation/objectValidation.spec.ts
+++ b/modules/test/playwright/tests/object-web/validation/objectValidation.spec.ts
@@ -27,6 +27,7 @@ import getRandomString from '../../../utils/getRandomString';
 import {journalPagesTest} from '../../journal-web/main/fixtures/journalPagesTest';
 import getFormContainerDefinition from '../../layout-content-page-editor-web/main/utils/getFormContainerDefinition';
 import getPageDefinition from '../../layout-content-page-editor-web/main/utils/getPageDefinition';
+import {getFreshObjectRelationshipName} from '../utils/getFreshObjectRelationshipName';
 
 export const test = mergeTests(
 	apiHelpersTest,
@@ -1583,8 +1584,13 @@ test.describe('Object Unique Composite Key Validation', () => {
 		const integerFieldName = 'integerField' + getRandomInt();
 		const objectRelationshipLabel =
 			'objectRelationshipLabel' + getRandomInt();
-		const objectRelationshipName =
-			'objectRelationshipName' + Math.floor(Math.random() * 99);
+		const objectRelationshipName = await getFreshObjectRelationshipName(
+			apiHelpers,
+			[
+				objectDefinition2.externalReferenceCode!,
+				objectDefinition1.externalReferenceCode!,
+			]
+		);
 		const picklistFieldName = 'picklistField' + getRandomInt();
 
 		const objectFieldAPIClient =

--- a/modules/test/playwright/tests/object-web/view/objectView.spec.ts
+++ b/modules/test/playwright/tests/object-web/view/objectView.spec.ts
@@ -21,6 +21,7 @@ import getRandomString from '../../../utils/getRandomString';
 import {waitForAlert} from '../../../utils/waitForAlert';
 import {generateObjectEntryValues} from '../utils/generateObjectEntry';
 import {generateObjectFields} from '../utils/generateObjectFields';
+import {getFreshObjectRelationshipName} from '../utils/getFreshObjectRelationshipName';
 
 export const test = mergeTests(
 	globalMenuPagesTest,
@@ -688,9 +689,10 @@ test(
 					label: {
 						en_US: 'objectRelationshipLabel' + getRandomInt(),
 					},
-					name:
-						'objectRelationshipName' +
-						Math.floor(Math.random() * 99),
+					name: await getFreshObjectRelationshipName(apiHelpers, [
+						'L_ACCOUNT',
+						objectDefinition.externalReferenceCode!,
+					]),
 					objectDefinitionExternalReferenceCode1: 'L_ACCOUNT',
 					objectDefinitionExternalReferenceCode2:
 						objectDefinition.externalReferenceCode,
@@ -786,9 +788,10 @@ test(
 					label: {
 						en_US: 'objectRelationshipLabel' + getRandomInt(),
 					},
-					name:
-						'objectRelationshipName' +
-						Math.floor(Math.random() * 99),
+					name: await getFreshObjectRelationshipName(apiHelpers, [
+						objectDefinition1.externalReferenceCode!,
+						objectDefinition2.externalReferenceCode!,
+					]),
 					objectDefinitionExternalReferenceCode1:
 						objectDefinition1.externalReferenceCode,
 					objectDefinitionExternalReferenceCode2:
@@ -875,7 +878,10 @@ test('can create an object custom view using object relationship entry', async (
 				label: {
 					en_US: 'objectRelationshipLabel' + getRandomInt(),
 				},
-				name: 'objectRelationshipName' + Math.floor(Math.random() * 99),
+				name: await getFreshObjectRelationshipName(apiHelpers, [
+					objectDefinition1.externalReferenceCode!,
+					objectDefinition2.externalReferenceCode!,
+				]),
 				objectDefinitionExternalReferenceCode1:
 					objectDefinition1.externalReferenceCode,
 				objectDefinitionExternalReferenceCode2:
@@ -1034,9 +1040,10 @@ test(
 					label: {
 						en_US: 'objectRelationshipLabel' + getRandomInt(),
 					},
-					name:
-						'objectRelationshipName' +
-						Math.floor(Math.random() * 99),
+					name: await getFreshObjectRelationshipName(apiHelpers, [
+						'L_USER',
+						objectDefinition.externalReferenceCode!,
+					]),
 					objectDefinitionExternalReferenceCode1: 'L_USER',
 					objectDefinitionExternalReferenceCode2:
 						objectDefinition.externalReferenceCode,
@@ -1261,9 +1268,10 @@ test(
 					label: {
 						en_US: 'objectRelationshipLabel' + getRandomInt(),
 					},
-					name:
-						'objectRelationshipName' +
-						Math.floor(Math.random() * 99),
+					name: await getFreshObjectRelationshipName(apiHelpers, [
+						'L_USER',
+						objectDefinition.externalReferenceCode!,
+					]),
 					objectDefinitionExternalReferenceCode1: 'L_USER',
 					objectDefinitionExternalReferenceCode2:
 						objectDefinition.externalReferenceCode,
@@ -1628,9 +1636,10 @@ test(
 					label: {
 						en_US: 'objectRelationshipLabel' + getRandomInt(),
 					},
-					name:
-						'objectRelationshipName' +
-						Math.floor(Math.random() * 99),
+					name: await getFreshObjectRelationshipName(apiHelpers, [
+						'L_USER',
+						objectDefinition.externalReferenceCode!,
+					]),
 					objectDefinitionExternalReferenceCode1: 'L_USER',
 					objectDefinitionExternalReferenceCode2:
 						objectDefinition.externalReferenceCode,
@@ -2034,9 +2043,10 @@ test(
 					label: {
 						en_US: 'objectRelationshipLabel' + getRandomInt(),
 					},
-					name:
-						'objectRelationshipName' +
-						Math.floor(Math.random() * 99),
+					name: await getFreshObjectRelationshipName(apiHelpers, [
+						objectDefinitionA.externalReferenceCode!,
+						objectDefinitionB.externalReferenceCode!,
+					]),
 					objectDefinitionExternalReferenceCode1:
 						objectDefinitionA.externalReferenceCode,
 					objectDefinitionExternalReferenceCode2:
@@ -2926,7 +2936,14 @@ test(
 				objectDefinitionA.externalReferenceCode,
 				{
 					label: {en_US: 'Relationship A' + getRandomInt()},
-					name: 'relationshipA' + getRandomInt(),
+					name: await getFreshObjectRelationshipName(
+						apiHelpers,
+						[
+							objectDefinitionA.externalReferenceCode!,
+							objectDefinitionC.externalReferenceCode!,
+						],
+						'relationshipA'
+					),
 					objectDefinitionExternalReferenceCode1:
 						objectDefinitionA.externalReferenceCode,
 					objectDefinitionExternalReferenceCode2:
@@ -2948,7 +2965,14 @@ test(
 				objectDefinitionB.externalReferenceCode,
 				{
 					label: {en_US: 'Relationship B' + getRandomInt()},
-					name: 'relationshipB' + getRandomInt(),
+					name: await getFreshObjectRelationshipName(
+						apiHelpers,
+						[
+							objectDefinitionB.externalReferenceCode!,
+							objectDefinitionC.externalReferenceCode!,
+						],
+						'relationshipB'
+					),
 					objectDefinitionExternalReferenceCode1:
 						objectDefinitionB.externalReferenceCode,
 					objectDefinitionExternalReferenceCode2:


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102998

## What Is Being Fixed

Object relationship names were drawn as `prefix + Math.floor(Math.random() * 99)` in whatever style each test was born with. Two draws on one definition collide ~1/100 runs (`HTTP 409: There is already an object relationship with this name`); on shared system definitions (L_USER, L_ACCOUNT) the 99-name space also collides between tests and with crashed-run leftovers. Seventeen tests draw two names each; names are unique per definition on **both** sides (the reverse relationship carries the same name). Per-site styles left future authors guessing which pattern to copy.

Root cause: `9b36c8fe4f9bd` introduced the 99-value draw for a single site that couldn't self-collide; every later migration copied it — `4467439bbfc4a` into a two-draw loop that could; the bulk arrived in the LPD-85191 subproject migrations.

## How It Is Being Fixed

One stop: `getFreshObjectRelationshipName` draws from a ten-digit space, asks **both** definitions whether the name is taken and redraws until free (collision with anything persisted is impossible), and refuses a prefix the name budget cannot hold — teaching the limit at authoring time. Two callers drawing in the same moment remain the create's own duplicate refusal's job, the only atomic claim. All 83 draw sites across the nine object specs converted; fixed literal names stay fixed (one is CSS-selector-encoded).

## PR Check

| Validation | Result |
|---|---|
| Source Format | ✅ passed |
| Local: all 76 converted-site tests in one batch (1 known unrelated flake, 3/3 on rerun) | ✅ passed |
| CI: full object batch on this branch alone — 0 unexpected, 0 name-collision faces | ✅ passed |

<!-- pr-check {"result": "success", "sha": "5286dbbf1ae95e3cdf221444d5b6122a63273102"} -->
