### PR TITLE
LPD-103207 Publish the selected web content from the widget menu

### DIFF
--- a/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/exportimport/portlet/preferences/processor/JournalContentExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/exportimport/portlet/preferences/processor/JournalContentExportImportPortletPreferencesProcessor.java
@@ -5,25 +5,45 @@
 
 package com.liferay.journal.content.web.internal.exportimport.portlet.preferences.processor;
 
+import com.liferay.dynamic.data.mapping.model.DDMTemplate;
+import com.liferay.dynamic.data.mapping.service.DDMTemplateLocalService;
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.exportimport.kernel.lar.PortletDataException;
+import com.liferay.exportimport.kernel.lar.PortletDataHandlerKeys;
+import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerUtil;
+import com.liferay.exportimport.kernel.staging.MergeLayoutPrototypesThreadLocal;
 import com.liferay.exportimport.portlet.preferences.processor.Capability;
 import com.liferay.exportimport.portlet.preferences.processor.ExportImportPortletPreferencesProcessor;
 import com.liferay.exportimport.portlet.preferences.processor.ExportImportPortletPreferencesProcessorHelper;
 import com.liferay.exportimport.portlet.preferences.processor.base.BaseExportImportPortletPreferencesProcessor;
+import com.liferay.journal.constants.JournalConstants;
 import com.liferay.journal.constants.JournalContentPortletKeys;
+import com.liferay.journal.constants.JournalPortletKeys;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.service.JournalArticleLocalService;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.PortletLocalService;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.kernel.xml.Element;
 
 import jakarta.portlet.PortletPreferences;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -40,12 +60,20 @@ public class JournalContentExportImportPortletPreferencesProcessor
 
 	@Override
 	public List<Capability> getExportCapabilities() {
-		return Collections.emptyList();
+		return ListUtil.fromArray(
+			_journalContentMetadataExporterImporterCapability);
 	}
 
 	@Override
 	public List<Capability> getImportCapabilities() {
-		return Collections.emptyList();
+		return ListUtil.fromArray(
+			_journalContentMetadataExporterImporterCapability,
+			_referencedStagedModelImporterCapability);
+	}
+
+	@Override
+	public boolean isPublishDisplayedContent() {
+		return ExportImportThreadLocal.isPortletStagingInProcess();
 	}
 
 	@Override
@@ -65,29 +93,36 @@ public class JournalContentExportImportPortletPreferencesProcessor
 		throws PortletDataException {
 
 		try {
-			Portlet portlet = _portletLocalService.getPortletById(
-				portletDataContext.getCompanyId(),
-				portletDataContext.getPortletId());
+			portletDataContext.addPortletPermissions(
+				JournalConstants.RESOURCE_NAME);
+		}
+		catch (PortalException portalException) {
+			throw _getPortletDataException(
+				portalException, "Unable to export portlet permissions",
+				PortletDataException.EXPORT_PORTLET_PERMISSIONS);
+		}
 
+		Group articleGroup = _getArticleGroup(
+			portletDataContext, portletPreferences);
+
+		try {
 			updateExportPortletPreferencesExternalReferenceCodes(
-				portletDataContext, portlet, portletPreferences,
-				"groupExternalReferenceCode", Group.class.getName());
-
-			return portletPreferences;
+				portletDataContext,
+				_portletLocalService.getPortletById(
+					portletDataContext.getCompanyId(),
+					portletDataContext.getPortletId()),
+				portletPreferences, "groupExternalReferenceCode",
+				Group.class.getName());
 		}
 		catch (Exception exception) {
-			PortletDataException portletDataException =
-				new PortletDataException(
-					"Unable to update portlet preferences during export",
-					exception);
-
-			portletDataException.setPortletId(
-				JournalContentPortletKeys.JOURNAL_CONTENT);
-			portletDataException.setType(
+			throw _getPortletDataException(
+				exception, "Unable to update portlet preferences during export",
 				PortletDataException.EXPORT_PORTLET_DATA);
-
-			throw portletDataException;
 		}
+
+		_exportArticle(portletDataContext, portletPreferences, articleGroup);
+
+		return portletPreferences;
 	}
 
 	@Override
