### PR TITLE
LPD-103307 Hand the relationship tab save's reload to its callers

### DIFF
--- a/modules/test/playwright/pages/object-web/object-layout/ObjectLayoutsPage.ts
+++ b/modules/test/playwright/pages/object-web/object-layout/ObjectLayoutsPage.ts
@@ -195,6 +195,14 @@ export class ObjectLayoutsPage {
 		await this.saveTabButton.click();
 	}
 
+	/**
+	 * Adds the relationship tab and returns the reload the layout save
+	 * schedules on the parent window. The caller must await it before its next
+	 * navigation, or the reload lands on whatever runs next and cancels it.
+	 * It is handed back rather than awaited here because the save's success
+	 * alert does not survive the reload, so a caller that reads the alert has
+	 * to read it first.
+	 */
 	async createObjectRelationshipTab(
 		objectLayoutName: string,
 		objectLayoutTabName: string,
@@ -204,7 +212,14 @@ export class ObjectLayoutsPage {
 
 		await this.addRelationshipTab(objectLayoutTabName, relationshipField);
 
+		const reload = this.page.waitForNavigation({
+			timeout: 10000,
+			waitUntil: 'load',
+		});
+
 		await this.saveUpdateLayoutButton.click();
+
+		return {reload};
 	}
 
 	async createObjectLayoutContent({

--- a/modules/test/playwright/tests/mcp-server-web/main/profiles.spec.ts
+++ b/modules/test/playwright/tests/mcp-server-web/main/profiles.spec.ts
@@ -100,6 +100,7 @@ async function createDataMask(
 
 createFDSTableTests(test, {
 	columns: ['Title', 'Path', 'Description', 'Last Modified'],
+	name: 'Profiles',
 	rowActions: ['Edit', 'Delete'],
 	sortOptions: ['Title', 'Last Modified'],
 	tag: '@LPD-99230',

--- a/modules/test/playwright/tests/object-web/entry/objectEntry.spec.ts
+++ b/modules/test/playwright/tests/object-web/entry/objectEntry.spec.ts
@@ -3115,11 +3115,13 @@ test.describe('Manage object entries through View Object Entries', () => {
 			objectLayoutTabName: 'Field Tab',
 		});
 
-		await objectLayoutsPage.createObjectRelationshipTab(
+		const {reload} = await objectLayoutsPage.createObjectRelationshipTab(
 			objectLayoutName,
 			'Relationship Tab',
 			'Relationship'
 		);
+
+		await reload;
 
 		await editObjectDetailsPage.goto(objectDefinition.name);
 
@@ -3585,11 +3587,13 @@ test.describe('Manage object entries through View Object Entries', () => {
 
 		await objectLayoutsPage.saveAddFieldButton.click();
 
-		await objectLayoutsPage.createObjectRelationshipTab(
+		const {reload} = await objectLayoutsPage.createObjectRelationshipTab(
 			objectLayoutName,
 			objectRelationshipTabName,
 			objectRelationshipLabel
 		);
+
+		await reload;
 
 		await viewObjectEntriesPage.goto(objectDefinition2.className);
 

--- a/modules/test/playwright/tests/object-web/layout/objectLayout.spec.ts
+++ b/modules/test/playwright/tests/object-web/layout/objectLayout.spec.ts
@@ -575,7 +575,7 @@ test.describe('Manage custom layouts through object layout tab', () => {
 
 		const objectLayoutRelTabName = getRandomString();
 
-		await objectLayoutsPage.createObjectRelationshipTab(
+		const {reload} = await objectLayoutsPage.createObjectRelationshipTab(
 			objectLayoutName,
 			objectLayoutRelTabName,
 			objectRelationship.label.en_US
@@ -585,6 +585,8 @@ test.describe('Manage custom layouts through object layout tab', () => {
 			page,
 			'Success:The object layout was updated successfully'
 		);
+
+		await reload;
 
 		const objectChildEntry = 'ChildEntry' + getRandomInt();
 
@@ -950,7 +952,7 @@ test.describe('Manage custom layouts through object layout tab', () => {
 			objectLayoutTabName: 'Field Tab',
 		});
 
-		await objectLayoutsPage.createObjectRelationshipTab(
+		const {reload} = await objectLayoutsPage.createObjectRelationshipTab(
 			objectLayoutName,
 			'Relationship Tab',
 			objectRelationship.label['en_US']
@@ -960,6 +962,8 @@ test.describe('Manage custom layouts through object layout tab', () => {
 			page,
 			'Success:The object layout was updated successfully'
 		);
+
+		await reload;
 
 		const applicationName =
 			'c/' + objectDefinition.name.toLowerCase() + 's';
@@ -1409,7 +1413,7 @@ test.describe('Manage custom layouts through object layout tab', () => {
 			objectLayoutTabName: 'Field Tab',
 		});
 
-		await objectLayoutsPage.createObjectRelationshipTab(
+		const {reload} = await objectLayoutsPage.createObjectRelationshipTab(
 			objectLayoutName,
 			'Relationship Tab',
 			objectRelationship.label['en_US']
@@ -1419,6 +1423,8 @@ test.describe('Manage custom layouts through object layout tab', () => {
 			page,
 			'Success:The object layout was updated successfully'
 		);
+
+		await reload;
 
 		const applicationName =
 			'c/' + objectDefinition.name.toLowerCase() + 's';

--- a/modules/test/playwright/tests/object-web/main/objectPermissions.spec.ts
+++ b/modules/test/playwright/tests/object-web/main/objectPermissions.spec.ts
@@ -218,11 +218,14 @@ test(
 				objectLayoutTabName: 'Field Tab',
 			});
 
-			await objectLayoutsPage.createObjectRelationshipTab(
-				objectLayoutName,
-				'Relationship Tab',
-				objectRelationship.label['en_US']
-			);
+			const {reload} =
+				await objectLayoutsPage.createObjectRelationshipTab(
+					objectLayoutName,
+					'Relationship Tab',
+					objectRelationship.label['en_US']
+				);
+
+			await reload;
 
 			await editObjectDetailsPage.goto(parentObjectDefinition.name);
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103307

## What Is Being Fixed

Creating a relationship tab in `ObjectLayoutsPage` ends on a bare click of the layout save, and that save schedules a reload on the parent window shortly after its own request answers. The helper returns with the reload in flight, so it lands on whatever the caller runs next: CI killed the layout permission test on a `page.goto` that was interrupted by a navigation to the layouts tab address — six statements and an entry post after the save that started it.

Root cause: 2574e62cafa80 (LPD-41076, "Create playwright test") wrote the save as a bare trailing click. 591a9ec20f7ec (LPD-102849) later gave the same save a reload-returning form for its other callers, but this helper kept the bare click.

## How It Is Being Fixed

Register the navigation wait before the click and hand it back, the way the layout save already does for its own callers, then await it at each of the six call sites. Awaiting inside the helper was tried and proven wrong: the reload wipes the save's success alert, and the three callers that read that alert time out waiting for it. So the callers that read the alert await the reload after reading it, and the three that navigate next await it before navigating.

The ten second bound on the wait keeps a missing reload loud and cheap: the reload lands within a couple of seconds of the save's answer, so the bound is generous headroom, while the default thirty second navigation timeout would spend a third of the test's ninety second budget before failing.

Five of the six call-site tests pass locally with the fix; the sixth fails identically on plain master with the same signature — a pre-existing environment failure, not introduced by this change. The fix is also aboard a fully green 64-job `ci:test:object` run and subsequent aggregate runs whose only failures were known externals.

The first commit is the LPD-99230 one-liner that repairs the Playwright TypeScript project on master (the LPD-102889 batch made `FDSTableOptions.name` required and `profiles.spec.ts` does not pass one), the same repair carried by #180594, #180604, #180605, #180607, and #180608 — identical patches merge clean; without it no Playwright-touching branch can type-check.

## PR Check

**pr-check: PASS** — tested on `18b4cac4176845a063a66e3914880b642d7e4702`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| TypeScript Check | PASS |

Source Format ran with commit message validation; the Playwright TypeScript project type-checks clean. The diff is Playwright-test-only, so no compile, baseline, or unit surfaces fire.

<!-- pr-check {"result": "success", "sha": "18b4cac4176845a063a66e3914880b642d7e4702"} -->
