### PR TITLE
LPD-103004 Assert the persisted status before reading the published list

### DIFF
--- a/modules/apps/object/object-test/src/testFunctional/tests/CreateObject.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/CreateObject.testcase
@@ -178,7 +178,39 @@ definition {
 
 		PortletEntry.publish();
 
+		// The publish answers through the browser, so read the persisted
+		// status back over the API before touching the list: a Draft here
+		// means the publish itself was lost, and an Approved here with a
+		// missing row after points at the list's rendering instead. The raw
+		// answer is echoed before any parsing, so a refused or empty answer
+		// names itself instead of dying inside the path lookup.
+
+		var portalURL = JSONCompany.getPortalURL();
+		var userPassword = PropsUtil.get("default.admin.password");
+
+		var curl = '''
+			${portalURL}/o/object-admin/v1.0/object-definitions?filter=name%20eq%20%27CustomObject73%27 \
+				-u test@liferay.com:${userPassword} \
+				-H accept:application/json
+		''';
+
+		var objectDefinitionsResponse = JSONCurlUtil.get(${curl});
+
+		echo("Object definitions answer after publish: ${objectDefinitionsResponse}");
+
+		var objectDefinitionStatus = JSONCurlUtil.get(${curl}, "$.items[0].status.label");
+
+		echo("Persisted status after publish: ${objectDefinitionStatus}");
+
+		TestUtils.assertEquals(
+			actual = ${objectDefinitionStatus},
+			expected = "approved");
+
 		ObjectAdmin.openObjectAdmin();
+
+		while ((IsElementNotPresent(key_label = "Custom Object 73", locator1 = "ObjectAdmin#OBJECT_STATUS")) && (maxIterations = "10")) {
+			Refresh();
+		}
 
 		AssertTextEquals(
 			key_label = "Custom Object 73",


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103004

## What Is Being Fixed

`CreateObject#CanPublishObjectWithPublishPermission` is a two-year intermittent: it publishes through the browser and reads the row's status off the reopened Object Admin list, and on CI the row is intermittently absent. A reload loop alone was **refuted** on an aggregate run — ten fresh loads still lacked the row, so the absence is persistent for that run, not a torn fetch. The old failure fired ~20s downstream at a list faithfully rendering the wrong state, attributing nothing.

**No cure is claimed** — the root cause of the missing row is deliberately still open. This hardens the test and instruments the failure so its next occurrence names its half: a `draft` status at the gate means the publish itself was lost (browser answered before its work committed); `approved` with a still-missing row narrows the remainder to the list's rendering for the restricted user.

## How It Is Being Fixed

Right after the publish, read the persisted status back over the API and assert it `approved` **before** touching the list, echoing the raw answer first so a refused or empty response names itself instead of dying inside the JSON-path lookup. The URL comes from `JSONCompany.getPortalURL()` (an earlier version hardcoded `localhost`, which on CI answers for the *wrong company* — the test company lives on the machine-hostname virtual host; that version died on its own instrument and the console proved the cause). The bounded reload loop stays for transient faces, since a server-rendered Poshi list exposes no signal to own.

## PR Check

| Validation | Result |
|---|---|
| Source Format | ✅ passed |
| CI (Poshi is CI-only by nature): functional batch passed on both full-batch runs carrying this shape | ✅ passed |
| Query shape validated against a live portal (filter finds the definition, path parses) | ✅ passed |

<!-- pr-check {"result": "success", "sha": "f73739989b585345fd4d248ae60a2cb753e36240"} -->