@@ -95,6 +130,16 @@ public class JournalContentExportImportPortletPreferencesProcessor
 			PortletDataContext portletDataContext,
 			PortletPreferences portletPreferences)
 		throws PortletDataException {
+
+		try {
+			portletDataContext.importPortletPermissions(
+				JournalConstants.RESOURCE_NAME);
+		}
+		catch (PortalException portalException) {
+			throw _getPortletDataException(
+				portalException, "Unable to import portlet permissions",
+				PortletDataException.IMPORT_PORTLET_PERMISSIONS);
+		}
 
 		try {
 			Company company = _companyLocalService.getCompanyById(
@@ -110,17 +155,9 @@ public class JournalContentExportImportPortletPreferencesProcessor
 			return portletPreferences;
 		}
 		catch (Exception exception) {
-			PortletDataException portletDataException =
-				new PortletDataException(
-					"Unable to update portlet preferences during import",
-					exception);
-
-			portletDataException.setPortletId(
-				JournalContentPortletKeys.JOURNAL_CONTENT);
-			portletDataException.setType(
+			throw _getPortletDataException(
+				exception, "Unable to update portlet preferences during import",
 				PortletDataException.IMPORT_PORTLET_DATA);
-
-			throw portletDataException;
 		}
 	}
 
@@ -161,8 +198,166 @@ public class JournalContentExportImportPortletPreferencesProcessor
 		return null;
 	}
 
+	private void _exportArticle(
+			PortletDataContext portletDataContext,
+			PortletPreferences portletPreferences, Group articleGroup)
+		throws PortletDataException {
+
+		String articleExternalReferenceCode = portletPreferences.getValue(
+			"articleExternalReferenceCode", null);
+
+		String portletId = portletDataContext.getPortletId();
+
+		if (Validator.isNull(articleExternalReferenceCode)) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					"No article external reference code found in preferences " +
+						"of portlet " + portletId);
+			}
+
+			return;
+		}
+
+		if (articleGroup == null) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					"No group found in preferences of portlet " + portletId);
+			}
+
+			return;
+		}
+
+		if (ExportImportThreadLocal.isStagingInProcess() &&
+			!articleGroup.isStagedPortlet(JournalPortletKeys.JOURNAL)) {
+
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					"Web content is not staged in the site " +
+						articleGroup.getName());
+			}
+
+			return;
+		}
+
+		if (!MapUtil.getBoolean(
+				portletDataContext.getParameterMap(),
+				PortletDataHandlerKeys.PORTLET_DATA) &&
+			MergeLayoutPrototypesThreadLocal.isInProgress()) {
+
+			return;
+		}
+
+		JournalArticle article =
+			_journalArticleLocalService.
+				fetchLatestArticleByExternalReferenceCode(
+					articleGroup.getGroupId(), articleExternalReferenceCode,
+					new int[] {
+						WorkflowConstants.STATUS_APPROVED,
+						WorkflowConstants.STATUS_EXPIRED,
+						WorkflowConstants.STATUS_SCHEDULED
+					});
+
+		if (article == null) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					StringBundler.concat(
+						"Portlet ", portletId,
+						" refers to an invalid external reference code ",
+						articleExternalReferenceCode));
+			}
+
+			return;
+		}
+
+		long scopeGroupId = portletDataContext.getScopeGroupId();
+
+		try {
+			portletDataContext.setScopeGroupId(articleGroup.getGroupId());
+
+			Element articleElement = portletDataContext.getExportDataElement(
+				article);
+
+			if (!GetterUtil.getBoolean(
+					articleElement.attributeValue("articleAdded"))) {
+
+				articleElement.addAttribute("articleAdded", "true");
+
+				StagedModelDataHandlerUtil.exportReferenceStagedModel(
+					portletDataContext, portletId, article);
+			}
+
+			_exportDDMTemplate(portletDataContext, portletPreferences, article);
+		}
+		finally {
+			portletDataContext.setScopeGroupId(scopeGroupId);
+		}
+	}
+
+	private void _exportDDMTemplate(
+			PortletDataContext portletDataContext,
+			PortletPreferences portletPreferences, JournalArticle article)
+		throws PortletDataException {
+
+		String ddmTemplateExternalReferenceCode = portletPreferences.getValue(
+			"ddmTemplateExternalReferenceCode", null);
+
+		if (Validator.isNull(ddmTemplateExternalReferenceCode)) {
+			return;
+		}
+
+		DDMTemplate ddmTemplate =
+			_ddmTemplateLocalService.fetchDDMTemplateByExternalReferenceCode(
+				ddmTemplateExternalReferenceCode, article.getGroupId(), true);
+
+		if ((ddmTemplate == null) ||
+			Objects.equals(
+				article.getDDMTemplateKey(), ddmTemplate.getTemplateKey())) {
+
+			return;
+		}
+
+		StagedModelDataHandlerUtil.exportReferenceStagedModel(
+			portletDataContext, article, ddmTemplate,
+			PortletDataContext.REFERENCE_TYPE_STRONG);
+	}
+
+	private Group _getArticleGroup(
+		PortletDataContext portletDataContext,
+		PortletPreferences portletPreferences) {
+
+		String groupExternalReferenceCode = portletPreferences.getValue(
+			"groupExternalReferenceCode", null);
+
+		if (Validator.isNull(groupExternalReferenceCode)) {
+			return _groupLocalService.fetchGroup(
+				portletDataContext.getScopeGroupId());
+		}
+
+		return _groupLocalService.fetchGroupByExternalReferenceCode(
+			groupExternalReferenceCode, portletDataContext.getCompanyId());
+	}
+
+	private PortletDataException _getPortletDataException(
+		Exception exception, String message, int type) {
+
+		PortletDataException portletDataException = new PortletDataException(
+			message, exception);
+
+		portletDataException.setPortletId(
+			JournalContentPortletKeys.JOURNAL_CONTENT);
+		portletDataException.setType(type);
+
+		return portletDataException;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		JournalContentExportImportPortletPreferencesProcessor.class);
+
 	@Reference
 	private CompanyLocalService _companyLocalService;
