### PR TITLE
LPD-103311 Boot the client extension against routes only the environment script writes

### DIFF
--- a/modules/test/playwright/env/common.sh
+++ b/modules/test/playwright/env/common.sh
@@ -609,17 +609,26 @@ function start_client_extension_spring_boot_application {
 
 		cd ${client_extension_dir}
 
-		local portal_url_hostname=$(echo ${LIFERAY_PORTAL_URL} | awk -F:// '{print $2}')
+		# The portal's Kubernetes agent owns the home's routes directory and
+		# rewrites its files from the company virtual host, which does not
+		# resolve the portal from here. The application reads the files once
+		# at boot through paths the workspace plugin derives from the home
+		# directory, so boot it against a private home whose routes only this
+		# script writes, and only after the portal's JWKS endpoint answers at
+		# the routed address.
 
-		echo "${portal_url_hostname}" > ${LIFERAY_HOME}/routes/default/dxp/com.liferay.lxc.dxp.domains
-		echo "${portal_url_hostname}" > ${LIFERAY_HOME}/routes/default/dxp/com.liferay.lxc.dxp.main.domain
-		echo "${portal_url_hostname}" > ${LIFERAY_HOME}/routes/default/dxp/com.liferay.lxc.dxp.mainDomain
+		local routes_home=$(mktemp -d)
 
-		local portal_url_scheme=$(echo ${LIFERAY_PORTAL_URL} | awk -F:// '{print $1}')
+		write_client_extension_dxp_routes "${routes_home}"
 
-		echo "${portal_url_scheme}" > ${LIFERAY_HOME}/routes/default/dxp/com.liferay.lxc.dxp.server.protocol
+		if ! curl --fail --output /dev/null --retry 12 --retry-all-errors --retry-delay 5 --silent "$(cat ${routes_home}/routes/default/dxp/com.liferay.lxc.dxp.server.protocol)://$(cat ${routes_home}/routes/default/dxp/com.liferay.lxc.dxp.mainDomain)/o/oauth2/jwks"
+		then
+			echo "The portal's JWKS endpoint does not answer at the routed address."
 
-		$(get_gradlew) bootRun -Pliferay.workspace.home.dir=${LIFERAY_HOME} &
+			exit 1
+		fi
+
+		$(get_gradlew) bootRun -Pliferay.workspace.home.dir=${routes_home} &
 
 		local sleep_duration=60
 		local sleep_interval=5
@@ -811,6 +820,22 @@ function wait_for_portal_log_inactivity {
 	done
 
 	echo "No portal activity detected in ${sleep_interval}s."
+}
+
+function write_client_extension_dxp_routes {
+	local routes_dir=${1}/routes/default/dxp
+
+	mkdir -p ${routes_dir}
+
+	local portal_url_hostname=$(echo ${LIFERAY_PORTAL_URL} | awk -F:// '{print $2}')
+
+	echo "${portal_url_hostname}" > ${routes_dir}/com.liferay.lxc.dxp.domains
+	echo "${portal_url_hostname}" > ${routes_dir}/com.liferay.lxc.dxp.main.domain
+	echo "${portal_url_hostname}" > ${routes_dir}/com.liferay.lxc.dxp.mainDomain
+
+	local portal_url_scheme=$(echo ${LIFERAY_PORTAL_URL} | awk -F:// '{print $1}')
+
+	echo "${portal_url_scheme}" > ${routes_dir}/com.liferay.lxc.dxp.server.protocol
 }
 
 main "${@}"

--- a/modules/test/playwright/env/common.sh
+++ b/modules/test/playwright/env/common.sh
@@ -588,7 +588,7 @@ function start_app_server {
 
 	local liferay_portal_url=${2}
 
-	while ! curl --output /dev/null --silent --head --fail ${liferay_portal_url}
+	while ! curl --fail --output /dev/null --silent ${liferay_portal_url}
 	do
 		sleep 5
 	done


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103311

## What Is Being Fixed

The client extension Spring Boot application that four object Playwright projects depend on dies at boot, taking three object client extension tests into ninety second timeouts each.

The application reads its portal address **once** at startup, through Spring's `configtree` import over the route files the workspace plugin derives from the home directory it is given (`LIFERAY_ROUTES_DXP = ${liferay.workspace.home.dir}/routes/${instance}/dxp`, injected by `ClientExtensionProjectConfigurator`). From those values it builds `<protocol>://<mainDomain>/o/oauth2/jwks` and fetches the portal's keys to construct its `jwtDecoder`. The portal's Kubernetes agent (`RoutesPortalK8sConfigMapModifier`) owns that same routes directory and rewrites those files from the company virtual host — on a test bundle, `localhost` with no port. When its rewrite lands before the application's single read, the application resolves `http://localhost:80/o/oauth2/jwks`, the fetch is refused, the bean fails, Spring cancels the context, and the harness reports the app as unable to start. The tests then run against a portal whose executor never came up.

The environment setup provokes the rewrite itself: deploying the client extension descriptor registers an OAuth2 application, and that configuration event is the agent's cue to refresh the routes.

Root cause: two writers have shared that directory since a2c21de00c276 (LRCI-4304) had the environment script write the route files — correct only while the script stayed the last writer before the application's read. It never could be reliably: the entire Gradle bootstrap sits between the script's `echo`s and Spring's read, and no ordering primitive exists between a shell write and another process's scheduled write. Writing the good values "harder" only narrows the window; the losing interleaving stays legal.

## How It Is Being Fixed

Stop sharing the directory. `bootRun` now gets a private home created with `mktemp -d`, whose routes only this script writes, so the agent can keep rewriting the bundle's copy forever and the application never reads there — immunity by construction rather than a timing bet. The route writer takes its target directory as an argument and creates it.

Before forking Gradle, the script also verifies the portal's JWKS endpoint answers **at the exact address it just wrote**, using one retrying `curl` rather than a polling loop. That covers the other way a read-once boot can fail — right address, endpoint not serving yet — and names which precondition failed if it ever does, instead of leaving another generic `bootRun` corpse.

The second commit drops `--head` from the portal readiness probe in the same script, so it reads the full homepage: a `HEAD` can answer 200 while the portal is still provisioning, which is what let the setup proceed into that window in the first place.

Validated end to end locally (application starts in about a second against the private home, answers `/ready`, stops clean). On CI the client extension axis is **green** both on a dedicated `ci:test:object` leg over current master and on the aggregate run that first carried this rework — the same base family where the previous form of the fix failed two of three runs.

## PR Check

**pr-check: PASS** — tested on `ffa72f0ce26e65339d7147013b2afe24d14e9491`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

Source Format ran with commit message validation. The diff is a single Playwright environment shell script, so no compile, baseline, TypeScript, or unit surfaces fire; the substantive evidence is the `ci:test:object` leg above, whose only failures were the learn resources S3 outage, the semantic versioning base state, and an unrelated Felix configuration admin error — none reachable from a script that only the Playwright environment setup sources.

<!-- pr-check {"result": "success", "sha": "ffa72f0ce26e65339d7147013b2afe24d14e9491"} -->
