### PR TITLE
LPD-103003 Skip the order address update when a group deletion is in process

### DIFF
--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/model/listener/AddressModelListener.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/model/listener/AddressModelListener.java
@@ -13,6 +13,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Address;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.ModelListener;
+import com.liferay.portal.kernel.util.GroupThreadLocal;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -41,6 +42,10 @@ public class AddressModelListener extends BaseModelListener<Address> {
 
 	@Override
 	public void onBeforeRemove(Address address) throws ModelListenerException {
+		if (GroupThreadLocal.isDeleteInProcess()) {
+			return;
+		}
+
 		try (SafeCloseable safeCloseable =
 				CTCollectionThreadLocal.setProductionModeWithSafeCloseable()) {
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103003

## What Is Being Fixed

`PortalLogAssertorTest` fails whole modules-integration batches on the `NoSuchGroupException` ERROR the data-guard sweep logs after every `ObjectActionLocalServiceTest` run. Instrumenting the sweep's silent fallback captured the real chain: **deleting a commerce channel is a circular data dependency** that cannot complete while the channel has orders with addresses — the channel deletes its own row, then its group; the group's listener deletes the channel's orders; deleting an order deletes its addresses; and the address listener updates the order to drop the address, which **re-reads the channel whose row died at the first step** (`NoSuchChannelException`, deterministic rollback). The sweep's raw fallback then orphans the orders/items, and deleting the leftover items later walks to the long-deleted group — the logged ERROR. Beyond CI: an admin deleting a channel that has orders-with-addresses hits the same rollback.

Root cause: born this way — `6c97ed22c6608` (LPS-161574) moved the order-address update into this listener to break a **code**-level circular dependency, closing this **data**-level one; `e63c5a6e4480c` (LPD-96741) made it a constant CI failure via the method-scope data guard.

## How It Is Being Fixed

Dissolve the cycle at its weakest edge: the listener returns early when `GroupThreadLocal.isDeleteInProcess()` — the flag `deleteGroup` sets before its listeners run. Clearing a deleted address off its orders is pointless while the surrounding group deletion is dismantling those very orders. The channel's cascade then completes through the proper services; no test change.

## PR Check

| Validation | Result |
|---|---|
| Source Format | ✅ passed |
| Deterministic before/after on identical unmodified test bytes: old module 2×ERROR per run → fixed module 0 ERRORs, 0 leftovers, tests pass | ✅ passed |

<!-- pr-check {"result": "success", "sha": "a1e2508c5fe214aa1b5b24848074b14a2b96e466"} -->
