### PR TITLE
LPD-99314 Remove the comments from the frontend changes

### DIFF
--- a/modules/apps/analytics/analytics-web/src/test/java/com/liferay/analytics/web/internal/servlet/taglib/AnalyticsTopHeadJSPDynamicIncludeTest.java
+++ b/modules/apps/analytics/analytics-web/src/test/java/com/liferay/analytics/web/internal/servlet/taglib/AnalyticsTopHeadJSPDynamicIncludeTest.java
@@ -186,7 +186,7 @@ public class AnalyticsTopHeadJSPDynamicIncludeTest {
 
 	private static final String _SERVER_NAME = RandomTestUtil.randomString();
 
-	private AnalyticsConfiguration _analyticsConfiguration = Mockito.mock(
+	private final AnalyticsConfiguration _analyticsConfiguration = Mockito.mock(
 		AnalyticsConfiguration.class);
 
 }

--- a/modules/apps/digital-signature/digital-signature-test/src/testFunctional/macros/DigitalSignature.macro
+++ b/modules/apps/digital-signature/digital-signature-test/src/testFunctional/macros/DigitalSignature.macro
@@ -431,13 +431,6 @@ definition {
 
 	@summary = "Default summary"
 	macro viewCreateDate(envelopeName = null) {
-
-		// The list is DocuSign's own sent items folder, which does not hold an
-		// envelope the moment the send is acknowledged, so ask for the list
-		// again until the envelope's own row is on it. Each ask waits for the
-		// list to finish fetching, because navigating away from it mid fetch
-		// logs a client abort that fails the whole run.
-
 		while ((IsElementNotPresent(envelopeName = ${envelopeName}, locator1 = "DigitalSignatureListView#DIGITAL_SIGNATURE_ENVELOPE_CREATE_DATE")) && (maxIterations = "10")) {
 			Refresh();
 
@@ -483,13 +476,6 @@ definition {
 
 	@summary = "Default summary"
 	macro viewEnvelopeIsGone(envelopeName = null) {
-
-		// The delete leaves the list to be fetched again before the row goes,
-		// and the list is only fetched once per render, so ask for it again
-		// until the envelope is off it. Each ask waits for the fetch to finish,
-		// because navigating away mid fetch logs a client abort that fails the
-		// whole run.
-
 		while ((IsElementPresent(envelopeName = ${envelopeName}, locator1 = "DigitalSignatureListView#DIGITAL_SIGNATURE_ENVELOPE_NAME")) && (maxIterations = "10")) {
 			Refresh();
 
@@ -503,14 +489,6 @@ definition {
 
 	@summary = "Default summary"
 	macro viewMoreRecipient(envelopeName = null) {
-
-		// The list is DocuSign's own sent items folder and it is fetched once
-		// per render, so the envelope's row is not on it the moment the send is
-		// acknowledged and waiting on a rendered page cannot make it appear.
-		// Ask for the list again, gated on its own fetch finishing, because
-		// navigating away from it mid fetch logs a client abort that fails the
-		// whole run.
-
 		while ((IsElementNotPresent(envelopeName = ${envelopeName}, locator1 = "DigitalSignatureListView#DIGITAL_SIGNATURE_ENVELOPE_RECIPIENTS_BADGE")) && (maxIterations = "10")) {
 			Refresh();
 

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/side_panel/SidePanel.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/side_panel/SidePanel.js
@@ -127,14 +127,6 @@ export default class SidePanel extends React.Component {
 	}
 
 	handleKeyupEvent(even) {
-
-		// This handler is bound to the panel iframe's window as well as to the
-		// top one, so an Escape raised inside the panel arrives here. A modal
-		// opened by the panel's own content belongs to the iframe's document,
-		// where the check below against the top document cannot see it, and the
-		// panel would close under a modal the user is still working in, taking
-		// every unsaved edit with it. Ask the document the event came from too.
-
 		const eventDocument = even.view?.document ?? even.target?.ownerDocument;
 
 		if (

--- a/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/Select/MultipleSelect.tsx
+++ b/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/Select/MultipleSelect.tsx
@@ -97,10 +97,6 @@ export function MultipleSelect({
 	useEffect(() => {
 		const multiSelectOptions = [] as LabelValueObject[];
 
-		// The multi select keys each selected label by its value, so a label
-		// carried on its own leaves every key undefined, and React discards and
-		// rebuilds the whole row on each change.
-
 		(options as MultiSelectItem[]).forEach(({children}) => {
 			return children.forEach(({checked, label, value}) => {
 				if (checked) {

--- a/modules/apps/object/object-test/src/testFunctional/tests/CreateObject.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/CreateObject.testcase
@@ -178,13 +178,6 @@ definition {
 
 		PortletEntry.publish();
 
-		// The publish answers through the browser, so read the persisted
-		// status back over the API before touching the list: a Draft here
-		// means the publish itself was lost, and an Approved here with a
-		// missing row after points at the list's rendering instead. The raw
-		// answer is echoed before any parsing, so a refused or empty answer
-		// names itself instead of dying inside the path lookup.
-
 		var portalURL = JSONCompany.getPortalURL();
 		var userPassword = PropsUtil.get("default.admin.password");
 

--- a/modules/apps/portal-security/portal-security-key-provider-aws/src/test/java/com/liferay/portal/security/key/provider/aws/internal/util/AWSByteBufferUtilTest.java
+++ b/modules/apps/portal-security/portal-security-key-provider-aws/src/test/java/com/liferay/portal/security/key/provider/aws/internal/util/AWSByteBufferUtilTest.java
@@ -36,6 +36,7 @@ public class AWSByteBufferUtilTest {
 		byte[] byteBufferBytes = AWSByteBufferUtil.getBytes(byteBuffer);
 
 		Assert.assertArrayEquals(bytes, byteBufferBytes);
+
 		Assert.assertArrayEquals(new byte[bytes.length], clonedBytes);
 	}
 
@@ -51,6 +52,7 @@ public class AWSByteBufferUtilTest {
 			byteBuffer.asReadOnlyBuffer());
 
 		Assert.assertArrayEquals(bytes, byteBufferBytes);
+
 		Assert.assertArrayEquals(bytes, clonedBytes);
 	}
 

--- a/modules/test/playwright/helpers/ApiHelpers.ts
+++ b/modules/test/playwright/helpers/ApiHelpers.ts
@@ -113,12 +113,6 @@ export function clearAuthToken(page: Page) {
 }
 
 export async function readAuthToken(page: Page) {
-
-	// Read the token when the caller knows the page is settled, which is right
-	// after signing in, and keep it for the session it belongs to. Reading it
-	// while a request is being built instead is what fails: a navigation racing
-	// the evaluation destroys the execution context and kills it.
-
 	const authToken = await page.evaluate(() => Liferay.authToken);
 
 	authTokens.set(page.context(), authToken);
@@ -387,11 +381,6 @@ export class ApiHelpers {
 		if (headers || response.status() !== 403) {
 			return response;
 		}
-
-		// The token belongs to the session that was live when it was read, so
-		// a test that has signed in again since leaves it stale and the portal
-		// answers Forbidden. Read it again and retry once, rather than failing
-		// the caller with a Forbidden body it cannot interpret.
 
 		clearAuthToken(this.page);
 

--- a/modules/test/playwright/helpers/ListTypeAdminApiHelper.ts
+++ b/modules/test/playwright/helpers/ListTypeAdminApiHelper.ts
@@ -33,12 +33,6 @@ export class ListTypeAdminApiHelper {
 	}
 
 	async getListTypeDefinitions(): Promise<ListTypeDefinitions> {
-
-		// Ask for every definition, not the first page of them: a caller
-		// counting what already exists has to see all of it, and the default
-		// page holds twenty while an environment that has been worked in holds
-		// far more.
-
 		return this.apiHelpers.get(
 			`${this.apiHelpers.baseUrl}${this.basePath}/list-type-definitions?page=-1`
 		);

--- a/modules/test/playwright/helpers/ObjectAdminApiHelper.ts
+++ b/modules/test/playwright/helpers/ObjectAdminApiHelper.ts
@@ -27,12 +27,6 @@ export class ObjectAdminApiHelper {
 	}
 
 	async getAllObjectDefinitions() {
-
-		// Ask for every definition, not the first page of them: the default
-		// page holds twenty while an environment that has been worked in holds
-		// far more, and a caller looking for one by reference code then finds
-		// nothing.
-
 		return this.apiHelpers.get(
 			`${this.apiHelpers.baseUrl}${this.basePath}/object-definitions?page=-1`
 		);

--- a/modules/test/playwright/pages/dynamic-data-mapping-form-web/FormSettingsModalPage.ts
+++ b/modules/test/playwright/pages/dynamic-data-mapping-form-web/FormSettingsModalPage.ts
@@ -23,12 +23,6 @@ export class FormSettingsModalPage {
 	}
 
 	async clickDoneButtonAndWaitForObjectFields(objectDefinitionId: number) {
-
-		// Closing the settings is what asks for the selected object's fields,
-		// and the publish validation reads the fields this ask populates. A
-		// publish clicked before the answer lands reads no fields and lets an
-		// unmapped form through, so the close waits for the answer it caused.
-
 		const objectFieldsResponsePromise = this.page.waitForResponse(
 			(response) =>
 				response.ok() &&

--- a/modules/test/playwright/pages/object-web/ViewObjectDefinitionsPage.ts
+++ b/modules/test/playwright/pages/object-web/ViewObjectDefinitionsPage.ts
@@ -98,13 +98,6 @@ export class ViewObjectDefinitionsPage {
 			name: 'Activate Object',
 		});
 
-		// The details form mounts with an enabled Activate Object toggle
-		// before the object definition has been fetched, and the fetch
-		// overwrites whatever the toggle holds by then, so a flip made too
-		// early is silently undone and saved away as a success. Save stays
-		// disabled until the fetch lands, so wait there, then flip the settled
-		// value and check the flip survived.
-
 		await expect(saveButton).toBeEnabled();
 
 		const toggled = await toggle.isChecked();
@@ -112,14 +105,6 @@ export class ViewObjectDefinitionsPage {
 		await toggle.click();
 
 		await expect(toggle).toBeChecked({checked: !toggled});
-
-		// The save answers with its PUT, shows its toast, and only then
-		// schedules a page reload a second later, so neither the click nor
-		// the toast says the work is done. Wait for the save's own answer,
-		// then consume the reload it schedules, so the caller's next
-		// navigation cannot collide with it. Ten seconds is generous headroom
-		// for that timer and fails loud, rather than quietly at the default
-		// half minute.
 
 		const saveResponse = this.page.waitForResponse(
 			(response) =>
@@ -129,12 +114,6 @@ export class ViewObjectDefinitionsPage {
 						'/o/object-admin/v1.0/object-definitions/by-external-reference-code/'
 					) && response.request().method() === 'PUT'
 		);
-
-		// The reload is waited on through the page's load event, which fires
-		// once per real document load: the same-document navigation the
-		// portlet fires around the save does not fire it, and the redirect
-		// the reload answers with first collapses into the one load of the
-		// final address.
 
 		const reload = this.page.waitForEvent('load', {timeout: 10000});
 
@@ -281,11 +260,6 @@ export class ViewObjectDefinitionsPage {
 		await this.page
 			.getByRole('button', {exact: true, name: 'Import'})
 			.click();
-
-		// The import is done when the listing request behind it answers, and a
-		// definition carrying many fields can take longer to import than the
-		// modal is given to disappear below. Wait for that answer first, so the
-		// modal is only timed once the work it is covering has finished.
 
 		const response = await responsePromise;
 

--- a/modules/test/playwright/pages/object-web/model-builder/ModelBuilderObjectDefinitionNodePage.ts
+++ b/modules/test/playwright/pages/object-web/model-builder/ModelBuilderObjectDefinitionNodePage.ts
@@ -120,12 +120,6 @@ export class ModelBuilderObjectDefinitionNodePage {
 		objectDefinitionName: string,
 		objectDefinitionNodes: Locator
 	) {
-
-		// The diagram floats the sidebars and the minimap over the canvas by
-		// design, so a node can legitimately sit under them and a regular
-		// click never passes the pointer interception check. Dispatch the
-		// click straight to the button instead.
-
 		await objectDefinitionNodes
 			.filter({hasText: objectDefinitionName})
 			.getByRole('button', {name: 'Show All Fields'})

--- a/modules/test/playwright/pages/object-web/object-action/EditObjectActionPage.ts
+++ b/modules/test/playwright/pages/object-web/object-action/EditObjectActionPage.ts
@@ -108,11 +108,6 @@ export class EditObjectActionPage {
 				.click();
 		}
 
-		// Saving closes the side panel and reloads the parent from a timer, so
-		// the reload is still in flight when the click resolves. Leaving it
-		// pending lands it in whatever step runs next, replacing the page under
-		// that step. Wait for it here.
-
 		await Promise.all([
 			this.page.waitForNavigation(),
 			this.saveButton.click(),

--- a/modules/test/playwright/pages/object-web/object-action/ViewObjectActionsPage.ts
+++ b/modules/test/playwright/pages/object-web/object-action/ViewObjectActionsPage.ts
@@ -29,11 +29,6 @@ export class ViewObjectActionsPage {
 	}
 
 	async gotoByObjectDefinitionId(objectDefinitionId: number) {
-
-		// The tab is asked for by address, so the page arrives freshly loaded
-		// and unscrolled, with every row below the sticky toolbar band
-		// instead of under it.
-
 		const portletId =
 			'com_liferay_object_web_internal_object_definitions_portlet_ObjectDefinitionsPortlet';
 

--- a/modules/test/playwright/pages/object-web/object-details/EditObjectDetailsPage.ts
+++ b/modules/test/playwright/pages/object-web/object-details/EditObjectDetailsPage.ts
@@ -108,11 +108,6 @@ export class EditObjectDetailsPage {
 	}
 
 	async waitForDetailsFormLoaded() {
-
-		// The form is interactive before its mount fetch lands, and the fetch
-		// merges the persisted definition over anything already typed. The
-		// toolbar buttons unlock only once that fetch is done, so wait there.
-
 		await expect(this.saveButton).toBeEnabled();
 	}
 

--- a/modules/test/playwright/pages/object-web/object-fields/ObjectFieldsPage.ts
+++ b/modules/test/playwright/pages/object-web/object-fields/ObjectFieldsPage.ts
@@ -252,18 +252,6 @@ export class ObjectFieldsPage {
 		await waitForPageToBeLoaded(this.page);
 	}
 
-	/**
-	 * Saves the field and hands back the navigation the save starts. The
-	 * success message renders before that navigation commits, so a caller that
-	 * cannot tolerate it in flight, such as one that asks for another address
-	 * next, awaits the returned promise at the point it needs it. Ten seconds
-	 * is generous headroom for that navigation and fails loud, rather than
-	 * quietly at the default half minute.
-	 *
-	 * The caller must await it. The promise is deliberately not swallowed: if
-	 * the save ever stops navigating, the wait fails and says so, rather than
-	 * passing quietly and leaving the collision it guards against unguarded.
-	 */
 	async saveObjectFieldReturningNavigation() {
 		const navigation = this.page.waitForNavigation({
 			timeout: 10000,
@@ -271,10 +259,6 @@ export class ObjectFieldsPage {
 		});
 
 		await this.editFieldSaveButton.click();
-
-		// Wrapped, because awaiting this method would otherwise flatten the
-		// promise and wait for the navigation here, which is what the caller is
-		// being given the chance to avoid.
 
 		return {navigation};
 	}

--- a/modules/test/playwright/pages/object-web/object-layout/ObjectLayoutsPage.ts
+++ b/modules/test/playwright/pages/object-web/object-layout/ObjectLayoutsPage.ts
@@ -195,14 +195,6 @@ export class ObjectLayoutsPage {
 		await this.saveTabButton.click();
 	}
 
-	/**
-	 * Adds the relationship tab and returns the reload the layout save
-	 * schedules on the parent window. The caller must await it before its next
-	 * navigation, or the reload lands on whatever runs next and cancels it.
-	 * It is handed back rather than awaited here because the save's success
-	 * alert does not survive the reload, so a caller that reads the alert has
-	 * to read it first.
-	 */
 	async createObjectRelationshipTab(
 		objectLayoutName: string,
 		objectLayoutTabName: string,
@@ -264,16 +256,6 @@ export class ObjectLayoutsPage {
 		await this.layoutsTabItem.click();
 	}
 
-	/**
-	 * Saves the layout and returns the reload the save schedules on the
-	 * parent window, which fires about a third of a second after the save's
-	 * own request answers. The caller must await it before its next
-	 * navigation, or the reload lands on whatever runs next and cancels it.
-	 * Ten seconds is generous headroom for that timer and fails loud, rather
-	 * than quietly at the default half minute. The promise is deliberately
-	 * not swallowed: if the save ever stops reloading, the wait fails and
-	 * says so.
-	 */
 	async saveObjectLayoutReturningReload() {
 		const reload = this.page.waitForNavigation({
 			timeout: 10000,
@@ -287,10 +269,6 @@ export class ObjectLayoutsPage {
 		await expect(saveButton).toBeVisible();
 
 		await saveButton.dispatchEvent('click');
-
-		// Wrapped, because awaiting this method would otherwise flatten the
-		// promise and wait for the reload here, which is what the caller is
-		// being given the chance to avoid.
 
 		return {reload};
 	}

--- a/modules/test/playwright/pages/object-web/object-view/EditObjectViewPage.ts
+++ b/modules/test/playwright/pages/object-web/object-view/EditObjectViewPage.ts
@@ -81,15 +81,6 @@ export class EditObjectViewPage {
 		await this.saveFilter.dispatchEvent('click');
 
 		if (filterValues) {
-
-			// Saving the filter rebuilds the side panel, and the rebuild is
-			// still in flight when the dispatch returns. A caller that clicks
-			// the view's own Save next binds a button that is torn out from
-			// under it, and retries against a panel that keeps rebuilding until
-			// the test times out. Wait for the filter form to go, which is what
-			// a saved filter produces. A filter with no value cannot save and
-			// keeps its form open to report that, so leave that case alone.
-
 			await expect(this.sidePanel.getByLabel('New Filter')).toBeHidden();
 		}
 	}

--- a/modules/test/playwright/pages/portal-workflow-kaleo-designer-web/ConfigurationTabPage.ts
+++ b/modules/test/playwright/pages/portal-workflow-kaleo-designer-web/ConfigurationTabPage.ts
@@ -35,17 +35,6 @@ export class ConfigurationTabPage {
 	}
 
 	async searchAssetType(assetType: string) {
-
-		// The tab a caller arrives from stays on screen until its navigation
-		// lands, and it carries its own search form, so a submit sent in that
-		// window filters the other table and navigates away from this tab for
-		// good. Ask for the tab and the keywords in one address instead: the
-		// table is rendered already filtered, with no form to race.
-
-		// Object definitions are registered as workflow asset types for the
-		// instance, so they are listed by the instance wide control panel and
-		// not by a site scoped one.
-
 		await this.page.goto(
 			'/group/control_panel/manage' +
 				'?p_p_id=com_liferay_portal_workflow_web_portlet_ControlPanelWorkflowPortlet' +
@@ -57,12 +46,6 @@ export class ConfigurationTabPage {
 	}
 
 	private async clickAssetTypeEditButton(assetType: string) {
-
-		// The table lists every workflow enabled asset type in the instance and
-		// pages at twenty rows, which leaves a generated object definition on the
-		// boundary of the first page. Filter by name so the lookup does not
-		// depend on how many asset types the instance happens to hold.
-
 		await this.searchAssetType(assetType);
 
 		const editButton = this.page
@@ -76,11 +59,6 @@ export class ConfigurationTabPage {
 			.getByRole('button', {name: 'Edit'});
 
 		await expect(editButton).toBeVisible();
-
-		// The edit button swaps the row into its inline edit form. A click
-		// fired before the row's script is wired gets swallowed, leaving the
-		// workflow definition select present but hidden, so retry the click
-		// until the select is visible.
 
 		await clickAndExpectToBeVisible({
 			target: this.getAssignWorkflowDropdown(assetType),

--- a/modules/test/playwright/pages/portal-workflow-task-web/WorkflowTasksPage.ts
+++ b/modules/test/playwright/pages/portal-workflow-task-web/WorkflowTasksPage.ts
@@ -47,10 +47,6 @@ export class WorkflowTasksPage {
 
 		await this.assignedToMyRolesLink.click();
 
-		// The tab is its own full navigation, so returning at the click hands
-		// the caller the list still on screen, whose rows go stale when the
-		// tab lands. Wait for the tab's address so the caller reads the tab.
-
 		await this.page.waitForURL(/tabs1=assigned-to-my-roles/);
 
 		await this.page.waitForLoadState();

--- a/modules/test/playwright/pages/product-navigation-applications-menu/GlobalMenuPage.ts
+++ b/modules/test/playwright/pages/product-navigation-applications-menu/GlobalMenuPage.ts
@@ -131,16 +131,6 @@ export class GlobalMenuPage {
 			name: categoryName,
 		});
 
-		// aria-expanded is the trigger's own open state, so it reads true as
-		// soon as the menu opens, even while the category list is still
-		// loading. Reading the list's contents instead reads "closed" for
-		// that whole load and re-clicks the trigger, which toggles the menu
-		// shut again. The pair may still start over: a caller's earlier step
-		// can have a navigation in flight, and when it lands it replaces the
-		// document and takes the open menu with it. That navigation belongs
-		// to the caller and cannot be waited on from here, so the fresh
-		// document gets asked again.
-
 		await expect(async () => {
 			if (
 				(await this.globalMenuButton.getAttribute('aria-expanded', {
@@ -148,9 +138,6 @@ export class GlobalMenuPage {
 				})) !== 'true'
 			) {
 				await this.globalMenuButton.click();
-
-				// Five seconds a look, so the loop asks again often instead
-				// of staring out the default before the next ask.
 
 				await expect(this.globalMenuButton).toHaveAttribute(
 					'aria-expanded',
@@ -160,9 +147,6 @@ export class GlobalMenuPage {
 			}
 
 			await expect(menuItem).toBeVisible({timeout: 5000});
-
-			// The menu marks the category that owns the current page with
-			// aria-current, and an item already marked needs no navigation.
 
 			if (
 				(await menuItem.getAttribute('aria-current', {

--- a/modules/test/playwright/tests/notifications-web/main/pages/NotificationsPage.ts
+++ b/modules/test/playwright/tests/notifications-web/main/pages/NotificationsPage.ts
@@ -58,13 +58,6 @@ export class NotificationsPage {
 	}
 
 	async goto(userName: string = 'Test Test') {
-
-		// The control panel sidebar can hold a menu item also named
-		// Notifications, the push notifications portlet's entry, so stay
-		// inside the profile dropdown. A click dispatched before the
-		// dropdown's scripts attach opens nothing, so click until the
-		// dropdown holds the item about to be used.
-
 		const notificationsMenuItem = this.page
 			.locator('.dropdown-menu.show')
 			.getByRole('menuitem', {name: 'Notifications'});

--- a/modules/test/playwright/tests/object-web/action/objectAction.spec.ts
+++ b/modules/test/playwright/tests/object-web/action/objectAction.spec.ts
@@ -352,11 +352,6 @@ test('can send notification email via download action', async ({
 		.getByRole('button', {name: 'Search'})
 		.waitFor({state: 'visible'});
 
-	// The queue entry is written inside the download request, before its
-	// first response byte, so a finished download means the entry is there.
-	// A bare click resolves on dispatch with the request still in flight, so
-	// own the download to its end before reading the queue.
-
 	const downloadPromise = page.waitForEvent('download');
 
 	await viewObjectEntriesPage.page.getByText('sampleFile.txt').click();

--- a/modules/test/playwright/tests/object-web/entry/objectEntry.spec.ts
+++ b/modules/test/playwright/tests/object-web/entry/objectEntry.spec.ts
@@ -4597,9 +4597,6 @@ test.describe('Manage object entries through View Object Entries', () => {
 			applicationName
 		);
 
-		// The save's navigation has had the entry seeding to land in; consume
-		// it before the next address is asked for, or the two collide.
-
 		await navigation;
 
 		await viewObjectEntriesPage.goto(objectDefinition.className);
@@ -5304,13 +5301,6 @@ test.describe('Manage object entries through View Object Entries', () => {
 
 			await expect(viewObjectEntriesPage.successMessage).toBeVisible();
 
-			// The save fires its toast before it navigates to the saved entry,
-			// and the remounted relationship field publishes an empty hidden
-			// input until its option fetch resolves, so a read taken here can
-			// see the render before the save or the field before its value.
-			// Land on the saved entry and reload so the read is the persisted
-			// value.
-
 			await page.waitForURL(/externalReferenceCode=/);
 
 			await page.reload();
@@ -5334,13 +5324,6 @@ test.describe('Manage object entries through View Object Entries', () => {
 			await viewObjectEntriesPage.saveObjectEntryButton.click();
 
 			await expect(viewObjectEntriesPage.successMessage).toBeVisible();
-
-			// The save fires its toast before it navigates to the saved entry,
-			// and the remounted relationship field publishes an empty hidden
-			// input until its option fetch resolves, so a read taken here can
-			// see the render before the save or the field before its value.
-			// Land on the saved entry and reload so the read is the persisted
-			// value.
 
 			await page.waitForURL(/externalReferenceCode=/);
 
@@ -6033,12 +6016,6 @@ test.describe('Manage object entries through View Object Entries', () => {
 
 		await viewObjectEntriesPage.goto(objectDefinition.className);
 
-		// The form the click opens is what asks for the accounts, so the wait
-		// for that answer is registered before the click. Registered after, it
-		// only ever matches a second ask, and the test asserts there is only
-		// one, so it waited out its whole budget exactly when the answer came
-		// promptly.
-
 		const accountsResponsePromise = page.waitForResponse(
 			(response) =>
 				response
@@ -6141,9 +6118,6 @@ test.describe('Manage object entries through View Object Entries', () => {
 		await page
 			.getByRole('button', {name: 'astronaut.png'})
 			.waitFor({state: 'visible'});
-
-		// The replaced temporary file is deleted asynchronously, so poll
-		// instead of asserting the very first read
 
 		await expect
 			.poll(

--- a/modules/test/playwright/tests/object-web/entry/objectPersonalData.spec.ts
+++ b/modules/test/playwright/tests/object-web/entry/objectPersonalData.spec.ts
@@ -110,12 +110,6 @@ test('can anonymize object entries', async ({
 
 	await personalDataErasurePage.anonymizeButton.click();
 
-	// The anonymize confirmation submits through the same queued form
-	// submission as the delete, so leaving for the users list here can kill
-	// it before it commits. The success alerts render after its redirect, one
-	// per anonymized application, so waiting for the first proves the
-	// anonymize reached the server.
-
 	await waitForAlert(page, undefined, {first: true});
 
 	await usersAndOrganizationsPage.goToUsers();
@@ -273,12 +267,6 @@ test('can delete object entries via personal data management', async ({
 	await personalDataErasurePage.allSelectedButton.click();
 
 	await personalDataErasurePage.deleteMenuItem.click();
-
-	// The delete confirmation submits its form through a loader that only
-	// queues the submission, so the click resolves while the delete has not
-	// been sent yet, and navigating away here kills it before it commits.
-	// The success alert renders after the delete's own redirect, so waiting
-	// for it proves the delete reached the server.
 
 	await waitForAlert(page);
 

--- a/modules/test/playwright/tests/object-web/field/objectField.spec.ts
+++ b/modules/test/playwright/tests/object-web/field/objectField.spec.ts
@@ -129,10 +129,6 @@ test.describe('Manage object fields through Model Builder', () => {
 				)
 		);
 
-		// Only what this test created is registered for deletion. Registering
-		// the definitions it merely found would delete picklists belonging to
-		// whatever else is running or expected to remain.
-
 		createdListTypeDefinitions.forEach(({id}) =>
 			apiHelpers.data.push({
 				id,
@@ -2534,12 +2530,6 @@ test.describe('Create Object Fields', () => {
 
 		await page.getByRole('button', {name: 'Cancel'}).click();
 
-		// Cancelling the modal only starts its close. The close lands later
-		// and returns focus to the element that opened the modal, so wait for
-		// the modal's own field to be gone before touching the page beneath,
-		// and give the Enter to the search box itself rather than to whatever
-		// holds focus by then.
-
 		await expect(objectFieldsPage.objectFieldLabelInput).toBeHidden();
 
 		const searchInput = page
@@ -2845,11 +2835,6 @@ test.describe('Manage object fields default value properties', () => {
 				});
 
 				booleanFieldName = objectFields[0].label['en_US'];
-
-				// An isolated folder keeps the diagram to this one definition, so
-				// the node is fitted into view; the Default folder holds every
-				// system definition and pushes the node's controls under the
-				// right sidebar, which Playwright cannot scroll away.
 
 				const objectFolder =
 					await apiHelpers.objectAdmin.postRandomObjectFolder();
@@ -3496,11 +3481,6 @@ test.describe('Manage object fields default value properties', () => {
 				objectFieldBusinessTypes: ['Text'],
 			});
 
-			// An isolated folder keeps the diagram to this one definition, so
-			// the node is fitted into view; the Default folder holds every
-			// system definition and pushes the node's controls out of the
-			// canvas viewport, which Playwright cannot scroll.
-
 			const objectFolder =
 				await apiHelpers.objectAdmin.postRandomObjectFolder();
 
@@ -3614,11 +3594,6 @@ test.describe('Manage object fields default value properties', () => {
 			const objectFields = generateObjectFields({
 				objectFieldBusinessTypes: ['Text'],
 			});
-
-			// An isolated folder keeps the diagram to this one definition, so
-			// the node is fitted into view; the Default folder holds every
-			// system definition and pushes the node's controls out of the
-			// canvas viewport, which Playwright cannot scroll.
 
 			const objectFolder =
 				await apiHelpers.objectAdmin.postRandomObjectFolder();

--- a/modules/test/playwright/tests/object-web/hierarchy/objectDefinitionHierarchy.spec.ts
+++ b/modules/test/playwright/tests/object-web/hierarchy/objectDefinitionHierarchy.spec.ts
@@ -1547,13 +1547,6 @@ test.describe('Manage root models elements through Objects Admin', () => {
 });
 
 test.describe('Disable inheritance modal flows', () => {
-
-	// Inheritance edges with linked entries cannot be PUT edge=false until
-	// the entries are gone, and apiHelpers cannot delete an edge=true
-	// relationship. Delete the parent entry here so the cascade clears the
-	// linked child, then PUT edge=false on the relationships so the
-	// automatic apiHelpers cleanup chain stays unblocked.
-
 	let parentApplicationName = '';
 	let parentEntryId: number | undefined;
 	let relationshipsForCleanup: ObjectRelationship[] = [];
@@ -1629,9 +1622,6 @@ test.describe('Disable inheritance modal flows', () => {
 		'shows modal blocking disabling inheritance when entries would be orphaned',
 		{tag: '@LPD-89021'},
 		async ({apiHelpers, objectRelationshipsPage}) => {
-
-			// Build a child with two inheritance parents and standalone=false
-
 			const parent1 =
 				await apiHelpers.objectAdmin.postRandomObjectDefinition({
 					status: {code: 0},
@@ -1678,8 +1668,6 @@ test.describe('Disable inheritance modal flows', () => {
 				'false'
 			);
 
-			// Create a child entry linked under parent1
-
 			parentApplicationName = parent1.restContextPath!.replace(
 				/^\/o\//,
 				''
@@ -1697,8 +1685,6 @@ test.describe('Disable inheritance modal flows', () => {
 				{data: {textField: 'linked-' + getRandomInt()}}
 			);
 
-			// Open Edit relationship and uncheck inheritance
-
 			await objectRelationshipsPage.goto(parent1.label!['en_US']);
 
 			await objectRelationshipsPage.actionsButton.click();
@@ -1706,8 +1692,6 @@ test.describe('Disable inheritance modal flows', () => {
 			await objectRelationshipsPage.editObjectRelationshipOption.click();
 
 			await objectRelationshipsPage.inheritanceCheckbox.click();
-
-			// Block modal fires directly from the pre-check (no warning step)
 
 			await expect(
 				objectRelationshipsPage.disableInheritanceNotAllowedModalHeader

--- a/modules/test/playwright/tests/object-web/list-type-definition/listTypeDefinition.spec.ts
+++ b/modules/test/playwright/tests/object-web/list-type-definition/listTypeDefinition.spec.ts
@@ -92,14 +92,6 @@ async function importPicklistFromFile(
 
 	await expect(page.getByLabel('External Reference Code')).not.toBeEmpty();
 
-	// Clicking Import fires a reference code check and then either imports and
-	// reloads the page, or, when the reference code already exists, asks about
-	// overwriting instead. Returning at the click leaves that chain in flight,
-	// and the caller's next navigation cancels it, so the picklist is silently
-	// never imported. Wait for whichever outcome the click reaches: the reload
-	// only ever happens after the import commits, and the overwrite prompt is
-	// the caller's to answer.
-
 	const importNavigation = page.waitForNavigation({waitUntil: 'load'}).then(
 		() => 'imported',
 		() => null
@@ -1156,13 +1148,6 @@ test.describe('manage picklists inside the picklists portlet', () => {
 			);
 
 		const [responseEntries]: ListTypeEntry[] = response.listTypeEntries;
-
-		// Read the table through assertions rather than a snapshot of its
-		// texts. The rows arrive with the data set's own render, which no load
-		// state marks, so a snapshot taken too early holds an empty list and
-		// the comparison then reports the expected value as undefined. Only the
-		// three leading cells are asserted, since the table also carries an
-		// item actions column that is not part of what this test states.
 
 		const listTypeDefinitionHeaders = [
 			'Name',

--- a/modules/test/playwright/tests/object-web/main/objectDefinition.spec.ts
+++ b/modules/test/playwright/tests/object-web/main/objectDefinition.spec.ts
@@ -1265,11 +1265,6 @@ test.describe('Manage object definitions through View Object Definitions', () =>
 					await editObjectDetailsPage.entryTitleField.textContent()
 				)?.trim() ?? '';
 
-			// The option already selected cannot be clicked: its own list item
-			// intercepts the pointer, so a run that finds the field already on
-			// the option it means to choose retries that click until the test
-			// times out. Choose one the field is not already on.
-
 			const entryTitleFieldName =
 				originalEntryTitleField === 'Screen Name'
 					? 'Email Address'
@@ -1290,12 +1285,6 @@ test.describe('Manage object definitions through View Object Definitions', () =>
 			await expect(editObjectDetailsPage.entryTitleField).toContainText(
 				entryTitleFieldName
 			);
-
-			// User is a system object shared by the whole run, so put its title
-			// field back the way it was found. Left on Screen Name, a later
-			// execution opens the dropdown with that option already selected and
-			// waits on it until the test times out, so the test can otherwise
-			// only pass once per environment.
 
 			await editObjectDetailsPage.entryTitleField.click();
 

--- a/modules/test/playwright/tests/object-web/relationship/objectRelationship.spec.ts
+++ b/modules/test/playwright/tests/object-web/relationship/objectRelationship.spec.ts
@@ -272,15 +272,6 @@ test.describe('Manage object relationships through Model Builder', () => {
 			type: 'One to Many',
 		});
 
-		// The badge showing the relationship count is rebuilt from a refetch
-		// the second relationship's save schedules, so right after the save the
-		// diagram still shows the single relationship's edge. That edge's label
-		// is random digits, so filtering edges by the text 2 matches it whenever
-		// the label contains a 2, and the click opens the sidebar instead of the
-		// menu, which only a click on the badge itself renders. Match the badge
-		// by its exact text, which the label cannot equal, and wait for it: the
-		// badge appearing is the save's rebuild finishing.
-
 		const manyRelationshipsEdge =
 			modelBuilderDiagramPage.objectRelationshipEdges.filter({
 				has: page.getByText('2', {exact: true}),
@@ -2941,9 +2932,6 @@ test.describe('Manage object relationships with system objects', () => {
 				restPath
 			);
 
-			// The layout save's reload has had the entry seeding to land in;
-			// consume it before the first navigation.
-
 			await reload;
 
 			const relateEntryToBothUsers = async (entryLabel: string) => {
@@ -3269,12 +3257,6 @@ test.describe('Manage object relationships with system objects', () => {
 				await expect(relationshipEntry).toBeVisible();
 				await relationshipEntry.click();
 
-				// Selecting relates the user and closes the picker, and the
-				// relating is still in flight when the click resolves. The next
-				// step opens the tab with a goto, which tears down the frame the
-				// post belongs to and cancels it. Wait for the picker to go and
-				// the row to appear.
-
 				await expect(
 					page.locator('iframe[title="Select"]')
 				).toBeHidden();
@@ -3553,14 +3535,6 @@ test.describe('Manage object relationship entries', () => {
 
 					await entryBItem.click();
 
-					// Selecting relates the entry and closes the picker, and
-					// the relating is still in flight when the click resolves.
-					// The next iteration asks for another address, which tears
-					// down the frame the request belongs to and cancels it, so
-					// the relationship is never made and the row asserted on
-					// below never arrives. Wait for the picker to go and the
-					// relationship to show.
-
 					await expect(
 						page.locator('iframe[title="Select"]')
 					).toBeHidden();
@@ -3710,9 +3684,6 @@ test.describe('Manage object relationship entries', () => {
 					relatedExternalReferenceCode: entryB.externalReferenceCode,
 				}
 			);
-
-			// The layout save's reload has had the entry seeding to land in;
-			// consume it before the first navigation.
 
 			await reload;
 
@@ -3865,9 +3836,6 @@ test.describe('Manage object relationship entries', () => {
 				restPath
 			);
 
-			// The layout save's reload has had the entry seeding to land in;
-			// consume it before the first navigation.
-
 			await reload;
 
 			const openEntryRelationshipTab = async (entryLabel: string) => {
@@ -3908,13 +3876,6 @@ test.describe('Manage object relationship entries', () => {
 
 				await expect(relationshipEntry).toBeVisible();
 				await relationshipEntry.click();
-
-				// Selecting relates the entry and closes the picker, and the
-				// relating is still in flight when the click resolves. The next
-				// step asks for another address, which tears down the frame the
-				// request belongs to and cancels it, so one of the two
-				// relationships is never made. Wait for the picker to go and
-				// the related row to show.
 
 				await expect(
 					page.locator('iframe[title="Select"]')
@@ -4061,9 +4022,6 @@ test.describe('Manage object relationship entries', () => {
 				await relationshipTab.click();
 			};
 
-			// The layout save's reload has had the entry seeding to land in;
-			// consume it before the first navigation.
-
 			await reload;
 
 			await openEntryRelationshipTab('Entry Test A');
@@ -4077,13 +4035,6 @@ test.describe('Manage object relationship entries', () => {
 
 			await expect(relationshipEntry).toBeVisible();
 			await relationshipEntry.click();
-
-			// Selecting relates the entry and closes the picker, and the
-			// relating is still in flight when the click resolves. The next step
-			// asks for another address, which tears down the frame the request
-			// belongs to and cancels it, so the relationship is never made and
-			// the row below never arrives. Wait for the picker to go and the
-			// relationship to show.
 
 			await expect(page.locator('iframe[title="Select"]')).toBeHidden();
 
@@ -4410,9 +4361,6 @@ test.describe('Manage object relationship entries', () => {
 				{[textFieldName]: 'Entry Test'},
 				restPath
 			);
-
-			// The layout save's reload has had the entry seeding to land in;
-			// consume it before the first navigation.
 
 			await reload;
 
@@ -4859,12 +4807,6 @@ test.describe('Manage object relationship entries', () => {
 					await expect(entry).toBeVisible();
 
 					await entry.click();
-
-					// Selecting relates the entry and closes the picker, and the
-					// relating is still in flight when the click resolves. The
-					// next step navigates away, so returning here lets that
-					// navigation race the save and the entry is never related.
-					// Wait for the picker to go and the row to appear.
 
 					await expect(
 						page.locator('iframe[title="Select"]')
@@ -5322,9 +5264,6 @@ test.describe('Manage object relationship entries', () => {
 				{['textField']: 'Entry 1'},
 				applicationName1
 			);
-
-			// The layout save's reload has had the entry seeding to land in;
-			// consume it before the first navigation.
 
 			await reload;
 

--- a/modules/test/playwright/tests/object-web/salesforce/objectSalesforce.spec.ts
+++ b/modules/test/playwright/tests/object-web/salesforce/objectSalesforce.spec.ts
@@ -53,12 +53,6 @@ test.beforeEach(async ({apiHelpers, instanceSettingsPage, page}) => {
 
 	page.setViewportSize({height: 1080, width: 1920});
 
-	// The external reference code names the Salesforce object that holds the
-	// entries, so neither it nor the definition's name can be randomized, and
-	// only one definition at a time can carry them. A run that dies before its
-	// own teardown leaves that definition behind and every later run against the
-	// same database is refused. Take the name back.
-
 	const leftoverObjectDefinition =
 		await apiHelpers.objectAdmin.getObjectDefinitionByName(
 			OBJECT_DEFINITION_NAME

--- a/modules/test/playwright/tests/object-web/utils/generateObjectEntry.ts
+++ b/modules/test/playwright/tests/object-web/utils/generateObjectEntry.ts
@@ -75,14 +75,6 @@ function generateObjectEntryValue({
 		case 'LongText':
 			return getRandomString();
 		case 'MultiselectPicklist':
-
-			// The two entries were drawn independently, so on a short list they
-			// were often the same one. Selecting one entry twice is not a
-			// multiselect: the second selection lands on an option that is
-			// already selected, which the admin theme renders pointer
-			// transparent, and the click never arrives. Which two entries they
-			// are does not matter, so take the one after the first.
-
 			return [
 				listTypeEntriesName[listTypeEntriesRandomLength1],
 				listTypeEntriesName[

--- a/modules/test/playwright/tests/object-web/utils/getFreshObjectRelationshipName.ts
+++ b/modules/test/playwright/tests/object-web/utils/getFreshObjectRelationshipName.ts
@@ -8,29 +8,11 @@ import {ObjectRelationshipAPI} from '@liferay/object-admin-rest-client-js';
 import {DataApiHelpers} from '../../../helpers/ApiHelpers';
 import {getRandomInt} from '../../../utils/getRandomInt';
 
-/**
- * Returns a relationship name that is free on both definitions the
- * relationship will connect. Relationship names are unique per definition, on
- * both sides, because the reverse relationship carries the same name, and on
- * a shared system definition the namespace also holds every other test's
- * relationships and every leftover a crashed run left behind. The name is
- * drawn from a ten digit space and each definition is asked whether it is
- * taken, drawing again until it is not, so a collision with anything already
- * persisted is impossible. Two callers drawing in the same moment can still
- * race each other, and for that window the create's own duplicate refusal
- * remains the arbiter, being the only atomic claim.
- *
- * Use this for every relationship name a test creates.
- */
 export async function getFreshObjectRelationshipName(
 	apiHelpers: DataApiHelpers,
 	objectDefinitionExternalReferenceCodes: string[],
 	prefix: string = 'objectRelName'
 ): Promise<string> {
-
-	// The name becomes part of a database column, so the validator holds it
-	// to a hard budget that the ten digits must fit inside as well.
-
 	if (prefix.length > 21) {
 		throw new Error(
 			`Prefix "${prefix}" is too long for a relationship name: the ` +

--- a/modules/test/playwright/tests/object-web/validation/objectValidation.spec.ts
+++ b/modules/test/playwright/tests/object-web/validation/objectValidation.spec.ts
@@ -1292,10 +1292,6 @@ test.describe('Object Groovy Validation', () => {
 			'Groovy'
 		);
 
-		// Saving the validation leaves a navigation in flight that aborts the
-		// reload, and it lands after the page has otherwise gone quiet, so
-		// waiting for a load state does not avoid it. Retry the reload instead.
-
 		await expect(async () => {
 			await page.reload({timeout: 15000});
 		}).toPass({timeout: 60000});

--- a/modules/test/playwright/tests/object-web/workflow/objectWorkflow.spec.ts
+++ b/modules/test/playwright/tests/object-web/workflow/objectWorkflow.spec.ts
@@ -203,11 +203,6 @@ test(
 
 		const label = objectDefinition.label['en_US'];
 
-		// What this test asserts is whether the object is listed, so reach the
-		// filtered Configuration tab by address. Walking the global menu adds
-		// two navigations that are torn down and rebuilt while the object
-		// definition redeploys, and neither of them is under test here.
-
 		await configurationTabPage.searchAssetType(label);
 
 		await expect(page.getByRole('row', {name: label})).toBeVisible();

--- a/modules/test/playwright/tests/site-admin-web/main/fixtures/localizationPagesTest.ts
+++ b/modules/test/playwright/tests/site-admin-web/main/fixtures/localizationPagesTest.ts
@@ -24,14 +24,6 @@ const localizationPagesTest = test.extend<{
 		}
 		finally {
 			try {
-
-				// Render the admin UI in English regardless of the current
-				// instance default language, so the settings navigation and
-				// controls resolve when the test left the instance in another
-				// language. Both calls carry the authenticity token: without
-				// it the portal answers Forbidden, and the body it returns for
-				// that is not always JSON.
-
 				const response = await page.request.get(
 					'/o/headless-admin-user/v1.0/my-user-account',
 					{headers: await getHeader(page)}
@@ -50,13 +42,6 @@ const localizationPagesTest = test.extend<{
 				await page.reload();
 			}
 			finally {
-
-				// The instance default language is instance wide state that
-				// every later test inherits, so restore it even when the steps
-				// above fail. Leaving it set fails sign-in verification,
-				// object definition labels, and site page creation across
-				// every file and worker that follows.
-
 				await localizationInstanceSettingsPage.goto('Language', false);
 
 				await localizationInstanceSettingsPage.setDefaultLanguage(

--- a/modules/test/playwright/utils/gotoWithRetry.ts
+++ b/modules/test/playwright/utils/gotoWithRetry.ts
@@ -5,15 +5,6 @@
 
 import {Page} from '@playwright/test';
 
-/**
- * Navigates like page.goto, surviving a navigation left pending by an earlier
- * step. An action whose success signal renders before its navigation commits,
- * like saving an object layout, leaves that navigation in flight, and when it
- * lands during a later goto the browser reports the goto as aborted or
- * interrupted even though nothing is wrong with the address. Let the pending
- * navigation land and go again: unlike settling for whatever page won, the
- * retry ends on the address the caller asked for.
- */
 export async function gotoWithRetry(
 	page: Page,
 	url: string,

--- a/modules/test/playwright/utils/performLogin.ts
+++ b/modules/test/playwright/utils/performLogin.ts
@@ -76,14 +76,6 @@ async function performLogin(
 	await page.getByLabel('Password').fill(password);
 	await page.getByLabel('Remember Me').setChecked(rememberMe);
 
-	// Two buttons on the page carry the name Sign In, the personal bar
-	// trigger and the prompt's own submit, and the prompt can re-render under
-	// the click: a pick by ordinal that is re-resolved in that window matches
-	// the only survivor, the trigger, which submits nothing. Scoped to the
-	// sign in form, the pick can only ever resolve to the submit, and the
-	// click's own wait for it to be enabled is the form's readiness signal,
-	// because the script that enables it attaches the submit handler first.
-
 	await page
 		.locator('form.sign-in-form')
 		.getByRole('button', {name: 'Sign In'})
@@ -116,9 +108,6 @@ export async function performLoginViaApi({
 	try {
 		await page.goto(loginUrl);
 
-		// Signing in replaces the session, so drop the token held for the one
-		// being left behind before the request that replaces it.
-
 		clearAuthToken(page);
 
 		const url = `${loginUrl}/c/portal/login`;
@@ -138,9 +127,6 @@ export async function performLoginViaApi({
 			.toBe(200);
 
 		await page.goto(loginUrl);
-
-		// The page has settled on the signed in session, so this is the moment
-		// to read the token every later request will carry.
 
 		await readAuthToken(page);
 	}
@@ -167,9 +153,6 @@ export async function performAnalyticsCloudLoginViaApi(
 	try {
 		await page.goto(loginUrl);
 
-		// Signing in replaces the session, so drop the token held for the one
-		// being left behind before the request that replaces it.
-
 		clearAuthToken(page);
 
 		const url = `${loginUrl}/c/portal/login`;
@@ -189,9 +172,6 @@ export async function performAnalyticsCloudLoginViaApi(
 			.toBe(200);
 
 		await page.goto(loginUrl);
-
-		// The page has settled on the signed in session, so this is the moment
-		// to read the token every later request will carry.
 
 		await readAuthToken(page);
 	}

--- a/modules/test/playwright/utils/waitForSearchToBeReady.ts
+++ b/modules/test/playwright/utils/waitForSearchToBeReady.ts
@@ -5,19 +5,6 @@
 
 import {Page, expect} from '@playwright/test';
 
-/**
- * Waits until the management toolbar's search accepts Enter.
- *
- * The server ships the search form's default submit button disabled, and a form
- * whose default button is disabled skips implicit submission entirely, so Enter
- * produces no submit event and no request. The typed text simply sits there, the
- * listing is never filtered, and an assertion about the filtered result fails
- * against unfiltered content. The button is enabled once the client script runs,
- * which is what this waits for.
- *
- * A load state is not enough on its own: after an SPA navigation the document
- * has already fired load while the swapped-in markup is still inert.
- */
 export async function waitForSearchToBeReady(page: Page) {
 	await expect(
 		page.locator('.management-bar button[type="submit"]')


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99314

## What Is Being Fixed

Frontend changes frequently, and as the code drifts an AI reading a stale comment weighs it higher than the reality of the code. This removes every comment the stabilization campaign's subtasks added to frontend files; the explanations live in those commits' messages instead.

## How It Is Being Fixed

All 158 subtasks of LPD-99314 plus the parent were resolved to their 245 commits on master, and every frontend file those commits touched (65 in all: ts, tsx, js, jsx, macro, testcase, function, and path) was swept twice: a comment line is removed when its content matches a line those commits added, or when git blame owns it to one of those tickets — both computed against the pristine tree. Lint pragmas and copyright headers were kept, and the only whitespace edits are the ones the source formatter itself applied. The result is 37 files and 482 pure comment and blank line deletions. Two pre-existing upstream source-format breaks the runs surfaced ride ahead as their own commits under their causing tickets (LPD-102208, LPD-103084).

## PR Check

**pr-check: PASS** — tested on `0d4bd850b6859c3a3fc6adf9150e31973fd93754`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Poshi Syntax | PASS |
| Java Unit Tests | PASS |
| JavaScript Unit Tests | PASS |
| Transaction Usage | PASS |

Source Format ran to convergence (zero modifications on the final pass). Java Unit covers the two touched test classes (AnalyticsTopHeadJSPDynamicIncludeTest, AWSByteBufferUtilTest); JavaScript Unit is frontend-data-set-web's Jest suite (246 tests), the only touched module with one. Baseline and Per-Module Compile matched by pattern but no exported API or production Java changed.

<!-- pr-check {"result": "success", "sha": "0d4bd850b6859c3a3fc6adf9150e31973fd93754"} -->
