### PR TITLE
LPD-82780 LPD-82781 LPD-82786 Migrate OpenSearch2 logging tests to LogCapture

### DIFF
--- a/modules/apps/headless/headless-cms/headless-cms-api/src/main/resources/com/liferay/headless/cms/resource/v1_0/packageinfo
+++ b/modules/apps/headless/headless-cms/headless-cms-api/src/main/resources/com/liferay/headless/cms/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 3.1.0
+version 3.0.0

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/logging/OpenSearchExceptionHandler.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/logging/OpenSearchExceptionHandler.java
@@ -34,9 +34,6 @@ public class OpenSearchExceptionHandler {
 		if (_logExceptionsOnly) {
 			_log.error(t, t);
 		}
-		else if (_logExceptionsOnly) {
-			_log.error(t, t);
-		}
 		else {
 			throw t;
 		}

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/logging/OpenSearchExceptionHandlerTest.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/logging/OpenSearchExceptionHandlerTest.java
@@ -8,12 +8,15 @@ package com.liferay.portal.search.opensearch2.internal.logging;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.search.SearchException;
-import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.search.opensearch2.internal.OpenSearchTestRule;
-import com.liferay.portal.search.test.rule.logging.ExpectedLogMethodTestRule;
-import com.liferay.portal.search.test.util.logging.ExpectedLog;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
+import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
+import java.util.List;
+
+import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -25,46 +28,53 @@ import org.junit.rules.ExpectedException;
 public class OpenSearchExceptionHandlerTest {
 
 	@ClassRule
-	public static final AggregateTestRule aggregateTestRule =
-		new AggregateTestRule(
-			ExpectedLogMethodTestRule.INSTANCE, LiferayUnitTestRule.INSTANCE);
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
 
 	@ClassRule
 	public static OpenSearchTestRule openSearchTestRule =
 		OpenSearchTestRule.INSTANCE;
 
-	@ExpectedLog(
-		expectedClass = OpenSearchExceptionHandlerTest.class,
-		expectedLevel = ExpectedLog.Level.INFO,
-		expectedLog = OpenSearchExceptionHandler.INDEX_NOT_FOUND_EXCEPTION_MESSAGE
-	)
 	@Test
 	public void testDeleteIndexNotFoundLogExceptionsOnlyFalse()
 		throws Throwable {
 
-		OpenSearchExceptionHandler openSearchExceptionHandler =
-			new OpenSearchExceptionHandler(_log, false);
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				OpenSearchExceptionHandlerTest.class.getName(),
+				LoggerTestUtil.INFO)) {
 
-		openSearchExceptionHandler.handleDeleteDocumentException(
-			new SearchException(
-				OpenSearchExceptionHandler.INDEX_NOT_FOUND_EXCEPTION_MESSAGE));
+			OpenSearchExceptionHandler openSearchExceptionHandler =
+				new OpenSearchExceptionHandler(_log, false);
+
+			SearchException searchException = new SearchException(
+				OpenSearchExceptionHandler.INDEX_NOT_FOUND_EXCEPTION_MESSAGE);
+
+			openSearchExceptionHandler.handleDeleteDocumentException(
+				searchException);
+
+			_assertLogCapture(logCapture, searchException, LoggerTestUtil.INFO);
+		}
 	}
 
-	@ExpectedLog(
-		expectedClass = OpenSearchExceptionHandlerTest.class,
-		expectedLevel = ExpectedLog.Level.INFO,
-		expectedLog = OpenSearchExceptionHandler.INDEX_NOT_FOUND_EXCEPTION_MESSAGE
-	)
 	@Test
 	public void testDeleteIndexNotFoundLogExceptionsOnlyTrue()
 		throws Throwable {
 
-		OpenSearchExceptionHandler openSearchExceptionHandler =
-			new OpenSearchExceptionHandler(_log, true);
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				OpenSearchExceptionHandlerTest.class.getName(),
+				LoggerTestUtil.INFO)) {
 
-		openSearchExceptionHandler.handleDeleteDocumentException(
-			new SearchException(
-				OpenSearchExceptionHandler.INDEX_NOT_FOUND_EXCEPTION_MESSAGE));
+			OpenSearchExceptionHandler openSearchExceptionHandler =
+				new OpenSearchExceptionHandler(_log, true);
+
+			SearchException searchException = new SearchException(
+				OpenSearchExceptionHandler.INDEX_NOT_FOUND_EXCEPTION_MESSAGE);
+
+			openSearchExceptionHandler.handleDeleteDocumentException(
+				searchException);
+
+			_assertLogCapture(logCapture, searchException, LoggerTestUtil.INFO);
+		}
 	}
 
 	@Test
@@ -80,18 +90,24 @@ public class OpenSearchExceptionHandlerTest {
 			new SearchException("deletion failed and results in exception"));
 	}
 
-	@ExpectedLog(
-		expectedClass = OpenSearchExceptionHandlerTest.class,
-		expectedLevel = ExpectedLog.Level.WARNING,
-		expectedLog = "deletion failed is only logged"
-	)
 	@Test
 	public void testDeleteLogExceptionsOnlyTrue() throws Throwable {
-		OpenSearchExceptionHandler openSearchExceptionHandler =
-			new OpenSearchExceptionHandler(_log, true);
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				OpenSearchExceptionHandlerTest.class.getName(),
+				LoggerTestUtil.ERROR)) {
 
-		openSearchExceptionHandler.handleDeleteDocumentException(
-			new SearchException("deletion failed is only logged"));
+			OpenSearchExceptionHandler openSearchExceptionHandler =
+				new OpenSearchExceptionHandler(_log, true);
+
+			SearchException searchException = new SearchException(
+				"deletion failed is only logged");
+
+			openSearchExceptionHandler.handleDeleteDocumentException(
+				searchException);
+
+			_assertLogCapture(
+				logCapture, searchException, LoggerTestUtil.ERROR);
+		}
 	}
 
 	@Test
@@ -106,22 +122,42 @@ public class OpenSearchExceptionHandlerTest {
 			new SearchException("some other random message"));
 	}
 
-	@ExpectedLog(
-		expectedClass = OpenSearchExceptionHandlerTest.class,
-		expectedLevel = ExpectedLog.Level.WARNING,
-		expectedLog = "some random message"
-	)
 	@Test
 	public void testLogExceptionsOnlyTrue() throws Throwable {
-		OpenSearchExceptionHandler openSearchExceptionHandler =
-			new OpenSearchExceptionHandler(_log, true);
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				OpenSearchExceptionHandlerTest.class.getName(),
+				LoggerTestUtil.ERROR)) {
 
-		openSearchExceptionHandler.logOrThrow(
-			new SearchException("some random message"));
+			OpenSearchExceptionHandler openSearchExceptionHandler =
+				new OpenSearchExceptionHandler(_log, true);
+
+			SearchException searchException = new SearchException(
+				"some random message");
+
+			openSearchExceptionHandler.logOrThrow(searchException);
+
+			_assertLogCapture(
+				logCapture, searchException, LoggerTestUtil.ERROR);
+		}
 	}
 
 	@Rule
 	public ExpectedException expectedException = ExpectedException.none();