+
+	@Reference
+	private DDMTemplateLocalService _ddmTemplateLocalService;
 
 	@Reference
 	private ExportImportPortletPreferencesProcessorHelper
@@ -172,6 +367,17 @@ public class JournalContentExportImportPortletPreferencesProcessor
 	private GroupLocalService _groupLocalService;
 
 	@Reference
+	private JournalArticleLocalService _journalArticleLocalService;
+
+	@Reference(
+		target = "(component.name=com.liferay.journal.content.web.internal.exportimport.portlet.preferences.processor.JournalContentMetadataExporterImporterCapability)"
+	)
+	private Capability _journalContentMetadataExporterImporterCapability;
+
+	@Reference
 	private PortletLocalService _portletLocalService;
+
+	@Reference(target = "(name=ReferencedStagedModelImporter)")
+	private Capability _referencedStagedModelImporterCapability;
 
 }

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/content/exportimport/test/JournalContentExportImportTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/content/exportimport/test/JournalContentExportImportTest.java
@@ -10,6 +10,9 @@ import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.exportimport.kernel.service.StagingLocalServiceUtil;
 import com.liferay.exportimport.test.util.lar.BasePortletExportImportTestCase;
 import com.liferay.journal.constants.JournalContentPortletKeys;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.service.JournalArticleLocalService;
+import com.liferay.journal.test.util.JournalTestUtil;
 import com.liferay.layout.exporter.PortletPreferencesPortletConfigurationExporter;
 import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.portal.kernel.model.Group;
@@ -22,6 +25,7 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -115,6 +119,70 @@ public class JournalContentExportImportTest
 	}
 
 	@Test
