### PR TITLE
LPD-103534 Expect the layout tab registration to outlive the relationship delete

### DIFF
--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectRelationshipLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectRelationshipLocalServiceTest.java
@@ -819,7 +819,7 @@ public class ObjectRelationshipLocalServiceTest {
 		_objectRelationshipLocalService.deleteObjectRelationship(
 			objectRelationship);
 
-		_assertObjectLayoutTab(0, objectLayoutTabs.get(1));
+		_assertObjectLayoutTab(1, objectLayoutTabs.get(1));
 	}
 
 	@Test


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103534

## What Is Being Fixed

`ObjectRelationshipLocalServiceTest.testDeleteObjectRelationshipWithObjectLayout` fails deterministically on every master tree since 2026-08-23. Commit `4e7f0f75a2e42d7672accf2c9f1ff472b1a95133` (LPD-102795) intentionally changed the layout tab contract — the tab's screen navigation registration now outlives the delete (stale entries are hidden from the UI and unregistered on undeploy), fixing OSGi registrations that could not be reverted on transaction rollback — but this pre-existing assertion was left expecting the registry to drop to zero on delete, so it fails on every `ci:test:object` run.

## How It Is Being Fixed

The test's post-delete assertion moves to the new contract: the tab's registration survives the relationship delete, so the test expects one registration instead of zero. The full class passes locally on a clean master bundle (9 of 9), and a fork `ci:test:object` run over the fix showed no failures unique to the pull.

## PR Check

**pr-check: PASS** — tested on `6c7e0854115ed6bb27365cf3c9900f27db2f213c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |
| Transaction Usage | PASS |

Baseline and Per-Module Compile matched by pattern but the diff is a single testIntegration assertion — no exported API or production code changes. The change additionally passed a fork `ci:test:object` run (59 of 62 jobs, no failures unique to the pull) and rides the LPD-99314 aggregate, where the previously failing test now passes.

<!-- pr-check {"result": "success", "sha": "6c7e0854115ed6bb27365cf3c9900f27db2f213c"} -->