+
+	private void _assertLogCapture(
+		LogCapture logCapture, SearchException searchException,
+		String logLevel) {
+
+		List<LogEntry> logEntries = logCapture.getLogEntries();
+
+		Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
+
+		LogEntry logEntry = logEntries.get(0);
+
+		Assert.assertEquals(logLevel, logEntry.getPriority());
+
+		Assert.assertSame(searchException, logEntry.getThrowable());
+	}
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		OpenSearchExceptionHandlerTest.class);

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/logging/OpenSearchExceptionHandlerTest.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/logging/OpenSearchExceptionHandlerTest.java
@@ -35,7 +35,7 @@ public class OpenSearchExceptionHandlerTest {
 
 	@Test
 	public void testDeleteIndexNotFoundLogExceptionsOnlyFalse()
-		throws Throwable {
+		throws SearchException {
 
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
 				OpenSearchExceptionHandlerTest.class.getName(),
@@ -56,7 +56,7 @@ public class OpenSearchExceptionHandlerTest {
 
 	@Test
 	public void testDeleteIndexNotFoundLogExceptionsOnlyTrue()
-		throws Throwable {
+		throws SearchException {
 
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
 				OpenSearchExceptionHandlerTest.class.getName(),
@@ -95,7 +95,7 @@ public class OpenSearchExceptionHandlerTest {
 	}
 
 	@Test
-	public void testDeleteLogExceptionsOnlyTrue() throws Throwable {
+	public void testDeleteLogExceptionsOnlyTrue() throws SearchException {
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
 				OpenSearchExceptionHandlerTest.class.getName(),
 				LoggerTestUtil.ERROR)) {
@@ -133,7 +133,7 @@ public class OpenSearchExceptionHandlerTest {
 	}
 
 	@Test
-	public void testLogExceptionsOnlyTrue() throws Throwable {
+	public void testLogExceptionsOnlyTrue() throws SearchException {
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
 				OpenSearchExceptionHandlerTest.class.getName(),
 				LoggerTestUtil.ERROR)) {

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/logging/OpenSearchExceptionHandlerTest.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/logging/OpenSearchExceptionHandlerTest.java
@@ -50,7 +50,7 @@ public class OpenSearchExceptionHandlerTest {
 			openSearchExceptionHandler.handleDeleteDocumentException(
 				searchException);
 
-			_assertLogCapture(logCapture, searchException, LoggerTestUtil.INFO);
+			_assertLogCapture(logCapture, LoggerTestUtil.INFO, searchException);
 		}
 	}
 
@@ -71,7 +71,7 @@ public class OpenSearchExceptionHandlerTest {
 			openSearchExceptionHandler.handleDeleteDocumentException(
 				searchException);
 
-			_assertLogCapture(logCapture, searchException, LoggerTestUtil.INFO);
+			_assertLogCapture(logCapture, LoggerTestUtil.INFO, searchException);
 		}
 	}
 
@@ -110,7 +110,7 @@ public class OpenSearchExceptionHandlerTest {
 				searchException);
 
 			_assertLogCapture(
-				logCapture, searchException, LoggerTestUtil.ERROR);
+				logCapture, LoggerTestUtil.ERROR, searchException);
 		}
 	}
 
@@ -147,13 +147,13 @@ public class OpenSearchExceptionHandlerTest {
 			openSearchExceptionHandler.logOrThrow(searchException);
 
 			_assertLogCapture(
-				logCapture, searchException, LoggerTestUtil.ERROR);
+				logCapture, LoggerTestUtil.ERROR, searchException);
 		}
 	}
 
 	private void _assertLogCapture(
-		LogCapture logCapture, SearchException searchException,
-		String logLevel) {
+		LogCapture logCapture, String logLevel,
+		SearchException searchException) {
 
 		List<LogEntry> logEntries = logCapture.getLogEntries();
 

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/logging/OpenSearchExceptionHandlerTest.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/logging/OpenSearchExceptionHandlerTest.java
@@ -162,7 +162,7 @@ public class OpenSearchExceptionHandlerTest {
 		LogEntry logEntry = logEntries.get(0);
 
 		Assert.assertEquals(logLevel, logEntry.getPriority());
-
+		Assert.assertEquals(searchException.toString(), logEntry.getMessage());
 		Assert.assertSame(searchException, logEntry.getThrowable());
 	}
 

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/logging/OpenSearchExceptionHandlerTest.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/logging/OpenSearchExceptionHandlerTest.java
@@ -18,9 +18,7 @@ import java.util.List;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 /**
  * @author Adam Brandizzi
@@ -78,16 +76,22 @@ public class OpenSearchExceptionHandlerTest {
 	}
 
 	@Test
-	public void testDeleteLogExceptionsOnlyFalse() throws Throwable {
-		expectedException.expect(SearchException.class);
-		expectedException.expectMessage(
-			"deletion failed and results in exception");
-
+	public void testDeleteLogExceptionsOnlyFalse() {
 		OpenSearchExceptionHandler openSearchExceptionHandler =
 			new OpenSearchExceptionHandler(_log, false);
 
-		openSearchExceptionHandler.handleDeleteDocumentException(
-			new SearchException("deletion failed and results in exception"));
+		SearchException searchException1 = new SearchException(
+			"deletion failed and results in exception");
+
+		try {
+			openSearchExceptionHandler.handleDeleteDocumentException(
+				searchException1);
+
+			Assert.fail();
+		}
+		catch (SearchException searchException2) {
+			Assert.assertSame(searchException1, searchException2);
+		}
 	}
 
 	@Test
@@ -111,15 +115,21 @@ public class OpenSearchExceptionHandlerTest {
 	}
 
 	@Test
-	public void testLogExceptionsOnlyFalse() throws Throwable {
-		expectedException.expect(SearchException.class);
-		expectedException.expectMessage("some other random message");
-
+	public void testLogExceptionsOnlyFalse() {
 		OpenSearchExceptionHandler openSearchExceptionHandler =
 			new OpenSearchExceptionHandler(_log, false);
 
-		openSearchExceptionHandler.logOrThrow(
-			new SearchException("some other random message"));
+		SearchException searchException1 = new SearchException(
+			"some other random message");
+
+		try {
+			openSearchExceptionHandler.logOrThrow(searchException1);
+
+			Assert.fail();
+		}
+		catch (SearchException searchException2) {
+			Assert.assertSame(searchException1, searchException2);
+		}
 	}
 
 	@Test
@@ -140,9 +150,6 @@ public class OpenSearchExceptionHandlerTest {
 				logCapture, searchException, LoggerTestUtil.ERROR);
 		}
 	}
-
-	@Rule
-	public ExpectedException expectedException = ExpectedException.none();
 
 	private void _assertLogCapture(
 		LogCapture logCapture, SearchException searchException,

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/logging/OpenSearchIndexSearcherLogExceptionsOnlyTest.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/logging/OpenSearchIndexSearcherLogExceptionsOnlyTest.java
@@ -10,20 +10,25 @@ import com.liferay.portal.kernel.search.BooleanQuery;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Query;
 import com.liferay.portal.kernel.search.TermQuery;
-import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.search.opensearch2.internal.OpenSearchIndexSearcher;
 import com.liferay.portal.search.opensearch2.internal.OpenSearchTestRule;
 import com.liferay.portal.search.opensearch2.internal.connection.TestOpenSearchConnectionManager;
 import com.liferay.portal.search.opensearch2.internal.indexing.LiferayOpenSearchIndexingFixtureFactory;
-import com.liferay.portal.search.test.rule.logging.ExpectedLogMethodTestRule;
 import com.liferay.portal.search.test.util.indexing.BaseIndexingTestCase;
 import com.liferay.portal.search.test.util.indexing.IndexingFixture;
-import com.liferay.portal.search.test.util.logging.ExpectedLog;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
+import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
+import java.util.List;
+
+import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
+
+import org.opensearch.client.opensearch._types.OpenSearchException;
 
 /**
  * @author Bryan Engler
@@ -32,32 +37,35 @@ public class OpenSearchIndexSearcherLogExceptionsOnlyTest
 	extends BaseIndexingTestCase {
 
 	@ClassRule
-	public static final AggregateTestRule aggregateTestRule =
-		new AggregateTestRule(
-			ExpectedLogMethodTestRule.INSTANCE, LiferayUnitTestRule.INSTANCE);
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
 
 	@ClassRule
 	public static OpenSearchTestRule openSearchTestRule =
 		OpenSearchTestRule.INSTANCE;
 
-	@ExpectedLog(
-		expectedClass = OpenSearchIndexSearcher.class,
-		expectedLevel = ExpectedLog.Level.WARNING,
-		expectedLog = "all shards failed"
-	)
 	@Test
 	public void testExceptionOnlyLoggedWhenQueryMalformedSearch() {
-		search(createSearchContext(), getMalformedQuery());
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				OpenSearchIndexSearcher.class.getName(),
+				LoggerTestUtil.ERROR)) {
+
+			search(createSearchContext(), getMalformedQuery());
+
+			_assertLogCapture(logCapture);
+		}
 	}
 
-	@ExpectedLog(
-		expectedClass = OpenSearchIndexSearcher.class,
-		expectedLevel = ExpectedLog.Level.WARNING,
-		expectedLog = "all shards failed"
-	)
 	@Test
 	public void testExceptionOnlyLoggedWhenQueryMalformedSearchCount() {
-		searchCount(createSearchContext(), getMalformedQuery());
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				OpenSearchIndexSearcher.class.getName(),
+				LoggerTestUtil.ERROR)) {
+
+			searchCount(createSearchContext(), getMalformedQuery());
+
+			_assertLogCapture(logCapture);
+		}
 	}
 
 	@Override
@@ -79,6 +87,24 @@ public class OpenSearchIndexSearcherLogExceptionsOnlyTest
 			BooleanClauseOccur.MUST);
 
 		return booleanQuery;
+	}
+
+	private void _assertLogCapture(LogCapture logCapture) {
+		List<LogEntry> logEntries = logCapture.getLogEntries();
+
+		Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
+
+		LogEntry logEntry = logEntries.get(0);
+
+		Assert.assertEquals(LoggerTestUtil.ERROR, logEntry.getPriority());
+
+		Throwable throwable = logEntry.getThrowable();
+
+		Assert.assertEquals(
+			"Request failed: [search_phase_execution_exception] all shards " +
+				"failed",
+			throwable.getMessage());
+		Assert.assertSame(OpenSearchException.class, throwable.getClass());
 	}
 
 }

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/logging/OpenSearchIndexSearcherLogExceptionsOnlyTest.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/logging/OpenSearchIndexSearcherLogExceptionsOnlyTest.java
@@ -10,7 +10,6 @@ import com.liferay.portal.kernel.search.BooleanQuery;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Query;
 import com.liferay.portal.kernel.search.TermQuery;
-import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.search.opensearch2.internal.OpenSearchIndexSearcher;
 import com.liferay.portal.search.opensearch2.internal.OpenSearchTestRule;
 import com.liferay.portal.search.opensearch2.internal.connection.TestOpenSearchConnectionManager;
@@ -22,6 +21,7 @@ import com.liferay.portal.test.log.LogEntry;
 import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.Assert;
@@ -73,9 +73,7 @@ public class OpenSearchIndexSearcherLogExceptionsOnlyTest
 		return LiferayOpenSearchIndexingFixtureFactory.builder(
 		).testOpenSearchConnectionManager(
 			new TestOpenSearchConnectionManager(
-				HashMapBuilder.<String, Object>put(
-					"logExceptionsOnly", true
-				).build())
+				Collections.singletonMap("logExceptionsOnly", true))
 		).build();
 	}
 

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/logging/OpenSearchIndexWriterLogExceptionsOnlyTest.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/logging/OpenSearchIndexWriterLogExceptionsOnlyTest.java
@@ -29,6 +29,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -46,6 +47,13 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 	@ClassRule
 	public static OpenSearchTestRule openSearchTestRule =
 		OpenSearchTestRule.INSTANCE;
+
+	@After
+	public void tearDownOpenSearchIndexWriterLogExceptionsOnlyTest()
+		throws SearchException {
+
+		getIndexWriter().deleteDocument(createSearchContext(), "1");
+	}
 
 	@Test
 	public void testAddDocument() throws Exception {

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/logging/OpenSearchIndexWriterLogExceptionsOnlyTest.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/logging/OpenSearchIndexWriterLogExceptionsOnlyTest.java
@@ -5,8 +5,6 @@
 
 package com.liferay.portal.search.opensearch2.internal.logging;
 
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.DocumentImpl;
 import com.liferay.portal.kernel.search.Field;
@@ -71,7 +69,7 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 	}
 
 	@Test
-	public void testAddDocuments() {
+	public void testAddDocuments() throws SearchException {
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
 				OpenSearchIndexWriter.class.getName(), LoggerTestUtil.ERROR)) {
 
@@ -81,15 +79,8 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 
 			IndexWriter indexWriter = getIndexWriter();
 
-			try {
-				indexWriter.addDocuments(
-					createSearchContext(), Arrays.asList(document));
-			}
-			catch (SearchException searchException) {
-				if (_log.isDebugEnabled()) {
-					_log.debug(searchException);
-				}
-			}
+			indexWriter.addDocuments(
+				createSearchContext(), Arrays.asList(document));
 
 			_assertLogCapture(
 				message -> Assert.assertEquals("Bulk add failed", message),
@@ -98,7 +89,7 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 	}
 
 	@Test
-	public void testAddDocumentsBulkExecutor() {
+	public void testAddDocumentsBulkExecutor() throws SearchException {
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
 				BulkDocumentRequestExecutor.class.getName(),
 				LoggerTestUtil.ERROR)) {
@@ -109,15 +100,8 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 
 			IndexWriter indexWriter = getIndexWriter();
 
-			try {
-				indexWriter.addDocuments(
-					createSearchContext(), Arrays.asList(document));
-			}
-			catch (SearchException searchException) {
-				if (_log.isDebugEnabled()) {
-					_log.debug(searchException);
-				}
-			}
+			indexWriter.addDocuments(
+				createSearchContext(), Arrays.asList(document));
 
 			String expectedMessage =
 				"failed to parse field [expirationDate] of type [date] in " +
@@ -132,7 +116,7 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 	}
 
 	@Test
-	public void testCommit() {
+	public void testCommit() throws SearchException {
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
 				OpenSearchIndexWriter.class.getName(), LoggerTestUtil.ERROR)) {
 
@@ -142,14 +126,7 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 
 			IndexWriter indexWriter = getIndexWriter();
 
-			try {
-				indexWriter.commit(searchContext);
-			}
-			catch (SearchException searchException) {
-				if (_log.isDebugEnabled()) {
-					_log.debug(searchException);
-				}
-			}
+			indexWriter.commit(searchContext);
 
 			_assertLogCapture(
 				message -> Assert.assertEquals(
@@ -161,25 +138,18 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 	}
 
 	@Test
-	public void testDeleteDocument() {
+	public void testDeleteDocument() throws SearchException {
 		SearchContext searchContext = new SearchContext();
 
 		searchContext.setCompanyId(1);
 
 		IndexWriter indexWriter = getIndexWriter();
 
-		try {
-			indexWriter.deleteDocument(searchContext, "1");
-		}
-		catch (SearchException searchException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(searchException);
-			}
-		}
+		indexWriter.deleteDocument(searchContext, "1");
 	}
 
 	@Test
-	public void testDeleteDocumentInfoLevel() {
+	public void testDeleteDocumentInfoLevel() throws SearchException {
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
 				OpenSearchIndexWriter.class.getName(), LoggerTestUtil.INFO)) {
 
@@ -189,14 +159,7 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 
 			IndexWriter indexWriter = getIndexWriter();
 
-			try {
-				indexWriter.deleteDocument(searchContext, "1");
-			}
-			catch (SearchException searchException) {
-				if (_log.isDebugEnabled()) {
-					_log.debug(searchException);
-				}
-			}
+			indexWriter.deleteDocument(searchContext, "1");
 
 			String expectedMessage =
 				"Request failed: [index_not_found_exception] no such index [1]";
@@ -210,7 +173,7 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 	}
 
 	@Test
-	public void testDeleteDocuments() {
+	public void testDeleteDocuments() throws SearchException {
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
 				OpenSearchIndexWriter.class.getName(), LoggerTestUtil.ERROR)) {
 
@@ -220,14 +183,7 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 
 			IndexWriter indexWriter = getIndexWriter();
 
-			try {
-				indexWriter.deleteDocuments(searchContext, Arrays.asList("1"));
-			}
-			catch (SearchException searchException) {
-				if (_log.isDebugEnabled()) {
-					_log.debug(searchException);
-				}
-			}
+			indexWriter.deleteDocuments(searchContext, Arrays.asList("1"));
 
 			_assertLogCapture(
 				message -> Assert.assertEquals("Bulk delete failed", message),
@@ -236,7 +192,7 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 	}
 
 	@Test
-	public void testDeleteDocumentsBulkExecutor() {
+	public void testDeleteDocumentsBulkExecutor() throws SearchException {
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
 				BulkDocumentRequestExecutor.class.getName(),
 				LoggerTestUtil.ERROR)) {
@@ -247,14 +203,7 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 
 			IndexWriter indexWriter = getIndexWriter();
 
-			try {
-				indexWriter.deleteDocuments(searchContext, Arrays.asList("1"));
-			}
-			catch (SearchException searchException) {
-				if (_log.isDebugEnabled()) {
-					_log.debug(searchException);
-				}
-			}
+			indexWriter.deleteDocuments(searchContext, Arrays.asList("1"));
 
 			String expectedMessage = "no such index [1]";
 
@@ -267,7 +216,7 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 	}
 
 	@Test
-	public void testDeleteEntityDocuments() {
+	public void testDeleteEntityDocuments() throws SearchException {
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
 				OpenSearchIndexWriter.class.getName(), LoggerTestUtil.ERROR)) {
 
@@ -277,14 +226,7 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 
 			IndexWriter indexWriter = getIndexWriter();
 
-			try {
-				indexWriter.deleteEntityDocuments(searchContext, "test");
-			}
-			catch (SearchException searchException) {
-				if (_log.isDebugEnabled()) {
-					_log.debug(searchException);
-				}
-			}
+			indexWriter.deleteEntityDocuments(searchContext, "test");
 
 			_assertLogCapture(
 				message -> Assert.assertEquals(
@@ -296,45 +238,32 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 	}
 
 	@Test
-	public void testPartiallyUpdateDocument() {
+	public void testPartiallyUpdateDocument() throws SearchException {
 		Document document = new DocumentImpl();
 
 		document.addKeyword(Field.UID, "1");
 
 		IndexWriter indexWriter = getIndexWriter();
 
-		try {
-			indexWriter.partiallyUpdateDocument(
-				createSearchContext(), document);
-		}
-		catch (SearchException searchException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(searchException);
-			}
-		}
+		indexWriter.partiallyUpdateDocument(createSearchContext(), document);
 	}
 
 	@Test
-	public void testPartiallyUpdateDocuments() {
+	public void testPartiallyUpdateDocuments() throws SearchException {
 		Document document = new DocumentImpl();
 
 		document.addKeyword(Field.UID, "1");
 
 		IndexWriter indexWriter = getIndexWriter();
 
-		try {
-			indexWriter.partiallyUpdateDocuments(
-				createSearchContext(), Arrays.asList(document));
-		}
-		catch (SearchException searchException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(searchException);
-			}
-		}
+		indexWriter.partiallyUpdateDocuments(
+			createSearchContext(), Arrays.asList(document));
 	}
 
 	@Test
-	public void testPartiallyUpdateDocumentsBulkExecutor() {
+	public void testPartiallyUpdateDocumentsBulkExecutor()
+		throws SearchException {
+
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
 				BulkDocumentRequestExecutor.class.getName(),
 				LoggerTestUtil.ERROR)) {
@@ -345,15 +274,8 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 
 			IndexWriter indexWriter = getIndexWriter();
 
-			try {
-				indexWriter.partiallyUpdateDocuments(
-					createSearchContext(), Arrays.asList(document));
-			}
-			catch (SearchException searchException) {
-				if (_log.isDebugEnabled()) {
-					_log.debug(searchException);
-				}
-			}
+			indexWriter.partiallyUpdateDocuments(
+				createSearchContext(), Arrays.asList(document));
 
 			String expectedMessage = "[1]: document missing";
 
@@ -366,7 +288,7 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 	}
 
 	@Test
-	public void testUpdateDocument() {
+	public void testUpdateDocument() throws SearchException {
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
 				OpenSearchIndexWriter.class.getName(), LoggerTestUtil.ERROR)) {
 
@@ -377,14 +299,7 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 
 			IndexWriter indexWriter = getIndexWriter();
 
-			try {
-				indexWriter.updateDocument(createSearchContext(), document);
-			}
-			catch (SearchException searchException) {
-				if (_log.isDebugEnabled()) {
-					_log.debug(searchException);
-				}
-			}
+			indexWriter.updateDocument(createSearchContext(), document);
 
 			_assertLogCapture(
 				message -> Assert.assertEquals("Update failed", message),
@@ -393,7 +308,7 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 	}
 
 	@Test
-	public void testUpdateDocumentBulkExecutor() {
+	public void testUpdateDocumentBulkExecutor() throws SearchException {
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
 				BulkDocumentRequestExecutor.class.getName(),
 				LoggerTestUtil.ERROR)) {
@@ -405,14 +320,7 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 
 			IndexWriter indexWriter = getIndexWriter();
 
-			try {
-				indexWriter.updateDocument(createSearchContext(), document);
-			}
-			catch (SearchException searchException) {
-				if (_log.isDebugEnabled()) {
-					_log.debug(searchException);
-				}
-			}
+			indexWriter.updateDocument(createSearchContext(), document);
 
 			String expectedMessage =
 				"failed to parse field [expirationDate] of type [date] in " +
@@ -427,7 +335,7 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 	}
 
 	@Test
-	public void testUpdateDocuments() {
+	public void testUpdateDocuments() throws SearchException {
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
 				OpenSearchIndexWriter.class.getName(), LoggerTestUtil.ERROR)) {
 
@@ -438,15 +346,8 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 
 			IndexWriter indexWriter = getIndexWriter();
 
-			try {
-				indexWriter.updateDocuments(
-					createSearchContext(), Arrays.asList(document));
-			}
-			catch (SearchException searchException) {
-				if (_log.isDebugEnabled()) {
-					_log.debug(searchException);
-				}
-			}
+			indexWriter.updateDocuments(
+				createSearchContext(), Arrays.asList(document));
 
 			_assertLogCapture(
 				message -> Assert.assertEquals("Bulk update failed", message),
@@ -455,7 +356,7 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 	}
 
 	@Test
-	public void testUpdateDocumentsBulkExecutor() {
+	public void testUpdateDocumentsBulkExecutor() throws SearchException {
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
 				BulkDocumentRequestExecutor.class.getName(),
 				LoggerTestUtil.ERROR)) {
@@ -467,15 +368,8 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 
 			IndexWriter indexWriter = getIndexWriter();
 
-			try {
-				indexWriter.updateDocuments(
-					createSearchContext(), Arrays.asList(document));
-			}
-			catch (SearchException searchException) {
-				if (_log.isDebugEnabled()) {
-					_log.debug(searchException);
-				}
-			}
+			indexWriter.updateDocuments(
+				createSearchContext(), Arrays.asList(document));
 
 			String expectedMessage =
 				"failed to parse field [expirationDate] of type [date] in " +
@@ -512,8 +406,5 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 		Assert.assertEquals(logLevel, logEntry.getPriority());
 		consumer.accept(logEntry.getMessage());
 	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		OpenSearchIndexWriterLogExceptionsOnlyTest.class);
 
 }

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/logging/OpenSearchIndexWriterLogExceptionsOnlyTest.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/logging/OpenSearchIndexWriterLogExceptionsOnlyTest.java
@@ -13,23 +13,25 @@ import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.IndexWriter;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.SearchException;
-import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.search.opensearch2.internal.OpenSearchIndexWriter;
 import com.liferay.portal.search.opensearch2.internal.OpenSearchTestRule;
 import com.liferay.portal.search.opensearch2.internal.connection.TestOpenSearchConnectionManager;
 import com.liferay.portal.search.opensearch2.internal.indexing.LiferayOpenSearchIndexingFixtureFactory;
 import com.liferay.portal.search.opensearch2.internal.search.engine.adapter.document.BulkDocumentRequestExecutor;
-import com.liferay.portal.search.test.rule.logging.ExpectedLogMethodTestRule;
 import com.liferay.portal.search.test.util.indexing.BaseIndexingTestCase;
 import com.liferay.portal.search.test.util.indexing.DocumentCreationHelpers;
 import com.liferay.portal.search.test.util.indexing.IndexingFixture;
-import com.liferay.portal.search.test.util.logging.ExpectedLog;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
+import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.function.Consumer;
 
+import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -40,99 +42,121 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 	extends BaseIndexingTestCase {
 
 	@ClassRule
-	public static final AggregateTestRule aggregateTestRule =
-		new AggregateTestRule(
-			ExpectedLogMethodTestRule.INSTANCE, LiferayUnitTestRule.INSTANCE);
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
 
 	@ClassRule
 	public static OpenSearchTestRule openSearchTestRule =
 		OpenSearchTestRule.INSTANCE;
 
-	@ExpectedLog(
-		expectedClass = OpenSearchIndexWriter.class,
-		expectedLevel = ExpectedLog.Level.WARNING,
-		expectedLog = "failed to parse field [expirationDate] of type [date]"
-	)
 	@Test
 	public void testAddDocument() throws Exception {
-		addDocument(
-			DocumentCreationHelpers.singleKeyword(
-				Field.EXPIRATION_DATE, "text"));
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				OpenSearchIndexWriter.class.getName(), LoggerTestUtil.ERROR)) {
+
+			addDocument(
+				DocumentCreationHelpers.singleKeyword(
+					Field.EXPIRATION_DATE, "text"));
+
+			String expectedMessage =
+				"failed to parse field [expirationDate] of type [date] in " +
+					"document with id";
+
+			_assertLogCapture(
+				message -> Assert.assertTrue(
+					message + " does not contain " + expectedMessage,
+					message.contains(expectedMessage)),
+				logCapture, LoggerTestUtil.ERROR);
+		}
 	}
 
-	@ExpectedLog(
-		expectedClass = OpenSearchIndexWriter.class,
-		expectedLevel = ExpectedLog.Level.WARNING,
-		expectedLog = "Bulk add failed"
-	)
 	@Test
 	public void testAddDocuments() {
-		List<Document> documents = new ArrayList<>();
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				OpenSearchIndexWriter.class.getName(), LoggerTestUtil.ERROR)) {
 
-		Document document = new DocumentImpl();
+			Document document = new DocumentImpl();
 
-		document.addKeyword(Field.EXPIRATION_DATE, "text");
+			document.addKeyword(Field.EXPIRATION_DATE, "text");
 
-		documents.add(document);
+			IndexWriter indexWriter = getIndexWriter();
 
-		IndexWriter indexWriter = getIndexWriter();
-
-		try {
-			indexWriter.addDocuments(createSearchContext(), documents);
-		}
-		catch (SearchException searchException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(searchException);
+			try {
+				indexWriter.addDocuments(
+					createSearchContext(), Arrays.asList(document));
 			}
+			catch (SearchException searchException) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(searchException);
+				}
+			}
+
+			_assertLogCapture(
+				message -> Assert.assertEquals("Bulk add failed", message),
+				logCapture, LoggerTestUtil.ERROR);
 		}
 	}
 
-	@ExpectedLog(
-		expectedClass = BulkDocumentRequestExecutor.class,
-		expectedLevel = ExpectedLog.Level.WARNING,
-		expectedLog = "failed to parse field [expirationDate] of type [date]"
-	)
 	@Test
 	public void testAddDocumentsBulkExecutor() {
-		List<Document> documents = new ArrayList<>();
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				BulkDocumentRequestExecutor.class.getName(),
+				LoggerTestUtil.ERROR)) {
 
-		Document document = new DocumentImpl();
+			Document document = new DocumentImpl();
 
-		document.addKeyword(Field.EXPIRATION_DATE, "text");
+			document.addKeyword(Field.EXPIRATION_DATE, "text");
 
-		documents.add(document);
+			IndexWriter indexWriter = getIndexWriter();
 
-		IndexWriter indexWriter = getIndexWriter();
-
-		try {
-			indexWriter.addDocuments(createSearchContext(), documents);
-		}
-		catch (SearchException searchException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(searchException);
+			try {
+				indexWriter.addDocuments(
+					createSearchContext(), Arrays.asList(document));
 			}
+			catch (SearchException searchException) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(searchException);
+				}
+			}
+
+			String expectedMessage =
+				"failed to parse field [expirationDate] of type [date] in " +
+					"document with id";
+
+			_assertLogCapture(
+				message -> Assert.assertTrue(
+					message + " does not contain " + expectedMessage,
+					message.contains(expectedMessage)),
+				logCapture, LoggerTestUtil.ERROR);
 		}
 	}
 
-	@ExpectedLog(
-		expectedClass = OpenSearchIndexWriter.class,
-		expectedLevel = ExpectedLog.Level.WARNING, expectedLog = "no such index"
-	)
 	@Test
 	public void testCommit() {
-		SearchContext searchContext = new SearchContext();
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				OpenSearchIndexWriter.class.getName(), LoggerTestUtil.ERROR)) {
 
-		searchContext.setCompanyId(1);
+			SearchContext searchContext = new SearchContext();
 
-		IndexWriter indexWriter = getIndexWriter();
+			searchContext.setCompanyId(1);
 
-		try {
-			indexWriter.commit(searchContext);
-		}
-		catch (SearchException searchException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(searchException);
+			IndexWriter indexWriter = getIndexWriter();
+
+			try {
+				indexWriter.commit(searchContext);
 			}
+			catch (SearchException searchException) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(searchException);
+				}
+			}
+
+			_assertLogCapture(
+				message -> Assert.assertEquals(
+					"Request failed: [index_not_found_exception] no such " +
+						"index [1]",
+					message),
+				logCapture, LoggerTestUtil.ERROR);
 		}
 	}
 
@@ -154,100 +178,120 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 		}
 	}
 
-	@ExpectedLog(
-		expectedClass = OpenSearchIndexWriter.class,
-		expectedLevel = ExpectedLog.Level.INFO, expectedLog = "no such index"
-	)
 	@Test
 	public void testDeleteDocumentInfoLevel() {
-		SearchContext searchContext = new SearchContext();
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				OpenSearchIndexWriter.class.getName(), LoggerTestUtil.INFO)) {
 
-		searchContext.setCompanyId(1);
+			SearchContext searchContext = new SearchContext();
 
-		IndexWriter indexWriter = getIndexWriter();
+			searchContext.setCompanyId(1);
 
-		try {
-			indexWriter.deleteDocument(searchContext, "1");
-		}
-		catch (SearchException searchException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(searchException);
+			IndexWriter indexWriter = getIndexWriter();
+
+			try {
+				indexWriter.deleteDocument(searchContext, "1");
 			}
+			catch (SearchException searchException) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(searchException);
+				}
+			}
+
+			String expectedMessage =
+				"Request failed: [index_not_found_exception] no such index [1]";
+
+			_assertLogCapture(
+				message -> Assert.assertTrue(
+					message + " does not contain " + expectedMessage,
+					message.contains(expectedMessage)),
+				logCapture, LoggerTestUtil.INFO);
 		}
 	}
 
-	@ExpectedLog(
-		expectedClass = OpenSearchIndexWriter.class,
-		expectedLevel = ExpectedLog.Level.WARNING,
-		expectedLog = "Bulk delete failed"
-	)
 	@Test
 	public void testDeleteDocuments() {
-		SearchContext searchContext = new SearchContext();
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				OpenSearchIndexWriter.class.getName(), LoggerTestUtil.ERROR)) {
 
-		searchContext.setCompanyId(1);
+			SearchContext searchContext = new SearchContext();
 
-		List<String> uids = new ArrayList<>();
+			searchContext.setCompanyId(1);
 
-		uids.add("1");
+			IndexWriter indexWriter = getIndexWriter();
 
-		IndexWriter indexWriter = getIndexWriter();
-
-		try {
-			indexWriter.deleteDocuments(searchContext, uids);
-		}
-		catch (SearchException searchException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(searchException);
+			try {
+				indexWriter.deleteDocuments(searchContext, Arrays.asList("1"));
 			}
+			catch (SearchException searchException) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(searchException);
+				}
+			}
+
+			_assertLogCapture(
+				message -> Assert.assertEquals("Bulk delete failed", message),
+				logCapture, LoggerTestUtil.ERROR);
 		}
 	}
 
-	@ExpectedLog(
-		expectedClass = BulkDocumentRequestExecutor.class,
-		expectedLevel = ExpectedLog.Level.WARNING, expectedLog = "no such index"
-	)
 	@Test
 	public void testDeleteDocumentsBulkExecutor() {
-		SearchContext searchContext = new SearchContext();
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				BulkDocumentRequestExecutor.class.getName(),
+				LoggerTestUtil.ERROR)) {
 
-		searchContext.setCompanyId(1);
+			SearchContext searchContext = new SearchContext();
 
-		List<String> uids = new ArrayList<>();
+			searchContext.setCompanyId(1);
 
-		uids.add("1");
+			IndexWriter indexWriter = getIndexWriter();
 
-		IndexWriter indexWriter = getIndexWriter();
-
-		try {
-			indexWriter.deleteDocuments(searchContext, uids);
-		}
-		catch (SearchException searchException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(searchException);
+			try {
+				indexWriter.deleteDocuments(searchContext, Arrays.asList("1"));
 			}
+			catch (SearchException searchException) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(searchException);
+				}
+			}
+
+			String expectedMessage = "no such index [1]";
+
+			_assertLogCapture(
+				message -> Assert.assertTrue(
+					message + " does not contain " + expectedMessage,
+					message.contains(expectedMessage)),
+				logCapture, LoggerTestUtil.ERROR);
 		}
 	}
 
-	@ExpectedLog(
-		expectedClass = OpenSearchIndexWriter.class,
-		expectedLevel = ExpectedLog.Level.WARNING, expectedLog = "no such index"
-	)
 	@Test
 	public void testDeleteEntityDocuments() {
-		SearchContext searchContext = new SearchContext();
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				OpenSearchIndexWriter.class.getName(), LoggerTestUtil.ERROR)) {
 
-		searchContext.setCompanyId(1);
+			SearchContext searchContext = new SearchContext();
 
-		IndexWriter indexWriter = getIndexWriter();
+			searchContext.setCompanyId(1);
 
-		try {
-			indexWriter.deleteEntityDocuments(searchContext, "test");
-		}
-		catch (SearchException searchException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(searchException);
+			IndexWriter indexWriter = getIndexWriter();
+
+			try {
+				indexWriter.deleteEntityDocuments(searchContext, "test");
 			}
+			catch (SearchException searchException) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(searchException);
+				}
+			}
+
+			_assertLogCapture(
+				message -> Assert.assertEquals(
+					"Request failed: [index_not_found_exception] no such " +
+						"index [1]",
+					message),
+				logCapture, LoggerTestUtil.ERROR);
 		}
 	}
 
@@ -274,17 +318,13 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 	public void testPartiallyUpdateDocuments() {
 		Document document = new DocumentImpl();
 
-		List<Document> documents = new ArrayList<>();
-
 		document.addKeyword(Field.UID, "1");
-
-		documents.add(document);
 
 		IndexWriter indexWriter = getIndexWriter();
 
 		try {
 			indexWriter.partiallyUpdateDocuments(
-				createSearchContext(), documents);
+				createSearchContext(), Arrays.asList(document));
 		}
 		catch (SearchException searchException) {
 			if (_log.isDebugEnabled()) {
@@ -293,134 +333,159 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 		}
 	}
 
-	@ExpectedLog(
-		expectedClass = BulkDocumentRequestExecutor.class,
-		expectedLevel = ExpectedLog.Level.WARNING,
-		expectedLog = "document missing"
-	)
 	@Test
 	public void testPartiallyUpdateDocumentsBulkExecutor() {
-		Document document = new DocumentImpl();
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				BulkDocumentRequestExecutor.class.getName(),
+				LoggerTestUtil.ERROR)) {
 
-		List<Document> documents = new ArrayList<>();
+			Document document = new DocumentImpl();
 
-		document.addKeyword(Field.UID, "1");
+			document.addKeyword(Field.UID, "1");
 
-		documents.add(document);
+			IndexWriter indexWriter = getIndexWriter();
 
-		IndexWriter indexWriter = getIndexWriter();
-
-		try {
-			indexWriter.partiallyUpdateDocuments(
-				createSearchContext(), documents);
-		}
-		catch (SearchException searchException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(searchException);
+			try {
+				indexWriter.partiallyUpdateDocuments(
+					createSearchContext(), Arrays.asList(document));
 			}
+			catch (SearchException searchException) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(searchException);
+				}
+			}
+
+			String expectedMessage = "[1]: document missing";
+
+			_assertLogCapture(
+				message -> Assert.assertTrue(
+					message + " does not contain " + expectedMessage,
+					message.contains(expectedMessage)),
+				logCapture, LoggerTestUtil.ERROR);
 		}
 	}
 
-	@ExpectedLog(
-		expectedClass = OpenSearchIndexWriter.class,
-		expectedLevel = ExpectedLog.Level.WARNING, expectedLog = "Update failed"
-	)
 	@Test
 	public void testUpdateDocument() {
-		Document document = new DocumentImpl();
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				OpenSearchIndexWriter.class.getName(), LoggerTestUtil.ERROR)) {
 
-		document.addKeyword(Field.EXPIRATION_DATE, "text");
-		document.addKeyword(Field.UID, "1");
+			Document document = new DocumentImpl();
 
-		IndexWriter indexWriter = getIndexWriter();
+			document.addKeyword(Field.EXPIRATION_DATE, "text");
+			document.addKeyword(Field.UID, "1");
 
-		try {
-			indexWriter.updateDocument(createSearchContext(), document);
-		}
-		catch (SearchException searchException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(searchException);
+			IndexWriter indexWriter = getIndexWriter();
+
+			try {
+				indexWriter.updateDocument(createSearchContext(), document);
 			}
+			catch (SearchException searchException) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(searchException);
+				}
+			}
+
+			_assertLogCapture(
+				message -> Assert.assertEquals("Update failed", message),
+				logCapture, LoggerTestUtil.ERROR);
 		}
 	}
 
-	@ExpectedLog(
-		expectedClass = BulkDocumentRequestExecutor.class,
-		expectedLevel = ExpectedLog.Level.WARNING,
-		expectedLog = "failed to parse field [expirationDate] of type [date]"
-	)
 	@Test
 	public void testUpdateDocumentBulkExecutor() {
-		Document document = new DocumentImpl();
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				BulkDocumentRequestExecutor.class.getName(),
+				LoggerTestUtil.ERROR)) {
 
-		document.addKeyword(Field.EXPIRATION_DATE, "text");
-		document.addKeyword(Field.UID, "1");
+			Document document = new DocumentImpl();
 
-		IndexWriter indexWriter = getIndexWriter();
+			document.addKeyword(Field.EXPIRATION_DATE, "text");
+			document.addKeyword(Field.UID, "1");
 
-		try {
-			indexWriter.updateDocument(createSearchContext(), document);
-		}
-		catch (SearchException searchException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(searchException);
+			IndexWriter indexWriter = getIndexWriter();
+
+			try {
+				indexWriter.updateDocument(createSearchContext(), document);
 			}
+			catch (SearchException searchException) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(searchException);
+				}
+			}
+
+			String expectedMessage =
+				"failed to parse field [expirationDate] of type [date] in " +
+					"document with id '1'. Preview of field's value: 'text'";
+
+			_assertLogCapture(
+				message -> Assert.assertTrue(
+					message + " does not contain " + expectedMessage,
+					message.contains(expectedMessage)),
+				logCapture, LoggerTestUtil.ERROR);
 		}
 	}
 
-	@ExpectedLog(
-		expectedClass = OpenSearchIndexWriter.class,
-		expectedLevel = ExpectedLog.Level.WARNING,
-		expectedLog = "Bulk update failed"
-	)
 	@Test
 	public void testUpdateDocuments() {
-		List<Document> documents = new ArrayList<>();
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				OpenSearchIndexWriter.class.getName(), LoggerTestUtil.ERROR)) {
 
-		Document document = new DocumentImpl();
+			Document document = new DocumentImpl();
 
-		document.addKeyword(Field.EXPIRATION_DATE, "text");
-		document.addKeyword(Field.UID, "1");
+			document.addKeyword(Field.EXPIRATION_DATE, "text");
+			document.addKeyword(Field.UID, "1");
 
-		documents.add(document);
+			IndexWriter indexWriter = getIndexWriter();
 
-		IndexWriter indexWriter = getIndexWriter();
-
-		try {
-			indexWriter.updateDocuments(createSearchContext(), documents);
-		}
-		catch (SearchException searchException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(searchException);
+			try {
+				indexWriter.updateDocuments(
+					createSearchContext(), Arrays.asList(document));
 			}
+			catch (SearchException searchException) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(searchException);
+				}
+			}
+
+			_assertLogCapture(
+				message -> Assert.assertEquals("Bulk update failed", message),
+				logCapture, LoggerTestUtil.ERROR);
 		}
 	}
 
-	@ExpectedLog(
-		expectedClass = BulkDocumentRequestExecutor.class,
-		expectedLevel = ExpectedLog.Level.WARNING,
-		expectedLog = "failed to parse field [expirationDate] of type [date]"
-	)
 	@Test
 	public void testUpdateDocumentsBulkExecutor() {
-		List<Document> documents = new ArrayList<>();
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				BulkDocumentRequestExecutor.class.getName(),
+				LoggerTestUtil.ERROR)) {
 
-		Document document = new DocumentImpl();
+			Document document = new DocumentImpl();
 
-		document.addKeyword(Field.EXPIRATION_DATE, "text");
-		document.addKeyword(Field.UID, "1");
+			document.addKeyword(Field.EXPIRATION_DATE, "text");
+			document.addKeyword(Field.UID, "1");
 
-		documents.add(document);
+			IndexWriter indexWriter = getIndexWriter();
 
-		IndexWriter indexWriter = getIndexWriter();
-
-		try {
-			indexWriter.updateDocuments(createSearchContext(), documents);
-		}
-		catch (SearchException searchException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(searchException);
+			try {
+				indexWriter.updateDocuments(
+					createSearchContext(), Arrays.asList(document));
 			}
+			catch (SearchException searchException) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(searchException);
+				}
+			}
+
+			String expectedMessage =
+				"failed to parse field [expirationDate] of type [date] in " +
+					"document with id '1'. Preview of field's value: 'text'";
+
+			_assertLogCapture(
+				message -> Assert.assertTrue(
+					message + " does not contain " + expectedMessage,
+					message.contains(expectedMessage)),
+				logCapture, LoggerTestUtil.ERROR);
 		}
 	}
 
@@ -433,6 +498,19 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 					"logExceptionsOnly", true
 				).build())
 		).build();
+	}
+
+	private void _assertLogCapture(
+		Consumer<String> consumer, LogCapture logCapture, String logLevel) {
+
+		List<LogEntry> logEntries = logCapture.getLogEntries();
+
+		Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
+
+		LogEntry logEntry = logEntries.get(0);
+
+		Assert.assertEquals(logLevel, logEntry.getPriority());
+		consumer.accept(logEntry.getMessage());
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/logging/OpenSearchIndexWriterLogExceptionsOnlyTest.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/logging/OpenSearchIndexWriterLogExceptionsOnlyTest.java
@@ -258,14 +258,23 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 
 	@Test
 	public void testPartiallyUpdateDocuments() throws SearchException {
-		Document document = new DocumentImpl();
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				OpenSearchIndexWriter.class.getName(), LoggerTestUtil.ERROR)) {
 
-		document.addKeyword(Field.UID, "1");
+			Document document = new DocumentImpl();
 
-		IndexWriter indexWriter = getIndexWriter();
+			document.addKeyword(Field.UID, "1");
 
-		indexWriter.partiallyUpdateDocuments(
-			createSearchContext(), Arrays.asList(document));
+			IndexWriter indexWriter = getIndexWriter();
+
+			indexWriter.partiallyUpdateDocuments(
+				createSearchContext(), Arrays.asList(document));
+
+			_assertLogCapture(
+				message -> Assert.assertEquals(
+					"Bulk partial update failed", message),
+				logCapture, LoggerTestUtil.ERROR);
+		}
 	}
 
 	@Test

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/logging/OpenSearchIndexWriterLogExceptionsOnlyTest.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/logging/OpenSearchIndexWriterLogExceptionsOnlyTest.java
@@ -56,7 +56,13 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 	public void tearDown() throws Exception {
 		super.tearDown();
 
-		getIndexWriter().deleteDocument(createSearchContext(), _UID);
+		IndexWriter indexWriter = getIndexWriter();
+
+		if (indexWriter == null) {
+			return;
+		}
+
+		indexWriter.deleteDocument(createSearchContext(), _UID);
 	}
 
 	@Test

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/logging/OpenSearchIndexWriterLogExceptionsOnlyTest.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/logging/OpenSearchIndexWriterLogExceptionsOnlyTest.java
@@ -72,7 +72,7 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 
 			addDocument(
 				DocumentCreationHelpers.singleKeyword(
-					Field.EXPIRATION_DATE, _EXPIRATION_DATE));
+					Field.EXPIRATION_DATE, _INVALID_DATE));
 
 			String expectedMessage =
 				"failed to parse field [expirationDate] of type [date] in " +
@@ -93,7 +93,7 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 
 			Document document = new DocumentImpl();
 
-			document.addKeyword(Field.EXPIRATION_DATE, _EXPIRATION_DATE);
+			document.addKeyword(Field.EXPIRATION_DATE, _INVALID_DATE);
 
 			IndexWriter indexWriter = getIndexWriter();
 
@@ -114,7 +114,7 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 
 			Document document = new DocumentImpl();
 
-			document.addKeyword(Field.EXPIRATION_DATE, _EXPIRATION_DATE);
+			document.addKeyword(Field.EXPIRATION_DATE, _INVALID_DATE);
 
 			IndexWriter indexWriter = getIndexWriter();
 
@@ -342,7 +342,7 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 
 			Document document = new DocumentImpl();
 
-			document.addKeyword(Field.EXPIRATION_DATE, _EXPIRATION_DATE);
+			document.addKeyword(Field.EXPIRATION_DATE, _INVALID_DATE);
 			document.addKeyword(Field.UID, _UID);
 
 			IndexWriter indexWriter = getIndexWriter();
@@ -363,7 +363,7 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 
 			Document document = new DocumentImpl();
 
-			document.addKeyword(Field.EXPIRATION_DATE, _EXPIRATION_DATE);
+			document.addKeyword(Field.EXPIRATION_DATE, _INVALID_DATE);
 			document.addKeyword(Field.UID, _UID);
 
 			IndexWriter indexWriter = getIndexWriter();
@@ -373,7 +373,7 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 			String expectedMessage = StringBundler.concat(
 				"failed to parse field [expirationDate] of type [date] in ",
 				"document with id '", _UID, "'. Preview of field's value: '",
-				_EXPIRATION_DATE, "'");
+				_INVALID_DATE, "'");
 
 			_assertLogCapture(
 				message -> Assert.assertTrue(
@@ -390,7 +390,7 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 
 			Document document = new DocumentImpl();
 
-			document.addKeyword(Field.EXPIRATION_DATE, _EXPIRATION_DATE);
+			document.addKeyword(Field.EXPIRATION_DATE, _INVALID_DATE);
 			document.addKeyword(Field.UID, _UID);
 
 			IndexWriter indexWriter = getIndexWriter();
@@ -412,7 +412,7 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 
 			Document document = new DocumentImpl();
 
-			document.addKeyword(Field.EXPIRATION_DATE, _EXPIRATION_DATE);
+			document.addKeyword(Field.EXPIRATION_DATE, _INVALID_DATE);
 			document.addKeyword(Field.UID, _UID);
 
 			IndexWriter indexWriter = getIndexWriter();
@@ -423,7 +423,7 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 			String expectedMessage = StringBundler.concat(
 				"failed to parse field [expirationDate] of type [date] in ",
 				"document with id '", _UID, "'. Preview of field's value: '",
-				_EXPIRATION_DATE, "'");
+				_INVALID_DATE, "'");
 
 			_assertLogCapture(
 				message -> Assert.assertTrue(
@@ -459,7 +459,7 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 
 	private static final long _COMPANY_ID = 1;
 
-	private static final String _EXPIRATION_DATE = "text";
+	private static final String _INVALID_DATE = "text";
 
 	private static final String _UID = "1";
 

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/logging/OpenSearchIndexWriterLogExceptionsOnlyTest.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/logging/OpenSearchIndexWriterLogExceptionsOnlyTest.java
@@ -12,7 +12,6 @@ import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.IndexWriter;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.SearchException;
-import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.search.opensearch2.internal.OpenSearchIndexWriter;
 import com.liferay.portal.search.opensearch2.internal.OpenSearchTestRule;
 import com.liferay.portal.search.opensearch2.internal.connection.TestOpenSearchConnectionManager;
@@ -27,6 +26,7 @@ import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -438,9 +438,7 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 		return LiferayOpenSearchIndexingFixtureFactory.builder(
 		).testOpenSearchConnectionManager(
 			new TestOpenSearchConnectionManager(
-				HashMapBuilder.<String, Object>put(
-					"logExceptionsOnly", true
-				).build())
+				Collections.singletonMap("logExceptionsOnly", true))
 		).build();
 	}
 

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/logging/OpenSearchIndexWriterLogExceptionsOnlyTest.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/logging/OpenSearchIndexWriterLogExceptionsOnlyTest.java
@@ -52,8 +52,9 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 		OpenSearchTestRule.INSTANCE;
 
 	@After
-	public void tearDownOpenSearchIndexWriterLogExceptionsOnlyTest()
-		throws SearchException {
+	@Override
+	public void tearDown() throws Exception {
+		super.tearDown();
 
 		getIndexWriter().deleteDocument(createSearchContext(), _UID);
 	}

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/logging/OpenSearchIndexWriterLogExceptionsOnlyTest.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/logging/OpenSearchIndexWriterLogExceptionsOnlyTest.java
@@ -66,7 +66,7 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 	}
 
 	@Test
-	public void testAddDocument() throws Exception {
+	public void testAddDocument() {
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
 				OpenSearchIndexWriter.class.getName(), LoggerTestUtil.ERROR)) {
 

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/logging/OpenSearchIndexWriterLogExceptionsOnlyTest.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/logging/OpenSearchIndexWriterLogExceptionsOnlyTest.java
@@ -5,6 +5,7 @@
 
 package com.liferay.portal.search.opensearch2.internal.logging;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.DocumentImpl;
 import com.liferay.portal.kernel.search.Field;
@@ -34,6 +35,8 @@ import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+import org.opensearch.client.opensearch._types.OpenSearchException;
+
 /**
  * @author Bryan Engler
  */
@@ -52,7 +55,7 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 	public void tearDownOpenSearchIndexWriterLogExceptionsOnlyTest()
 		throws SearchException {
 
-		getIndexWriter().deleteDocument(createSearchContext(), "1");
+		getIndexWriter().deleteDocument(createSearchContext(), _UID);
 	}
 
 	@Test
@@ -62,7 +65,7 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 
 			addDocument(
 				DocumentCreationHelpers.singleKeyword(
-					Field.EXPIRATION_DATE, "text"));
+					Field.EXPIRATION_DATE, _EXPIRATION_DATE));
 
 			String expectedMessage =
 				"failed to parse field [expirationDate] of type [date] in " +
