### PR TITLE
LPD-103246 Defer the duplicate topics date pattern to call time [STABLE FIX]

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/dashboard/governance/components/ReviewDuplicateTopicsModal.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/dashboard/governance/components/ReviewDuplicateTopicsModal.tsx
@@ -41,14 +41,16 @@ const SORTS: TSort[] = [
 const DUPLICATE_TOPICS_NESTED_FIELDS =
 	'embedded,file.metadata,systemProperties.objectDefinitionBrief';
 
-const DATE_PATTERN = {
-	day: 'numeric',
-	hour: 'numeric',
-	minute: 'numeric',
-	month: 'numeric',
-	timeZone: Liferay.ThemeDisplay.getTimeZone(),
-	year: 'numeric',
-} as const;
+function getDatePattern() {
+	return {
+		day: 'numeric',
+		hour: 'numeric',
+		minute: 'numeric',
+		month: 'numeric',
+		timeZone: Liferay.ThemeDisplay.getTimeZone(),
+		year: 'numeric',
+	} as const;
+}
 
 function AssetItem({
 	additionalProps,
@@ -84,7 +86,7 @@ function AssetItem({
 
 				<ClayList.ItemText>
 					{`${Liferay.Language.get('last-modified')} ${dateFormat(
-						DATE_PATTERN,
+						getDatePattern(),
 						asset.dateModified
 					)}`}
 				</ClayList.ItemText>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103246

## What Is Being Fixed

`DATE_PATTERN` in `ReviewDuplicateTopicsModal.tsx` calls `Liferay.ThemeDisplay.getTimeZone()` at module scope, so importing the file is enough to run it. The modal is reachable from the package entry point (`index.ts` exports `Dashboards`, which reaches `GovernanceDashboard`, `DuplicationAndSimilarity`, and this modal), so every consumer of `@liferay/site-cms-site-initializer` evaluates it on import.

`site-cmp-site-initializer` is such a consumer, through `utils/api.ts`, and its Jest setup stubs `ThemeDisplay` without `getTimeZone`. Its `Column.spec.tsx` suite died during the import, before a test ran:

```
FAIL src/main/resources/META-INF/resources/tests/js/Column.spec.tsx
  ● Test suite failed to run
    TypeError: Liferay.ThemeDisplay.getTimeZone is not a function
```

## How It Is Being Fixed

Reading the time zone inside a function defers it to render time, the way `getDateOptions()` already does in `ReviewDateRenderer`. Every other `getTimeZone` call site in the module is already inside a function or component, so this was the only one evaluated at import.

## Why Are There No Tests?

The fix is covered by the suite it unbroke, `site-cmp-site-initializer` `Column.spec.tsx` (7/7), and by the 32 `site-cms-site-initializer` dashboard suites (146 tests). The regression surfaced in existing coverage and is verified by it, so a new test would duplicate it.

