### PR TITLE
LPD-101550 Preserve SVG sprite and accessibility attributes

### DIFF
--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/model/listener/test/FragmentEntryLinkModelListenerTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/model/listener/test/FragmentEntryLinkModelListenerTest.java
@@ -112,6 +112,7 @@ public class FragmentEntryLinkModelListenerTest {
 		_testAddFragmentEntryLinkEscapeTextField();
 		_testAddFragmentEntryLinkPreservesInlineSVGInLinkField();
 		_testAddFragmentEntryLinkPreservesSpriteReferenceInLinkField();
+		_testAddFragmentEntryLinkPreservesSVGAccessibilityAttributes();
 		_testAddFragmentEntryLinkSanitizesLinkFieldScriptContent();
 		_testAddFragmentEntryLinkSanitizesScriptInInlineSVGLinkField();
 		_testAddFragmentEntryLinkWithEmbeddedPortlet();
@@ -273,15 +274,16 @@ public class FragmentEntryLinkModelListenerTest {
 		String xlinkHrefURL =
 			"/o/classic-theme/images/clay/icons.svg#social-linkedin";
 
-		String editableFieldValue = StringBundler.concat(
-			"<svg viewBox=\"0 0 512 512\"><use href=\"", hrefURL,
-			"\"></use><use xlink:href=\"", xlinkHrefURL,
-			"\"></use></svg> Read More");
-
 		FragmentEntryLink fragmentEntryLink = _addFragmentEntryLink(
 			_fragmentCollectionContributorRegistry.getFragmentEntry(
 				"BASIC_COMPONENT-button"),
-			_createEditableValues("link", editableFieldValue), _serviceContext);
+			_createEditableValues(
+				"link",
+				StringBundler.concat(
+					"<svg viewBox=\"0 0 512 512\"><use href=\"", hrefURL,
+					"\"></use><use xlink:href=\"", xlinkHrefURL,
+					"\"></use></svg> Read More")),
+			_serviceContext);
 
 		String editableValues = fragmentEntryLink.getEditableValues();
 
@@ -289,6 +291,28 @@ public class FragmentEntryLinkModelListenerTest {
 		Assert.assertTrue(
 			editableValues, editableValues.contains(xlinkHrefURL));
 		Assert.assertTrue(editableValues, editableValues.contains("Read More"));
+	}
+
+	private void _testAddFragmentEntryLinkPreservesSVGAccessibilityAttributes()
+		throws Exception {
+
+		FragmentEntryLink fragmentEntryLink = _addFragmentEntryLink(
+			_fragmentCollectionContributorRegistry.getFragmentEntry(
+				"BASIC_COMPONENT-button"),
+			_createEditableValues(
+				"link",
+				StringBundler.concat(
+					"<svg aria-hidden=\"true\" focusable=\"false\" ",
+					"role=\"presentation\" viewBox=\"0 0 24 24\">",
+					"<path d=\"M12 2L2 7l10 5 10-5-10-5z\"></path></svg>")),
+			_serviceContext);
+
+		String editableValues = fragmentEntryLink.getEditableValues();
+
+		Assert.assertTrue(
+			editableValues, editableValues.contains("aria-hidden"));
+		Assert.assertTrue(editableValues, editableValues.contains("focusable"));
+		Assert.assertTrue(editableValues, editableValues.contains("role="));
 	}
 
 	private void _testAddFragmentEntryLinkSanitizesLinkFieldScriptContent()

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/model/listener/test/FragmentEntryLinkModelListenerTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/model/listener/test/FragmentEntryLinkModelListenerTest.java
@@ -34,6 +34,7 @@ import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionRequest;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionResponse;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -107,6 +108,7 @@ public class FragmentEntryLinkModelListenerTest {
 	}
 
 	@Test
+	@TestInfo({"LPD-97145", "LPD-101550"})
 	public void testAddFragmentEntryLink() throws Exception {
 		_testAddFragmentEntryLinkDoesNotEscapeLinkFieldHTMLContent();
 		_testAddFragmentEntryLinkEscapeTextField();
@@ -123,6 +125,7 @@ public class FragmentEntryLinkModelListenerTest {
 	}
 
 	@Test
+	@TestInfo("LPD-97145")
 	public void testUpdateFragmentEntryLink() throws Exception {
 		_testUpdateFragmentEntryLinkEscapeTextField();
 		_testUpdateFragmentEntryLinkWithHTMLField();

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/model/listener/test/FragmentEntryLinkModelListenerTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/model/listener/test/FragmentEntryLinkModelListenerTest.java
@@ -111,6 +111,7 @@ public class FragmentEntryLinkModelListenerTest {
 		_testAddFragmentEntryLinkDoesNotEscapeLinkFieldHTMLContent();
 		_testAddFragmentEntryLinkEscapeTextField();
 		_testAddFragmentEntryLinkPreservesInlineSVGInLinkField();
+		_testAddFragmentEntryLinkPreservesSpriteReferenceInLinkField();
 		_testAddFragmentEntryLinkSanitizesLinkFieldScriptContent();
 		_testAddFragmentEntryLinkSanitizesScriptInInlineSVGLinkField();
 		_testAddFragmentEntryLinkWithEmbeddedPortlet();
@@ -265,6 +266,31 @@ public class FragmentEntryLinkModelListenerTest {
 		Assert.assertTrue(editableValues, editableValues.contains("Read More"));
 	}
 
+	private void _testAddFragmentEntryLinkPreservesSpriteReferenceInLinkField()
+		throws Exception {
+
+		String hrefURL = "/o/classic-theme/images/clay/icons.svg#home";
+		String xlinkHrefURL =
+			"/o/classic-theme/images/clay/icons.svg#social-linkedin";
+
+		String editableFieldValue = StringBundler.concat(
+			"<svg viewBox=\"0 0 512 512\"><use href=\"", hrefURL,
+			"\"></use><use xlink:href=\"", xlinkHrefURL,
+			"\"></use></svg> Read More");
+
+		FragmentEntryLink fragmentEntryLink = _addFragmentEntryLink(
+			_fragmentCollectionContributorRegistry.getFragmentEntry(
+				"BASIC_COMPONENT-button"),
+			_createEditableValues("link", editableFieldValue), _serviceContext);
+
+		String editableValues = fragmentEntryLink.getEditableValues();
+
+		Assert.assertTrue(editableValues, editableValues.contains(hrefURL));
+		Assert.assertTrue(
+			editableValues, editableValues.contains(xlinkHrefURL));
+		Assert.assertTrue(editableValues, editableValues.contains("Read More"));
+	}
+
 	private void _testAddFragmentEntryLinkSanitizesLinkFieldScriptContent()
 		throws Exception {
 
@@ -290,13 +316,15 @@ public class FragmentEntryLinkModelListenerTest {
 	private void _testAddFragmentEntryLinkSanitizesScriptInInlineSVGLinkField()
 		throws Exception {
 
-		String expectedURL = "https://example.com/sprite#x";
+		String crossOriginURL = "https://example.com/sprite.svg#x";
+		String protocolRelativeURL = "//example.com/sprite.svg#x";
 
 		String editableFieldValue = StringBundler.concat(
 			"<svg onload=\"alert('xss');\" viewBox=\"0 0 24 24\">",
 			"<script>alert('xss');</script>",
 			"<foreignObject><script>alert('xss');</script></foreignObject>",
-			"<use href=\"", expectedURL, "\"></use>",
+			"<use href=\"", crossOriginURL, "\"></use><use xlink:href=\"",
+			protocolRelativeURL, "\"></use>",
 			"<path d=\"M12 2L2 7l10 5 10-5-10-5z\"></path></svg>");
 
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
@@ -312,16 +340,18 @@ public class FragmentEntryLinkModelListenerTest {
 
 			String editableValues = fragmentEntryLink.getEditableValues();
 
+			Assert.assertFalse(
+				editableValues, editableValues.contains("<script"));
 			Assert.assertTrue(editableValues, editableValues.contains("<svg"));
 			Assert.assertTrue(editableValues, editableValues.contains("<path"));
 			Assert.assertFalse(
 				editableValues, editableValues.contains("alert"));
 			Assert.assertFalse(
-				editableValues, editableValues.contains(expectedURL));
-			Assert.assertFalse(
 				editableValues, editableValues.contains("onload"));
 			Assert.assertFalse(
-				editableValues, editableValues.contains("<script"));
+				editableValues, editableValues.contains(crossOriginURL));
+			Assert.assertFalse(
+				editableValues, editableValues.contains(protocolRelativeURL));
 		}
 	}
 

--- a/modules/apps/portal-security/portal-security-antisamy/build.gradle
+++ b/modules/apps/portal-security/portal-security-antisamy/build.gradle
@@ -1056,6 +1056,24 @@ private String _filterFragmentSanitizer(String line) {
 			|					<literal value="http://www.w3.org/1999/xlink"/>
 			|				</literal-list>
 			|			</attribute>
+			|			<attribute name="aria-hidden" onInvalid="removeAttribute">
+			|				<literal-list>
+			|					<literal value="false"/>
+			|					<literal value="true"/>
+			|				</literal-list>
+			|			</attribute>
+			|			<attribute name="focusable" onInvalid="removeAttribute">
+			|				<literal-list>
+			|					<literal value="auto"/>
+			|					<literal value="false"/>
+			|					<literal value="true"/>
+			|				</literal-list>
+			|			</attribute>
+			|			<attribute name="role" onInvalid="removeAttribute">
+			|				<regexp-list>
+			|					<regexp name="svgKeyword"/>
+			|				</regexp-list>
+			|			</attribute>
 			|			<attribute name="fill"/>
 			|			<attribute name="fill-opacity"/>
 			|			<attribute name="fill-rule"/>

--- a/modules/apps/portal-security/portal-security-antisamy/build.gradle
+++ b/modules/apps/portal-security/portal-security-antisamy/build.gradle
@@ -474,6 +474,7 @@ private String _filterFragmentSanitizer(String line) {
 			|		<regexp name="svgPaint" value="(none|currentColor|transparent|inherit|context-fill|context-stroke|#[0-9a-fA-F]{3,8}|rgba?\\([0-9,.\\s%]*\\)|hsla?\\([0-9,.\\s%]*\\)|url\\(\\s*#[a-zA-Z0-9\\-_:.]+\\s*\\)(\\s+(none|currentColor|#[0-9a-fA-F]{3,8}))?|[a-zA-Z]+)"/>
 			|		<regexp name="svgLocalRef" value="(none|url\\(\\s*#[a-zA-Z0-9\\-_:.]+\\s*\\))"/>
 			|		<regexp name="svgHrefLocal" value="#[a-zA-Z0-9\\-_:.]+"/>
+			|		<regexp name="svgHrefSameOrigin" value="(#[a-zA-Z0-9\\-_:.]+|/?[a-zA-Z0-9\\-_.][a-zA-Z0-9\\-_./]*\\.svg#[a-zA-Z0-9\\-_:.]+)"/>
 			|		<regexp name="svgKeyword" value="[a-zA-Z][a-zA-Z\\-]*"/>
 			|		<regexp name="svgPreserveAspectRatio" value="(none|x(Min|Mid|Max)Y(Min|Mid|Max))(\\s+(meet|slice))?"/>
 			|${line}""".stripMargin()
@@ -1321,10 +1322,14 @@ private String _filterFragmentSanitizer(String line) {
 			|			</attribute>
 			|			<attribute name="href" onInvalid="removeAttribute">
 			|				<regexp-list>
-			|					<regexp name="svgHrefLocal"/>
+			|					<regexp name="svgHrefSameOrigin"/>
 			|				</regexp-list>
 			|			</attribute>
-			|			<attribute name="xlink:href"/>
+			|			<attribute name="xlink:href" onInvalid="removeAttribute">
+			|				<regexp-list>
+			|					<regexp name="svgHrefSameOrigin"/>
+			|				</regexp-list>
+			|			</attribute>
 			|			<attribute name="fill"/>
 			|			<attribute name="fill-opacity"/>
 			|			<attribute name="fill-rule"/>

--- a/modules/apps/portal-security/portal-security-antisamy/build.gradle
+++ b/modules/apps/portal-security/portal-security-antisamy/build.gradle
@@ -482,39 +482,91 @@ private String _filterFragmentSanitizer(String line) {
 	else if (line.contains("</common-attributes>")) {
 		line = """\
 			|
-			|		<attribute name="viewBox" onInvalid="removeAttribute">
+			|		<attribute name="alignment-baseline" onInvalid="removeAttribute">
 			|			<regexp-list>
-			|				<regexp name="svgViewBox"/>
+			|				<regexp name="svgKeyword"/>
 			|			</regexp-list>
 			|		</attribute>
 			|
-			|		<attribute name="viewbox" onInvalid="removeAttribute">
+			|		<attribute name="baseline-shift" onInvalid="removeAttribute">
 			|			<regexp-list>
-			|				<regexp name="svgViewBox"/>
+			|				<regexp value="[a-zA-Z0-9%.\\-]+"/>
 			|			</regexp-list>
 			|		</attribute>
 			|
-			|		<attribute name="x" onInvalid="removeAttribute">
+			|		<attribute name="clip-path" onInvalid="removeAttribute">
+			|			<regexp-list>
+			|				<regexp name="svgLocalRef"/>
+			|			</regexp-list>
+			|		</attribute>
+			|
+			|		<attribute name="clip-rule" onInvalid="removeAttribute">
+			|			<literal-list>
+			|				<literal value="nonzero"/>
+			|				<literal value="evenodd"/>
+			|				<literal value="inherit"/>
+			|			</literal-list>
+			|		</attribute>
+			|
+			|		<attribute name="color" onInvalid="removeAttribute">
+			|			<regexp-list>
+			|				<regexp name="svgPaint"/>
+			|			</regexp-list>
+			|		</attribute>
+			|
+			|		<attribute name="color-interpolation" onInvalid="removeAttribute">
+			|			<regexp-list>
+			|				<regexp name="svgKeyword"/>
+			|			</regexp-list>
+			|		</attribute>
+			|
+			|		<attribute name="cursor" onInvalid="removeAttribute">
+			|			<regexp-list>
+			|				<regexp name="svgKeyword"/>
+			|			</regexp-list>
+			|		</attribute>
+			|
+			|		<attribute name="cx" onInvalid="removeAttribute">
 			|			<regexp-list>
 			|				<regexp name="svgLength"/>
 			|			</regexp-list>
 			|		</attribute>
 			|
-			|		<attribute name="y" onInvalid="removeAttribute">
+			|		<attribute name="cy" onInvalid="removeAttribute">
 			|			<regexp-list>
 			|				<regexp name="svgLength"/>
 			|			</regexp-list>
 			|		</attribute>
 			|
-			|		<attribute name="preserveAspectRatio" onInvalid="removeAttribute">
+			|		<attribute name="direction" onInvalid="removeAttribute">
+			|			<literal-list>
+			|				<literal value="ltr"/>
+			|				<literal value="rtl"/>
+			|				<literal value="inherit"/>
+			|			</literal-list>
+			|		</attribute>
+			|
+			|		<attribute name="display" onInvalid="removeAttribute">
 			|			<regexp-list>
-			|				<regexp name="svgPreserveAspectRatio"/>
+			|				<regexp name="svgKeyword"/>
 			|			</regexp-list>
 			|		</attribute>
 			|
-			|		<attribute name="preserveaspectratio" onInvalid="removeAttribute">
+			|		<attribute name="dominant-baseline" onInvalid="removeAttribute">
 			|			<regexp-list>
-			|				<regexp name="svgPreserveAspectRatio"/>
+			|				<regexp name="svgKeyword"/>
+			|			</regexp-list>
+			|		</attribute>
+			|
+			|		<attribute name="dx" onInvalid="removeAttribute">
+			|			<regexp-list>
+			|				<regexp name="svgNumberList"/>
+			|			</regexp-list>
+			|		</attribute>
+			|
+			|		<attribute name="dy" onInvalid="removeAttribute">
+			|			<regexp-list>
+			|				<regexp name="svgNumberList"/>
 			|			</regexp-list>
 			|		</attribute>
 			|
@@ -538,21 +590,247 @@ private String _filterFragmentSanitizer(String line) {
 			|			</literal-list>
 			|		</attribute>
 			|
+			|		<attribute name="font-family" onInvalid="removeAttribute">
+			|			<regexp-list>
+			|				<regexp value="[a-zA-Z0-9\\s,._\\-]+"/>
+			|			</regexp-list>
+			|		</attribute>
+			|
+			|		<attribute name="font-size" onInvalid="removeAttribute">
+			|			<regexp-list>
+			|				<regexp name="svgLength"/>
+			|			</regexp-list>
+			|		</attribute>
+			|
+			|		<attribute name="font-stretch" onInvalid="removeAttribute">
+			|			<regexp-list>
+			|				<regexp name="svgKeyword"/>
+			|			</regexp-list>
+			|		</attribute>
+			|
+			|		<attribute name="font-style" onInvalid="removeAttribute">
+			|			<regexp-list>
+			|				<regexp name="svgKeyword"/>
+			|			</regexp-list>
+			|		</attribute>
+			|
+			|		<attribute name="font-variant" onInvalid="removeAttribute">
+			|			<regexp-list>
+			|				<regexp name="svgKeyword"/>
+			|			</regexp-list>
+			|		</attribute>
+			|
+			|		<attribute name="font-weight" onInvalid="removeAttribute">
+			|			<regexp-list>
+			|				<regexp value="[a-zA-Z0-9]+"/>
+			|			</regexp-list>
+			|		</attribute>
+			|
+			|		<attribute name="glyph-orientation-horizontal" onInvalid="removeAttribute">
+			|			<regexp-list>
+			|				<regexp name="svgKeyword"/>
+			|			</regexp-list>
+			|		</attribute>
+			|
+			|		<attribute name="glyph-orientation-vertical" onInvalid="removeAttribute">
+			|			<regexp-list>
+			|				<regexp name="svgKeyword"/>
+			|			</regexp-list>
+			|		</attribute>
+			|
+			|		<attribute name="gradientTransform" onInvalid="removeAttribute">
+			|			<regexp-list>
+			|				<regexp name="svgTransformList"/>
+			|			</regexp-list>
+			|		</attribute>
+			|
+			|		<attribute name="gradienttransform" onInvalid="removeAttribute">
+			|			<regexp-list>
+			|				<regexp name="svgTransformList"/>
+			|			</regexp-list>
+			|		</attribute>
+			|
+			|		<attribute name="gradientUnits" onInvalid="removeAttribute">
+			|			<literal-list>
+			|				<literal value="userSpaceOnUse"/>
+			|				<literal value="objectBoundingBox"/>
+			|			</literal-list>
+			|		</attribute>
+			|
+			|		<attribute name="gradientunits" onInvalid="removeAttribute">
+			|			<literal-list>
+			|				<literal value="userSpaceOnUse"/>
+			|				<literal value="objectBoundingBox"/>
+			|			</literal-list>
+			|		</attribute>
+			|
+			|		<attribute name="image-rendering" onInvalid="removeAttribute">
+			|			<regexp-list>
+			|				<regexp name="svgKeyword"/>
+			|			</regexp-list>
+			|		</attribute>
+			|
+			|		<attribute name="lengthAdjust" onInvalid="removeAttribute">
+			|			<literal-list>
+			|				<literal value="spacing"/>
+			|				<literal value="spacingAndGlyphs"/>
+			|			</literal-list>
+			|		</attribute>
+			|
+			|		<attribute name="lengthadjust" onInvalid="removeAttribute">
+			|			<literal-list>
+			|				<literal value="spacing"/>
+			|				<literal value="spacingAndGlyphs"/>
+			|			</literal-list>
+			|		</attribute>
+			|
+			|		<attribute name="letter-spacing" onInvalid="removeAttribute">
+			|			<regexp-list>
+			|				<regexp name="svgLength"/>
+			|			</regexp-list>
+			|		</attribute>
+			|
+			|		<attribute name="marker-end" onInvalid="removeAttribute">
+			|			<regexp-list>
+			|				<regexp name="svgLocalRef"/>
+			|			</regexp-list>
+			|		</attribute>
+			|
+			|		<attribute name="marker-mid" onInvalid="removeAttribute">
+			|			<regexp-list>
+			|				<regexp name="svgLocalRef"/>
+			|			</regexp-list>
+			|		</attribute>
+			|
+			|		<attribute name="marker-start" onInvalid="removeAttribute">
+			|			<regexp-list>
+			|				<regexp name="svgLocalRef"/>
+			|			</regexp-list>
+			|		</attribute>
+			|
+			|		<attribute name="mask" onInvalid="removeAttribute">
+			|			<regexp-list>
+			|				<regexp name="svgLocalRef"/>
+			|			</regexp-list>
+			|		</attribute>
+			|
+			|		<attribute name="mask-type" onInvalid="removeAttribute">
+			|			<regexp-list>
+			|				<regexp name="svgKeyword"/>
+			|			</regexp-list>
+			|		</attribute>
+			|
+			|		<attribute name="opacity" onInvalid="removeAttribute">
+			|			<regexp-list>
+			|				<regexp name="number"/>
+			|			</regexp-list>
+			|		</attribute>
+			|
+			|		<attribute name="overflow" onInvalid="removeAttribute">
+			|			<literal-list>
+			|				<literal value="visible"/>
+			|				<literal value="hidden"/>
+			|				<literal value="scroll"/>
+			|				<literal value="auto"/>
+			|				<literal value="inherit"/>
+			|			</literal-list>
+			|		</attribute>
+			|
+			|		<attribute name="paint-order" onInvalid="removeAttribute">
+			|			<regexp-list>
+			|				<regexp value="[a-zA-Z\\s]+"/>
+			|			</regexp-list>
+			|		</attribute>
+			|
+			|		<attribute name="pointer-events" onInvalid="removeAttribute">
+			|			<regexp-list>
+			|				<regexp name="svgKeyword"/>
+			|			</regexp-list>
+			|		</attribute>
+			|
+			|		<attribute name="points" onInvalid="removeAttribute">
+			|			<regexp-list>
+			|				<regexp name="svgNumberList"/>
+			|			</regexp-list>
+			|		</attribute>
+			|
+			|		<attribute name="preserveAspectRatio" onInvalid="removeAttribute">
+			|			<regexp-list>
+			|				<regexp name="svgPreserveAspectRatio"/>
+			|			</regexp-list>
+			|		</attribute>
+			|
+			|		<attribute name="preserveaspectratio" onInvalid="removeAttribute">
+			|			<regexp-list>
+			|				<regexp name="svgPreserveAspectRatio"/>
+			|			</regexp-list>
+			|		</attribute>
+			|
+			|		<attribute name="r" onInvalid="removeAttribute">
+			|			<regexp-list>
+			|				<regexp name="svgLength"/>
+			|			</regexp-list>
+			|		</attribute>
+			|
+			|		<attribute name="rotate" onInvalid="removeAttribute">
+			|			<regexp-list>
+			|				<regexp name="svgNumberList"/>
+			|			</regexp-list>
+			|		</attribute>
+			|
+			|		<attribute name="rx" onInvalid="removeAttribute">
+			|			<regexp-list>
+			|				<regexp name="svgLength"/>
+			|			</regexp-list>
+			|		</attribute>
+			|
+			|		<attribute name="ry" onInvalid="removeAttribute">
+			|			<regexp-list>
+			|				<regexp name="svgLength"/>
+			|			</regexp-list>
+			|		</attribute>
+			|
+			|		<attribute name="shape-rendering" onInvalid="removeAttribute">
+			|			<regexp-list>
+			|				<regexp name="svgKeyword"/>
+			|			</regexp-list>
+			|		</attribute>
+			|
+			|		<attribute name="spreadMethod" onInvalid="removeAttribute">
+			|			<literal-list>
+			|				<literal value="pad"/>
+			|				<literal value="reflect"/>
+			|				<literal value="repeat"/>
+			|			</literal-list>
+			|		</attribute>
+			|
+			|		<attribute name="spreadmethod" onInvalid="removeAttribute">
+			|			<literal-list>
+			|				<literal value="pad"/>
+			|				<literal value="reflect"/>
+			|				<literal value="repeat"/>
+			|			</literal-list>
+			|		</attribute>
+			|
 			|		<attribute name="stroke" onInvalid="removeAttribute">
 			|			<regexp-list>
 			|				<regexp name="svgPaint"/>
 			|			</regexp-list>
 			|		</attribute>
 			|
-			|		<attribute name="stroke-width" onInvalid="removeAttribute">
+			|		<attribute name="stroke-dasharray" onInvalid="removeAttribute">
 			|			<regexp-list>
-			|				<regexp name="svgLength"/>
+			|				<regexp name="svgNumberList"/>
 			|			</regexp-list>
+			|			<literal-list>
+			|				<literal value="none"/>
+			|				<literal value="inherit"/>
+			|			</literal-list>
 			|		</attribute>
 			|
-			|		<attribute name="stroke-opacity" onInvalid="removeAttribute">
+			|		<attribute name="stroke-dashoffset" onInvalid="removeAttribute">
 			|			<regexp-list>
-			|				<regexp name="number"/>
+			|				<regexp name="svgLength"/>
 			|			</regexp-list>
 			|		</attribute>
 			|
@@ -576,280 +854,48 @@ private String _filterFragmentSanitizer(String line) {
 			|			</literal-list>
 			|		</attribute>
 			|
-			|		<attribute name="stroke-dasharray" onInvalid="removeAttribute">
-			|			<regexp-list>
-			|				<regexp name="svgNumberList"/>
-			|			</regexp-list>
-			|			<literal-list>
-			|				<literal value="none"/>
-			|				<literal value="inherit"/>
-			|			</literal-list>
-			|		</attribute>
-			|
-			|		<attribute name="stroke-dashoffset" onInvalid="removeAttribute">
-			|			<regexp-list>
-			|				<regexp name="svgLength"/>
-			|			</regexp-list>
-			|		</attribute>
-			|
 			|		<attribute name="stroke-miterlimit" onInvalid="removeAttribute">
 			|			<regexp-list>
 			|				<regexp name="number"/>
 			|			</regexp-list>
 			|		</attribute>
 			|
-			|		<attribute name="opacity" onInvalid="removeAttribute">
+			|		<attribute name="stroke-opacity" onInvalid="removeAttribute">
 			|			<regexp-list>
 			|				<regexp name="number"/>
 			|			</regexp-list>
 			|		</attribute>
 			|
-			|		<attribute name="color" onInvalid="removeAttribute">
+			|		<attribute name="stroke-width" onInvalid="removeAttribute">
 			|			<regexp-list>
-			|				<regexp name="svgPaint"/>
+			|				<regexp name="svgLength"/>
 			|			</regexp-list>
 			|		</attribute>
 			|
-			|		<attribute name="display" onInvalid="removeAttribute">
-			|			<regexp-list>
-			|				<regexp name="svgKeyword"/>
-			|			</regexp-list>
-			|		</attribute>
-			|
-			|		<attribute name="visibility" onInvalid="removeAttribute">
+			|		<attribute name="text-anchor" onInvalid="removeAttribute">
 			|			<literal-list>
-			|				<literal value="visible"/>
-			|				<literal value="hidden"/>
-			|				<literal value="collapse"/>
+			|				<literal value="start"/>
+			|				<literal value="middle"/>
+			|				<literal value="end"/>
 			|				<literal value="inherit"/>
 			|			</literal-list>
 			|		</attribute>
 			|
-			|		<attribute name="overflow" onInvalid="removeAttribute">
-			|			<literal-list>
-			|				<literal value="visible"/>
-			|				<literal value="hidden"/>
-			|				<literal value="scroll"/>
-			|				<literal value="auto"/>
-			|				<literal value="inherit"/>
-			|			</literal-list>
-			|		</attribute>
-			|
-			|		<attribute name="transform" onInvalid="removeAttribute">
+			|		<attribute name="text-decoration" onInvalid="removeAttribute">
 			|			<regexp-list>
-			|				<regexp name="svgTransformList"/>
+			|				<regexp value="[a-zA-Z\\s\\-]+"/>
 			|			</regexp-list>
 			|		</attribute>
 			|
-			|		<attribute name="clip-path" onInvalid="removeAttribute">
-			|			<regexp-list>
-			|				<regexp name="svgLocalRef"/>
-			|			</regexp-list>
-			|		</attribute>
-			|
-			|		<attribute name="clip-rule" onInvalid="removeAttribute">
-			|			<literal-list>
-			|				<literal value="nonzero"/>
-			|				<literal value="evenodd"/>
-			|				<literal value="inherit"/>
-			|			</literal-list>
-			|		</attribute>
-			|
-			|		<attribute name="mask" onInvalid="removeAttribute">
-			|			<regexp-list>
-			|				<regexp name="svgLocalRef"/>
-			|			</regexp-list>
-			|		</attribute>
-			|
-			|		<attribute name="marker-start" onInvalid="removeAttribute">
-			|			<regexp-list>
-			|				<regexp name="svgLocalRef"/>
-			|			</regexp-list>
-			|		</attribute>
-			|
-			|		<attribute name="marker-mid" onInvalid="removeAttribute">
-			|			<regexp-list>
-			|				<regexp name="svgLocalRef"/>
-			|			</regexp-list>
-			|		</attribute>
-			|
-			|		<attribute name="marker-end" onInvalid="removeAttribute">
-			|			<regexp-list>
-			|				<regexp name="svgLocalRef"/>
-			|			</regexp-list>
-			|		</attribute>
-			|
-			|		<attribute name="vector-effect" onInvalid="removeAttribute">
+			|		<attribute name="text-overflow" onInvalid="removeAttribute">
 			|			<regexp-list>
 			|				<regexp name="svgKeyword"/>
 			|			</regexp-list>
 			|		</attribute>
 			|
-			|		<attribute name="shape-rendering" onInvalid="removeAttribute">
+			|		<attribute name="text-rendering" onInvalid="removeAttribute">
 			|			<regexp-list>
 			|				<regexp name="svgKeyword"/>
-			|			</regexp-list>
-			|		</attribute>
-			|
-			|		<attribute name="image-rendering" onInvalid="removeAttribute">
-			|			<regexp-list>
-			|				<regexp name="svgKeyword"/>
-			|			</regexp-list>
-			|		</attribute>
-			|
-			|		<attribute name="color-interpolation" onInvalid="removeAttribute">
-			|			<regexp-list>
-			|				<regexp name="svgKeyword"/>
-			|			</regexp-list>
-			|		</attribute>
-			|
-			|		<attribute name="pointer-events" onInvalid="removeAttribute">
-			|			<regexp-list>
-			|				<regexp name="svgKeyword"/>
-			|			</regexp-list>
-			|		</attribute>
-			|
-			|		<attribute name="paint-order" onInvalid="removeAttribute">
-			|			<regexp-list>
-			|				<regexp value="[a-zA-Z\\s]+"/>
-			|			</regexp-list>
-			|		</attribute>
-			|
-			|		<attribute name="cursor" onInvalid="removeAttribute">
-			|			<regexp-list>
-			|				<regexp name="svgKeyword"/>
-			|			</regexp-list>
-			|		</attribute>
-			|
-			|		<attribute name="mask-type" onInvalid="removeAttribute">
-			|			<regexp-list>
-			|				<regexp name="svgKeyword"/>
-			|			</regexp-list>
-			|		</attribute>
-			|
-			|		<attribute name="xlink:href" onInvalid="removeAttribute">
-			|			<regexp-list>
-			|				<regexp name="svgHrefLocal"/>
-			|			</regexp-list>
-			|		</attribute>
-			|
-			|		<attribute name="cx" onInvalid="removeAttribute">
-			|			<regexp-list>
-			|				<regexp name="svgLength"/>
-			|			</regexp-list>
-			|		</attribute>
-			|
-			|		<attribute name="cy" onInvalid="removeAttribute">
-			|			<regexp-list>
-			|				<regexp name="svgLength"/>
-			|			</regexp-list>
-			|		</attribute>
-			|
-			|		<attribute name="r" onInvalid="removeAttribute">
-			|			<regexp-list>
-			|				<regexp name="svgLength"/>
-			|			</regexp-list>
-			|		</attribute>
-			|
-			|		<attribute name="rx" onInvalid="removeAttribute">
-			|			<regexp-list>
-			|				<regexp name="svgLength"/>
-			|			</regexp-list>
-			|		</attribute>
-			|
-			|		<attribute name="ry" onInvalid="removeAttribute">
-			|			<regexp-list>
-			|				<regexp name="svgLength"/>
-			|			</regexp-list>
-			|		</attribute>
-			|
-			|		<attribute name="x1" onInvalid="removeAttribute">
-			|			<regexp-list>
-			|				<regexp name="svgLength"/>
-			|			</regexp-list>
-			|		</attribute>
-			|
-			|		<attribute name="y1" onInvalid="removeAttribute">
-			|			<regexp-list>
-			|				<regexp name="svgLength"/>
-			|			</regexp-list>
-			|		</attribute>
-			|
-			|		<attribute name="x2" onInvalid="removeAttribute">
-			|			<regexp-list>
-			|				<regexp name="svgLength"/>
-			|			</regexp-list>
-			|		</attribute>
-			|
-			|		<attribute name="y2" onInvalid="removeAttribute">
-			|			<regexp-list>
-			|				<regexp name="svgLength"/>
-			|			</regexp-list>
-			|		</attribute>
-			|
-			|		<attribute name="points" onInvalid="removeAttribute">
-			|			<regexp-list>
-			|				<regexp name="svgNumberList"/>
-			|			</regexp-list>
-			|		</attribute>
-			|
-			|		<attribute name="gradientUnits" onInvalid="removeAttribute">
-			|			<literal-list>
-			|				<literal value="userSpaceOnUse"/>
-			|				<literal value="objectBoundingBox"/>
-			|			</literal-list>
-			|		</attribute>
-			|
-			|		<attribute name="gradientunits" onInvalid="removeAttribute">
-			|			<literal-list>
-			|				<literal value="userSpaceOnUse"/>
-			|				<literal value="objectBoundingBox"/>
-			|			</literal-list>
-			|		</attribute>
-			|
-			|		<attribute name="gradientTransform" onInvalid="removeAttribute">
-			|			<regexp-list>
-			|				<regexp name="svgTransformList"/>
-			|			</regexp-list>
-			|		</attribute>
-			|
-			|		<attribute name="gradienttransform" onInvalid="removeAttribute">
-			|			<regexp-list>
-			|				<regexp name="svgTransformList"/>
-			|			</regexp-list>
-			|		</attribute>
-			|
-			|		<attribute name="spreadMethod" onInvalid="removeAttribute">
-			|			<literal-list>
-			|				<literal value="pad"/>
-			|				<literal value="reflect"/>
-			|				<literal value="repeat"/>
-			|			</literal-list>
-			|		</attribute>
-			|
-			|		<attribute name="spreadmethod" onInvalid="removeAttribute">
-			|			<literal-list>
-			|				<literal value="pad"/>
-			|				<literal value="reflect"/>
-			|				<literal value="repeat"/>
-			|			</literal-list>
-			|		</attribute>
-			|
-			|		<attribute name="dx" onInvalid="removeAttribute">
-			|			<regexp-list>
-			|				<regexp name="svgNumberList"/>
-			|			</regexp-list>
-			|		</attribute>
-			|
-			|		<attribute name="dy" onInvalid="removeAttribute">
-			|			<regexp-list>
-			|				<regexp name="svgNumberList"/>
-			|			</regexp-list>
-			|		</attribute>
-			|
-			|		<attribute name="rotate" onInvalid="removeAttribute">
-			|			<regexp-list>
-			|				<regexp name="svgNumberList"/>
 			|			</regexp-list>
 			|		</attribute>
 			|
@@ -865,118 +911,9 @@ private String _filterFragmentSanitizer(String line) {
 			|			</regexp-list>
 			|		</attribute>
 			|
-			|		<attribute name="lengthAdjust" onInvalid="removeAttribute">
-			|			<literal-list>
-			|				<literal value="spacing"/>
-			|				<literal value="spacingAndGlyphs"/>
-			|			</literal-list>
-			|		</attribute>
-			|
-			|		<attribute name="lengthadjust" onInvalid="removeAttribute">
-			|			<literal-list>
-			|				<literal value="spacing"/>
-			|				<literal value="spacingAndGlyphs"/>
-			|			</literal-list>
-			|		</attribute>
-			|
-			|		<attribute name="font-family" onInvalid="removeAttribute">
+			|		<attribute name="transform" onInvalid="removeAttribute">
 			|			<regexp-list>
-			|				<regexp value="[a-zA-Z0-9\\s,._\\-]+"/>
-			|			</regexp-list>
-			|		</attribute>
-			|
-			|		<attribute name="font-size" onInvalid="removeAttribute">
-			|			<regexp-list>
-			|				<regexp name="svgLength"/>
-			|			</regexp-list>
-			|		</attribute>
-			|
-			|		<attribute name="font-weight" onInvalid="removeAttribute">
-			|			<regexp-list>
-			|				<regexp value="[a-zA-Z0-9]+"/>
-			|			</regexp-list>
-			|		</attribute>
-			|
-			|		<attribute name="font-style" onInvalid="removeAttribute">
-			|			<regexp-list>
-			|				<regexp name="svgKeyword"/>
-			|			</regexp-list>
-			|		</attribute>
-			|
-			|		<attribute name="font-variant" onInvalid="removeAttribute">
-			|			<regexp-list>
-			|				<regexp name="svgKeyword"/>
-			|			</regexp-list>
-			|		</attribute>
-			|
-			|		<attribute name="font-stretch" onInvalid="removeAttribute">
-			|			<regexp-list>
-			|				<regexp name="svgKeyword"/>
-			|			</regexp-list>
-			|		</attribute>
-			|
-			|		<attribute name="text-anchor" onInvalid="removeAttribute">
-			|			<literal-list>
-			|				<literal value="start"/>
-			|				<literal value="middle"/>
-			|				<literal value="end"/>
-			|				<literal value="inherit"/>
-			|			</literal-list>
-			|		</attribute>
-			|
-			|		<attribute name="dominant-baseline" onInvalid="removeAttribute">
-			|			<regexp-list>
-			|				<regexp name="svgKeyword"/>
-			|			</regexp-list>
-			|		</attribute>
-			|
-			|		<attribute name="alignment-baseline" onInvalid="removeAttribute">
-			|			<regexp-list>
-			|				<regexp name="svgKeyword"/>
-			|			</regexp-list>
-			|		</attribute>
-			|
-			|		<attribute name="baseline-shift" onInvalid="removeAttribute">
-			|			<regexp-list>
-			|				<regexp value="[a-zA-Z0-9%.\\-]+"/>
-			|			</regexp-list>
-			|		</attribute>
-			|
-			|		<attribute name="direction" onInvalid="removeAttribute">
-			|			<literal-list>
-			|				<literal value="ltr"/>
-			|				<literal value="rtl"/>
-			|				<literal value="inherit"/>
-			|			</literal-list>
-			|		</attribute>
-			|
-			|		<attribute name="letter-spacing" onInvalid="removeAttribute">
-			|			<regexp-list>
-			|				<regexp name="svgLength"/>
-			|			</regexp-list>
-			|		</attribute>
-			|
-			|		<attribute name="word-spacing" onInvalid="removeAttribute">
-			|			<regexp-list>
-			|				<regexp name="svgLength"/>
-			|			</regexp-list>
-			|		</attribute>
-			|
-			|		<attribute name="text-decoration" onInvalid="removeAttribute">
-			|			<regexp-list>
-			|				<regexp value="[a-zA-Z\\s\\-]+"/>
-			|			</regexp-list>
-			|		</attribute>
-			|
-			|		<attribute name="text-rendering" onInvalid="removeAttribute">
-			|			<regexp-list>
-			|				<regexp name="svgKeyword"/>
-			|			</regexp-list>
-			|		</attribute>
-			|
-			|		<attribute name="writing-mode" onInvalid="removeAttribute">
-			|			<regexp-list>
-			|				<regexp name="svgKeyword"/>
+			|				<regexp name="svgTransformList"/>
 			|			</regexp-list>
 			|		</attribute>
 			|
@@ -986,27 +923,90 @@ private String _filterFragmentSanitizer(String line) {
 			|			</regexp-list>
 			|		</attribute>
 			|
+			|		<attribute name="vector-effect" onInvalid="removeAttribute">
+			|			<regexp-list>
+			|				<regexp name="svgKeyword"/>
+			|			</regexp-list>
+			|		</attribute>
+			|
+			|		<attribute name="viewBox" onInvalid="removeAttribute">
+			|			<regexp-list>
+			|				<regexp name="svgViewBox"/>
+			|			</regexp-list>
+			|		</attribute>
+			|
+			|		<attribute name="viewbox" onInvalid="removeAttribute">
+			|			<regexp-list>
+			|				<regexp name="svgViewBox"/>
+			|			</regexp-list>
+			|		</attribute>
+			|
+			|		<attribute name="visibility" onInvalid="removeAttribute">
+			|			<literal-list>
+			|				<literal value="visible"/>
+			|				<literal value="hidden"/>
+			|				<literal value="collapse"/>
+			|				<literal value="inherit"/>
+			|			</literal-list>
+			|		</attribute>
+			|
 			|		<attribute name="white-space" onInvalid="removeAttribute">
 			|			<regexp-list>
 			|				<regexp name="svgKeyword"/>
 			|			</regexp-list>
 			|		</attribute>
 			|
-			|		<attribute name="text-overflow" onInvalid="removeAttribute">
+			|		<attribute name="word-spacing" onInvalid="removeAttribute">
+			|			<regexp-list>
+			|				<regexp name="svgLength"/>
+			|			</regexp-list>
+			|		</attribute>
+			|
+			|		<attribute name="writing-mode" onInvalid="removeAttribute">
 			|			<regexp-list>
 			|				<regexp name="svgKeyword"/>
 			|			</regexp-list>
 			|		</attribute>
 			|
-			|		<attribute name="glyph-orientation-horizontal" onInvalid="removeAttribute">
+			|		<attribute name="x" onInvalid="removeAttribute">
 			|			<regexp-list>
-			|				<regexp name="svgKeyword"/>
+			|				<regexp name="svgLength"/>
 			|			</regexp-list>
 			|		</attribute>
 			|
-			|		<attribute name="glyph-orientation-vertical" onInvalid="removeAttribute">
+			|		<attribute name="x1" onInvalid="removeAttribute">
 			|			<regexp-list>
-			|				<regexp name="svgKeyword"/>
+			|				<regexp name="svgLength"/>
+			|			</regexp-list>
+			|		</attribute>
+			|
+			|		<attribute name="x2" onInvalid="removeAttribute">
+			|			<regexp-list>
+			|				<regexp name="svgLength"/>
+			|			</regexp-list>
+			|		</attribute>
+			|
+			|		<attribute name="xlink:href" onInvalid="removeAttribute">
+			|			<regexp-list>
+			|				<regexp name="svgHrefLocal"/>
+			|			</regexp-list>
+			|		</attribute>
+			|
+			|		<attribute name="y" onInvalid="removeAttribute">
+			|			<regexp-list>
+			|				<regexp name="svgLength"/>
+			|			</regexp-list>
+			|		</attribute>
+			|
+			|		<attribute name="y1" onInvalid="removeAttribute">
+			|			<regexp-list>
+			|				<regexp name="svgLength"/>
+			|			</regexp-list>
+			|		</attribute>
+			|
+			|		<attribute name="y2" onInvalid="removeAttribute">
+			|			<regexp-list>
+			|				<regexp name="svgLength"/>
 			|			</regexp-list>
 			|		</attribute>
 			|
@@ -1015,26 +1015,11 @@ private String _filterFragmentSanitizer(String line) {
 	else if (line.contains("</tag-rules>")) {
 		line = """\
 			|		<tag name="svg" action="validate">
-			|			<attribute name="viewBox"/>
-			|			<attribute name="viewbox"/>
-			|			<attribute name="width" onInvalid="removeAttribute">
-			|				<regexp-list>
-			|					<regexp name="svgLength"/>
-			|				</regexp-list>
-			|			</attribute>
-			|			<attribute name="height" onInvalid="removeAttribute">
-			|				<regexp-list>
-			|					<regexp name="svgLength"/>
-			|				</regexp-list>
-			|			</attribute>
-			|			<attribute name="x"/>
-			|			<attribute name="y"/>
-			|			<attribute name="preserveAspectRatio"/>
-			|			<attribute name="preserveaspectratio"/>
-			|			<attribute name="version" onInvalid="removeAttribute">
-			|				<regexp-list>
-			|					<regexp value="[0-9.]+"/>
-			|				</regexp-list>
+			|			<attribute name="aria-hidden" onInvalid="removeAttribute">
+			|				<literal-list>
+			|					<literal value="false"/>
+			|					<literal value="true"/>
+			|				</literal-list>
 			|			</attribute>
 			|			<attribute name="baseProfile" onInvalid="removeAttribute">
 			|				<regexp-list>
@@ -1046,6 +1031,69 @@ private String _filterFragmentSanitizer(String line) {
 			|					<regexp name="svgKeyword"/>
 			|				</regexp-list>
 			|			</attribute>
+			|			<attribute name="clip-path"/>
+			|			<attribute name="clip-rule"/>
+			|			<attribute name="color"/>
+			|			<attribute name="color-interpolation"/>
+			|			<attribute name="cursor"/>
+			|			<attribute name="display"/>
+			|			<attribute name="fill"/>
+			|			<attribute name="fill-opacity"/>
+			|			<attribute name="fill-rule"/>
+			|			<attribute name="focusable" onInvalid="removeAttribute">
+			|				<literal-list>
+			|					<literal value="auto"/>
+			|					<literal value="false"/>
+			|					<literal value="true"/>
+			|				</literal-list>
+			|			</attribute>
+			|			<attribute name="height" onInvalid="removeAttribute">
+			|				<regexp-list>
+			|					<regexp name="svgLength"/>
+			|				</regexp-list>
+			|			</attribute>
+			|			<attribute name="image-rendering"/>
+			|			<attribute name="marker-end"/>
+			|			<attribute name="marker-mid"/>
+			|			<attribute name="marker-start"/>
+			|			<attribute name="mask"/>
+			|			<attribute name="mask-type"/>
+			|			<attribute name="opacity"/>
+			|			<attribute name="overflow"/>
+			|			<attribute name="paint-order"/>
+			|			<attribute name="pointer-events"/>
+			|			<attribute name="preserveAspectRatio"/>
+			|			<attribute name="preserveaspectratio"/>
+			|			<attribute name="role" onInvalid="removeAttribute">
+			|				<regexp-list>
+			|					<regexp name="svgKeyword"/>
+			|				</regexp-list>
+			|			</attribute>
+			|			<attribute name="shape-rendering"/>
+			|			<attribute name="stroke"/>
+			|			<attribute name="stroke-dasharray"/>
+			|			<attribute name="stroke-dashoffset"/>
+			|			<attribute name="stroke-linecap"/>
+			|			<attribute name="stroke-linejoin"/>
+			|			<attribute name="stroke-miterlimit"/>
+			|			<attribute name="stroke-opacity"/>
+			|			<attribute name="stroke-width"/>
+			|			<attribute name="transform"/>
+			|			<attribute name="vector-effect"/>
+			|			<attribute name="version" onInvalid="removeAttribute">
+			|				<regexp-list>
+			|					<regexp value="[0-9.]+"/>
+			|				</regexp-list>
+			|			</attribute>
+			|			<attribute name="viewBox"/>
+			|			<attribute name="viewbox"/>
+			|			<attribute name="visibility"/>
+			|			<attribute name="width" onInvalid="removeAttribute">
+			|				<regexp-list>
+			|					<regexp name="svgLength"/>
+			|				</regexp-list>
+			|			</attribute>
+			|			<attribute name="x"/>
 			|			<attribute name="xmlns" onInvalid="removeAttribute">
 			|				<literal-list>
 			|					<literal value="http://www.w3.org/2000/svg"/>
@@ -1056,89 +1104,41 @@ private String _filterFragmentSanitizer(String line) {
 			|					<literal value="http://www.w3.org/1999/xlink"/>
 			|				</literal-list>
 			|			</attribute>
-			|			<attribute name="aria-hidden" onInvalid="removeAttribute">
-			|				<literal-list>
-			|					<literal value="false"/>
-			|					<literal value="true"/>
-			|				</literal-list>
-			|			</attribute>
-			|			<attribute name="focusable" onInvalid="removeAttribute">
-			|				<literal-list>
-			|					<literal value="auto"/>
-			|					<literal value="false"/>
-			|					<literal value="true"/>
-			|				</literal-list>
-			|			</attribute>
-			|			<attribute name="role" onInvalid="removeAttribute">
-			|				<regexp-list>
-			|					<regexp name="svgKeyword"/>
-			|				</regexp-list>
-			|			</attribute>
-			|			<attribute name="fill"/>
-			|			<attribute name="fill-opacity"/>
-			|			<attribute name="fill-rule"/>
-			|			<attribute name="stroke"/>
-			|			<attribute name="stroke-width"/>
-			|			<attribute name="stroke-opacity"/>
-			|			<attribute name="stroke-linecap"/>
-			|			<attribute name="stroke-linejoin"/>
-			|			<attribute name="stroke-dasharray"/>
-			|			<attribute name="stroke-dashoffset"/>
-			|			<attribute name="stroke-miterlimit"/>
-			|			<attribute name="opacity"/>
-			|			<attribute name="color"/>
-			|			<attribute name="display"/>
-			|			<attribute name="visibility"/>
-			|			<attribute name="overflow"/>
-			|			<attribute name="transform"/>
-			|			<attribute name="clip-path"/>
-			|			<attribute name="clip-rule"/>
-			|			<attribute name="mask"/>
-			|			<attribute name="marker-start"/>
-			|			<attribute name="marker-mid"/>
-			|			<attribute name="marker-end"/>
-			|			<attribute name="vector-effect"/>
-			|			<attribute name="shape-rendering"/>
-			|			<attribute name="image-rendering"/>
-			|			<attribute name="color-interpolation"/>
-			|			<attribute name="pointer-events"/>
-			|			<attribute name="paint-order"/>
-			|			<attribute name="cursor"/>
-			|			<attribute name="mask-type"/>
+			|			<attribute name="y"/>
 			|		</tag>
 			|
 			|		<tag name="g" action="validate">
+			|			<attribute name="clip-path"/>
+			|			<attribute name="clip-rule"/>
+			|			<attribute name="color"/>
+			|			<attribute name="color-interpolation"/>
+			|			<attribute name="cursor"/>
+			|			<attribute name="display"/>
 			|			<attribute name="fill"/>
 			|			<attribute name="fill-opacity"/>
 			|			<attribute name="fill-rule"/>
+			|			<attribute name="image-rendering"/>
+			|			<attribute name="marker-end"/>
+			|			<attribute name="marker-mid"/>
+			|			<attribute name="marker-start"/>
+			|			<attribute name="mask"/>
+			|			<attribute name="mask-type"/>
+			|			<attribute name="opacity"/>
+			|			<attribute name="overflow"/>
+			|			<attribute name="paint-order"/>
+			|			<attribute name="pointer-events"/>
+			|			<attribute name="shape-rendering"/>
 			|			<attribute name="stroke"/>
-			|			<attribute name="stroke-width"/>
-			|			<attribute name="stroke-opacity"/>
-			|			<attribute name="stroke-linecap"/>
-			|			<attribute name="stroke-linejoin"/>
 			|			<attribute name="stroke-dasharray"/>
 			|			<attribute name="stroke-dashoffset"/>
+			|			<attribute name="stroke-linecap"/>
+			|			<attribute name="stroke-linejoin"/>
 			|			<attribute name="stroke-miterlimit"/>
-			|			<attribute name="opacity"/>
-			|			<attribute name="color"/>
-			|			<attribute name="display"/>
-			|			<attribute name="visibility"/>
-			|			<attribute name="overflow"/>
+			|			<attribute name="stroke-opacity"/>
+			|			<attribute name="stroke-width"/>
 			|			<attribute name="transform"/>
-			|			<attribute name="clip-path"/>
-			|			<attribute name="clip-rule"/>
-			|			<attribute name="mask"/>
-			|			<attribute name="marker-start"/>
-			|			<attribute name="marker-mid"/>
-			|			<attribute name="marker-end"/>
 			|			<attribute name="vector-effect"/>
-			|			<attribute name="shape-rendering"/>
-			|			<attribute name="image-rendering"/>
-			|			<attribute name="color-interpolation"/>
-			|			<attribute name="pointer-events"/>
-			|			<attribute name="paint-order"/>
-			|			<attribute name="cursor"/>
-			|			<attribute name="mask-type"/>
+			|			<attribute name="visibility"/>
 			|		</tag>
 			|
 			|		<tag name="defs" action="validate">
@@ -1160,20 +1160,32 @@ private String _filterFragmentSanitizer(String line) {
 			|		</tag>
 			|
 			|		<tag name="symbol" action="validate">
-			|			<attribute name="viewBox"/>
-			|			<attribute name="viewbox"/>
-			|			<attribute name="preserveAspectRatio"/>
-			|			<attribute name="preserveaspectratio"/>
-			|			<attribute name="width" onInvalid="removeAttribute">
-			|				<regexp-list>
-			|					<regexp name="svgLength"/>
-			|				</regexp-list>
-			|			</attribute>
+			|			<attribute name="clip-path"/>
+			|			<attribute name="clip-rule"/>
+			|			<attribute name="color"/>
+			|			<attribute name="color-interpolation"/>
+			|			<attribute name="cursor"/>
+			|			<attribute name="display"/>
+			|			<attribute name="fill"/>
+			|			<attribute name="fill-opacity"/>
+			|			<attribute name="fill-rule"/>
 			|			<attribute name="height" onInvalid="removeAttribute">
 			|				<regexp-list>
 			|					<regexp name="svgLength"/>
 			|				</regexp-list>
 			|			</attribute>
+			|			<attribute name="image-rendering"/>
+			|			<attribute name="marker-end"/>
+			|			<attribute name="marker-mid"/>
+			|			<attribute name="marker-start"/>
+			|			<attribute name="mask"/>
+			|			<attribute name="mask-type"/>
+			|			<attribute name="opacity"/>
+			|			<attribute name="overflow"/>
+			|			<attribute name="paint-order"/>
+			|			<attribute name="pointer-events"/>
+			|			<attribute name="preserveAspectRatio"/>
+			|			<attribute name="preserveaspectratio"/>
 			|			<attribute name="refX" onInvalid="removeAttribute">
 			|				<regexp-list>
 			|					<regexp name="svgLength"/>
@@ -1194,51 +1206,32 @@ private String _filterFragmentSanitizer(String line) {
 			|					<regexp name="svgLength"/>
 			|				</regexp-list>
 			|			</attribute>
-			|			<attribute name="fill"/>
-			|			<attribute name="fill-opacity"/>
-			|			<attribute name="fill-rule"/>
+			|			<attribute name="shape-rendering"/>
 			|			<attribute name="stroke"/>
-			|			<attribute name="stroke-width"/>
-			|			<attribute name="stroke-opacity"/>
-			|			<attribute name="stroke-linecap"/>
-			|			<attribute name="stroke-linejoin"/>
 			|			<attribute name="stroke-dasharray"/>
 			|			<attribute name="stroke-dashoffset"/>
+			|			<attribute name="stroke-linecap"/>
+			|			<attribute name="stroke-linejoin"/>
 			|			<attribute name="stroke-miterlimit"/>
-			|			<attribute name="opacity"/>
-			|			<attribute name="color"/>
-			|			<attribute name="display"/>
-			|			<attribute name="visibility"/>
-			|			<attribute name="overflow"/>
+			|			<attribute name="stroke-opacity"/>
+			|			<attribute name="stroke-width"/>
 			|			<attribute name="transform"/>
-			|			<attribute name="clip-path"/>
-			|			<attribute name="clip-rule"/>
-			|			<attribute name="mask"/>
-			|			<attribute name="marker-start"/>
-			|			<attribute name="marker-mid"/>
-			|			<attribute name="marker-end"/>
 			|			<attribute name="vector-effect"/>
-			|			<attribute name="shape-rendering"/>
-			|			<attribute name="image-rendering"/>
-			|			<attribute name="color-interpolation"/>
-			|			<attribute name="pointer-events"/>
-			|			<attribute name="paint-order"/>
-			|			<attribute name="cursor"/>
-			|			<attribute name="mask-type"/>
+			|			<attribute name="viewBox"/>
+			|			<attribute name="viewbox"/>
+			|			<attribute name="visibility"/>
+			|			<attribute name="width" onInvalid="removeAttribute">
+			|				<regexp-list>
+			|					<regexp name="svgLength"/>
+			|				</regexp-list>
+			|			</attribute>
 			|		</tag>
 			|
 			|		<tag name="mask" action="validate">
-			|			<attribute name="maskUnits" onInvalid="removeAttribute">
-			|				<literal-list>
-			|					<literal value="userSpaceOnUse"/>
-			|					<literal value="objectBoundingBox"/>
-			|				</literal-list>
-			|			</attribute>
-			|			<attribute name="maskunits" onInvalid="removeAttribute">
-			|				<literal-list>
-			|					<literal value="userSpaceOnUse"/>
-			|					<literal value="objectBoundingBox"/>
-			|				</literal-list>
+			|			<attribute name="height" onInvalid="removeAttribute">
+			|				<regexp-list>
+			|					<regexp name="svgLength"/>
+			|				</regexp-list>
 			|			</attribute>
 			|			<attribute name="maskContentUnits" onInvalid="removeAttribute">
 			|				<literal-list>
@@ -1252,44 +1245,37 @@ private String _filterFragmentSanitizer(String line) {
 			|					<literal value="objectBoundingBox"/>
 			|				</literal-list>
 			|			</attribute>
-			|			<attribute name="x"/>
-			|			<attribute name="y"/>
+			|			<attribute name="maskUnits" onInvalid="removeAttribute">
+			|				<literal-list>
+			|					<literal value="userSpaceOnUse"/>
+			|					<literal value="objectBoundingBox"/>
+			|				</literal-list>
+			|			</attribute>
+			|			<attribute name="maskunits" onInvalid="removeAttribute">
+			|				<literal-list>
+			|					<literal value="userSpaceOnUse"/>
+			|					<literal value="objectBoundingBox"/>
+			|				</literal-list>
+			|			</attribute>
 			|			<attribute name="width" onInvalid="removeAttribute">
 			|				<regexp-list>
 			|					<regexp name="svgLength"/>
 			|				</regexp-list>
 			|			</attribute>
-			|			<attribute name="height" onInvalid="removeAttribute">
-			|				<regexp-list>
-			|					<regexp name="svgLength"/>
-			|				</regexp-list>
-			|			</attribute>
+			|			<attribute name="x"/>
+			|			<attribute name="y"/>
 			|		</tag>
 			|
 			|		<tag name="pattern" action="validate">
-			|			<attribute name="x"/>
-			|			<attribute name="y"/>
-			|			<attribute name="width" onInvalid="removeAttribute">
-			|				<regexp-list>
-			|					<regexp name="svgLength"/>
-			|				</regexp-list>
-			|			</attribute>
 			|			<attribute name="height" onInvalid="removeAttribute">
 			|				<regexp-list>
 			|					<regexp name="svgLength"/>
 			|				</regexp-list>
 			|			</attribute>
-			|			<attribute name="patternUnits" onInvalid="removeAttribute">
-			|				<literal-list>
-			|					<literal value="userSpaceOnUse"/>
-			|					<literal value="objectBoundingBox"/>
-			|				</literal-list>
-			|			</attribute>
-			|			<attribute name="patternunits" onInvalid="removeAttribute">
-			|				<literal-list>
-			|					<literal value="userSpaceOnUse"/>
-			|					<literal value="objectBoundingBox"/>
-			|				</literal-list>
+			|			<attribute name="href" onInvalid="removeAttribute">
+			|				<regexp-list>
+			|					<regexp name="svgHrefLocal"/>
+			|				</regexp-list>
 			|			</attribute>
 			|			<attribute name="patternContentUnits" onInvalid="removeAttribute">
 			|				<literal-list>
@@ -1313,26 +1299,42 @@ private String _filterFragmentSanitizer(String line) {
 			|					<regexp name="svgTransformList"/>
 			|				</regexp-list>
 			|			</attribute>
-			|			<attribute name="viewBox"/>
-			|			<attribute name="viewbox"/>
+			|			<attribute name="patternUnits" onInvalid="removeAttribute">
+			|				<literal-list>
+			|					<literal value="userSpaceOnUse"/>
+			|					<literal value="objectBoundingBox"/>
+			|				</literal-list>
+			|			</attribute>
+			|			<attribute name="patternunits" onInvalid="removeAttribute">
+			|				<literal-list>
+			|					<literal value="userSpaceOnUse"/>
+			|					<literal value="objectBoundingBox"/>
+			|				</literal-list>
+			|			</attribute>
 			|			<attribute name="preserveAspectRatio"/>
 			|			<attribute name="preserveaspectratio"/>
-			|			<attribute name="href" onInvalid="removeAttribute">
-			|				<regexp-list>
-			|					<regexp name="svgHrefLocal"/>
-			|				</regexp-list>
-			|			</attribute>
-			|			<attribute name="xlink:href"/>
-			|		</tag>
-			|
-			|		<tag name="use" action="validate">
-			|			<attribute name="x"/>
-			|			<attribute name="y"/>
+			|			<attribute name="viewBox"/>
+			|			<attribute name="viewbox"/>
 			|			<attribute name="width" onInvalid="removeAttribute">
 			|				<regexp-list>
 			|					<regexp name="svgLength"/>
 			|				</regexp-list>
 			|			</attribute>
+			|			<attribute name="x"/>
+			|			<attribute name="xlink:href"/>
+			|			<attribute name="y"/>
+			|		</tag>
+			|
+			|		<tag name="use" action="validate">
+			|			<attribute name="clip-path"/>
+			|			<attribute name="clip-rule"/>
+			|			<attribute name="color"/>
+			|			<attribute name="color-interpolation"/>
+			|			<attribute name="cursor"/>
+			|			<attribute name="display"/>
+			|			<attribute name="fill"/>
+			|			<attribute name="fill-opacity"/>
+			|			<attribute name="fill-rule"/>
 			|			<attribute name="height" onInvalid="removeAttribute">
 			|				<regexp-list>
 			|					<regexp name="svgLength"/>
@@ -1343,50 +1345,66 @@ private String _filterFragmentSanitizer(String line) {
 			|					<regexp name="svgHrefSameOrigin"/>
 			|				</regexp-list>
 			|			</attribute>
+			|			<attribute name="image-rendering"/>
+			|			<attribute name="marker-end"/>
+			|			<attribute name="marker-mid"/>
+			|			<attribute name="marker-start"/>
+			|			<attribute name="mask"/>
+			|			<attribute name="mask-type"/>
+			|			<attribute name="opacity"/>
+			|			<attribute name="overflow"/>
+			|			<attribute name="paint-order"/>
+			|			<attribute name="pointer-events"/>
+			|			<attribute name="shape-rendering"/>
+			|			<attribute name="stroke"/>
+			|			<attribute name="stroke-dasharray"/>
+			|			<attribute name="stroke-dashoffset"/>
+			|			<attribute name="stroke-linecap"/>
+			|			<attribute name="stroke-linejoin"/>
+			|			<attribute name="stroke-miterlimit"/>
+			|			<attribute name="stroke-opacity"/>
+			|			<attribute name="stroke-width"/>
+			|			<attribute name="transform"/>
+			|			<attribute name="vector-effect"/>
+			|			<attribute name="visibility"/>
+			|			<attribute name="width" onInvalid="removeAttribute">
+			|				<regexp-list>
+			|					<regexp name="svgLength"/>
+			|				</regexp-list>
+			|			</attribute>
+			|			<attribute name="x"/>
 			|			<attribute name="xlink:href" onInvalid="removeAttribute">
 			|				<regexp-list>
 			|					<regexp name="svgHrefSameOrigin"/>
 			|				</regexp-list>
 			|			</attribute>
-			|			<attribute name="fill"/>
-			|			<attribute name="fill-opacity"/>
-			|			<attribute name="fill-rule"/>
-			|			<attribute name="stroke"/>
-			|			<attribute name="stroke-width"/>
-			|			<attribute name="stroke-opacity"/>
-			|			<attribute name="stroke-linecap"/>
-			|			<attribute name="stroke-linejoin"/>
-			|			<attribute name="stroke-dasharray"/>
-			|			<attribute name="stroke-dashoffset"/>
-			|			<attribute name="stroke-miterlimit"/>
-			|			<attribute name="opacity"/>
-			|			<attribute name="color"/>
-			|			<attribute name="display"/>
-			|			<attribute name="visibility"/>
-			|			<attribute name="overflow"/>
-			|			<attribute name="transform"/>
-			|			<attribute name="clip-path"/>
-			|			<attribute name="clip-rule"/>
-			|			<attribute name="mask"/>
-			|			<attribute name="marker-start"/>
-			|			<attribute name="marker-mid"/>
-			|			<attribute name="marker-end"/>
-			|			<attribute name="vector-effect"/>
-			|			<attribute name="shape-rendering"/>
-			|			<attribute name="image-rendering"/>
-			|			<attribute name="color-interpolation"/>
-			|			<attribute name="pointer-events"/>
-			|			<attribute name="paint-order"/>
-			|			<attribute name="cursor"/>
-			|			<attribute name="mask-type"/>
+			|			<attribute name="y"/>
 			|		</tag>
 			|
 			|		<tag name="path" action="validate">
+			|			<attribute name="clip-path"/>
+			|			<attribute name="clip-rule"/>
+			|			<attribute name="color"/>
+			|			<attribute name="color-interpolation"/>
+			|			<attribute name="cursor"/>
 			|			<attribute name="d" onInvalid="removeAttribute">
 			|				<regexp-list>
 			|					<regexp name="svgPathData"/>
 			|				</regexp-list>
 			|			</attribute>
+			|			<attribute name="display"/>
+			|			<attribute name="fill"/>
+			|			<attribute name="fill-opacity"/>
+			|			<attribute name="fill-rule"/>
+			|			<attribute name="image-rendering"/>
+			|			<attribute name="marker-end"/>
+			|			<attribute name="marker-mid"/>
+			|			<attribute name="marker-start"/>
+			|			<attribute name="mask"/>
+			|			<attribute name="mask-type"/>
+			|			<attribute name="opacity"/>
+			|			<attribute name="overflow"/>
+			|			<attribute name="paint-order"/>
 			|			<attribute name="pathLength" onInvalid="removeAttribute">
 			|				<regexp-list>
 			|					<regexp name="number"/>
@@ -1397,293 +1415,279 @@ private String _filterFragmentSanitizer(String line) {
 			|					<regexp name="number"/>
 			|				</regexp-list>
 			|			</attribute>
-			|			<attribute name="fill"/>
-			|			<attribute name="fill-opacity"/>
-			|			<attribute name="fill-rule"/>
+			|			<attribute name="pointer-events"/>
+			|			<attribute name="shape-rendering"/>
 			|			<attribute name="stroke"/>
-			|			<attribute name="stroke-width"/>
-			|			<attribute name="stroke-opacity"/>
-			|			<attribute name="stroke-linecap"/>
-			|			<attribute name="stroke-linejoin"/>
 			|			<attribute name="stroke-dasharray"/>
 			|			<attribute name="stroke-dashoffset"/>
+			|			<attribute name="stroke-linecap"/>
+			|			<attribute name="stroke-linejoin"/>
 			|			<attribute name="stroke-miterlimit"/>
-			|			<attribute name="opacity"/>
-			|			<attribute name="color"/>
-			|			<attribute name="display"/>
-			|			<attribute name="visibility"/>
-			|			<attribute name="overflow"/>
+			|			<attribute name="stroke-opacity"/>
+			|			<attribute name="stroke-width"/>
 			|			<attribute name="transform"/>
-			|			<attribute name="clip-path"/>
-			|			<attribute name="clip-rule"/>
-			|			<attribute name="mask"/>
-			|			<attribute name="marker-start"/>
-			|			<attribute name="marker-mid"/>
-			|			<attribute name="marker-end"/>
 			|			<attribute name="vector-effect"/>
-			|			<attribute name="shape-rendering"/>
-			|			<attribute name="image-rendering"/>
-			|			<attribute name="color-interpolation"/>
-			|			<attribute name="pointer-events"/>
-			|			<attribute name="paint-order"/>
-			|			<attribute name="cursor"/>
-			|			<attribute name="mask-type"/>
+			|			<attribute name="visibility"/>
 			|		</tag>
 			|
 			|		<tag name="circle" action="validate">
+			|			<attribute name="clip-path"/>
+			|			<attribute name="clip-rule"/>
+			|			<attribute name="color"/>
+			|			<attribute name="color-interpolation"/>
+			|			<attribute name="cursor"/>
 			|			<attribute name="cx"/>
 			|			<attribute name="cy"/>
-			|			<attribute name="r"/>
+			|			<attribute name="display"/>
 			|			<attribute name="fill"/>
 			|			<attribute name="fill-opacity"/>
 			|			<attribute name="fill-rule"/>
+			|			<attribute name="image-rendering"/>
+			|			<attribute name="marker-end"/>
+			|			<attribute name="marker-mid"/>
+			|			<attribute name="marker-start"/>
+			|			<attribute name="mask"/>
+			|			<attribute name="mask-type"/>
+			|			<attribute name="opacity"/>
+			|			<attribute name="overflow"/>
+			|			<attribute name="paint-order"/>
+			|			<attribute name="pointer-events"/>
+			|			<attribute name="r"/>
+			|			<attribute name="shape-rendering"/>
 			|			<attribute name="stroke"/>
-			|			<attribute name="stroke-width"/>
-			|			<attribute name="stroke-opacity"/>
-			|			<attribute name="stroke-linecap"/>
-			|			<attribute name="stroke-linejoin"/>
 			|			<attribute name="stroke-dasharray"/>
 			|			<attribute name="stroke-dashoffset"/>
+			|			<attribute name="stroke-linecap"/>
+			|			<attribute name="stroke-linejoin"/>
 			|			<attribute name="stroke-miterlimit"/>
-			|			<attribute name="opacity"/>
-			|			<attribute name="color"/>
-			|			<attribute name="display"/>
-			|			<attribute name="visibility"/>
-			|			<attribute name="overflow"/>
+			|			<attribute name="stroke-opacity"/>
+			|			<attribute name="stroke-width"/>
 			|			<attribute name="transform"/>
-			|			<attribute name="clip-path"/>
-			|			<attribute name="clip-rule"/>
-			|			<attribute name="mask"/>
-			|			<attribute name="marker-start"/>
-			|			<attribute name="marker-mid"/>
-			|			<attribute name="marker-end"/>
 			|			<attribute name="vector-effect"/>
-			|			<attribute name="shape-rendering"/>
-			|			<attribute name="image-rendering"/>
-			|			<attribute name="color-interpolation"/>
-			|			<attribute name="pointer-events"/>
-			|			<attribute name="paint-order"/>
-			|			<attribute name="cursor"/>
-			|			<attribute name="mask-type"/>
+			|			<attribute name="visibility"/>
 			|		</tag>
 			|
 			|		<tag name="rect" action="validate">
-			|			<attribute name="x"/>
-			|			<attribute name="y"/>
-			|			<attribute name="width" onInvalid="removeAttribute">
-			|				<regexp-list>
-			|					<regexp name="svgLength"/>
-			|				</regexp-list>
-			|			</attribute>
+			|			<attribute name="clip-path"/>
+			|			<attribute name="clip-rule"/>
+			|			<attribute name="color"/>
+			|			<attribute name="color-interpolation"/>
+			|			<attribute name="cursor"/>
+			|			<attribute name="display"/>
+			|			<attribute name="fill"/>
+			|			<attribute name="fill-opacity"/>
+			|			<attribute name="fill-rule"/>
 			|			<attribute name="height" onInvalid="removeAttribute">
 			|				<regexp-list>
 			|					<regexp name="svgLength"/>
 			|				</regexp-list>
 			|			</attribute>
+			|			<attribute name="image-rendering"/>
+			|			<attribute name="marker-end"/>
+			|			<attribute name="marker-mid"/>
+			|			<attribute name="marker-start"/>
+			|			<attribute name="mask"/>
+			|			<attribute name="mask-type"/>
+			|			<attribute name="opacity"/>
+			|			<attribute name="overflow"/>
+			|			<attribute name="paint-order"/>
+			|			<attribute name="pointer-events"/>
 			|			<attribute name="rx"/>
 			|			<attribute name="ry"/>
-			|			<attribute name="fill"/>
-			|			<attribute name="fill-opacity"/>
-			|			<attribute name="fill-rule"/>
+			|			<attribute name="shape-rendering"/>
 			|			<attribute name="stroke"/>
-			|			<attribute name="stroke-width"/>
-			|			<attribute name="stroke-opacity"/>
-			|			<attribute name="stroke-linecap"/>
-			|			<attribute name="stroke-linejoin"/>
 			|			<attribute name="stroke-dasharray"/>
 			|			<attribute name="stroke-dashoffset"/>
+			|			<attribute name="stroke-linecap"/>
+			|			<attribute name="stroke-linejoin"/>
 			|			<attribute name="stroke-miterlimit"/>
-			|			<attribute name="opacity"/>
-			|			<attribute name="color"/>
-			|			<attribute name="display"/>
-			|			<attribute name="visibility"/>
-			|			<attribute name="overflow"/>
+			|			<attribute name="stroke-opacity"/>
+			|			<attribute name="stroke-width"/>
 			|			<attribute name="transform"/>
-			|			<attribute name="clip-path"/>
-			|			<attribute name="clip-rule"/>
-			|			<attribute name="mask"/>
-			|			<attribute name="marker-start"/>
-			|			<attribute name="marker-mid"/>
-			|			<attribute name="marker-end"/>
 			|			<attribute name="vector-effect"/>
-			|			<attribute name="shape-rendering"/>
-			|			<attribute name="image-rendering"/>
-			|			<attribute name="color-interpolation"/>
-			|			<attribute name="pointer-events"/>
-			|			<attribute name="paint-order"/>
-			|			<attribute name="cursor"/>
-			|			<attribute name="mask-type"/>
+			|			<attribute name="visibility"/>
+			|			<attribute name="width" onInvalid="removeAttribute">
+			|				<regexp-list>
+			|					<regexp name="svgLength"/>
+			|				</regexp-list>
+			|			</attribute>
+			|			<attribute name="x"/>
+			|			<attribute name="y"/>
 			|		</tag>
 			|
 			|		<tag name="line" action="validate">
-			|			<attribute name="x1"/>
-			|			<attribute name="y1"/>
-			|			<attribute name="x2"/>
-			|			<attribute name="y2"/>
+			|			<attribute name="clip-path"/>
+			|			<attribute name="clip-rule"/>
+			|			<attribute name="color"/>
+			|			<attribute name="color-interpolation"/>
+			|			<attribute name="cursor"/>
+			|			<attribute name="display"/>
 			|			<attribute name="fill"/>
 			|			<attribute name="fill-opacity"/>
 			|			<attribute name="fill-rule"/>
+			|			<attribute name="image-rendering"/>
+			|			<attribute name="marker-end"/>
+			|			<attribute name="marker-mid"/>
+			|			<attribute name="marker-start"/>
+			|			<attribute name="mask"/>
+			|			<attribute name="mask-type"/>
+			|			<attribute name="opacity"/>
+			|			<attribute name="overflow"/>
+			|			<attribute name="paint-order"/>
+			|			<attribute name="pointer-events"/>
+			|			<attribute name="shape-rendering"/>
 			|			<attribute name="stroke"/>
-			|			<attribute name="stroke-width"/>
-			|			<attribute name="stroke-opacity"/>
-			|			<attribute name="stroke-linecap"/>
-			|			<attribute name="stroke-linejoin"/>
 			|			<attribute name="stroke-dasharray"/>
 			|			<attribute name="stroke-dashoffset"/>
+			|			<attribute name="stroke-linecap"/>
+			|			<attribute name="stroke-linejoin"/>
 			|			<attribute name="stroke-miterlimit"/>
-			|			<attribute name="opacity"/>
-			|			<attribute name="color"/>
-			|			<attribute name="display"/>
-			|			<attribute name="visibility"/>
-			|			<attribute name="overflow"/>
+			|			<attribute name="stroke-opacity"/>
+			|			<attribute name="stroke-width"/>
 			|			<attribute name="transform"/>
-			|			<attribute name="clip-path"/>
-			|			<attribute name="clip-rule"/>
-			|			<attribute name="mask"/>
-			|			<attribute name="marker-start"/>
-			|			<attribute name="marker-mid"/>
-			|			<attribute name="marker-end"/>
 			|			<attribute name="vector-effect"/>
-			|			<attribute name="shape-rendering"/>
-			|			<attribute name="image-rendering"/>
-			|			<attribute name="color-interpolation"/>
-			|			<attribute name="pointer-events"/>
-			|			<attribute name="paint-order"/>
-			|			<attribute name="cursor"/>
-			|			<attribute name="mask-type"/>
+			|			<attribute name="visibility"/>
+			|			<attribute name="x1"/>
+			|			<attribute name="x2"/>
+			|			<attribute name="y1"/>
+			|			<attribute name="y2"/>
 			|		</tag>
 			|
 			|		<tag name="polyline" action="validate">
-			|			<attribute name="points"/>
+			|			<attribute name="clip-path"/>
+			|			<attribute name="clip-rule"/>
+			|			<attribute name="color"/>
+			|			<attribute name="color-interpolation"/>
+			|			<attribute name="cursor"/>
+			|			<attribute name="display"/>
 			|			<attribute name="fill"/>
 			|			<attribute name="fill-opacity"/>
 			|			<attribute name="fill-rule"/>
+			|			<attribute name="image-rendering"/>
+			|			<attribute name="marker-end"/>
+			|			<attribute name="marker-mid"/>
+			|			<attribute name="marker-start"/>
+			|			<attribute name="mask"/>
+			|			<attribute name="mask-type"/>
+			|			<attribute name="opacity"/>
+			|			<attribute name="overflow"/>
+			|			<attribute name="paint-order"/>
+			|			<attribute name="pointer-events"/>
+			|			<attribute name="points"/>
+			|			<attribute name="shape-rendering"/>
 			|			<attribute name="stroke"/>
-			|			<attribute name="stroke-width"/>
-			|			<attribute name="stroke-opacity"/>
-			|			<attribute name="stroke-linecap"/>
-			|			<attribute name="stroke-linejoin"/>
 			|			<attribute name="stroke-dasharray"/>
 			|			<attribute name="stroke-dashoffset"/>
+			|			<attribute name="stroke-linecap"/>
+			|			<attribute name="stroke-linejoin"/>
 			|			<attribute name="stroke-miterlimit"/>
-			|			<attribute name="opacity"/>
-			|			<attribute name="color"/>
-			|			<attribute name="display"/>
-			|			<attribute name="visibility"/>
-			|			<attribute name="overflow"/>
+			|			<attribute name="stroke-opacity"/>
+			|			<attribute name="stroke-width"/>
 			|			<attribute name="transform"/>
-			|			<attribute name="clip-path"/>
-			|			<attribute name="clip-rule"/>
-			|			<attribute name="mask"/>
-			|			<attribute name="marker-start"/>
-			|			<attribute name="marker-mid"/>
-			|			<attribute name="marker-end"/>
 			|			<attribute name="vector-effect"/>
-			|			<attribute name="shape-rendering"/>
-			|			<attribute name="image-rendering"/>
-			|			<attribute name="color-interpolation"/>
-			|			<attribute name="pointer-events"/>
-			|			<attribute name="paint-order"/>
-			|			<attribute name="cursor"/>
-			|			<attribute name="mask-type"/>
+			|			<attribute name="visibility"/>
 			|		</tag>
 			|
 			|		<tag name="polygon" action="validate">
-			|			<attribute name="points"/>
+			|			<attribute name="clip-path"/>
+			|			<attribute name="clip-rule"/>
+			|			<attribute name="color"/>
+			|			<attribute name="color-interpolation"/>
+			|			<attribute name="cursor"/>
+			|			<attribute name="display"/>
 			|			<attribute name="fill"/>
 			|			<attribute name="fill-opacity"/>
 			|			<attribute name="fill-rule"/>
+			|			<attribute name="image-rendering"/>
+			|			<attribute name="marker-end"/>
+			|			<attribute name="marker-mid"/>
+			|			<attribute name="marker-start"/>
+			|			<attribute name="mask"/>
+			|			<attribute name="mask-type"/>
+			|			<attribute name="opacity"/>
+			|			<attribute name="overflow"/>
+			|			<attribute name="paint-order"/>
+			|			<attribute name="pointer-events"/>
+			|			<attribute name="points"/>
+			|			<attribute name="shape-rendering"/>
 			|			<attribute name="stroke"/>
-			|			<attribute name="stroke-width"/>
-			|			<attribute name="stroke-opacity"/>
-			|			<attribute name="stroke-linecap"/>
-			|			<attribute name="stroke-linejoin"/>
 			|			<attribute name="stroke-dasharray"/>
 			|			<attribute name="stroke-dashoffset"/>
+			|			<attribute name="stroke-linecap"/>
+			|			<attribute name="stroke-linejoin"/>
 			|			<attribute name="stroke-miterlimit"/>
-			|			<attribute name="opacity"/>
-			|			<attribute name="color"/>
-			|			<attribute name="display"/>
-			|			<attribute name="visibility"/>
-			|			<attribute name="overflow"/>
+			|			<attribute name="stroke-opacity"/>
+			|			<attribute name="stroke-width"/>
 			|			<attribute name="transform"/>
-			|			<attribute name="clip-path"/>
-			|			<attribute name="clip-rule"/>
-			|			<attribute name="mask"/>
-			|			<attribute name="marker-start"/>
-			|			<attribute name="marker-mid"/>
-			|			<attribute name="marker-end"/>
 			|			<attribute name="vector-effect"/>
-			|			<attribute name="shape-rendering"/>
-			|			<attribute name="image-rendering"/>
-			|			<attribute name="color-interpolation"/>
-			|			<attribute name="pointer-events"/>
-			|			<attribute name="paint-order"/>
-			|			<attribute name="cursor"/>
-			|			<attribute name="mask-type"/>
+			|			<attribute name="visibility"/>
 			|		</tag>
 			|
 			|		<tag name="ellipse" action="validate">
+			|			<attribute name="clip-path"/>
+			|			<attribute name="clip-rule"/>
+			|			<attribute name="color"/>
+			|			<attribute name="color-interpolation"/>
+			|			<attribute name="cursor"/>
 			|			<attribute name="cx"/>
 			|			<attribute name="cy"/>
-			|			<attribute name="rx"/>
-			|			<attribute name="ry"/>
+			|			<attribute name="display"/>
 			|			<attribute name="fill"/>
 			|			<attribute name="fill-opacity"/>
 			|			<attribute name="fill-rule"/>
+			|			<attribute name="image-rendering"/>
+			|			<attribute name="marker-end"/>
+			|			<attribute name="marker-mid"/>
+			|			<attribute name="marker-start"/>
+			|			<attribute name="mask"/>
+			|			<attribute name="mask-type"/>
+			|			<attribute name="opacity"/>
+			|			<attribute name="overflow"/>
+			|			<attribute name="paint-order"/>
+			|			<attribute name="pointer-events"/>
+			|			<attribute name="rx"/>
+			|			<attribute name="ry"/>
+			|			<attribute name="shape-rendering"/>
 			|			<attribute name="stroke"/>
-			|			<attribute name="stroke-width"/>
-			|			<attribute name="stroke-opacity"/>
-			|			<attribute name="stroke-linecap"/>
-			|			<attribute name="stroke-linejoin"/>
 			|			<attribute name="stroke-dasharray"/>
 			|			<attribute name="stroke-dashoffset"/>
+			|			<attribute name="stroke-linecap"/>
+			|			<attribute name="stroke-linejoin"/>
 			|			<attribute name="stroke-miterlimit"/>
-			|			<attribute name="opacity"/>
-			|			<attribute name="color"/>
-			|			<attribute name="display"/>
-			|			<attribute name="visibility"/>
-			|			<attribute name="overflow"/>
+			|			<attribute name="stroke-opacity"/>
+			|			<attribute name="stroke-width"/>
 			|			<attribute name="transform"/>
-			|			<attribute name="clip-path"/>
-			|			<attribute name="clip-rule"/>
-			|			<attribute name="mask"/>
-			|			<attribute name="marker-start"/>
-			|			<attribute name="marker-mid"/>
-			|			<attribute name="marker-end"/>
 			|			<attribute name="vector-effect"/>
-			|			<attribute name="shape-rendering"/>
-			|			<attribute name="image-rendering"/>
-			|			<attribute name="color-interpolation"/>
-			|			<attribute name="pointer-events"/>
-			|			<attribute name="paint-order"/>
-			|			<attribute name="cursor"/>
-			|			<attribute name="mask-type"/>
+			|			<attribute name="visibility"/>
 			|		</tag>
 			|
 			|		<tag name="lineargradient" action="validate">
-			|			<attribute name="x1"/>
-			|			<attribute name="y1"/>
-			|			<attribute name="x2"/>
-			|			<attribute name="y2"/>
-			|			<attribute name="gradientUnits"/>
-			|			<attribute name="gradientunits"/>
 			|			<attribute name="gradientTransform"/>
 			|			<attribute name="gradienttransform"/>
-			|			<attribute name="spreadMethod"/>
-			|			<attribute name="spreadmethod"/>
+			|			<attribute name="gradientUnits"/>
+			|			<attribute name="gradientunits"/>
 			|			<attribute name="href" onInvalid="removeAttribute">
 			|				<regexp-list>
 			|					<regexp name="svgHrefLocal"/>
 			|				</regexp-list>
 			|			</attribute>
+			|			<attribute name="spreadMethod"/>
+			|			<attribute name="spreadmethod"/>
+			|			<attribute name="x1"/>
+			|			<attribute name="x2"/>
 			|			<attribute name="xlink:href"/>
+			|			<attribute name="y1"/>
+			|			<attribute name="y2"/>
 			|		</tag>
 			|
 			|		<tag name="radialgradient" action="validate">
 			|			<attribute name="cx"/>
 			|			<attribute name="cy"/>
-			|			<attribute name="r"/>
+			|			<attribute name="fr" onInvalid="removeAttribute">
+			|				<regexp-list>
+			|					<regexp name="svgLength"/>
+			|				</regexp-list>
+			|			</attribute>
 			|			<attribute name="fx" onInvalid="removeAttribute">
 			|				<regexp-list>
 			|					<regexp name="svgLength"/>
@@ -1694,22 +1698,18 @@ private String _filterFragmentSanitizer(String line) {
 			|					<regexp name="svgLength"/>
 			|				</regexp-list>
 			|			</attribute>
-			|			<attribute name="fr" onInvalid="removeAttribute">
-			|				<regexp-list>
-			|					<regexp name="svgLength"/>
-			|				</regexp-list>
-			|			</attribute>
-			|			<attribute name="gradientUnits"/>
-			|			<attribute name="gradientunits"/>
 			|			<attribute name="gradientTransform"/>
 			|			<attribute name="gradienttransform"/>
-			|			<attribute name="spreadMethod"/>
-			|			<attribute name="spreadmethod"/>
+			|			<attribute name="gradientUnits"/>
+			|			<attribute name="gradientunits"/>
 			|			<attribute name="href" onInvalid="removeAttribute">
 			|				<regexp-list>
 			|					<regexp name="svgHrefLocal"/>
 			|				</regexp-list>
 			|			</attribute>
+			|			<attribute name="r"/>
+			|			<attribute name="spreadMethod"/>
+			|			<attribute name="spreadmethod"/>
 			|			<attribute name="xlink:href"/>
 			|		</tag>
 			|
@@ -1732,131 +1732,131 @@ private String _filterFragmentSanitizer(String line) {
 			|		</tag>
 			|
 			|		<tag name="text" action="validate">
-			|			<attribute name="x"/>
-			|			<attribute name="y"/>
+			|			<attribute name="alignment-baseline"/>
+			|			<attribute name="baseline-shift"/>
+			|			<attribute name="clip-path"/>
+			|			<attribute name="clip-rule"/>
+			|			<attribute name="color"/>
+			|			<attribute name="color-interpolation"/>
+			|			<attribute name="cursor"/>
+			|			<attribute name="direction"/>
+			|			<attribute name="display"/>
+			|			<attribute name="dominant-baseline"/>
 			|			<attribute name="dx"/>
 			|			<attribute name="dy"/>
-			|			<attribute name="rotate"/>
-			|			<attribute name="textLength"/>
-			|			<attribute name="textlength"/>
-			|			<attribute name="lengthAdjust"/>
-			|			<attribute name="lengthadjust"/>
 			|			<attribute name="fill"/>
 			|			<attribute name="fill-opacity"/>
 			|			<attribute name="fill-rule"/>
-			|			<attribute name="stroke"/>
-			|			<attribute name="stroke-width"/>
-			|			<attribute name="stroke-opacity"/>
-			|			<attribute name="stroke-linecap"/>
-			|			<attribute name="stroke-linejoin"/>
-			|			<attribute name="stroke-dasharray"/>
-			|			<attribute name="stroke-dashoffset"/>
-			|			<attribute name="stroke-miterlimit"/>
-			|			<attribute name="opacity"/>
-			|			<attribute name="color"/>
-			|			<attribute name="display"/>
-			|			<attribute name="visibility"/>
-			|			<attribute name="overflow"/>
-			|			<attribute name="transform"/>
-			|			<attribute name="clip-path"/>
-			|			<attribute name="clip-rule"/>
-			|			<attribute name="mask"/>
-			|			<attribute name="marker-start"/>
-			|			<attribute name="marker-mid"/>
-			|			<attribute name="marker-end"/>
-			|			<attribute name="vector-effect"/>
-			|			<attribute name="shape-rendering"/>
-			|			<attribute name="image-rendering"/>
-			|			<attribute name="color-interpolation"/>
-			|			<attribute name="pointer-events"/>
-			|			<attribute name="paint-order"/>
-			|			<attribute name="cursor"/>
-			|			<attribute name="mask-type"/>
 			|			<attribute name="font-family"/>
 			|			<attribute name="font-size"/>
-			|			<attribute name="font-weight"/>
+			|			<attribute name="font-stretch"/>
 			|			<attribute name="font-style"/>
 			|			<attribute name="font-variant"/>
-			|			<attribute name="font-stretch"/>
-			|			<attribute name="text-anchor"/>
-			|			<attribute name="dominant-baseline"/>
-			|			<attribute name="alignment-baseline"/>
-			|			<attribute name="baseline-shift"/>
-			|			<attribute name="direction"/>
-			|			<attribute name="letter-spacing"/>
-			|			<attribute name="word-spacing"/>
-			|			<attribute name="text-decoration"/>
-			|			<attribute name="text-rendering"/>
-			|			<attribute name="writing-mode"/>
-			|			<attribute name="unicode-bidi"/>
-			|			<attribute name="white-space"/>
-			|			<attribute name="text-overflow"/>
+			|			<attribute name="font-weight"/>
 			|			<attribute name="glyph-orientation-horizontal"/>
 			|			<attribute name="glyph-orientation-vertical"/>
+			|			<attribute name="image-rendering"/>
+			|			<attribute name="lengthAdjust"/>
+			|			<attribute name="lengthadjust"/>
+			|			<attribute name="letter-spacing"/>
+			|			<attribute name="marker-end"/>
+			|			<attribute name="marker-mid"/>
+			|			<attribute name="marker-start"/>
+			|			<attribute name="mask"/>
+			|			<attribute name="mask-type"/>
+			|			<attribute name="opacity"/>
+			|			<attribute name="overflow"/>
+			|			<attribute name="paint-order"/>
+			|			<attribute name="pointer-events"/>
+			|			<attribute name="rotate"/>
+			|			<attribute name="shape-rendering"/>
+			|			<attribute name="stroke"/>
+			|			<attribute name="stroke-dasharray"/>
+			|			<attribute name="stroke-dashoffset"/>
+			|			<attribute name="stroke-linecap"/>
+			|			<attribute name="stroke-linejoin"/>
+			|			<attribute name="stroke-miterlimit"/>
+			|			<attribute name="stroke-opacity"/>
+			|			<attribute name="stroke-width"/>
+			|			<attribute name="text-anchor"/>
+			|			<attribute name="text-decoration"/>
+			|			<attribute name="text-overflow"/>
+			|			<attribute name="text-rendering"/>
+			|			<attribute name="textLength"/>
+			|			<attribute name="textlength"/>
+			|			<attribute name="transform"/>
+			|			<attribute name="unicode-bidi"/>
+			|			<attribute name="vector-effect"/>
+			|			<attribute name="visibility"/>
+			|			<attribute name="white-space"/>
+			|			<attribute name="word-spacing"/>
+			|			<attribute name="writing-mode"/>
+			|			<attribute name="x"/>
+			|			<attribute name="y"/>
 			|		</tag>
 			|
 			|		<tag name="tspan" action="validate">
-			|			<attribute name="x"/>
-			|			<attribute name="y"/>
+			|			<attribute name="alignment-baseline"/>
+			|			<attribute name="baseline-shift"/>
+			|			<attribute name="clip-path"/>
+			|			<attribute name="clip-rule"/>
+			|			<attribute name="color"/>
+			|			<attribute name="color-interpolation"/>
+			|			<attribute name="cursor"/>
+			|			<attribute name="direction"/>
+			|			<attribute name="display"/>
+			|			<attribute name="dominant-baseline"/>
 			|			<attribute name="dx"/>
 			|			<attribute name="dy"/>
-			|			<attribute name="rotate"/>
-			|			<attribute name="textLength"/>
-			|			<attribute name="textlength"/>
-			|			<attribute name="lengthAdjust"/>
-			|			<attribute name="lengthadjust"/>
 			|			<attribute name="fill"/>
 			|			<attribute name="fill-opacity"/>
 			|			<attribute name="fill-rule"/>
-			|			<attribute name="stroke"/>
-			|			<attribute name="stroke-width"/>
-			|			<attribute name="stroke-opacity"/>
-			|			<attribute name="stroke-linecap"/>
-			|			<attribute name="stroke-linejoin"/>
-			|			<attribute name="stroke-dasharray"/>
-			|			<attribute name="stroke-dashoffset"/>
-			|			<attribute name="stroke-miterlimit"/>
-			|			<attribute name="opacity"/>
-			|			<attribute name="color"/>
-			|			<attribute name="display"/>
-			|			<attribute name="visibility"/>
-			|			<attribute name="overflow"/>
-			|			<attribute name="transform"/>
-			|			<attribute name="clip-path"/>
-			|			<attribute name="clip-rule"/>
-			|			<attribute name="mask"/>
-			|			<attribute name="marker-start"/>
-			|			<attribute name="marker-mid"/>
-			|			<attribute name="marker-end"/>
-			|			<attribute name="vector-effect"/>
-			|			<attribute name="shape-rendering"/>
-			|			<attribute name="image-rendering"/>
-			|			<attribute name="color-interpolation"/>
-			|			<attribute name="pointer-events"/>
-			|			<attribute name="paint-order"/>
-			|			<attribute name="cursor"/>
-			|			<attribute name="mask-type"/>
 			|			<attribute name="font-family"/>
 			|			<attribute name="font-size"/>
-			|			<attribute name="font-weight"/>
+			|			<attribute name="font-stretch"/>
 			|			<attribute name="font-style"/>
 			|			<attribute name="font-variant"/>
-			|			<attribute name="font-stretch"/>
-			|			<attribute name="text-anchor"/>
-			|			<attribute name="dominant-baseline"/>
-			|			<attribute name="alignment-baseline"/>
-			|			<attribute name="baseline-shift"/>
-			|			<attribute name="direction"/>
-			|			<attribute name="letter-spacing"/>
-			|			<attribute name="word-spacing"/>
-			|			<attribute name="text-decoration"/>
-			|			<attribute name="text-rendering"/>
-			|			<attribute name="writing-mode"/>
-			|			<attribute name="unicode-bidi"/>
-			|			<attribute name="white-space"/>
-			|			<attribute name="text-overflow"/>
+			|			<attribute name="font-weight"/>
 			|			<attribute name="glyph-orientation-horizontal"/>
 			|			<attribute name="glyph-orientation-vertical"/>
+			|			<attribute name="image-rendering"/>
+			|			<attribute name="lengthAdjust"/>
+			|			<attribute name="lengthadjust"/>
+			|			<attribute name="letter-spacing"/>
+			|			<attribute name="marker-end"/>
+			|			<attribute name="marker-mid"/>
+			|			<attribute name="marker-start"/>
+			|			<attribute name="mask"/>
+			|			<attribute name="mask-type"/>
+			|			<attribute name="opacity"/>
+			|			<attribute name="overflow"/>
+			|			<attribute name="paint-order"/>
+			|			<attribute name="pointer-events"/>
+			|			<attribute name="rotate"/>
+			|			<attribute name="shape-rendering"/>
+			|			<attribute name="stroke"/>
+			|			<attribute name="stroke-dasharray"/>
+			|			<attribute name="stroke-dashoffset"/>
+			|			<attribute name="stroke-linecap"/>
+			|			<attribute name="stroke-linejoin"/>
+			|			<attribute name="stroke-miterlimit"/>
+			|			<attribute name="stroke-opacity"/>
+			|			<attribute name="stroke-width"/>
+			|			<attribute name="text-anchor"/>
+			|			<attribute name="text-decoration"/>
+			|			<attribute name="text-overflow"/>
+			|			<attribute name="text-rendering"/>
+			|			<attribute name="textLength"/>
+			|			<attribute name="textlength"/>
+			|			<attribute name="transform"/>
+			|			<attribute name="unicode-bidi"/>
+			|			<attribute name="vector-effect"/>
+			|			<attribute name="visibility"/>
+			|			<attribute name="white-space"/>
+			|			<attribute name="word-spacing"/>
+			|			<attribute name="writing-mode"/>
+			|			<attribute name="x"/>
+			|			<attribute name="y"/>
 			|		</tag>
 			|
 			|		<tag name="title" action="validate">

--- a/modules/apps/portal-security/portal-security-antisamy/src/main/resources/META-INF/resources/fragment-sanitizer-configuration.xml
+++ b/modules/apps/portal-security/portal-security-antisamy/src/main/resources/META-INF/resources/fragment-sanitizer-configuration.xml
@@ -125,6 +125,7 @@ http://www.w3.org/TR/html401/struct/global.html
 		<regexp name="svgPaint" value="(none|currentColor|transparent|inherit|context-fill|context-stroke|#[0-9a-fA-F]{3,8}|rgba?\([0-9,.\s%]*\)|hsla?\([0-9,.\s%]*\)|url\(\s*#[a-zA-Z0-9\-_:.]+\s*\)(\s+(none|currentColor|#[0-9a-fA-F]{3,8}))?|[a-zA-Z]+)"/>
 		<regexp name="svgLocalRef" value="(none|url\(\s*#[a-zA-Z0-9\-_:.]+\s*\))"/>
 		<regexp name="svgHrefLocal" value="#[a-zA-Z0-9\-_:.]+"/>
+		<regexp name="svgHrefSameOrigin" value="(#[a-zA-Z0-9\-_:.]+|/?[a-zA-Z0-9\-_.][a-zA-Z0-9\-_./]*\.svg#[a-zA-Z0-9\-_:.]+)"/>
 		<regexp name="svgKeyword" value="[a-zA-Z][a-zA-Z\-]*"/>
 		<regexp name="svgPreserveAspectRatio" value="(none|x(Min|Mid|Max)Y(Min|Mid|Max))(\s+(meet|slice))?"/>
 	</common-regexps>
@@ -477,39 +478,91 @@ http://www.w3.org/TR/html401/struct/global.html
 		 </attribute>
 
 
-		<attribute name="viewBox" onInvalid="removeAttribute">
+		<attribute name="alignment-baseline" onInvalid="removeAttribute">
 			<regexp-list>
-				<regexp name="svgViewBox"/>
+				<regexp name="svgKeyword"/>
 			</regexp-list>
 		</attribute>
 
-		<attribute name="viewbox" onInvalid="removeAttribute">
+		<attribute name="baseline-shift" onInvalid="removeAttribute">
 			<regexp-list>
-				<regexp name="svgViewBox"/>
+				<regexp value="[a-zA-Z0-9%.\-]+"/>
 			</regexp-list>
 		</attribute>
 
-		<attribute name="x" onInvalid="removeAttribute">
+		<attribute name="clip-path" onInvalid="removeAttribute">
+			<regexp-list>
+				<regexp name="svgLocalRef"/>
+			</regexp-list>
+		</attribute>
+
+		<attribute name="clip-rule" onInvalid="removeAttribute">
+			<literal-list>
+				<literal value="nonzero"/>
+				<literal value="evenodd"/>
+				<literal value="inherit"/>
+			</literal-list>
+		</attribute>
+
+		<attribute name="color" onInvalid="removeAttribute">
+			<regexp-list>
+				<regexp name="svgPaint"/>
+			</regexp-list>
+		</attribute>
+
+		<attribute name="color-interpolation" onInvalid="removeAttribute">
+			<regexp-list>
+				<regexp name="svgKeyword"/>
+			</regexp-list>
+		</attribute>
+
+		<attribute name="cursor" onInvalid="removeAttribute">
+			<regexp-list>
+				<regexp name="svgKeyword"/>
+			</regexp-list>
+		</attribute>
+
+		<attribute name="cx" onInvalid="removeAttribute">
 			<regexp-list>
 				<regexp name="svgLength"/>
 			</regexp-list>
 		</attribute>
 
-		<attribute name="y" onInvalid="removeAttribute">
+		<attribute name="cy" onInvalid="removeAttribute">
 			<regexp-list>
 				<regexp name="svgLength"/>
 			</regexp-list>
 		</attribute>
 
-		<attribute name="preserveAspectRatio" onInvalid="removeAttribute">
+		<attribute name="direction" onInvalid="removeAttribute">
+			<literal-list>
+				<literal value="ltr"/>
+				<literal value="rtl"/>
+				<literal value="inherit"/>
+			</literal-list>
+		</attribute>
+
+		<attribute name="display" onInvalid="removeAttribute">
 			<regexp-list>
-				<regexp name="svgPreserveAspectRatio"/>
+				<regexp name="svgKeyword"/>
 			</regexp-list>
 		</attribute>
 
-		<attribute name="preserveaspectratio" onInvalid="removeAttribute">
+		<attribute name="dominant-baseline" onInvalid="removeAttribute">
 			<regexp-list>
-				<regexp name="svgPreserveAspectRatio"/>
+				<regexp name="svgKeyword"/>
+			</regexp-list>
+		</attribute>
+
+		<attribute name="dx" onInvalid="removeAttribute">
+			<regexp-list>
+				<regexp name="svgNumberList"/>
+			</regexp-list>
+		</attribute>
+
+		<attribute name="dy" onInvalid="removeAttribute">
+			<regexp-list>
+				<regexp name="svgNumberList"/>
 			</regexp-list>
 		</attribute>
 
@@ -533,21 +586,247 @@ http://www.w3.org/TR/html401/struct/global.html
 			</literal-list>
 		</attribute>
 
+		<attribute name="font-family" onInvalid="removeAttribute">
+			<regexp-list>
+				<regexp value="[a-zA-Z0-9\s,._\-]+"/>
+			</regexp-list>
+		</attribute>
+
+		<attribute name="font-size" onInvalid="removeAttribute">
+			<regexp-list>
+				<regexp name="svgLength"/>
+			</regexp-list>
+		</attribute>
+
+		<attribute name="font-stretch" onInvalid="removeAttribute">
+			<regexp-list>
+				<regexp name="svgKeyword"/>
+			</regexp-list>
+		</attribute>
+
+		<attribute name="font-style" onInvalid="removeAttribute">
+			<regexp-list>
+				<regexp name="svgKeyword"/>
+			</regexp-list>
+		</attribute>
+
+		<attribute name="font-variant" onInvalid="removeAttribute">
+			<regexp-list>
+				<regexp name="svgKeyword"/>
+			</regexp-list>
+		</attribute>
+
+		<attribute name="font-weight" onInvalid="removeAttribute">
+			<regexp-list>
+				<regexp value="[a-zA-Z0-9]+"/>
+			</regexp-list>
+		</attribute>
+
+		<attribute name="glyph-orientation-horizontal" onInvalid="removeAttribute">
+			<regexp-list>
+				<regexp name="svgKeyword"/>
+			</regexp-list>
+		</attribute>
+
+		<attribute name="glyph-orientation-vertical" onInvalid="removeAttribute">
+			<regexp-list>
+				<regexp name="svgKeyword"/>
+			</regexp-list>
+		</attribute>
+
+		<attribute name="gradientTransform" onInvalid="removeAttribute">
+			<regexp-list>
+				<regexp name="svgTransformList"/>
+			</regexp-list>
+		</attribute>
+
+		<attribute name="gradienttransform" onInvalid="removeAttribute">
+			<regexp-list>
+				<regexp name="svgTransformList"/>
+			</regexp-list>
+		</attribute>
+
+		<attribute name="gradientUnits" onInvalid="removeAttribute">
+			<literal-list>
+				<literal value="userSpaceOnUse"/>
+				<literal value="objectBoundingBox"/>
+			</literal-list>
+		</attribute>
+
+		<attribute name="gradientunits" onInvalid="removeAttribute">
+			<literal-list>
+				<literal value="userSpaceOnUse"/>
+				<literal value="objectBoundingBox"/>
+			</literal-list>
+		</attribute>
+
+		<attribute name="image-rendering" onInvalid="removeAttribute">
+			<regexp-list>
+				<regexp name="svgKeyword"/>
+			</regexp-list>
+		</attribute>
+
+		<attribute name="lengthAdjust" onInvalid="removeAttribute">
+			<literal-list>
+				<literal value="spacing"/>
+				<literal value="spacingAndGlyphs"/>
+			</literal-list>
+		</attribute>
+
+		<attribute name="lengthadjust" onInvalid="removeAttribute">
+			<literal-list>
+				<literal value="spacing"/>
+				<literal value="spacingAndGlyphs"/>
+			</literal-list>
+		</attribute>
+
+		<attribute name="letter-spacing" onInvalid="removeAttribute">
+			<regexp-list>
+				<regexp name="svgLength"/>
+			</regexp-list>
+		</attribute>
+
+		<attribute name="marker-end" onInvalid="removeAttribute">
+			<regexp-list>
+				<regexp name="svgLocalRef"/>
+			</regexp-list>
+		</attribute>
+
+		<attribute name="marker-mid" onInvalid="removeAttribute">
+			<regexp-list>
+				<regexp name="svgLocalRef"/>
+			</regexp-list>
+		</attribute>
+
+		<attribute name="marker-start" onInvalid="removeAttribute">
+			<regexp-list>
+				<regexp name="svgLocalRef"/>
+			</regexp-list>
+		</attribute>
+
+		<attribute name="mask" onInvalid="removeAttribute">
+			<regexp-list>
+				<regexp name="svgLocalRef"/>
+			</regexp-list>
+		</attribute>
+
+		<attribute name="mask-type" onInvalid="removeAttribute">
+			<regexp-list>
+				<regexp name="svgKeyword"/>
+			</regexp-list>
+		</attribute>
+
+		<attribute name="opacity" onInvalid="removeAttribute">
+			<regexp-list>
+				<regexp name="number"/>
+			</regexp-list>
+		</attribute>
+
+		<attribute name="overflow" onInvalid="removeAttribute">
+			<literal-list>
+				<literal value="visible"/>
+				<literal value="hidden"/>
+				<literal value="scroll"/>
+				<literal value="auto"/>
+				<literal value="inherit"/>
+			</literal-list>
+		</attribute>
+
+		<attribute name="paint-order" onInvalid="removeAttribute">
+			<regexp-list>
+				<regexp value="[a-zA-Z\s]+"/>
+			</regexp-list>
+		</attribute>
+
+		<attribute name="pointer-events" onInvalid="removeAttribute">
+			<regexp-list>
+				<regexp name="svgKeyword"/>
+			</regexp-list>
+		</attribute>
+
+		<attribute name="points" onInvalid="removeAttribute">
+			<regexp-list>
+				<regexp name="svgNumberList"/>
+			</regexp-list>
+		</attribute>
+
+		<attribute name="preserveAspectRatio" onInvalid="removeAttribute">
+			<regexp-list>
+				<regexp name="svgPreserveAspectRatio"/>
+			</regexp-list>
+		</attribute>
+
+		<attribute name="preserveaspectratio" onInvalid="removeAttribute">
+			<regexp-list>
+				<regexp name="svgPreserveAspectRatio"/>
+			</regexp-list>
+		</attribute>
+
+		<attribute name="r" onInvalid="removeAttribute">
+			<regexp-list>
+				<regexp name="svgLength"/>
+			</regexp-list>
+		</attribute>
+
+		<attribute name="rotate" onInvalid="removeAttribute">
+			<regexp-list>
+				<regexp name="svgNumberList"/>
+			</regexp-list>
+		</attribute>
+
+		<attribute name="rx" onInvalid="removeAttribute">
+			<regexp-list>
+				<regexp name="svgLength"/>
+			</regexp-list>
+		</attribute>
+
+		<attribute name="ry" onInvalid="removeAttribute">
+			<regexp-list>
+				<regexp name="svgLength"/>
+			</regexp-list>
+		</attribute>
+
+		<attribute name="shape-rendering" onInvalid="removeAttribute">
+			<regexp-list>
+				<regexp name="svgKeyword"/>
+			</regexp-list>
+		</attribute>
+
+		<attribute name="spreadMethod" onInvalid="removeAttribute">
+			<literal-list>
+				<literal value="pad"/>
+				<literal value="reflect"/>
+				<literal value="repeat"/>
+			</literal-list>
+		</attribute>
+
+		<attribute name="spreadmethod" onInvalid="removeAttribute">
+			<literal-list>
+				<literal value="pad"/>
+				<literal value="reflect"/>
+				<literal value="repeat"/>
+			</literal-list>
+		</attribute>
+
 		<attribute name="stroke" onInvalid="removeAttribute">
 			<regexp-list>
 				<regexp name="svgPaint"/>
 			</regexp-list>
 		</attribute>
 
-		<attribute name="stroke-width" onInvalid="removeAttribute">
+		<attribute name="stroke-dasharray" onInvalid="removeAttribute">
 			<regexp-list>
-				<regexp name="svgLength"/>
+				<regexp name="svgNumberList"/>
 			</regexp-list>
+			<literal-list>
+				<literal value="none"/>
+				<literal value="inherit"/>
+			</literal-list>
 		</attribute>
 
-		<attribute name="stroke-opacity" onInvalid="removeAttribute">
+		<attribute name="stroke-dashoffset" onInvalid="removeAttribute">
 			<regexp-list>
-				<regexp name="number"/>
+				<regexp name="svgLength"/>
 			</regexp-list>
 		</attribute>
 
@@ -571,280 +850,48 @@ http://www.w3.org/TR/html401/struct/global.html
 			</literal-list>
 		</attribute>
 
-		<attribute name="stroke-dasharray" onInvalid="removeAttribute">
-			<regexp-list>
-				<regexp name="svgNumberList"/>
-			</regexp-list>
-			<literal-list>
-				<literal value="none"/>
-				<literal value="inherit"/>
-			</literal-list>
-		</attribute>
-
-		<attribute name="stroke-dashoffset" onInvalid="removeAttribute">
-			<regexp-list>
-				<regexp name="svgLength"/>
-			</regexp-list>
-		</attribute>
-
 		<attribute name="stroke-miterlimit" onInvalid="removeAttribute">
 			<regexp-list>
 				<regexp name="number"/>
 			</regexp-list>
 		</attribute>
 
-		<attribute name="opacity" onInvalid="removeAttribute">
+		<attribute name="stroke-opacity" onInvalid="removeAttribute">
 			<regexp-list>
 				<regexp name="number"/>
 			</regexp-list>
 		</attribute>
 
-		<attribute name="color" onInvalid="removeAttribute">
+		<attribute name="stroke-width" onInvalid="removeAttribute">
 			<regexp-list>
-				<regexp name="svgPaint"/>
+				<regexp name="svgLength"/>
 			</regexp-list>
 		</attribute>
 
-		<attribute name="display" onInvalid="removeAttribute">
-			<regexp-list>
-				<regexp name="svgKeyword"/>
-			</regexp-list>
-		</attribute>
-
-		<attribute name="visibility" onInvalid="removeAttribute">
+		<attribute name="text-anchor" onInvalid="removeAttribute">
 			<literal-list>
-				<literal value="visible"/>
-				<literal value="hidden"/>
-				<literal value="collapse"/>
+				<literal value="start"/>
+				<literal value="middle"/>
+				<literal value="end"/>
 				<literal value="inherit"/>
 			</literal-list>
 		</attribute>
 
-		<attribute name="overflow" onInvalid="removeAttribute">
-			<literal-list>
-				<literal value="visible"/>
-				<literal value="hidden"/>
-				<literal value="scroll"/>
-				<literal value="auto"/>
-				<literal value="inherit"/>
-			</literal-list>
-		</attribute>
-
-		<attribute name="transform" onInvalid="removeAttribute">
+		<attribute name="text-decoration" onInvalid="removeAttribute">
 			<regexp-list>
-				<regexp name="svgTransformList"/>
+				<regexp value="[a-zA-Z\s\-]+"/>
 			</regexp-list>
 		</attribute>
 
-		<attribute name="clip-path" onInvalid="removeAttribute">
-			<regexp-list>
-				<regexp name="svgLocalRef"/>
-			</regexp-list>
-		</attribute>
-
-		<attribute name="clip-rule" onInvalid="removeAttribute">
-			<literal-list>
-				<literal value="nonzero"/>
-				<literal value="evenodd"/>
-				<literal value="inherit"/>
-			</literal-list>
-		</attribute>
-
-		<attribute name="mask" onInvalid="removeAttribute">
-			<regexp-list>
-				<regexp name="svgLocalRef"/>
-			</regexp-list>
-		</attribute>
-
-		<attribute name="marker-start" onInvalid="removeAttribute">
-			<regexp-list>
-				<regexp name="svgLocalRef"/>
-			</regexp-list>
-		</attribute>
-
-		<attribute name="marker-mid" onInvalid="removeAttribute">
-			<regexp-list>
-				<regexp name="svgLocalRef"/>
-			</regexp-list>
-		</attribute>
-
-		<attribute name="marker-end" onInvalid="removeAttribute">
-			<regexp-list>
-				<regexp name="svgLocalRef"/>
-			</regexp-list>
-		</attribute>
-
-		<attribute name="vector-effect" onInvalid="removeAttribute">
+		<attribute name="text-overflow" onInvalid="removeAttribute">
 			<regexp-list>
 				<regexp name="svgKeyword"/>
 			</regexp-list>
 		</attribute>
 
-		<attribute name="shape-rendering" onInvalid="removeAttribute">
+		<attribute name="text-rendering" onInvalid="removeAttribute">
 			<regexp-list>
 				<regexp name="svgKeyword"/>
-			</regexp-list>
-		</attribute>
-
-		<attribute name="image-rendering" onInvalid="removeAttribute">
-			<regexp-list>
-				<regexp name="svgKeyword"/>
-			</regexp-list>
-		</attribute>
-
-		<attribute name="color-interpolation" onInvalid="removeAttribute">
-			<regexp-list>
-				<regexp name="svgKeyword"/>
-			</regexp-list>
-		</attribute>
-
-		<attribute name="pointer-events" onInvalid="removeAttribute">
-			<regexp-list>
-				<regexp name="svgKeyword"/>
-			</regexp-list>
-		</attribute>
-
-		<attribute name="paint-order" onInvalid="removeAttribute">
-			<regexp-list>
-				<regexp value="[a-zA-Z\s]+"/>
-			</regexp-list>
-		</attribute>
-
-		<attribute name="cursor" onInvalid="removeAttribute">
-			<regexp-list>
-				<regexp name="svgKeyword"/>
-			</regexp-list>
-		</attribute>
-
-		<attribute name="mask-type" onInvalid="removeAttribute">
-			<regexp-list>
-				<regexp name="svgKeyword"/>
-			</regexp-list>
-		</attribute>
-
-		<attribute name="xlink:href" onInvalid="removeAttribute">
-			<regexp-list>
-				<regexp name="svgHrefLocal"/>
-			</regexp-list>
-		</attribute>
-
-		<attribute name="cx" onInvalid="removeAttribute">
-			<regexp-list>
-				<regexp name="svgLength"/>
-			</regexp-list>
-		</attribute>
-
-		<attribute name="cy" onInvalid="removeAttribute">
-			<regexp-list>
-				<regexp name="svgLength"/>
-			</regexp-list>
-		</attribute>
-
-		<attribute name="r" onInvalid="removeAttribute">
-			<regexp-list>
-				<regexp name="svgLength"/>
-			</regexp-list>
-		</attribute>
-
-		<attribute name="rx" onInvalid="removeAttribute">
-			<regexp-list>
-				<regexp name="svgLength"/>
-			</regexp-list>
-		</attribute>
-
-		<attribute name="ry" onInvalid="removeAttribute">
-			<regexp-list>
-				<regexp name="svgLength"/>
-			</regexp-list>
-		</attribute>
-
-		<attribute name="x1" onInvalid="removeAttribute">
-			<regexp-list>
-				<regexp name="svgLength"/>
-			</regexp-list>
-		</attribute>
-
-		<attribute name="y1" onInvalid="removeAttribute">
-			<regexp-list>
-				<regexp name="svgLength"/>
-			</regexp-list>
-		</attribute>
-
-		<attribute name="x2" onInvalid="removeAttribute">
-			<regexp-list>
-				<regexp name="svgLength"/>
-			</regexp-list>
-		</attribute>
-
-		<attribute name="y2" onInvalid="removeAttribute">
-			<regexp-list>
-				<regexp name="svgLength"/>
-			</regexp-list>
-		</attribute>
-
-		<attribute name="points" onInvalid="removeAttribute">
-			<regexp-list>
-				<regexp name="svgNumberList"/>
-			</regexp-list>
-		</attribute>
-
-		<attribute name="gradientUnits" onInvalid="removeAttribute">
-			<literal-list>
-				<literal value="userSpaceOnUse"/>
-				<literal value="objectBoundingBox"/>
-			</literal-list>
-		</attribute>
-
-		<attribute name="gradientunits" onInvalid="removeAttribute">
-			<literal-list>
-				<literal value="userSpaceOnUse"/>
-				<literal value="objectBoundingBox"/>
-			</literal-list>
-		</attribute>
-
-		<attribute name="gradientTransform" onInvalid="removeAttribute">
-			<regexp-list>
-				<regexp name="svgTransformList"/>
-			</regexp-list>
-		</attribute>
-
-		<attribute name="gradienttransform" onInvalid="removeAttribute">
-			<regexp-list>
-				<regexp name="svgTransformList"/>
-			</regexp-list>
-		</attribute>
-
-		<attribute name="spreadMethod" onInvalid="removeAttribute">
-			<literal-list>
-				<literal value="pad"/>
-				<literal value="reflect"/>
-				<literal value="repeat"/>
-			</literal-list>
-		</attribute>
-
-		<attribute name="spreadmethod" onInvalid="removeAttribute">
-			<literal-list>
-				<literal value="pad"/>
-				<literal value="reflect"/>
-				<literal value="repeat"/>
-			</literal-list>
-		</attribute>
-
-		<attribute name="dx" onInvalid="removeAttribute">
-			<regexp-list>
-				<regexp name="svgNumberList"/>
-			</regexp-list>
-		</attribute>
-
-		<attribute name="dy" onInvalid="removeAttribute">
-			<regexp-list>
-				<regexp name="svgNumberList"/>
-			</regexp-list>
-		</attribute>
-
-		<attribute name="rotate" onInvalid="removeAttribute">
-			<regexp-list>
-				<regexp name="svgNumberList"/>
 			</regexp-list>
 		</attribute>
 
@@ -860,118 +907,9 @@ http://www.w3.org/TR/html401/struct/global.html
 			</regexp-list>
 		</attribute>
 
-		<attribute name="lengthAdjust" onInvalid="removeAttribute">
-			<literal-list>
-				<literal value="spacing"/>
-				<literal value="spacingAndGlyphs"/>
-			</literal-list>
-		</attribute>
-
-		<attribute name="lengthadjust" onInvalid="removeAttribute">
-			<literal-list>
-				<literal value="spacing"/>
-				<literal value="spacingAndGlyphs"/>
-			</literal-list>
-		</attribute>
-
-		<attribute name="font-family" onInvalid="removeAttribute">
+		<attribute name="transform" onInvalid="removeAttribute">
 			<regexp-list>
-				<regexp value="[a-zA-Z0-9\s,._\-]+"/>
-			</regexp-list>
-		</attribute>
-
-		<attribute name="font-size" onInvalid="removeAttribute">
-			<regexp-list>
-				<regexp name="svgLength"/>
-			</regexp-list>
-		</attribute>
-
-		<attribute name="font-weight" onInvalid="removeAttribute">
-			<regexp-list>
-				<regexp value="[a-zA-Z0-9]+"/>
-			</regexp-list>
-		</attribute>
-
-		<attribute name="font-style" onInvalid="removeAttribute">
-			<regexp-list>
-				<regexp name="svgKeyword"/>
-			</regexp-list>
-		</attribute>
-
-		<attribute name="font-variant" onInvalid="removeAttribute">
-			<regexp-list>
-				<regexp name="svgKeyword"/>
-			</regexp-list>
-		</attribute>
-
-		<attribute name="font-stretch" onInvalid="removeAttribute">
-			<regexp-list>
-				<regexp name="svgKeyword"/>
-			</regexp-list>
-		</attribute>
-
-		<attribute name="text-anchor" onInvalid="removeAttribute">
-			<literal-list>
-				<literal value="start"/>
-				<literal value="middle"/>
-				<literal value="end"/>
-				<literal value="inherit"/>
-			</literal-list>
-		</attribute>
-
-		<attribute name="dominant-baseline" onInvalid="removeAttribute">
-			<regexp-list>
-				<regexp name="svgKeyword"/>
-			</regexp-list>
-		</attribute>
-
-		<attribute name="alignment-baseline" onInvalid="removeAttribute">
-			<regexp-list>
-				<regexp name="svgKeyword"/>
-			</regexp-list>
-		</attribute>
-
-		<attribute name="baseline-shift" onInvalid="removeAttribute">
-			<regexp-list>
-				<regexp value="[a-zA-Z0-9%.\-]+"/>
-			</regexp-list>
-		</attribute>
-
-		<attribute name="direction" onInvalid="removeAttribute">
-			<literal-list>
-				<literal value="ltr"/>
-				<literal value="rtl"/>
-				<literal value="inherit"/>
-			</literal-list>
-		</attribute>
-
-		<attribute name="letter-spacing" onInvalid="removeAttribute">
-			<regexp-list>
-				<regexp name="svgLength"/>
-			</regexp-list>
-		</attribute>
-
-		<attribute name="word-spacing" onInvalid="removeAttribute">
-			<regexp-list>
-				<regexp name="svgLength"/>
-			</regexp-list>
-		</attribute>
-
-		<attribute name="text-decoration" onInvalid="removeAttribute">
-			<regexp-list>
-				<regexp value="[a-zA-Z\s\-]+"/>
-			</regexp-list>
-		</attribute>
-
-		<attribute name="text-rendering" onInvalid="removeAttribute">
-			<regexp-list>
-				<regexp name="svgKeyword"/>
-			</regexp-list>
-		</attribute>
-
-		<attribute name="writing-mode" onInvalid="removeAttribute">
-			<regexp-list>
-				<regexp name="svgKeyword"/>
+				<regexp name="svgTransformList"/>
 			</regexp-list>
 		</attribute>
 
@@ -981,27 +919,90 @@ http://www.w3.org/TR/html401/struct/global.html
 			</regexp-list>
 		</attribute>
 
+		<attribute name="vector-effect" onInvalid="removeAttribute">
+			<regexp-list>
+				<regexp name="svgKeyword"/>
+			</regexp-list>
+		</attribute>
+
+		<attribute name="viewBox" onInvalid="removeAttribute">
+			<regexp-list>
+				<regexp name="svgViewBox"/>
+			</regexp-list>
+		</attribute>
+
+		<attribute name="viewbox" onInvalid="removeAttribute">
+			<regexp-list>
+				<regexp name="svgViewBox"/>
+			</regexp-list>
+		</attribute>
+
+		<attribute name="visibility" onInvalid="removeAttribute">
+			<literal-list>
+				<literal value="visible"/>
+				<literal value="hidden"/>
+				<literal value="collapse"/>
+				<literal value="inherit"/>
+			</literal-list>
+		</attribute>
+
 		<attribute name="white-space" onInvalid="removeAttribute">
 			<regexp-list>
 				<regexp name="svgKeyword"/>
 			</regexp-list>
 		</attribute>
 
-		<attribute name="text-overflow" onInvalid="removeAttribute">
+		<attribute name="word-spacing" onInvalid="removeAttribute">
+			<regexp-list>
+				<regexp name="svgLength"/>
+			</regexp-list>
+		</attribute>
+
+		<attribute name="writing-mode" onInvalid="removeAttribute">
 			<regexp-list>
 				<regexp name="svgKeyword"/>
 			</regexp-list>
 		</attribute>
 
-		<attribute name="glyph-orientation-horizontal" onInvalid="removeAttribute">
+		<attribute name="x" onInvalid="removeAttribute">
 			<regexp-list>
-				<regexp name="svgKeyword"/>
+				<regexp name="svgLength"/>
 			</regexp-list>
 		</attribute>
 
-		<attribute name="glyph-orientation-vertical" onInvalid="removeAttribute">
+		<attribute name="x1" onInvalid="removeAttribute">
 			<regexp-list>
-				<regexp name="svgKeyword"/>
+				<regexp name="svgLength"/>
+			</regexp-list>
+		</attribute>
+
+		<attribute name="x2" onInvalid="removeAttribute">
+			<regexp-list>
+				<regexp name="svgLength"/>
+			</regexp-list>
+		</attribute>
+
+		<attribute name="xlink:href" onInvalid="removeAttribute">
+			<regexp-list>
+				<regexp name="svgHrefLocal"/>
+			</regexp-list>
+		</attribute>
+
+		<attribute name="y" onInvalid="removeAttribute">
+			<regexp-list>
+				<regexp name="svgLength"/>
+			</regexp-list>
+		</attribute>
+
+		<attribute name="y1" onInvalid="removeAttribute">
+			<regexp-list>
+				<regexp name="svgLength"/>
+			</regexp-list>
+		</attribute>
+
+		<attribute name="y2" onInvalid="removeAttribute">
+			<regexp-list>
+				<regexp name="svgLength"/>
 			</regexp-list>
 		</attribute>
 
@@ -1493,26 +1494,11 @@ http://www.w3.org/TR/html401/struct/global.html
 		<tag name="legend" action="validate"/>
 
 		<tag name="svg" action="validate">
-			<attribute name="viewBox"/>
-			<attribute name="viewbox"/>
-			<attribute name="width" onInvalid="removeAttribute">
-				<regexp-list>
-					<regexp name="svgLength"/>
-				</regexp-list>
-			</attribute>
-			<attribute name="height" onInvalid="removeAttribute">
-				<regexp-list>
-					<regexp name="svgLength"/>
-				</regexp-list>
-			</attribute>
-			<attribute name="x"/>
-			<attribute name="y"/>
-			<attribute name="preserveAspectRatio"/>
-			<attribute name="preserveaspectratio"/>
-			<attribute name="version" onInvalid="removeAttribute">
-				<regexp-list>
-					<regexp value="[0-9.]+"/>
-				</regexp-list>
+			<attribute name="aria-hidden" onInvalid="removeAttribute">
+				<literal-list>
+					<literal value="false"/>
+					<literal value="true"/>
+				</literal-list>
 			</attribute>
 			<attribute name="baseProfile" onInvalid="removeAttribute">
 				<regexp-list>
@@ -1524,6 +1510,69 @@ http://www.w3.org/TR/html401/struct/global.html
 					<regexp name="svgKeyword"/>
 				</regexp-list>
 			</attribute>
+			<attribute name="clip-path"/>
+			<attribute name="clip-rule"/>
+			<attribute name="color"/>
+			<attribute name="color-interpolation"/>
+			<attribute name="cursor"/>
+			<attribute name="display"/>
+			<attribute name="fill"/>
+			<attribute name="fill-opacity"/>
+			<attribute name="fill-rule"/>
+			<attribute name="focusable" onInvalid="removeAttribute">
+				<literal-list>
+					<literal value="auto"/>
+					<literal value="false"/>
+					<literal value="true"/>
+				</literal-list>
+			</attribute>
+			<attribute name="height" onInvalid="removeAttribute">
+				<regexp-list>
+					<regexp name="svgLength"/>
+				</regexp-list>
+			</attribute>
+			<attribute name="image-rendering"/>
+			<attribute name="marker-end"/>
+			<attribute name="marker-mid"/>
+			<attribute name="marker-start"/>
+			<attribute name="mask"/>
+			<attribute name="mask-type"/>
+			<attribute name="opacity"/>
+			<attribute name="overflow"/>
+			<attribute name="paint-order"/>
+			<attribute name="pointer-events"/>
+			<attribute name="preserveAspectRatio"/>
+			<attribute name="preserveaspectratio"/>
+			<attribute name="role" onInvalid="removeAttribute">
+				<regexp-list>
+					<regexp name="svgKeyword"/>
+				</regexp-list>
+			</attribute>
+			<attribute name="shape-rendering"/>
+			<attribute name="stroke"/>
+			<attribute name="stroke-dasharray"/>
+			<attribute name="stroke-dashoffset"/>
+			<attribute name="stroke-linecap"/>
+			<attribute name="stroke-linejoin"/>
+			<attribute name="stroke-miterlimit"/>
+			<attribute name="stroke-opacity"/>
+			<attribute name="stroke-width"/>
+			<attribute name="transform"/>
+			<attribute name="vector-effect"/>
+			<attribute name="version" onInvalid="removeAttribute">
+				<regexp-list>
+					<regexp value="[0-9.]+"/>
+				</regexp-list>
+			</attribute>
+			<attribute name="viewBox"/>
+			<attribute name="viewbox"/>
+			<attribute name="visibility"/>
+			<attribute name="width" onInvalid="removeAttribute">
+				<regexp-list>
+					<regexp name="svgLength"/>
+				</regexp-list>
+			</attribute>
+			<attribute name="x"/>
 			<attribute name="xmlns" onInvalid="removeAttribute">
 				<literal-list>
 					<literal value="http://www.w3.org/2000/svg"/>
@@ -1534,71 +1583,41 @@ http://www.w3.org/TR/html401/struct/global.html
 					<literal value="http://www.w3.org/1999/xlink"/>
 				</literal-list>
 			</attribute>
-			<attribute name="fill"/>
-			<attribute name="fill-opacity"/>
-			<attribute name="fill-rule"/>
-			<attribute name="stroke"/>
-			<attribute name="stroke-width"/>
-			<attribute name="stroke-opacity"/>
-			<attribute name="stroke-linecap"/>
-			<attribute name="stroke-linejoin"/>
-			<attribute name="stroke-dasharray"/>
-			<attribute name="stroke-dashoffset"/>
-			<attribute name="stroke-miterlimit"/>
-			<attribute name="opacity"/>
-			<attribute name="color"/>
-			<attribute name="display"/>
-			<attribute name="visibility"/>
-			<attribute name="overflow"/>
-			<attribute name="transform"/>
-			<attribute name="clip-path"/>
-			<attribute name="clip-rule"/>
-			<attribute name="mask"/>
-			<attribute name="marker-start"/>
-			<attribute name="marker-mid"/>
-			<attribute name="marker-end"/>
-			<attribute name="vector-effect"/>
-			<attribute name="shape-rendering"/>
-			<attribute name="image-rendering"/>
-			<attribute name="color-interpolation"/>
-			<attribute name="pointer-events"/>
-			<attribute name="paint-order"/>
-			<attribute name="cursor"/>
-			<attribute name="mask-type"/>
+			<attribute name="y"/>
 		</tag>
 
 		<tag name="g" action="validate">
+			<attribute name="clip-path"/>
+			<attribute name="clip-rule"/>
+			<attribute name="color"/>
+			<attribute name="color-interpolation"/>
+			<attribute name="cursor"/>
+			<attribute name="display"/>
 			<attribute name="fill"/>
 			<attribute name="fill-opacity"/>
 			<attribute name="fill-rule"/>
+			<attribute name="image-rendering"/>
+			<attribute name="marker-end"/>
+			<attribute name="marker-mid"/>
+			<attribute name="marker-start"/>
+			<attribute name="mask"/>
+			<attribute name="mask-type"/>
+			<attribute name="opacity"/>
+			<attribute name="overflow"/>
+			<attribute name="paint-order"/>
+			<attribute name="pointer-events"/>
+			<attribute name="shape-rendering"/>
 			<attribute name="stroke"/>
-			<attribute name="stroke-width"/>
-			<attribute name="stroke-opacity"/>
-			<attribute name="stroke-linecap"/>
-			<attribute name="stroke-linejoin"/>
 			<attribute name="stroke-dasharray"/>
 			<attribute name="stroke-dashoffset"/>
+			<attribute name="stroke-linecap"/>
+			<attribute name="stroke-linejoin"/>
 			<attribute name="stroke-miterlimit"/>
-			<attribute name="opacity"/>
-			<attribute name="color"/>
-			<attribute name="display"/>
-			<attribute name="visibility"/>
-			<attribute name="overflow"/>
+			<attribute name="stroke-opacity"/>
+			<attribute name="stroke-width"/>
 			<attribute name="transform"/>
-			<attribute name="clip-path"/>
-			<attribute name="clip-rule"/>
-			<attribute name="mask"/>
-			<attribute name="marker-start"/>
-			<attribute name="marker-mid"/>
-			<attribute name="marker-end"/>
 			<attribute name="vector-effect"/>
-			<attribute name="shape-rendering"/>
-			<attribute name="image-rendering"/>
-			<attribute name="color-interpolation"/>
-			<attribute name="pointer-events"/>
-			<attribute name="paint-order"/>
-			<attribute name="cursor"/>
-			<attribute name="mask-type"/>
+			<attribute name="visibility"/>
 		</tag>
 
 		<tag name="defs" action="validate">
@@ -1620,20 +1639,32 @@ http://www.w3.org/TR/html401/struct/global.html
 		</tag>
 
 		<tag name="symbol" action="validate">
-			<attribute name="viewBox"/>
-			<attribute name="viewbox"/>
-			<attribute name="preserveAspectRatio"/>
-			<attribute name="preserveaspectratio"/>
-			<attribute name="width" onInvalid="removeAttribute">
-				<regexp-list>
-					<regexp name="svgLength"/>
-				</regexp-list>
-			</attribute>
+			<attribute name="clip-path"/>
+			<attribute name="clip-rule"/>
+			<attribute name="color"/>
+			<attribute name="color-interpolation"/>
+			<attribute name="cursor"/>
+			<attribute name="display"/>
+			<attribute name="fill"/>
+			<attribute name="fill-opacity"/>
+			<attribute name="fill-rule"/>
 			<attribute name="height" onInvalid="removeAttribute">
 				<regexp-list>
 					<regexp name="svgLength"/>
 				</regexp-list>
 			</attribute>
+			<attribute name="image-rendering"/>
+			<attribute name="marker-end"/>
+			<attribute name="marker-mid"/>
+			<attribute name="marker-start"/>
+			<attribute name="mask"/>
+			<attribute name="mask-type"/>
+			<attribute name="opacity"/>
+			<attribute name="overflow"/>
+			<attribute name="paint-order"/>
+			<attribute name="pointer-events"/>
+			<attribute name="preserveAspectRatio"/>
+			<attribute name="preserveaspectratio"/>
 			<attribute name="refX" onInvalid="removeAttribute">
 				<regexp-list>
 					<regexp name="svgLength"/>
@@ -1654,51 +1685,32 @@ http://www.w3.org/TR/html401/struct/global.html
 					<regexp name="svgLength"/>
 				</regexp-list>
 			</attribute>
-			<attribute name="fill"/>
-			<attribute name="fill-opacity"/>
-			<attribute name="fill-rule"/>
+			<attribute name="shape-rendering"/>
 			<attribute name="stroke"/>
-			<attribute name="stroke-width"/>
-			<attribute name="stroke-opacity"/>
-			<attribute name="stroke-linecap"/>
-			<attribute name="stroke-linejoin"/>
 			<attribute name="stroke-dasharray"/>
 			<attribute name="stroke-dashoffset"/>
+			<attribute name="stroke-linecap"/>
+			<attribute name="stroke-linejoin"/>
 			<attribute name="stroke-miterlimit"/>
-			<attribute name="opacity"/>
-			<attribute name="color"/>
-			<attribute name="display"/>
-			<attribute name="visibility"/>
-			<attribute name="overflow"/>
+			<attribute name="stroke-opacity"/>
+			<attribute name="stroke-width"/>
 			<attribute name="transform"/>
-			<attribute name="clip-path"/>
-			<attribute name="clip-rule"/>
-			<attribute name="mask"/>
-			<attribute name="marker-start"/>
-			<attribute name="marker-mid"/>
-			<attribute name="marker-end"/>
 			<attribute name="vector-effect"/>
-			<attribute name="shape-rendering"/>
-			<attribute name="image-rendering"/>
-			<attribute name="color-interpolation"/>
-			<attribute name="pointer-events"/>
-			<attribute name="paint-order"/>
-			<attribute name="cursor"/>
-			<attribute name="mask-type"/>
+			<attribute name="viewBox"/>
+			<attribute name="viewbox"/>
+			<attribute name="visibility"/>
+			<attribute name="width" onInvalid="removeAttribute">
+				<regexp-list>
+					<regexp name="svgLength"/>
+				</regexp-list>
+			</attribute>
 		</tag>
 
 		<tag name="mask" action="validate">
-			<attribute name="maskUnits" onInvalid="removeAttribute">
-				<literal-list>
-					<literal value="userSpaceOnUse"/>
-					<literal value="objectBoundingBox"/>
-				</literal-list>
-			</attribute>
-			<attribute name="maskunits" onInvalid="removeAttribute">
-				<literal-list>
-					<literal value="userSpaceOnUse"/>
-					<literal value="objectBoundingBox"/>
-				</literal-list>
+			<attribute name="height" onInvalid="removeAttribute">
+				<regexp-list>
+					<regexp name="svgLength"/>
+				</regexp-list>
 			</attribute>
 			<attribute name="maskContentUnits" onInvalid="removeAttribute">
 				<literal-list>
@@ -1712,44 +1724,37 @@ http://www.w3.org/TR/html401/struct/global.html
 					<literal value="objectBoundingBox"/>
 				</literal-list>
 			</attribute>
-			<attribute name="x"/>
-			<attribute name="y"/>
+			<attribute name="maskUnits" onInvalid="removeAttribute">
+				<literal-list>
+					<literal value="userSpaceOnUse"/>
+					<literal value="objectBoundingBox"/>
+				</literal-list>
+			</attribute>
+			<attribute name="maskunits" onInvalid="removeAttribute">
+				<literal-list>
+					<literal value="userSpaceOnUse"/>
+					<literal value="objectBoundingBox"/>
+				</literal-list>
+			</attribute>
 			<attribute name="width" onInvalid="removeAttribute">
 				<regexp-list>
 					<regexp name="svgLength"/>
 				</regexp-list>
 			</attribute>
-			<attribute name="height" onInvalid="removeAttribute">
-				<regexp-list>
-					<regexp name="svgLength"/>
-				</regexp-list>
-			</attribute>
+			<attribute name="x"/>
+			<attribute name="y"/>
 		</tag>
 
 		<tag name="pattern" action="validate">
-			<attribute name="x"/>
-			<attribute name="y"/>
-			<attribute name="width" onInvalid="removeAttribute">
-				<regexp-list>
-					<regexp name="svgLength"/>
-				</regexp-list>
-			</attribute>
 			<attribute name="height" onInvalid="removeAttribute">
 				<regexp-list>
 					<regexp name="svgLength"/>
 				</regexp-list>
 			</attribute>
-			<attribute name="patternUnits" onInvalid="removeAttribute">
-				<literal-list>
-					<literal value="userSpaceOnUse"/>
-					<literal value="objectBoundingBox"/>
-				</literal-list>
-			</attribute>
-			<attribute name="patternunits" onInvalid="removeAttribute">
-				<literal-list>
-					<literal value="userSpaceOnUse"/>
-					<literal value="objectBoundingBox"/>
-				</literal-list>
+			<attribute name="href" onInvalid="removeAttribute">
+				<regexp-list>
+					<regexp name="svgHrefLocal"/>
+				</regexp-list>
 			</attribute>
 			<attribute name="patternContentUnits" onInvalid="removeAttribute">
 				<literal-list>
@@ -1773,26 +1778,42 @@ http://www.w3.org/TR/html401/struct/global.html
 					<regexp name="svgTransformList"/>
 				</regexp-list>
 			</attribute>
-			<attribute name="viewBox"/>
-			<attribute name="viewbox"/>
+			<attribute name="patternUnits" onInvalid="removeAttribute">
+				<literal-list>
+					<literal value="userSpaceOnUse"/>
+					<literal value="objectBoundingBox"/>
+				</literal-list>
+			</attribute>
+			<attribute name="patternunits" onInvalid="removeAttribute">
+				<literal-list>
+					<literal value="userSpaceOnUse"/>
+					<literal value="objectBoundingBox"/>
+				</literal-list>
+			</attribute>
 			<attribute name="preserveAspectRatio"/>
 			<attribute name="preserveaspectratio"/>
-			<attribute name="href" onInvalid="removeAttribute">
-				<regexp-list>
-					<regexp name="svgHrefLocal"/>
-				</regexp-list>
-			</attribute>
-			<attribute name="xlink:href"/>
-		</tag>
-
-		<tag name="use" action="validate">
-			<attribute name="x"/>
-			<attribute name="y"/>
+			<attribute name="viewBox"/>
+			<attribute name="viewbox"/>
 			<attribute name="width" onInvalid="removeAttribute">
 				<regexp-list>
 					<regexp name="svgLength"/>
 				</regexp-list>
 			</attribute>
+			<attribute name="x"/>
+			<attribute name="xlink:href"/>
+			<attribute name="y"/>
+		</tag>
+
+		<tag name="use" action="validate">
+			<attribute name="clip-path"/>
+			<attribute name="clip-rule"/>
+			<attribute name="color"/>
+			<attribute name="color-interpolation"/>
+			<attribute name="cursor"/>
+			<attribute name="display"/>
+			<attribute name="fill"/>
+			<attribute name="fill-opacity"/>
+			<attribute name="fill-rule"/>
 			<attribute name="height" onInvalid="removeAttribute">
 				<regexp-list>
 					<regexp name="svgLength"/>
@@ -1800,49 +1821,69 @@ http://www.w3.org/TR/html401/struct/global.html
 			</attribute>
 			<attribute name="href" onInvalid="removeAttribute">
 				<regexp-list>
-					<regexp name="svgHrefLocal"/>
+					<regexp name="svgHrefSameOrigin"/>
 				</regexp-list>
 			</attribute>
-			<attribute name="xlink:href"/>
-			<attribute name="fill"/>
-			<attribute name="fill-opacity"/>
-			<attribute name="fill-rule"/>
+			<attribute name="image-rendering"/>
+			<attribute name="marker-end"/>
+			<attribute name="marker-mid"/>
+			<attribute name="marker-start"/>
+			<attribute name="mask"/>
+			<attribute name="mask-type"/>
+			<attribute name="opacity"/>
+			<attribute name="overflow"/>
+			<attribute name="paint-order"/>
+			<attribute name="pointer-events"/>
+			<attribute name="shape-rendering"/>
 			<attribute name="stroke"/>
-			<attribute name="stroke-width"/>
-			<attribute name="stroke-opacity"/>
-			<attribute name="stroke-linecap"/>
-			<attribute name="stroke-linejoin"/>
 			<attribute name="stroke-dasharray"/>
 			<attribute name="stroke-dashoffset"/>
+			<attribute name="stroke-linecap"/>
+			<attribute name="stroke-linejoin"/>
 			<attribute name="stroke-miterlimit"/>
-			<attribute name="opacity"/>
-			<attribute name="color"/>
-			<attribute name="display"/>
-			<attribute name="visibility"/>
-			<attribute name="overflow"/>
+			<attribute name="stroke-opacity"/>
+			<attribute name="stroke-width"/>
 			<attribute name="transform"/>
-			<attribute name="clip-path"/>
-			<attribute name="clip-rule"/>
-			<attribute name="mask"/>
-			<attribute name="marker-start"/>
-			<attribute name="marker-mid"/>
-			<attribute name="marker-end"/>
 			<attribute name="vector-effect"/>
-			<attribute name="shape-rendering"/>
-			<attribute name="image-rendering"/>
-			<attribute name="color-interpolation"/>
-			<attribute name="pointer-events"/>
-			<attribute name="paint-order"/>
-			<attribute name="cursor"/>
-			<attribute name="mask-type"/>
+			<attribute name="visibility"/>
+			<attribute name="width" onInvalid="removeAttribute">
+				<regexp-list>
+					<regexp name="svgLength"/>
+				</regexp-list>
+			</attribute>
+			<attribute name="x"/>
+			<attribute name="xlink:href" onInvalid="removeAttribute">
+				<regexp-list>
+					<regexp name="svgHrefSameOrigin"/>
+				</regexp-list>
+			</attribute>
+			<attribute name="y"/>
 		</tag>
 
 		<tag name="path" action="validate">
+			<attribute name="clip-path"/>
+			<attribute name="clip-rule"/>
+			<attribute name="color"/>
+			<attribute name="color-interpolation"/>
+			<attribute name="cursor"/>
 			<attribute name="d" onInvalid="removeAttribute">
 				<regexp-list>
 					<regexp name="svgPathData"/>
 				</regexp-list>
 			</attribute>
+			<attribute name="display"/>
+			<attribute name="fill"/>
+			<attribute name="fill-opacity"/>
+			<attribute name="fill-rule"/>
+			<attribute name="image-rendering"/>
+			<attribute name="marker-end"/>
+			<attribute name="marker-mid"/>
+			<attribute name="marker-start"/>
+			<attribute name="mask"/>
+			<attribute name="mask-type"/>
+			<attribute name="opacity"/>
+			<attribute name="overflow"/>
+			<attribute name="paint-order"/>
 			<attribute name="pathLength" onInvalid="removeAttribute">
 				<regexp-list>
 					<regexp name="number"/>
@@ -1853,293 +1894,279 @@ http://www.w3.org/TR/html401/struct/global.html
 					<regexp name="number"/>
 				</regexp-list>
 			</attribute>
-			<attribute name="fill"/>
-			<attribute name="fill-opacity"/>
-			<attribute name="fill-rule"/>
+			<attribute name="pointer-events"/>
+			<attribute name="shape-rendering"/>
 			<attribute name="stroke"/>
-			<attribute name="stroke-width"/>
-			<attribute name="stroke-opacity"/>
-			<attribute name="stroke-linecap"/>
-			<attribute name="stroke-linejoin"/>
 			<attribute name="stroke-dasharray"/>
 			<attribute name="stroke-dashoffset"/>
+			<attribute name="stroke-linecap"/>
+			<attribute name="stroke-linejoin"/>
 			<attribute name="stroke-miterlimit"/>
-			<attribute name="opacity"/>
-			<attribute name="color"/>
-			<attribute name="display"/>
-			<attribute name="visibility"/>
-			<attribute name="overflow"/>
+			<attribute name="stroke-opacity"/>
+			<attribute name="stroke-width"/>
 			<attribute name="transform"/>
-			<attribute name="clip-path"/>
-			<attribute name="clip-rule"/>
-			<attribute name="mask"/>
-			<attribute name="marker-start"/>
-			<attribute name="marker-mid"/>
-			<attribute name="marker-end"/>
 			<attribute name="vector-effect"/>
-			<attribute name="shape-rendering"/>
-			<attribute name="image-rendering"/>
-			<attribute name="color-interpolation"/>
-			<attribute name="pointer-events"/>
-			<attribute name="paint-order"/>
-			<attribute name="cursor"/>
-			<attribute name="mask-type"/>
+			<attribute name="visibility"/>
 		</tag>
 
 		<tag name="circle" action="validate">
+			<attribute name="clip-path"/>
+			<attribute name="clip-rule"/>
+			<attribute name="color"/>
+			<attribute name="color-interpolation"/>
+			<attribute name="cursor"/>
 			<attribute name="cx"/>
 			<attribute name="cy"/>
-			<attribute name="r"/>
+			<attribute name="display"/>
 			<attribute name="fill"/>
 			<attribute name="fill-opacity"/>
 			<attribute name="fill-rule"/>
+			<attribute name="image-rendering"/>
+			<attribute name="marker-end"/>
+			<attribute name="marker-mid"/>
+			<attribute name="marker-start"/>
+			<attribute name="mask"/>
+			<attribute name="mask-type"/>
+			<attribute name="opacity"/>
+			<attribute name="overflow"/>
+			<attribute name="paint-order"/>
+			<attribute name="pointer-events"/>
+			<attribute name="r"/>
+			<attribute name="shape-rendering"/>
 			<attribute name="stroke"/>
-			<attribute name="stroke-width"/>
-			<attribute name="stroke-opacity"/>
-			<attribute name="stroke-linecap"/>
-			<attribute name="stroke-linejoin"/>
 			<attribute name="stroke-dasharray"/>
 			<attribute name="stroke-dashoffset"/>
+			<attribute name="stroke-linecap"/>
+			<attribute name="stroke-linejoin"/>
 			<attribute name="stroke-miterlimit"/>
-			<attribute name="opacity"/>
-			<attribute name="color"/>
-			<attribute name="display"/>
-			<attribute name="visibility"/>
-			<attribute name="overflow"/>
+			<attribute name="stroke-opacity"/>
+			<attribute name="stroke-width"/>
 			<attribute name="transform"/>
-			<attribute name="clip-path"/>
-			<attribute name="clip-rule"/>
-			<attribute name="mask"/>
-			<attribute name="marker-start"/>
-			<attribute name="marker-mid"/>
-			<attribute name="marker-end"/>
 			<attribute name="vector-effect"/>
-			<attribute name="shape-rendering"/>
-			<attribute name="image-rendering"/>
-			<attribute name="color-interpolation"/>
-			<attribute name="pointer-events"/>
-			<attribute name="paint-order"/>
-			<attribute name="cursor"/>
-			<attribute name="mask-type"/>
+			<attribute name="visibility"/>
 		</tag>
 
 		<tag name="rect" action="validate">
-			<attribute name="x"/>
-			<attribute name="y"/>
-			<attribute name="width" onInvalid="removeAttribute">
-				<regexp-list>
-					<regexp name="svgLength"/>
-				</regexp-list>
-			</attribute>
+			<attribute name="clip-path"/>
+			<attribute name="clip-rule"/>
+			<attribute name="color"/>
+			<attribute name="color-interpolation"/>
+			<attribute name="cursor"/>
+			<attribute name="display"/>
+			<attribute name="fill"/>
+			<attribute name="fill-opacity"/>
+			<attribute name="fill-rule"/>
 			<attribute name="height" onInvalid="removeAttribute">
 				<regexp-list>
 					<regexp name="svgLength"/>
 				</regexp-list>
 			</attribute>
+			<attribute name="image-rendering"/>
+			<attribute name="marker-end"/>
+			<attribute name="marker-mid"/>
+			<attribute name="marker-start"/>
+			<attribute name="mask"/>
+			<attribute name="mask-type"/>
+			<attribute name="opacity"/>
+			<attribute name="overflow"/>
+			<attribute name="paint-order"/>
+			<attribute name="pointer-events"/>
 			<attribute name="rx"/>
 			<attribute name="ry"/>
-			<attribute name="fill"/>
-			<attribute name="fill-opacity"/>
-			<attribute name="fill-rule"/>
+			<attribute name="shape-rendering"/>
 			<attribute name="stroke"/>
-			<attribute name="stroke-width"/>
-			<attribute name="stroke-opacity"/>
-			<attribute name="stroke-linecap"/>
-			<attribute name="stroke-linejoin"/>
 			<attribute name="stroke-dasharray"/>
 			<attribute name="stroke-dashoffset"/>
+			<attribute name="stroke-linecap"/>
+			<attribute name="stroke-linejoin"/>
 			<attribute name="stroke-miterlimit"/>
-			<attribute name="opacity"/>
-			<attribute name="color"/>
-			<attribute name="display"/>
-			<attribute name="visibility"/>
-			<attribute name="overflow"/>
+			<attribute name="stroke-opacity"/>
+			<attribute name="stroke-width"/>
 			<attribute name="transform"/>
-			<attribute name="clip-path"/>
-			<attribute name="clip-rule"/>
-			<attribute name="mask"/>
-			<attribute name="marker-start"/>
-			<attribute name="marker-mid"/>
-			<attribute name="marker-end"/>
 			<attribute name="vector-effect"/>
-			<attribute name="shape-rendering"/>
-			<attribute name="image-rendering"/>
-			<attribute name="color-interpolation"/>
-			<attribute name="pointer-events"/>
-			<attribute name="paint-order"/>
-			<attribute name="cursor"/>
-			<attribute name="mask-type"/>
+			<attribute name="visibility"/>
+			<attribute name="width" onInvalid="removeAttribute">
+				<regexp-list>
+					<regexp name="svgLength"/>
+				</regexp-list>
+			</attribute>
+			<attribute name="x"/>
+			<attribute name="y"/>
 		</tag>
 
 		<tag name="line" action="validate">
-			<attribute name="x1"/>
-			<attribute name="y1"/>
-			<attribute name="x2"/>
-			<attribute name="y2"/>
+			<attribute name="clip-path"/>
+			<attribute name="clip-rule"/>
+			<attribute name="color"/>
+			<attribute name="color-interpolation"/>
+			<attribute name="cursor"/>
+			<attribute name="display"/>
 			<attribute name="fill"/>
 			<attribute name="fill-opacity"/>
 			<attribute name="fill-rule"/>
+			<attribute name="image-rendering"/>
+			<attribute name="marker-end"/>
+			<attribute name="marker-mid"/>
+			<attribute name="marker-start"/>
+			<attribute name="mask"/>
+			<attribute name="mask-type"/>
+			<attribute name="opacity"/>
+			<attribute name="overflow"/>
+			<attribute name="paint-order"/>
+			<attribute name="pointer-events"/>
+			<attribute name="shape-rendering"/>
 			<attribute name="stroke"/>
-			<attribute name="stroke-width"/>
-			<attribute name="stroke-opacity"/>
-			<attribute name="stroke-linecap"/>
-			<attribute name="stroke-linejoin"/>
 			<attribute name="stroke-dasharray"/>
 			<attribute name="stroke-dashoffset"/>
+			<attribute name="stroke-linecap"/>
+			<attribute name="stroke-linejoin"/>
 			<attribute name="stroke-miterlimit"/>
-			<attribute name="opacity"/>
-			<attribute name="color"/>
-			<attribute name="display"/>
-			<attribute name="visibility"/>
-			<attribute name="overflow"/>
+			<attribute name="stroke-opacity"/>
+			<attribute name="stroke-width"/>
 			<attribute name="transform"/>
-			<attribute name="clip-path"/>
-			<attribute name="clip-rule"/>
-			<attribute name="mask"/>
-			<attribute name="marker-start"/>
-			<attribute name="marker-mid"/>
-			<attribute name="marker-end"/>
 			<attribute name="vector-effect"/>
-			<attribute name="shape-rendering"/>
-			<attribute name="image-rendering"/>
-			<attribute name="color-interpolation"/>
-			<attribute name="pointer-events"/>
-			<attribute name="paint-order"/>
-			<attribute name="cursor"/>
-			<attribute name="mask-type"/>
+			<attribute name="visibility"/>
+			<attribute name="x1"/>
+			<attribute name="x2"/>
+			<attribute name="y1"/>
+			<attribute name="y2"/>
 		</tag>
 
 		<tag name="polyline" action="validate">
-			<attribute name="points"/>
+			<attribute name="clip-path"/>
+			<attribute name="clip-rule"/>
+			<attribute name="color"/>
+			<attribute name="color-interpolation"/>
+			<attribute name="cursor"/>
+			<attribute name="display"/>
 			<attribute name="fill"/>
 			<attribute name="fill-opacity"/>
 			<attribute name="fill-rule"/>
+			<attribute name="image-rendering"/>
+			<attribute name="marker-end"/>
+			<attribute name="marker-mid"/>
+			<attribute name="marker-start"/>
+			<attribute name="mask"/>
+			<attribute name="mask-type"/>
+			<attribute name="opacity"/>
+			<attribute name="overflow"/>
+			<attribute name="paint-order"/>
+			<attribute name="pointer-events"/>
+			<attribute name="points"/>
+			<attribute name="shape-rendering"/>
 			<attribute name="stroke"/>
-			<attribute name="stroke-width"/>
-			<attribute name="stroke-opacity"/>
-			<attribute name="stroke-linecap"/>
-			<attribute name="stroke-linejoin"/>
 			<attribute name="stroke-dasharray"/>
 			<attribute name="stroke-dashoffset"/>
+			<attribute name="stroke-linecap"/>
+			<attribute name="stroke-linejoin"/>
 			<attribute name="stroke-miterlimit"/>
-			<attribute name="opacity"/>
-			<attribute name="color"/>
-			<attribute name="display"/>
-			<attribute name="visibility"/>
-			<attribute name="overflow"/>
+			<attribute name="stroke-opacity"/>
+			<attribute name="stroke-width"/>
 			<attribute name="transform"/>
-			<attribute name="clip-path"/>
-			<attribute name="clip-rule"/>
-			<attribute name="mask"/>
-			<attribute name="marker-start"/>
-			<attribute name="marker-mid"/>
-			<attribute name="marker-end"/>
 			<attribute name="vector-effect"/>
-			<attribute name="shape-rendering"/>
-			<attribute name="image-rendering"/>
-			<attribute name="color-interpolation"/>
-			<attribute name="pointer-events"/>
-			<attribute name="paint-order"/>
-			<attribute name="cursor"/>
-			<attribute name="mask-type"/>
+			<attribute name="visibility"/>
 		</tag>
 
 		<tag name="polygon" action="validate">
-			<attribute name="points"/>
+			<attribute name="clip-path"/>
+			<attribute name="clip-rule"/>
+			<attribute name="color"/>
+			<attribute name="color-interpolation"/>
+			<attribute name="cursor"/>
+			<attribute name="display"/>
 			<attribute name="fill"/>
 			<attribute name="fill-opacity"/>
 			<attribute name="fill-rule"/>
+			<attribute name="image-rendering"/>
+			<attribute name="marker-end"/>
+			<attribute name="marker-mid"/>
+			<attribute name="marker-start"/>
+			<attribute name="mask"/>
+			<attribute name="mask-type"/>
+			<attribute name="opacity"/>
+			<attribute name="overflow"/>
+			<attribute name="paint-order"/>
+			<attribute name="pointer-events"/>
+			<attribute name="points"/>
+			<attribute name="shape-rendering"/>
 			<attribute name="stroke"/>
-			<attribute name="stroke-width"/>
-			<attribute name="stroke-opacity"/>
-			<attribute name="stroke-linecap"/>
-			<attribute name="stroke-linejoin"/>
 			<attribute name="stroke-dasharray"/>
 			<attribute name="stroke-dashoffset"/>
+			<attribute name="stroke-linecap"/>
+			<attribute name="stroke-linejoin"/>
 			<attribute name="stroke-miterlimit"/>
-			<attribute name="opacity"/>
-			<attribute name="color"/>
-			<attribute name="display"/>
-			<attribute name="visibility"/>
-			<attribute name="overflow"/>
+			<attribute name="stroke-opacity"/>
+			<attribute name="stroke-width"/>
 			<attribute name="transform"/>
-			<attribute name="clip-path"/>
-			<attribute name="clip-rule"/>
-			<attribute name="mask"/>
-			<attribute name="marker-start"/>
-			<attribute name="marker-mid"/>
-			<attribute name="marker-end"/>
 			<attribute name="vector-effect"/>
-			<attribute name="shape-rendering"/>
-			<attribute name="image-rendering"/>
-			<attribute name="color-interpolation"/>
-			<attribute name="pointer-events"/>
-			<attribute name="paint-order"/>
-			<attribute name="cursor"/>
-			<attribute name="mask-type"/>
+			<attribute name="visibility"/>
 		</tag>
 
 		<tag name="ellipse" action="validate">
+			<attribute name="clip-path"/>
+			<attribute name="clip-rule"/>
+			<attribute name="color"/>
+			<attribute name="color-interpolation"/>
+			<attribute name="cursor"/>
 			<attribute name="cx"/>
 			<attribute name="cy"/>
-			<attribute name="rx"/>
-			<attribute name="ry"/>
+			<attribute name="display"/>
 			<attribute name="fill"/>
 			<attribute name="fill-opacity"/>
 			<attribute name="fill-rule"/>
+			<attribute name="image-rendering"/>
+			<attribute name="marker-end"/>
+			<attribute name="marker-mid"/>
+			<attribute name="marker-start"/>
+			<attribute name="mask"/>
+			<attribute name="mask-type"/>
+			<attribute name="opacity"/>
+			<attribute name="overflow"/>
+			<attribute name="paint-order"/>
+			<attribute name="pointer-events"/>
+			<attribute name="rx"/>
+			<attribute name="ry"/>
+			<attribute name="shape-rendering"/>
 			<attribute name="stroke"/>
-			<attribute name="stroke-width"/>
-			<attribute name="stroke-opacity"/>
-			<attribute name="stroke-linecap"/>
-			<attribute name="stroke-linejoin"/>
 			<attribute name="stroke-dasharray"/>
 			<attribute name="stroke-dashoffset"/>
+			<attribute name="stroke-linecap"/>
+			<attribute name="stroke-linejoin"/>
 			<attribute name="stroke-miterlimit"/>
-			<attribute name="opacity"/>
-			<attribute name="color"/>
-			<attribute name="display"/>
-			<attribute name="visibility"/>
-			<attribute name="overflow"/>
+			<attribute name="stroke-opacity"/>
+			<attribute name="stroke-width"/>
 			<attribute name="transform"/>
-			<attribute name="clip-path"/>
-			<attribute name="clip-rule"/>
-			<attribute name="mask"/>
-			<attribute name="marker-start"/>
-			<attribute name="marker-mid"/>
-			<attribute name="marker-end"/>
 			<attribute name="vector-effect"/>
-			<attribute name="shape-rendering"/>
-			<attribute name="image-rendering"/>
-			<attribute name="color-interpolation"/>
-			<attribute name="pointer-events"/>
-			<attribute name="paint-order"/>
-			<attribute name="cursor"/>
-			<attribute name="mask-type"/>
+			<attribute name="visibility"/>
 		</tag>
 
 		<tag name="lineargradient" action="validate">
-			<attribute name="x1"/>
-			<attribute name="y1"/>
-			<attribute name="x2"/>
-			<attribute name="y2"/>
-			<attribute name="gradientUnits"/>
-			<attribute name="gradientunits"/>
 			<attribute name="gradientTransform"/>
 			<attribute name="gradienttransform"/>
-			<attribute name="spreadMethod"/>
-			<attribute name="spreadmethod"/>
+			<attribute name="gradientUnits"/>
+			<attribute name="gradientunits"/>
 			<attribute name="href" onInvalid="removeAttribute">
 				<regexp-list>
 					<regexp name="svgHrefLocal"/>
 				</regexp-list>
 			</attribute>
+			<attribute name="spreadMethod"/>
+			<attribute name="spreadmethod"/>
+			<attribute name="x1"/>
+			<attribute name="x2"/>
 			<attribute name="xlink:href"/>
+			<attribute name="y1"/>
+			<attribute name="y2"/>
 		</tag>
 
 		<tag name="radialgradient" action="validate">
 			<attribute name="cx"/>
 			<attribute name="cy"/>
-			<attribute name="r"/>
+			<attribute name="fr" onInvalid="removeAttribute">
+				<regexp-list>
+					<regexp name="svgLength"/>
+				</regexp-list>
+			</attribute>
 			<attribute name="fx" onInvalid="removeAttribute">
 				<regexp-list>
 					<regexp name="svgLength"/>
@@ -2150,22 +2177,18 @@ http://www.w3.org/TR/html401/struct/global.html
 					<regexp name="svgLength"/>
 				</regexp-list>
 			</attribute>
-			<attribute name="fr" onInvalid="removeAttribute">
-				<regexp-list>
-					<regexp name="svgLength"/>
-				</regexp-list>
-			</attribute>
-			<attribute name="gradientUnits"/>
-			<attribute name="gradientunits"/>
 			<attribute name="gradientTransform"/>
 			<attribute name="gradienttransform"/>
-			<attribute name="spreadMethod"/>
-			<attribute name="spreadmethod"/>
+			<attribute name="gradientUnits"/>
+			<attribute name="gradientunits"/>
 			<attribute name="href" onInvalid="removeAttribute">
 				<regexp-list>
 					<regexp name="svgHrefLocal"/>
 				</regexp-list>
 			</attribute>
+			<attribute name="r"/>
+			<attribute name="spreadMethod"/>
+			<attribute name="spreadmethod"/>
 			<attribute name="xlink:href"/>
 		</tag>
 
@@ -2188,131 +2211,131 @@ http://www.w3.org/TR/html401/struct/global.html
 		</tag>
 
 		<tag name="text" action="validate">
-			<attribute name="x"/>
-			<attribute name="y"/>
+			<attribute name="alignment-baseline"/>
+			<attribute name="baseline-shift"/>
+			<attribute name="clip-path"/>
+			<attribute name="clip-rule"/>
+			<attribute name="color"/>
+			<attribute name="color-interpolation"/>
+			<attribute name="cursor"/>
+			<attribute name="direction"/>
+			<attribute name="display"/>
+			<attribute name="dominant-baseline"/>
 			<attribute name="dx"/>
 			<attribute name="dy"/>
-			<attribute name="rotate"/>
-			<attribute name="textLength"/>
-			<attribute name="textlength"/>
-			<attribute name="lengthAdjust"/>
-			<attribute name="lengthadjust"/>
 			<attribute name="fill"/>
 			<attribute name="fill-opacity"/>
 			<attribute name="fill-rule"/>
-			<attribute name="stroke"/>
-			<attribute name="stroke-width"/>
-			<attribute name="stroke-opacity"/>
-			<attribute name="stroke-linecap"/>
-			<attribute name="stroke-linejoin"/>
-			<attribute name="stroke-dasharray"/>
-			<attribute name="stroke-dashoffset"/>
-			<attribute name="stroke-miterlimit"/>
-			<attribute name="opacity"/>
-			<attribute name="color"/>
-			<attribute name="display"/>
-			<attribute name="visibility"/>
-			<attribute name="overflow"/>
-			<attribute name="transform"/>
-			<attribute name="clip-path"/>
-			<attribute name="clip-rule"/>
-			<attribute name="mask"/>
-			<attribute name="marker-start"/>
-			<attribute name="marker-mid"/>
-			<attribute name="marker-end"/>
-			<attribute name="vector-effect"/>
-			<attribute name="shape-rendering"/>
-			<attribute name="image-rendering"/>
-			<attribute name="color-interpolation"/>
-			<attribute name="pointer-events"/>
-			<attribute name="paint-order"/>
-			<attribute name="cursor"/>
-			<attribute name="mask-type"/>
 			<attribute name="font-family"/>
 			<attribute name="font-size"/>
-			<attribute name="font-weight"/>
+			<attribute name="font-stretch"/>
 			<attribute name="font-style"/>
 			<attribute name="font-variant"/>
-			<attribute name="font-stretch"/>
-			<attribute name="text-anchor"/>
-			<attribute name="dominant-baseline"/>
-			<attribute name="alignment-baseline"/>
-			<attribute name="baseline-shift"/>
-			<attribute name="direction"/>
-			<attribute name="letter-spacing"/>
-			<attribute name="word-spacing"/>
-			<attribute name="text-decoration"/>
-			<attribute name="text-rendering"/>
-			<attribute name="writing-mode"/>
-			<attribute name="unicode-bidi"/>
-			<attribute name="white-space"/>
-			<attribute name="text-overflow"/>
+			<attribute name="font-weight"/>
 			<attribute name="glyph-orientation-horizontal"/>
 			<attribute name="glyph-orientation-vertical"/>
+			<attribute name="image-rendering"/>
+			<attribute name="lengthAdjust"/>
+			<attribute name="lengthadjust"/>
+			<attribute name="letter-spacing"/>
+			<attribute name="marker-end"/>
+			<attribute name="marker-mid"/>
+			<attribute name="marker-start"/>
+			<attribute name="mask"/>
+			<attribute name="mask-type"/>
+			<attribute name="opacity"/>
+			<attribute name="overflow"/>
+			<attribute name="paint-order"/>
+			<attribute name="pointer-events"/>
+			<attribute name="rotate"/>
+			<attribute name="shape-rendering"/>
+			<attribute name="stroke"/>
+			<attribute name="stroke-dasharray"/>
+			<attribute name="stroke-dashoffset"/>
+			<attribute name="stroke-linecap"/>
+			<attribute name="stroke-linejoin"/>
+			<attribute name="stroke-miterlimit"/>
+			<attribute name="stroke-opacity"/>
+			<attribute name="stroke-width"/>
+			<attribute name="text-anchor"/>
+			<attribute name="text-decoration"/>
+			<attribute name="text-overflow"/>
+			<attribute name="text-rendering"/>
+			<attribute name="textLength"/>
+			<attribute name="textlength"/>
+			<attribute name="transform"/>
+			<attribute name="unicode-bidi"/>
+			<attribute name="vector-effect"/>
+			<attribute name="visibility"/>
+			<attribute name="white-space"/>
+			<attribute name="word-spacing"/>
+			<attribute name="writing-mode"/>
+			<attribute name="x"/>
+			<attribute name="y"/>
 		</tag>
 
 		<tag name="tspan" action="validate">
-			<attribute name="x"/>
-			<attribute name="y"/>
+			<attribute name="alignment-baseline"/>
+			<attribute name="baseline-shift"/>
+			<attribute name="clip-path"/>
+			<attribute name="clip-rule"/>
+			<attribute name="color"/>
+			<attribute name="color-interpolation"/>
+			<attribute name="cursor"/>
+			<attribute name="direction"/>
+			<attribute name="display"/>
+			<attribute name="dominant-baseline"/>
 			<attribute name="dx"/>
 			<attribute name="dy"/>
-			<attribute name="rotate"/>
-			<attribute name="textLength"/>
-			<attribute name="textlength"/>
-			<attribute name="lengthAdjust"/>
-			<attribute name="lengthadjust"/>
 			<attribute name="fill"/>
 			<attribute name="fill-opacity"/>
 			<attribute name="fill-rule"/>
-			<attribute name="stroke"/>
-			<attribute name="stroke-width"/>
-			<attribute name="stroke-opacity"/>
-			<attribute name="stroke-linecap"/>
-			<attribute name="stroke-linejoin"/>
-			<attribute name="stroke-dasharray"/>
-			<attribute name="stroke-dashoffset"/>
-			<attribute name="stroke-miterlimit"/>
-			<attribute name="opacity"/>
-			<attribute name="color"/>
-			<attribute name="display"/>
-			<attribute name="visibility"/>
-			<attribute name="overflow"/>
-			<attribute name="transform"/>
-			<attribute name="clip-path"/>
-			<attribute name="clip-rule"/>
-			<attribute name="mask"/>
-			<attribute name="marker-start"/>
-			<attribute name="marker-mid"/>
-			<attribute name="marker-end"/>
-			<attribute name="vector-effect"/>
-			<attribute name="shape-rendering"/>
-			<attribute name="image-rendering"/>
-			<attribute name="color-interpolation"/>
-			<attribute name="pointer-events"/>
-			<attribute name="paint-order"/>
-			<attribute name="cursor"/>
-			<attribute name="mask-type"/>
 			<attribute name="font-family"/>
 			<attribute name="font-size"/>
-			<attribute name="font-weight"/>
+			<attribute name="font-stretch"/>
 			<attribute name="font-style"/>
 			<attribute name="font-variant"/>
-			<attribute name="font-stretch"/>
-			<attribute name="text-anchor"/>
-			<attribute name="dominant-baseline"/>
-			<attribute name="alignment-baseline"/>
-			<attribute name="baseline-shift"/>
-			<attribute name="direction"/>
-			<attribute name="letter-spacing"/>
-			<attribute name="word-spacing"/>
-			<attribute name="text-decoration"/>
-			<attribute name="text-rendering"/>
-			<attribute name="writing-mode"/>
-			<attribute name="unicode-bidi"/>
-			<attribute name="white-space"/>
-			<attribute name="text-overflow"/>
+			<attribute name="font-weight"/>
 			<attribute name="glyph-orientation-horizontal"/>
 			<attribute name="glyph-orientation-vertical"/>
+			<attribute name="image-rendering"/>
+			<attribute name="lengthAdjust"/>
+			<attribute name="lengthadjust"/>
+			<attribute name="letter-spacing"/>
+			<attribute name="marker-end"/>
+			<attribute name="marker-mid"/>
+			<attribute name="marker-start"/>
+			<attribute name="mask"/>
+			<attribute name="mask-type"/>
+			<attribute name="opacity"/>
+			<attribute name="overflow"/>
+			<attribute name="paint-order"/>
+			<attribute name="pointer-events"/>
+			<attribute name="rotate"/>
+			<attribute name="shape-rendering"/>
+			<attribute name="stroke"/>
+			<attribute name="stroke-dasharray"/>
+			<attribute name="stroke-dashoffset"/>
+			<attribute name="stroke-linecap"/>
+			<attribute name="stroke-linejoin"/>
+			<attribute name="stroke-miterlimit"/>
+			<attribute name="stroke-opacity"/>
+			<attribute name="stroke-width"/>
+			<attribute name="text-anchor"/>
+			<attribute name="text-decoration"/>
+			<attribute name="text-overflow"/>
+			<attribute name="text-rendering"/>
+			<attribute name="textLength"/>
+			<attribute name="textlength"/>
+			<attribute name="transform"/>
+			<attribute name="unicode-bidi"/>
+			<attribute name="vector-effect"/>
+			<attribute name="visibility"/>
+			<attribute name="white-space"/>
+			<attribute name="word-spacing"/>
+			<attribute name="writing-mode"/>
+			<attribute name="x"/>
+			<attribute name="y"/>
 		</tag>
 
 		<tag name="title" action="validate">


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101550

## What Is Being Fixed

An inline SVG placed in a fragment link editable field came back from the sanitizer stripped of two things it needs to render.

A Clay sprite reference such as `<use href="/o/frontend-icons/icons.svg#add">` lost its `href` entirely. The fragment policy gated that attribute with the `svgHrefLocal` regexp, which accepts only a bare `#id` fragment, so any reference naming the sprite file was removed and the icon rendered empty. The `xlink:href` counterpart on the same element was declared with no regexp at all, so it was accepted unconditionally, cross origin references included.

The accessibility attributes of an inline SVG were removed on every sanitized surface. `role`, `aria-hidden` and `focusable` are declared neither in the fragment policy nor in AntiSamy's own default policy, so a decorative icon lost the very attributes that hide it from a screen reader.

## How It Is Being Fixed

A new `svgHrefSameOrigin` regexp accepts either a local fragment identifier or a same origin path ending in `.svg#id`, and it now gates both `href` and `xlink:href` on the `use` element. That restores the sprite reference and, on the `xlink:href` side, tightens an attribute that previously had no validation: the cross origin and protocol relative forms are still dropped.

`aria-hidden` and `focusable` are declared on the `svg` tag against literal lists, and `role` against the existing `svgKeyword` regexp. All three carry `onInvalid="removeAttribute"`, so an unexpected value costs the attribute rather than the element.

The policy XML is generated by the `processFragmentSanitizerConfiguration` task, so every edit lives in `_filterFragmentSanitizer` in the module's `build.gradle` and the regenerated file is committed on its own.

Following review feedback, the attribute names of the SVG tag rules are now sorted. They had been grouped by declaration shape, with the entries carrying a regexp or literal list ahead of the bare self closing ones, which hid the order of both groups. The sort interleaves the two shapes and is behaviour neutral: AntiSamy keys attributes by name, and the regenerated policy is identical to the reviewed one under an order insensitive comparison of its XML tree.

`FragmentEntryLinkModelListenerTest` covers the sprite reference, the accessibility attributes and the sanitizing of a script inside an inline SVG.

## PR Check

**pr-check: SKIPPED** — Baseline fails on a semantic versioning defect that predates this branch and that it cannot fix: the `headless-cms-api` `resource/v1_0` packageinfo reads 3.1.0 against a released 3.0.0 with an UNCHANGED delta, landed by aed5313800a5c under LPD-97871. The other six matched validations passed: Source Format, Transaction Usage, Per-Module Compile, Integration Test Compile, Structural Smoke and Java Unit Tests.

<!-- pr-check {"reason": "Baseline fails on a semantic versioning defect that predates this branch and that it cannot fix: the headless-cms-api resource/v1_0 packageinfo reads 3.1.0 against a released 3.0.0 with an UNCHANGED delta, landed by aed5313800a5c under LPD-97871. The other six matched validations passed.", "result": "skipped", "sha": "e0b04ba8c9cbd21929a7c2096ae94aada5a98922"} -->