+	@TestInfo("LPD-103207")
+	public void testExportImportSelectedArticleWithLayoutStaging()
+		throws Exception {
+
+		JournalArticle article = JournalTestUtil.addArticle(
+			group.getGroupId(), 0);
+
+		ExportImportThreadLocal.setLayoutStagingInProcess(true);
+
+		try {
+			_exportImportSelectedArticle(article, false);
+		}
+		finally {
+			ExportImportThreadLocal.setLayoutStagingInProcess(false);
+		}
+
+		Assert.assertNull(
+			_journalArticleLocalService.
+				fetchLatestArticleByExternalReferenceCode(
+					importedGroup.getGroupId(),
+					article.getExternalReferenceCode()));
+	}
+
+	@Test
+	@TestInfo("LPD-103207")
+	public void testExportImportSelectedArticleWithoutStaging()
+		throws Exception {
+
+		JournalArticle article = JournalTestUtil.addArticle(
+			group.getGroupId(), 0);
+
+		_exportImportSelectedArticle(article, false);
+
+		Assert.assertNotNull(
+			_journalArticleLocalService.
+				fetchLatestArticleByExternalReferenceCode(
+					importedGroup.getGroupId(),
+					article.getExternalReferenceCode()));
+	}
+
+	@Test
+	@TestInfo("LPD-103207")
+	public void testExportImportSelectedArticleWithPortletStaging()
+		throws Exception {
+
+		JournalArticle article = JournalTestUtil.addArticle(
+			group.getGroupId(), 0);
+
+		_exportImportSelectedArticle(article, true);
+
+		JournalArticle importedArticle =
+			_journalArticleLocalService.
+				fetchLatestArticleByExternalReferenceCode(
+					importedGroup.getGroupId(),
+					article.getExternalReferenceCode());
+
+		Assert.assertNotNull(importedArticle);
+		Assert.assertEquals(
+			article.getTitle(LocaleUtil.getSiteDefault()),
+			importedArticle.getTitle(LocaleUtil.getSiteDefault()));
+		Assert.assertEquals(article.getContent(), importedArticle.getContent());
+	}
+
+	@Test
 	@TestInfo("LPD-98716")
 	public void testGetPortletConfigurationWithLocalStaging() throws Exception {
 		StagingLocalServiceUtil.enableLocalStaging(
@@ -202,6 +270,20 @@ public class JournalContentExportImportTest
 		ExportImportThreadLocal.setPortletStagingInProcess(false);
 	}
 
+	private void _exportImportSelectedArticle(
+			JournalArticle article, boolean portletStagingInProcess)
+		throws Exception {
+
+		exportImportPortlet(
+			LayoutTestUtil.addPortletToLayout(
+				TestPropsValues.getUserId(), layout, getPortletId(), "column-1",
+				HashMapBuilder.put(
+					"articleExternalReferenceCode",
+					new String[] {article.getExternalReferenceCode()}
+				).build()),
+			portletStagingInProcess);
+	}
+
 	private Object _getExportedGroupExternalReferenceCode(
 			String groupExternalReferenceCode)
 		throws Exception {
@@ -222,6 +304,9 @@ public class JournalContentExportImportTest
 
 	@Inject
 	private GroupLocalService _groupLocalService;
+
+	@Inject
+	private JournalArticleLocalService _journalArticleLocalService;
 
 	@Inject
 	private PortletPreferencesPortletConfigurationExporter


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103207

Reviewed and approved on liferay-headless/liferay-portal#4156.

## What Is Being Fixed

Publishing a Web Content Display widget through its own **Options → Staging → Publish to Live** reports *Successful* but nothing reaches Live: no new `JournalArticle` version is created in the Live group, the Live page keeps rendering the previous version, and nothing is logged. Reported by a customer on 2026.Q1.7 in LPP-65271 / LRHC-153056, and reproducible on master once `feature.flag.LPD-76864` (Widget Pages) is enabled.

The widget-level publish is still the legacy LAR export/import flow — only the *layout* publish moved to the batch engine, and journal is not among the portlets that got a `BatchEnginePortletDataHandler`. Because `JournalContentPortletDataHandler` exports no data of its own and `isDisplayPortlet()` is true for it, `JournalContentExportImportPortletPreferencesProcessor` was the only hook that could pull the referenced article into the LAR. That processor was deleted in `0a6b5925d3e83` ("LPD-80422 This class is no longer necessary") and later re-created by LPD-98716 as a stub that only rewrites `groupExternalReferenceCode`, so the article, the display template, the portlet permissions and the `ReferencedStagedModelImporter` import capability all stopped travelling. Neither change carried export/import coverage, so nothing caught it.

There is a second, older layer. The deleted class hard-coded `isPublishDisplayedContent()` to `false`, and `ExportImportHelperImpl` consults that override whenever `ExportImportThreadLocal.isStagingInProcess()` — true for both layout *and* portlet staging. So the widget-level publish only ever wrote a weak missing reference. That is LPD-37071 / LPP-55668 from 2024; its fix added an unconditional `exportStagedModel`, which broke Poshi `Staging#PublishViaPortletWithoutContent` (LPD-38992) and was reverted.

## How It Is Being Fixed

Both changes are confined to `journal-content-web`, so no other display widget and no layout publish changes behaviour.

`isPublishDisplayedContent()` now returns `ExportImportThreadLocal.isPortletStagingInProcess()` instead of a hard-coded `false`. During a portlet publish the user explicitly asked for this widget — the *Selected Web Content* control in that dialog is rendered checked and disabled, so it cannot even be turned off — and `exportReferenceStagedModel` therefore exports the article. During a layout publish it still returns `false` and the article is left out, because the user decides there whether web content is published at all; that is the distinction the reverted LPD-37071 patch missed.

On top of that, the processor regains the pieces LPD-80422 removed: the referenced article export (guarded by the `articleAdded` element attribute), the strong DDM template reference when the widget uses a non-default display template, the portlet permission export and import, and both capabilities — `JournalContentMetadataExporterImporterCapability`, which was left dangling as dead code, and `ReferencedStagedModelImporter`, without which an exported reference would never be imported. LPD-98716's group ERC translation is kept as is; the article and template ERCs need no translation any more, since the primary-key maps that used to carry them no longer exist. The article's group is resolved before that translation runs, because the translation rewrites `groupExternalReferenceCode` to the target group's.

Verified end to end on a local bundle: with the fix, the widget publish moves the Live article to the new version and the Live page renders it; an Advanced Publish Process of the page with *Web Content* unchecked still leaves Live untouched. The three new integration tests in `JournalContentExportImportTest` cover portlet staging, layout staging and plain LAR export/import; the two positive ones fail without the fix, and the layout-staging one guards the LPD-38992 regression.

Wiki Display, Form, DDL Display and KB Display carry the same hard-coded `isPublishDisplayedContent() == false` and are still affected. Fixing them generically would mean returning `true` early in `ExportImportHelperImpl.isPublishDisplayedContent` when `isPortletStagingInProcess()`; that is left out here to keep the change small and backportable to `release-2026.q1`, and is noted on the ticket.

## PR Check

**pr-check: PASS** — tested on `920f102606b63f983003376b228313c159ea798f`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "920f102606b63f983003376b228313c159ea798f"} -->
