### PR TITLE
LPD-103302 Delete only the picklists the field test creates

### DIFF
--- a/modules/test/playwright/tests/mcp-server-web/main/profiles.spec.ts
+++ b/modules/test/playwright/tests/mcp-server-web/main/profiles.spec.ts
@@ -100,6 +100,7 @@ async function createDataMask(
 
 createFDSTableTests(test, {
 	columns: ['Title', 'Path', 'Description', 'Last Modified'],
+	name: 'Profiles',
 	rowActions: ['Edit', 'Delete'],
 	sortOptions: ['Title', 'Last Modified'],
 	tag: '@LPD-99230',

--- a/modules/test/playwright/tests/object-web/field/objectField.spec.ts
+++ b/modules/test/playwright/tests/object-web/field/objectField.spec.ts
@@ -120,22 +120,28 @@ test.describe('Manage object fields through Model Builder', () => {
 			await apiHelpers.listTypeAdmin.getListTypeDefinitions()
 		).items;
 
-		const allListTypeDefinitions = existingListTypeDefinitions.concat(
-			await Promise.all(
-				Array(22)
-					.fill(null)
-					.map(
-						async () =>
-							await apiHelpers.listTypeAdmin.postRandomListTypeDefinition()
-					)
-			)
+		const createdListTypeDefinitions = await Promise.all(
+			Array(22)
+				.fill(null)
+				.map(
+					async () =>
+						await apiHelpers.listTypeAdmin.postRandomListTypeDefinition()
+				)
 		);
 
-		allListTypeDefinitions.forEach(({id}) =>
+		// Only what this test created is registered for deletion. Registering
+		// the definitions it merely found would delete picklists belonging to
+		// whatever else is running or expected to remain.
+
+		createdListTypeDefinitions.forEach(({id}) =>
 			apiHelpers.data.push({
 				id,
 				type: 'listTypeDefinition',
 			})
+		);
+
+		const allListTypeDefinitions = existingListTypeDefinitions.concat(
+			createdListTypeDefinitions
 		);
 
 		await modelBuilderDiagramPage.goto({objectFolderName: 'Default'});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103302

## What Is Being Fixed

The picklist listing test in the object-web field suite registers every definition it counted for teardown deletion — the ones it created and the ones it merely found — so its cleanup deletes picklists it does not own. The test passes either way, which is what makes the behavior easy to miss.

To be explicit about what this is: **an ownership correction, not a failure fix.** It breaks no test on CI as composed today — the suite runs on one worker, the field project is a single spec file with no shared fixtures, every later test creates its own picklists, and the delete helper swallows refusals, so system picklists and picklists still referenced by an object field survive the sweep. The damage lands on persistent environments instead: one run of the suite against a worked-in portal silently destroys every unguarded picklist that existed beforehand. The hazard also grew with LPD-103296 (#180605), which made `getListTypeDefinitions` answer every page instead of the first twenty, so the sweep it feeds widened from at most twenty found picklists to all of them.

Root cause: 843ef96b60134 (LPD-31952, "Taken into account all picklists already created") widened the deletion list along with the count when it made the expected total include pre-existing picklists. Before it, only the twenty two the test created were registered.

## How It Is Being Fixed

Register only what the test created for deletion, and keep the found definitions for the count they were read for. No assertion changes and no CI outcome changes under the current axis composition.

Demonstrated against a live portal by leaving three picklists in place and running the test: unchanged, it passes and all three are gone afterwards; with this change, it passes and all three remain. The fix is also aboard a fully green 64-job `ci:test:object` run and subsequent aggregate runs whose only failures were known externals.

The first commit is the LPD-99230 one-liner that repairs the Playwright TypeScript project on master (the LPD-102889 batch made `FDSTableOptions.name` required and `profiles.spec.ts` does not pass one), the same repair carried by #180594, #180604, and #180605 — identical patches merge clean; without it no Playwright-touching branch can type-check.

## PR Check

**pr-check: PASS** — tested on `d8b4a7113f27eaa967500b386bb5536260b9c3f2`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| TypeScript Check | PASS |

Source Format ran with commit message validation; the Playwright TypeScript project type-checks clean. The diff is Playwright-test-only, so no compile, baseline, or unit surfaces fire.

<!-- pr-check {"result": "success", "sha": "d8b4a7113f27eaa967500b386bb5536260b9c3f2"} -->
