### PR TITLE
LPD-103160 Give the search the Enter the cancelled modal steals

### DIFF
--- a/modules/test/playwright/tests/object-web/field/objectField.spec.ts
+++ b/modules/test/playwright/tests/object-web/field/objectField.spec.ts
@@ -2528,14 +2528,23 @@ test.describe('Create Object Fields', () => {
 
 		await page.getByRole('button', {name: 'Cancel'}).click();
 
-		await page
+		// Cancelling the modal only starts its close. The close lands later
+		// and returns focus to the element that opened the modal, so wait for
+		// the modal's own field to be gone before touching the page beneath,
+		// and give the Enter to the search box itself rather than to whatever
+		// holds focus by then.
+
+		await expect(objectFieldsPage.objectFieldLabelInput).toBeHidden();
+
+		const searchInput = page
 			.getByRole('search')
-			.getByRole('searchbox', {name: 'Search'})
-			.fill('Cancel Field');
+			.getByRole('searchbox', {name: 'Search'});
+
+		await searchInput.fill('Cancel Field');
 
 		await waitForSearchToBeReady(page);
 
-		await page.keyboard.press('Enter');
+		await searchInput.press('Enter');
 
 		await expect(page.getByText('No Results Found')).toBeVisible();
 	});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103160

## What Is Being Fixed

The object field test that cancels the field creation modal fails on CI waiting for the list's empty state: it searches for a label that matches nothing and `No Results Found` never appears. The failure looks like a search defect but is a focus race. Cancelling the modal only starts its close: the modal library closes on a short timer and, when it fires, returns focus to the element that was focused when the modal opened — here the Add Object Field button. The test types into the list search while that close is still pending, so the restore lands after the search box was focused and takes the focus away again. The Enter meant for the search then activates the Add Object Field button instead and **reopens the modal**: no query is ever submitted, the list keeps every field, and the empty state never arrives.

Measured on the page with the fill-to-Enter gap widened by three hundred milliseconds to hold the window open: at Enter time the focus sits on the Add Object Field button with the search already holding its text, and after the Enter the modal is open again with focus on its title. The unchanged test fails under that widening with CI's exact error, where this test has failed twice — including once against pure master.

## How It Is Being Fixed

Own both ends of the race:

- wait for the modal's own field to be gone before touching the page beneath — the field disappears in the same task that moves the focus, so its absence guarantees the restore has already happened;
- press Enter on the search box itself rather than on whatever holds the focus by then, so the submit stops depending on ambient focus entirely.

With the widening in place the unchanged test fails with CI's exact error and the fixed test passes three runs of three; without it the fixed test passes as well, on a portal built clean from the branch. An earlier form of this fix (the wait alone) rode a full `ci:test:object` run in which all sixty four jobs passed.

## PR Check

**pr-check: PASS** — tested on `e05f09a756fbf60840775577454747dccc73a45c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Baseline | PASS |

Source Format ran in current-branch mode with commit message validation, including the TypeScript check that covers this diff's compile surface. Baseline's only finding is the known pre-existing excessive version increase on `headless-cms-api`, reproduced identically by `ant baseline-all` on plain master at the same base; nothing under this diff was touched. Per-Module Compile and JavaScript Unit Tests matched by file pattern but have no target here: `modules/test/playwright` is not in the Gradle build, and its `test` script is the Playwright runner itself, exercised by the validation runs above.

<!-- pr-check {"result": "success", "sha": "e05f09a756fbf9bfdba96ce84d33e9616a4da622"} -->
