### PR TITLE
LPD-103296 Ask for every definition, not the first page of them

### DIFF
--- a/modules/test/playwright/helpers/ListTypeAdminApiHelper.ts
+++ b/modules/test/playwright/helpers/ListTypeAdminApiHelper.ts
@@ -33,8 +33,14 @@ export class ListTypeAdminApiHelper {
 	}
 
 	async getListTypeDefinitions(): Promise<ListTypeDefinitions> {
+
+		// Ask for every definition, not the first page of them: a caller
+		// counting what already exists has to see all of it, and the default
+		// page holds twenty while an environment that has been worked in holds
+		// far more.
+
 		return this.apiHelpers.get(
-			`${this.apiHelpers.baseUrl}${this.basePath}/list-type-definitions`
+			`${this.apiHelpers.baseUrl}${this.basePath}/list-type-definitions?page=-1`
 		);
 	}
 

--- a/modules/test/playwright/helpers/ObjectAdminApiHelper.ts
+++ b/modules/test/playwright/helpers/ObjectAdminApiHelper.ts
@@ -27,8 +27,14 @@ export class ObjectAdminApiHelper {
 	}
 
 	async getAllObjectDefinitions() {
+
+		// Ask for every definition, not the first page of them: the default
+		// page holds twenty while an environment that has been worked in holds
+		// far more, and a caller looking for one by reference code then finds
+		// nothing.
+
 		return this.apiHelpers.get(
-			`${this.apiHelpers.baseUrl}${this.basePath}/object-definitions`
+			`${this.apiHelpers.baseUrl}${this.basePath}/object-definitions?page=-1`
 		);
 	}
 

--- a/modules/test/playwright/tests/mcp-server-web/main/profiles.spec.ts
+++ b/modules/test/playwright/tests/mcp-server-web/main/profiles.spec.ts
@@ -100,6 +100,7 @@ async function createDataMask(
 
 createFDSTableTests(test, {
 	columns: ['Title', 'Path', 'Description', 'Last Modified'],
+	name: 'Profiles',
 	rowActions: ['Edit', 'Delete'],
 	sortOptions: ['Title', 'Last Modified'],
 	tag: '@LPD-99230',


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103296

## What Is Being Fixed

Two Playwright API helpers named for retrieving everything actually fetch only the endpoint's default page of twenty.

`ObjectAdminApiHelper.getAllObjectDefinitions` answers twenty definitions, so its two callers that search the answer for the account system object by reference code find nothing on any environment holding more than twenty definitions and die with a TypeError reading an id from undefined. `ListTypeAdminApiHelper.getListTypeDefinitions` has the same truncation: its caller counts what already exists, adds the twenty two picklists it creates, and asserts the dropdown holds exactly that many — so the count starts from a truncated page while the dropdown lists everything, and the assertion fails by the difference (CI showed forty two expected against forty eight listed). Neither is a rare state, since every definition or picklist another test leaves behind counts toward the twenty.

The object definitions helper was born asking for one page in 9af7e1b9639e5 (LPD-55176), named for every definition but correct only while an environment stays small. The picklist helper was added reading a single page in c8083d65f65e6 (LPD-25554); 843ef96b60134 (LPD-31952) then built the expected count on it, which fixed the empty-environment assumption but inherited the truncation, and 09d7f7ff5244c (LPD-85191) carried it into the field subproject unchanged.

## How It Is Being Fixed

Ask both endpoints for every page with `page=-1`, one commit per helper.

Measured against a live portal holding forty three definitions: the unchanged call answers twenty items without the account definition among them, and asking for every page answers all forty three with it present; both callers fail on the first form with CI's TypeError and pass on the second. With twenty six picklists in place the unchanged helper fails the test at forty two expected against forty eight listed, the shape CI showed, and passes on the same state with the fix. The fix is also aboard a fully green 64-job `ci:test:object` run and subsequent aggregate runs whose only failures were known externals.

The first commit is the LPD-99230 one-liner that repairs the Playwright TypeScript project on master (the LPD-102889 batch made `FDSTableOptions.name` required and `profiles.spec.ts` does not pass one), the same repair carried by #180594 and #180604 — identical patches merge clean; without it no Playwright-touching branch can type-check.

## PR Check

**pr-check: PASS** — tested on `f3ab2690732bebc4971c97d6caa1abac3cabc2a7`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| TypeScript Check | PASS |

Source Format ran with commit message validation; the Playwright TypeScript project type-checks clean. The diff is Playwright-test-only, so no compile, baseline, or unit surfaces fire.

<!-- pr-check {"result": "success", "sha": "f3ab2690732bebc4971c97d6caa1abac3cabc2a7"} -->
