### PR TITLE
LPD-103280 Own the notifications profile menu walk

### DIFF
--- a/modules/test/playwright/tests/mcp-server-web/main/profiles.spec.ts
+++ b/modules/test/playwright/tests/mcp-server-web/main/profiles.spec.ts
@@ -100,6 +100,7 @@ async function createDataMask(
 
 createFDSTableTests(test, {
 	columns: ['Title', 'Path', 'Description', 'Last Modified'],
+	name: 'Profiles',
 	rowActions: ['Edit', 'Delete'],
 	sortOptions: ['Title', 'Last Modified'],
 	tag: '@LPD-99230',

--- a/modules/test/playwright/tests/notifications-web/main/pages/NotificationsPage.ts
+++ b/modules/test/playwright/tests/notifications-web/main/pages/NotificationsPage.ts
@@ -5,6 +5,8 @@
 
 import {Locator, Page} from '@playwright/test';
 
+import {clickAndExpectToBeVisible} from '../../../../utils/clickAndExpectToBeVisible';
+
 export class NotificationsPage {
 	readonly page: Page;
 	readonly backButton: Locator;
@@ -56,15 +58,27 @@ export class NotificationsPage {
 	}
 
 	async goto(userName: string = 'Test Test') {
-		await this.page.getByLabel(`${userName} User Profile`).click();
 
 		// The control panel sidebar can hold a menu item also named
 		// Notifications, the push notifications portlet's entry, so stay
-		// inside the dropdown this click just opened.
+		// inside the profile dropdown. A click dispatched before the
+		// dropdown's scripts attach opens nothing, so click until the
+		// dropdown holds the item about to be used.
 
-		await this.page
+		const notificationsMenuItem = this.page
 			.locator('.dropdown-menu.show')
-			.getByRole('menuitem', {name: 'Notifications'})
-			.click();
+			.getByRole('menuitem', {name: 'Notifications'});
+
+		await clickAndExpectToBeVisible({
+			target: notificationsMenuItem,
+			trigger: this.page.getByLabel(`${userName} User Profile`),
+		});
+
+		await notificationsMenuItem.click();
+
+		await this.page.waitForURL(
+			/com_liferay_notifications_web_portlet_NotificationsPortlet/,
+			{waitUntil: 'commit'}
+		);
 	}
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103280

## What Is Being Fixed

The notifications page object reaches its portlet by walking the user profile dropdown, and on CI the walk intermittently spent its whole ninety second budget waiting for the dropdown's Notifications item while passing runs found it within seconds. An instrumented CI run that reproduced the failure 29 times out of 40 executions showed the same state every time: the click on the profile button completes, but no dropdown ever carries the `show` class — the personal menu's own Notifications entry sits in the DOM at zero size inside a hidden menu. The menu never opened: the single click landed before the dropdown's toggle was effective, and nothing retried it. The portal log of a failing run holds no error, ruling out the server side items fetch.

An earlier fix that navigated by address instead was withdrawn after review: the `/group/guest` mapping is private and locks out the two non administrator callers, the target layout is minted lazily by the very walk the address removed, and the landing chrome the tests assert differs by entry path. The walk was never wrong — the unowned open was.

## How It Is Being Fixed

`NotificationsPage.goto` keeps the walk and owns it: it clicks the profile button until the open dropdown holds the Notifications item (the repository's canonical retry helper for clicks that land before scripts attach), clicks the item, and waits for the portlet URL to commit so callers never start asserting against the page the walk began on. Waiting for `commit` rather than `load` keeps each pass cheap enough for the caller that wraps the whole walk in a five second retry budget; every caller's first action after the walk is an auto waiting assertion or sits inside a retry wrapper, so commit is sufficient for all seven call sites.

The first commit repairs the Playwright TypeScript project's type check, broken on master by a missing FDS table name in the LPD-99230 profiles spec, which fails any source format run whose diff touches a TypeScript file.

## Evidence

An amplified CI comparison with the same instrument and volume as the diagnosis run: the naked click failed 29 of 40 executions, the owned walk passed 40 of 40. Locally every runnable caller passes, including both non administrator callers; the one caller that fails does so identically on the unfixed walk in two control runs, pinning its failure to local environment latency. The fix also rode eight full aggregate CI runs with its axes green.

## PR Check

**pr-check: PASS** — tested on `68a9c1e812280e62cba43dce47c88559c3c604a5`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| TypeScript Check | PASS |

Source Format ran with commit message validation; the Playwright TypeScript project type-checks clean (the first commit repairs the check itself, broken on master by the LPD-99230 batch's missing FDS table name). The diff is Playwright-test-only, so no compile, baseline, or unit surfaces fire.

<!-- pr-check {"result": "success", "sha": "68a9c1e812280e62cba43dce47c88559c3c604a5"} -->