### PR TITLE
LPD-102964 Standardize portal cache name constants

### DIFF
--- a/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/processor/FragmentEntryProcessorRegistryImpl.java
+++ b/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/processor/FragmentEntryProcessorRegistryImpl.java
@@ -448,7 +448,7 @@ public class FragmentEntryProcessorRegistryImpl
 
 	private static final String _DOCUMENT_PORTAL_CACHE_NAME =
 		FragmentEntryProcessorRegistryImpl.class.getName() +
-			"#_documentPortalCache";
+			"._documentPortalCache";
 
 	private static final ThreadLocal<Set<String>> _validHTMLs =
 		new CentralizedThreadLocal(

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/main/ProjectFaroController.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/main/ProjectFaroController.java
@@ -1972,7 +1972,7 @@ public class ProjectFaroController extends BaseFaroController {
 	}
 
 	private static final String _PORTAL_CACHE_NAME =
-		ProjectFaroController.class.getName() + "_PROVISION_BACKOFF";
+		ProjectFaroController.class.getName() + ".provisionBackoffPortalCache";
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		ProjectFaroController.class);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102964

## What Is Being Fixed

The private portal cache name constants in `ProjectFaroController` (added by the provisioning backoff work in this ticket) and in the unrelated `FragmentEntryProcessorRegistryImpl` used inconsistent naming: one mixed a `#` method-reference-style separator into a plain field name, and the other used a shouting `_PROVISION_BACKOFF` suffix.

## How It Is Being Fixed

Both cache name constants are renamed to a single, consistent dot-separated convention (`<ClassName>.<camelCaseName>`) already used elsewhere in the codebase for portal cache names. This is a pure naming change with no effect on caching behavior.

## Why Are There No Tests?

Naming standardization only — cache-name string literals renamed for consistency, no behavior change, so no new test coverage is needed.

## PR Check

**pr-check: PASS** — tested on `9036ca3da373e02d8a6e01042df7ccf1df85619c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS (pre-existing failure on `master`, confirmed unrelated to this branch's diff) |
| Workspace Build | PASS |
| Java Unit Tests | PASS (pre-existing failure on `master`, confirmed unrelated to this branch's diff) |

**Baseline note:** `portal-kernel`'s `com.liferay.exportimport.kernel.xstream` (committed `3.0.0`, recommended `2.0.0`) and `com.liferay.portal.kernel.servlet` (committed `18.0.0`, recommended `17.3.0`) already carry an excessive version increase on `master` itself, verified by running `ant baseline-all` against a clean `master` checkout — neither package is touched by this branch.

**Java Unit Tests note:** `fragment-impl`'s `PortletRegistryImplTest` fails with `NoClassDefFoundError: com/liferay/petra/process/ProcessExecutor` on `master` itself (verified by rerunning the same test there) — a pre-existing missing test-classpath dependency in the module's `build.gradle`, not something this branch's change caused.

<!-- pr-check {"result": "success", "sha": "9036ca3da373e02d8a6e01042df7ccf1df85619c"} -->
