### PR TITLE
LPD-102999 Settle the details form before typing at the remaining sites

### DIFF
--- a/modules/test/playwright/tests/object-web/main/objectDefinition.spec.ts
+++ b/modules/test/playwright/tests/object-web/main/objectDefinition.spec.ts
@@ -1214,6 +1214,8 @@ test.describe('Manage object definitions through View Object Definitions', () =>
 
 		await editObjectDetailsPage.goToDetailsTab();
 
+		await editObjectDetailsPage.waitForDetailsFormLoaded();
+
 		await editObjectDetailsPage.selectLabelLanguage('pt_BR');
 
 		await editObjectDetailsPage.labelInput.fill(label);
@@ -1317,6 +1319,8 @@ test.describe('Manage object definitions through View Object Definitions', () =>
 
 		await editObjectDetailsPage.goToDetailsTab();
 
+		await editObjectDetailsPage.waitForDetailsFormLoaded();
+
 		await expect(editObjectDetailsPage.nameInput).toBeDisabled();
 		await expect(editObjectDetailsPage.scopeCombobox).toBeDisabled();
 
@@ -1374,6 +1378,8 @@ test.describe('Manage object definitions through View Object Definitions', () =>
 		await editObjectDetailsPage.goto(objectDefinition.label['en_US']);
 
 		await editObjectDetailsPage.goToDetailsTab();
+
+		await editObjectDetailsPage.waitForDetailsFormLoaded();
 
 		await editObjectDetailsPage.labelInput.fill(label);
 		await editObjectDetailsPage.pluralLabelInput.fill(pluralLabel);
@@ -1509,6 +1515,8 @@ test.describe('Manage object definitions through View Object Definitions', () =>
 		await editObjectDetailsPage.goto(objectDefinition.label['en_US']);
 
 		await editObjectDetailsPage.goToDetailsTab();
+
+		await editObjectDetailsPage.waitForDetailsFormLoaded();
 
 		const label = 'UpdatedLabel' + getRandomInt();
 
@@ -2015,6 +2023,8 @@ test.describe('Manage object definitions through View Object Definitions', () =>
 			await editObjectDetailsPage.goto(objectDefinition.label['en_US']);
 
 			await editObjectDetailsPage.goToDetailsTab();
+
+			await editObjectDetailsPage.waitForDetailsFormLoaded();
 
 			await editObjectDetailsPage.labelInput.fill(newLabel);
 			await editObjectDetailsPage.pluralLabelInput.fill(newPluralLabel);

--- a/modules/test/playwright/tests/object-web/upgrade/objectUpgrade.spec.ts
+++ b/modules/test/playwright/tests/object-web/upgrade/objectUpgrade.spec.ts
@@ -88,6 +88,8 @@ test.describe.serial('View Custom Object1 after upgrade', () => {
 		});
 
 		await test.step('Edit object definition details', async () => {
+			await editObjectDetailsPage.waitForDetailsFormLoaded();
+
 			await editObjectDetailsPage.labelInput.fill(
 				'Custom Object1 Updated'
 			);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102999

## What Is Being Fixed

Tests typing into the object-definition details form right after opening it intermittently save the **original** values away behind a success alert. The form renders filled and interactive from JSP props, but a redundant mount fetch later **merges the persisted definition over the form state** — a fill landing before the merge is silently reverted, and Save (held disabled until that fetch, per LPD-65515) then writes the reverted values. LPD-102867 gated the observed victim; five sibling sites in objectDefinition.spec and one in objectUpgrade.spec carry the same window (the toggle face of this exact mechanism was caught live as inverted PUT bodies in a CI trace this week).

Root cause: the class pair — `2a21a6079b4ee` (LPS-162430) created the mount fetch merging over live fields; `a53240b9c397e` (LPD-65515) made the loss deterministic by holding Save until the fetch lands.

## How It Is Being Fixed

Gate each site with the existing `waitForDetailsFormLoaded()` before typing — a pure ownership wait on the form's readiness contract (Save-enabled ⇒ the overwrite pass already happened). Deliberately not folded into the shared tab helper (27 callers incl. read-only users, for whom Save never enables). The upgrade-spec site is its own commit: the upgrade project only runs on CI's upgraded-database fixture, so that commit stays independently droppable and its CI axis is its only possible leg.

## PR Check

| Validation | Result |
|---|---|
| Source Format | ✅ passed |
| Local: five objectDefinition targets in one batch | ✅ passed |
| Full-batch aggregate rides (AGG23–24 ×5) incl. the upgrade axis | ✅ passed |

<!-- pr-check {"result": "success", "sha": "3d7a878b0476630b01e9a68ec5a33159b853c1ef"} -->
