### PR TITLE
LPD-103568 Answer the object entry save after its workflow reaches a task

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -7008,6 +7008,26 @@ public class ObjectEntryLocalServiceImpl
 			ServiceContext serviceContext)
 		throws PortalException {
 
+		// The walk to the workflow's first task otherwise runs on another
+		// thread after this request is answered, so the task the caller looks
+		// for right after saving does not exist yet. Waiting for the walk
+		// makes the answer cover the task it creates.
+
+		Map<String, Serializable> workflowContext =
+			(Map<String, Serializable>)serviceContext.getAttribute(
+				"workflowContext");
+
+		if (workflowContext == null) {
+			workflowContext = new HashMap<>();
+		}
+
+		workflowContext.put(
+			WorkflowConstants.CONTEXT_WAIT_FOR_COMPLETION,
+			Boolean.TRUE.toString());
+
+		serviceContext.setAttribute(
+			"workflowContext", (Serializable)workflowContext);
+
 		WorkflowHandlerRegistryUtil.startWorkflowInstance(
 			objectEntry.getCompanyId(), objectEntry.getNonzeroGroupId(), userId,
 			className, objectEntry.getObjectEntryId(), objectEntry,

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryStartWorkflowInstanceWaitTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryStartWorkflowInstanceWaitTest.java
@@ -1,0 +1,158 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.service.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.field.util.ObjectFieldUtil;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.model.WorkflowInstanceLink;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalService;
+import com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.SystemProperties;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.kernel.workflow.WorkflowTask;
+import com.liferay.portal.kernel.workflow.WorkflowTaskManager;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.io.Serializable;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Shuyang Zhou
+ */
+@RunWith(Arquillian.class)
+public class ObjectEntryStartWorkflowInstanceWaitTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Test
+	public void testAddObjectEntryAnswersAfterItsWorkflowReachesATask()
+		throws Exception {
+
+		_objectDefinition = ObjectDefinitionTestUtil.publishObjectDefinition(
+			Collections.singletonList(
+				ObjectFieldUtil.createObjectField(
+					ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+					ObjectFieldConstants.DB_TYPE_STRING,
+					RandomTestUtil.randomString(), "textObjectFieldName")),
+			ObjectDefinitionConstants.SCOPE_COMPANY);
+
+		_workflowDefinitionLinkLocalService.updateWorkflowDefinitionLink(
+			TestPropsValues.getUserId(), TestPropsValues.getCompanyId(), 0,
+			_objectDefinition.getClassName(), 0, 0, "Single Approver", 1);
+
+		// The signaler walks the workflow graph inline in test mode, which
+		// would hide the wait this test guards. Clear the mode so the walk
+		// takes the production path, where only the wait the save asks for
+		// through the workflow context keeps the first task's creation inside
+		// the save.
+
+		String liferayMode = SystemProperties.get("liferay.mode");
+
+		SystemProperties.set("liferay.mode", StringPool.BLANK);
+
+		try {
+			ServiceContext serviceContext =
+				ServiceContextTestUtil.getServiceContext();
+
+			serviceContext.setWorkflowAction(WorkflowConstants.ACTION_PUBLISH);
+
+			ObjectEntry objectEntry = _objectEntryLocalService.addObjectEntry(
+				0, TestPropsValues.getUserId(),
+				_objectDefinition.getObjectDefinitionId(),
+				ObjectEntryFolderConstants.
+					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+				null,
+				HashMapBuilder.<String, Serializable>put(
+					"textObjectFieldName", RandomTestUtil.randomString()
+				).build(),
+				serviceContext);
+
+			Assert.assertEquals(
+				WorkflowConstants.STATUS_PENDING, objectEntry.getStatus());
+
+			WorkflowInstanceLink workflowInstanceLink =
+				_workflowInstanceLinkLocalService.fetchWorkflowInstanceLink(
+					TestPropsValues.getCompanyId(),
+					objectEntry.getNonzeroGroupId(),
+					_objectDefinition.getClassName(),
+					objectEntry.getObjectEntryId());
+
+			Assert.assertNotNull(workflowInstanceLink);
+
+			List<WorkflowTask> workflowTasks =
+				_workflowTaskManager.getWorkflowTasksByUserRoles(
+					TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+					false, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+
+			boolean found = false;
+
+			for (WorkflowTask workflowTask : workflowTasks) {
+				if (workflowTask.getWorkflowInstanceId() ==
+						workflowInstanceLink.getWorkflowInstanceId()) {
+
+					found = true;
+
+					break;
+				}
+			}
+
+			Assert.assertTrue(workflowTasks.toString(), found);
+		}
+		finally {
+			SystemProperties.set(
+				"liferay.mode", GetterUtil.getString(liferayMode));
+		}
+	}
+
+	@DeleteAfterTestRun
+	private ObjectDefinition _objectDefinition;
+
+	@Inject
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Inject
+	private WorkflowDefinitionLinkLocalService
+		_workflowDefinitionLinkLocalService;
+
+	@Inject
+	private WorkflowInstanceLinkLocalService _workflowInstanceLinkLocalService;
+
+	@Inject
+	private WorkflowTaskManager _workflowTaskManager;
+
+}

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/IndexWriterHelperImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/IndexWriterHelperImpl.java
@@ -325,6 +325,11 @@ public class IndexWriterHelperImpl implements IndexWriterHelper {
 	 */
 	@Deprecated
 	@Override
+	public boolean isIndexCommitImmediately() {
+		return _commitImmediately;
+	}
+
+	@Override
 	public boolean isIndexReadOnly() {
 		return _indexStatusManager.isIndexReadOnly();
 	}

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/petra/executor/WorkflowMetricsPortalExecutor.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/petra/executor/WorkflowMetricsPortalExecutor.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.NamedThreadFactory;
 import com.liferay.portal.kernel.util.PortalClassLoaderUtil;
 import com.liferay.portal.kernel.util.PortalRunMode;
+import com.liferay.portal.kernel.workflow.WorkflowWaitForCompletionThreadLocal;
 
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -38,7 +39,9 @@ public class WorkflowMetricsPortalExecutor {
 	public <T extends Throwable> NoticeableFuture<?> execute(
 		UnsafeRunnable<T> unsafeRunnable) {
 
-		if (PortalRunMode.isTestMode()) {
+		if (PortalRunMode.isTestMode() ||
+			WorkflowWaitForCompletionThreadLocal.isWaitForCompletion()) {
+
 			try {
 				unsafeRunnable.run();
 			}

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/BaseWorkflowMetricsIndexer.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/BaseWorkflowMetricsIndexer.java
@@ -8,10 +8,10 @@ package com.liferay.portal.workflow.metrics.internal.search.index;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.IndexWriterHelperUtil;
 import com.liferay.portal.kernel.util.DateUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.kernel.util.PortalRunMode;
 import com.liferay.portal.search.capabilities.SearchCapabilities;
 import com.liferay.portal.search.document.Document;
 import com.liferay.portal.search.document.DocumentBuilder;
@@ -63,9 +63,8 @@ public abstract class BaseWorkflowMetricsIndexer {
 		if (ListUtil.isNotEmpty(
 				bulkDocumentRequest.getBulkableDocumentRequests())) {
 
-			if (PortalRunMode.isTestMode()) {
-				bulkDocumentRequest.setRefresh(true);
-			}
+			bulkDocumentRequest.setRefresh(
+				IndexWriterHelperUtil.isIndexCommitImmediately());
 
 			searchEngineAdapter.execute(bulkDocumentRequest);
 		}
@@ -93,9 +92,8 @@ public abstract class BaseWorkflowMetricsIndexer {
 		IndexDocumentRequest indexDocumentRequest = new IndexDocumentRequest(
 			getIndexName(document.getLong("companyId")), document);
 
-		if (PortalRunMode.isTestMode()) {
-			indexDocumentRequest.setRefresh(true);
-		}
+		indexDocumentRequest.setRefresh(
+			IndexWriterHelperUtil.isIndexCommitImmediately());
 
 		searchEngineAdapter.execute(indexDocumentRequest);
 	}
@@ -190,9 +188,8 @@ public abstract class BaseWorkflowMetricsIndexer {
 		if (ListUtil.isNotEmpty(
 				bulkDocumentRequest.getBulkableDocumentRequests())) {
 
-			if (PortalRunMode.isTestMode()) {
-				bulkDocumentRequest.setRefresh(true);
-			}
+			bulkDocumentRequest.setRefresh(
+				IndexWriterHelperUtil.isIndexCommitImmediately());
 
 			searchEngineAdapter.execute(bulkDocumentRequest);
 		}
@@ -216,9 +213,8 @@ public abstract class BaseWorkflowMetricsIndexer {
 			getIndexName(document.getLong("companyId")),
 			document.getString("uid"), document);
 
-		if (PortalRunMode.isTestMode()) {
-			updateDocumentRequest.setRefresh(true);
-		}
+		updateDocumentRequest.setRefresh(
+			IndexWriterHelperUtil.isIndexCommitImmediately());
 
 		updateDocumentRequest.setUpsert(true);
 

--- a/portal-impl/src/com/liferay/portal/service/impl/WorkflowInstanceLinkLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/WorkflowInstanceLinkLocalServiceImpl.java
@@ -5,6 +5,7 @@
 
 package com.liferay.portal.service.impl;
 
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.bean.BeanReference;
@@ -30,6 +31,7 @@ import com.liferay.portal.kernel.workflow.WorkflowInstance;
 import com.liferay.portal.kernel.workflow.WorkflowInstanceManagerUtil;
 import com.liferay.portal.kernel.workflow.WorkflowNode;
 import com.liferay.portal.kernel.workflow.WorkflowThreadLocal;
+import com.liferay.portal.kernel.workflow.WorkflowWaitForCompletionThreadLocal;
 import com.liferay.portal.service.base.WorkflowInstanceLinkLocalServiceBaseImpl;
 
 import java.io.Serializable;
@@ -314,12 +316,19 @@ public class WorkflowInstanceLinkLocalServiceImpl
 		workflowContext.put(
 			WorkflowConstants.CONTEXT_GROUP_ID, String.valueOf(groupId));
 
-		WorkflowInstance workflowInstance =
-			WorkflowInstanceManagerUtil.startWorkflowInstance(
-				companyId, groupId, userId,
-				workflowDefinitionLink.getWorkflowDefinitionName(),
-				workflowDefinitionLink.getWorkflowDefinitionVersion(), null,
-				workflowContext, waitForCompletion);
+		WorkflowInstance workflowInstance = null;
+
+		try (SafeCloseable safeCloseable =
+				WorkflowWaitForCompletionThreadLocal.
+					setWaitForCompletionWithSafeCloseable(waitForCompletion)) {
+
+			workflowInstance =
+				WorkflowInstanceManagerUtil.startWorkflowInstance(
+					companyId, groupId, userId,
+					workflowDefinitionLink.getWorkflowDefinitionName(),
+					workflowDefinitionLink.getWorkflowDefinitionVersion(), null,
+					workflowContext, waitForCompletion);
+		}
 
 		addWorkflowInstanceLink(
 			userId, companyId, groupId, className, classPK,

--- a/portal-kernel/src/com/liferay/portal/kernel/search/IndexWriterHelper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/IndexWriterHelper.java
@@ -71,6 +71,8 @@ public interface IndexWriterHelper {
 	 *             com.liferay.portal.search.index.IndexStatusManager#isIndexReadOnly}
 	 */
 	@Deprecated
+	public boolean isIndexCommitImmediately();
+
 	public boolean isIndexReadOnly();
 
 	/**

--- a/portal-kernel/src/com/liferay/portal/kernel/search/IndexWriterHelperUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/IndexWriterHelperUtil.java
@@ -137,6 +137,12 @@ public class IndexWriterHelperUtil {
 	 *             com.liferay.portal.search.index.IndexStatusManager#isIndexReadOnly}
 	 */
 	@Deprecated
+	public static boolean isIndexCommitImmediately() {
+		IndexWriterHelper indexWriterHelper = _getIndexWriterHelper();
+
+		return indexWriterHelper.isIndexCommitImmediately();
+	}
+
 	public static boolean isIndexReadOnly() {
 		IndexWriterHelper indexWriterHelper = _getIndexWriterHelper();
 

--- a/portal-kernel/src/com/liferay/portal/kernel/search/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/packageinfo
@@ -1,1 +1,1 @@
-version 24.2.0
+version 24.3.0

--- a/portal-kernel/src/com/liferay/portal/kernel/workflow/BaseWorkflowHandler.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/workflow/BaseWorkflowHandler.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalServiceUtil;
 import com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalServiceUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -298,7 +299,10 @@ public abstract class BaseWorkflowHandler<T> implements WorkflowHandler<T> {
 
 		WorkflowInstanceLinkLocalServiceUtil.startWorkflowInstance(
 			companyId, groupId, userId, getClassName(), classPK,
-			workflowContext);
+			workflowContext,
+			GetterUtil.getBoolean(
+				workflowContext.get(
+					WorkflowConstants.CONTEXT_WAIT_FOR_COMPLETION)));
 	}
 
 	private String _getBackURL(

--- a/portal-kernel/src/com/liferay/portal/kernel/workflow/WorkflowConstants.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/workflow/WorkflowConstants.java
@@ -52,6 +52,9 @@ public class WorkflowConstants {
 
 	public static final String CONTEXT_USER_URL = "userURL";
 
+	public static final String CONTEXT_WAIT_FOR_COMPLETION =
+		"waitForCompletion";
+
 	public static final long DEFAULT_GROUP_ID = 0;
 
 	public static final String LABEL_ANY = "any";

--- a/portal-kernel/src/com/liferay/portal/kernel/workflow/WorkflowWaitForCompletionThreadLocal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/workflow/WorkflowWaitForCompletionThreadLocal.java
@@ -1,0 +1,31 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.workflow;
+
+import com.liferay.petra.lang.CentralizedThreadLocal;
+import com.liferay.petra.lang.SafeCloseable;
+
+/**
+ * @author Shuyang Zhou
+ */
+public class WorkflowWaitForCompletionThreadLocal {
+
+	public static boolean isWaitForCompletion() {
+		return _waitForCompletion.get();
+	}
+
+	public static SafeCloseable setWaitForCompletionWithSafeCloseable(
+		boolean waitForCompletion) {
+
+		return _waitForCompletion.setWithSafeCloseable(waitForCompletion);
+	}
+
+	private static final CentralizedThreadLocal<Boolean> _waitForCompletion =
+		new CentralizedThreadLocal<>(
+			WorkflowWaitForCompletionThreadLocal.class + "._waitForCompletion",
+			() -> Boolean.FALSE);
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/workflow/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/workflow/packageinfo
@@ -1,1 +1,1 @@
-version 27.4.0
+version 27.5.0


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103568

## What Is Being Fixed

Two single-thread executors defer work the object entry save causes past the save's answer, so anything that acts on the answer races the runtime. DefaultKaleoSignaler walks the workflow graph — the walk that creates the task instance token — on a one-thread pool after the save returns, so a tasks list fetched right after the save can carry no task however long a UI waits on it. WorkflowMetricsPortalExecutor defers the workflow metrics index writes the same way, so the metrics pages render zero instances at click time. Both executors run inline only under liferay.mode=test, which the Playwright CI does not set, so the flakes are structural there and invisible under Poshi.

## How It Is Being Fixed

The save's answer covers what the save causes, opt-in through the existing waitForCompletion plumbing. WorkflowConstants.CONTEXT_WAIT_FOR_COMPLETION travels the workflow context from the object entry save through BaseWorkflowHandler into WorkflowInstanceLinkLocalServiceImpl, which brackets the workflow start with WorkflowWaitForCompletionThreadLocal (a CentralizedThreadLocal, so nesting restores correctly) — the Kaleo walk runs inline and WorkflowMetricsPortalExecutor executes inline for that save. Separately, the metrics indexer's refresh gates stop reading PortalRunMode.isTestMode and instead pass IndexWriterHelperUtil.isIndexCommitImmediately() through, exposed on the IndexWriterHelper interface, so metrics writes follow the portal's own commit-immediately configuration. A new integration guard test publishes a definition linked to Single Approver with liferay.mode cleared and asserts the save answers with the workflow instance link and its task present.

## PR Check

**pr-check: PASS** — tested on `ca4eb618227bd37cd07ecaf5060b4646eccd4328`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Transaction Usage | PASS |
| Full Portal Build | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

Baseline ran genuinely (`--rerun`, `1 executed`) on portal-kernel and on each changed module (object-service, portal-search, portal-workflow-metrics-service); the kernel packageinfo bumps ride the change. Cross-Module Compile is covered by the Full Portal Build (`ant all`), which compiles every `.lfrbuild-portal` module against the branch kernel. Java Unit Tests ran the two counterparts of changed classes (ObjectEntryLocalServiceImplTest, IndexWriterHelperImplTest). The change passed a fork `ci:test:object` run 62 out of 62; the final-tip gate run's two unique failures are both external and pre-attributed — the known CanPublish flake (fix in review) and the deterministic LPD-102795 master test breakage (fix in review as LPD-103534).

<!-- pr-check {"result": "success", "sha": "ca4eb618227bd37cd07ecaf5060b4646eccd4328"} -->
