### PR TITLE
LPD-103271 Separate CI stability from the learn resources server's health

### DIFF
--- a/modules/apps/learn/learn-test/bnd.bnd
+++ b/modules/apps/learn/learn-test/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Liferay Learn Test
+Bundle-SymbolicName: com.liferay.learn.test
+Bundle-Version: 1.0.0

--- a/modules/apps/learn/learn-test/build.gradle
+++ b/modules/apps/learn/learn-test/build.gradle
@@ -1,0 +1,4 @@
+dependencies {
+	testIntegrationImplementation project(":apps:learn:learn-api")
+	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
+}

--- a/modules/apps/learn/learn-test/src/testIntegration/java/com/liferay/learn/test/LearnResourcesTest.java
+++ b/modules/apps/learn/learn-test/src/testIntegration/java/com/liferay/learn/test/LearnResourcesTest.java
@@ -1,0 +1,65 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.learn.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.learn.LearnMessageUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Shuyang Zhou
+ */
+@RunWith(Arquillian.class)
+public class LearnResourcesTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testGlobalServerServesLearnResources() throws Exception {
+
+		// Every learn message in the product renders from the resource files
+		// this global server serves, so when it stops serving them, learn
+		// links silently vanish portal wide. Guard the server itself here
+		// instead of leaving its outages to surface as unrelated UI test
+		// failures.
+
+		Http.Options options = new Http.Options();
+
+		options.setLocation(
+			"https://s3.amazonaws.com/learn-resources.liferay.com" +
+				"/marketplace-store-web.json");
+
+		String body = _http.URLtoString(options);
+
+		Http.Response response = options.getResponse();
+
+		Assert.assertEquals(body, 200, response.getResponseCode());
+
+		JSONObject jsonObject = LearnMessageUtil.getJSONObject(
+			"marketplace-store-web");
+
+		Assert.assertTrue(
+			jsonObject.toString(),
+			jsonObject.keys(
+			).hasNext());
+	}
+
+	@Inject
+	private Http _http;
+
+}

--- a/modules/test/playwright/env/common.sh
+++ b/modules/test/playwright/env/common.sh
@@ -93,6 +93,8 @@ function combine_properties_files {
 function default_set_up {
 	update_portal_ext_properties
 
+	start_learn_resources_server
+
 	start_default_app_server
 
 	deploy_parent_project_osgi_modules
@@ -114,6 +116,8 @@ function default_set_up {
 
 function default_tear_down {
 	stop_default_app_server
+
+	stop_learn_resources_server
 }
 
 function delete_property {
@@ -644,6 +648,79 @@ function start_client_extension_spring_boot_application {
 	else
 		echo "The directory ${client_extension_dir} does not exist."
 	fi
+}
+
+function start_learn_resources_server {
+
+	# The portal resolves learn resources over HTTP, and with
+	# learn.resources.mode=dev it asks its own host on port 3062. Serve the
+	# repository's copies from here, where the app server runs, with the
+	# JDK's own static file server: this script's environment carries a JDK
+	# by construction, while node only exists inside the test runner's
+	# container, whose localhost the portal cannot reach.
+
+	local jwebserver=$(command -v jwebserver)
+
+	if [[ -z ${jwebserver} ]]
+	then
+		local java=$(command -v java)
+
+		if [[ -n ${java} ]]
+		then
+			jwebserver="$(dirname "$(readlink -f "${java}")")/jwebserver"
+		fi
+	fi
+
+	if [[ ! -x ${jwebserver} ]]
+	then
+		echo "Unable to find jwebserver."
+
+		exit 1
+	fi
+
+	local learn_resources_dir=${_PORTAL_PROJECT_DIR}/learn-resources/data
+
+	if [[ ! -d ${learn_resources_dir} ]]
+	then
+		echo "Unable to find ${learn_resources_dir}."
+
+		exit 1
+	fi
+
+	${jwebserver} -b 127.0.0.1 -d "${learn_resources_dir}" -p 3062 &
+
+	echo ${!} > /tmp/learn-resources-server.pid
+
+	local sleep_duration=30
+	local sleep_interval=1
+	local total_duration=0
+
+	while ! curl --fail --output /dev/null --silent "http://localhost:3062/object-web.json"
+	do
+		if [ ${total_duration} -ge ${sleep_duration} ]
+		then
+			echo "Unable to start the learn resources server."
+
+			exit 1
+		fi
+
+		sleep ${sleep_interval}
+
+		total_duration=$((total_duration + sleep_interval))
+	done
+
+	echo "Started the learn resources server on port 3062."
+}
+
+function stop_learn_resources_server {
+	if [[ ! -f /tmp/learn-resources-server.pid ]]
+	then
+		return 0
+	fi
+
+	kill $(cat /tmp/learn-resources-server.pid) 2>/dev/null
+
+	rm -f /tmp/learn-resources-server.pid
 }
 
 function start_default_app_server {

--- a/modules/test/playwright/env/portal-ext.properties
+++ b/modules/test/playwright/env/portal-ext.properties
@@ -8,6 +8,7 @@ setup.wizard.enabled=false
 virtual.hosts.default.site.name=
 virtual.hosts.valid.hosts=*
 web.server.http.port=8080
+learn.resources.mode=dev
 
 captcha.enforce.disabled=true
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103271

## What Is Being Fixed

Three object suite Playwright tests assert the Learn more documentation links, and those links render only when the portal's server side fetch of the learn resource files from the global server at `s3.amazonaws.com/learn-resources.liferay.com` succeeds. On August 19 that server began answering `403 AccessDenied` (a hard flip between two builds ninety minutes apart, still ongoing, and reproduced by the master routine itself), the links vanished portal wide, and the three tests turned every `ci:test:object` run red.

That one signal entangled two different problems:

- a **production usability problem**: learn links silently disappear on every portal in default mode once the four hour cache expires, with the fetch failure swallowed at debug level, so nothing reports it;
- a **CI stability problem**: the object suite's outcome depended on an external service that no object commit can fix, so its red could not be trusted as a signal about the code under test.

## How It Is Being Fixed

The two problems are separated and each gets its own owner.

- **Production usability** gets a dedicated guard: the new `learn-test` module's `LearnResourcesTest` asserts the global server answers 200 with usable JSON and surfaces the server's own error body in the assertion when it does not. It runs in the learn module's own lane (learn changes and the master routines), so an outage of the server reads as exactly one clearly named failure where the learn machinery lives — instead of as unrelated UI test failures scattered through other suites. It is red right now, on purpose: it is reporting the live outage.
- **CI stability** stops depending on the mirror: the Playwright environment serves the repository's own `learn-resources/data` files from a local web server in the product's documented dev mode. Those files are the authored source of the mirror's content (every change to them is a feature commit, and the docs team fixes links there too), so the suite renders learn links from data versioned with the code under test and stays green regardless of the mirror's health.

## PR Check

**pr-check: PASS** — tested on `0b348459e1274930695520b68bd2cec2c8c75c4e`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | PASS |

Source Format ran with commit message validation. Structural Smoke ran `ModulesStructureTest` (8 of 8) for the new `learn-test` module. The module is test-only, so there is no deployable compile or baseline surface; the guard test itself was additionally executed against the live outage and fails with the server's `AccessDenied` body in the assertion, which is its intended behavior until the server recovers.

<!-- pr-check {"result": "success", "sha": "0b348459e1274930695520b68bd2cec2c8c75c4e"} -->
