### PR TITLE
LPD-97871 Use JSONUtil.toJSONArray to build the locales JSON array

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/SectionDisplayContextUtil.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/SectionDisplayContextUtil.java
@@ -924,35 +924,30 @@ public class SectionDisplayContextUtil {
 	public static JSONArray getLocalesJSONArray(
 		Locale locale, Collection<Locale> locales) {
 
-		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
-
-		locales.forEach(
+		return JSONUtil.toJSONArray(
+			locales,
 			currentLocale -> {
 				String w3cLanguageId = LocaleUtil.toW3cLanguageId(
 					currentLocale);
 
-				String symbol =
+				return JSONUtil.put(
+					"displayName",
+					LocaleUtil.getLocaleDisplayName(currentLocale, locale)
+				).put(
+					"id", LocaleUtil.toLanguageId(currentLocale)
+				).put(
+					"label", w3cLanguageId
+				).put(
+					"languageId", LocaleUtil.toLanguageId(currentLocale)
+				).put(
+					"name", currentLocale.getDisplayName()
+				).put(
+					"symbol",
 					com.liferay.portal.kernel.util.StringUtil.toLowerCase(
-						w3cLanguageId);
-
-				jsonArray.put(
-					JSONUtil.put(
-						"displayName",
-						LocaleUtil.getLocaleDisplayName(currentLocale, locale)
-					).put(
-						"id", LocaleUtil.toLanguageId(currentLocale)
-					).put(
-						"label", w3cLanguageId
-					).put(
-						"languageId", LocaleUtil.toLanguageId(currentLocale)
-					).put(
-						"name", currentLocale.getDisplayName()
-					).put(
-						"symbol", symbol
-					));
-			});
-
-		return jsonArray;
+						w3cLanguageId)
+				);
+			},
+			_log);
 	}
 
 	public static List<FDSActionDropdownItem>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97871

## What Is Being Fixed

Follow-up requested in https://github.com/brianchandotcom/liferay-portal/pull/180491: `SectionDisplayContextUtil.getLocalesJSONArray` built the locales array by creating an empty `JSONArray` and appending to it inside a `forEach`.

## How It Is Being Fixed

The method now delegates to `JSONUtil.toJSONArray`, mapping each locale straight to its `JSONObject`. It uses the overload that takes a `Log` so the method keeps its current signature instead of declaring the checked exception of the basic overload.

## Why Are There No Tests?

This is a refactor requested by the reviewer on already merged code; the JSON output is covered by the existing `BaseSectionDisplayContextTestCase`.

## PR Check

**pr-check: PASS** — tested on `83136df28e23ab8e0177d87d70d68e1ecf81a544`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "83136df28e23ab8e0177d87d70d68e1ecf81a544"} -->