@@ -83,7 +86,7 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 
 			Document document = new DocumentImpl();
 
-			document.addKeyword(Field.EXPIRATION_DATE, "text");
+			document.addKeyword(Field.EXPIRATION_DATE, _EXPIRATION_DATE);
 
 			IndexWriter indexWriter = getIndexWriter();
 
@@ -104,7 +107,7 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 
 			Document document = new DocumentImpl();
 
-			document.addKeyword(Field.EXPIRATION_DATE, "text");
+			document.addKeyword(Field.EXPIRATION_DATE, _EXPIRATION_DATE);
 
 			IndexWriter indexWriter = getIndexWriter();
 
@@ -130,7 +133,7 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 
 			SearchContext searchContext = new SearchContext();
 
-			searchContext.setCompanyId(1);
+			searchContext.setCompanyId(_COMPANY_ID);
 
 			IndexWriter indexWriter = getIndexWriter();
 
@@ -138,8 +141,9 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 
 			_assertLogCapture(
 				message -> Assert.assertEquals(
-					"Request failed: [index_not_found_exception] no such " +
-						"index [1]",
+					StringBundler.concat(
+						"Request failed: [index_not_found_exception] no such ",
+						"index [", _COMPANY_ID, "]"),
 					message),
 				logCapture, LoggerTestUtil.ERROR);
 		}
