### PR TITLE
LPD-103400 Return to the entry list and reclaim a leftover Salesforce definition

### DIFF
--- a/modules/test/playwright/tests/object-web/salesforce/objectSalesforce.spec.ts
+++ b/modules/test/playwright/tests/object-web/salesforce/objectSalesforce.spec.ts
@@ -24,6 +24,10 @@ import getPageDefinition from '../../layout-content-page-editor-web/main/utils/g
 import {generateObjectFields} from '../utils/generateObjectFields';
 import {salesforceConfig} from './salesforce.config';
 
+const EXTERNAL_REFERENCE_CODE = 'Playwright_Test__c';
+
+const OBJECT_DEFINITION_NAME = 'PlaywrightTest';
+
 const test = mergeTests(
 	dataApiHelpersTest,
 	featureFlagsTest({
@@ -37,7 +41,7 @@ const test = mergeTests(
 	pageEditorPagesTest
 );
 
-test.beforeEach(async ({instanceSettingsPage, page}) => {
+test.beforeEach(async ({apiHelpers, instanceSettingsPage, page}) => {
 	test.skip(
 		!salesforceConfig.salesforceLoginURL ||
 			!salesforceConfig.salesforceConsumerKey ||
@@ -48,6 +52,21 @@ test.beforeEach(async ({instanceSettingsPage, page}) => {
 	);
 
 	page.setViewportSize({height: 1080, width: 1920});
+
+	// The external reference code names the Salesforce object that holds the
+	// entries, so neither it nor the definition's name can be randomized, and
+	// only one definition at a time can carry them. A run that dies before its
+	// own teardown leaves that definition behind and every later run against the
+	// same database is refused. Take the name back.
+
+	const leftoverObjectDefinition =
+		await apiHelpers.objectAdmin.getObjectDefinitionByName(
+			OBJECT_DEFINITION_NAME
+		);
+
+	if (leftoverObjectDefinition) {
+		await apiHelpers.deleteObjectDefinition(leftoverObjectDefinition.id);
+	}
 
 	await test.step('Setup Salesforce Instance Settings', async () => {
 		await instanceSettingsPage.goToInstanceSetting(
@@ -99,9 +118,9 @@ test('Assert CRUD with created custom object using Salesforce storage type', asy
 	const {body: objectDefinition} =
 		await objectDefinitionAPIClient.postObjectDefinition({
 			active: true,
-			externalReferenceCode: 'Playwright_Test__c',
+			externalReferenceCode: EXTERNAL_REFERENCE_CODE,
 			label: {en_US: 'Playwright Test'},
-			name: 'PlaywrightTest',
+			name: OBJECT_DEFINITION_NAME,
 			objectFields,
 			panelCategoryKey: 'control_panel.object',
 			pluralLabel: {en_US: 'Playwright Tests'},
@@ -227,9 +246,9 @@ test('Assert CRUD with created custom object using Salesforce storage type in fo
 	const {body: objectDefinition} =
 		await objectDefinitionAPIClient.postObjectDefinition({
 			active: true,
-			externalReferenceCode: 'Playwright_Test__c',
+			externalReferenceCode: EXTERNAL_REFERENCE_CODE,
 			label: {en_US: 'Playwright Test'},
-			name: 'PlaywrightTest',
+			name: OBJECT_DEFINITION_NAME,
 			objectFields,
 			panelCategoryKey: 'control_panel.object',
 			pluralLabel: {en_US: 'Playwright Tests'},

--- a/modules/test/playwright/tests/object-web/salesforce/objectSalesforce.spec.ts
+++ b/modules/test/playwright/tests/object-web/salesforce/objectSalesforce.spec.ts
@@ -16,6 +16,7 @@ import {isolatedSiteTest} from '../../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../../fixtures/loginTest';
 import {objectPagesTest} from '../../../fixtures/objectPagesTest';
 import {pageEditorPagesTest} from '../../../fixtures/pageEditorPagesTest';
+import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
 import getRandomString from '../../../utils/getRandomString';
 import {waitForAlert} from '../../../utils/waitForAlert';
 import getFormContainerDefinition from '../../layout-content-page-editor-web/main/utils/getFormContainerDefinition';
@@ -149,13 +150,16 @@ test('Assert CRUD with created custom object using Salesforce storage type', asy
 
 		await viewObjectEntriesPage.saveObjectEntryButton.click();
 		await waitForAlert(page);
-		await viewObjectEntriesPage.backButton.click();
 	});
 
 	await test.step('Read Object Entry', async () => {
-		await expect(
-			page.getByRole('cell', {exact: true, name: objectFieldValue})
-		).toBeVisible();
+		await clickAndExpectToBeVisible({
+			target: page.getByRole('cell', {
+				exact: true,
+				name: objectFieldValue,
+			}),
+			trigger: viewObjectEntriesPage.backButton,
+		});
 	});
 
 	await test.step('Update Object Entry', async () => {
@@ -173,11 +177,14 @@ test('Assert CRUD with created custom object using Salesforce storage type', asy
 
 		await viewObjectEntriesPage.saveObjectEntryButton.click();
 		await expect(viewObjectEntriesPage.successMessage).toBeVisible();
-		await viewObjectEntriesPage.backButton.click();
 
-		await expect(
-			page.getByRole('cell', {exact: true, name: objectFieldUpdatedValue})
-		).toBeVisible();
+		await clickAndExpectToBeVisible({
+			target: page.getByRole('cell', {
+				exact: true,
+				name: objectFieldUpdatedValue,
+			}),
+			trigger: viewObjectEntriesPage.backButton,
+		});
 	});
 
 	await test.step('Delete Object Entry', async () => {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103400

## What Is Being Fixed

Two independent faults in the same Salesforce playwright spec, each making it fail for reasons unrelated to the behavior under test.

**The Back click races the save's own navigation.** The CRUD test saves an entry, clicks Back and asserts the new row in the list, but nothing ties that click to the list coming up. Saving issues its own navigation, so the two race and whichever loses leaves the assertion running against the entry form until it times out. It failed five times in eleven runs. The write is not what fails: in one failing run the list request had already returned the awaited row, correctly sorted by create date, while the page still showed the form.

**A dead run keeps the spec's identifiers.** The external reference code has to name the real Salesforce object, so it cannot be randomized, and the definition's name is hardcoded beside it. Only one definition per database can hold either, so a run that dies between creating the definition and its teardown leaves them held and every later run on that database is refused before it reaches the behavior it tests. One interrupted run poisons the spec until someone deletes the definition by hand.

## How It Is Being Fixed

The list is asked for through `clickAndExpectToBeVisible`, which clicks Back only while the awaited row is absent, so a Back that already worked costs nothing and a Back that lost the race is repeated.

Whatever definition holds the hardcoded name is deleted before this run creates its own. The lookup goes by name rather than by external reference code because the name is what the database refuses on: `ObjectDefinitionLocalServiceImpl`'s external reference code validation only checks length and the system prefix, while its name validation looks the name up with `fetchByC_N` and raises `ObjectDefinitionNameException.MustNotBeDuplicate`. The name is also the only one of the two that the object definition entity model accepts as a filter.

In a healthy run the guard does nothing: the data fixture deletes the definition in a `finally`, so an ordinary failing run still cleans up, and the lookup then finds nothing. It fires only when a teardown never ran at all. It cannot disturb a healthy run either — the lookup is scoped to the run's own database, and the project runs one worker at a time, so no sibling test can be holding the definition.

Deliberately excluded: an earlier version also deleted every row in the shared Salesforce object after each test and searched the list before reading a row. The search was measured to fix nothing, because the view's own create-date sort already keeps a new row on the first page, and the delete reached into an org that concurrent continuous integration batches share while having separate databases.

## Testing

- Back click: twelve consecutive passing runs, against five failures in eleven before.
- Reclaim: measured against the live Salesforce org with a definition deliberately left holding the name and code — both tests fail without the change, on the create the leftover refuses, and both pass with it. Repeated on the final form of this branch.
- Both commits are byte for byte what two consecutive fully green object suite runs carried, each sixty two of sixty two axes with no unexpected and no flaky result.

## PR Check

**pr-check: PASS** — tested on `d061d0e3a0702b853eca8cbc38fae13f64db2325`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Baseline | PASS |
| JavaScript Unit Tests | PASS |
| Per-Module Compile | PASS |

The last two matched the diff but have nothing to run against it. The changed path is the Playwright harness, whose `package.json` `test` script is the Playwright runner itself, which pr-check puts out of scope, and which has no Java to compile or deploy. The equivalent check for a TypeScript change, `tsc --noEmit` over the harness, is clean.

<!-- pr-check {"result": "success", "sha": "d061d0e3a0702b853eca8cbc38fae13f64db2325"} -->
