### PR TITLE
LPD-103000 Await the relationship modal assertions the Address test makes

### DIFF
--- a/modules/test/playwright/tests/object-web/relationship/objectRelationship.spec.ts
+++ b/modules/test/playwright/tests/object-web/relationship/objectRelationship.spec.ts
@@ -95,7 +95,7 @@ test.describe('Manage object relationships through Model Builder', () => {
 					commerceOrderDefinition.id
 				);
 
-				expect(
+				await expect(
 					addNewObjectRelationshipModalPage.modalHeader
 				).toBeVisible();
 			});
@@ -108,7 +108,7 @@ test.describe('Manage object relationships through Model Builder', () => {
 					customPostalAddressDefinition.id
 				);
 
-				expect(
+				await expect(
 					addNewObjectRelationshipModalPage.modalHeader
 				).toBeVisible();
 			});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103000

## What Is Being Fixed

The Address relationship test asserts twice that the add-relationship modal opened after a connect drag — and neither assertion is awaited. Both are dropped promises that assert nothing; the test only ever proved the drags didn't throw, while its steps claim to verify the modal.

Root cause: born this way — `209781c6e583b` (LPD-51156) wrote both assertions without the await.

## How It Is Being Fixed

Await both assertions, so the test checks what its steps say it checks. Nothing else changes. Since awaiting a formerly floating assertion can expose a latently failing check, the awaited form was validated first: fresh local pass on the final bytes, the whole-set batches, and four full-batch aggregate rides — the modal genuinely opens and the assertions pass when actually executed.

## PR Check

| Validation | Result |
|---|---|
| Source Format | ✅ passed |
| Local target (fresh + batches) | ✅ passed |
| Full-batch aggregate rides (AGG24 ×4), target quiet | ✅ passed |

<!-- pr-check {"result": "success", "sha": "06f9f1064ffe9535b8f718a3b43d327338720d60"} -->
