### PR TITLE
LPD-103432 Stop the intermittent 500 when deleting an object definition

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/model/listener/ObjectEntryModelListener.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/model/listener/ObjectEntryModelListener.java
@@ -12,6 +12,7 @@ import com.liferay.list.type.service.ListTypeEntryLocalService;
 import com.liferay.object.action.engine.ObjectActionEngine;
 import com.liferay.object.constants.ObjectActionTriggerConstants;
 import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.definition.util.ObjectDefinitionThreadLocal;
 import com.liferay.object.entry.util.ObjectEntryPayloadUtil;
 import com.liferay.object.entry.util.ObjectEntryThreadLocal;
 import com.liferay.object.field.business.type.ObjectFieldBusinessType;
@@ -124,7 +125,10 @@ public class ObjectEntryModelListener extends BaseModelListener<ObjectEntry> {
 
 			User user = _userLocalService.getUser(userId);
 
-			if (!objectEntry.isInTrash()) {
+			if (!ObjectDefinitionThreadLocal.isDeleteObjectDefinitionId(
+					objectEntry.getObjectDefinitionId()) &&
+				!objectEntry.isInTrash()) {
+
 				_executeObjectActions(
 					ObjectActionTriggerConstants.KEY_ON_AFTER_DELETE,
 					objectEntry, objectEntry, user);

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -3814,7 +3814,13 @@ public class ObjectEntryLocalServiceImpl
 
 				String deletionType = objectRelationship.getDeletionType();
 
-				if (ObjectEntryThreadLocal.isDisassociateRelatedModels()) {
+				if (ObjectEntryThreadLocal.isDisassociateRelatedModels() ||
+					(Objects.equals(
+						deletionType,
+						ObjectRelationshipConstants.DELETION_TYPE_PREVENT) &&
+					 ObjectDefinitionThreadLocal.isDeleteObjectDefinitionId(
+						 objectDefinitionId))) {
+
 					deletionType =
 						ObjectRelationshipConstants.DELETION_TYPE_DISASSOCIATE;
 				}

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectActionLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectActionLocalServiceTest.java
@@ -55,6 +55,7 @@ import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.constants.ObjectFieldSettingConstants;
 import com.liferay.object.constants.ObjectRelationshipConstants;
+import com.liferay.object.definition.util.ObjectDefinitionThreadLocal;
 import com.liferay.object.exception.ObjectActionErrorMessageException;
 import com.liferay.object.exception.ObjectActionExecutorKeyException;
 import com.liferay.object.exception.ObjectActionNameException;
@@ -86,6 +87,7 @@ import com.liferay.object.test.util.ObjectRelationshipTestUtil;
 import com.liferay.object.test.util.TreeTestUtil;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
@@ -2819,6 +2821,55 @@ public class ObjectActionLocalServiceTest {
 				objectDefinitionAAA.getName()
 			},
 			_objectEntryLocalService, _objectRelationshipLocalService);
+	}
+
+	@Test
+	public void testOnAfterDeleteObjectActionWhileDeletingObjectDefinition()
+		throws Exception {
+
+		_objectDefinition = _publishCustomObjectDefinition();
+
+		_addObjectAction(
+			RandomTestUtil.randomString(),
+			ObjectActionExecutorConstants.KEY_GROOVY,
+			ObjectActionTriggerConstants.KEY_ON_AFTER_DELETE,
+			UnicodePropertiesBuilder.put(
+				"script", "println \"Hello World\""
+			).build(),
+			false);
+
+		// Skip the object action while the object definition is being deleted
+
+		ObjectEntry objectEntry = _addObjectEntry(
+			_objectDefinition,
+			HashMapBuilder.<String, Serializable>put(
+				"firstName", "John"
+			).build());
+
+		try (SafeCloseable safeCloseable =
+				ObjectDefinitionThreadLocal.
+					setDeleteObjectDefinitionIdWithSafeCloseable(
+						_objectDefinition.getObjectDefinitionId())) {
+
+			_objectEntryLocalService.deleteObjectEntry(objectEntry);
+		}
+
+		Assert.assertNull(
+			_objectEntryLocalService.fetchObjectEntry(
+				objectEntry.getObjectEntryId()));
+		Assert.assertEquals(0, _argumentsList.size());
+
+		// Execute the object action when no object definition is being deleted
+
+		objectEntry = _addObjectEntry(
+			_objectDefinition,
+			HashMapBuilder.<String, Serializable>put(
+				"firstName", "Paul"
+			).build());
+
+		_objectEntryLocalService.deleteObjectEntry(objectEntry);
+
+		_assertGroovyObjectActionExecutorArguments("Paul", objectEntry);
 	}
 
 	@Test

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
@@ -2830,6 +2830,54 @@ public class ObjectDefinitionLocalServiceTest {
 	}
 
 	@Test
+	public void testDeleteObjectDefinitionWithPreventObjectRelationship()
+		throws Exception {
+
+		ObjectDefinition objectDefinition1 =
+			ObjectDefinitionTestUtil.publishObjectDefinition();
+		ObjectDefinition objectDefinition2 =
+			ObjectDefinitionTestUtil.publishObjectDefinition();
+
+		ObjectRelationship objectRelationship =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				_objectRelationshipLocalService, objectDefinition1,
+				objectDefinition2,
+				ObjectRelationshipConstants.DELETION_TYPE_PREVENT,
+				StringUtil.randomId(),
+				ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
+		ObjectEntry objectEntry1 = ObjectEntryTestUtil.addObjectEntry(
+			0, objectDefinition1.getObjectDefinitionId(),
+			Collections.emptyMap());
+		ObjectEntry objectEntry2 = ObjectEntryTestUtil.addObjectEntry(
+			0, objectDefinition2.getObjectDefinitionId(),
+			Collections.emptyMap());
+
+		ObjectRelationshipTestUtil.relateObjectEntries(
+			objectEntry1.getObjectEntryId(), objectEntry2.getObjectEntryId(),
+			objectRelationship, TestPropsValues.getUserId());
+
+		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition1);
+
+		Assert.assertNull(
+			_objectDefinitionLocalService.fetchObjectDefinition(
+				objectDefinition1.getObjectDefinitionId()));
+		Assert.assertNull(
+			_objectEntryLocalService.fetchObjectEntry(
+				objectEntry1.getObjectEntryId()));
+		Assert.assertNull(
+			_objectRelationshipLocalService.fetchObjectRelationship(
+				objectRelationship.getObjectRelationshipId()));
+
+		Assert.assertNotNull(
+			_objectDefinitionLocalService.fetchObjectDefinition(
+				objectDefinition2.getObjectDefinitionId()));
+		Assert.assertNotNull(
+			_objectEntryLocalService.fetchObjectEntry(
+				objectEntry2.getObjectEntryId()));
+	}
+
+	@Test
 	public void testEnableAccountEntryRestrictedForNondefaultStorageType()
 		throws Exception {
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103432

## What Is Being Fixed

`DELETE /o/object-admin/v1.0/object-definitions/{id}` intermittently returns 500 during CI test teardown, surfacing as a nameless "Internal Server Error" because the resource rewraps every failure and the JAX-RS mapper unwraps exactly one level. The portal logs of four baseline sightings named two object-side causes: the entry model listener's on-after-delete action query auto-flushes the definition delete's own pending action deletes into an optimistic lock failure when a concurrent status write has bumped an action row, and the per-entry relationship walk sits outside the definition-delete guard, so a definition whose entries hold PREVENT relationships dies mid-walk with `RequiredObjectRelationshipException` depending purely on teardown walk order.

## How It Is Being Fixed

Two guards, each with its integration guard test. The listener skips the on-after-delete action execution when the entry's own definition is being deleted — the actions are already queued for deletion, so the query was guaranteed empty and its only observable effect was the fatal flush. The relationship walk downgrades PREVENT to DISASSOCIATE when the entry's own definition is being deleted, next to the downgrade the disassociate flag already performs: the relationship dies with the definition, so there is nothing left to prevent for, and the surviving side keeps its entries.

## PR Check

**pr-check: PASS** — tested on `7727011c64c3415a6e8db73b0fbe9bcc564d87cf`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

Baseline matched by pattern but no exported package is touched (both production classes are internal/impl), so no version bump applies; Java Unit has no matching src/test counterpart. Additional verification: both full test classes (ObjectActionLocalServiceTest, ObjectDefinitionLocalServiceTest) pass locally on a freshly built bundle, and the branch passed two fork `ci:test:object` runs with zero failures unique to the pull.

<!-- pr-check {"result": "success", "sha": "7727011c64c3415a6e8db73b0fbe9bcc564d87cf"} -->
