### PR TITLE
LPD-99785 Reserve segments schema version 4.0.1 for backport

### DIFF
--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/upgrade/registry/SegmentsServiceUpgradeStepRegistrator.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/upgrade/registry/SegmentsServiceUpgradeStepRegistrator.java
@@ -133,8 +133,10 @@ public class SegmentsServiceUpgradeStepRegistrator
 			new com.liferay.segments.internal.upgrade.v4_0_0.
 				SegmentsExperienceUpgradeProcess());
 
+		registry.register("4.0.0", "4.0.1", new DummyUpgradeStep());
+
 		registry.register(
-			"4.0.0", "4.1.0", SegmentsExperienceAudienceEntryRelTable.create());
+			"4.0.1", "4.1.0", SegmentsExperienceAudienceEntryRelTable.create());
 
 		registry.register(
 			"4.1.0", "4.1.1",


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99785

## What Is Being Fixed

The fix for LPD-99785 is being backported to release-2026.q1, where the default experience external reference code alignment is registered as an upgrade from 4.0.0 to 4.0.1, because neither v4_1_0 (SegmentsExperienceAudienceEntryRelTable) nor v4_1_1 exists on that branch. On master 4.0.1 was never a vertex in the segments service upgrade graph, so a database upgraded on release-2026.q1 had no route out of 4.0.1: ReleaseGraphManager found no path and UpgradeExecutor threw "Unable to upgrade com.liferay.segments.service to 4.1.1 from 4.0.1".

## How It Is Being Fixed

SegmentsServiceUpgradeStepRegistrator now registers a DummyUpgradeStep from 4.0.0 to 4.0.1, reserving the version that release-2026.q1 hands out without doing any work on master, where the alignment is carried by the later 4.1.0 to 4.1.1 step. The following edge is re-anchored from 4.0.0 to 4.0.1 rather than left in place, so the chain stays linear and 4.0.1 does not become a second end node. Databases arriving from release-2026.q1 therefore run the 4.1.1 step again, which is harmless because its query skips experiences that are already aligned.

## Why Are There No Tests?

The change only reserves a schema version vertex in the upgrade graph so release-2026.q1 databases have a forward path; there is no new behavior to assert, and the existing 4.1.1 upgrade step already carries coverage.

## PR Check

**pr-check: PASS** — tested on `56c394b6160a77ecce1f22275a893b99bdf1c3b7`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "56c394b6160a77ecce1f22275a893b99bdf1c3b7"} -->
