### PR TITLE
LPD-103184 Publish class names to the pool only after their inserts commit

### DIFF
--- a/modules/apps/asset/asset-entry-rel-service/src/main/java/com/liferay/asset/entry/rel/service/impl/AssetEntryAssetCategoryRelLocalServiceImpl.java
+++ b/modules/apps/asset/asset-entry-rel-service/src/main/java/com/liferay/asset/entry/rel/service/impl/AssetEntryAssetCategoryRelLocalServiceImpl.java
@@ -21,7 +21,6 @@ import com.liferay.portal.kernel.mass.delete.MassDeleteCacheThreadLocal;
 import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistry;
-import com.liferay.portal.kernel.search.SearchException;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
@@ -294,8 +293,8 @@ public class AssetEntryAssetCategoryRelLocalServiceImpl
 					assetEntry.getClassName(), assetEntry.getClassPK());
 			}
 		}
-		catch (SearchException searchException) {
-			_log.error("Unable to reindex asset entry", searchException);
+		catch (Exception exception) {
+			_log.error("Unable to reindex asset entry", exception);
 		}
 	}
 

--- a/modules/apps/portal/portal-classname-test/bnd.bnd
+++ b/modules/apps/portal/portal-classname-test/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Liferay Portal Class Name Test
+Bundle-SymbolicName: com.liferay.portal.classname.test
+Bundle-Version: 1.0.0

--- a/modules/apps/portal/portal-classname-test/build.gradle
+++ b/modules/apps/portal/portal-classname-test/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
+}

