### PR TITLE
LPD-103429 Undeploy the services an inactive object definition deployed

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -1211,6 +1211,8 @@ public class ObjectDefinitionLocalServiceImpl
 			_undeploy(entry.getKey(), entry.getValue(), objectDefinition);
 		}
 
+		_unregister(_inactiveServiceRegistrationsMap, objectDefinition);
+
 		_invalidatePortalCache(objectDefinition);
 	}
 
@@ -2692,17 +2694,26 @@ public class ObjectDefinitionLocalServiceImpl
 
 		objectDefinitionDeployer.undeploy(objectDefinition);
 
+		_unregister(serviceRegistrationsMap, objectDefinition);
+	}
+
+	private void _unregister(
+		Map<String, List<ServiceRegistration<?>>> serviceRegistrationsMap,
+		ObjectDefinition objectDefinition) {
+
 		List<ServiceRegistration<?>> serviceRegistrations =
 			serviceRegistrationsMap.remove(
 				DBPartitionUtil.getPartitionKey(
 					objectDefinition.getObjectDefinitionId()));
 
-		if (serviceRegistrations != null) {
-			for (ServiceRegistration<?> serviceRegistration :
-					serviceRegistrations) {
+		if (serviceRegistrations == null) {
+			return;
+		}
 
-				serviceRegistration.unregister();
-			}
+		for (ServiceRegistration<?> serviceRegistration :
+				serviceRegistrations) {
+
+			serviceRegistration.unregister();
 		}
 	}
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionDeployerRegistrationTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionDeployerRegistrationTest.java
@@ -1,0 +1,117 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.service.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.object.constants.ObjectRelationshipConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.related.models.ObjectRelatedModelsProvider;
+import com.liferay.object.related.models.ObjectRelatedModelsProviderRegistryUtil;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.Arrays;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceReference;
+
+/**
+ * @author Shuyang Zhou
+ */
+@RunWith(Arquillian.class)
+public class ObjectDefinitionDeployerRegistrationTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_objectDefinition = ObjectDefinitionTestUtil.publishObjectDefinition();
+	}
+
+	@Test
+	public void testDeployAfterDeployInactive() throws Exception {
+		_objectDefinitionLocalService.deployInactiveObjectDefinition(
+			_objectDefinition);
+
+		_objectDefinitionLocalService.deployObjectDefinition(_objectDefinition);
+
+		for (String objectRelationshipType : _OBJECT_RELATIONSHIP_TYPES) {
+			ServiceReference<?>[] serviceReferences = _getServiceReferences(
+				objectRelationshipType);
+
+			Assert.assertEquals(
+				Arrays.toString(serviceReferences), 1,
+				serviceReferences.length);
+		}
+	}
+
+	@Test
+	public void testUndeployAfterDeployInactive() throws Exception {
+		_objectDefinitionLocalService.deployInactiveObjectDefinition(
+			_objectDefinition);
+
+		_objectDefinitionLocalService.undeployObjectDefinition(
+			_objectDefinition);
+
+		for (String objectRelationshipType : _OBJECT_RELATIONSHIP_TYPES) {
+			ServiceReference<?>[] serviceReferences = _getServiceReferences(
+				objectRelationshipType);
+
+			Assert.assertNull(
+				Arrays.toString(serviceReferences), serviceReferences);
+		}
+	}
+
+	private ServiceReference<?>[] _getServiceReferences(
+			String objectRelationshipType)
+		throws Exception {
+
+		Bundle bundle = FrameworkUtil.getBundle(
+			ObjectDefinitionDeployerRegistrationTest.class);
+
+		BundleContext bundleContext = bundle.getBundleContext();
+
+		return bundleContext.getServiceReferences(
+			ObjectRelatedModelsProvider.class.getName(),
+			StringBundler.concat(
+				"(&(",
+				ObjectRelatedModelsProviderRegistryUtil.
+					KEY_OBJECT_DEFINITION_ERC,
+				"=", _objectDefinition.getExternalReferenceCode(), ")(",
+				ObjectRelatedModelsProviderRegistryUtil.KEY_RELATIONSHIP_TYPE,
+				"=", objectRelationshipType, "))"));
+	}
+
+	private static final String[] _OBJECT_RELATIONSHIP_TYPES = {
+		ObjectRelationshipConstants.TYPE_MANY_TO_MANY,
+		ObjectRelationshipConstants.TYPE_ONE_TO_MANY,
+		ObjectRelationshipConstants.TYPE_ONE_TO_ONE
+	};
+
+	@DeleteAfterTestRun
+	private ObjectDefinition _objectDefinition;
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103429

## What Is Being Fixed

An object definition that is approved but not active deploys its own related models providers into a map of its own. `undeployObjectDefinition` releases every other registration map but never that one, so those providers stay registered. Activating the definition again leaves two providers for each relationship type, and deleting it leaves behind the providers of a definition that no longer exists.

It is not merely a leak. `ObjectRelatedModelsProviderRegistryImpl` opens a **single value** map keyed by class name, company and relationship type, and its bucket keeps the oldest registration when the ranking is equal. Neither registration sets a ranking, so the **stale** provider is the one being served, holding the definition as it was before it was activated.

Root cause is in the commit messages: LPS-192669 added the map with no counterpart in `undeployObjectDefinition`, and then made the active to inactive to active cycle reachable while relying on the undeploy it calls to release them.

## How It Is Being Fixed

The map removal and unregistration half of the existing `_undeploy` helper is extracted into `_unregister`, and `undeployObjectDefinition` calls it for the inactive map — exactly where the other two maps are already released.

The new integration test asks the service registry itself for the providers of one definition and one relationship type, stating the invariant the registry depends on: exactly one provider per relationship type per definition.

## Testing

Both tests fail without the fix and pass with it, on the same container. Without it the deploy case reports two providers where one is expected — printing both registrations under one external reference code, the lower service id being the stale one the registry serves — and the undeploy case finds a survivor. A sweep of the object definition and object relationship lifecycle tests is 41 of 41.

`ci:test:object` on fork pull request shuyangzhou#12606 finished with **every axis successful, 4024 tests passed and none failed**, read from `build-report.json` rather than the summary comment. That run carried this **byte-identical implementation**; the test file was afterwards simplified (a registry-side LDAP filter, `@DeleteAfterTestRun`, and `assertNull` to match the contract that `getServiceReferences` returns null rather than an empty array), and the failing-then-passing pair was re-established locally against the rewritten test.

## PR Check

**pr-check: PASS** — tested on `fbd8b1473304143accc2d2104adbbc7b5ee4227b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Service Builder | PASS |
| Baseline | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |
