### PR TITLE
LPD-103303 Wait for the picklist table instead of snapshotting its texts

### DIFF
--- a/modules/test/playwright/tests/mcp-server-web/main/profiles.spec.ts
+++ b/modules/test/playwright/tests/mcp-server-web/main/profiles.spec.ts
@@ -100,6 +100,7 @@ async function createDataMask(
 
 createFDSTableTests(test, {
 	columns: ['Title', 'Path', 'Description', 'Last Modified'],
+	name: 'Profiles',
 	rowActions: ['Edit', 'Delete'],
 	sortOptions: ['Title', 'Last Modified'],
 	tag: '@LPD-99230',

--- a/modules/test/playwright/tests/object-web/list-type-definition/listTypeDefinition.spec.ts
+++ b/modules/test/playwright/tests/object-web/list-type-definition/listTypeDefinition.spec.ts
@@ -1126,7 +1126,6 @@ test.describe('manage picklists inside the picklists portlet', () => {
 	test('ensure picklist entry keys starting with upper case are correctly rendered in the entries', async ({
 		apiHelpers,
 		listTypeDefinitionPage,
-		page,
 	}) => {
 		const listTypeDefinition: ListTypeDefinition =
 			await apiHelpers.listTypeAdmin.postRandomListTypeDefinition();
@@ -1158,39 +1157,33 @@ test.describe('manage picklists inside the picklists portlet', () => {
 
 		const [responseEntries]: ListTypeEntry[] = response.listTypeEntries;
 
-		const frameElement = await page.$('iframe');
-		const frame = await frameElement.contentFrame();
-		await frame.waitForLoadState('networkidle');
+		// Read the table through assertions rather than a snapshot of its
+		// texts. The rows arrive with the data set's own render, which no load
+		// state marks, so a snapshot taken too early holds an empty list and
+		// the comparison then reports the expected value as undefined. Only the
+		// three leading cells are asserted, since the table also carries an
+		// item actions column that is not part of what this test states.
 
-		const listTypeDefinitionHeader =
-			await listTypeDefinitionPage.frameLocator
-				.locator('.fds th')
-				.allInnerTexts();
-
-		const listTypeDefinitionContent =
-			await listTypeDefinitionPage.frameLocator
-				.locator('.fds td')
-				.allInnerTexts();
-
-		const listTypeDefinitionHeaderTemplate = [
+		const listTypeDefinitionHeaders = [
 			'Name',
 			'Key',
 			'External Reference Code',
 		];
 
-		const listTypeDefinitionContentTemplate = [
+		const listTypeDefinitionEntry = [
 			listTypeDefinitionEntryName,
 			listTypeDefinitionEntryKey,
 			responseEntries.externalReferenceCode,
 		];
 
-		for (let i = 0; i < 3; i++) {
-			expect(listTypeDefinitionHeaderTemplate[i]).toBe(
-				listTypeDefinitionHeader[i]
-			);
-			expect(listTypeDefinitionContentTemplate[i]).toBe(
-				listTypeDefinitionContent[i]
-			);
+		for (let i = 0; i < listTypeDefinitionHeaders.length; i++) {
+			await expect(
+				listTypeDefinitionPage.frameLocator.locator('.fds th').nth(i)
+			).toHaveText(listTypeDefinitionHeaders[i]);
+
+			await expect(
+				listTypeDefinitionPage.frameLocator.locator('.fds td').nth(i)
+			).toHaveText(listTypeDefinitionEntry[i]);
 		}
 	});
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103303

## What Is Being Fixed

The `listTypeDefinition.spec.ts` test that checks picklist entry rendering reads the entry table with `allInnerTexts()` — a one-shot snapshot that does not wait — after a `networkidle` wait that says nothing about the data set having rendered its rows. Taken too early the snapshot is empty. And because the comparison is written with the expected and actual arguments the wrong way round (`expect(template[i]).toBe(snapshot[i])`), the failure reads as an expected value of `undefined` against a received `Name`, which points at the hard-coded template rather than at the empty read. CI showed it exactly that way.

Root cause: f08e27970fb20 (LPD-27497, "Assert picklist table integrity") was born with both defects — the one-shot snapshot and the reversed comparison — and 3bdf60bcc403c (LPD-85191) carried it into the list-type-definition subproject unchanged.

## How It Is Being Fixed

Assert the three leading cells of the header and the row through locators that wait, using `toHaveText` on `nth` cells — the wait rides the effect's own signal, the cell content. The table also carries an item actions column, so the assertions name the cells they mean rather than the whole row. The raw iframe handle and its load state wait go with the snapshot, since the assertions cover what they were guarding.

Reproduced by taking the load state wait away, which makes the read early on demand: the snapshot form then fails with CI's exact message every time, and the asserted form passes both runs from the same state. The fix is also aboard a fully green 64-job `ci:test:object` run and subsequent aggregate runs whose only failures were known externals.

The first commit is the LPD-99230 one-liner that repairs the Playwright TypeScript project on master (the LPD-102889 batch made `FDSTableOptions.name` required and `profiles.spec.ts` does not pass one), the same repair carried by #180594, #180604, #180605, and #180607 — identical patches merge clean; without it no Playwright-touching branch can type-check.

## PR Check

**pr-check: PASS** — tested on `16be2b0bd03c103ddea82315693ebded00d173f4`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| TypeScript Check | PASS |

Source Format ran with commit message validation; the Playwright TypeScript project type-checks clean. The diff is Playwright-test-only, so no compile, baseline, or unit surfaces fire.

<!-- pr-check {"result": "success", "sha": "16be2b0bd03c103ddea82315693ebded00d173f4"} -->