--- a/modules/apps/portal/portal-classname-test/src/testIntegration/java/com/liferay/portal/classname/test/ClassNameLocalServiceTest.java
+++ b/modules/apps/portal/portal-classname-test/src/testIntegration/java/com/liferay/portal/classname/test/ClassNameLocalServiceTest.java
@@ -1,0 +1,173 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.classname.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.portal.kernel.model.ClassName;
+import com.liferay.portal.kernel.model.CompanyConstants;
+import com.liferay.portal.kernel.security.auth.CompanyInheritableThreadLocalCallable;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.util.PortalClassLoaderUtil;
+import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.kernel.util.ProxyUtil;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
+import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.FutureTask;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Shuyang Zhou
+ */
+@RunWith(Arquillian.class)
+public class ClassNameLocalServiceTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testConcurrentGetClassName() throws Exception {
+
+		// Pause the first resolver at its class name pool write, let the test
+		// thread resolve the same new value to completion, then release the
+		// paused thread into the unique index violation and its rollback. The
+		// paused thread must come back with the winner's committed row, and
+		// the pool must never serve an ID whose insert rolled back.
+
+		String value = ClassNameLocalServiceTest.class.getName();
+
+		// A leftover row from an earlier run would turn the first resolution
+		// into a plain read, so drop it
+
+		ClassName className = _classNameLocalService.fetchClassName(value);
+
+		if (className.getClassNameId() > 0) {
+			_classNameLocalService.deleteClassName(className);
+		}
+
+		className = null;
+
+		FutureTask<ClassName> futureTask = new FutureTask<>(
+			new CompanyInheritableThreadLocalCallable<>(
+				() -> _classNameLocalService.getClassName(value)));
+
+		Thread thread = new Thread(futureTask, "Class Name Local Service Test");
+
+		ClassLoader classLoader = PortalClassLoaderUtil.getClassLoader();
+
+		Class<?> classNamePoolClass = classLoader.loadClass(
+			"com.liferay.portal.service.impl.ClassNameLocalServiceImpl$" +
+				"ClassNamePool");
+
+		Map<Long, Map<String, Long>> classNameIdsMap =
+			ReflectionTestUtil.getFieldValue(
+				classNamePoolClass, "_classNameIdsMap");
+
+		Long companyId = CompanyConstants.SYSTEM;
+
+		if (PropsValues.DATABASE_PARTITION_ENABLED) {
+			companyId = CompanyThreadLocal.getNonsystemCompanyId();
+		}
+
+		Map<String, Long> classNameIds = classNameIdsMap.get(companyId);
+
+		CountDownLatch pausedCountDownLatch = new CountDownLatch(1);
+		CountDownLatch resumeCountDownLatch = new CountDownLatch(1);
+
+		classNameIdsMap.put(
+			companyId,
+			(Map<String, Long>)ProxyUtil.newDelegateProxyInstance(
+				classLoader, Map.class,
+				new Object() {
+
+					public Object put(Object key, Object putValue) {
+						if (value.equals(key) &&
+							(Thread.currentThread() == thread)) {
+
+							pausedCountDownLatch.countDown();
+
+							try {
+								resumeCountDownLatch.await();
+							}
+							catch (InterruptedException interruptedException) {
+								ReflectionUtil.throwException(
+									interruptedException);
+							}
+						}
+
+						return classNameIds.put((String)key, (Long)putValue);
+					}
+
+				},
+				classNameIds));
+
+		// With the pool publish deferred to the commit callback, the paused
+		// thread only pauses after its insert commits, so the resolution on
+		// the test thread reads the committed row and no unique index
+		// violation occurs. Capture the SQL error logger so a regression that
+		// revives the violation surfaces as an asserted log entry
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"org.hibernate.engine.jdbc.spi.SqlExceptionHelper",
+				LoggerTestUtil.ERROR)) {
+
+			thread.start();
+
+			pausedCountDownLatch.await();
+
+			className = _classNameLocalService.getClassName(value);
+
+			resumeCountDownLatch.countDown();
+
+			ClassName pausedThreadClassName = futureTask.get();
+
+			Assert.assertEquals(
+				className.getClassNameId(),
+				pausedThreadClassName.getClassNameId());
+
+			long pooledClassNameId = _classNameLocalService.getClassNameId(
+				value);
+
+			Assert.assertEquals(className.getClassNameId(), pooledClassNameId);
+
+			ClassName persistedClassName = _classNameLocalService.getClassName(
+				pooledClassNameId);
+
+			Assert.assertEquals(value, persistedClassName.getValue());
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertTrue(logEntries.toString(), logEntries.isEmpty());
+		}
+		finally {
+			classNameIdsMap.put(companyId, classNameIds);
+
+			if (className != null) {
+				_classNameLocalService.deleteClassName(className);
+			}
+		}
+	}
+
+	@Inject
+	private ClassNameLocalService _classNameLocalService;
+
+}

--- a/portal-impl/src/com/liferay/portal/service/impl/ClassNameLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ClassNameLocalServiceImpl.java
@@ -153,7 +153,13 @@ public class ClassNameLocalServiceImpl
 				_log.debug(throwable);
 			}
 
-			return ClassNamePool.fetchByValue(value);
+			// The failure usually means a concurrent insert of the same value
+			// won. Ask again in a fresh transaction, whose snapshot holds
+			// every committed row on any isolation level and none of the
+			// current transaction's uncommitted writes, so the retry returns
+			// the winner's committed row or fails for real
+
+			return classNameLocalService.addClassName(value);
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/service/impl/ClassNameLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ClassNameLocalServiceImpl.java
@@ -15,6 +15,7 @@ import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.model.ModelHintsUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.transaction.Propagation;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.transaction.Transactional;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.PropsValues;
@@ -47,9 +48,24 @@ public class ClassNameLocalServiceImpl
 			className.setValue(value);
 
 			className = classNamePersistence.update(className);
-		}
 
-		ClassNamePool.add(className);
+			ClassName newClassName = className;
+
+			// The pool has no transaction awareness, so a created row must
+			// only publish after its transaction commits. Publishing earlier
+			// leaks the class name ID into the pool even when the insert rolls
+			// back, and the pool then serves an ID that has no backing row
+
+			TransactionCallbackUtil.registerCommitCallback(
+				() -> {
+					ClassNamePool.add(newClassName);
+
+					return null;
+				});
+		}
+		else {
+			ClassNamePool.add(className);
+		}
 
 		return className;
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103184

