### PR TITLE
LPD-103271 Read the Learn resources from a directory or S3, nothing else

### DIFF
--- a/learn-resources/README.md
+++ b/learn-resources/README.md
@@ -72,25 +72,15 @@ That's how you link to Liferay Learn resources!
 
 ## Previewing Liferay Learn Resource Links
 
-If you want to test your link, you don't have to recompile your module. From this folder (`learn-resources`), you can run a quick dev server that's configured with only one portal property/environment variable:
+If you want to test your link, you don't have to recompile your module. Point the `learn.resources.dir` portal property (or the `LIFERAY_LEARN_PERIOD_RESOURCES_PERIOD_DIR` environment variable with Docker) at this folder's `data` directory:
 
 ```properties
-learn.resources.mode=dev|off|on
+learn.resources.dir=/path/to/liferay-portal/learn-resources/data
 ```
 
-or
+Resources are then read from that directory on every request, so your edits show up immediately. Without the property, resources are read from <https://s3.amazonaws.com/learn-resources.liferay.com> with a four hour cache.
 
-```bash
-LIFERAY_LEARN_PERIOD_RESOURCES_PERIOD_MODE=dev|off|on
-```
-
-Use the property with a local bundle and the environment variable with Docker.
-
-`dev`: Set this value and then run `docker compose up` from the `learn-resources` folder to start a small dev server. You can then access <http://localhost:3062/[json file name]> to access your resources. For example, if you're modifying `server-admin-web.json`, access <http://localhost:3062/server-admin-web.json>.
-
-`on`: Set this value to read Learn resources from <https://s3.amazonaws.com/learn-resources.liferay.com>.
-
-`off`: Set this value to disable the Learn tag library.
+Set `learn.resources.mode=off` (or `LIFERAY_LEARN_PERIOD_RESOURCES_PERIOD_MODE=off`) to disable the Learn tag library.
 
 ## Adding a Resource Link to a React Component
 

--- a/learn-resources/docker-compose.yml
+++ b/learn-resources/docker-compose.yml
@@ -1,8 +1,0 @@
-services:
-    web-server:
-        image: lipanski/docker-static-website:latest
-        ports:
-            -   "3062:3000"
-        volumes:
-            -   ./httpd.conf:/home/static/httpd.conf:ro
-            -   ./data:/home/static

--- a/modules/apps/learn/learn-api/build.gradle
+++ b/modules/apps/learn/learn-api/build.gradle
@@ -4,3 +4,7 @@ dependencies {
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-string")
 }
+
+test {
+	systemProperty "learn.resources.data.dir", new File(rootDir.parentFile, "learn-resources/data")
+}

--- a/modules/apps/learn/learn-api/src/main/java/com/liferay/learn/LearnMessageUtil.java
+++ b/modules/apps/learn/learn-api/src/main/java/com/liferay/learn/LearnMessageUtil.java
@@ -12,8 +12,10 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.HttpUtil;
 import com.liferay.portal.kernel.util.PropsUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.webcache.WebCacheItem;
 import com.liferay.portal.kernel.webcache.WebCachePoolUtil;
 
@@ -57,6 +59,9 @@ public class LearnMessageUtil {
 		return jsonObject;
 	}
 
+	private static final String _LEARN_RESOURCES_DIR = PropsUtil.get(
+		"learn.resources.dir");
+
 	private static final boolean _LEARN_RESOURCES_MODE_DEV = Objects.equals(
 		PropsUtil.get("learn.resources.mode"), "dev");
 
