### PR TITLE
LPD-103433 Open the pending items from the card that owns the link

### DIFF
--- a/modules/test/playwright/pages/portal-workflow-metrics-web/MetricsPage.ts
+++ b/modules/test/playwright/pages/portal-workflow-metrics-web/MetricsPage.ts
@@ -13,9 +13,16 @@ export class MetricsPage {
 
 	constructor(page: Page) {
 		this.page = page;
+
+		// Three links on the process pages are named Total Pending: this
+		// summary card, the process list's column header and the workload by
+		// step card's column header. Name the card by the class only it
+		// carries, so the locator is strict and the click waits for the card
+		// itself rather than taking whichever of the three has rendered.
+
 		this.totalPendingItems = this.page
 			.getByRole('link', {name: 'Total Pending'})
-			.first();
+			.and(this.page.locator('.process-tabs-summary-card'));
 	}
 
 	async chooseProcess(processName: string) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103433

## What Is Being Fixed

The Playwright test "can view Asset Title, Asset Type and Item Subject of an entry on metrics page" (objectEntry.spec.ts) intermittently times out waiting for the entry's label on the workflow metrics pending items list — seven occurrences across clean-master baseline runs, one of them failing both attempts. Three links on the metrics process page are named Total Pending (the pending items summary card and two sortable column headers); the helper took the first match, which is decided by render order, and the card mounts last because it waits for the dashboard's own metrics answer. The click therefore usually lands on a sort header: the pending items list never opens, no instances request is ever made, and the wait starves. The failing attempt's own trace confirms it — the last click resolved to the first match, the network log carries no instances request after it, and the same trace's process metrics response reports instanceCount 1, so the workflow instance was indexed correctly.

## How It Is Being Fixed

Name the card by the class only it carries: `getByRole('link', {name: 'Total Pending'})` combined with `.process-tabs-summary-card`. The locator is strict, so a click cannot land on a header and a future fourth match fails loudly instead of silently choosing, and the click waits for the card itself — the dashboard's own signal that the answer behind the number has arrived.

## PR Check

**pr-check: PASS** — tested on `27c1a801ee121ac4772b3791804569b7d7af26b9`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

Baseline, Per-Module Compile, and JavaScript Unit Tests matched by file pattern but are inapplicable to this playwright-page-object-only diff (no exported API can change; modules/test/playwright is not a deployable Gradle module and has no Jest suite). The TypeScript check ran inside Source Format's frontend pass. The change additionally passed a fork `ci:test:object` run with no failures unique to the pull, and the test passes locally.

<!-- pr-check {"result": "success", "sha": "27c1a801ee121ac4772b3791804569b7d7af26b9"} -->