## What Is Being Fixed

Integration tests across the object suite die intermittently with `java.lang.RuntimeException: Unable to get class name from id <n>`, thrown from `PortalImpl.getClassName` via `AssetEntryAssetCategoryRelLocalServiceImpl._reindex` while the test adds an object entry. The error aborts the caller's whole transaction and is logged nowhere, because `_reindex` only catches `SearchException`. A sweep of 782 CI build reports from July 1 to August 19 found the signature in 41 builds, landing on a different victim test each time.

The class name ID that fails to resolve comes from `ClassNamePool`, the JVM-static cache inside `ClassNameLocalServiceImpl`: when two threads resolve the same new value concurrently, both insert with distinct counter IDs, the loser violates the unique index on `ClassName_.value` at commit, and its rolled back ID stays published in the pool for the JVM's lifetime. Every later resolution of that value serves the phantom ID, and callers persist it into rows such as `AssetEntry.classNameId`.

## Root Cause

d360a70fb389abc5123fdffc0519fb6dbe72b24d (LPD-17727, 2024-02-24, Mariano Alvaro Saiz) moved `ClassNamePool.add` inside `addClassName`'s `REQUIRES_NEW` transaction, before the commit, and added a `catch (Throwable)` in `getClassName` that returns the unvalidated pool entry. That single commit created both halves of this two-and-a-half-year transaction rollback pollution: the uncommitted publish leaks the loser's ID into the pool, and the catch then hands the leaked ID to the caller. It also reversed an invariant two earlier commits had deliberately maintained: LPS-79806 published the pool through a transaction commit callback, and LPS-110102 kept the publish outside the new transaction so only committed rows could enter the pool.

## How It Is Being Fixed

- `addClassName` publishes a created row to the pool through `TransactionCallbackUtil.registerCommitCallback`, restoring the LPS-79806 invariant: a rolled back insert can no longer leak its ID.
- When `addClassName` fails, `getClassName` asks again in a fresh transaction instead of serving the unvalidated pool entry. The new transaction's snapshot holds every committed row on any isolation level and none of the caller's uncommitted writes, so the retry returns the concurrent winner's committed row, and a retry that also fails propagates instead of returning null (which previously became a `NullPointerException` in `getClassNameId`).
- `AssetEntryAssetCategoryRelLocalServiceImpl._reindex` catches `Exception`, so a class name resolution failure degrades to the error log line the catch always intended instead of silently aborting the caller's transaction (born broken in b9fe16f489c1a, LPS-91405).

A new integration test module, `portal-classname-test`, forces the race deterministically against the real service, database, and transactions: it swaps the class name pool's value map for a delegating proxy that pauses a resolver thread at its pool write, resolves the same value to completion on the test thread, then releases the paused thread, asserting both threads agree on one committed class name ID and that the captured Hibernate SQL error logger stays empty. Against the unfixed code the test fails every run with the paused thread returning the rolled back ID; against the fixed code it passes repeatedly.

## PR Check

**pr-check: PASS** — tested on `65da47574344ec621e70ba32a4de696a14f7c44e`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Full Portal Build | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | PASS |
| Structural Smoke | PASS |
| Baseline | PASS |

Transaction Usage: the branch adds `TransactionCallbackUtil.registerCommitCallback` in `ClassNameLocalServiceImpl`; initiator is on the Core Infrastructure whitelist. Baseline: the changed module's `baseline` task passes clean; `ant baseline-all` aborts only on the known master-side `headless-cms-api` excessive version, whose upstream repair is already queued.

<!-- pr-check {"result": "success", "sha": "65da47574344ec621e70ba32a4de696a14f7c44e"} -->