@@ -149,11 +153,11 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 	public void testDeleteDocument() throws SearchException {
 		SearchContext searchContext = new SearchContext();
 
-		searchContext.setCompanyId(1);
+		searchContext.setCompanyId(_COMPANY_ID);
 
 		IndexWriter indexWriter = getIndexWriter();
 
-		indexWriter.deleteDocument(searchContext, "1");
+		indexWriter.deleteDocument(searchContext, _UID);
 	}
 
 	@Test
@@ -163,19 +167,19 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 
 			SearchContext searchContext = new SearchContext();
 
-			searchContext.setCompanyId(1);
+			searchContext.setCompanyId(_COMPANY_ID);
 
 			IndexWriter indexWriter = getIndexWriter();
 
-			indexWriter.deleteDocument(searchContext, "1");
+			indexWriter.deleteDocument(searchContext, _UID);
 
-			String expectedMessage =
-				"Request failed: [index_not_found_exception] no such index [1]";
+			String expectedMessage = StringBundler.concat(
+				OpenSearchException.class.getName(), ": Request failed: ",
+				"[index_not_found_exception] no such index [", _COMPANY_ID,
+				"]");
 
 			_assertLogCapture(
-				message -> Assert.assertTrue(
-					message + " does not contain " + expectedMessage,
-					message.contains(expectedMessage)),
+				message -> Assert.assertEquals(expectedMessage, message),
 				logCapture, LoggerTestUtil.INFO);
 		}
 	}
