### PR TITLE
LPD-103001 Wait for the import to answer before timing its modal

### DIFF
--- a/modules/test/playwright/pages/object-web/ViewObjectDefinitionsPage.ts
+++ b/modules/test/playwright/pages/object-web/ViewObjectDefinitionsPage.ts
@@ -240,6 +240,13 @@ export class ViewObjectDefinitionsPage {
 			.getByRole('button', {exact: true, name: 'Import'})
 			.click();
 
+		// The import is done when the listing request behind it answers, and a
+		// definition carrying many fields can take longer to import than the
+		// modal is given to disappear below. Wait for that answer first, so the
+		// modal is only timed once the work it is covering has finished.
+
+		const response = await responsePromise;
+
 		await this.page
 			.locator('.modal-body')
 			.waitFor({state: 'hidden', timeout: 10000});
@@ -249,8 +256,6 @@ export class ViewObjectDefinitionsPage {
 				hasText: 'The object definition failed to import.',
 			})
 		).toBeHidden();
-
-		const response = await responsePromise;
 
 		const {items} = await response.json();
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103001

## What Is Being Fixed

Importing an object definition intermittently fails with the import modal still on screen: the helper waits for the modal to disappear within 10s and only **afterwards** awaits the listing response that signals the import finished — a definition carrying many fields outlives the bound, and the test fails on a wait that was never measuring the import. CI recorded both halves in one run: the listing request answered at **11.16s**; the modal wait gave up at **10.04s**.

Root cause: born this way — `488684e39ac50` (LPD-82332) wrote the helper with the modal wait ahead of the response await from creation, carrying its ancestor's ordering from when definitions were small enough that the bound was never hit.

## How It Is Being Fixed

A reorder — no new waits, no changed budgets: await the response first, then time the modal. The import is owned by its own signal with no arbitrary bound; the 10s times only what it was meant to time (modal dismissal after the work is done).

## PR Check

| Validation | Result |
|---|---|
| Source Format | ✅ passed |
| Local: heaviest import path fresh + whole-set batch | ✅ passed |
| Full-batch aggregate rides (AGG24 ×4), import tests quiet | ✅ passed |

<!-- pr-check {"result": "success", "sha": "6c1001fa3d3ef6bd5cf301bf531ab461db576b4a"} -->
