### PR TITLE
LPD-103336 Let the Gradle bootstrap finish before timing the application

### DIFF
--- a/modules/test/playwright/env/common.sh
+++ b/modules/test/playwright/env/common.sh
@@ -628,6 +628,14 @@ function start_client_extension_spring_boot_application {
 			exit 1
 		fi
 
+		# Finish the Gradle bootstrap before the readiness wait below starts
+		# timing the application. A cold wrapper cache downloads a Gradle
+		# distribution and starts a daemon on the first invocation, which the
+		# wait cannot tell apart from a slow application and which alone can
+		# outlast the whole budget.
+
+		$(get_gradlew) classes -Pliferay.workspace.home.dir=${routes_home}
+
 		$(get_gradlew) bootRun -Pliferay.workspace.home.dir=${routes_home} &
 
 		local sleep_duration=60


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103336

## What Is Being Fixed

The Playwright client extension environment script starts a Spring Boot client extension and then waits sixty seconds for it to answer `/ready`, but the clock starts before the Gradle invocation that builds and runs it. On a cold wrapper cache that invocation first downloads the pinned Gradle distribution and starts a daemon, which took sixty nine seconds on a warm network here, so the wait can expire before the application has been asked to start at all.

The script then reports the application as unable to start and exits, and the batch runs against a portal with no client extension registered, where every later symptom points at the missing extension rather than at the wait that gave up. The same wait guards four object-web projects and three others, so one cold node can take all of them down.

## How It Is Being Fixed

The compile runs synchronously before `bootRun`, against the same private routes home the application boots from, so the download, the daemon start and the compile all finish before the readiness wait begins. The wait then measures only the application's own start.

The timeout is deliberately not raised: the synchronous step needs no bound of its own, and keeping the wait short keeps a genuine failure cheap and diagnosable. On a warm cache the added step answers in two seconds.

## PR Check

**pr-check: PASS** — tested on `c8939896a5568d72661a2c0f6c66f0e5cf86d59d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Baseline | PASS |

<!-- pr-check {"result": "success", "sha": "c8939896a5568d72661a2c0f6c66f0e5cf86d59d"} -->