@@ -187,11 +191,11 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 
 			SearchContext searchContext = new SearchContext();
 
-			searchContext.setCompanyId(1);
+			searchContext.setCompanyId(_COMPANY_ID);
 
 			IndexWriter indexWriter = getIndexWriter();
 
-			indexWriter.deleteDocuments(searchContext, Arrays.asList("1"));
+			indexWriter.deleteDocuments(searchContext, Arrays.asList(_UID));
 
 			_assertLogCapture(
 				message -> Assert.assertEquals("Bulk delete failed", message),
@@ -207,13 +211,14 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 
 			SearchContext searchContext = new SearchContext();
 
-			searchContext.setCompanyId(1);
+			searchContext.setCompanyId(_COMPANY_ID);
 
 			IndexWriter indexWriter = getIndexWriter();
 
-			indexWriter.deleteDocuments(searchContext, Arrays.asList("1"));
+			indexWriter.deleteDocuments(searchContext, Arrays.asList(_UID));
 
-			String expectedMessage = "no such index [1]";
+			String expectedMessage = StringBundler.concat(
+				"no such index [", _COMPANY_ID, "]");
 
 			_assertLogCapture(
 				message -> Assert.assertTrue(
@@ -230,7 +235,7 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 
 			SearchContext searchContext = new SearchContext();
 
-			searchContext.setCompanyId(1);
+			searchContext.setCompanyId(_COMPANY_ID);
 
 			IndexWriter indexWriter = getIndexWriter();
 
@@ -238,8 +243,9 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 
 			_assertLogCapture(
 				message -> Assert.assertEquals(
-					"Request failed: [index_not_found_exception] no such " +
-						"index [1]",
+					StringBundler.concat(
+						"Request failed: [index_not_found_exception] no such ",
+						"index [", _COMPANY_ID, "]"),
 					message),
 				logCapture, LoggerTestUtil.ERROR);
 		}
@@ -249,7 +255,7 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 	public void testPartiallyUpdateDocument() throws SearchException {
 		Document document = new DocumentImpl();
 
-		document.addKeyword(Field.UID, "1");
+		document.addKeyword(Field.UID, _UID);
 
 		IndexWriter indexWriter = getIndexWriter();
 
@@ -263,7 +269,7 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 
 			Document document = new DocumentImpl();
 
-			document.addKeyword(Field.UID, "1");
+			document.addKeyword(Field.UID, _UID);
 
 			IndexWriter indexWriter = getIndexWriter();
 
@@ -287,14 +293,15 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 
 			Document document = new DocumentImpl();
 
-			document.addKeyword(Field.UID, "1");
+			document.addKeyword(Field.UID, _UID);
 
 			IndexWriter indexWriter = getIndexWriter();
 
 			indexWriter.partiallyUpdateDocuments(
 				createSearchContext(), Arrays.asList(document));
 
-			String expectedMessage = "[1]: document missing";
+			String expectedMessage = StringBundler.concat(
+				"[", _UID, "]: document missing");
 
 			_assertLogCapture(
 				message -> Assert.assertTrue(
@@ -311,8 +318,8 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 
 			Document document = new DocumentImpl();
 
-			document.addKeyword(Field.EXPIRATION_DATE, "text");
-			document.addKeyword(Field.UID, "1");
+			document.addKeyword(Field.EXPIRATION_DATE, _EXPIRATION_DATE);
+			document.addKeyword(Field.UID, _UID);
 
 			IndexWriter indexWriter = getIndexWriter();
 
@@ -332,16 +339,17 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 
 			Document document = new DocumentImpl();
 
-			document.addKeyword(Field.EXPIRATION_DATE, "text");
-			document.addKeyword(Field.UID, "1");
+			document.addKeyword(Field.EXPIRATION_DATE, _EXPIRATION_DATE);
+			document.addKeyword(Field.UID, _UID);
 
 			IndexWriter indexWriter = getIndexWriter();
 
 			indexWriter.updateDocument(createSearchContext(), document);
 
-			String expectedMessage =
-				"failed to parse field [expirationDate] of type [date] in " +
-					"document with id '1'. Preview of field's value: 'text'";
+			String expectedMessage = StringBundler.concat(
+				"failed to parse field [expirationDate] of type [date] in ",
+				"document with id '", _UID, "'. Preview of field's value: '",
+				_EXPIRATION_DATE, "'");
 
 			_assertLogCapture(
 				message -> Assert.assertTrue(
@@ -358,8 +366,8 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 
 			Document document = new DocumentImpl();
 
-			document.addKeyword(Field.EXPIRATION_DATE, "text");
-			document.addKeyword(Field.UID, "1");
+			document.addKeyword(Field.EXPIRATION_DATE, _EXPIRATION_DATE);
+			document.addKeyword(Field.UID, _UID);
 
 			IndexWriter indexWriter = getIndexWriter();
 
@@ -380,17 +388,18 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 
 			Document document = new DocumentImpl();
 
-			document.addKeyword(Field.EXPIRATION_DATE, "text");
-			document.addKeyword(Field.UID, "1");
+			document.addKeyword(Field.EXPIRATION_DATE, _EXPIRATION_DATE);
+			document.addKeyword(Field.UID, _UID);
 
 			IndexWriter indexWriter = getIndexWriter();
 
 			indexWriter.updateDocuments(
 				createSearchContext(), Arrays.asList(document));
 
-			String expectedMessage =
-				"failed to parse field [expirationDate] of type [date] in " +
-					"document with id '1'. Preview of field's value: 'text'";
+			String expectedMessage = StringBundler.concat(
+				"failed to parse field [expirationDate] of type [date] in ",
+				"document with id '", _UID, "'. Preview of field's value: '",
+				_EXPIRATION_DATE, "'");
 
 			_assertLogCapture(
 				message -> Assert.assertTrue(
@@ -423,5 +432,11 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 		Assert.assertEquals(logLevel, logEntry.getPriority());
 		consumer.accept(logEntry.getMessage());
 	}
+
+	private static final long _COMPANY_ID = 1;
+
+	private static final String _EXPIRATION_DATE = "text";
+
+	private static final String _UID = "1";
 
 }

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/logging/OpenSearchIndexWriterLogExceptionsOnlyTest.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/logging/OpenSearchIndexWriterLogExceptionsOnlyTest.java
@@ -151,13 +151,21 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 
 	@Test
 	public void testDeleteDocument() throws SearchException {
-		SearchContext searchContext = new SearchContext();
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				OpenSearchIndexWriter.class.getName(), LoggerTestUtil.ERROR)) {
 
-		searchContext.setCompanyId(_COMPANY_ID);
+			SearchContext searchContext = new SearchContext();
 
-		IndexWriter indexWriter = getIndexWriter();
+			searchContext.setCompanyId(_COMPANY_ID);
 
-		indexWriter.deleteDocument(searchContext, _UID);
+			IndexWriter indexWriter = getIndexWriter();
+
+			indexWriter.deleteDocument(searchContext, _UID);
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertEquals(logEntries.toString(), 0, logEntries.size());
+		}
 	}
 
 	@Test

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/logging/OpenSearchIndexWriterLogExceptionsOnlyTest.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/logging/OpenSearchIndexWriterLogExceptionsOnlyTest.java
@@ -159,7 +159,7 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 	@Test
 	public void testDeleteDocument() throws SearchException {
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
-				OpenSearchIndexWriter.class.getName(), LoggerTestUtil.ERROR)) {
+				OpenSearchIndexWriter.class.getName(), LoggerTestUtil.WARN)) {
 
 			SearchContext searchContext = new SearchContext();
 

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/logging/OpenSearchIndexWriterLogExceptionsOnlyTest.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/logging/OpenSearchIndexWriterLogExceptionsOnlyTest.java
@@ -261,13 +261,22 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 
 	@Test
 	public void testPartiallyUpdateDocument() throws SearchException {
-		Document document = new DocumentImpl();
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				OpenSearchIndexWriter.class.getName(), LoggerTestUtil.ERROR)) {
 
-		document.addKeyword(Field.UID, _UID);
+			Document document = new DocumentImpl();
 
-		IndexWriter indexWriter = getIndexWriter();
+			document.addKeyword(Field.UID, _UID);
 
-		indexWriter.partiallyUpdateDocument(createSearchContext(), document);
+			IndexWriter indexWriter = getIndexWriter();
+
+			indexWriter.partiallyUpdateDocument(
+				createSearchContext(), document);
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertEquals(logEntries.toString(), 0, logEntries.size());
+		}
 	}
 
 	@Test

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/logging/OpenSearchIndexWriterLogExceptionsOnlyTest.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/logging/OpenSearchIndexWriterLogExceptionsOnlyTest.java
@@ -12,6 +12,10 @@ import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.IndexWriter;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.SearchException;
+import com.liferay.portal.search.engine.adapter.SearchEngineAdapter;
+import com.liferay.portal.search.engine.adapter.index.DeleteIndexRequest;
+import com.liferay.portal.search.engine.adapter.index.IndicesExistsIndexRequest;
+import com.liferay.portal.search.engine.adapter.index.IndicesExistsIndexResponse;
 import com.liferay.portal.search.opensearch2.internal.OpenSearchIndexWriter;
 import com.liferay.portal.search.opensearch2.internal.OpenSearchTestRule;
 import com.liferay.portal.search.opensearch2.internal.connection.TestOpenSearchConnectionManager;
@@ -32,6 +36,7 @@ import java.util.function.Consumer;
 
 import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -50,6 +55,26 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 	@ClassRule
 	public static OpenSearchTestRule openSearchTestRule =
 		OpenSearchTestRule.INSTANCE;
+
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+
+		String indexName = String.valueOf(_COMPANY_ID);
+
+		SearchEngineAdapter searchEngineAdapter = getSearchEngineAdapter();
+
+		IndicesExistsIndexResponse indicesExistsIndexResponse =
+			searchEngineAdapter.execute(
+				new IndicesExistsIndexRequest(indexName));
+
+		if (!indicesExistsIndexResponse.isExists()) {
+			return;
+		}
+
+		searchEngineAdapter.execute(new DeleteIndexRequest(indexName));
+	}
 
 	@After
 	@Override

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/logging/OpenSearchIndexWriterLogExceptionsOnlyTest.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/logging/OpenSearchIndexWriterLogExceptionsOnlyTest.java
@@ -107,7 +107,7 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 				message -> Assert.assertTrue(
 					message + " does not contain " + expectedMessage,
 					message.contains(expectedMessage)),
-				logCapture, LoggerTestUtil.ERROR);
+				logCapture, LoggerTestUtil.ERROR, OpenSearchException.class);
 		}
 	}
 
