### PR TITLE
LPD-103430 Own the accounts answer the add entry form asks for

### DIFF
--- a/modules/test/playwright/tests/object-web/entry/objectEntry.spec.ts
+++ b/modules/test/playwright/tests/object-web/entry/objectEntry.spec.ts
@@ -6033,17 +6033,25 @@ test.describe('Manage object entries through View Object Entries', () => {
 
 		await viewObjectEntriesPage.goto(objectDefinition.className);
 
-		await viewObjectEntriesPage.clickAddObjectEntry(
-			objectDefinition.label['en_US']
-		);
+		// The form the click opens is what asks for the accounts, so the wait
+		// for that answer is registered before the click. Registered after, it
+		// only ever matches a second ask, and the test asserts there is only
+		// one, so it waited out its whole budget exactly when the answer came
+		// promptly.
 
-		await page.waitForResponse(
+		const accountsResponsePromise = page.waitForResponse(
 			(response) =>
 				response
 					.url()
 					.includes('/o/headless-admin-user/v1.0/accounts') &&
 				response.request().method() === 'GET'
 		);
+
+		await viewObjectEntriesPage.clickAddObjectEntry(
+			objectDefinition.label['en_US']
+		);
+
+		await accountsResponsePromise;
 
 		expect(apiCalls).toBe(1);
 		expect(apiURL).not.toContain('pageSize=-1');


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103430

## What Is Being Fixed

The Playwright test "verify that relationship API is called only once and uses pagination when adding object entry" (objectEntry.spec.ts) intermittently burns its whole 90s budget on `page.waitForResponse` and fails. Its complete Testray history shows eleven matching failures, all on CI-owned clean-master builds (ten EE Development Acceptance (master) builds from 2026-04-25 through 2026-08-07, one EE Package Tester 2026.q2.9) and none on fork pull requests.

## How It Is Being Fixed

The test registers the wait for the accounts response after the click that opens the add entry form — but that click triggers the only accounts request the test permits, so a prompt answer is missed and the wait can only ever match a second request the test itself asserts never happens. The fix registers the wait before the click, holds the promise, and awaits it after, so the request the click triggers is the request the test waits on. The assertions are unchanged. Root cause: born this way in af2d886340b23ff50450d9763075869c6bbb6921 (LPD-66761).

## PR Check

**pr-check: PASS** — tested on `39a400571e9c10b25045bc5f4218d9d5c63f510a`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

Baseline, Per-Module Compile, and JavaScript Unit Tests matched by file pattern but are inapplicable to this playwright-spec-only diff: no Java/bnd/packageinfo is touched so no exported API can change; modules/test/playwright is a yarn workspace, not a deployable Gradle module; and it has no Jest suite (its test script is the Playwright runner, which needs a live portal). The TypeScript check ran inside Source Format's frontend pass. The change additionally rode two fully green ci:test:object aggregate runs (62/62 twice on 2026-08-21) and a 61/61 run on 2026-08-22.

<!-- pr-check {"result": "success", "sha": "39a400571e9c10b25045bc5f4218d9d5c63f510a"} -->
