### PR TITLE
LPD-103408 Read the Digital Signature list in the envelope's own row

### DIFF
--- a/modules/apps/digital-signature/digital-signature-test/src/testFunctional/macros/DigitalSignature.macro
+++ b/modules/apps/digital-signature/digital-signature-test/src/testFunctional/macros/DigitalSignature.macro
@@ -482,10 +482,44 @@ definition {
 	}
 
 	@summary = "Default summary"
-	macro viewMoreRecipient() {
-		WaitForElementPresent(locator1 = "DigitalSignatureListView#DIGITAL_SIGNATURE_RECIPIENTS_BADGE");
+	macro viewEnvelopeIsGone(envelopeName = null) {
 
-		AssertElementPresent(locator1 = "DigitalSignatureListView#DIGITAL_SIGNATURE_RECIPIENTS_BADGE");
+		// The delete leaves the list to be fetched again before the row goes,
+		// and the list is only fetched once per render, so ask for it again
+		// until the envelope is off it. Each ask waits for the fetch to finish,
+		// because navigating away mid fetch logs a client abort that fails the
+		// whole run.
+
+		while ((IsElementPresent(envelopeName = ${envelopeName}, locator1 = "DigitalSignatureListView#DIGITAL_SIGNATURE_ENVELOPE_NAME")) && (maxIterations = "10")) {
+			Refresh();
+
+			DigitalSignature.waitForListViewLoad();
+		}
+
+		AssertElementNotPresent(
+			envelopeName = ${envelopeName},
+			locator1 = "DigitalSignatureListView#DIGITAL_SIGNATURE_ENVELOPE_NAME");
+	}
+
+	@summary = "Default summary"
+	macro viewMoreRecipient(envelopeName = null) {
+
+		// The list is DocuSign's own sent items folder and it is fetched once
+		// per render, so the envelope's row is not on it the moment the send is
+		// acknowledged and waiting on a rendered page cannot make it appear.
+		// Ask for the list again, gated on its own fetch finishing, because
+		// navigating away from it mid fetch logs a client abort that fails the
+		// whole run.
+
+		while ((IsElementNotPresent(envelopeName = ${envelopeName}, locator1 = "DigitalSignatureListView#DIGITAL_SIGNATURE_ENVELOPE_RECIPIENTS_BADGE")) && (maxIterations = "10")) {
+			Refresh();
+
+			DigitalSignature.waitForListViewLoad();
+		}
+
+		AssertElementPresent(
+			envelopeName = ${envelopeName},
+			locator1 = "DigitalSignatureListView#DIGITAL_SIGNATURE_ENVELOPE_RECIPIENTS_BADGE");
 	}
 
 	@summary = "Default summary"

--- a/modules/apps/digital-signature/digital-signature-test/src/testFunctional/macros/DigitalSignature.macro
+++ b/modules/apps/digital-signature/digital-signature-test/src/testFunctional/macros/DigitalSignature.macro
@@ -430,10 +430,23 @@ definition {
 	}
 
 	@summary = "Default summary"
-	macro viewCreateDate() {
-		WaitForElementPresent(locator1 = "DigitalSignatureListView#DIGITAL_SIGNATURE_RECENT_CREATE_DATE");
+	macro viewCreateDate(envelopeName = null) {
 
-		AssertElementPresent(locator1 = "DigitalSignatureListView#DIGITAL_SIGNATURE_RECENT_CREATE_DATE");
+		// The list is DocuSign's own sent items folder, which does not hold an
+		// envelope the moment the send is acknowledged, so ask for the list
+		// again until the envelope's own row is on it. Each ask waits for the
+		// list to finish fetching, because navigating away from it mid fetch
+		// logs a client abort that fails the whole run.
+
+		while ((IsElementNotPresent(envelopeName = ${envelopeName}, locator1 = "DigitalSignatureListView#DIGITAL_SIGNATURE_ENVELOPE_CREATE_DATE")) && (maxIterations = "10")) {
+			Refresh();
+
+			DigitalSignature.waitForListViewLoad();
+		}
+
+		AssertElementPresent(
+			envelopeName = ${envelopeName},
+			locator1 = "DigitalSignatureListView#DIGITAL_SIGNATURE_ENVELOPE_CREATE_DATE");
 	}
 
 	@summary = "Default summary"

--- a/modules/apps/digital-signature/digital-signature-test/src/testFunctional/paths/DigitalSignatureListView.path
+++ b/modules/apps/digital-signature/digital-signature-test/src/testFunctional/paths/DigitalSignatureListView.path
@@ -16,8 +16,8 @@
 	<td></td>
 </tr>
 <tr>
-	<td>DIGITAL_SIGNATURE_RECIPIENTS_BADGE</td>
-	<td>//span[contains(@class, 'badge-item')]</td>
+	<td>DIGITAL_SIGNATURE_ENVELOPE_RECIPIENTS_BADGE</td>
+	<td>//tr[contains(., '${envelopeName}')]//span[contains(@class, 'badge-item')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/modules/apps/digital-signature/digital-signature-test/src/testFunctional/paths/DigitalSignatureListView.path
+++ b/modules/apps/digital-signature/digital-signature-test/src/testFunctional/paths/DigitalSignatureListView.path
@@ -76,8 +76,8 @@
 	<td></td>
 </tr>
 <tr>
-	<td>DIGITAL_SIGNATURE_RECENT_CREATE_DATE</td>
-	<td>//td[contains(., 'a few seconds ago')]</td>
+	<td>DIGITAL_SIGNATURE_ENVELOPE_CREATE_DATE</td>
+	<td>//tr[contains(., '${envelopeName}')]//td[contains(., 'ago')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/modules/apps/digital-signature/digital-signature-test/src/testFunctional/tests/DigitalSignatureListView.testcase
+++ b/modules/apps/digital-signature/digital-signature-test/src/testFunctional/tests/DigitalSignatureListView.testcase
@@ -201,12 +201,14 @@ definition {
 	@description = "LPS-131206. Verify if is possible view on list when an envelope have more recipients than one"
 	@priority = 4
 	test HaveMoreRecipientsThanOne {
+		var envelopeName = "Poshi Test HaveMoreRecipientsThanOne ${StringUtil.randomString(8)}";
+
 		task ("Given a digital envelope is created") {
 			DigitalSignature.createEnvelope(
 				addEmail = "test@liferay.com",
 				addFullName = "Recipient Full Name",
 				addMessage = "Email Message",
-				addName = "Poshi Test HaveMoreRecipientsThanOne",
+				addName = ${envelopeName},
 				addSubject = "Email Subject",
 				dmDocumentFile = "Alice's Adventures in Wonderland.pdf");
 		}
@@ -224,11 +226,11 @@ definition {
 
 			Refresh();
 
-			DigitalSignature.viewMoreRecipient();
+			DigitalSignature.viewMoreRecipient(envelopeName = ${envelopeName});
 
-			DigitalSignature.deleteEnvelope(envelopeName = "Poshi Test HaveMoreRecipientsThanOne");
+			DigitalSignature.deleteEnvelope(envelopeName = ${envelopeName});
 
-			AssertElementNotPresent(locator1 = "DigitalSignatureListView#DIGITAL_SIGNATURE_RECIPIENTS_BADGE");
+			DigitalSignature.viewEnvelopeIsGone(envelopeName = ${envelopeName});
 
 			DigitalSignature.waitForListViewLoad();
 

--- a/modules/apps/digital-signature/digital-signature-test/src/testFunctional/tests/DigitalSignatureListView.testcase
+++ b/modules/apps/digital-signature/digital-signature-test/src/testFunctional/tests/DigitalSignatureListView.testcase
@@ -133,12 +133,14 @@ definition {
 	@description = "LPS-131206. Verify if the Create Date column shows the date correctly after created one envelope in local Timezone "
 	@priority = 4
 	test CanViewCorrectDate {
+		var envelopeName = "Poshi Test CanViewCorrectDate ${StringUtil.randomString(8)}";
+
 		task ("When a digital envelope is created") {
 			DigitalSignature.createEnvelope(
 				addEmail = "test@liferay.com",
 				addFullName = "Recipient Full Name",
 				addMessage = "Email Message",
-				addName = "Poshi Test CanViewCorrectDate",
+				addName = ${envelopeName},
 				addSubject = "Email Subject",
 				dmDocumentFile = "Alice's Adventures in Wonderland.pdf");
 
@@ -150,9 +152,9 @@ definition {
 		task ("Then the date the digital signature was created is shown") {
 			Refresh();
 
-			DigitalSignature.viewCreateDate();
+			DigitalSignature.viewCreateDate(envelopeName = ${envelopeName});
 
-			DigitalSignature.deleteEnvelope(envelopeName = "Poshi Test CanViewCorrectDate");
+			DigitalSignature.deleteEnvelope(envelopeName = ${envelopeName});
 
 			DMNavigator.openDocumentsAndMediaAdmin(siteURLKey = "guest");
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103408

## What Is Being Fixed

Two tests in the Digital Signature list view read the whole page instead of their own envelope's row, and that page is DocuSign's own sent items folder for an account every run shares. `DSEnvelopeManagerImpl` asks for it with `folder_types=sentitems` and no Liferay scope of its own, and the portlet fetches it once per render.

`CanViewCorrectDate` sends an envelope, refreshes, and asserts a create date reading "a few seconds ago" is somewhere on the page. It failed in the object suite's functional batch, and the screenshot shows why: the newest row on the page was twelve minutes old and the envelope just sent was not on the list at all. The assertion was demanding that the *account's* newest row be brand new.

`HaveMoreRecipientsThanOne` asserts a recipients badge is on the page, then deletes its envelope and asserts no recipients badge is on the page at all. On a shared account those fail in opposite directions: another run's multi-recipient envelope satisfies the first for free, and makes the second fail even though this run deleted what it made.

Both tests also hardcode their envelope name, so a row left behind by an earlier run satisfies a presence assertion just as well as this run's own row — and such rows accumulate precisely because this failure aborts the test before its delete step.

## Why The Row Is Absent

An acknowledged send is not a listable envelope. Measured directly against the account these tests use, with nothing else writing to it: the create answers `status: sent` after about two seconds, and the sent items listing does not hold the envelope for another one to three seconds after that, taking two to four reads before it appears.

The lag belongs to the folder index, not to the envelope. In the same probe, a point read of `GET /envelopes/{envelopeId}` and a list filtered by `envelope_ids` both returned it on the very first read, while `folder_types=sentitems` needed three. DocuSign's specification points the same way: the list endpoint requires one of `from_date`, `envelope_ids` or `transaction_ids`, and documents `transaction_ids` as the way to determine whether an envelope was created.

Nothing on the write can change that. The specification lists exactly four query parameters for creating an envelope — two reserved for DocuSign, the others about routing order and template roles — so there is no parameter that makes an acknowledged create immediately listable, and `query_budget` on the read does not help either: it returned in half a second without the envelope.

So a page rendered inside that window shows the account's older envelopes and not this one, however long an assertion then waits on it. The screenshot is exactly that: a quiet account whose newest other envelope happened to be twelve minutes old.

## How It Is Being Fixed

The list is asked for again until the envelope's own row is on it, and every ask is gated on the list finishing its fetch, because navigating away from it mid fetch logs a client abort that fails the whole run.

The create date and the recipients badge are read inside that row rather than anywhere on the page, and after the delete the test asserts the envelope itself is gone, which is what the step is checking. That check needs the same requery, since the list has to be fetched again before the row disappears.

Each envelope gets a name only its run can hold. Without it this would be a silent pass, because the locators assert presence and a leftover row under the same hardcoded name satisfies them. A per-run name also makes the delete unambiguous, since `deleteEnvelope` takes the first row whose name contains the argument.

## Testing

- Both tests pass against the live DocuSign sandbox, `CanViewCorrectDate` twice, including with the refresh gate in place.
- The post-delete requery came from a failing run: the first version of the recipients test failed at exactly that assertion, because the list had not been fetched again.
- The continuous integration failure is not locally reproducible, since this machine's refresh and page load land after the window closes. Its evidence is the screenshot and the measurement above.
- Apart from the envelope names, both commits are what two consecutive fully green object suite runs carried, each sixty two of sixty two axes with no unexpected and no flaky result.
- The four probe envelopes created while measuring were moved to the recycle bin, so nothing was left in the shared org.

## PR Check

**pr-check: PASS** — tested on `b653e0626e0bc3d36e0f50ec8d19b9c973d9cbd3`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Poshi Syntax | PASS |
| Baseline | PASS |

<!-- pr-check {"result": "success", "sha": "b653e0626e0bc3d36e0f50ec8d19b9c973d9cbd3"} -->
