### PR TITLE
LPD-103271 Read the Learn resources from a directory instead of a server

### DIFF
--- a/modules/apps/learn/learn-api/build.gradle
+++ b/modules/apps/learn/learn-api/build.gradle
@@ -4,3 +4,7 @@ dependencies {
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-string")
 }
+
+test {
+	systemProperty "learn.resources.data.dir", new File(rootDir.parentFile, "learn-resources/data")
+}

--- a/modules/apps/learn/learn-api/src/main/java/com/liferay/learn/LearnMessageUtil.java
+++ b/modules/apps/learn/learn-api/src/main/java/com/liferay/learn/LearnMessageUtil.java
@@ -12,8 +12,10 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.HttpUtil;
 import com.liferay.portal.kernel.util.PropsUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.webcache.WebCacheItem;
 import com.liferay.portal.kernel.webcache.WebCachePoolUtil;
 
@@ -57,6 +59,9 @@ public class LearnMessageUtil {
 		return jsonObject;
 	}
 
+	private static final String _LEARN_RESOURCES_DIR = PropsUtil.get(
+		"learn.resources.dir");
+
 	private static final boolean _LEARN_RESOURCES_MODE_DEV = Objects.equals(
 		PropsUtil.get("learn.resources.mode"), "dev");
 
@@ -77,6 +82,25 @@ public class LearnMessageUtil {
 			try {
 				if (_LEARN_RESOURCES_MODE_OFF) {
 					return JSONFactoryUtil.createJSONObject();
+				}
+
+				if (_LEARN_RESOURCES_MODE_DEV &&
+					Validator.isNotNull(_LEARN_RESOURCES_DIR)) {
+
+					// The dev server exists only to serve these files over
+					// HTTP, so a caller that can name the directory holding
+					// them does not need it.
+
+					String fileName = StringBundler.concat(
+						_LEARN_RESOURCES_DIR, StringPool.SLASH, _resource,
+						".json");
+
+					if (_log.isDebugEnabled()) {
+						_log.debug("Reading " + fileName);
+					}
+
+					return JSONFactoryUtil.createJSONObject(
+						FileUtil.read(fileName));
 				}
 
 				StringBundler sb = new StringBundler(4);

--- a/modules/apps/learn/learn-api/src/test/java/com/liferay/learn/LearnResourcesTest.java
+++ b/modules/apps/learn/learn-api/src/test/java/com/liferay/learn/LearnResourcesTest.java
@@ -1,0 +1,130 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.learn;
+
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Shuyang Zhou
+ */
+public class LearnResourcesTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testGlobalServerServesEveryLearnResource() {
+
+		// Every learn message in the product renders from one of these
+		// resources, and a read that fails is swallowed into an empty object,
+		// so a resource the global server stops serving makes learn links
+		// vanish with nothing in the log. This repository holds a copy of every
+		// resource the product asks for, so the directory names what has to be
+		// served.
+
+		String dirName = System.getProperty("learn.resources.data.dir");
+
+		Assert.assertNotNull(
+			"The build did not set \"learn.resources.data.dir\"", dirName);
+
+		File dir = new File(dirName);
+
+		Assert.assertTrue(dirName + " is not a directory", dir.isDirectory());
+
+		File[] files = dir.listFiles(
+			(directory, name) -> name.endsWith(".json"));
+
+		Assert.assertNotNull(dir.toString(), files);
+		Assert.assertTrue("No learn resources in " + dir, files.length > 0);
+
+		List<String> unservedURLs = new ArrayList<>();
+
+		int timeout = _TIMEOUT;
+
+		for (File file : files) {
+			String url =
+				"https://s3.amazonaws.com/learn-resources.liferay.com/" +
+					file.getName();
+
+			String failure = _getFailure(url, timeout);
+
+			if (failure != null) {
+				unservedURLs.add(failure);
+
+				// The first failure answers what the remaining reads are
+				// asking: the doubt is no longer about one resource but about
+				// the server or the route to it. So every read before it waits
+				// as long as a slow continuous integration machine can need,
+				// and every read after it waits only long enough to tell a
+				// server that is down from one that is merely slow.
+
+				timeout = _TIMEOUT_AFTER_FAILURE;
+			}
+		}
+
+		Assert.assertTrue(unservedURLs.toString(), unservedURLs.isEmpty());
+	}
+
+	private String _getFailure(String url, int timeout) {
+		try {
+			HttpURLConnection httpURLConnection = (HttpURLConnection)new URL(
+				url
+			).openConnection();
+
+			httpURLConnection.setConnectTimeout(timeout);
+			httpURLConnection.setReadTimeout(timeout);
+
+			int responseCode = httpURLConnection.getResponseCode();
+
+			if (responseCode != HttpURLConnection.HTTP_OK) {
+				return url + " answered " + responseCode;
+			}
+
+			byte[] bytes = new byte[1];
+
+			try (InputStream inputStream = httpURLConnection.getInputStream()) {
+				if (inputStream.read(bytes) == -1) {
+					return url + " answered nothing";
+				}
+			}
+
+			if (bytes[0] != '{') {
+				return url + " does not answer with a JSON object";
+			}
+
+			return null;
+		}
+		catch (IOException ioException) {
+
+			// A read that fails is reported like any other, rather than thrown,
+			// so one unreachable resource does not hide the state of the rest.
+
+			return url + " could not be read: " + ioException;
+		}
+	}
+
+	private static final int _TIMEOUT = 30000;
+
+	private static final int _TIMEOUT_AFTER_FAILURE = 5000;
+
+}

--- a/modules/test/playwright/env/common.sh
+++ b/modules/test/playwright/env/common.sh
@@ -93,6 +93,8 @@ function combine_properties_files {
 function default_set_up {
 	update_portal_ext_properties
 
+	update_learn_resources_dir
+
 	start_default_app_server
 
 	deploy_parent_project_osgi_modules
@@ -744,6 +746,41 @@ function stop_client_extension_spring_boot_application {
 
 function stop_default_app_server {
 	stop_app_server ${LIFERAY_HOME} ${LIFERAY_PORTAL_URL}
+}
+
+function update_learn_resources_dir {
+
+	# The portal reads its learn resources from this checkout, so a test that
+	# clicks a learn link depends on no server, neither the global one nor a
+	# local one. Where a checkout sits relative to a portal's home is
+	# configured rather than fixed, so only this script can name the path.
+
+	local learn_resources_dir=${_PORTAL_PROJECT_DIR}/learn-resources/data
+
+	if [[ ! -d ${learn_resources_dir} ]]
+	then
+		echo "Unable to find ${learn_resources_dir}."
+
+		exit 1
+	fi
+
+	# A bundle carries one of these files under each application server it
+	# ships with, and a bundle built with every default carries none at all, in
+	# which case the portal still reads the one its home holds.
+
+	local properties_files=$(get_tomcat_portal_ext_properties_file)
+
+	if [[ -z ${properties_files} ]]
+	then
+		properties_files=${LIFERAY_HOME}/portal-ext.properties
+	fi
+
+	local properties_file
+
+	for properties_file in ${properties_files}
+	do
+		echo "learn.resources.dir=${learn_resources_dir}" >> ${properties_file}
+	done
 }
 
 function update_portal_ext_properties {

--- a/modules/test/playwright/env/portal-ext.properties
+++ b/modules/test/playwright/env/portal-ext.properties
@@ -8,6 +8,7 @@ setup.wizard.enabled=false
 virtual.hosts.default.site.name=
 virtual.hosts.valid.hosts=*
 web.server.http.port=8080
+learn.resources.mode=dev
 
 captcha.enforce.disabled=true
 

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -11871,11 +11871,24 @@
 ##
 
     #
+    # Set the value to the directory that holds the Learn resource files, such
+    # as the learn-resources/data directory of a liferay-portal checkout. The
+    # value is read only when the property "learn.resources.mode" is set to
+    # "dev", and it is then read instead of http://localhost:3062, so no dev
+    # server is needed.
+    #
+    # Env: LIFERAY_LEARN_PERIOD_RESOURCES_PERIOD_DIR
+    #
+    learn.resources.dir=
+
+    #
     # Set the value to "dev" to read Learn resources from http://localhost:3062.
     # Go to the learn-resources directory (i.e.
     # https://github.com/liferay/liferay-portal/tree/master/learn-resources) and
     # run "docker-compose up" to start the dev server. You can then access
-    # http://localhost:3062/server-admin-web.json and other resources.
+    # http://localhost:3062/server-admin-web.json and other resources. Set the
+    # property "learn.resources.dir" to read the same files from that directory
+    # and skip the dev server.
     #
     # Set the value to "off" to disable the Learn tag library.
     #

--- a/test.properties
+++ b/test.properties
@@ -1513,6 +1513,7 @@
 
     test.batch.class.names.includes[modules-unit_stable]=\
         **/jenkins-results-parser/**/TestPropertiesPQLValidationTest.java,\
+        **/learn-api/**/LearnResourcesTest.java,\
         **/portal-tools-sample-sql-builder/**/SampleSQLBuilderTest.java,\
         portal-impl/**/Log4jConfigUtilTest.java
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103271

Replaces #180660 and #180589. #180589 solved this by running a static file server next to the app server; #180660 was this approach, resent here with two refinements — the guard now runs in the stable unit batch, and its waits tighten once something has failed.

## What Is Being Fixed

The playwright tests that click a "Learn more." link depend on the global learn resources server at `https://s3.amazonaws.com/learn-resources.liferay.com` answering, and that dependency has taken whole runs down: both instances of the object field test and one relationship test failed together in a pure master baseline and again in two aggregate runs, which is one failed read cached for the entire build, while the same tests passed in fifty six earlier runs.

The read is swallowed into an empty JSON object at debug level, so a resource the server stops serving makes learn links vanish from a page with nothing in the log, and the outage surfaces as unrelated interface tests failing to find a link.

## How It Is Being Fixed

**A new property, `learn.resources.dir`.** Learn resources were read over HTTP in every mode: from the global server normally, and from `http://localhost:3062` when `learn.resources.mode` is `dev`. That dev server exists only to hand out files that already sit in this repository, under `learn-resources/data`. When the new property is set and the mode is `dev`, the resource is read from that directory instead and no server is involved. The mode still decides everything else: `off` returns an empty object, `dev` without the directory still reads localhost, and `on` still reads the global server.

**The test environment points the portal at the checkout.** Where a checkout sits relative to a portal's home is configured rather than fixed, so nothing the portal knows can derive that path and the environment script names it. It writes the path into every `portal-ext.properties` the home holds, because a bundle carries one under each application server it ships with, and into a file it creates when the home holds none, which is what a bundle built with every default looks like.

**The guard becomes a plain unit test in `learn-api`,** named in the stable unit batch. It iterates every resource this repository holds and reports all of them whose address on the global server does not answer with a JSON object, rather than checking a single hardcoded resource from an integration test. The build hands it the directory, so the test makes no assumption about where it runs. Naming it in `test.batch.class.names.includes[modules-unit_stable]` puts it in the stable suite and in the required list for a relevant unit run, so an outage becomes a named test failure rather than something a reader discovers through unrelated interface tests.

Its waits tighten once something has gone wrong. Every read is given thirty seconds, so a slow machine or a slow but living server is simply accepted. The first failure changes the question from whether one resource is slow to whether the server is answering at all, so every read after it is given five seconds.

## Testing

- The unit test passes across all 37 resources in about four seconds, and both of its guards fail as intended: a bogus `zzz-instrument-check.json` in the data directory produces `... answered 403`, and removing the build's system property produces `The build did not set "learn.resources.data.dir"`, so a misconfigured build cannot pass silently.
- With every resource made unroutable, it reports all 37 and finishes in 212 seconds, where a flat thirty second wait would have spent about 37 minutes.
- Measured on a running portal with nothing listening on port 3062, so a rendered learn link can only have come from the directory: with dev mode alone the two "unsupported translations" tests both fail; with the directory named as well, both pass, and so does the Postal Address relationship test that follows the same kind of link. Those are exactly the three learn failures seen in the baseline run.
- The environment function was exercised against two synthetic bundles: one carrying two `portal-ext.properties` files, where the property lands in both, and one carrying none, where the file is created under the portal's home.

## PR Check

**pr-check: PASS** — tested on `8792587d04dfe6cb8f68a2a65811ab03bbb1d2b6`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| PQL Validation | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

Integration Test Compile had no affected module: no `testIntegration` source set compiles against `learn-api`, and the integration test this change removes was the only one that did. Cross-Module Compile covered all 25 modules that compile against `learn-api`, preceded by `ant compile install-portal-snapshots` so they were checked against this branch's portal core.

<!-- pr-check {"result": "success", "sha": "8792587d04dfe6cb8f68a2a65811ab03bbb1d2b6"} -->
