### PR TITLE
LPD-103435 Let the settings close wait for the object fields it asks for

### DIFF
--- a/modules/test/playwright/pages/dynamic-data-mapping-form-web/FormSettingsModalPage.ts
+++ b/modules/test/playwright/pages/dynamic-data-mapping-form-web/FormSettingsModalPage.ts
@@ -22,6 +22,29 @@ export class FormSettingsModalPage {
 		await this.doneButton.click();
 	}
 
+	async clickDoneButtonAndWaitForObjectFields(objectDefinitionId: number) {
+
+		// Closing the settings is what asks for the selected object's fields,
+		// and the publish validation reads the fields this ask populates. A
+		// publish clicked before the answer lands reads no fields and lets an
+		// unmapped form through, so the close waits for the answer it caused.
+
+		const objectFieldsResponsePromise = this.page.waitForResponse(
+			(response) =>
+				response.ok() &&
+				response.request().method() === 'GET' &&
+				response
+					.url()
+					.includes(
+						`/o/object-admin/v1.0/object-definitions/${objectDefinitionId}`
+					)
+		);
+
+		await this.doneButton.click();
+
+		await objectFieldsResponsePromise;
+	}
+
 	async selectObject(objectLabel: string) {
 		await this.objectSelect.click();
 

--- a/modules/test/playwright/tests/object-web/forms-integration/objectFormsIntegration.spec.ts
+++ b/modules/test/playwright/tests/object-web/forms-integration/objectFormsIntegration.spec.ts
@@ -1873,7 +1873,9 @@ test(
 			objectDefinition.label['en_US']
 		);
 
-		await formSettingsModalPage.clickDoneButton();
+		await formSettingsModalPage.clickDoneButtonAndWaitForObjectFields(
+			objectDefinition.id
+		);
 
 		await formBuilderPage.publishButton.click();
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103435

## What Is Being Fixed

The ci:test:object playwright test "mapping form to a object definition and fields to an object field is required when using Object as storage type" (objectFormsIntegration.spec.ts) fails intermittently. Closing the form settings after selecting an object storage type is what requests that object's fields, and the publish validation that decides whether to show the Unmapped Object Required modal reads the fields that request populates. A publish clicked before the answer lands reads an empty field list, the gate passes vacuously, and the form publishes with an unmapped field instead of showing the modal the test waits for. This test is the only caller that goes select object, close settings, publish with no field-mapping interaction in between, so nothing synchronizes on the fields fetch before the gate runs.

## How It Is Being Fixed

Add `FormSettingsModalPage#clickDoneButtonAndWaitForObjectFields(objectDefinitionId)`: arm a `waitForResponse` for the object-admin object-definitions GET before clicking Done, click, then await the response the close itself causes. Only the object-selected close in the failing test switches to it; the earlier close in the same test selects no object, fires no fields request, and keeps the plain click. Other callers either fire no request or already synchronize by reading the fetched fields through the UI before publishing.

## PR Check

**pr-check: PASS** — tested on `1711c238b39c53429adcf4179cbe4f7d0e7b9958`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

Baseline, Per-Module Compile, and JavaScript Unit Tests matched by file pattern but are inapplicable to this playwright-spec-only diff (no exported API can change; modules/test/playwright is not a deployable Gradle module and has no Jest suite). The TypeScript check ran inside Source Format's frontend pass. The change additionally passed a fork `ci:test:object` run (60 of 62 jobs; the sole failure unique to the pull is the known Poshi ObjectFields formula-field flake family, unrelated to this diff), and the changed test passes locally.

<!-- pr-check {"result": "success", "sha": "1711c238b39c53429adcf4179cbe4f7d0e7b9958"} -->
