### PR TITLE
LPD-103436 Activate a custom view's lone pre-order sort item

### DIFF
--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/display/context/ViewObjectEntriesDisplayContext.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/display/context/ViewObjectEntriesDisplayContext.java
@@ -245,11 +245,23 @@ public class ViewObjectEntriesDisplayContext {
 			return fdsSortItemList;
 		}
 
+		List<ObjectViewSortColumn> objectViewSortColumns =
+			objectView.getObjectViewSortColumns();
+
 		for (ObjectViewSortColumn objectViewSortColumn :
-				objectView.getObjectViewSortColumns()) {
+				objectViewSortColumns) {
+
+			// A lone sort item is applied to the query whether or not it is
+			// active, but only an active item renders the header's sort
+			// indicator. Activate the lone item so the header shows the order
+			// the rows already follow. Items on a multi-column list stay
+			// inactive: there, only active items are applied, so activating
+			// them would change the query.
 
 			fdsSortItemList.add(
-				FDSSortItemBuilder.setDirection(
+				FDSSortItemBuilder.setActive(
+					objectViewSortColumns.size() == 1
+				).setDirection(
 					objectViewSortColumn.getSortOrder()
 				).setKey(
 					() -> {

--- a/modules/test/playwright/tests/object-web/view/objectView.spec.ts
+++ b/modules/test/playwright/tests/object-web/view/objectView.spec.ts
@@ -199,7 +199,7 @@ test('assert that the user is able to use the ERC field in Sort, on the Custom V
 		entry2
 	);
 
-	await page.getByTitle('Sortable Column').dblclick();
+	await page.getByTitle('Sortable Column').click();
 
 	await expect(page.locator('.cell-externalReferenceCode').nth(1)).toHaveText(
 		entry2
@@ -2556,7 +2556,7 @@ test(
 		await page
 			.getByRole('columnheader', {name: 'textField'})
 			.getByRole('button')
-			.dblclick();
+			.click();
 
 		const descendingCells = page.getByRole('cell');
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103436

## What Is Being Fixed

A custom view pre-orders its entries through `objectViewSortColumns`, and the frontend data set applies a lone sort item to the query whether or not it is active — but renders the column's sort indicator only for an active one. The rows arrive ordered while the header shows no arrow and commits no `aria-sort`, and the first header click requests the ascending order the rows already have: a real user must click twice to flip the order. The playwright tests carried that double click, and its two rapidly interleaving list requests race each other — the ci:test:object flake on the objectView sort tests.

Root cause is two-sided: `bda324c2ad7582748a08fff9b86c490a9421a6b2` (LPS-146897) added the pre-order sort items without marking them active — inactive yet applied, so the header lied from birth — and `0029ff9c1ebeb85855a4a217e3f16e27c5f2dc91` (LPD-30224) later entrenched the lone-item request rule that the header render never learned.

## How It Is Being Fixed

`ViewObjectEntriesDisplayContext` marks the sort item active when the view has exactly one sort column, mirroring the request path's lone-item rule, so the header shows the order the rows already follow and the first click flips it. Items on a multi-column list stay inactive: there only active items are applied, so activating them would change the query. The two objectView tests drop their double clicks for single clicks. Request traffic for single-column views is byte-identical (the lone item was already applied), and `active=true` is a configuration nine other portal views already ship.

## PR Check

**pr-check: PASS** — tested on `f5d2cd22a024d8a5a282d34ebb94e51045716037`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Java Unit Tests | PASS |
| Transaction Usage | PASS |

Integration Test Compile matched but `object-web` has no testIntegration sources (Gradle NO-SOURCE); Baseline matched but no exported package changes (Gradle SKIPPED); JavaScript Unit Tests matched on the playwright spec, which has no Jest suite. The tree is byte-identical to the fork `ci:test:object` run on shuyangzhou#12630 (59/61; the sole unique failed job died before running tests — artifacts directory holds only the jenkins console — and at attempt level the run had zero unexpected tests, with both changed tests passing on their first attempt). Both tests also pass locally against the deployed change.

<!-- pr-check {"result": "success", "sha": "f5d2cd22a024d8a5a282d34ebb94e51045716037"} -->
