### PR TITLE
LPD-103434 Wait for the relate the already-related test's picker fires

### DIFF
--- a/modules/test/playwright/tests/object-web/relationship/objectRelationship.spec.ts
+++ b/modules/test/playwright/tests/object-web/relationship/objectRelationship.spec.ts
@@ -3552,6 +3552,25 @@ test.describe('Manage object relationship entries', () => {
 					await expect(entryBItem).toBeVisible();
 
 					await entryBItem.click();
+
+					// Selecting relates the entry and closes the picker, and
+					// the relating is still in flight when the click resolves.
+					// The next iteration asks for another address, which tears
+					// down the frame the request belongs to and cancels it, so
+					// the relationship is never made and the row asserted on
+					// below never arrives. Wait for the picker to go and the
+					// relationship to show.
+
+					await expect(
+						page.locator('iframe[title="Select"]')
+					).toBeHidden();
+
+					await expect(
+						page
+							.getByRole('row')
+							.filter({hasText: 'Entry B'})
+							.first()
+					).toBeVisible();
 				}
 			});
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103434

## What Is Being Fixed

The Playwright test "already-related entry is kept on both objects when associated with another entry" (objectRelationship.spec.ts) intermittently fails on clean-master baseline runs. Clicking an entry in the relationship picker does not itself write anything — the parent frame loads its own scripts after the selection and only then submits the relate — and the test's loop ends on the click and navigates to the next entry, tearing down the frame the pending relate belongs to. The failing run's trace shows the losing iteration's script fetch aborted by the navigation, no relate request ever issued for it, and the server answering an empty related-entries list; the winning iteration's relate got out roughly forty milliseconds before its navigation.

## How It Is Being Fixed

Own the relate inside the loop, mirroring the shipped LPD-102725/LPD-102844 siblings: after the picker click, wait for the picker iframe to be gone and for the related-entries row to show before leaving the iteration. Both waits are the effect's own signals, and the closing assertion becomes a real regression check for an unlinked relationship instead of being satisfiable by a write that never happened.

## PR Check

**pr-check: PASS** — tested on `63ceba40eb3d921cef0d4e0cb5fef1737b1307c0`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

Baseline, Per-Module Compile, and JavaScript Unit Tests matched by file pattern but are inapplicable to this playwright-spec-only diff (no exported API can change; modules/test/playwright is not a deployable Gradle module and has no Jest suite). The TypeScript check ran inside Source Format's frontend pass. The change additionally passed a fork `ci:test:object` run with every job green, and the test passes locally.

<!-- pr-check {"result": "success", "sha": "63ceba40eb3d921cef0d4e0cb5fef1737b1307c0"} -->
