### PR TITLE
LPD-101239 Show when an individual became known

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/model/Individual.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/model/Individual.java
@@ -87,6 +87,14 @@ public class Individual {
 		return _id;
 	}
 
+	public Date getKnownSinceDate() {
+		if (_knownSinceDate == null) {
+			return null;
+		}
+
+		return new Date(_knownSinceDate.getTime());
+	}
+
 	public Date getLastActivityDate() {
 		if (_lastActivityDate == null) {
 			return null;
@@ -169,6 +177,12 @@ public class Individual {
 
 	public void setId(String id) {
 		_id = id;
+	}
+
+	public void setKnownSinceDate(Date knownSinceDate) {
+		if (knownSinceDate != null) {
+			_knownSinceDate = new Date(knownSinceDate.getTime());
+		}
 	}
 
 	public void setLastActivityDate(Date lastActivityDate) {
@@ -362,6 +376,7 @@ public class Individual {
 	private Map<String, Object> _embeddedResources = new HashMap<>();
 	private Date _firstActivityDate;
 	private String _id;
+	private Date _knownSinceDate;
 	private Date _lastActivityDate;
 	private String _lastSessionCountry;
 	private String _profileType;

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_vertical_timeline.scss
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_vertical_timeline.scss
@@ -95,6 +95,7 @@
 		padding: 2px 6px;
 	}
 
+	.became-known-label,
 	.data-source-label {
 		font-size: $fontSizeSmall;
 	}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/model/display/contacts/IndividualDisplay.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/model/display/contacts/IndividualDisplay.java
@@ -51,6 +51,7 @@ public class IndividualDisplay implements FaroEntityDisplay {
 		_dateCreated = individual.getDateCreated();
 		_firstActivityDate = individual.getFirstActivityDate();
 		_id = individual.getId();
+		_knownSinceDate = individual.getKnownSinceDate();
 		_lastActivityDate = individual.getLastActivityDate();
 		_lastSessionCountry = individual.getLastSessionCountry();
 
@@ -140,6 +141,7 @@ public class IndividualDisplay implements FaroEntityDisplay {
 	@JsonIgnore
 	private Individual _individual;
 
+	private Date _knownSinceDate;
 	private Date _lastActivityDate;
 	private String _lastSessionCountry;
 	private String _name;

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/profile/components/IndividualAttributesCDP.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/profile/components/IndividualAttributesCDP.tsx
@@ -9,6 +9,7 @@ import {SectionHeader} from 'shared/components/SectionHeader';
 interface IIndividualAttributesProps {
 	children?: React.ReactNode;
 	contactId?: string;
+	knownSinceDate?: string | null;
 	loading?: boolean;
 	propertiesData: Map<string, any>;
 	showEmptyState?: boolean;
@@ -23,6 +24,7 @@ const INFO_LANGUAGE_MAP: Record<string, string> = {
 	familyName: Liferay.Language.get('last-name'),
 	givenName: Liferay.Language.get('first-name'),
 	jobTitle: Liferay.Language.get('job-title'),
+	knownSinceDate: Liferay.Language.get('known-since-date'),
 	languageId: Liferay.Language.get('language'),
 	middleName: Liferay.Language.get('middle-name'),
 	prefix: Liferay.Language.get('prefix'),
@@ -53,6 +55,7 @@ const contextualInfoConfig: DataDrivenConfig = [
 			{className: 'col-12 col-md-4 col-sm-6', key: 'familyName'},
 			{className: 'col-12 col-md-4 col-sm-6', key: 'birthDate'},
 			{className: 'col-12 col-md-4 col-sm-6', key: 'suffix'},
+			{className: 'col-12 col-md-4 col-sm-6', key: 'knownSinceDate'},
 		],
 		title: Liferay.Language.get('personal-information'),
 	},
@@ -61,6 +64,7 @@ const contextualInfoConfig: DataDrivenConfig = [
 const IndividualAttributesCDP: React.FC<IIndividualAttributesProps> = ({
 	children: emptyState,
 	contactId,
+	knownSinceDate,
 	loading = false,
 	propertiesData,
 	showEmptyState,
@@ -75,6 +79,12 @@ const IndividualAttributesCDP: React.FC<IIndividualAttributesProps> = ({
 		}
 
 		if (key === 'contactId') return contactId;
+
+		if (key === 'knownSinceDate') {
+			return knownSinceDate
+				? formatUTCDate(knownSinceDate, getCustomDateFormat())
+				: undefined;
+		}
 
 		return propertiesData?.get(key) || undefined;
 	};

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/profile/components/__tests__/IndividualAttributesCDP.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/profile/components/__tests__/IndividualAttributesCDP.tsx
@@ -51,6 +51,17 @@ describe('IndividualAttributesCDP', () => {
 		expect(getByText('Jan 1, 2020')).toBeTruthy();
 	});
 
+	it('should correctly format the known since date', () => {
+		const {getByText} = render(
+			<IndividualAttributesCDP
+				knownSinceDate="2026-03-04T10:15:00.000Z"
+				propertiesData={fromJS(mockProperties)}
+			/>
+		);
+
+		expect(getByText('Mar 4, 2026')).toBeTruthy();
+	});
+
 	it('should display the fallback dash for missing values', () => {
 		const {getAllByText} = render(
 			<IndividualAttributesCDP propertiesData={fromJS({})} />

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/profile/components/__tests__/__snapshots__/IndividualAttributesCDP.tsx.snap
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/profile/components/__tests__/__snapshots__/IndividualAttributesCDP.tsx.snap
@@ -375,6 +375,32 @@ exports[`IndividualAttributesCDP should render 1`] = `
                   </span>
                 </div>
               </div>
+              <div
+                class="col-12 col-md-4 col-sm-6 align-items-start d-flex mb-2"
+              >
+                <span
+                  class="sticker flex-shrink-0 mr-3 sticker-unstyled sticker-lg"
+                >
+                  <span
+                    class="sticker-overlay"
+                  />
+                </span>
+                <div
+                  class="d-flex flex-column mt-1"
+                >
+                  <span
+                    class="text-3 text-secondary"
+                  >
+                    Known Since Date
+                  </span>
+                  <span
+                    class="font-weight-semi-bold text-break text-dark"
+                    style="word-break: break-all;"
+                  >
+                    -
+                  </span>
+                </div>
+              </div>
             </div>
           </div>
         </div>

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/profile/pages/IndividualProfileCDP.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/profile/pages/IndividualProfileCDP.tsx
@@ -149,6 +149,7 @@ const IndividualProfileCDP: React.FC<IIndividualProfileCDPProps> = ({
 		<>
 			<IndividualAttributesCDP
 				contactId={individualId}
+				knownSinceDate={individual.get('knownSinceDate')}
 				loading={dataSourceLoading}
 				propertiesData={individual.get('properties')}
 				showEmptyState={showEmptyState}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/apollo/resolvers/EventsByUserSessionsResolver.js
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/apollo/resolvers/EventsByUserSessionsResolver.js
@@ -4,6 +4,7 @@ export default () => ({
 	userSessions: [
 		{
 			__typename: 'UserSession',
+			becameKnown: false,
 			browserName: 'Default Browser',
 			completeDate: 'Fri May 08 18:00:15 GMT 2026',
 			contentLanguageId: null,
@@ -61,6 +62,7 @@ export default () => ({
 		},
 		{
 			__typename: 'UserSession',
+			becameKnown: true,
 			browserName: 'Chrome Mobile',
 			completeDate: 'Thu May 07 20:15:10 GMT 2026',
 			contentLanguageId: 'en-US',
@@ -99,6 +101,7 @@ export default () => ({
 		},
 		{
 			__typename: 'UserSession',
+			becameKnown: false,
 			browserName: 'Chrome',
 			completeDate: 'Thu May 07 19:57:32 GMT 2026',
 			contentLanguageId: 'en-US',
@@ -248,6 +251,7 @@ export default () => ({
 		},
 		{
 			__typename: 'UserSession',
+			becameKnown: false,
 			browserName: 'Default Browser',
 			completeDate: 'Thu May 07 21:15:44 GMT 2026',
 			contentLanguageId: null,

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/VerticalTimeline.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/VerticalTimeline.tsx
@@ -148,6 +148,22 @@ const DataSourceLabel: FC<{applicationId?: string; isWebhook: boolean}> = ({
 		</ClayLabel>
 	) : null;
 
+const BecameKnownLabel: FC = () => (
+	<ClayLabel
+		className="became-known-label flex-shrink-0 font-weight-semi-bold m-0"
+		displayType="success"
+		withClose={false}
+	>
+		<ClayLabel.ItemBefore>
+			<ClayIcon symbol="user" />
+		</ClayLabel.ItemBefore>
+
+		<ClayLabel.ItemExpand>
+			{Liferay.Language.get('became-known')}
+		</ClayLabel.ItemExpand>
+	</ClayLabel>
+);
+
 const ExternalLink: FC<{url: string}> = ({url}) => (
 	<ClayLink
 		className="subtitle align-items-center align-self-start d-inline-flex font-weight-normal mw-100 text-secondary"
@@ -238,6 +254,7 @@ const SessionRow: FC<IRowProps<VerticalTimelineSession>> = ({
 	item: {
 		applicationId,
 		attributes,
+		becameKnown,
 		browserName,
 		device,
 		endTime,
@@ -293,6 +310,8 @@ const SessionRow: FC<IRowProps<VerticalTimelineSession>> = ({
 				</div>
 
 				<div className="row-details ml-auto pl-3 d-flex align-items-center">
+					{becameKnown && <BecameKnownLabel />}
+
 					{LDPEnabled && (
 						<DataSourceLabel
 							applicationId={applicationId}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/__tests__/VerticalTimeline.jsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/__tests__/VerticalTimeline.jsx
@@ -185,6 +185,28 @@ describe('VerticalTimeline', () => {
 			expect(screen.queryByText('DXP')).not.toBeInTheDocument();
 		});
 
+		it('shows the became known label for the session the individual was identified in', () => {
+			renderTimeline({items: [{...SESSION_ITEM, becameKnown: true}]});
+
+			expect(screen.getByText('Became Known')).toBeInTheDocument();
+		});
+
+		it('hides the became known label for every other session', () => {
+			renderTimeline({items: [SESSION_ITEM]});
+
+			expect(screen.queryByText('Became Known')).not.toBeInTheDocument();
+		});
+
+		it('lays the became known icon out beside its text', () => {
+			renderTimeline({items: [{...SESSION_ITEM, becameKnown: true}]});
+
+			const label = screen.getByText('Became Known').closest('.label');
+
+			expect(
+				label.querySelector('.label-item-before .lexicon-icon')
+			).toBeInTheDocument();
+		});
+
 		it('hides the data source label when the workspace is not on the LDP plan', () => {
 			renderTimeline({
 				items: [{...SESSION_ITEM, applicationId: 'WebContent'}],

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/queries/UserSessionQuery.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/queries/UserSessionQuery.ts
@@ -17,6 +17,7 @@ export interface UserSessionEvent {
 }
 
 export interface UserSession {
+	becameKnown: boolean;
 	browserName: string;
 	completeDate: Date;
 	contentLanguageID: string;
@@ -78,6 +79,7 @@ export default gql`
 		) {
 			userSessions {
 				... on UserSession {
+					becameKnown
 					browserName
 					completeDate
 					contentLanguageId

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/reducers/__tests__/__snapshots__/normalizer.js.snap
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/reducers/__tests__/__snapshots__/normalizer.js.snap
@@ -54,6 +54,7 @@ Immutable.Map {
         "demographics": Immutable.Map {},
         "firstActivityDate": null,
         "id": null,
+        "knownSinceDate": null,
         "lastActivityDate": null,
         "lastSessionCountry": null,
         "name": "",

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/__tests__/activities.jsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/__tests__/activities.jsx
@@ -317,6 +317,22 @@ describe('activities', () => {
 
 			expect(session.duration).toBeUndefined();
 		});
+
+		it('marks the session the individual became known in', () => {
+			const [, session] = formatSessions([
+				data.mockSession(0, {becameKnown: true})
+			]);
+
+			expect(session.becameKnown).toBe(true);
+		});
+
+		it('leaves the sessions unmarked when the individual is still anonymous', () => {
+			const [, session] = formatSessions([
+				data.mockSession(0, {becameKnown: false})
+			]);
+
+			expect(session.becameKnown).toBe(false);
+		});
 	});
 
 	describe('getActivityLabel', () => {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/activities.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/activities.tsx
@@ -66,6 +66,7 @@ export type VerticalTimelinePageGroup = {
 export type VerticalTimelineSession = {
 	applicationId: string;
 	attributes: Record<string, unknown>;
+	becameKnown?: boolean;
 	browserName?: string;
 	device: string;
 	endTime?: Date | string | null;
@@ -455,6 +456,7 @@ export const formatSessions = (
 					timezoneOffset: session.timezoneOffset,
 					userAgent: session.userAgent,
 				},
+				becameKnown: session.becameKnown,
 				browserName: session.browserName,
 				device: session.deviceType,
 				endTime: session.completeDate,

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/records/Individual.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/records/Individual.ts
@@ -10,6 +10,7 @@ interface IIndividual {
 	demographics: Map<string, any>;
 	firstActivityDate: string;
 	id: string;
+	knownSinceDate: string | null;
 	lastActivityDate: string;
 	lastSessionCountry: string | null;
 	name: string;
@@ -27,6 +28,7 @@ export default class Individual
 		demographics: Map(),
 		firstActivityDate: null,
 		id: null,
+		knownSinceDate: null,
 		lastActivityDate: null,
 		lastSessionCountry: null,
 		name: '',
@@ -43,6 +45,7 @@ export default class Individual
 	declare demographics: Map<string, any>;
 	declare firstActivityDate: string;
 	declare id: string;
+	declare knownSinceDate: string | null;
 	declare lastActivityDate: string;
 	declare lastSessionCountry: string | null;
 	declare name: string;

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/records/__tests__/__snapshots__/index.js.snap
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/records/__tests__/__snapshots__/index.js.snap
@@ -94,6 +94,7 @@ Immutable.Record {
   "demographics": Immutable.Map {},
   "firstActivityDate": null,
   "id": null,
+  "knownSinceDate": null,
   "lastActivityDate": null,
   "lastSessionCountry": null,
   "name": "",

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language.properties
@@ -233,6 +233,7 @@ basic-settings=Basic Settings
 basic-web-content=Basic Web Content
 batch=Batch
 batch-segment=Batch Segment
+became-known=Became Known
 before=Before
 behavioral=Behavioral
 behaviors=Behaviors


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101239

## What Is Being Fixed

Nothing in Analytics Cloud showed when an individual stopped being anonymous. The individual profile had no field for that date even though the backend already computed it, and in the activity stream the event that identified the individual read like any other, so there was no way to recognize newly identified engagement or to tell which session was responsible for it.

## How It Is Being Fixed

The Analytics Cloud backend exposes both data points, so this pull request is the portal half of the story. The engine client's `Individual` model and `IndividualDisplay` carry `knownSinceDate` through to the frontend, the individual record picks it up, and the profile's attributes card renders it as "Known Since", empty while the individual is still anonymous.

For the activity stream, the user session query asks for the new `becameKnown` flag and the vertical timeline badges the session it comes back true for. The badge sits in the session header, next to the data source and the device, rather than on the event itself: the backend resolves the transition per session, which is also what keeps a single session badged no matter how many identification events it contains. Both the profile field and the badge derive from the same identity resolution date, so the two cannot disagree.

## PR Check

**pr-check: PASS** — tested on `dce5f83f1be761a15aa0cd6d163583cc1fd38e99`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Baseline | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "dce5f83f1be761a15aa0cd6d163583cc1fd38e99"} -->