@@ -77,6 +82,25 @@ public class LearnMessageUtil {
 			try {
 				if (_LEARN_RESOURCES_MODE_OFF) {
 					return JSONFactoryUtil.createJSONObject();
+				}
+
+				if (_LEARN_RESOURCES_MODE_DEV &&
+					Validator.isNotNull(_LEARN_RESOURCES_DIR)) {
+
+					// The dev server exists only to serve these files over
+					// HTTP, so a caller that can name the directory holding
+					// them does not need it.
+
+					String fileName = StringBundler.concat(
+						_LEARN_RESOURCES_DIR, StringPool.SLASH, _resource,
+						".json");
+
+					if (_log.isDebugEnabled()) {
+						_log.debug("Reading " + fileName);
+					}
+
+					return JSONFactoryUtil.createJSONObject(
+						FileUtil.read(fileName));
 				}
 
 				StringBundler sb = new StringBundler(4);

--- a/modules/apps/learn/learn-api/src/main/java/com/liferay/learn/LearnMessageUtil.java
+++ b/modules/apps/learn/learn-api/src/main/java/com/liferay/learn/LearnMessageUtil.java
@@ -87,10 +87,6 @@ public class LearnMessageUtil {
 				if (_LEARN_RESOURCES_MODE_DEV &&
 					Validator.isNotNull(_LEARN_RESOURCES_DIR)) {
 
-					// The dev server exists only to serve these files over
-					// HTTP, so a caller that can name the directory holding
-					// them does not need it.
-
 					String fileName = StringBundler.concat(
 						_LEARN_RESOURCES_DIR, StringPool.SLASH, _resource,
 						".json");

--- a/modules/apps/learn/learn-api/src/main/java/com/liferay/learn/LearnMessageUtil.java
+++ b/modules/apps/learn/learn-api/src/main/java/com/liferay/learn/LearnMessageUtil.java
@@ -62,9 +62,6 @@ public class LearnMessageUtil {
 	private static final String _LEARN_RESOURCES_DIR = PropsUtil.get(
 		"learn.resources.dir");
 
-	private static final boolean _LEARN_RESOURCES_MODE_DEV = Objects.equals(
-		PropsUtil.get("learn.resources.mode"), "dev");
-
 	private static final boolean _LEARN_RESOURCES_MODE_OFF = Objects.equals(
 		PropsUtil.get("learn.resources.mode"), "off");
 
@@ -84,9 +81,7 @@ public class LearnMessageUtil {
 					return JSONFactoryUtil.createJSONObject();
 				}
 
-				if (_LEARN_RESOURCES_MODE_DEV &&
-					Validator.isNotNull(_LEARN_RESOURCES_DIR)) {
-
+				if (Validator.isNotNull(_LEARN_RESOURCES_DIR)) {
 					String fileName = StringBundler.concat(
 						_LEARN_RESOURCES_DIR, StringPool.SLASH, _resource,
 						".json");
@@ -99,20 +94,9 @@ public class LearnMessageUtil {
 						FileUtil.read(fileName));
 				}
 
-				StringBundler sb = new StringBundler(4);
-
-				if (_LEARN_RESOURCES_MODE_DEV) {
-					sb.append("http://localhost:3062/");
-				}
-				else {
-					sb.append("https://s3.amazonaws.com");
-					sb.append("/learn-resources.liferay.com/");
-				}
-
-				sb.append(_resource);
-				sb.append(".json");
-
-				String url = sb.toString();
+				String url = StringBundler.concat(
+					"https://s3.amazonaws.com/learn-resources.liferay.com/",
+					_resource, ".json");
 
 				if (_log.isDebugEnabled()) {
 					_log.debug("Reading " + url);
@@ -132,7 +116,7 @@ public class LearnMessageUtil {
 
 		@Override
 		public long getRefreshTime() {
-			if (_LEARN_RESOURCES_MODE_DEV) {
+			if (Validator.isNotNull(_LEARN_RESOURCES_DIR)) {
 				return 0;
 			}
 

--- a/modules/apps/learn/learn-api/src/test/java/com/liferay/learn/LearnResourcesTest.java
+++ b/modules/apps/learn/learn-api/src/test/java/com/liferay/learn/LearnResourcesTest.java
@@ -1,0 +1,130 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.learn;
+
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Shuyang Zhou
+ */
+public class LearnResourcesTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testGlobalServerServesEveryLearnResource() {
+
+		// Every learn message in the product renders from one of these
+		// resources, and a read that fails is swallowed into an empty object,
+		// so a resource the global server stops serving makes learn links
+		// vanish with nothing in the log. This repository holds a copy of every
+		// resource the product asks for, so the directory names what has to be
+		// served.
+
+		String dirName = System.getProperty("learn.resources.data.dir");
+
+		Assert.assertNotNull(
+			"The build did not set \"learn.resources.data.dir\"", dirName);
+
+		File dir = new File(dirName);
+
+		Assert.assertTrue(dirName + " is not a directory", dir.isDirectory());
+
+		File[] files = dir.listFiles(
+			(directory, name) -> name.endsWith(".json"));
+
+		Assert.assertNotNull(dir.toString(), files);
+		Assert.assertTrue("No learn resources in " + dir, files.length > 0);
+
+		List<String> unservedURLs = new ArrayList<>();
+
+		int timeout = _TIMEOUT;
+
+		for (File file : files) {
+			String url =
+				"https://s3.amazonaws.com/learn-resources.liferay.com/" +
+					file.getName();
+
+			String failure = _getFailure(url, timeout);
+
+			if (failure != null) {
+				unservedURLs.add(failure);
+
+				// The first failure answers what the remaining reads are
+				// asking: the doubt is no longer about one resource but about
+				// the server or the route to it. So every read before it waits
+				// as long as a slow continuous integration machine can need,
+				// and every read after it waits only long enough to tell a
+				// server that is down from one that is merely slow.
+
+				timeout = _TIMEOUT_AFTER_FAILURE;
+			}
+		}
+
+		Assert.assertTrue(unservedURLs.toString(), unservedURLs.isEmpty());
+	}
+
+	private String _getFailure(String url, int timeout) {
+		try {
+			HttpURLConnection httpURLConnection = (HttpURLConnection)new URL(
+				url
+			).openConnection();
+
+			httpURLConnection.setConnectTimeout(timeout);
+			httpURLConnection.setReadTimeout(timeout);
+
+			int responseCode = httpURLConnection.getResponseCode();
+
+			if (responseCode != HttpURLConnection.HTTP_OK) {
+				return url + " answered " + responseCode;
+			}
+
+			byte[] bytes = new byte[1];
+
+			try (InputStream inputStream = httpURLConnection.getInputStream()) {
+				if (inputStream.read(bytes) == -1) {
+					return url + " answered nothing";
+				}
+			}
+
+			if (bytes[0] != '{') {
+				return url + " does not answer with a JSON object";
+			}
+
+			return null;
+		}
+		catch (IOException ioException) {
+
+			// A read that fails is reported like any other, rather than thrown,
+			// so one unreachable resource does not hide the state of the rest.
+
+			return url + " could not be read: " + ioException;
+		}
+	}
+
+	private static final int _TIMEOUT = 30000;
+
+	private static final int _TIMEOUT_AFTER_FAILURE = 5000;
+
+}

--- a/modules/apps/learn/learn-api/src/test/java/com/liferay/learn/LearnResourcesTest.java
+++ b/modules/apps/learn/learn-api/src/test/java/com/liferay/learn/LearnResourcesTest.java
@@ -72,7 +72,7 @@ public class LearnResourcesTest {
 
 	private String _getFailure(String url, int timeout) {
 		try {
-			URL urlObject = new URL(urlString);
+			URL urlObject = new URL(url);
 
 			HttpURLConnection httpURLConnection =
 				(HttpURLConnection)urlObject.openConnection();

--- a/modules/apps/learn/learn-api/src/test/java/com/liferay/learn/LearnResourcesTest.java
+++ b/modules/apps/learn/learn-api/src/test/java/com/liferay/learn/LearnResourcesTest.java
@@ -34,14 +34,6 @@ public class LearnResourcesTest {
 
 	@Test
 	public void testGlobalServerServesEveryLearnResource() {
-
-		// Every learn message in the product renders from one of these
-		// resources, and a read that fails is swallowed into an empty object,
-		// so a resource the global server stops serving makes learn links
-		// vanish with nothing in the log. This repository holds a copy of every
-		// resource the product asks for, so the directory names what has to be
-		// served.
-
 		String dirName = System.getProperty("learn.resources.data.dir");
 
 		Assert.assertNotNull(
@@ -70,13 +62,6 @@ public class LearnResourcesTest {
 
 			if (failure != null) {
 				unservedURLs.add(failure);
-
-				// The first failure answers what the remaining reads are
-				// asking: the doubt is no longer about one resource but about
-				// the server or the route to it. So every read before it waits
-				// as long as a slow continuous integration machine can need,
-				// and every read after it waits only long enough to tell a
-				// server that is down from one that is merely slow.
 
 				timeout = _TIMEOUT_AFTER_FAILURE;
 			}
@@ -115,10 +100,6 @@ public class LearnResourcesTest {
 			return null;
 		}
 		catch (IOException ioException) {
-
-			// A read that fails is reported like any other, rather than thrown,
-			// so one unreachable resource does not hide the state of the rest.
-
 			return url + " could not be read: " + ioException;
 		}
 	}

--- a/modules/apps/learn/learn-api/src/test/java/com/liferay/learn/LearnResourcesTest.java
+++ b/modules/apps/learn/learn-api/src/test/java/com/liferay/learn/LearnResourcesTest.java
@@ -72,9 +72,10 @@ public class LearnResourcesTest {
 
 	private String _getFailure(String url, int timeout) {
 		try {
-			HttpURLConnection httpURLConnection = (HttpURLConnection)new URL(
-				url
-			).openConnection();
+			URL urlObject = new URL(urlString);
+
+			HttpURLConnection httpURLConnection =
+				(HttpURLConnection)urlObject.openConnection();
 
 			httpURLConnection.setConnectTimeout(timeout);
 			httpURLConnection.setReadTimeout(timeout);

--- a/modules/test/playwright/env/common.sh
+++ b/modules/test/playwright/env/common.sh
@@ -93,6 +93,8 @@ function combine_properties_files {
 function default_set_up {
 	update_portal_ext_properties
 
+	update_learn_resources_dir
+
 	start_default_app_server
 
 	deploy_parent_project_osgi_modules
@@ -744,6 +746,41 @@ function stop_client_extension_spring_boot_application {
 
 function stop_default_app_server {
 	stop_app_server ${LIFERAY_HOME} ${LIFERAY_PORTAL_URL}
+}
+
+function update_learn_resources_dir {
+
+	# The portal reads its learn resources from this checkout, so a test that
+	# clicks a learn link depends on no server, neither the global one nor a
+	# local one. Where a checkout sits relative to a portal's home is
+	# configured rather than fixed, so only this script can name the path.
+
+	local learn_resources_dir=${_PORTAL_PROJECT_DIR}/learn-resources/data
+
+	if [[ ! -d ${learn_resources_dir} ]]
+	then
+		echo "Unable to find ${learn_resources_dir}."
+
+		exit 1
+	fi
+
+	# A bundle carries one of these files under each application server it
+	# ships with, and a bundle built with every default carries none at all, in
+	# which case the portal still reads the one its home holds.
+
+	local properties_files=$(get_tomcat_portal_ext_properties_file)
+
+	if [[ -z ${properties_files} ]]
+	then
+		properties_files=${LIFERAY_HOME}/portal-ext.properties
+	fi
+
+	local properties_file
+
+	for properties_file in ${properties_files}
+	do
+		echo "learn.resources.dir=${learn_resources_dir}" >> ${properties_file}
+	done
 }
 
 function update_portal_ext_properties {

--- a/modules/test/playwright/env/common.sh
+++ b/modules/test/playwright/env/common.sh
@@ -749,12 +749,6 @@ function stop_default_app_server {
 }
 
 function update_learn_resources_dir {
-
-	# The portal reads its learn resources from this checkout, so a test that
-	# clicks a learn link depends on no server, neither the global one nor a
-	# local one. Where a checkout sits relative to a portal's home is
-	# configured rather than fixed, so only this script can name the path.
-
 	local learn_resources_dir=${_PORTAL_PROJECT_DIR}/learn-resources/data
 
 	if [[ ! -d ${learn_resources_dir} ]]
@@ -763,10 +757,6 @@ function update_learn_resources_dir {
 
 		exit 1
 	fi
-
-	# A bundle carries one of these files under each application server it
-	# ships with, and a bundle built with every default carries none at all, in
-	# which case the portal still reads the one its home holds.
 
 	local properties_files=$(get_tomcat_portal_ext_properties_file)
 

--- a/modules/test/playwright/env/portal-ext.properties
+++ b/modules/test/playwright/env/portal-ext.properties
@@ -8,6 +8,7 @@ setup.wizard.enabled=false
 virtual.hosts.default.site.name=
 virtual.hosts.valid.hosts=*
 web.server.http.port=8080
+learn.resources.mode=dev
 
 captcha.enforce.disabled=true
 

--- a/modules/test/playwright/env/portal-ext.properties
+++ b/modules/test/playwright/env/portal-ext.properties
@@ -8,7 +8,6 @@ setup.wizard.enabled=false
 virtual.hosts.default.site.name=
 virtual.hosts.valid.hosts=*
 web.server.http.port=8080
-learn.resources.mode=dev
 
 captcha.enforce.disabled=true
 

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -11872,32 +11872,22 @@
 
     #
     # Set the value to the directory that holds the Learn resource files, such
-    # as the learn-resources/data directory of a liferay-portal checkout. The
-    # value is read only when the property "learn.resources.mode" is set to
-    # "dev", and it is then read instead of http://localhost:3062, so no dev
-    # server is needed.
+    # as the learn-resources/data directory of a liferay-portal checkout. When
+    # the value is set, Learn resources are read from that directory on every
+    # request. When the value is not set, Learn resources are read from
+    # https://s3.amazonaws.com/learn-resources.liferay.com.
     #
     # Env: LIFERAY_LEARN_PERIOD_RESOURCES_PERIOD_DIR
     #
     learn.resources.dir=
 
     #
-    # Set the value to "dev" to read Learn resources from http://localhost:3062.
-    # Go to the learn-resources directory (i.e.
-    # https://github.com/liferay/liferay-portal/tree/master/learn-resources) and
-    # run "docker-compose up" to start the dev server. You can then access
-    # http://localhost:3062/server-admin-web.json and other resources. Set the
-    # property "learn.resources.dir" to read the same files from that directory
-    # and skip the dev server.
-    #
     # Set the value to "off" to disable the Learn tag library.
     #
-    # Set the value to "on" to read Learn resources from
-    # https://s3.amazonaws.com/learn-resources.liferay.com.
+    # Set the value to "on" to read Learn resources.
     #
     # Env: LIFERAY_LEARN_PERIOD_RESOURCES_PERIOD_MODE
     #
-    #learn.resources.mode=dev
     #learn.resources.mode=off
     learn.resources.mode=on
 

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -11871,11 +11871,24 @@
 ##
 
     #
+    # Set the value to the directory that holds the Learn resource files, such
+    # as the learn-resources/data directory of a liferay-portal checkout. The
+    # value is read only when the property "learn.resources.mode" is set to
+    # "dev", and it is then read instead of http://localhost:3062, so no dev
+    # server is needed.
+    #
+    # Env: LIFERAY_LEARN_PERIOD_RESOURCES_PERIOD_DIR
+    #
+    learn.resources.dir=
+
+    #
     # Set the value to "dev" to read Learn resources from http://localhost:3062.
     # Go to the learn-resources directory (i.e.
     # https://github.com/liferay/liferay-portal/tree/master/learn-resources) and
     # run "docker-compose up" to start the dev server. You can then access
-    # http://localhost:3062/server-admin-web.json and other resources.
+    # http://localhost:3062/server-admin-web.json and other resources. Set the
+    # property "learn.resources.dir" to read the same files from that directory
+    # and skip the dev server.
     #
     # Set the value to "off" to disable the Learn tag library.
     #

--- a/test.properties
+++ b/test.properties
@@ -1513,6 +1513,7 @@
 
     test.batch.class.names.includes[modules-unit_stable]=\
         **/jenkins-results-parser/**/TestPropertiesPQLValidationTest.java,\
+        **/learn-api/**/LearnResourcesTest.java,\
         **/portal-tools-sample-sql-builder/**/SampleSQLBuilderTest.java,\
         portal-impl/**/Log4jConfigUtilTest.java
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103271

Resent on top of shuyangzhou#12632, replacing brianchandotcom#180673.

## What Is Being Fixed

The Learn tag library's dev mode existed to point resource reads away from S3 while editing them, first at a dev server on localhost:3062 and later at a directory. The directory serves that whole purpose by itself, and only the Learn workflow ever used the server.

## How It Is Being Fixed

The mode's dev value and the localhost:3062 URL are gone: when `learn.resources.dir` is set, resources are read from that directory on every request; when it is not set, they are read from S3 with the usual four hour cache. The `off` value stays as the tag library's kill switch. The dev server itself (`learn-resources/docker-compose.yml` and its httpd configuration) is removed and the README teaches the directory property instead. On top of that ride the earlier commits: the guard test that fetches every resource this repository names from S3, and the test environment wiring that points `learn.resources.dir` at the checkout.

## PR Check

**pr-check: PASS** — tested on `1987ac5fb3c74c3c2672bb4f601360688901d461`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Java Unit Tests | PASS |
| Transaction Usage | PASS |

Java Unit is learn-api's LearnResourcesTest, run green against live S3 (all 37 resources answered). Source Format is clean on every touched file; the run also reports a pre-existing violation in portal-security-key-provider-aws that is unrelated to this branch and already fixed on brianchandotcom#180733. Baseline matched by pattern but only a private static field was removed from the exported class — no API change.

<!-- pr-check {"result": "success", "sha": "1987ac5fb3c74c3c2672bb4f601360688901d461"} -->
