### PR TITLE
LPD-103619 Sign the hierarchy tests in through the API

### DIFF
--- a/modules/test/playwright/tests/object-web/hierarchy/objectDefinitionHierarchy.spec.ts
+++ b/modules/test/playwright/tests/object-web/hierarchy/objectDefinitionHierarchy.spec.ts
@@ -16,7 +16,8 @@ import {loginTest} from '../../../fixtures/loginTest';
 import {objectPagesTest} from '../../../fixtures/objectPagesTest';
 import {getRandomInt} from '../../../utils/getRandomInt';
 import getRandomString from '../../../utils/getRandomString';
-import performLogin, {
+import {
+	performLoginViaApi,
 	performLogout,
 	userData,
 } from '../../../utils/performLogin';
@@ -573,7 +574,7 @@ test.describe('Manage root model elements through View Object Entries', () => {
 			};
 
 			await performLogout(page);
-			await performLogin(page, user1.alternateName);
+			await performLoginViaApi({page, screenName: user1.alternateName});
 
 			await viewObjectEntriesPage.goto(objectDefinition1.className);
 
@@ -597,7 +598,7 @@ test.describe('Manage root model elements through View Object Entries', () => {
 			};
 
 			await performLogout(page);
-			await performLogin(page, user2.alternateName);
+			await performLoginViaApi({page, screenName: user2.alternateName});
 
 			await viewObjectEntriesPage.goto(objectDefinition1.className);
 
@@ -614,7 +615,7 @@ test.describe('Manage root model elements through View Object Entries', () => {
 		}
 		finally {
 			await performLogout(page);
-			await performLogin(page, 'test');
+			await performLoginViaApi({page, screenName: 'test'});
 
 			const objectRelationshipAPIClient =
 				await apiHelpers.buildRestClient(ObjectRelationshipAPI);

--- a/modules/test/playwright/utils/performLogin.ts
+++ b/modules/test/playwright/utils/performLogin.ts
@@ -73,6 +73,8 @@ async function performLogin(
 
 	await emailAddressInput.fill(`${screenName}${domain}`);
 
+	await expect(emailAddressInput).toHaveValue(`${screenName}${domain}`);
+
 	await page.getByLabel('Password').fill(password);
 	await page.getByLabel('Remember Me').setChecked(rememberMe);
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103619

## What Is Being Fixed

The hierarchy suite's account-restricted test signs three users in through the sign-in form with remember me on. Remember me deliberately keeps the previous user's address across logout, so each prompt arrives prefilled with whoever signed in last. Playwright's fill types its value out of band with nothing reading it back, and when the form's validator takes focus inside that window the typed address is swallowed while the prefill stays. The users share a credential, so the submit signs the previous user back in cleanly and the assertion for the new user's name burns its whole budget on a session that can never show it.

## How It Is Being Fixed

The hierarchy tests sign in through the API, as every other user-switching object-web spec already does: the credential travels in the request itself, so there is no field, no prefill and no focus to race. As defense in depth for the remaining form logins, performLogin reads the email field back after filling it, so any future swallow fails immediately, named, at the field. Root cause is pinned in the commit message: the account-restricted test was born with the three form logins in 3f282725b235d (LPD-40194) and carried unchanged into this spec by d60fad3fb6339 (LPD-85191).

## PR Check

**pr-check: PASS** — tested on `7e79cc71709c01a07d0573ccb5dc1abddf45d574`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

Baseline, Per-Module Compile, and JavaScript Unit Tests matched by file pattern but are inapplicable to this playwright-only diff (no exported API can change; modules/test/playwright is not a deployable module and its test script is Playwright, not Jest). The TypeScript check ran inside Source Format's frontend pass. The change passed fork `ci:test:object` runs: 59 out of 61 (sole unique failure attributed to covered noise) and, after the comment-policy rework, 58 out of 62 where the sole unique failure is the deterministic LPD-102795 master test breakage (fix in review as LPD-103534) that fails identically on pure-master baseline runs.

<!-- pr-check {"result": "success", "sha": "7e79cc71709c01a07d0573ccb5dc1abddf45d574"} -->
