### PR TITLE
LPD-103561 Let the field panel finish reading before typing over its label

### DIFF
--- a/modules/test/playwright/tests/object-web/field/objectField.spec.ts
+++ b/modules/test/playwright/tests/object-web/field/objectField.spec.ts
@@ -370,6 +370,10 @@ test.describe('Manage object fields through Model Builder', () => {
 
 		const picklistFieldName = 'picklistField' + getRandomInt();
 
+		await expect(page.getByPlaceholder('Text to translate...')).toHaveValue(
+			objectFields[0].label['en_US']
+		);
+
 		await page
 			.getByPlaceholder('Text to translate...')
 			.fill(picklistFieldName);
@@ -704,6 +708,10 @@ test.describe('Manage object fields through Model Builder', () => {
 					.filter({hasText: objectDefinition.label['en_US']})
 					.getByText(objectFieldLabel, {exact: true})
 					.click();
+
+				await expect(page.getByText('LabelMandatory')).toHaveValue(
+					objectFieldLabel
+				);
 
 				await page.getByText('LabelMandatory').fill(updatedFieldLabel);
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103561

## What Is Being Fixed

Two Playwright tests in `objectField.spec.ts` — the draft picklist edit and the model builder field update — open a field's edit panel by clicking the field and type the new label straight away. The panel fills that input from its own read of the field, issued when the panel opens, so typing first is a race the test loses whenever the answer arrives late: the read lands after the typing and replaces or surrounds it with the old label. The assertions ask for the new name exactly, so once that happens the test cannot pass; in the model builder case the failing run's trace showed the save had already become a no-op before it fired.

## How It Is Being Fixed

Before typing, wait for the input to hold the field's current label — the panel's own signal that its read has finished — so the window the read could land in is closed by construction rather than waited out. Root cause is pinned in the commit message: both sites were born with the click and the fill adjacent (c74f26d3f455a, LPD-31855, for the picklist edit; af7280d63cd88, LPD-80345, for the model builder update) and carried unchanged into this spec by 09d7f7ff5244c (LPD-85191).

## PR Check

**pr-check: PASS** — tested on `3a6fabc13c7f8abcdf2e88549d52bba509530c5c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

Baseline, Per-Module Compile, and JavaScript Unit Tests matched by file pattern but are inapplicable to this playwright-spec-only diff (no exported API can change; modules/test/playwright is not a deployable module and its test script is Playwright, not Jest). The TypeScript check ran inside Source Format's frontend pass. The change additionally passed a fork `ci:test:object` run with 61 out of 61 jobs.

<!-- pr-check {"result": "success", "sha": "3a6fabc13c7f8abcdf2e88549d52bba509530c5c"} -->