@@ -177,7 +177,7 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 						"Request failed: [index_not_found_exception] no such ",
 						"index [", _COMPANY_ID, "]"),
 					message),
-				logCapture, LoggerTestUtil.ERROR);
+				logCapture, LoggerTestUtil.ERROR, OpenSearchException.class);
 		}
 	}
 
@@ -220,7 +220,7 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 
 			_assertLogCapture(
 				message -> Assert.assertEquals(expectedMessage, message),
-				logCapture, LoggerTestUtil.INFO);
+				logCapture, LoggerTestUtil.INFO, OpenSearchException.class);
 		}
 	}
 
@@ -287,7 +287,7 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 						"Request failed: [index_not_found_exception] no such ",
 						"index [", _COMPANY_ID, "]"),
 					message),
-				logCapture, LoggerTestUtil.ERROR);
+				logCapture, LoggerTestUtil.ERROR, OpenSearchException.class);
 		}
 	}
 
@@ -470,6 +470,13 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 	private void _assertLogCapture(
 		Consumer<String> consumer, LogCapture logCapture, String logLevel) {
 
+		_assertLogCapture(consumer, logCapture, logLevel, null);
+	}
+
+	private void _assertLogCapture(
+		Consumer<String> consumer, LogCapture logCapture, String logLevel,
+		Class<?> throwableClass) {
+
 		List<LogEntry> logEntries = logCapture.getLogEntries();
 
 		Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
@@ -477,6 +484,16 @@ public class OpenSearchIndexWriterLogExceptionsOnlyTest
 		LogEntry logEntry = logEntries.get(0);
 
 		Assert.assertEquals(logLevel, logEntry.getPriority());
+
+		Throwable throwable = logEntry.getThrowable();
+
+		if (throwableClass == null) {
+			Assert.assertNull(String.valueOf(throwable), throwable);
+		}
+		else {
+			Assert.assertSame(throwableClass, throwable.getClass());
+		}
+
 		consumer.accept(logEntry.getMessage());
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-82780
https://liferay.atlassian.net/browse/LPD-82781
https://liferay.atlassian.net/browse/LPD-82786

## What Is Being Fixed

Three OpenSearch2 logging tests asserted through the legacy `@ExpectedLog` annotation, which only checked that the concatenation of every captured message contained a substring. It never asserted how many entries were logged, nor at which level, so a test could pass while logging three entries instead of one, or while logging at a level the code was never meant to use.

Migrating them to `LogCapture` makes all three explicit. Along the way it restores three assertions that were lost on master years ago, and fixes a cross-test pollution bug that was silently disarming one of them.

## How It Is Being Fixed

The first ten commits, by @victorhcunha, replace `@ExpectedLog` and JUnit's `ExpectedException` with `LoggerTestUtil.configureLog4JLogger` plus explicit assertions on the entry count, the level and the message, and stop the tests from swallowing `SearchException`.

The remaining twelve address review findings, one concern per commit:

- `tearDown` now overrides `BaseIndexingTestCase.tearDown()` instead of shadowing it under a class-name-suffixed name, which is reserved for the static `setUpClass`/`tearDownClass` methods that cannot be overridden.
- That cleanup now returns early when `setUp` failed. Without the guard it threw a `NullPointerException` reaching for the company ID, so every failing test reported that second failure on top of the real one and buried the cause.
- `setUp` deletes the index for the company these tests expect to be absent. Six tests assert `index_not_found` for it; with the index present, five fail loudly and `testDeleteDocument` passes for the wrong reason, because it asserts that nothing is logged and a successful delete logs nothing. Verified both ways against a local OpenSearch 2.19.5.
- `testDeleteDocument` captures at WARN rather than ERROR, the level the assertion originally ran at, so a regression that logged the index-not-found path at WARN can no longer slip past a capture that disabled it.
- `OpenSearchExceptionHandlerTest` asserts the logged message again. The migration had replaced that with an identity check on the throwable, which does not cover it: the handler logs through the two-argument overload, so the message comes from the first argument independently.
- The unreachable second branch in `OpenSearchExceptionHandler.logOrThrow` is gone. It repeated the condition the first branch already took, and has been dead since the method was extracted out of `ElasticsearchIndexWriter`.
- Smaller items: `_INVALID_DATE` no longer claims to be an expiration date, the fixture configuration uses `Collections.singletonMap`, the `throws` clauses say what the bodies actually throw, the helper parameters are sorted, and the logged throwable is asserted.

Every commit was verified standing alone: Source Formatter clean with no auto-fixes, and all 24 unit tests green on each one individually, so no commit depends on a later one to pass.

## A Note On The Baseline Commit

This branch also carries one commit that does not belong to it, `LPD-97871 Semantic versioning`, because `ant baseline-all` refused to pass without it.

@veroglez — this is from https://github.com/brianchandotcom/liferay-portal/pull/180491. `f5f62bc232d30` raised `headless-cms-api`'s `resource/v1_0` package from `3.0.0` to `3.1.0`, but no commit on LPD-97871 changed any Java under that module, so the exported API never moved and the increase was excessive. A clean baseline lowers it straight back to `3.0.0`.

The reason it reached master is that the `pr-check` result on that pull request was stale when it was closed out:

| | |
| --- | --- |
| `pr-check` recorded on | `f8abc36021d94c661767334fd5c822c24f4c6966`, committed 2026-08-12 |
| Pull request opened and closed | 2026-08-19, a week later |
| Tested SHA present in the pull request's 28 commits | no |
| Head at merge | `59523267732db`, itself a `Semantic versioning` commit |
| Baseline in the recorded results table | absent |

So neither semantic versioning commit was covered by the result that was published. A week is long enough for a lot to go stale, and two things did: the version bump itself, and the `pr-check` that was supposed to catch it. The Baseline validation also became repository-wide on 2026-08-13, the day after that run, so the published result predates the check that would have flagged this.

A fresh `pr-check` before closing out to Brian would have caught it. Please rerun one on the current head rather than publishing a result from an earlier SHA, especially after appending commits.

## PR Check

**pr-check: PASS** — tested on `211a6c357e567813c1dd4c81c74de001468d82de`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

Integration Test Compile matched the diff but the module has no `testIntegration` source set, so the task does not exist and it is reported as not applicable rather than as a pass.

<!-- pr-check {"result": "success", "sha": "211a6c357e567813c1dd4c81c74de001468d82de"} -->
