### PR TITLE
LPD-102897 Gate the generated JAXRSWhiteboardTestUtil call at version 16

### DIFF
--- a/modules/apps/ai-hub-cell/ai-hub-cell-rest-test/src/testIntegration/java/com/liferay/ai/hub/cell/rest/resource/v1_0/test/BaseAuthorizationTokenResourceTestCase.java
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-rest-test/src/testIntegration/java/com/liferay/ai/hub/cell/rest/resource/v1_0/test/BaseAuthorizationTokenResourceTestCase.java
@@ -1076,4 +1076,4 @@ public abstract class BaseAuthorizationTokenResourceTestCase {
 			_authorizationTokenResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-975468442
+// LIFERAY-REST-BUILDER-HASH:-1960899736

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/BaseChannelResourceTestCase.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/BaseChannelResourceTestCase.java
@@ -866,4 +866,4 @@ public abstract class BaseChannelResourceTestCase {
 		_channelResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-959111347
+// LIFERAY-REST-BUILDER-HASH:1370908089

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/BaseConnectionInfoResourceTestCase.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/BaseConnectionInfoResourceTestCase.java
@@ -864,4 +864,4 @@ public abstract class BaseConnectionInfoResourceTestCase {
 		_connectionInfoResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:666958402
+// LIFERAY-REST-BUILDER-HASH:-143933370

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/BaseExpiredAssetResourceTestCase.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/BaseExpiredAssetResourceTestCase.java
@@ -1034,4 +1034,4 @@ public abstract class BaseExpiredAssetResourceTestCase {
 		_expiredAssetResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1136795737
+// LIFERAY-REST-BUILDER-HASH:-260891891

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/BaseInventoryAnalysisResourceTestCase.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/BaseInventoryAnalysisResourceTestCase.java
@@ -857,4 +857,4 @@ public abstract class BaseInventoryAnalysisResourceTestCase {
 			_inventoryAnalysisResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1510322232
+// LIFERAY-REST-BUILDER-HASH:-1147834138

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/BaseObjectEntryAcquisitionChannelResourceTestCase.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/BaseObjectEntryAcquisitionChannelResourceTestCase.java
@@ -983,4 +983,4 @@ public abstract class BaseObjectEntryAcquisitionChannelResourceTestCase {
 			_objectEntryAcquisitionChannelResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1511523125
+// LIFERAY-REST-BUILDER-HASH:-685668885

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/BaseObjectEntryHistogramMetricResourceTestCase.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/BaseObjectEntryHistogramMetricResourceTestCase.java
@@ -827,4 +827,4 @@ public abstract class BaseObjectEntryHistogramMetricResourceTestCase {
 		ObjectEntryHistogramMetricResource _objectEntryHistogramMetricResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1218959824
+// LIFERAY-REST-BUILDER-HASH:-1980494986

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/BaseObjectEntryMetricResourceTestCase.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/BaseObjectEntryMetricResourceTestCase.java
@@ -982,4 +982,4 @@ public abstract class BaseObjectEntryMetricResourceTestCase {
 			_objectEntryMetricResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1923436524
+// LIFERAY-REST-BUILDER-HASH:721431744

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/BaseObjectEntryTopPagesResourceTestCase.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/BaseObjectEntryTopPagesResourceTestCase.java
@@ -828,4 +828,4 @@ public abstract class BaseObjectEntryTopPagesResourceTestCase {
 			_objectEntryTopPagesResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1947271638
+// LIFERAY-REST-BUILDER-HASH:22522788

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/BaseOverviewResourceTestCase.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/BaseOverviewResourceTestCase.java
@@ -874,4 +874,4 @@ public abstract class BaseOverviewResourceTestCase {
 		_overviewResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-133224662
+// LIFERAY-REST-BUILDER-HASH:-1351552524

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/BasePerformanceAssetConsumptionResourceTestCase.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/BasePerformanceAssetConsumptionResourceTestCase.java
@@ -902,4 +902,4 @@ public abstract class BasePerformanceAssetConsumptionResourceTestCase {
 			_performanceAssetConsumptionResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1808851412
+// LIFERAY-REST-BUILDER-HASH:1585409000

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/BasePerformanceHistogramMetricResourceTestCase.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/BasePerformanceHistogramMetricResourceTestCase.java
@@ -827,4 +827,4 @@ public abstract class BasePerformanceHistogramMetricResourceTestCase {
 		PerformanceHistogramMetricResource _performanceHistogramMetricResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1239931234
+// LIFERAY-REST-BUILDER-HASH:1053144910

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/BasePerformanceMetricResourceTestCase.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/BasePerformanceMetricResourceTestCase.java
@@ -872,4 +872,4 @@ public abstract class BasePerformanceMetricResourceTestCase {
 			_performanceMetricResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1774326604
+// LIFERAY-REST-BUILDER-HASH:818500898

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/BasePerformanceOverviewMetricResourceTestCase.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/BasePerformanceOverviewMetricResourceTestCase.java
@@ -902,4 +902,4 @@ public abstract class BasePerformanceOverviewMetricResourceTestCase {
 		PerformanceOverviewMetricResource _performanceOverviewMetricResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:928970038
+// LIFERAY-REST-BUILDER-HASH:-267532298

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/BasePerformanceTopAssetResourceTestCase.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/BasePerformanceTopAssetResourceTestCase.java
@@ -1627,4 +1627,4 @@ public abstract class BasePerformanceTopAssetResourceTestCase {
 			_performanceTopAssetResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1183603819
+// LIFERAY-REST-BUILDER-HASH:1085740111

--- a/modules/apps/analytics/analytics-rest-test/src/testIntegration/java/com/liferay/analytics/rest/resource/v1_0/test/BaseGraphQLResourceTestCase.java
+++ b/modules/apps/analytics/analytics-rest-test/src/testIntegration/java/com/liferay/analytics/rest/resource/v1_0/test/BaseGraphQLResourceTestCase.java
@@ -645,4 +645,4 @@ public abstract class BaseGraphQLResourceTestCase {
 		_graphQLResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1926422323
+// LIFERAY-REST-BUILDER-HASH:840096281

--- a/modules/apps/analytics/analytics-settings-rest-test/src/testIntegration/java/com/liferay/analytics/settings/rest/resource/v1_0/test/BaseAnalyticsDXPEntityBatchExporterResourceTestCase.java
+++ b/modules/apps/analytics/analytics-settings-rest-test/src/testIntegration/java/com/liferay/analytics/settings/rest/resource/v1_0/test/BaseAnalyticsDXPEntityBatchExporterResourceTestCase.java
@@ -692,4 +692,4 @@ public abstract class BaseAnalyticsDXPEntityBatchExporterResourceTestCase {
 			_analyticsDXPEntityBatchExporterResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:449751273
+// LIFERAY-REST-BUILDER-HASH:1572038377

--- a/modules/apps/analytics/analytics-settings-rest-test/src/testIntegration/java/com/liferay/analytics/settings/rest/resource/v1_0/test/BaseChannelResourceTestCase.java
+++ b/modules/apps/analytics/analytics-settings-rest-test/src/testIntegration/java/com/liferay/analytics/settings/rest/resource/v1_0/test/BaseChannelResourceTestCase.java
@@ -1415,4 +1415,4 @@ public abstract class BaseChannelResourceTestCase {
 		_channelResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-935160684
+// LIFERAY-REST-BUILDER-HASH:-2031789518

--- a/modules/apps/analytics/analytics-settings-rest-test/src/testIntegration/java/com/liferay/analytics/settings/rest/resource/v1_0/test/BaseContactAccountGroupResourceTestCase.java
+++ b/modules/apps/analytics/analytics-settings-rest-test/src/testIntegration/java/com/liferay/analytics/settings/rest/resource/v1_0/test/BaseContactAccountGroupResourceTestCase.java
@@ -1201,4 +1201,4 @@ public abstract class BaseContactAccountGroupResourceTestCase {
 		ContactAccountGroupResource _contactAccountGroupResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1764942799
+// LIFERAY-REST-BUILDER-HASH:-229269393

--- a/modules/apps/analytics/analytics-settings-rest-test/src/testIntegration/java/com/liferay/analytics/settings/rest/resource/v1_0/test/BaseContactConfigurationResourceTestCase.java
+++ b/modules/apps/analytics/analytics-settings-rest-test/src/testIntegration/java/com/liferay/analytics/settings/rest/resource/v1_0/test/BaseContactConfigurationResourceTestCase.java
@@ -933,4 +933,4 @@ public abstract class BaseContactConfigurationResourceTestCase {
 		ContactConfigurationResource _contactConfigurationResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1670735837
+// LIFERAY-REST-BUILDER-HASH:-212476325

--- a/modules/apps/analytics/analytics-settings-rest-test/src/testIntegration/java/com/liferay/analytics/settings/rest/resource/v1_0/test/BaseContactOrganizationResourceTestCase.java
+++ b/modules/apps/analytics/analytics-settings-rest-test/src/testIntegration/java/com/liferay/analytics/settings/rest/resource/v1_0/test/BaseContactOrganizationResourceTestCase.java
@@ -1201,4 +1201,4 @@ public abstract class BaseContactOrganizationResourceTestCase {
 		ContactOrganizationResource _contactOrganizationResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1300109580
+// LIFERAY-REST-BUILDER-HASH:-557013386

--- a/modules/apps/analytics/analytics-settings-rest-test/src/testIntegration/java/com/liferay/analytics/settings/rest/resource/v1_0/test/BaseContactUserGroupResourceTestCase.java
+++ b/modules/apps/analytics/analytics-settings-rest-test/src/testIntegration/java/com/liferay/analytics/settings/rest/resource/v1_0/test/BaseContactUserGroupResourceTestCase.java
@@ -1169,4 +1169,4 @@ public abstract class BaseContactUserGroupResourceTestCase {
 			ContactUserGroupResource _contactUserGroupResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:2018713281
+// LIFERAY-REST-BUILDER-HASH:-160461761

--- a/modules/apps/analytics/analytics-settings-rest-test/src/testIntegration/java/com/liferay/analytics/settings/rest/resource/v1_0/test/BaseDataSourceResourceTestCase.java
+++ b/modules/apps/analytics/analytics-settings-rest-test/src/testIntegration/java/com/liferay/analytics/settings/rest/resource/v1_0/test/BaseDataSourceResourceTestCase.java
@@ -961,4 +961,4 @@ public abstract class BaseDataSourceResourceTestCase {
 		_dataSourceResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:209428717
+// LIFERAY-REST-BUILDER-HASH:225012269

--- a/modules/apps/analytics/analytics-settings-rest-test/src/testIntegration/java/com/liferay/analytics/settings/rest/resource/v1_0/test/BaseFieldResourceTestCase.java
+++ b/modules/apps/analytics/analytics-settings-rest-test/src/testIntegration/java/com/liferay/analytics/settings/rest/resource/v1_0/test/BaseFieldResourceTestCase.java
@@ -1534,4 +1534,4 @@ public abstract class BaseFieldResourceTestCase {
 		_fieldResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1791637975
+// LIFERAY-REST-BUILDER-HASH:240802553

--- a/modules/apps/analytics/analytics-settings-rest-test/src/testIntegration/java/com/liferay/analytics/settings/rest/resource/v1_0/test/BaseFieldSummaryResourceTestCase.java
+++ b/modules/apps/analytics/analytics-settings-rest-test/src/testIntegration/java/com/liferay/analytics/settings/rest/resource/v1_0/test/BaseFieldSummaryResourceTestCase.java
@@ -818,4 +818,4 @@ public abstract class BaseFieldSummaryResourceTestCase {
 			_fieldSummaryResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-689454202
+// LIFERAY-REST-BUILDER-HASH:-1320729932

--- a/modules/apps/analytics/analytics-settings-rest-test/src/testIntegration/java/com/liferay/analytics/settings/rest/resource/v1_0/test/BaseRecommendationConfigurationResourceTestCase.java
+++ b/modules/apps/analytics/analytics-settings-rest-test/src/testIntegration/java/com/liferay/analytics/settings/rest/resource/v1_0/test/BaseRecommendationConfigurationResourceTestCase.java
@@ -892,4 +892,4 @@ public abstract class BaseRecommendationConfigurationResourceTestCase {
 			_recommendationConfigurationResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-903166979
+// LIFERAY-REST-BUILDER-HASH:-716745133

--- a/modules/apps/analytics/analytics-settings-rest-test/src/testIntegration/java/com/liferay/analytics/settings/rest/resource/v1_0/test/BaseSiteResourceTestCase.java
+++ b/modules/apps/analytics/analytics-settings-rest-test/src/testIntegration/java/com/liferay/analytics/settings/rest/resource/v1_0/test/BaseSiteResourceTestCase.java
@@ -1194,4 +1194,4 @@ public abstract class BaseSiteResourceTestCase {
 		_siteResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1692921719
+// LIFERAY-REST-BUILDER-HASH:-550813445

--- a/modules/apps/batch-planner/batch-planner-rest-test/src/testIntegration/java/com/liferay/batch/planner/rest/resource/v1_0/test/BaseAssetLibraryScopeResourceTestCase.java
+++ b/modules/apps/batch-planner/batch-planner-rest-test/src/testIntegration/java/com/liferay/batch/planner/rest/resource/v1_0/test/BaseAssetLibraryScopeResourceTestCase.java
@@ -996,4 +996,4 @@ public abstract class BaseAssetLibraryScopeResourceTestCase {
 			_assetLibraryScopeResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-2081900363
+// LIFERAY-REST-BUILDER-HASH:-750259067

--- a/modules/apps/batch-planner/batch-planner-rest-test/src/testIntegration/java/com/liferay/batch/planner/rest/resource/v1_0/test/BaseFieldResourceTestCase.java
+++ b/modules/apps/batch-planner/batch-planner-rest-test/src/testIntegration/java/com/liferay/batch/planner/rest/resource/v1_0/test/BaseFieldResourceTestCase.java
@@ -1136,4 +1136,4 @@ public abstract class BaseFieldResourceTestCase {
 		_fieldResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1607638201
+// LIFERAY-REST-BUILDER-HASH:-1058307851

--- a/modules/apps/batch-planner/batch-planner-rest-test/src/testIntegration/java/com/liferay/batch/planner/rest/resource/v1_0/test/BasePlanResourceTestCase.java
+++ b/modules/apps/batch-planner/batch-planner-rest-test/src/testIntegration/java/com/liferay/batch/planner/rest/resource/v1_0/test/BasePlanResourceTestCase.java
@@ -1784,4 +1784,4 @@ public abstract class BasePlanResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1356100555
+// LIFERAY-REST-BUILDER-HASH:1864640133

--- a/modules/apps/batch-planner/batch-planner-rest-test/src/testIntegration/java/com/liferay/batch/planner/rest/resource/v1_0/test/BaseSiteScopeResourceTestCase.java
+++ b/modules/apps/batch-planner/batch-planner-rest-test/src/testIntegration/java/com/liferay/batch/planner/rest/resource/v1_0/test/BaseSiteScopeResourceTestCase.java
@@ -925,4 +925,4 @@ public abstract class BaseSiteScopeResourceTestCase {
 		_siteScopeResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-300824700
+// LIFERAY-REST-BUILDER-HASH:610131484

--- a/modules/apps/batch-planner/batch-planner-rest-test/src/testIntegration/java/com/liferay/batch/planner/rest/resource/v1_0/test/BaseStrategyResourceTestCase.java
+++ b/modules/apps/batch-planner/batch-planner-rest-test/src/testIntegration/java/com/liferay/batch/planner/rest/resource/v1_0/test/BaseStrategyResourceTestCase.java
@@ -965,4 +965,4 @@ public abstract class BaseStrategyResourceTestCase {
 		_strategyResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-578153939
+// LIFERAY-REST-BUILDER-HASH:-450650573

--- a/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseBulkActionResourceTestCase.java
+++ b/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseBulkActionResourceTestCase.java
@@ -2412,4 +2412,4 @@ public abstract class BaseBulkActionResourceTestCase {
 		_bulkActionResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-769022986
+// LIFERAY-REST-BUILDER-HASH:-1070069828

--- a/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseKeywordResourceTestCase.java
+++ b/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseKeywordResourceTestCase.java
@@ -812,4 +812,4 @@ public abstract class BaseKeywordResourceTestCase {
 		_keywordResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1803946370
+// LIFERAY-REST-BUILDER-HASH:-1547286324

--- a/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseSelectionResourceTestCase.java
+++ b/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseSelectionResourceTestCase.java
@@ -784,4 +784,4 @@ public abstract class BaseSelectionResourceTestCase {
 		_selectionResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-495706157
+// LIFERAY-REST-BUILDER-HASH:-1791200377

--- a/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseStatusResourceTestCase.java
+++ b/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseStatusResourceTestCase.java
@@ -776,4 +776,4 @@ public abstract class BaseStatusResourceTestCase {
 	private com.liferay.bulk.rest.resource.v1_0.StatusResource _statusResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1484947973
+// LIFERAY-REST-BUILDER-HASH:-1947261087

--- a/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
+++ b/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
@@ -872,4 +872,4 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		_taxonomyCategoryResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:501174375
+// LIFERAY-REST-BUILDER-HASH:871734171

--- a/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
+++ b/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
@@ -958,4 +958,4 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 		_taxonomyVocabularyResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:653097417
+// LIFERAY-REST-BUILDER-HASH:603398661

--- a/modules/apps/captcha/captcha-rest-test/src/testIntegration/java/com/liferay/captcha/rest/resource/v1_0/test/BaseCaptchaResourceTestCase.java
+++ b/modules/apps/captcha/captcha-rest-test/src/testIntegration/java/com/liferay/captcha/rest/resource/v1_0/test/BaseCaptchaResourceTestCase.java
@@ -951,4 +951,4 @@ public abstract class BaseCaptchaResourceTestCase {
 		_captchaResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1825876171
+// LIFERAY-REST-BUILDER-HASH:-896183819

--- a/modules/apps/change-tracking/change-tracking-rest-test/src/testIntegration/java/com/liferay/change/tracking/rest/resource/v1_0/test/BaseCTCollectionResourceTestCase.java
+++ b/modules/apps/change-tracking/change-tracking-rest-test/src/testIntegration/java/com/liferay/change/tracking/rest/resource/v1_0/test/BaseCTCollectionResourceTestCase.java
@@ -3071,4 +3071,4 @@ public abstract class BaseCTCollectionResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1235572798
+// LIFERAY-REST-BUILDER-HASH:572142392

--- a/modules/apps/change-tracking/change-tracking-rest-test/src/testIntegration/java/com/liferay/change/tracking/rest/resource/v1_0/test/BaseCTEntryResourceTestCase.java
+++ b/modules/apps/change-tracking/change-tracking-rest-test/src/testIntegration/java/com/liferay/change/tracking/rest/resource/v1_0/test/BaseCTEntryResourceTestCase.java
@@ -3008,4 +3008,4 @@ public abstract class BaseCTEntryResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-2132826123
+// LIFERAY-REST-BUILDER-HASH:362045105

--- a/modules/apps/change-tracking/change-tracking-rest-test/src/testIntegration/java/com/liferay/change/tracking/rest/resource/v1_0/test/BaseCTProcessResourceTestCase.java
+++ b/modules/apps/change-tracking/change-tracking-rest-test/src/testIntegration/java/com/liferay/change/tracking/rest/resource/v1_0/test/BaseCTProcessResourceTestCase.java
@@ -2037,4 +2037,4 @@ public abstract class BaseCTProcessResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:705283846
+// LIFERAY-REST-BUILDER-HASH:-674099792

--- a/modules/apps/change-tracking/change-tracking-rest-test/src/testIntegration/java/com/liferay/change/tracking/rest/resource/v1_0/test/BaseCTRemoteResourceTestCase.java
+++ b/modules/apps/change-tracking/change-tracking-rest-test/src/testIntegration/java/com/liferay/change/tracking/rest/resource/v1_0/test/BaseCTRemoteResourceTestCase.java
@@ -2365,4 +2365,4 @@ public abstract class BaseCTRemoteResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-42766915
+// LIFERAY-REST-BUILDER-HASH:-1369078473

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountAddressResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountAddressResourceTestCase.java
@@ -3114,4 +3114,4 @@ public abstract class BaseAccountAddressResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:101480578
+// LIFERAY-REST-BUILDER-HASH:-1464011430

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountChannelEntryResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountChannelEntryResourceTestCase.java
@@ -7829,4 +7829,4 @@ public abstract class BaseAccountChannelEntryResourceTestCase {
 		AccountChannelEntryResource _accountChannelEntryResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:856819472
+// LIFERAY-REST-BUILDER-HASH:-966479408

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountChannelShippingOptionResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountChannelShippingOptionResourceTestCase.java
@@ -2458,4 +2458,4 @@ public abstract class BaseAccountChannelShippingOptionResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-816743371
+// LIFERAY-REST-BUILDER-HASH:2146386553

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountMemberResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountMemberResourceTestCase.java
@@ -2167,4 +2167,4 @@ public abstract class BaseAccountMemberResourceTestCase {
 		AccountMemberResource _accountMemberResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-557722975
+// LIFERAY-REST-BUILDER-HASH:937531351

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountOrganizationResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountOrganizationResourceTestCase.java
@@ -1574,4 +1574,4 @@ public abstract class BaseAccountOrganizationResourceTestCase {
 		AccountOrganizationResource _accountOrganizationResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1079964600
+// LIFERAY-REST-BUILDER-HASH:-1905533952

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountResourceTestCase.java
@@ -2975,4 +2975,4 @@ public abstract class BaseAccountResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1753001542
+// LIFERAY-REST-BUILDER-HASH:528439064

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAdminAccountGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAdminAccountGroupResourceTestCase.java
@@ -2338,4 +2338,4 @@ public abstract class BaseAdminAccountGroupResourceTestCase {
 		AdminAccountGroupResource _adminAccountGroupResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:475024337
+// LIFERAY-REST-BUILDER-HASH:971620219

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseUserResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseUserResourceTestCase.java
@@ -1238,4 +1238,4 @@ public abstract class BaseUserResourceTestCase {
 			_userResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:907790884
+// LIFERAY-REST-BUILDER-HASH:72764708

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseAttachmentResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseAttachmentResourceTestCase.java
@@ -3140,4 +3140,4 @@ public abstract class BaseAttachmentResourceTestCase {
 			AttachmentResource _attachmentResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1064169648
+// LIFERAY-REST-BUILDER-HASH:-778216684

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseCatalogResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseCatalogResourceTestCase.java
@@ -3081,4 +3081,4 @@ public abstract class BaseCatalogResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-2077125740
+// LIFERAY-REST-BUILDER-HASH:-1223836946

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseCategoryResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseCategoryResourceTestCase.java
@@ -1374,4 +1374,4 @@ public abstract class BaseCategoryResourceTestCase {
 			CategoryResource _categoryResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1653729852
+// LIFERAY-REST-BUILDER-HASH:-2069903382

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseCurrencyResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseCurrencyResourceTestCase.java
@@ -2696,4 +2696,4 @@ public abstract class BaseCurrencyResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:110937973
+// LIFERAY-REST-BUILDER-HASH:2014737205

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseDiagramResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseDiagramResourceTestCase.java
@@ -1469,4 +1469,4 @@ public abstract class BaseDiagramResourceTestCase {
 			DiagramResource _diagramResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1077894769
+// LIFERAY-REST-BUILDER-HASH:888242743

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseGroupedProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseGroupedProductResourceTestCase.java
@@ -1729,4 +1729,4 @@ public abstract class BaseGroupedProductResourceTestCase {
 		GroupedProductResource _groupedProductResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:278809043
+// LIFERAY-REST-BUILDER-HASH:992581107

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseLinkedProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseLinkedProductResourceTestCase.java
@@ -1102,4 +1102,4 @@ public abstract class BaseLinkedProductResourceTestCase {
 		LinkedProductResource _linkedProductResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1468705318
+// LIFERAY-REST-BUILDER-HASH:-1396732102

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseListTypeDefinitionResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseListTypeDefinitionResourceTestCase.java
@@ -1655,4 +1655,4 @@ public abstract class BaseListTypeDefinitionResourceTestCase {
 		ListTypeDefinitionResource _listTypeDefinitionResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:953132531
+// LIFERAY-REST-BUILDER-HASH:-451129057

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseLowStockActionResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseLowStockActionResourceTestCase.java
@@ -890,4 +890,4 @@ public abstract class BaseLowStockActionResourceTestCase {
 		LowStockActionResource _lowStockActionResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:924838040
+// LIFERAY-REST-BUILDER-HASH:-391347418

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseMappedProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseMappedProductResourceTestCase.java
@@ -2510,4 +2510,4 @@ public abstract class BaseMappedProductResourceTestCase {
 		MappedProductResource _mappedProductResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1508361579
+// LIFERAY-REST-BUILDER-HASH:631225623

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseOptionCategoryResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseOptionCategoryResourceTestCase.java
@@ -2648,4 +2648,4 @@ public abstract class BaseOptionCategoryResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-656503796
+// LIFERAY-REST-BUILDER-HASH:762727376

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseOptionResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseOptionResourceTestCase.java
@@ -2619,4 +2619,4 @@ public abstract class BaseOptionResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1202625452
+// LIFERAY-REST-BUILDER-HASH:1317230364

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseOptionValueResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseOptionValueResourceTestCase.java
@@ -2679,4 +2679,4 @@ public abstract class BaseOptionValueResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1242146751
+// LIFERAY-REST-BUILDER-HASH:-1992069813

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BasePinResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BasePinResourceTestCase.java
@@ -1711,4 +1711,4 @@ public abstract class BasePinResourceTestCase {
 			_pinResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1951282552
+// LIFERAY-REST-BUILDER-HASH:-1820267270

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductAccountGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductAccountGroupResourceTestCase.java
@@ -2013,4 +2013,4 @@ public abstract class BaseProductAccountGroupResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:582209496
+// LIFERAY-REST-BUILDER-HASH:1059371086

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductChannelResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductChannelResourceTestCase.java
@@ -2081,4 +2081,4 @@ public abstract class BaseProductChannelResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1821927395
+// LIFERAY-REST-BUILDER-HASH:1943052233

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductConfigurationListAccountGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductConfigurationListAccountGroupResourceTestCase.java
@@ -2255,4 +2255,4 @@ public abstract class BaseProductConfigurationListAccountGroupResourceTestCase {
 			_productConfigurationListAccountGroupResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1876989107
+// LIFERAY-REST-BUILDER-HASH:1826590815

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductConfigurationListAccountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductConfigurationListAccountResourceTestCase.java
@@ -2175,4 +2175,4 @@ public abstract class BaseProductConfigurationListAccountResourceTestCase {
 			_productConfigurationListAccountResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1886208427
+// LIFERAY-REST-BUILDER-HASH:556815719

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductConfigurationListChannelResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductConfigurationListChannelResourceTestCase.java
@@ -2202,4 +2202,4 @@ public abstract class BaseProductConfigurationListChannelResourceTestCase {
 			_productConfigurationListChannelResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:804800920
+// LIFERAY-REST-BUILDER-HASH:-1917632920

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductConfigurationListOrderTypeResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductConfigurationListOrderTypeResourceTestCase.java
@@ -2229,4 +2229,4 @@ public abstract class BaseProductConfigurationListOrderTypeResourceTestCase {
 			_productConfigurationListOrderTypeResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-2055687588
+// LIFERAY-REST-BUILDER-HASH:496774210

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductConfigurationListResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductConfigurationListResourceTestCase.java
@@ -3259,4 +3259,4 @@ public abstract class BaseProductConfigurationListResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1116529354
+// LIFERAY-REST-BUILDER-HASH:183403122

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductConfigurationResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductConfigurationResourceTestCase.java
@@ -4120,4 +4120,4 @@ public abstract class BaseProductConfigurationResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1363491745
+// LIFERAY-REST-BUILDER-HASH:1639619659

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductGroupProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductGroupProductResourceTestCase.java
@@ -1833,4 +1833,4 @@ public abstract class BaseProductGroupProductResourceTestCase {
 		ProductGroupProductResource _productGroupProductResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:820585801
+// LIFERAY-REST-BUILDER-HASH:-1910112997

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductGroupResourceTestCase.java
@@ -2565,4 +2565,4 @@ public abstract class BaseProductGroupResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1469687122
+// LIFERAY-REST-BUILDER-HASH:1555901044

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductOptionResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductOptionResourceTestCase.java
@@ -2806,4 +2806,4 @@ public abstract class BaseProductOptionResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-791099840
+// LIFERAY-REST-BUILDER-HASH:1623159652

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductOptionValueResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductOptionValueResourceTestCase.java
@@ -2211,4 +2211,4 @@ public abstract class BaseProductOptionValueResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-834852254
+// LIFERAY-REST-BUILDER-HASH:-254680598

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductResourceTestCase.java
@@ -4486,4 +4486,4 @@ public abstract class BaseProductResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-87666848
+// LIFERAY-REST-BUILDER-HASH:1916098994

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductShippingConfigurationResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductShippingConfigurationResourceTestCase.java
@@ -1067,4 +1067,4 @@ public abstract class BaseProductShippingConfigurationResourceTestCase {
 			_productShippingConfigurationResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-129617844
+// LIFERAY-REST-BUILDER-HASH:1603352252

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductSpecificationResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductSpecificationResourceTestCase.java
@@ -2910,4 +2910,4 @@ public abstract class BaseProductSpecificationResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-2084641704
+// LIFERAY-REST-BUILDER-HASH:-80451470

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductSubscriptionConfigurationResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductSubscriptionConfigurationResourceTestCase.java
@@ -1187,4 +1187,4 @@ public abstract class BaseProductSubscriptionConfigurationResourceTestCase {
 			_productSubscriptionConfigurationResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:680292822
+// LIFERAY-REST-BUILDER-HASH:838478536

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductTaxConfigurationResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductTaxConfigurationResourceTestCase.java
@@ -1303,4 +1303,4 @@ public abstract class BaseProductTaxConfigurationResourceTestCase {
 		ProductTaxConfigurationResource _productTaxConfigurationResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1507837641
+// LIFERAY-REST-BUILDER-HASH:-487847265

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductVirtualSettingsFileEntryResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductVirtualSettingsFileEntryResourceTestCase.java
@@ -2114,4 +2114,4 @@ public abstract class BaseProductVirtualSettingsFileEntryResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-101082303
+// LIFERAY-REST-BUILDER-HASH:-78377821

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductVirtualSettingsResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductVirtualSettingsResourceTestCase.java
@@ -1954,4 +1954,4 @@ public abstract class BaseProductVirtualSettingsResourceTestCase {
 		ProductVirtualSettingsResource _productVirtualSettingsResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1849493210
+// LIFERAY-REST-BUILDER-HASH:1272460650

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseRelatedProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseRelatedProductResourceTestCase.java
@@ -2017,4 +2017,4 @@ public abstract class BaseRelatedProductResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1503546258
+// LIFERAY-REST-BUILDER-HASH:-285214760

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseSkuResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseSkuResourceTestCase.java
@@ -3906,4 +3906,4 @@ public abstract class BaseSkuResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1857619166
+// LIFERAY-REST-BUILDER-HASH:-1674735668

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseSkuSubscriptionConfigurationResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseSkuSubscriptionConfigurationResourceTestCase.java
@@ -1189,4 +1189,4 @@ public abstract class BaseSkuSubscriptionConfigurationResourceTestCase {
 			_skuSubscriptionConfigurationResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1728189433
+// LIFERAY-REST-BUILDER-HASH:-1323663119

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseSkuUnitOfMeasureResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseSkuUnitOfMeasureResourceTestCase.java
@@ -2312,4 +2312,4 @@ public abstract class BaseSkuUnitOfMeasureResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1887086028
+// LIFERAY-REST-BUILDER-HASH:690831298

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseSkuVirtualSettingsFileEntryResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseSkuVirtualSettingsFileEntryResourceTestCase.java
@@ -2073,4 +2073,4 @@ public abstract class BaseSkuVirtualSettingsFileEntryResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1487198603
+// LIFERAY-REST-BUILDER-HASH:-471438989

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseSkuVirtualSettingsResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseSkuVirtualSettingsResourceTestCase.java
@@ -1959,4 +1959,4 @@ public abstract class BaseSkuVirtualSettingsResourceTestCase {
 		SkuVirtualSettingsResource _skuVirtualSettingsResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1543382622
+// LIFERAY-REST-BUILDER-HASH:1995442238

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseSpecificationResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseSpecificationResourceTestCase.java
@@ -2826,4 +2826,4 @@ public abstract class BaseSpecificationResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-154341486
+// LIFERAY-REST-BUILDER-HASH:-64179380

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseAccountAddressChannelResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseAccountAddressChannelResourceTestCase.java
@@ -2073,4 +2073,4 @@ public abstract class BaseAccountAddressChannelResourceTestCase {
 		AccountAddressChannelResource _accountAddressChannelResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-805291236
+// LIFERAY-REST-BUILDER-HASH:575968942

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseAccountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseAccountResourceTestCase.java
@@ -966,4 +966,4 @@ public abstract class BaseAccountResourceTestCase {
 			AccountResource _accountResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1301806547
+// LIFERAY-REST-BUILDER-HASH:897185725

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseCategoryDisplayPageResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseCategoryDisplayPageResourceTestCase.java
@@ -2745,4 +2745,4 @@ public abstract class BaseCategoryDisplayPageResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-24908787
+// LIFERAY-REST-BUILDER-HASH:-852947983

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseChannelAccountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseChannelAccountResourceTestCase.java
@@ -1942,4 +1942,4 @@ public abstract class BaseChannelAccountResourceTestCase {
 		ChannelAccountResource _channelAccountResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1962838807
+// LIFERAY-REST-BUILDER-HASH:254200743

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseChannelResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseChannelResourceTestCase.java
@@ -2939,4 +2939,4 @@ public abstract class BaseChannelResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:390894538
+// LIFERAY-REST-BUILDER-HASH:-764896178

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseDefaultCategoryDisplayPageResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseDefaultCategoryDisplayPageResourceTestCase.java
@@ -1010,4 +1010,4 @@ public abstract class BaseDefaultCategoryDisplayPageResourceTestCase {
 		DefaultCategoryDisplayPageResource _defaultCategoryDisplayPageResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1860069235
+// LIFERAY-REST-BUILDER-HASH:69254861

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseDefaultProductDisplayPageResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseDefaultProductDisplayPageResourceTestCase.java
@@ -1009,4 +1009,4 @@ public abstract class BaseDefaultProductDisplayPageResourceTestCase {
 		DefaultProductDisplayPageResource _defaultProductDisplayPageResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1001282095
+// LIFERAY-REST-BUILDER-HASH:-1449362093

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseOrderTypeResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseOrderTypeResourceTestCase.java
@@ -1088,4 +1088,4 @@ public abstract class BaseOrderTypeResourceTestCase {
 			OrderTypeResource _orderTypeResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:431691974
+// LIFERAY-REST-BUILDER-HASH:316863820

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BasePaymentMethodGroupRelOrderTypeResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BasePaymentMethodGroupRelOrderTypeResourceTestCase.java
@@ -1851,4 +1851,4 @@ public abstract class BasePaymentMethodGroupRelOrderTypeResourceTestCase {
 			_paymentMethodGroupRelOrderTypeResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-2143504994
+// LIFERAY-REST-BUILDER-HASH:-2034807256

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BasePaymentMethodGroupRelTermResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BasePaymentMethodGroupRelTermResourceTestCase.java
@@ -1780,4 +1780,4 @@ public abstract class BasePaymentMethodGroupRelTermResourceTestCase {
 		PaymentMethodGroupRelTermResource _paymentMethodGroupRelTermResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1061641689
+// LIFERAY-REST-BUILDER-HASH:-1207903945

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseProductDisplayPageResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseProductDisplayPageResourceTestCase.java
@@ -2725,4 +2725,4 @@ public abstract class BaseProductDisplayPageResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-2053074979
+// LIFERAY-REST-BUILDER-HASH:430881437

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseShippingFixedOptionOrderTypeResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseShippingFixedOptionOrderTypeResourceTestCase.java
@@ -1830,4 +1830,4 @@ public abstract class BaseShippingFixedOptionOrderTypeResourceTestCase {
 			_shippingFixedOptionOrderTypeResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:634024446
+// LIFERAY-REST-BUILDER-HASH:-1169854316

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseShippingFixedOptionTermResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseShippingFixedOptionTermResourceTestCase.java
@@ -1755,4 +1755,4 @@ public abstract class BaseShippingFixedOptionTermResourceTestCase {
 		ShippingFixedOptionTermResource _shippingFixedOptionTermResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-523605429
+// LIFERAY-REST-BUILDER-HASH:-2000386841

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseShippingMethodResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseShippingMethodResourceTestCase.java
@@ -1155,4 +1155,4 @@ public abstract class BaseShippingMethodResourceTestCase {
 		ShippingMethodResource _shippingMethodResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1274607488
+// LIFERAY-REST-BUILDER-HASH:1230858394

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseTaxCategoryResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseTaxCategoryResourceTestCase.java
@@ -1324,4 +1324,4 @@ public abstract class BaseTaxCategoryResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-955358082
+// LIFERAY-REST-BUILDER-HASH:-109005242

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseTermResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseTermResourceTestCase.java
@@ -1103,4 +1103,4 @@ public abstract class BaseTermResourceTestCase {
 			_termResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1007152398
+// LIFERAY-REST-BUILDER-HASH:203171866

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-test/src/testIntegration/java/com/liferay/headless/commerce/admin/inventory/resource/v1_0/test/BaseAccountGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-test/src/testIntegration/java/com/liferay/headless/commerce/admin/inventory/resource/v1_0/test/BaseAccountGroupResourceTestCase.java
@@ -990,4 +990,4 @@ public abstract class BaseAccountGroupResourceTestCase {
 		AccountGroupResource _accountGroupResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1228626292
+// LIFERAY-REST-BUILDER-HASH:-781755298

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-test/src/testIntegration/java/com/liferay/headless/commerce/admin/inventory/resource/v1_0/test/BaseAccountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-test/src/testIntegration/java/com/liferay/headless/commerce/admin/inventory/resource/v1_0/test/BaseAccountResourceTestCase.java
@@ -992,4 +992,4 @@ public abstract class BaseAccountResourceTestCase {
 			AccountResource _accountResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-809472579
+// LIFERAY-REST-BUILDER-HASH:-1018509893

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-test/src/testIntegration/java/com/liferay/headless/commerce/admin/inventory/resource/v1_0/test/BaseChannelResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-test/src/testIntegration/java/com/liferay/headless/commerce/admin/inventory/resource/v1_0/test/BaseChannelResourceTestCase.java
@@ -1203,4 +1203,4 @@ public abstract class BaseChannelResourceTestCase {
 			ChannelResource _channelResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1755402283
+// LIFERAY-REST-BUILDER-HASH:699967363

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-test/src/testIntegration/java/com/liferay/headless/commerce/admin/inventory/resource/v1_0/test/BaseOrderTypeResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-test/src/testIntegration/java/com/liferay/headless/commerce/admin/inventory/resource/v1_0/test/BaseOrderTypeResourceTestCase.java
@@ -932,4 +932,4 @@ public abstract class BaseOrderTypeResourceTestCase {
 		OrderTypeResource _orderTypeResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:632379370
+// LIFERAY-REST-BUILDER-HASH:1260183874

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-test/src/testIntegration/java/com/liferay/headless/commerce/admin/inventory/resource/v1_0/test/BaseReplenishmentItemResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-test/src/testIntegration/java/com/liferay/headless/commerce/admin/inventory/resource/v1_0/test/BaseReplenishmentItemResourceTestCase.java
@@ -2987,4 +2987,4 @@ public abstract class BaseReplenishmentItemResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:885910024
+// LIFERAY-REST-BUILDER-HASH:61516798

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-test/src/testIntegration/java/com/liferay/headless/commerce/admin/inventory/resource/v1_0/test/BaseWarehouseAccountGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-test/src/testIntegration/java/com/liferay/headless/commerce/admin/inventory/resource/v1_0/test/BaseWarehouseAccountGroupResourceTestCase.java
@@ -2062,4 +2062,4 @@ public abstract class BaseWarehouseAccountGroupResourceTestCase {
 		WarehouseAccountGroupResource _warehouseAccountGroupResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1606768704
+// LIFERAY-REST-BUILDER-HASH:1501728878

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-test/src/testIntegration/java/com/liferay/headless/commerce/admin/inventory/resource/v1_0/test/BaseWarehouseAccountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-test/src/testIntegration/java/com/liferay/headless/commerce/admin/inventory/resource/v1_0/test/BaseWarehouseAccountResourceTestCase.java
@@ -1977,4 +1977,4 @@ public abstract class BaseWarehouseAccountResourceTestCase {
 		WarehouseAccountResource _warehouseAccountResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:338334926
+// LIFERAY-REST-BUILDER-HASH:-1126494228

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-test/src/testIntegration/java/com/liferay/headless/commerce/admin/inventory/resource/v1_0/test/BaseWarehouseChannelResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-test/src/testIntegration/java/com/liferay/headless/commerce/admin/inventory/resource/v1_0/test/BaseWarehouseChannelResourceTestCase.java
@@ -1977,4 +1977,4 @@ public abstract class BaseWarehouseChannelResourceTestCase {
 		WarehouseChannelResource _warehouseChannelResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:389352678
+// LIFERAY-REST-BUILDER-HASH:-340345488

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-test/src/testIntegration/java/com/liferay/headless/commerce/admin/inventory/resource/v1_0/test/BaseWarehouseItemResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-test/src/testIntegration/java/com/liferay/headless/commerce/admin/inventory/resource/v1_0/test/BaseWarehouseItemResourceTestCase.java
@@ -2804,4 +2804,4 @@ public abstract class BaseWarehouseItemResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1697972696
+// LIFERAY-REST-BUILDER-HASH:1443494140

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-test/src/testIntegration/java/com/liferay/headless/commerce/admin/inventory/resource/v1_0/test/BaseWarehouseOrderTypeResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-test/src/testIntegration/java/com/liferay/headless/commerce/admin/inventory/resource/v1_0/test/BaseWarehouseOrderTypeResourceTestCase.java
@@ -2053,4 +2053,4 @@ public abstract class BaseWarehouseOrderTypeResourceTestCase {
 		WarehouseOrderTypeResource _warehouseOrderTypeResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-2092124157
+// LIFERAY-REST-BUILDER-HASH:1755377591

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-test/src/testIntegration/java/com/liferay/headless/commerce/admin/inventory/resource/v1_0/test/BaseWarehouseResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-test/src/testIntegration/java/com/liferay/headless/commerce/admin/inventory/resource/v1_0/test/BaseWarehouseResourceTestCase.java
@@ -2729,4 +2729,4 @@ public abstract class BaseWarehouseResourceTestCase {
 		WarehouseResource _warehouseResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-861282692
+// LIFERAY-REST-BUILDER-HASH:242419662

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseAccountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseAccountResourceTestCase.java
@@ -1561,4 +1561,4 @@ public abstract class BaseAccountResourceTestCase {
 			_accountResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1603892496
+// LIFERAY-REST-BUILDER-HASH:-1919852434

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseAttachmentResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseAttachmentResourceTestCase.java
@@ -3277,4 +3277,4 @@ public abstract class BaseAttachmentResourceTestCase {
 			AttachmentResource _attachmentResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-2074613880
+// LIFERAY-REST-BUILDER-HASH:1607620888

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseBillingAddressResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseBillingAddressResourceTestCase.java
@@ -2030,4 +2030,4 @@ public abstract class BaseBillingAddressResourceTestCase {
 		BillingAddressResource _billingAddressResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:865825710
+// LIFERAY-REST-BUILDER-HASH:407808778

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseChannelResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseChannelResourceTestCase.java
@@ -1597,4 +1597,4 @@ public abstract class BaseChannelResourceTestCase {
 			_channelResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1124008549
+// LIFERAY-REST-BUILDER-HASH:-1741857619

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderAccountGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderAccountGroupResourceTestCase.java
@@ -1011,4 +1011,4 @@ public abstract class BaseOrderAccountGroupResourceTestCase {
 		OrderAccountGroupResource _orderAccountGroupResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1139932473
+// LIFERAY-REST-BUILDER-HASH:-485303887

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderItemResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderItemResourceTestCase.java
@@ -4470,4 +4470,4 @@ public abstract class BaseOrderItemResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1445080516
+// LIFERAY-REST-BUILDER-HASH:-2144780102

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderNoteResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderNoteResourceTestCase.java
@@ -2538,4 +2538,4 @@ public abstract class BaseOrderNoteResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1513384965
+// LIFERAY-REST-BUILDER-HASH:234228893

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderResourceTestCase.java
@@ -7193,4 +7193,4 @@ public abstract class BaseOrderResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1345565149
+// LIFERAY-REST-BUILDER-HASH:1590110119

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderRuleAccountGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderRuleAccountGroupResourceTestCase.java
@@ -2061,4 +2061,4 @@ public abstract class BaseOrderRuleAccountGroupResourceTestCase {
 		OrderRuleAccountGroupResource _orderRuleAccountGroupResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:769652770
+// LIFERAY-REST-BUILDER-HASH:-1537239710

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderRuleAccountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderRuleAccountResourceTestCase.java
@@ -1976,4 +1976,4 @@ public abstract class BaseOrderRuleAccountResourceTestCase {
 		OrderRuleAccountResource _orderRuleAccountResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:2089337278
+// LIFERAY-REST-BUILDER-HASH:-25325074

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderRuleChannelResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderRuleChannelResourceTestCase.java
@@ -1976,4 +1976,4 @@ public abstract class BaseOrderRuleChannelResourceTestCase {
 		OrderRuleChannelResource _orderRuleChannelResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:973115658
+// LIFERAY-REST-BUILDER-HASH:-1784896602

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderRuleOrderTypeResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderRuleOrderTypeResourceTestCase.java
@@ -1754,4 +1754,4 @@ public abstract class BaseOrderRuleOrderTypeResourceTestCase {
 		OrderRuleOrderTypeResource _orderRuleOrderTypeResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1003452887
+// LIFERAY-REST-BUILDER-HASH:285724189

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderRuleResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderRuleResourceTestCase.java
@@ -3131,4 +3131,4 @@ public abstract class BaseOrderRuleResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1308193022
+// LIFERAY-REST-BUILDER-HASH:-1505172286

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderTypeChannelResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderTypeChannelResourceTestCase.java
@@ -1871,4 +1871,4 @@ public abstract class BaseOrderTypeChannelResourceTestCase {
 		OrderTypeChannelResource _orderTypeChannelResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:2031086071
+// LIFERAY-REST-BUILDER-HASH:-1740736233

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderTypeResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderTypeResourceTestCase.java
@@ -3013,4 +3013,4 @@ public abstract class BaseOrderTypeResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:933936068
+// LIFERAY-REST-BUILDER-HASH:2086007500

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseShippingAddressResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseShippingAddressResourceTestCase.java
@@ -2125,4 +2125,4 @@ public abstract class BaseShippingAddressResourceTestCase {
 		ShippingAddressResource _shippingAddressResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1854795099
+// LIFERAY-REST-BUILDER-HASH:1222567121

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseTermOrderTypeResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseTermOrderTypeResourceTestCase.java
@@ -1670,4 +1670,4 @@ public abstract class BaseTermOrderTypeResourceTestCase {
 		TermOrderTypeResource _termOrderTypeResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-425483617
+// LIFERAY-REST-BUILDER-HASH:1117305183

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseTermResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseTermResourceTestCase.java
@@ -2914,4 +2914,4 @@ public abstract class BaseTermResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:445378104
+// LIFERAY-REST-BUILDER-HASH:2136794486

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-payment-test/src/testIntegration/java/com/liferay/headless/commerce/admin/payment/resource/v1_0/test/BasePaymentResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-payment-test/src/testIntegration/java/com/liferay/headless/commerce/admin/payment/resource/v1_0/test/BasePaymentResourceTestCase.java
@@ -3888,4 +3888,4 @@ public abstract class BasePaymentResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1834791019
+// LIFERAY-REST-BUILDER-HASH:2069239583

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseDiscountAccountGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseDiscountAccountGroupResourceTestCase.java
@@ -1699,4 +1699,4 @@ public abstract class BaseDiscountAccountGroupResourceTestCase {
 		DiscountAccountGroupResource _discountAccountGroupResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1154890854
+// LIFERAY-REST-BUILDER-HASH:-1892993090

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseDiscountCategoryResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseDiscountCategoryResourceTestCase.java
@@ -1646,4 +1646,4 @@ public abstract class BaseDiscountCategoryResourceTestCase {
 		DiscountCategoryResource _discountCategoryResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1008291427
+// LIFERAY-REST-BUILDER-HASH:-904401247

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseDiscountProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseDiscountProductResourceTestCase.java
@@ -1634,4 +1634,4 @@ public abstract class BaseDiscountProductResourceTestCase {
 		DiscountProductResource _discountProductResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:228676967
+// LIFERAY-REST-BUILDER-HASH:-1400190089

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseDiscountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseDiscountResourceTestCase.java
@@ -2885,4 +2885,4 @@ public abstract class BaseDiscountResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1768381368
+// LIFERAY-REST-BUILDER-HASH:-1393585512

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseDiscountRuleResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseDiscountRuleResourceTestCase.java
@@ -1960,4 +1960,4 @@ public abstract class BaseDiscountRuleResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:356296316
+// LIFERAY-REST-BUILDER-HASH:-208841260

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BasePriceEntryResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BasePriceEntryResourceTestCase.java
@@ -2567,4 +2567,4 @@ public abstract class BasePriceEntryResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1938163471
+// LIFERAY-REST-BUILDER-HASH:1515985247

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BasePriceListAccountGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BasePriceListAccountGroupResourceTestCase.java
@@ -1741,4 +1741,4 @@ public abstract class BasePriceListAccountGroupResourceTestCase {
 		PriceListAccountGroupResource _priceListAccountGroupResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1081427064
+// LIFERAY-REST-BUILDER-HASH:1137857794

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BasePriceListResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BasePriceListResourceTestCase.java
@@ -2775,4 +2775,4 @@ public abstract class BasePriceListResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-639109450
+// LIFERAY-REST-BUILDER-HASH:2137627640

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseTierPriceResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseTierPriceResourceTestCase.java
@@ -2359,4 +2359,4 @@ public abstract class BaseTierPriceResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1529751491
+// LIFERAY-REST-BUILDER-HASH:465138235

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseAccountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseAccountResourceTestCase.java
@@ -1126,4 +1126,4 @@ public abstract class BaseAccountResourceTestCase {
 			AccountResource _accountResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1347982730
+// LIFERAY-REST-BUILDER-HASH:-120029448

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseCategoryResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseCategoryResourceTestCase.java
@@ -1249,4 +1249,4 @@ public abstract class BaseCategoryResourceTestCase {
 			CategoryResource _categoryResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1805143229
+// LIFERAY-REST-BUILDER-HASH:2015193955

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseChannelResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseChannelResourceTestCase.java
@@ -1337,4 +1337,4 @@ public abstract class BaseChannelResourceTestCase {
 			ChannelResource _channelResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-930850098
+// LIFERAY-REST-BUILDER-HASH:1564892596

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountAccountGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountAccountGroupResourceTestCase.java
@@ -2041,4 +2041,4 @@ public abstract class BaseDiscountAccountGroupResourceTestCase {
 		DiscountAccountGroupResource _discountAccountGroupResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1717813157
+// LIFERAY-REST-BUILDER-HASH:1098365513

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountAccountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountAccountResourceTestCase.java
@@ -1968,4 +1968,4 @@ public abstract class BaseDiscountAccountResourceTestCase {
 		DiscountAccountResource _discountAccountResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-560167823
+// LIFERAY-REST-BUILDER-HASH:663427877

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountCategoryResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountCategoryResourceTestCase.java
@@ -1975,4 +1975,4 @@ public abstract class BaseDiscountCategoryResourceTestCase {
 		DiscountCategoryResource _discountCategoryResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1070924466
+// LIFERAY-REST-BUILDER-HASH:987447250

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountChannelResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountChannelResourceTestCase.java
@@ -1968,4 +1968,4 @@ public abstract class BaseDiscountChannelResourceTestCase {
 		DiscountChannelResource _discountChannelResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-538051715
+// LIFERAY-REST-BUILDER-HASH:-937430203

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountOrderTypeResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountOrderTypeResourceTestCase.java
@@ -2017,4 +2017,4 @@ public abstract class BaseDiscountOrderTypeResourceTestCase {
 		DiscountOrderTypeResource _discountOrderTypeResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1436948434
+// LIFERAY-REST-BUILDER-HASH:-1089144564

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountProductGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountProductGroupResourceTestCase.java
@@ -2041,4 +2041,4 @@ public abstract class BaseDiscountProductGroupResourceTestCase {
 		DiscountProductGroupResource _discountProductGroupResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1107478547
+// LIFERAY-REST-BUILDER-HASH:279128653

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountProductResourceTestCase.java
@@ -1968,4 +1968,4 @@ public abstract class BaseDiscountProductResourceTestCase {
 		DiscountProductResource _discountProductResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1422636321
+// LIFERAY-REST-BUILDER-HASH:284779153

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountResourceTestCase.java
@@ -3514,4 +3514,4 @@ public abstract class BaseDiscountResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-2013816979
+// LIFERAY-REST-BUILDER-HASH:-474098931

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountRuleResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountRuleResourceTestCase.java
@@ -2335,4 +2335,4 @@ public abstract class BaseDiscountRuleResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:753941585
+// LIFERAY-REST-BUILDER-HASH:-364007303

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountSkuResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountSkuResourceTestCase.java
@@ -2020,4 +2020,4 @@ public abstract class BaseDiscountSkuResourceTestCase {
 		DiscountSkuResource _discountSkuResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:557491330
+// LIFERAY-REST-BUILDER-HASH:1863025622

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseOrderTypeResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseOrderTypeResourceTestCase.java
@@ -1072,4 +1072,4 @@ public abstract class BaseOrderTypeResourceTestCase {
 			OrderTypeResource _orderTypeResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1521980021
+// LIFERAY-REST-BUILDER-HASH:-1388703353

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceEntryResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceEntryResourceTestCase.java
@@ -3761,4 +3761,4 @@ public abstract class BasePriceEntryResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:283006115
+// LIFERAY-REST-BUILDER-HASH:-181939245

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListAccountGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListAccountGroupResourceTestCase.java
@@ -2088,4 +2088,4 @@ public abstract class BasePriceListAccountGroupResourceTestCase {
 		PriceListAccountGroupResource _priceListAccountGroupResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1289856920
+// LIFERAY-REST-BUILDER-HASH:-1695490926

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListAccountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListAccountResourceTestCase.java
@@ -2003,4 +2003,4 @@ public abstract class BasePriceListAccountResourceTestCase {
 		PriceListAccountResource _priceListAccountResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:353991394
+// LIFERAY-REST-BUILDER-HASH:-1896717748

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListChannelResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListChannelResourceTestCase.java
@@ -2003,4 +2003,4 @@ public abstract class BasePriceListChannelResourceTestCase {
 		PriceListChannelResource _priceListChannelResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1946323660
+// LIFERAY-REST-BUILDER-HASH:500742818

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListDiscountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListDiscountResourceTestCase.java
@@ -1771,4 +1771,4 @@ public abstract class BasePriceListDiscountResourceTestCase {
 		PriceListDiscountResource _priceListDiscountResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1390205405
+// LIFERAY-REST-BUILDER-HASH:1790708961

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListOrderTypeResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListOrderTypeResourceTestCase.java
@@ -1781,4 +1781,4 @@ public abstract class BasePriceListOrderTypeResourceTestCase {
 		PriceListOrderTypeResource _priceListOrderTypeResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1423825269
+// LIFERAY-REST-BUILDER-HASH:-153287307

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListResourceTestCase.java
@@ -3479,4 +3479,4 @@ public abstract class BasePriceListResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1931135519
+// LIFERAY-REST-BUILDER-HASH:-1638251613

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceModifierCategoryResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceModifierCategoryResourceTestCase.java
@@ -2064,4 +2064,4 @@ public abstract class BasePriceModifierCategoryResourceTestCase {
 		PriceModifierCategoryResource _priceModifierCategoryResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-278315604
+// LIFERAY-REST-BUILDER-HASH:-1979630628

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceModifierProductGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceModifierProductGroupResourceTestCase.java
@@ -2103,4 +2103,4 @@ public abstract class BasePriceModifierProductGroupResourceTestCase {
 		PriceModifierProductGroupResource _priceModifierProductGroupResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:540114363
+// LIFERAY-REST-BUILDER-HASH:647030183

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceModifierProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceModifierProductResourceTestCase.java
@@ -2050,4 +2050,4 @@ public abstract class BasePriceModifierProductResourceTestCase {
 		PriceModifierProductResource _priceModifierProductResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1347917699
+// LIFERAY-REST-BUILDER-HASH:-2063237793

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceModifierResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceModifierResourceTestCase.java
@@ -3114,4 +3114,4 @@ public abstract class BasePriceModifierResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-2144978635
+// LIFERAY-REST-BUILDER-HASH:544334601

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePricingAccountGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePricingAccountGroupResourceTestCase.java
@@ -1160,4 +1160,4 @@ public abstract class BasePricingAccountGroupResourceTestCase {
 		PricingAccountGroupResource _pricingAccountGroupResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:609505755
+// LIFERAY-REST-BUILDER-HASH:-1298687297

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseProductGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseProductGroupResourceTestCase.java
@@ -1118,4 +1118,4 @@ public abstract class BaseProductGroupResourceTestCase {
 		ProductGroupResource _productGroupResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1444835609
+// LIFERAY-REST-BUILDER-HASH:-1824232681

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseProductResourceTestCase.java
@@ -1326,4 +1326,4 @@ public abstract class BaseProductResourceTestCase {
 			ProductResource _productResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-190882206
+// LIFERAY-REST-BUILDER-HASH:1380419696

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseSkuResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseSkuResourceTestCase.java
@@ -1272,4 +1272,4 @@ public abstract class BaseSkuResourceTestCase {
 			_skuResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1152371583
+// LIFERAY-REST-BUILDER-HASH:-220940209

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseTierPriceResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseTierPriceResourceTestCase.java
@@ -2785,4 +2785,4 @@ public abstract class BaseTierPriceResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-552869269
+// LIFERAY-REST-BUILDER-HASH:1741204141

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-test/src/testIntegration/java/com/liferay/headless/commerce/admin/shipment/resource/v1_0/test/BaseShipmentItemResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-test/src/testIntegration/java/com/liferay/headless/commerce/admin/shipment/resource/v1_0/test/BaseShipmentItemResourceTestCase.java
@@ -2974,4 +2974,4 @@ public abstract class BaseShipmentItemResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1747108258
+// LIFERAY-REST-BUILDER-HASH:-2088247656

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-test/src/testIntegration/java/com/liferay/headless/commerce/admin/shipment/resource/v1_0/test/BaseShipmentResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-test/src/testIntegration/java/com/liferay/headless/commerce/admin/shipment/resource/v1_0/test/BaseShipmentResourceTestCase.java
@@ -3397,4 +3397,4 @@ public abstract class BaseShipmentResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:538203171
+// LIFERAY-REST-BUILDER-HASH:-740596653

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-test/src/testIntegration/java/com/liferay/headless/commerce/admin/shipment/resource/v1_0/test/BaseShippingAddressResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-test/src/testIntegration/java/com/liferay/headless/commerce/admin/shipment/resource/v1_0/test/BaseShippingAddressResourceTestCase.java
@@ -1968,4 +1968,4 @@ public abstract class BaseShippingAddressResourceTestCase {
 		ShippingAddressResource _shippingAddressResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1751238274
+// LIFERAY-REST-BUILDER-HASH:-967722048

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-test/src/testIntegration/java/com/liferay/headless/commerce/admin/site/setting/resource/v1_0/test/BaseAvailabilityEstimateResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-test/src/testIntegration/java/com/liferay/headless/commerce/admin/site/setting/resource/v1_0/test/BaseAvailabilityEstimateResourceTestCase.java
@@ -2304,4 +2304,4 @@ public abstract class BaseAvailabilityEstimateResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1011027500
+// LIFERAY-REST-BUILDER-HASH:517337168

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-test/src/testIntegration/java/com/liferay/headless/commerce/admin/site/setting/resource/v1_0/test/BaseMeasurementUnitResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-test/src/testIntegration/java/com/liferay/headless/commerce/admin/site/setting/resource/v1_0/test/BaseMeasurementUnitResourceTestCase.java
@@ -3446,4 +3446,4 @@ public abstract class BaseMeasurementUnitResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1905793555
+// LIFERAY-REST-BUILDER-HASH:-1503941057

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-test/src/testIntegration/java/com/liferay/headless/commerce/admin/site/setting/resource/v1_0/test/BaseTaxCategoryResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-test/src/testIntegration/java/com/liferay/headless/commerce/admin/site/setting/resource/v1_0/test/BaseTaxCategoryResourceTestCase.java
@@ -1663,4 +1663,4 @@ public abstract class BaseTaxCategoryResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:366103485
+// LIFERAY-REST-BUILDER-HASH:137147779

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-test/src/testIntegration/java/com/liferay/headless/commerce/admin/site/setting/resource/v1_0/test/BaseWarehouseResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-test/src/testIntegration/java/com/liferay/headless/commerce/admin/site/setting/resource/v1_0/test/BaseWarehouseResourceTestCase.java
@@ -2147,4 +2147,4 @@ public abstract class BaseWarehouseResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:819974563
+// LIFERAY-REST-BUILDER-HASH:-1826494371

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseAddressResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseAddressResourceTestCase.java
@@ -2483,4 +2483,4 @@ public abstract class BaseAddressResourceTestCase {
 			AddressResource _addressResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1890906323
+// LIFERAY-REST-BUILDER-HASH:-157432053

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseAttachmentResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseAttachmentResourceTestCase.java
@@ -2399,4 +2399,4 @@ public abstract class BaseAttachmentResourceTestCase {
 			AttachmentResource _attachmentResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1553951030
+// LIFERAY-REST-BUILDER-HASH:39547340

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseCartCommentResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseCartCommentResourceTestCase.java
@@ -2842,4 +2842,4 @@ public abstract class BaseCartCommentResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-159794487
+// LIFERAY-REST-BUILDER-HASH:1824240125

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseCartItemResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseCartItemResourceTestCase.java
@@ -3572,4 +3572,4 @@ public abstract class BaseCartItemResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1496152069
+// LIFERAY-REST-BUILDER-HASH:-1281365433

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseCartResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseCartResourceTestCase.java
@@ -5556,4 +5556,4 @@ public abstract class BaseCartResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-450237951
+// LIFERAY-REST-BUILDER-HASH:-1693009787

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseCartTransitionResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseCartTransitionResourceTestCase.java
@@ -1170,4 +1170,4 @@ public abstract class BaseCartTransitionResourceTestCase {
 		CartTransitionResource _cartTransitionResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:498769508
+// LIFERAY-REST-BUILDER-HASH:-46586626

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BasePaymentMethodResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BasePaymentMethodResourceTestCase.java
@@ -1129,4 +1129,4 @@ public abstract class BasePaymentMethodResourceTestCase {
 		PaymentMethodResource _paymentMethodResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1206160197
+// LIFERAY-REST-BUILDER-HASH:964254175

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseShippingMethodResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseShippingMethodResourceTestCase.java
@@ -1180,4 +1180,4 @@ public abstract class BaseShippingMethodResourceTestCase {
 		ShippingMethodResource _shippingMethodResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-2059108936
+// LIFERAY-REST-BUILDER-HASH:1947027166

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseTermResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseTermResourceTestCase.java
@@ -1338,4 +1338,4 @@ public abstract class BaseTermResourceTestCase {
 			_termResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1397501932
+// LIFERAY-REST-BUILDER-HASH:1941224440

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseAccountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseAccountResourceTestCase.java
@@ -1821,4 +1821,4 @@ public abstract class BaseAccountResourceTestCase {
 			AccountResource _accountResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:404774570
+// LIFERAY-REST-BUILDER-HASH:-759734374

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseAttachmentResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseAttachmentResourceTestCase.java
@@ -1821,4 +1821,4 @@ public abstract class BaseAttachmentResourceTestCase {
 		AttachmentResource _attachmentResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:229790678
+// LIFERAY-REST-BUILDER-HASH:1606719704

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseCategoryResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseCategoryResourceTestCase.java
@@ -1174,4 +1174,4 @@ public abstract class BaseCategoryResourceTestCase {
 		CategoryResource _categoryResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1524997409
+// LIFERAY-REST-BUILDER-HASH:-633083465

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseChannelResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseChannelResourceTestCase.java
@@ -1385,4 +1385,4 @@ public abstract class BaseChannelResourceTestCase {
 			ChannelResource _channelResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-989498453
+// LIFERAY-REST-BUILDER-HASH:545866831

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseCurrencyResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseCurrencyResourceTestCase.java
@@ -2037,4 +2037,4 @@ public abstract class BaseCurrencyResourceTestCase {
 		CurrencyResource _currencyResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-929614855
+// LIFERAY-REST-BUILDER-HASH:-508614821

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseLinkedProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseLinkedProductResourceTestCase.java
@@ -1133,4 +1133,4 @@ public abstract class BaseLinkedProductResourceTestCase {
 		LinkedProductResource _linkedProductResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1154524911
+// LIFERAY-REST-BUILDER-HASH:-765896529

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseMappedProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseMappedProductResourceTestCase.java
@@ -1984,4 +1984,4 @@ public abstract class BaseMappedProductResourceTestCase {
 		MappedProductResource _mappedProductResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-2135661329
+// LIFERAY-REST-BUILDER-HASH:-575874943

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BasePinResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BasePinResourceTestCase.java
@@ -1610,4 +1610,4 @@ public abstract class BasePinResourceTestCase {
 			_pinResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1842910535
+// LIFERAY-REST-BUILDER-HASH:1869230087

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseProductOptionResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseProductOptionResourceTestCase.java
@@ -1733,4 +1733,4 @@ public abstract class BaseProductOptionResourceTestCase {
 		ProductOptionResource _productOptionResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1643943526
+// LIFERAY-REST-BUILDER-HASH:-1979710248

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseProductOptionValueResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseProductOptionValueResourceTestCase.java
@@ -2166,4 +2166,4 @@ public abstract class BaseProductOptionValueResourceTestCase {
 		ProductOptionValueResource _productOptionValueResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-2073010502
+// LIFERAY-REST-BUILDER-HASH:-2020703516

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseProductResourceTestCase.java
@@ -2673,4 +2673,4 @@ public abstract class BaseProductResourceTestCase {
 			ProductResource _productResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:733190270
+// LIFERAY-REST-BUILDER-HASH:2135337906

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseProductSpecificationResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseProductSpecificationResourceTestCase.java
@@ -1794,4 +1794,4 @@ public abstract class BaseProductSpecificationResourceTestCase {
 		ProductSpecificationResource _productSpecificationResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1968040117
+// LIFERAY-REST-BUILDER-HASH:1307306255

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseRelatedProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseRelatedProductResourceTestCase.java
@@ -1188,4 +1188,4 @@ public abstract class BaseRelatedProductResourceTestCase {
 		RelatedProductResource _relatedProductResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1638789426
+// LIFERAY-REST-BUILDER-HASH:-777514474

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseSkuResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseSkuResourceTestCase.java
@@ -2775,4 +2775,4 @@ public abstract class BaseSkuResourceTestCase {
 			_skuResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-433990222
+// LIFERAY-REST-BUILDER-HASH:1667992802

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseWishListItemResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseWishListItemResourceTestCase.java
@@ -1956,4 +1956,4 @@ public abstract class BaseWishListItemResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1331478085
+// LIFERAY-REST-BUILDER-HASH:2143667919

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseWishListResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseWishListResourceTestCase.java
@@ -1872,4 +1872,4 @@ public abstract class BaseWishListResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:157378916
+// LIFERAY-REST-BUILDER-HASH:143514494

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/order/resource/v1_0/test/BaseAttachmentResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/order/resource/v1_0/test/BaseAttachmentResourceTestCase.java
@@ -2454,4 +2454,4 @@ public abstract class BaseAttachmentResourceTestCase {
 		AttachmentResource _attachmentResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-839019984
+// LIFERAY-REST-BUILDER-HASH:-1745038414

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/order/resource/v1_0/test/BaseOrderTransitionResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/order/resource/v1_0/test/BaseOrderTransitionResourceTestCase.java
@@ -1170,4 +1170,4 @@ public abstract class BaseOrderTransitionResourceTestCase {
 		OrderTransitionResource _orderTransitionResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1885534223
+// LIFERAY-REST-BUILDER-HASH:-1244484715

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/order/resource/v1_0/test/BasePlacedOrderAddressResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/order/resource/v1_0/test/BasePlacedOrderAddressResourceTestCase.java
@@ -2581,4 +2581,4 @@ public abstract class BasePlacedOrderAddressResourceTestCase {
 		PlacedOrderAddressResource _placedOrderAddressResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:147976249
+// LIFERAY-REST-BUILDER-HASH:510336759

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/order/resource/v1_0/test/BasePlacedOrderCommentResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/order/resource/v1_0/test/BasePlacedOrderCommentResourceTestCase.java
@@ -2003,4 +2003,4 @@ public abstract class BasePlacedOrderCommentResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1949105143
+// LIFERAY-REST-BUILDER-HASH:-847286961

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/order/resource/v1_0/test/BasePlacedOrderItemResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/order/resource/v1_0/test/BasePlacedOrderItemResourceTestCase.java
@@ -3333,4 +3333,4 @@ public abstract class BasePlacedOrderItemResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1987037721
+// LIFERAY-REST-BUILDER-HASH:-124964727

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/order/resource/v1_0/test/BasePlacedOrderItemShipmentResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/order/resource/v1_0/test/BasePlacedOrderItemShipmentResourceTestCase.java
@@ -1907,4 +1907,4 @@ public abstract class BasePlacedOrderItemShipmentResourceTestCase {
 		PlacedOrderItemShipmentResource _placedOrderItemShipmentResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1310499212
+// LIFERAY-REST-BUILDER-HASH:-1769731430

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/order/resource/v1_0/test/BasePlacedOrderResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/order/resource/v1_0/test/BasePlacedOrderResourceTestCase.java
@@ -5239,4 +5239,4 @@ public abstract class BasePlacedOrderResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1107605360
+// LIFERAY-REST-BUILDER-HASH:2080378824

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/order/resource/v1_0/test/BaseShipmentResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/order/resource/v1_0/test/BaseShipmentResourceTestCase.java
@@ -2551,4 +2551,4 @@ public abstract class BaseShipmentResourceTestCase {
 			ShipmentResource _shipmentResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1608434512
+// LIFERAY-REST-BUILDER-HASH:1379184576

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/order/resource/v1_0/test/BaseTermResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/order/resource/v1_0/test/BaseTermResourceTestCase.java
@@ -1539,4 +1539,4 @@ public abstract class BaseTermResourceTestCase {
 			_termResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1787031472
+// LIFERAY-REST-BUILDER-HASH:-1902076580

--- a/modules/apps/cookies/cookies-rest-test/src/testIntegration/java/com/liferay/cookies/rest/resource/v1_0/test/BaseCookiesConsentPreferenceResourceTestCase.java
+++ b/modules/apps/cookies/cookies-rest-test/src/testIntegration/java/com/liferay/cookies/rest/resource/v1_0/test/BaseCookiesConsentPreferenceResourceTestCase.java
@@ -1429,4 +1429,4 @@ public abstract class BaseCookiesConsentPreferenceResourceTestCase {
 			_cookiesConsentPreferenceResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1814284656
+// LIFERAY-REST-BUILDER-HASH:-1877775746

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataDefinitionFieldLinkResourceTestCase.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataDefinitionFieldLinkResourceTestCase.java
@@ -967,4 +967,4 @@ public abstract class BaseDataDefinitionFieldLinkResourceTestCase {
 			DataDefinitionFieldLinkResource _dataDefinitionFieldLinkResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1765820803
+// LIFERAY-REST-BUILDER-HASH:-1054609693

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataDefinitionResourceTestCase.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataDefinitionResourceTestCase.java
@@ -3598,4 +3598,4 @@ public abstract class BaseDataDefinitionResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1189306303
+// LIFERAY-REST-BUILDER-HASH:-533575419

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataLayoutResourceTestCase.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataLayoutResourceTestCase.java
@@ -2745,4 +2745,4 @@ public abstract class BaseDataLayoutResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:40054769
+// LIFERAY-REST-BUILDER-HASH:1082803305

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataListViewResourceTestCase.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataListViewResourceTestCase.java
@@ -2430,4 +2430,4 @@ public abstract class BaseDataListViewResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-324985018
+// LIFERAY-REST-BUILDER-HASH:-2129177568

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataRecordCollectionResourceTestCase.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataRecordCollectionResourceTestCase.java
@@ -2556,4 +2556,4 @@ public abstract class BaseDataRecordCollectionResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:195330629
+// LIFERAY-REST-BUILDER-HASH:1582735863

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataRecordResourceTestCase.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataRecordResourceTestCase.java
@@ -2651,4 +2651,4 @@ public abstract class BaseDataRecordResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-225014576
+// LIFERAY-REST-BUILDER-HASH:464182490

--- a/modules/apps/digital-signature/digital-signature-rest-test/src/testIntegration/java/com/liferay/digital/signature/rest/resource/v1_0/test/BaseDSEnvelopeResourceTestCase.java
+++ b/modules/apps/digital-signature/digital-signature-rest-test/src/testIntegration/java/com/liferay/digital/signature/rest/resource/v1_0/test/BaseDSEnvelopeResourceTestCase.java
@@ -1868,4 +1868,4 @@ public abstract class BaseDSEnvelopeResourceTestCase {
 		_dsEnvelopeResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1521357880
+// LIFERAY-REST-BUILDER-HASH:-1958071544

--- a/modules/apps/digital-signature/digital-signature-rest-test/src/testIntegration/java/com/liferay/digital/signature/rest/resource/v1_0/test/BaseDSRecipientViewDefinitionResourceTestCase.java
+++ b/modules/apps/digital-signature/digital-signature-rest-test/src/testIntegration/java/com/liferay/digital/signature/rest/resource/v1_0/test/BaseDSRecipientViewDefinitionResourceTestCase.java
@@ -1241,4 +1241,4 @@ public abstract class BaseDSRecipientViewDefinitionResourceTestCase {
 		DSRecipientViewDefinitionResource _dsRecipientViewDefinitionResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:97720334
+// LIFERAY-REST-BUILDER-HASH:-1496098326

--- a/modules/apps/dispatch/dispatch-rest-test/src/testIntegration/java/com/liferay/dispatch/rest/resource/v1_0/test/BaseDispatchTriggerResourceTestCase.java
+++ b/modules/apps/dispatch/dispatch-rest-test/src/testIntegration/java/com/liferay/dispatch/rest/resource/v1_0/test/BaseDispatchTriggerResourceTestCase.java
@@ -1723,4 +1723,4 @@ public abstract class BaseDispatchTriggerResourceTestCase {
 		_dispatchTriggerResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1588092456
+// LIFERAY-REST-BUILDER-HASH:1956562510

--- a/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/BaseExportPreviewResourceTestCase.java
+++ b/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/BaseExportPreviewResourceTestCase.java
@@ -884,4 +884,4 @@ public abstract class BaseExportPreviewResourceTestCase {
 		_exportPreviewResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-660362624
+// LIFERAY-REST-BUILDER-HASH:140398052

--- a/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/BaseExportProcessResourceTestCase.java
+++ b/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/BaseExportProcessResourceTestCase.java
@@ -2757,4 +2757,4 @@ public abstract class BaseExportProcessResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1124267225
+// LIFERAY-REST-BUILDER-HASH:-747273035

--- a/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/BaseImportPreviewResourceTestCase.java
+++ b/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/BaseImportPreviewResourceTestCase.java
@@ -1175,4 +1175,4 @@ public abstract class BaseImportPreviewResourceTestCase {
 		_importPreviewResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-558585794
+// LIFERAY-REST-BUILDER-HASH:1362300636

--- a/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/BaseImportProcessResourceTestCase.java
+++ b/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/BaseImportProcessResourceTestCase.java
@@ -2733,4 +2733,4 @@ public abstract class BaseImportProcessResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-140984819
+// LIFERAY-REST-BUILDER-HASH:-948697315

--- a/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/BasePublishPreviewResourceTestCase.java
+++ b/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/BasePublishPreviewResourceTestCase.java
@@ -840,4 +840,4 @@ public abstract class BasePublishPreviewResourceTestCase {
 		_publishPreviewResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:10249719
+// LIFERAY-REST-BUILDER-HASH:1198422367

--- a/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/BasePublishProcessResourceTestCase.java
+++ b/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/BasePublishProcessResourceTestCase.java
@@ -2052,4 +2052,4 @@ public abstract class BasePublishProcessResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:559692138
+// LIFERAY-REST-BUILDER-HASH:-1955663072

--- a/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/BaseReportEntryResourceTestCase.java
+++ b/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/BaseReportEntryResourceTestCase.java
@@ -2035,4 +2035,4 @@ public abstract class BaseReportEntryResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-885060697
+// LIFERAY-REST-BUILDER-HASH:-128866049

--- a/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/BaseScheduledPublishProcessResourceTestCase.java
+++ b/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/BaseScheduledPublishProcessResourceTestCase.java
@@ -1674,4 +1674,4 @@ public abstract class BaseScheduledPublishProcessResourceTestCase {
 			ScheduledPublishProcessResource _scheduledPublishProcessResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1629459487
+// LIFERAY-REST-BUILDER-HASH:286661717

--- a/modules/apps/headless/headless-admin-address/headless-admin-address-test/src/testIntegration/java/com/liferay/headless/admin/address/resource/v1_0/test/BaseCountryResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-address/headless-admin-address-test/src/testIntegration/java/com/liferay/headless/admin/address/resource/v1_0/test/BaseCountryResourceTestCase.java
@@ -3400,4 +3400,4 @@ public abstract class BaseCountryResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1718770931
+// LIFERAY-REST-BUILDER-HASH:-1342702515

--- a/modules/apps/headless/headless-admin-address/headless-admin-address-test/src/testIntegration/java/com/liferay/headless/admin/address/resource/v1_0/test/BaseRegionResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-address/headless-admin-address-test/src/testIntegration/java/com/liferay/headless/admin/address/resource/v1_0/test/BaseRegionResourceTestCase.java
@@ -3176,4 +3176,4 @@ public abstract class BaseRegionResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1216458893
+// LIFERAY-REST-BUILDER-HASH:1277958029

--- a/modules/apps/headless/headless-admin-configuration/headless-admin-configuration-test/src/testIntegration/java/com/liferay/headless/admin/configuration/resource/v1_0/test/BaseInstanceConfigurationResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-configuration/headless-admin-configuration-test/src/testIntegration/java/com/liferay/headless/admin/configuration/resource/v1_0/test/BaseInstanceConfigurationResourceTestCase.java
@@ -1115,4 +1115,4 @@ public abstract class BaseInstanceConfigurationResourceTestCase {
 		InstanceConfigurationResource _instanceConfigurationResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:796340588
+// LIFERAY-REST-BUILDER-HASH:-2128496776

--- a/modules/apps/headless/headless-admin-configuration/headless-admin-configuration-test/src/testIntegration/java/com/liferay/headless/admin/configuration/resource/v1_0/test/BaseSiteConfigurationResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-configuration/headless-admin-configuration-test/src/testIntegration/java/com/liferay/headless/admin/configuration/resource/v1_0/test/BaseSiteConfigurationResourceTestCase.java
@@ -1169,4 +1169,4 @@ public abstract class BaseSiteConfigurationResourceTestCase {
 		SiteConfigurationResource _siteConfigurationResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1258074121
+// LIFERAY-REST-BUILDER-HASH:-1026579495

--- a/modules/apps/headless/headless-admin-configuration/headless-admin-configuration-test/src/testIntegration/java/com/liferay/headless/admin/configuration/resource/v1_0/test/BaseSystemConfigurationResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-configuration/headless-admin-configuration-test/src/testIntegration/java/com/liferay/headless/admin/configuration/resource/v1_0/test/BaseSystemConfigurationResourceTestCase.java
@@ -1101,4 +1101,4 @@ public abstract class BaseSystemConfigurationResourceTestCase {
 		SystemConfigurationResource _systemConfigurationResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-327591374
+// LIFERAY-REST-BUILDER-HASH:-1034181774

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-test/src/testIntegration/java/com/liferay/headless/admin/content/resource/v1_0/test/BaseDisplayPageTemplateResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-test/src/testIntegration/java/com/liferay/headless/admin/content/resource/v1_0/test/BaseDisplayPageTemplateResourceTestCase.java
@@ -1648,4 +1648,4 @@ public abstract class BaseDisplayPageTemplateResourceTestCase {
 			DisplayPageTemplateResource _displayPageTemplateResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1373734010
+// LIFERAY-REST-BUILDER-HASH:-977838320

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-test/src/testIntegration/java/com/liferay/headless/admin/content/resource/v1_0/test/BasePageDefinitionResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-test/src/testIntegration/java/com/liferay/headless/admin/content/resource/v1_0/test/BasePageDefinitionResourceTestCase.java
@@ -855,4 +855,4 @@ public abstract class BasePageDefinitionResourceTestCase {
 			_pageDefinitionResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:292462024
+// LIFERAY-REST-BUILDER-HASH:1200547314

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-test/src/testIntegration/java/com/liferay/headless/admin/content/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-test/src/testIntegration/java/com/liferay/headless/admin/content/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
@@ -2917,4 +2917,4 @@ public abstract class BaseStructuredContentResourceTestCase {
 			StructuredContentResource _structuredContentResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:871950705
+// LIFERAY-REST-BUILDER-HASH:552102945

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/BaseFragmentResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/BaseFragmentResourceTestCase.java
@@ -2239,4 +2239,4 @@ public abstract class BaseFragmentResourceTestCase {
 		_fragmentResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1098441790
+// LIFERAY-REST-BUILDER-HASH:-999662990

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/BaseFragmentSetResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/BaseFragmentSetResourceTestCase.java
@@ -2041,4 +2041,4 @@ public abstract class BaseFragmentSetResourceTestCase {
 			_fragmentSetResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:206612899
+// LIFERAY-REST-BUILDER-HASH:-1078551447

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/BaseResourceFileResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/BaseResourceFileResourceTestCase.java
@@ -2218,4 +2218,4 @@ public abstract class BaseResourceFileResourceTestCase {
 			_resourceFileResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1484533591
+// LIFERAY-REST-BUILDER-HASH:-565088293

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/BaseResourceFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/BaseResourceFolderResourceTestCase.java
@@ -2242,4 +2242,4 @@ public abstract class BaseResourceFolderResourceTestCase {
 			_resourceFolderResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-15130935
+// LIFERAY-REST-BUILDER-HASH:-1367045151

--- a/modules/apps/headless/headless-admin-language-override/headless-admin-language-override-impl/rest-config.yaml
+++ b/modules/apps/headless/headless-admin-language-override/headless-admin-language-override-impl/rest-config.yaml
@@ -6,7 +6,7 @@ application:
     name: Liferay.Headless.Admin.Language.Override
 author: Thiago Buarque
 clientDir: ../headless-admin-language-override-client/src/main/java
-compatibilityVersion: 15
+compatibilityVersion: 16
 forcePredictableOperationId: true
 javaEEPackage: jakarta
 testDir: ../headless-admin-language-override-test/src/testIntegration/java

--- a/modules/apps/headless/headless-admin-language-override/headless-admin-language-override-test/src/testIntegration/java/com/liferay/headless/admin/language/override/resource/v1_0/test/BaseLanguageOverrideResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-language-override/headless-admin-language-override-test/src/testIntegration/java/com/liferay/headless/admin/language/override/resource/v1_0/test/BaseLanguageOverrideResourceTestCase.java
@@ -2125,4 +2125,4 @@ public abstract class BaseLanguageOverrideResourceTestCase {
 		LanguageOverrideResource _languageOverrideResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1520172040
+// LIFERAY-REST-BUILDER-HASH:2026385472

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-test/src/testIntegration/java/com/liferay/headless/admin/list/type/resource/v1_0/test/BaseListTypeDefinitionResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-test/src/testIntegration/java/com/liferay/headless/admin/list/type/resource/v1_0/test/BaseListTypeDefinitionResourceTestCase.java
@@ -2828,4 +2828,4 @@ public abstract class BaseListTypeDefinitionResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1668619461
+// LIFERAY-REST-BUILDER-HASH:-2003600457

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-test/src/testIntegration/java/com/liferay/headless/admin/list/type/resource/v1_0/test/BaseListTypeEntryResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-test/src/testIntegration/java/com/liferay/headless/admin/list/type/resource/v1_0/test/BaseListTypeEntryResourceTestCase.java
@@ -3298,4 +3298,4 @@ public abstract class BaseListTypeEntryResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:930767519
+// LIFERAY-REST-BUILDER-HASH:-1083116375

--- a/modules/apps/headless/headless-admin-server/headless-admin-server-test/src/testIntegration/java/com/liferay/headless/admin/server/resource/v1_0/test/BaseDatabaseSchemaExportResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-server/headless-admin-server-test/src/testIntegration/java/com/liferay/headless/admin/server/resource/v1_0/test/BaseDatabaseSchemaExportResourceTestCase.java
@@ -965,4 +965,4 @@ public abstract class BaseDatabaseSchemaExportResourceTestCase {
 			DatabaseSchemaExportResource _databaseSchemaExportResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:369589545
+// LIFERAY-REST-BUILDER-HASH:-884731311

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BaseDisplayPageTemplateFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BaseDisplayPageTemplateFolderResourceTestCase.java
@@ -2434,4 +2434,4 @@ public abstract class BaseDisplayPageTemplateFolderResourceTestCase {
 		DisplayPageTemplateFolderResource _displayPageTemplateFolderResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1018167928
+// LIFERAY-REST-BUILDER-HASH:1804930348

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BaseDisplayPageTemplateResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BaseDisplayPageTemplateResourceTestCase.java
@@ -2705,4 +2705,4 @@ public abstract class BaseDisplayPageTemplateResourceTestCase {
 			DisplayPageTemplateResource _displayPageTemplateResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1658615624
+// LIFERAY-REST-BUILDER-HASH:813250976

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BaseFriendlyUrlHistoryResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BaseFriendlyUrlHistoryResourceTestCase.java
@@ -816,4 +816,4 @@ public abstract class BaseFriendlyUrlHistoryResourceTestCase {
 			_friendlyUrlHistoryResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:2139202000
+// LIFERAY-REST-BUILDER-HASH:-357194944

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BaseMasterPageResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BaseMasterPageResourceTestCase.java
@@ -2303,4 +2303,4 @@ public abstract class BaseMasterPageResourceTestCase {
 		_masterPageResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-498592246
+// LIFERAY-REST-BUILDER-HASH:-772465156

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BaseNavigationMenuResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BaseNavigationMenuResourceTestCase.java
@@ -2073,4 +2073,4 @@ public abstract class BaseNavigationMenuResourceTestCase {
 		_navigationMenuResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-987770916
+// LIFERAY-REST-BUILDER-HASH:-769561966

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BasePageElementResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BasePageElementResourceTestCase.java
@@ -1564,4 +1564,4 @@ public abstract class BasePageElementResourceTestCase {
 		_pageElementResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1144979140
+// LIFERAY-REST-BUILDER-HASH:-132937944

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BasePageExperienceResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BasePageExperienceResourceTestCase.java
@@ -1527,4 +1527,4 @@ public abstract class BasePageExperienceResourceTestCase {
 		_pageExperienceResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:240127262
+// LIFERAY-REST-BUILDER-HASH:846984412

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BasePageSpecificationResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BasePageSpecificationResourceTestCase.java
@@ -2314,4 +2314,4 @@ public abstract class BasePageSpecificationResourceTestCase {
 			_pageSpecificationResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1728147100
+// LIFERAY-REST-BUILDER-HASH:497217390

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BasePageSpecificationVersionResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BasePageSpecificationVersionResourceTestCase.java
@@ -1616,4 +1616,4 @@ public abstract class BasePageSpecificationVersionResourceTestCase {
 		PageSpecificationVersionResource _pageSpecificationVersionResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1787763006
+// LIFERAY-REST-BUILDER-HASH:557695178

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BasePageTemplateResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BasePageTemplateResourceTestCase.java
@@ -2826,4 +2826,4 @@ public abstract class BasePageTemplateResourceTestCase {
 		_pageTemplateResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1704584716
+// LIFERAY-REST-BUILDER-HASH:-518989674

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BasePageTemplateSetResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BasePageTemplateSetResourceTestCase.java
@@ -2158,4 +2158,4 @@ public abstract class BasePageTemplateSetResourceTestCase {
 			_pageTemplateSetResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1440076324
+// LIFERAY-REST-BUILDER-HASH:809253136

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BaseSitePageResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BaseSitePageResourceTestCase.java
@@ -2382,4 +2382,4 @@ public abstract class BaseSitePageResourceTestCase {
 		_sitePageResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:364860708
+// LIFERAY-REST-BUILDER-HASH:-674533440

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BaseSiteResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BaseSiteResourceTestCase.java
@@ -2556,4 +2556,4 @@ public abstract class BaseSiteResourceTestCase {
 		_siteResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1982169433
+// LIFERAY-REST-BUILDER-HASH:-1554261833

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BaseSiteTemplateResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BaseSiteTemplateResourceTestCase.java
@@ -1377,4 +1377,4 @@ public abstract class BaseSiteTemplateResourceTestCase {
 		_siteTemplateResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:680587508
+// LIFERAY-REST-BUILDER-HASH:1605806690

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BaseStyleBookResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BaseStyleBookResourceTestCase.java
@@ -2824,4 +2824,4 @@ public abstract class BaseStyleBookResourceTestCase {
 		_styleBookResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:83030005
+// LIFERAY-REST-BUILDER-HASH:-1912454625

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BaseUtilityPageResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BaseUtilityPageResourceTestCase.java
@@ -2314,4 +2314,4 @@ public abstract class BaseUtilityPageResourceTestCase {
 		_utilityPageResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-71575996
+// LIFERAY-REST-BUILDER-HASH:1651862908

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BaseWidgetPageWidgetInstanceResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BaseWidgetPageWidgetInstanceResourceTestCase.java
@@ -1799,4 +1799,4 @@ public abstract class BaseWidgetPageWidgetInstanceResourceTestCase {
 		WidgetPageWidgetInstanceResource _widgetPageWidgetInstanceResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-432510653
+// LIFERAY-REST-BUILDER-HASH:1999132043

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseKeywordResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseKeywordResourceTestCase.java
@@ -4465,4 +4465,4 @@ public abstract class BaseKeywordResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:148906130
+// LIFERAY-REST-BUILDER-HASH:632355200

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
@@ -7083,4 +7083,4 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 			TaxonomyCategoryResource _taxonomyCategoryResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1988617113
+// LIFERAY-REST-BUILDER-HASH:395872311

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
@@ -5319,4 +5319,4 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:5359092
+// LIFERAY-REST-BUILDER-HASH:-256627596

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseAccountGroupResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseAccountGroupResourceTestCase.java
@@ -3401,4 +3401,4 @@ public abstract class BaseAccountGroupResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1662775926
+// LIFERAY-REST-BUILDER-HASH:-1471190772

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseAccountResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseAccountResourceTestCase.java
@@ -6550,4 +6550,4 @@ public abstract class BaseAccountResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1619740004
+// LIFERAY-REST-BUILDER-HASH:-67839286

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseAccountRoleResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseAccountRoleResourceTestCase.java
@@ -3567,4 +3567,4 @@ public abstract class BaseAccountRoleResourceTestCase {
 		_accountRoleResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:84584596
+// LIFERAY-REST-BUILDER-HASH:-1778758738

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseEmailAddressResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseEmailAddressResourceTestCase.java
@@ -2574,4 +2574,4 @@ public abstract class BaseEmailAddressResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1667600975
+// LIFERAY-REST-BUILDER-HASH:-562246833

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseOrganizationResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseOrganizationResourceTestCase.java
@@ -8112,4 +8112,4 @@ public abstract class BaseOrganizationResourceTestCase {
 		_organizationResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1236298735
+// LIFERAY-REST-BUILDER-HASH:2118077767

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BasePhoneResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BasePhoneResourceTestCase.java
@@ -2479,4 +2479,4 @@ public abstract class BasePhoneResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1926358202
+// LIFERAY-REST-BUILDER-HASH:-1887387510

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BasePostalAddressResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BasePostalAddressResourceTestCase.java
@@ -3864,4 +3864,4 @@ public abstract class BasePostalAddressResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1719397881
+// LIFERAY-REST-BUILDER-HASH:-143634137

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseRoleResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseRoleResourceTestCase.java
@@ -3679,4 +3679,4 @@ public abstract class BaseRoleResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1962818139
+// LIFERAY-REST-BUILDER-HASH:1521853113

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSegmentResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSegmentResourceTestCase.java
@@ -1365,4 +1365,4 @@ public abstract class BaseSegmentResourceTestCase {
 		_segmentResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:531229057
+// LIFERAY-REST-BUILDER-HASH:1359208251

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSegmentUserResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSegmentUserResourceTestCase.java
@@ -1084,4 +1084,4 @@ public abstract class BaseSegmentUserResourceTestCase {
 		_segmentUserResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-148301052
+// LIFERAY-REST-BUILDER-HASH:1302333128

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSharedAssetResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSharedAssetResourceTestCase.java
@@ -2312,4 +2312,4 @@ public abstract class BaseSharedAssetResourceTestCase {
 		_sharedAssetResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-805903262
+// LIFERAY-REST-BUILDER-HASH:1792328812

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSiteResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSiteResourceTestCase.java
@@ -1914,4 +1914,4 @@ public abstract class BaseSiteResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1905547185
+// LIFERAY-REST-BUILDER-HASH:1296514193

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSubscriptionResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSubscriptionResourceTestCase.java
@@ -1426,4 +1426,4 @@ public abstract class BaseSubscriptionResourceTestCase {
 		_subscriptionResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1140867762
+// LIFERAY-REST-BUILDER-HASH:-515872710

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseTicketResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseTicketResourceTestCase.java
@@ -1219,4 +1219,4 @@ public abstract class BaseTicketResourceTestCase {
 		_ticketResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1731837631
+// LIFERAY-REST-BUILDER-HASH:1273551895

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseUserAccountFullNameDefinitionResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseUserAccountFullNameDefinitionResourceTestCase.java
@@ -859,4 +859,4 @@ public abstract class BaseUserAccountFullNameDefinitionResourceTestCase {
 			_userAccountFullNameDefinitionResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:865529990
+// LIFERAY-REST-BUILDER-HASH:-278766328

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseUserAccountResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseUserAccountResourceTestCase.java
@@ -9644,4 +9644,4 @@ public abstract class BaseUserAccountResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1977945887
+// LIFERAY-REST-BUILDER-HASH:-1670083259

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseUserGroupResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseUserGroupResourceTestCase.java
@@ -3083,4 +3083,4 @@ public abstract class BaseUserGroupResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1154136050
+// LIFERAY-REST-BUILDER-HASH:391646870

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseWebUrlResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseWebUrlResourceTestCase.java
@@ -2414,4 +2414,4 @@ public abstract class BaseWebUrlResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:91570254
+// LIFERAY-REST-BUILDER-HASH:647278982

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseAssigneeResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseAssigneeResourceTestCase.java
@@ -1004,4 +1004,4 @@ public abstract class BaseAssigneeResourceTestCase {
 		_assigneeResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:93675876
+// LIFERAY-REST-BUILDER-HASH:-566526892

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseTransitionResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseTransitionResourceTestCase.java
@@ -1378,4 +1378,4 @@ public abstract class BaseTransitionResourceTestCase {
 		_transitionResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1666829394
+// LIFERAY-REST-BUILDER-HASH:998402890

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowDefinitionLinkResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowDefinitionLinkResourceTestCase.java
@@ -2012,4 +2012,4 @@ public abstract class BaseWorkflowDefinitionLinkResourceTestCase {
 		WorkflowDefinitionLinkResource _workflowDefinitionLinkResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-991586530
+// LIFERAY-REST-BUILDER-HASH:1353544308

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowDefinitionResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowDefinitionResourceTestCase.java
@@ -3093,4 +3093,4 @@ public abstract class BaseWorkflowDefinitionResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1453249279
+// LIFERAY-REST-BUILDER-HASH:-877794647

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowInstanceResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowInstanceResourceTestCase.java
@@ -2003,4 +2003,4 @@ public abstract class BaseWorkflowInstanceResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:935639679
+// LIFERAY-REST-BUILDER-HASH:1449713701

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowLogResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowLogResourceTestCase.java
@@ -2131,4 +2131,4 @@ public abstract class BaseWorkflowLogResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1329062441
+// LIFERAY-REST-BUILDER-HASH:424809395

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowTaskAssignableUsersResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowTaskAssignableUsersResourceTestCase.java
@@ -856,4 +856,4 @@ public abstract class BaseWorkflowTaskAssignableUsersResourceTestCase {
 			_workflowTaskAssignableUsersResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1749878099
+// LIFERAY-REST-BUILDER-HASH:-137185597

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowTaskResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowTaskResourceTestCase.java
@@ -3463,4 +3463,4 @@ public abstract class BaseWorkflowTaskResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-299908165
+// LIFERAY-REST-BUILDER-HASH:-2120728447

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowTaskTransitionsResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowTaskTransitionsResourceTestCase.java
@@ -844,4 +844,4 @@ public abstract class BaseWorkflowTaskTransitionsResourceTestCase {
 		WorkflowTaskTransitionsResource _workflowTaskTransitionsResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1241930176
+// LIFERAY-REST-BUILDER-HASH:932157364

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/BaseAssetLibraryResourceTestCase.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/BaseAssetLibraryResourceTestCase.java
@@ -2590,4 +2590,4 @@ public abstract class BaseAssetLibraryResourceTestCase {
 			_assetLibraryResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:223965448
+// LIFERAY-REST-BUILDER-HASH:483980998

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/BaseConnectedSiteResourceTestCase.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/BaseConnectedSiteResourceTestCase.java
@@ -1613,4 +1613,4 @@ public abstract class BaseConnectedSiteResourceTestCase {
 			_connectedSiteResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1699971052
+// LIFERAY-REST-BUILDER-HASH:-1432969686

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/BaseRoleResourceTestCase.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/BaseRoleResourceTestCase.java
@@ -1379,4 +1379,4 @@ public abstract class BaseRoleResourceTestCase {
 		_roleResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1532492382
+// LIFERAY-REST-BUILDER-HASH:921557394

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/BaseUserAccountResourceTestCase.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/BaseUserAccountResourceTestCase.java
@@ -1583,4 +1583,4 @@ public abstract class BaseUserAccountResourceTestCase {
 		_userAccountResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:234936934
+// LIFERAY-REST-BUILDER-HASH:1987242996

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/BaseUserGroupResourceTestCase.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/BaseUserGroupResourceTestCase.java
@@ -1545,4 +1545,4 @@ public abstract class BaseUserGroupResourceTestCase {
 		_userGroupResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-892704179
+// LIFERAY-REST-BUILDER-HASH:-984323621

--- a/modules/apps/headless/headless-cmp/headless-cmp-test/src/testIntegration/java/com/liferay/headless/cmp/resource/v1_0/test/BaseContentCoverageResourceTestCase.java
+++ b/modules/apps/headless/headless-cmp/headless-cmp-test/src/testIntegration/java/com/liferay/headless/cmp/resource/v1_0/test/BaseContentCoverageResourceTestCase.java
@@ -876,4 +876,4 @@ public abstract class BaseContentCoverageResourceTestCase {
 		_contentCoverageResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-220918846
+// LIFERAY-REST-BUILDER-HASH:-1818262170

--- a/modules/apps/headless/headless-cmp/headless-cmp-test/src/testIntegration/java/com/liferay/headless/cmp/resource/v1_0/test/BaseTaskAssigneeResourceTestCase.java
+++ b/modules/apps/headless/headless-cmp/headless-cmp-test/src/testIntegration/java/com/liferay/headless/cmp/resource/v1_0/test/BaseTaskAssigneeResourceTestCase.java
@@ -1088,4 +1088,4 @@ public abstract class BaseTaskAssigneeResourceTestCase {
 		_taskAssigneeResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:392385223
+// LIFERAY-REST-BUILDER-HASH:675541071

--- a/modules/apps/headless/headless-cmp/headless-cmp-test/src/testIntegration/java/com/liferay/headless/cmp/resource/v1_0/test/BaseTaskStatisticsResourceTestCase.java
+++ b/modules/apps/headless/headless-cmp/headless-cmp-test/src/testIntegration/java/com/liferay/headless/cmp/resource/v1_0/test/BaseTaskStatisticsResourceTestCase.java
@@ -880,4 +880,4 @@ public abstract class BaseTaskStatisticsResourceTestCase {
 		_taskStatisticsResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-582721745
+// LIFERAY-REST-BUILDER-HASH:-2098989361

--- a/modules/apps/headless/headless-cmp/headless-cmp-test/src/testIntegration/java/com/liferay/headless/cmp/resource/v1_0/test/BaseUserAccountResourceTestCase.java
+++ b/modules/apps/headless/headless-cmp/headless-cmp-test/src/testIntegration/java/com/liferay/headless/cmp/resource/v1_0/test/BaseUserAccountResourceTestCase.java
@@ -1246,4 +1246,4 @@ public abstract class BaseUserAccountResourceTestCase {
 		_userAccountResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:206960770
+// LIFERAY-REST-BUILDER-HASH:365697724

--- a/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/BaseAssetPermissionActionResourceTestCase.java
+++ b/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/BaseAssetPermissionActionResourceTestCase.java
@@ -955,4 +955,4 @@ public abstract class BaseAssetPermissionActionResourceTestCase {
 		_assetPermissionActionResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1943702772
+// LIFERAY-REST-BUILDER-HASH:-1718202976

--- a/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/BaseAssetStatisticsResourceTestCase.java
+++ b/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/BaseAssetStatisticsResourceTestCase.java
@@ -1037,4 +1037,4 @@ public abstract class BaseAssetStatisticsResourceTestCase {
 		_assetStatisticsResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-583460990
+// LIFERAY-REST-BUILDER-HASH:-1448042726

--- a/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/BaseAssetUsageResourceTestCase.java
+++ b/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/BaseAssetUsageResourceTestCase.java
@@ -1242,4 +1242,4 @@ public abstract class BaseAssetUsageResourceTestCase {
 		_assetUsageResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:637300106
+// LIFERAY-REST-BUILDER-HASH:1710696920

--- a/modules/apps/headless/headless-data-mask/headless-data-mask-test/src/testIntegration/java/com/liferay/headless/data/mask/resource/v1_0/test/BaseRedactionResourceTestCase.java
+++ b/modules/apps/headless/headless-data-mask/headless-data-mask-test/src/testIntegration/java/com/liferay/headless/data/mask/resource/v1_0/test/BaseRedactionResourceTestCase.java
@@ -883,4 +883,4 @@ public abstract class BaseRedactionResourceTestCase {
 		_redactionResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1703231214
+// LIFERAY-REST-BUILDER-HASH:-1194360532

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseAssetEntryResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseAssetEntryResourceTestCase.java
@@ -1616,4 +1616,4 @@ public abstract class BaseAssetEntryResourceTestCase {
 		_assetEntryResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1862261043
+// LIFERAY-REST-BUILDER-HASH:77419703

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingImageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingImageResourceTestCase.java
@@ -3029,4 +3029,4 @@ public abstract class BaseBlogPostingImageResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-750457521
+// LIFERAY-REST-BUILDER-HASH:98455111

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingResourceTestCase.java
@@ -4211,4 +4211,4 @@ public abstract class BaseBlogPostingResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-82846811
+// LIFERAY-REST-BUILDER-HASH:236181765

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseCommentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseCommentResourceTestCase.java
@@ -5964,4 +5964,4 @@ public abstract class BaseCommentResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1623654693
+// LIFERAY-REST-BUILDER-HASH:896006691

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentElementResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentElementResourceTestCase.java
@@ -1888,4 +1888,4 @@ public abstract class BaseContentElementResourceTestCase {
 		_contentElementResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:544129200
+// LIFERAY-REST-BUILDER-HASH:222722296

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentSetElementResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentSetElementResourceTestCase.java
@@ -2334,4 +2334,4 @@ public abstract class BaseContentSetElementResourceTestCase {
 			_contentSetElementResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1813654313
+// LIFERAY-REST-BUILDER-HASH:1020416431

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentStructureResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentStructureResourceTestCase.java
@@ -2751,4 +2751,4 @@ public abstract class BaseContentStructureResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1105824789
+// LIFERAY-REST-BUILDER-HASH:-1252607151

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentTemplateResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentTemplateResourceTestCase.java
@@ -2514,4 +2514,4 @@ public abstract class BaseContentTemplateResourceTestCase {
 		_contentTemplateResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1340328372
+// LIFERAY-REST-BUILDER-HASH:617226286

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentDataDefinitionTypeResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentDataDefinitionTypeResourceTestCase.java
@@ -3699,4 +3699,4 @@ public abstract class BaseDocumentDataDefinitionTypeResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1056668484
+// LIFERAY-REST-BUILDER-HASH:-1112301978

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentFolderResourceTestCase.java
@@ -5740,4 +5740,4 @@ public abstract class BaseDocumentFolderResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1399892835
+// LIFERAY-REST-BUILDER-HASH:-891028281

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentMetadataSetResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentMetadataSetResourceTestCase.java
@@ -3812,4 +3812,4 @@ public abstract class BaseDocumentMetadataSetResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:120344408
+// LIFERAY-REST-BUILDER-HASH:1358941128

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentResourceTestCase.java
@@ -6637,4 +6637,4 @@ public abstract class BaseDocumentResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1797711030
+// LIFERAY-REST-BUILDER-HASH:942273406

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentShortcutResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentShortcutResourceTestCase.java
@@ -3215,4 +3215,4 @@ public abstract class BaseDocumentShortcutResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:2005011164
+// LIFERAY-REST-BUILDER-HASH:717886000

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseArticleResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseArticleResourceTestCase.java
@@ -5762,4 +5762,4 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-75772117
+// LIFERAY-REST-BUILDER-HASH:1875384139

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseAttachmentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseAttachmentResourceTestCase.java
@@ -2739,4 +2739,4 @@ public abstract class BaseKnowledgeBaseAttachmentResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:284197187
+// LIFERAY-REST-BUILDER-HASH:405644095

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseFolderResourceTestCase.java
@@ -3567,4 +3567,4 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:382909007
+// LIFERAY-REST-BUILDER-HASH:1420575689

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseLanguageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseLanguageResourceTestCase.java
@@ -1197,4 +1197,4 @@ public abstract class BaseLanguageResourceTestCase {
 		_languageResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-957859256
+// LIFERAY-REST-BUILDER-HASH:1578909766

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardAttachmentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardAttachmentResourceTestCase.java
@@ -3065,4 +3065,4 @@ public abstract class BaseMessageBoardAttachmentResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-107475217
+// LIFERAY-REST-BUILDER-HASH:-1253159879

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardMessageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardMessageResourceTestCase.java
@@ -5734,4 +5734,4 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1465091103
+// LIFERAY-REST-BUILDER-HASH:-1282023631

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardSectionResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardSectionResourceTestCase.java
@@ -3884,4 +3884,4 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-221035429
+// LIFERAY-REST-BUILDER-HASH:978631343

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardThreadResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardThreadResourceTestCase.java
@@ -5289,4 +5289,4 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-927999840
+// LIFERAY-REST-BUILDER-HASH:-1231426236

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseNavigationMenuResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseNavigationMenuResourceTestCase.java
@@ -3146,4 +3146,4 @@ public abstract class BaseNavigationMenuResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:451193228
+// LIFERAY-REST-BUILDER-HASH:-1607625964

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseSitePageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseSitePageResourceTestCase.java
@@ -2753,4 +2753,4 @@ public abstract class BaseSitePageResourceTestCase {
 		_sitePageResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1685978573
+// LIFERAY-REST-BUILDER-HASH:-2098185359

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentFolderResourceTestCase.java
@@ -5660,4 +5660,4 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:197868639
+// LIFERAY-REST-BUILDER-HASH:-117075989

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
@@ -7302,4 +7302,4 @@ public abstract class BaseStructuredContentResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:679538615
+// LIFERAY-REST-BUILDER-HASH:1383426471

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiNodeResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiNodeResourceTestCase.java
@@ -3067,4 +3067,4 @@ public abstract class BaseWikiNodeResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1387322972
+// LIFERAY-REST-BUILDER-HASH:103535602

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiPageAttachmentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiPageAttachmentResourceTestCase.java
@@ -2701,4 +2701,4 @@ public abstract class BaseWikiPageAttachmentResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-410025008
+// LIFERAY-REST-BUILDER-HASH:581103386

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiPageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiPageResourceTestCase.java
@@ -3405,4 +3405,4 @@ public abstract class BaseWikiPageResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1174507058
+// LIFERAY-REST-BUILDER-HASH:389471106

--- a/modules/apps/headless/headless-dsr/headless-dsr-test/src/testIntegration/java/com/liferay/headless/dsr/resource/v1_0/test/BaseInvitedMemberResourceTestCase.java
+++ b/modules/apps/headless/headless-dsr/headless-dsr-test/src/testIntegration/java/com/liferay/headless/dsr/resource/v1_0/test/BaseInvitedMemberResourceTestCase.java
@@ -1097,4 +1097,4 @@ public abstract class BaseInvitedMemberResourceTestCase {
 		_invitedMemberResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-325074069
+// LIFERAY-REST-BUILDER-HASH:-455330471

--- a/modules/apps/headless/headless-dsr/headless-dsr-test/src/testIntegration/java/com/liferay/headless/dsr/resource/v1_0/test/BaseRoomResourceTestCase.java
+++ b/modules/apps/headless/headless-dsr/headless-dsr-test/src/testIntegration/java/com/liferay/headless/dsr/resource/v1_0/test/BaseRoomResourceTestCase.java
@@ -950,4 +950,4 @@ public abstract class BaseRoomResourceTestCase {
 	private com.liferay.headless.dsr.resource.v1_0.RoomResource _roomResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1753495557
+// LIFERAY-REST-BUILDER-HASH:338024101

--- a/modules/apps/headless/headless-dsr/headless-dsr-test/src/testIntegration/java/com/liferay/headless/dsr/resource/v1_0/test/BaseUserAccountResourceTestCase.java
+++ b/modules/apps/headless/headless-dsr/headless-dsr-test/src/testIntegration/java/com/liferay/headless/dsr/resource/v1_0/test/BaseUserAccountResourceTestCase.java
@@ -1380,4 +1380,4 @@ public abstract class BaseUserAccountResourceTestCase {
 		_userAccountResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-739556775
+// LIFERAY-REST-BUILDER-HASH:-1964201755

--- a/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormDocumentResourceTestCase.java
+++ b/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormDocumentResourceTestCase.java
@@ -1790,4 +1790,4 @@ public abstract class BaseFormDocumentResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-456068011
+// LIFERAY-REST-BUILDER-HASH:-1666247483

--- a/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormRecordResourceTestCase.java
+++ b/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormRecordResourceTestCase.java
@@ -1938,4 +1938,4 @@ public abstract class BaseFormRecordResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-2142159999
+// LIFERAY-REST-BUILDER-HASH:890039045

--- a/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormResourceTestCase.java
+++ b/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormResourceTestCase.java
@@ -2179,4 +2179,4 @@ public abstract class BaseFormResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1497149175
+// LIFERAY-REST-BUILDER-HASH:-993343311

--- a/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormStructureResourceTestCase.java
+++ b/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormStructureResourceTestCase.java
@@ -1718,4 +1718,4 @@ public abstract class BaseFormStructureResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1433814619
+// LIFERAY-REST-BUILDER-HASH:1754149827

--- a/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/resource/v1_0/test/BaseCollaboratorResourceTestCase.java
+++ b/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/resource/v1_0/test/BaseCollaboratorResourceTestCase.java
@@ -2553,4 +2553,4 @@ public abstract class BaseCollaboratorResourceTestCase {
 		_collaboratorResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:386819873
+// LIFERAY-REST-BUILDER-HASH:-706184675

--- a/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/resource/v1_0/test/BaseObjectEntryFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/resource/v1_0/test/BaseObjectEntryFolderResourceTestCase.java
@@ -3736,4 +3736,4 @@ public abstract class BaseObjectEntryFolderResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:146182008
+// LIFERAY-REST-BUILDER-HASH:2086445716

--- a/modules/apps/headless/headless-pim/headless-pim-test/src/testIntegration/java/com/liferay/headless/pim/resource/v1_0/test/BaseLinkReferenceResourceTestCase.java
+++ b/modules/apps/headless/headless-pim/headless-pim-test/src/testIntegration/java/com/liferay/headless/pim/resource/v1_0/test/BaseLinkReferenceResourceTestCase.java
@@ -1395,4 +1395,4 @@ public abstract class BaseLinkReferenceResourceTestCase {
 		_linkReferenceResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1714626277
+// LIFERAY-REST-BUILDER-HASH:-1293353253

--- a/modules/apps/headless/headless-pim/headless-pim-test/src/testIntegration/java/com/liferay/headless/pim/resource/v1_0/test/BaseLinkResourceTestCase.java
+++ b/modules/apps/headless/headless-pim/headless-pim-test/src/testIntegration/java/com/liferay/headless/pim/resource/v1_0/test/BaseLinkResourceTestCase.java
@@ -866,4 +866,4 @@ public abstract class BaseLinkResourceTestCase {
 	private com.liferay.headless.pim.resource.v1_0.LinkResource _linkResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:928762267
+// LIFERAY-REST-BUILDER-HASH:-687791139

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-test/src/testIntegration/java/com/liferay/headless/portal/instances/resource/v1_0/test/BasePortalInstanceResourceTestCase.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-test/src/testIntegration/java/com/liferay/headless/portal/instances/resource/v1_0/test/BasePortalInstanceResourceTestCase.java
@@ -1449,4 +1449,4 @@ public abstract class BasePortalInstanceResourceTestCase {
 			PortalInstanceResource _portalInstanceResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-668246542
+// LIFERAY-REST-BUILDER-HASH:890027372

--- a/modules/apps/headless/headless-site/headless-site-test/src/testIntegration/java/com/liferay/headless/site/resource/v1_0/test/BaseSiteResourceTestCase.java
+++ b/modules/apps/headless/headless-site/headless-site-test/src/testIntegration/java/com/liferay/headless/site/resource/v1_0/test/BaseSiteResourceTestCase.java
@@ -2264,4 +2264,4 @@ public abstract class BaseSiteResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:905349500
+// LIFERAY-REST-BUILDER-HASH:1680003006

--- a/modules/apps/headless/headless-user-notification/headless-user-notification-test/src/testIntegration/java/com/liferay/headless/user/notification/resource/v1_0/test/BaseUserNotificationResourceTestCase.java
+++ b/modules/apps/headless/headless-user-notification/headless-user-notification-test/src/testIntegration/java/com/liferay/headless/user/notification/resource/v1_0/test/BaseUserNotificationResourceTestCase.java
@@ -2247,4 +2247,4 @@ public abstract class BaseUserNotificationResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-583804229
+// LIFERAY-REST-BUILDER-HASH:-1919343893

--- a/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/resource/v1_0/test/BaseToolResourceTestCase.java
+++ b/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/resource/v1_0/test/BaseToolResourceTestCase.java
@@ -903,4 +903,4 @@ public abstract class BaseToolResourceTestCase {
 		_toolResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:757826955
+// LIFERAY-REST-BUILDER-HASH:2038430757

--- a/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/resource/v1_0/test/BaseToolSetResourceTestCase.java
+++ b/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/resource/v1_0/test/BaseToolSetResourceTestCase.java
@@ -910,4 +910,4 @@ public abstract class BaseToolSetResourceTestCase {
 		_toolSetResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1061719681
+// LIFERAY-REST-BUILDER-HASH:1838648977

--- a/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/resource/v1_0/test/BaseToolSummaryResourceTestCase.java
+++ b/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/resource/v1_0/test/BaseToolSummaryResourceTestCase.java
@@ -969,4 +969,4 @@ public abstract class BaseToolSummaryResourceTestCase {
 		_toolSummaryResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:568890171
+// LIFERAY-REST-BUILDER-HASH:-110779709

--- a/modules/apps/notification/notification-rest-test/src/testIntegration/java/com/liferay/notification/rest/resource/v1_0/test/BaseNotificationQueueEntryResourceTestCase.java
+++ b/modules/apps/notification/notification-rest-test/src/testIntegration/java/com/liferay/notification/rest/resource/v1_0/test/BaseNotificationQueueEntryResourceTestCase.java
@@ -2744,4 +2744,4 @@ public abstract class BaseNotificationQueueEntryResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1556382892
+// LIFERAY-REST-BUILDER-HASH:-686226840

--- a/modules/apps/notification/notification-rest-test/src/testIntegration/java/com/liferay/notification/rest/resource/v1_0/test/BaseNotificationTemplateResourceTestCase.java
+++ b/modules/apps/notification/notification-rest-test/src/testIntegration/java/com/liferay/notification/rest/resource/v1_0/test/BaseNotificationTemplateResourceTestCase.java
@@ -3263,4 +3263,4 @@ public abstract class BaseNotificationTemplateResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1681993548
+// LIFERAY-REST-BUILDER-HASH:1686967002

--- a/modules/apps/oauth-client/oauth-client-rest-test/src/testIntegration/java/com/liferay/oauth/client/rest/resource/v1_0/test/BaseOAuthClientASLocalMetadataResourceTestCase.java
+++ b/modules/apps/oauth-client/oauth-client-rest-test/src/testIntegration/java/com/liferay/oauth/client/rest/resource/v1_0/test/BaseOAuthClientASLocalMetadataResourceTestCase.java
@@ -1689,4 +1689,4 @@ public abstract class BaseOAuthClientASLocalMetadataResourceTestCase {
 		OAuthClientASLocalMetadataResource _oAuthClientASLocalMetadataResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-2036238474
+// LIFERAY-REST-BUILDER-HASH:-633496622

--- a/modules/apps/oauth-client/oauth-client-rest-test/src/testIntegration/java/com/liferay/oauth/client/rest/resource/v1_0/test/BaseOAuthClientEntryResourceTestCase.java
+++ b/modules/apps/oauth-client/oauth-client-rest-test/src/testIntegration/java/com/liferay/oauth/client/rest/resource/v1_0/test/BaseOAuthClientEntryResourceTestCase.java
@@ -1883,4 +1883,4 @@ public abstract class BaseOAuthClientEntryResourceTestCase {
 		_oAuthClientEntryResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1274816773
+// LIFERAY-REST-BUILDER-HASH:1242866101

--- a/modules/apps/oauth-client/oauth-client-rest-test/src/testIntegration/java/com/liferay/oauth/client/rest/resource/v1_0/test/BaseOAuthClientPRLocalMetadataResourceTestCase.java
+++ b/modules/apps/oauth-client/oauth-client-rest-test/src/testIntegration/java/com/liferay/oauth/client/rest/resource/v1_0/test/BaseOAuthClientPRLocalMetadataResourceTestCase.java
@@ -1544,4 +1544,4 @@ public abstract class BaseOAuthClientPRLocalMetadataResourceTestCase {
 		OAuthClientPRLocalMetadataResource _oAuthClientPRLocalMetadataResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1182858124
+// LIFERAY-REST-BUILDER-HASH:367353136

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectActionResourceTestCase.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectActionResourceTestCase.java
@@ -3282,4 +3282,4 @@ public abstract class BaseObjectActionResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-859749928
+// LIFERAY-REST-BUILDER-HASH:979147092

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectDefinitionResourceTestCase.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectDefinitionResourceTestCase.java
@@ -4273,4 +4273,4 @@ public abstract class BaseObjectDefinitionResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-135108606
+// LIFERAY-REST-BUILDER-HASH:740775768

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectFieldResourceTestCase.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectFieldResourceTestCase.java
@@ -3776,4 +3776,4 @@ public abstract class BaseObjectFieldResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1893038348
+// LIFERAY-REST-BUILDER-HASH:-1782045654

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectFolderResourceTestCase.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectFolderResourceTestCase.java
@@ -2291,4 +2291,4 @@ public abstract class BaseObjectFolderResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1374542052
+// LIFERAY-REST-BUILDER-HASH:1055017992

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectLayoutResourceTestCase.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectLayoutResourceTestCase.java
@@ -2871,4 +2871,4 @@ public abstract class BaseObjectLayoutResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1611659387
+// LIFERAY-REST-BUILDER-HASH:-1004593641

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectRelationshipResourceTestCase.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectRelationshipResourceTestCase.java
@@ -3856,4 +3856,4 @@ public abstract class BaseObjectRelationshipResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1022095284
+// LIFERAY-REST-BUILDER-HASH:-1050300364

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectValidationRuleResourceTestCase.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectValidationRuleResourceTestCase.java
@@ -3422,4 +3422,4 @@ public abstract class BaseObjectValidationRuleResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:892918329
+// LIFERAY-REST-BUILDER-HASH:13291743

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectViewResourceTestCase.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectViewResourceTestCase.java
@@ -2966,4 +2966,4 @@ public abstract class BaseObjectViewResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1641069327
+// LIFERAY-REST-BUILDER-HASH:1884330761

--- a/modules/apps/portal-language/portal-language-rest-test/src/testIntegration/java/com/liferay/portal/language/rest/resource/v1_0/test/BaseMessageResourceTestCase.java
+++ b/modules/apps/portal-language/portal-language-rest-test/src/testIntegration/java/com/liferay/portal/language/rest/resource/v1_0/test/BaseMessageResourceTestCase.java
@@ -987,4 +987,4 @@ public abstract class BaseMessageResourceTestCase {
 		_messageResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-304448410
+// LIFERAY-REST-BUILDER-HASH:-575665882

--- a/modules/apps/portal-search/portal-search-rest-test/src/testIntegration/java/com/liferay/portal/search/rest/resource/v1_0/test/BaseEmbeddingModelResourceTestCase.java
+++ b/modules/apps/portal-search/portal-search-rest-test/src/testIntegration/java/com/liferay/portal/search/rest/resource/v1_0/test/BaseEmbeddingModelResourceTestCase.java
@@ -970,4 +970,4 @@ public abstract class BaseEmbeddingModelResourceTestCase {
 		_embeddingModelResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1879855815
+// LIFERAY-REST-BUILDER-HASH:-2087022899

--- a/modules/apps/portal-search/portal-search-rest-test/src/testIntegration/java/com/liferay/portal/search/rest/resource/v1_0/test/BaseEmbeddingProviderValidationResultResourceTestCase.java
+++ b/modules/apps/portal-search/portal-search-rest-test/src/testIntegration/java/com/liferay/portal/search/rest/resource/v1_0/test/BaseEmbeddingProviderValidationResultResourceTestCase.java
@@ -961,4 +961,4 @@ public abstract class BaseEmbeddingProviderValidationResultResourceTestCase {
 			_embeddingProviderValidationResultResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-817748539
+// LIFERAY-REST-BUILDER-HASH:776978557

--- a/modules/apps/portal-search/portal-search-rest-test/src/testIntegration/java/com/liferay/portal/search/rest/resource/v1_0/test/BaseSearchResultResourceTestCase.java
+++ b/modules/apps/portal-search/portal-search-rest-test/src/testIntegration/java/com/liferay/portal/search/rest/resource/v1_0/test/BaseSearchResultResourceTestCase.java
@@ -1590,4 +1590,4 @@ public abstract class BaseSearchResultResourceTestCase {
 		_searchResultResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1595048715
+// LIFERAY-REST-BUILDER-HASH:775790197

--- a/modules/apps/portal-search/portal-search-rest-test/src/testIntegration/java/com/liferay/portal/search/rest/resource/v1_0/test/BaseSuggestionResourceTestCase.java
+++ b/modules/apps/portal-search/portal-search-rest-test/src/testIntegration/java/com/liferay/portal/search/rest/resource/v1_0/test/BaseSuggestionResourceTestCase.java
@@ -865,4 +865,4 @@ public abstract class BaseSuggestionResourceTestCase {
 		_suggestionResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:892663300
+// LIFERAY-REST-BUILDER-HASH:1846621158

--- a/modules/apps/portal-security-audit/portal-security-audit-rest-test/src/testIntegration/java/com/liferay/portal/security/audit/rest/resource/v1_0/test/BaseAuditEventResourceTestCase.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-rest-test/src/testIntegration/java/com/liferay/portal/security/audit/rest/resource/v1_0/test/BaseAuditEventResourceTestCase.java
@@ -1606,4 +1606,4 @@ public abstract class BaseAuditEventResourceTestCase {
 			_auditEventResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-267771397
+// LIFERAY-REST-BUILDER-HASH:-1291666865

--- a/modules/apps/portal-security/portal-security-fips-rest-test/src/testIntegration/java/com/liferay/portal/security/fips/rest/resource/v1_0/test/BaseFIPSHealthVerificationResourceTestCase.java
+++ b/modules/apps/portal-security/portal-security-fips-rest-test/src/testIntegration/java/com/liferay/portal/security/fips/rest/resource/v1_0/test/BaseFIPSHealthVerificationResourceTestCase.java
@@ -951,4 +951,4 @@ public abstract class BaseFIPSHealthVerificationResourceTestCase {
 		FIPSHealthVerificationResource _fipsHealthVerificationResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:2019561479
+// LIFERAY-REST-BUILDER-HASH:-1282906327

--- a/modules/apps/site/site-dsr-analytics-rest-test/src/testIntegration/java/com/liferay/site/dsr/analytics/rest/resource/v1_0/test/BaseDocumentsMetricResourceTestCase.java
+++ b/modules/apps/site/site-dsr-analytics-rest-test/src/testIntegration/java/com/liferay/site/dsr/analytics/rest/resource/v1_0/test/BaseDocumentsMetricResourceTestCase.java
@@ -814,4 +814,4 @@ public abstract class BaseDocumentsMetricResourceTestCase {
 			DocumentsMetricResource _documentsMetricResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1882752430
+// LIFERAY-REST-BUILDER-HASH:664886386

--- a/modules/apps/site/site-dsr-analytics-rest-test/src/testIntegration/java/com/liferay/site/dsr/analytics/rest/resource/v1_0/test/BaseEventsResourceTestCase.java
+++ b/modules/apps/site/site-dsr-analytics-rest-test/src/testIntegration/java/com/liferay/site/dsr/analytics/rest/resource/v1_0/test/BaseEventsResourceTestCase.java
@@ -765,4 +765,4 @@ public abstract class BaseEventsResourceTestCase {
 		_eventsResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1009272717
+// LIFERAY-REST-BUILDER-HASH:-1078464647

--- a/modules/apps/site/site-dsr-analytics-rest-test/src/testIntegration/java/com/liferay/site/dsr/analytics/rest/resource/v1_0/test/BaseIdentityActivityResourceTestCase.java
+++ b/modules/apps/site/site-dsr-analytics-rest-test/src/testIntegration/java/com/liferay/site/dsr/analytics/rest/resource/v1_0/test/BaseIdentityActivityResourceTestCase.java
@@ -864,4 +864,4 @@ public abstract class BaseIdentityActivityResourceTestCase {
 			IdentityActivityResource _identityActivityResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1793142427
+// LIFERAY-REST-BUILDER-HASH:396132511

--- a/modules/apps/site/site-dsr-analytics-rest-test/src/testIntegration/java/com/liferay/site/dsr/analytics/rest/resource/v1_0/test/BaseMostActiveVisitorsResourceTestCase.java
+++ b/modules/apps/site/site-dsr-analytics-rest-test/src/testIntegration/java/com/liferay/site/dsr/analytics/rest/resource/v1_0/test/BaseMostActiveVisitorsResourceTestCase.java
@@ -830,4 +830,4 @@ public abstract class BaseMostActiveVisitorsResourceTestCase {
 			MostActiveVisitorsResource _mostActiveVisitorsResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:894128429
+// LIFERAY-REST-BUILDER-HASH:1669855183

--- a/modules/apps/site/site-dsr-analytics-rest-test/src/testIntegration/java/com/liferay/site/dsr/analytics/rest/resource/v1_0/test/BaseSiteHistogramMetricResourceTestCase.java
+++ b/modules/apps/site/site-dsr-analytics-rest-test/src/testIntegration/java/com/liferay/site/dsr/analytics/rest/resource/v1_0/test/BaseSiteHistogramMetricResourceTestCase.java
@@ -804,4 +804,4 @@ public abstract class BaseSiteHistogramMetricResourceTestCase {
 		SiteHistogramMetricResource _siteHistogramMetricResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1217707786
+// LIFERAY-REST-BUILDER-HASH:2143284564

--- a/modules/apps/site/site-dsr-analytics-rest-test/src/testIntegration/java/com/liferay/site/dsr/analytics/rest/resource/v1_0/test/BaseSiteVisitorBehaviorMetricResourceTestCase.java
+++ b/modules/apps/site/site-dsr-analytics-rest-test/src/testIntegration/java/com/liferay/site/dsr/analytics/rest/resource/v1_0/test/BaseSiteVisitorBehaviorMetricResourceTestCase.java
@@ -922,4 +922,4 @@ public abstract class BaseSiteVisitorBehaviorMetricResourceTestCase {
 		SiteVisitorBehaviorMetricResource _siteVisitorBehaviorMetricResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-916943614
+// LIFERAY-REST-BUILDER-HASH:574665920

--- a/modules/apps/site/site-dsr-analytics-rest-test/src/testIntegration/java/com/liferay/site/dsr/analytics/rest/resource/v1_0/test/BaseUserSessionsResourceTestCase.java
+++ b/modules/apps/site/site-dsr-analytics-rest-test/src/testIntegration/java/com/liferay/site/dsr/analytics/rest/resource/v1_0/test/BaseUserSessionsResourceTestCase.java
@@ -805,4 +805,4 @@ public abstract class BaseUserSessionsResourceTestCase {
 			_userSessionsResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1284674252
+// LIFERAY-REST-BUILDER-HASH:-883043102

--- a/modules/apps/site/site-dsr-analytics-rest-test/src/testIntegration/java/com/liferay/site/dsr/analytics/rest/resource/v1_0/test/BaseVisitFrequencyResourceTestCase.java
+++ b/modules/apps/site/site-dsr-analytics-rest-test/src/testIntegration/java/com/liferay/site/dsr/analytics/rest/resource/v1_0/test/BaseVisitFrequencyResourceTestCase.java
@@ -810,4 +810,4 @@ public abstract class BaseVisitFrequencyResourceTestCase {
 			_visitFrequencyResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-240781876
+// LIFERAY-REST-BUILDER-HASH:1779397328

--- a/modules/dxp/apps/analytics/analytics-reports-rest-test/src/testIntegration/java/com/liferay/analytics/reports/rest/resource/v1_0/test/BaseAssetAppearsOnHistogramMetricResourceTestCase.java
+++ b/modules/dxp/apps/analytics/analytics-reports-rest-test/src/testIntegration/java/com/liferay/analytics/reports/rest/resource/v1_0/test/BaseAssetAppearsOnHistogramMetricResourceTestCase.java
@@ -861,4 +861,4 @@ public abstract class BaseAssetAppearsOnHistogramMetricResourceTestCase {
 			_assetAppearsOnHistogramMetricResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1725768077
+// LIFERAY-REST-BUILDER-HASH:-1122515283

--- a/modules/dxp/apps/analytics/analytics-reports-rest-test/src/testIntegration/java/com/liferay/analytics/reports/rest/resource/v1_0/test/BaseAssetDeviceMetricResourceTestCase.java
+++ b/modules/dxp/apps/analytics/analytics-reports-rest-test/src/testIntegration/java/com/liferay/analytics/reports/rest/resource/v1_0/test/BaseAssetDeviceMetricResourceTestCase.java
@@ -809,4 +809,4 @@ public abstract class BaseAssetDeviceMetricResourceTestCase {
 			AssetDeviceMetricResource _assetDeviceMetricResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1159733648
+// LIFERAY-REST-BUILDER-HASH:-1335061486

--- a/modules/dxp/apps/analytics/analytics-reports-rest-test/src/testIntegration/java/com/liferay/analytics/reports/rest/resource/v1_0/test/BaseAssetHistogramMetricResourceTestCase.java
+++ b/modules/dxp/apps/analytics/analytics-reports-rest-test/src/testIntegration/java/com/liferay/analytics/reports/rest/resource/v1_0/test/BaseAssetHistogramMetricResourceTestCase.java
@@ -820,4 +820,4 @@ public abstract class BaseAssetHistogramMetricResourceTestCase {
 		AssetHistogramMetricResource _assetHistogramMetricResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1896797818
+// LIFERAY-REST-BUILDER-HASH:-1002928174

--- a/modules/dxp/apps/analytics/analytics-reports-rest-test/src/testIntegration/java/com/liferay/analytics/reports/rest/resource/v1_0/test/BaseAssetMetricResourceTestCase.java
+++ b/modules/dxp/apps/analytics/analytics-reports-rest-test/src/testIntegration/java/com/liferay/analytics/reports/rest/resource/v1_0/test/BaseAssetMetricResourceTestCase.java
@@ -1086,4 +1086,4 @@ public abstract class BaseAssetMetricResourceTestCase {
 		_assetMetricResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1055838964
+// LIFERAY-REST-BUILDER-HASH:-1058318658

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-test/src/testIntegration/java/com/liferay/headless/commerce/machine/learning/resource/v1_0/test/BaseAccountCategoryForecastResourceTestCase.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-test/src/testIntegration/java/com/liferay/headless/commerce/machine/learning/resource/v1_0/test/BaseAccountCategoryForecastResourceTestCase.java
@@ -1311,4 +1311,4 @@ public abstract class BaseAccountCategoryForecastResourceTestCase {
 		AccountCategoryForecastResource _accountCategoryForecastResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-943285442
+// LIFERAY-REST-BUILDER-HASH:-2060510202

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-test/src/testIntegration/java/com/liferay/headless/commerce/machine/learning/resource/v1_0/test/BaseAccountForecastResourceTestCase.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-test/src/testIntegration/java/com/liferay/headless/commerce/machine/learning/resource/v1_0/test/BaseAccountForecastResourceTestCase.java
@@ -1162,4 +1162,4 @@ public abstract class BaseAccountForecastResourceTestCase {
 		AccountForecastResource _accountForecastResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1716321167
+// LIFERAY-REST-BUILDER-HASH:445886757

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-test/src/testIntegration/java/com/liferay/headless/commerce/machine/learning/resource/v1_0/test/BaseSkuForecastResourceTestCase.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-test/src/testIntegration/java/com/liferay/headless/commerce/machine/learning/resource/v1_0/test/BaseSkuForecastResourceTestCase.java
@@ -1180,4 +1180,4 @@ public abstract class BaseSkuForecastResourceTestCase {
 		SkuForecastResource _skuForecastResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1647416585
+// LIFERAY-REST-BUILDER-HASH:-1273520291

--- a/modules/dxp/apps/osb/osb-testray/osb-testray-rest-test/src/testIntegration/java/com/liferay/osb/testray/rest/resource/v1_0/test/BaseCompareRunsResourceTestCase.java
+++ b/modules/dxp/apps/osb/osb-testray/osb-testray-rest-test/src/testIntegration/java/com/liferay/osb/testray/rest/resource/v1_0/test/BaseCompareRunsResourceTestCase.java
@@ -807,4 +807,4 @@ public abstract class BaseCompareRunsResourceTestCase {
 		_compareRunsResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-366928723
+// LIFERAY-REST-BUILDER-HASH:712169799

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseAssigneeMetricResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseAssigneeMetricResourceTestCase.java
@@ -885,4 +885,4 @@ public abstract class BaseAssigneeMetricResourceTestCase {
 		AssigneeMetricResource _assigneeMetricResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-872246306
+// LIFERAY-REST-BUILDER-HASH:-923786422

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseAssigneeResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseAssigneeResourceTestCase.java
@@ -931,4 +931,4 @@ public abstract class BaseAssigneeResourceTestCase {
 			_assigneeResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1065557931
+// LIFERAY-REST-BUILDER-HASH:-1546401929

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseCalendarResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseCalendarResourceTestCase.java
@@ -942,4 +942,4 @@ public abstract class BaseCalendarResourceTestCase {
 			_calendarResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:2131814318
+// LIFERAY-REST-BUILDER-HASH:-993941124

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseHistogramMetricResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseHistogramMetricResourceTestCase.java
@@ -850,4 +850,4 @@ public abstract class BaseHistogramMetricResourceTestCase {
 		HistogramMetricResource _histogramMetricResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-626758230
+// LIFERAY-REST-BUILDER-HASH:-341322714

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseIndexResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseIndexResourceTestCase.java
@@ -937,4 +937,4 @@ public abstract class BaseIndexResourceTestCase {
 		_indexResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-462730893
+// LIFERAY-REST-BUILDER-HASH:66190643

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseInstanceResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseInstanceResourceTestCase.java
@@ -2380,4 +2380,4 @@ public abstract class BaseInstanceResourceTestCase {
 			_instanceResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1650317587
+// LIFERAY-REST-BUILDER-HASH:-1949606893

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseNodeMetricResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseNodeMetricResourceTestCase.java
@@ -1255,4 +1255,4 @@ public abstract class BaseNodeMetricResourceTestCase {
 			NodeMetricResource _nodeMetricResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1529456593
+// LIFERAY-REST-BUILDER-HASH:59973943

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseNodeResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseNodeResourceTestCase.java
@@ -1581,4 +1581,4 @@ public abstract class BaseNodeResourceTestCase {
 		_nodeResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-2145507888
+// LIFERAY-REST-BUILDER-HASH:-847438518

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseProcessMetricResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseProcessMetricResourceTestCase.java
@@ -1184,4 +1184,4 @@ public abstract class BaseProcessMetricResourceTestCase {
 			ProcessMetricResource _processMetricResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:665765925
+// LIFERAY-REST-BUILDER-HASH:1227357919

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseProcessResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseProcessResourceTestCase.java
@@ -1905,4 +1905,4 @@ public abstract class BaseProcessResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-973497629
+// LIFERAY-REST-BUILDER-HASH:-1205617699

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseProcessVersionResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseProcessVersionResourceTestCase.java
@@ -905,4 +905,4 @@ public abstract class BaseProcessVersionResourceTestCase {
 		ProcessVersionResource _processVersionResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-976344069
+// LIFERAY-REST-BUILDER-HASH:1385403235

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseReindexStatusResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseReindexStatusResourceTestCase.java
@@ -893,4 +893,4 @@ public abstract class BaseReindexStatusResourceTestCase {
 			ReindexStatusResource _reindexStatusResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:475753515
+// LIFERAY-REST-BUILDER-HASH:1105907277

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseRoleResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseRoleResourceTestCase.java
@@ -893,4 +893,4 @@ public abstract class BaseRoleResourceTestCase {
 		_roleResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1517840150
+// LIFERAY-REST-BUILDER-HASH:-1453713972

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseSLAResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseSLAResourceTestCase.java
@@ -2118,4 +2118,4 @@ public abstract class BaseSLAResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1768689182
+// LIFERAY-REST-BUILDER-HASH:1312053522

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseSLAResultResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseSLAResultResourceTestCase.java
@@ -1135,4 +1135,4 @@ public abstract class BaseSLAResultResourceTestCase {
 			_slaResultResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-78292101
+// LIFERAY-REST-BUILDER-HASH:1489412341

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseTaskResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseTaskResourceTestCase.java
@@ -2170,4 +2170,4 @@ public abstract class BaseTaskResourceTestCase {
 		_taskResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:874060697
+// LIFERAY-REST-BUILDER-HASH:743900153

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseTimeRangeResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseTimeRangeResourceTestCase.java
@@ -1000,4 +1000,4 @@ public abstract class BaseTimeRangeResourceTestCase {
 			_timeRangeResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-220348739
+// LIFERAY-REST-BUILDER-HASH:425905913

--- a/modules/dxp/apps/saml/saml-admin-rest-test/src/testIntegration/java/com/liferay/saml/admin/rest/resource/v1_0/test/BaseSamlProviderResourceTestCase.java
+++ b/modules/dxp/apps/saml/saml-admin-rest-test/src/testIntegration/java/com/liferay/saml/admin/rest/resource/v1_0/test/BaseSamlProviderResourceTestCase.java
@@ -1085,4 +1085,4 @@ public abstract class BaseSamlProviderResourceTestCase {
 		_samlProviderResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-816617077
+// LIFERAY-REST-BUILDER-HASH:620039223

--- a/modules/dxp/apps/scim/scim-rest-test/src/testIntegration/java/com/liferay/scim/rest/resource/v1_0/test/BaseGroupResourceTestCase.java
+++ b/modules/dxp/apps/scim/scim-rest-test/src/testIntegration/java/com/liferay/scim/rest/resource/v1_0/test/BaseGroupResourceTestCase.java
@@ -1046,4 +1046,4 @@ public abstract class BaseGroupResourceTestCase {
 	private com.liferay.scim.rest.resource.v1_0.GroupResource _groupResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1701759722
+// LIFERAY-REST-BUILDER-HASH:2074763702

--- a/modules/dxp/apps/scim/scim-rest-test/src/testIntegration/java/com/liferay/scim/rest/resource/v1_0/test/BaseResourceTypesResourceTestCase.java
+++ b/modules/dxp/apps/scim/scim-rest-test/src/testIntegration/java/com/liferay/scim/rest/resource/v1_0/test/BaseResourceTypesResourceTestCase.java
@@ -656,4 +656,4 @@ public abstract class BaseResourceTypesResourceTestCase {
 		_resourceTypesResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1009577421
+// LIFERAY-REST-BUILDER-HASH:-947249195

--- a/modules/dxp/apps/scim/scim-rest-test/src/testIntegration/java/com/liferay/scim/rest/resource/v1_0/test/BaseSchemaResourceTestCase.java
+++ b/modules/dxp/apps/scim/scim-rest-test/src/testIntegration/java/com/liferay/scim/rest/resource/v1_0/test/BaseSchemaResourceTestCase.java
@@ -1011,4 +1011,4 @@ public abstract class BaseSchemaResourceTestCase {
 	private com.liferay.scim.rest.resource.v1_0.SchemaResource _schemaResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1634409088
+// LIFERAY-REST-BUILDER-HASH:1763374322

--- a/modules/dxp/apps/scim/scim-rest-test/src/testIntegration/java/com/liferay/scim/rest/resource/v1_0/test/BaseServiceProviderConfigResourceTestCase.java
+++ b/modules/dxp/apps/scim/scim-rest-test/src/testIntegration/java/com/liferay/scim/rest/resource/v1_0/test/BaseServiceProviderConfigResourceTestCase.java
@@ -1080,4 +1080,4 @@ public abstract class BaseServiceProviderConfigResourceTestCase {
 		_serviceProviderConfigResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-838953082
+// LIFERAY-REST-BUILDER-HASH:1989273176

--- a/modules/dxp/apps/scim/scim-rest-test/src/testIntegration/java/com/liferay/scim/rest/resource/v1_0/test/BaseUserResourceTestCase.java
+++ b/modules/dxp/apps/scim/scim-rest-test/src/testIntegration/java/com/liferay/scim/rest/resource/v1_0/test/BaseUserResourceTestCase.java
@@ -1911,4 +1911,4 @@ public abstract class BaseUserResourceTestCase {
 	private com.liferay.scim.rest.resource.v1_0.UserResource _userResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:576896976
+// LIFERAY-REST-BUILDER-HASH:1562514838

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseFieldMappingInfoResourceTestCase.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseFieldMappingInfoResourceTestCase.java
@@ -984,4 +984,4 @@ public abstract class BaseFieldMappingInfoResourceTestCase {
 			FieldMappingInfoResource _fieldMappingInfoResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1027422505
+// LIFERAY-REST-BUILDER-HASH:165727499

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseKeywordQueryContributorResourceTestCase.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseKeywordQueryContributorResourceTestCase.java
@@ -914,4 +914,4 @@ public abstract class BaseKeywordQueryContributorResourceTestCase {
 		KeywordQueryContributorResource _keywordQueryContributorResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1603422436
+// LIFERAY-REST-BUILDER-HASH:-4931402

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseModelPrefilterContributorResourceTestCase.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseModelPrefilterContributorResourceTestCase.java
@@ -925,4 +925,4 @@ public abstract class BaseModelPrefilterContributorResourceTestCase {
 		ModelPrefilterContributorResource _modelPrefilterContributorResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:929430064
+// LIFERAY-REST-BUILDER-HASH:-1091532988

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseQueryPrefilterContributorResourceTestCase.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseQueryPrefilterContributorResourceTestCase.java
@@ -925,4 +925,4 @@ public abstract class BaseQueryPrefilterContributorResourceTestCase {
 		QueryPrefilterContributorResource _queryPrefilterContributorResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1939764596
+// LIFERAY-REST-BUILDER-HASH:-184284482

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseSXPBlueprintResourceTestCase.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseSXPBlueprintResourceTestCase.java
@@ -3060,4 +3060,4 @@ public abstract class BaseSXPBlueprintResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:915581443
+// LIFERAY-REST-BUILDER-HASH:2138345443

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseSXPElementResourceTestCase.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseSXPElementResourceTestCase.java
@@ -3082,4 +3082,4 @@ public abstract class BaseSXPElementResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1765963639
+// LIFERAY-REST-BUILDER-HASH:-283542985

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseSXPParameterContributorDefinitionResourceTestCase.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseSXPParameterContributorDefinitionResourceTestCase.java
@@ -1101,4 +1101,4 @@ public abstract class BaseSXPParameterContributorDefinitionResourceTestCase {
 			_sxpParameterContributorDefinitionResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1493930634
+// LIFERAY-REST-BUILDER-HASH:-1569724980

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseSearchIndexResourceTestCase.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseSearchIndexResourceTestCase.java
@@ -886,4 +886,4 @@ public abstract class BaseSearchIndexResourceTestCase {
 			_searchIndexResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1814090673
+// LIFERAY-REST-BUILDER-HASH:-1181310937

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseSearchResponseResourceTestCase.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseSearchResponseResourceTestCase.java
@@ -1083,4 +1083,4 @@ public abstract class BaseSearchResponseResourceTestCase {
 			_searchResponseResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1267842596
+// LIFERAY-REST-BUILDER-HASH:1526286982

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseSearchableAssetNameDisplayResourceTestCase.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseSearchableAssetNameDisplayResourceTestCase.java
@@ -1064,4 +1064,4 @@ public abstract class BaseSearchableAssetNameDisplayResourceTestCase {
 		SearchableAssetNameDisplayResource _searchableAssetNameDisplayResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:830863722
+// LIFERAY-REST-BUILDER-HASH:-880526260

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseSearchableAssetNameResourceTestCase.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseSearchableAssetNameResourceTestCase.java
@@ -892,4 +892,4 @@ public abstract class BaseSearchableAssetNameResourceTestCase {
 		SearchableAssetNameResource _searchableAssetNameResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1737333744
+// LIFERAY-REST-BUILDER-HASH:1891928228

--- a/modules/dxp/apps/segments/segments-asah-rest-test/src/testIntegration/java/com/liferay/segments/asah/rest/resource/v1_0/test/BaseAsahSegmentsEntryResourceTestCase.java
+++ b/modules/dxp/apps/segments/segments-asah-rest-test/src/testIntegration/java/com/liferay/segments/asah/rest/resource/v1_0/test/BaseAsahSegmentsEntryResourceTestCase.java
@@ -963,4 +963,4 @@ public abstract class BaseAsahSegmentsEntryResourceTestCase {
 			_asahSegmentsEntryResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1541437046
+// LIFERAY-REST-BUILDER-HASH:1004372060

--- a/modules/dxp/apps/segments/segments-asah-rest-test/src/testIntegration/java/com/liferay/segments/asah/rest/resource/v1_0/test/BaseExperimentResourceTestCase.java
+++ b/modules/dxp/apps/segments/segments-asah-rest-test/src/testIntegration/java/com/liferay/segments/asah/rest/resource/v1_0/test/BaseExperimentResourceTestCase.java
@@ -1507,4 +1507,4 @@ public abstract class BaseExperimentResourceTestCase {
 		_experimentResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:2066892557
+// LIFERAY-REST-BUILDER-HASH:1951874977

--- a/modules/dxp/apps/segments/segments-asah-rest-test/src/testIntegration/java/com/liferay/segments/asah/rest/resource/v1_0/test/BaseExperimentRunResourceTestCase.java
+++ b/modules/dxp/apps/segments/segments-asah-rest-test/src/testIntegration/java/com/liferay/segments/asah/rest/resource/v1_0/test/BaseExperimentRunResourceTestCase.java
@@ -893,4 +893,4 @@ public abstract class BaseExperimentRunResourceTestCase {
 		_experimentRunResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:806244922
+// LIFERAY-REST-BUILDER-HASH:1779788694

--- a/modules/dxp/apps/segments/segments-asah-rest-test/src/testIntegration/java/com/liferay/segments/asah/rest/resource/v1_0/test/BaseStatusResourceTestCase.java
+++ b/modules/dxp/apps/segments/segments-asah-rest-test/src/testIntegration/java/com/liferay/segments/asah/rest/resource/v1_0/test/BaseStatusResourceTestCase.java
@@ -1075,4 +1075,4 @@ public abstract class BaseStatusResourceTestCase {
 		_statusResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-434745386
+// LIFERAY-REST-BUILDER-HASH:2065580320

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseAssetLibraryTestEntityResourceTestCase.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseAssetLibraryTestEntityResourceTestCase.java
@@ -1444,4 +1444,4 @@ public abstract class BaseAssetLibraryTestEntityResourceTestCase {
 		AssetLibraryTestEntityResource _assetLibraryTestEntityResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-988210256
+// LIFERAY-REST-BUILDER-HASH:1627030650

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseBatchTestEntityResourceTestCase.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseBatchTestEntityResourceTestCase.java
@@ -2239,4 +2239,4 @@ public abstract class BaseBatchTestEntityResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1231386215
+// LIFERAY-REST-BUILDER-HASH:-896738835

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseCompanyTestEntityResourceTestCase.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseCompanyTestEntityResourceTestCase.java
@@ -2433,4 +2433,4 @@ public abstract class BaseCompanyTestEntityResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1289075350
+// LIFERAY-REST-BUILDER-HASH:-1387896118

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseERCAssetLibraryTestEntityResourceTestCase.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseERCAssetLibraryTestEntityResourceTestCase.java
@@ -2308,4 +2308,4 @@ public abstract class BaseERCAssetLibraryTestEntityResourceTestCase {
 		ERCAssetLibraryTestEntityResource _ercAssetLibraryTestEntityResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-206906867
+// LIFERAY-REST-BUILDER-HASH:2032910613

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseERCScopedTestEntityResourceTestCase.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseERCScopedTestEntityResourceTestCase.java
@@ -3621,4 +3621,4 @@ public abstract class BaseERCScopedTestEntityResourceTestCase {
 		ERCScopedTestEntityResource _ercScopedTestEntityResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1576855979
+// LIFERAY-REST-BUILDER-HASH:-833940637

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseERCSiteTestEntityResourceTestCase.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseERCSiteTestEntityResourceTestCase.java
@@ -2117,4 +2117,4 @@ public abstract class BaseERCSiteTestEntityResourceTestCase {
 		ERCSiteTestEntityResource _ercSiteTestEntityResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-26633653
+// LIFERAY-REST-BUILDER-HASH:-86898165

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseEntityModelResourceTestEntity1ResourceTestCase.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseEntityModelResourceTestEntity1ResourceTestCase.java
@@ -964,4 +964,4 @@ public abstract class BaseEntityModelResourceTestEntity1ResourceTestCase {
 			_entityModelResourceTestEntity1Resource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1370605316
+// LIFERAY-REST-BUILDER-HASH:1532347274

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseEntityModelResourceTestEntity2ResourceTestCase.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseEntityModelResourceTestEntity2ResourceTestCase.java
@@ -1297,4 +1297,4 @@ public abstract class BaseEntityModelResourceTestEntity2ResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1453303447
+// LIFERAY-REST-BUILDER-HASH:-759759311

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseFilterResourceTestCase.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseFilterResourceTestCase.java
@@ -826,4 +826,4 @@ public abstract class BaseFilterResourceTestCase {
 			_filterResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:92239318
+// LIFERAY-REST-BUILDER-HASH:-2004825744

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseMultipartTestEntityResourceTestCase.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseMultipartTestEntityResourceTestCase.java
@@ -1715,4 +1715,4 @@ public abstract class BaseMultipartTestEntityResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1880659694
+// LIFERAY-REST-BUILDER-HASH:221974512

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseSchemaResourceTestCase.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseSchemaResourceTestCase.java
@@ -847,4 +847,4 @@ public abstract class BaseSchemaResourceTestCase {
 			_schemaResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1177798196
+// LIFERAY-REST-BUILDER-HASH:1932757044

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseScopedTestEntityResourceTestCase.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseScopedTestEntityResourceTestCase.java
@@ -2754,4 +2754,4 @@ public abstract class BaseScopedTestEntityResourceTestCase {
 		ScopedTestEntityResource _scopedTestEntityResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1808568735
+// LIFERAY-REST-BUILDER-HASH:-1300096575

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseSharedInternalModelBatchTestEntityResourceTestCase.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseSharedInternalModelBatchTestEntityResourceTestCase.java
@@ -1755,4 +1755,4 @@ public abstract class BaseSharedInternalModelBatchTestEntityResourceTestCase {
 			_sharedInternalModelBatchTestEntityResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-226938671
+// LIFERAY-REST-BUILDER-HASH:1233778903

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseSiteTestEntityResourceTestCase.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseSiteTestEntityResourceTestCase.java
@@ -2544,4 +2544,4 @@ public abstract class BaseSiteTestEntityResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1136969515
+// LIFERAY-REST-BUILDER-HASH:1597179641

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseSortResourceTestCase.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseSortResourceTestCase.java
@@ -798,4 +798,4 @@ public abstract class BaseSortResourceTestCase {
 			_sortResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1745282873
+// LIFERAY-REST-BUILDER-HASH:-576786169

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseTestEntityAddressResourceTestCase.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseTestEntityAddressResourceTestCase.java
@@ -1257,4 +1257,4 @@ public abstract class BaseTestEntityAddressResourceTestCase {
 		TestEntityAddressResource _testEntityAddressResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-2004975741
+// LIFERAY-REST-BUILDER-HASH:-282487031

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseTestEntityResourceTestCase.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseTestEntityResourceTestCase.java
@@ -2521,4 +2521,4 @@ public abstract class BaseTestEntityResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1240060338
+// LIFERAY-REST-BUILDER-HASH:-1633153362

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
@@ -113,7 +113,11 @@ import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
-import com.liferay.portal.kernel.test.util.JAXRSWhiteboardTestUtil;
+
+<#if freeMarkerTool.isVersionCompatible(configYAML, 16)>
+	import com.liferay.portal.kernel.test.util.JAXRSWhiteboardTestUtil;
+</#if>
+
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.RoleTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -219,7 +223,9 @@ public abstract class Base${schemaName}ResourceTestCase {
 	public static void setUpClass() throws Exception {
 		_format = FastDateFormatFactoryUtil.getSimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
 
-		JAXRSWhiteboardTestUtil.ensureReady();
+		<#if freeMarkerTool.isVersionCompatible(configYAML, 16)>
+			JAXRSWhiteboardTestUtil.ensureReady();
+		</#if>
 	}
 
 	@Before


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102897

## What Is Being Fixed

`adb656095` made `base_resource_test_case.ftl` import and call `JAXRSWhiteboardTestUtil` unconditionally. Its sibling commit `f38202fe387fd` added that class to `portal-test`, so a REST Builder consumer that resolves an older `com.liferay.portal.test` artifact now gets a generated `Base<Schema>ResourceTestCase` that fails to compile with `cannot find symbol: class JAXRSWhiteboardTestUtil`. The file is rewritten on every `buildREST`, so the only workarounds are pinning an older REST Builder, dropping `testDir`, or upgrading the platform.

## How It Is Being Fixed

The template already gates version dependent output through `freeMarkerTool.isVersionCompatible(configYAML, N)` in fourteen places, at versions 2 through 15. Both the import and the `ensureReady()` call now sit behind the same guard at version 16, so the call is emitted only when `compatibilityVersion` says the target platform provides the class.

`headless-admin-language-override` was the one module still on `compatibilityVersion: 15`. It was authored after the sweep that moved every other REST Builder module to 16, so its 15 was inherited from the config it was copied from rather than chosen. Left behind it would have been the only module the new gate stripped the whiteboard call from, reintroducing the transient 404 flakiness that LPD-100865 fixed, so it moves to 16 as well.

## Why Are There No Tests?

REST Builder has no template rendering test harness, and its test bed `portal-tools-rest-builder-test-impl` is itself pinned at compatibility version 16, so nothing there can exercise a version 16 gate. The repository is the test instead. Before the bump, regenerating `headless-admin-language-override` at 15 stripped both the import and the call from `BaseLanguageOverrideResourceTestCase`, showing the gate fires. After the bump, `ant build-rests` across all 447 generated files produced only `LIFERAY-REST-BUILDER-HASH` line changes and no generated content change at all, showing the gate is inert at 16.

## PR Check

**pr-check: PASS** — tested on `80411f74a51046b0deadcd89c5f5b1857e94fa57`

| Validation | Result |
| --- | --- |
| REST Builder | PASS |
| Source Format | PASS |
| Transaction Usage | PASS |
| Java Unit Tests | PASS |

Per-Module Compile and Integration Test Compile were trimmed from the run at the developer's direction: all 447 changed generated files differ from master only in their trailing `// LIFERAY-REST-BUILDER-HASH` comment.

Baseline was trimmed as well. It flags `export-import-test-util`, whose exports grew in `LPD-100541` without a version bump, so `ant baseline-all` fails on current master independently of this branch. The bump was directed out of this pull request and belongs with the change that owes it.

<!-- pr-check {"result": "success", "sha": "80411f74a51046b0deadcd89c5f5b1857e94fa57"} -->
