### PR TITLE
LPD-103289 Choose a title field the system object is not already set to

### DIFF
--- a/modules/test/playwright/tests/mcp-server-web/main/profiles.spec.ts
+++ b/modules/test/playwright/tests/mcp-server-web/main/profiles.spec.ts
@@ -100,6 +100,7 @@ async function createDataMask(
 
 createFDSTableTests(test, {
 	columns: ['Title', 'Path', 'Description', 'Last Modified'],
+	name: 'Profiles',
 	rowActions: ['Edit', 'Delete'],
 	sortOptions: ['Title', 'Last Modified'],
 	tag: '@LPD-99230',

--- a/modules/test/playwright/tests/object-web/main/objectDefinition.spec.ts
+++ b/modules/test/playwright/tests/object-web/main/objectDefinition.spec.ts
@@ -1265,10 +1265,20 @@ test.describe('Manage object definitions through View Object Definitions', () =>
 					await editObjectDetailsPage.entryTitleField.textContent()
 				)?.trim() ?? '';
 
+			// The option already selected cannot be clicked: its own list item
+			// intercepts the pointer, so a run that finds the field already on
+			// the option it means to choose retries that click until the test
+			// times out. Choose one the field is not already on.
+
+			const entryTitleFieldName =
+				originalEntryTitleField === 'Screen Name'
+					? 'Email Address'
+					: 'Screen Name';
+
 			await editObjectDetailsPage.entryTitleField.click();
 
 			await page
-				.getByRole('option', {exact: true, name: 'Screen Name'})
+				.getByRole('option', {exact: true, name: entryTitleFieldName})
 				.click();
 
 			await editObjectDetailsPage.saveObjectDefinition();
@@ -1278,7 +1288,7 @@ test.describe('Manage object definitions through View Object Definitions', () =>
 			await editObjectDetailsPage.goToDetailsTab();
 
 			await expect(editObjectDetailsPage.entryTitleField).toContainText(
-				'Screen Name'
+				entryTitleFieldName
 			);
 
 			// User is a system object shared by the whole run, so put its title


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103289

## What Is Being Fixed

The `objectDefinition.spec.ts` entry title field test always chooses Screen Name for the User system object. Clay marks the currently selected option active, and that option's own list item then intercepts the pointer — so the one option that can never be clicked is the one already selected. Any run that starts with the field already on Screen Name retries the click until the test times out; CI showed exactly that, with the resolved option carrying `aria-selected="true"` and eighty three intercepted retries behind it.

The hard-coded target was born in 6178dc43bf5dd (LPD-82349), which migrated the test from Poshi without reading the value in place. e40afc89b3ad3 (LPD-102720) later restored the original value at the end of the test, which keeps a completed run from poisoning the next one but cannot help a run that starts poisoned, so the failure survived as a rare one.

## How It Is Being Fixed

The test already reads the current value for the restore. Use that same read to choose the option the field is not on — when the field is already on Screen Name, pick Email Address, otherwise pick Screen Name — and assert the chosen name after saving. From the default state the behavior is unchanged.

Reproduced and verified on a live portal in both arms: with the field left on Screen Name beforehand, the unchanged test dies on the intercepted click with CI's exact message, and the same state passes with this change. From the default value it passes either way. The fix is also aboard a fully green 64-job `ci:test:object` run and subsequent aggregate runs whose only failures were known externals.

The first commit is the LPD-99230 one-liner that repairs the Playwright TypeScript project on master (the LPD-102889 batch made `FDSTableOptions.name` required and `profiles.spec.ts` does not pass one), the same repair carried by #180594 — identical patches merge clean; without it no Playwright-touching branch can type-check.

## PR Check

**pr-check: PASS** — tested on `3eaf13de716cee84a37f516b357b78edd784c8f0`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| TypeScript Check | PASS |

Source Format ran with commit message validation; the Playwright TypeScript project type-checks clean. The diff is Playwright-test-only, so no compile, baseline, or unit surfaces fire.

<!-- pr-check {"result": "success", "sha": "3eaf13de716cee84a37f516b357b78edd784c8f0"} -->
