### PR TITLE
LPD-103252 Report an invalid object entry value on its own field

### DIFF
--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/handler/ObjectEntryInfoItemExceptionRequestHandler.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/handler/ObjectEntryInfoItemExceptionRequestHandler.java
@@ -360,6 +360,22 @@ public class ObjectEntryInfoItemExceptionRequestHandler {
 				infoFieldUniqueId);
 		}
 
+		if (exception instanceof ObjectEntryValuesException.InvalidValue) {
+			ObjectEntryValuesException.InvalidValue objectEntryValuesException =
+				(ObjectEntryValuesException.InvalidValue)exception;
+
+			String infoFieldUniqueId = _getInfoFieldUniqueId(
+				groupId, infoItemFormProvider, objectDefinition,
+				objectEntryValuesException.getObjectFieldName());
+
+			if (infoFieldUniqueId == null) {
+				throw new InfoFormException();
+			}
+
+			throw new InfoFormValidationException.InvalidInfoFieldValue(
+				infoFieldUniqueId);
+		}
+
 		if (exception instanceof ObjectEntryValuesException.ListTypeEntry) {
 			ObjectEntryValuesException.ListTypeEntry
 				objectEntryValuesException =

--- a/modules/apps/object/object-web/src/test/java/com/liferay/object/web/internal/info/item/handler/ObjectEntryInfoItemExceptionRequestHandlerTest.java
+++ b/modules/apps/object/object-web/src/test/java/com/liferay/object/web/internal/info/item/handler/ObjectEntryInfoItemExceptionRequestHandlerTest.java
@@ -38,12 +38,13 @@ public class ObjectEntryInfoItemExceptionRequestHandlerTest {
 		LiferayUnitTestRule.INSTANCE;
 
 	@Test
-	@TestInfo({"LPD-96532", "LPD-97485"})
+	@TestInfo({"LPD-96532", "LPD-97485", "LPD-103252"})
 	public void testHandleInfoFormException() throws Exception {
 		_testHandleInfoFormExceptionWhenAssetCategoryExceptionTypeIsAtLeastOneCategory();
 		_testHandleInfoFormExceptionWhenAssetCategoryExceptionTypeIsTooManyCategories();
 		_testHandleInfoFormExceptionWhenDuplicateExternalReferenceCode();
 		_testHandleInfoFormExceptionWhenDuplicateFriendlyURL();
+		_testHandleInfoFormExceptionWhenInvalidValue();
 		_testHandleInfoFormExceptionWhenRequiredLanguageId();
 	}
 
@@ -151,6 +152,20 @@ public class ObjectEntryInfoItemExceptionRequestHandlerTest {
 						new ModelListenerException(
 							new GroupFriendlyURLException(
 								GroupFriendlyURLException.DUPLICATE)),
+						0, _mockInfoItemFormProvider(),
+						Mockito.mock(ObjectDefinition.class)));
+	}
+
+	private void _testHandleInfoFormExceptionWhenInvalidValue()
+		throws Exception {
+
+		Assert.assertThrows(
+			InfoFormValidationException.InvalidInfoFieldValue.class,
+			() ->
+				ObjectEntryInfoItemExceptionRequestHandler.
+					handleInfoFormException(
+						new ObjectEntryValuesException.InvalidValue(
+							RandomTestUtil.randomString()),
 						0, _mockInfoItemFormProvider(),
 						Mockito.mock(ObjectDefinition.class)));
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103252

## What Is Being Fixed

When an object entry value fails validation with `ObjectEntryValuesException.InvalidValue`, a form built with the Info framework showed a generic error banner and left the offending field unmarked.

`ObjectEntryInfoItemExceptionRequestHandler` maps every other specific `ObjectEntryValuesException` subclass to an `InfoFormValidationException` carrying the info field unique id, but `InvalidValue` was not mapped, so it fell through to a plain `InfoFormException`. `EditInfoItemStrutsAction` then recorded it under the form level bucket rather than the `InfoFormException.class` bucket that carries a field unique id, and `FragmentEntryInputTemplateNodeContextHelperImpl` never set an error message on the input.

The assignee input fragment made this visible. An assignee whose user or role no longer exists, or the Guest role, produced a generic error with nothing pointing at the assignee field, and pressing submit again failed the same way.

## How It Is Being Fixed

`InvalidValue` already carries the object field name, so the handler resolves it to the info field unique id and rethrows `InfoFormValidationException.InvalidInfoFieldValue`, the same translation already applied to `ListTypeEntry`. The error then lands in the bucket the fragment inspects, so the field renders its own message and the `has-error` class.

This needs no new exception type, no change to any object field business type, and no new language key, since `InvalidInfoFieldValue` already resolves `this-field-is-invalid`. Relationship and rich text fields also throw `InvalidValue`, so they gain the same field level reporting.

## PR Check

**pr-check: PASS** - tested on `aa1e2a9ba38013009320f39d04176caae4336554`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

Scope notes. Source Format ran module scoped rather than through `ant format-source-current-branch`, and Baseline ran its network free local version check rather than `ant baseline-all`, because local `master` in the checkout used for the run points at an unrelated branch. The changed classes live in a non exported `...web.internal...` package, so no semantic versioning bump is owed.

<!-- pr-check {"result": "success", "sha": "aa1e2a9ba38013009320f39d04176caae4336554"} -->
