### PR TITLE
LPD-103004 Wait out the reload the publish schedules before navigating

### DIFF
--- a/modules/apps/object/object-test/src/testFunctional/tests/CreateObject.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/CreateObject.testcase
@@ -178,6 +178,10 @@ definition {
 
 		PortletEntry.publish();
 
+		AssertElementNotPresent(
+			key_text = "Publish",
+			locator1 = "Button#ANY");
+
 		var portalURL = JSONCompany.getPortalURL();
 		var userPassword = PropsUtil.get("default.admin.password");
 
@@ -200,10 +204,6 @@ definition {
 			expected = "approved");
 
 		ObjectAdmin.openObjectAdmin();
-
-		while ((IsElementNotPresent(key_label = "Custom Object 73", locator1 = "ObjectAdmin#OBJECT_STATUS")) && (maxIterations = "10")) {
-			Refresh();
-		}
 
 		AssertTextEquals(
 			key_label = "Custom Object 73",


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103004

## What Is Being Fixed

Follow-up to this ticket's first change (#180456). Publishing the object definition schedules a full reload of the edit page one second after the success message, and CanPublishObjectWithPublishPermission navigated to the object list inside that window: the deferred reload then yanks the browser back to the edit page, so the list and its status cell are never on screen and the assertion dies on the wrong page. The interim refresh loop from the first change re-rendered the same wrong page ten times, because after the yank-back a refresh re-asks the edit page.

## How It Is Being Fixed

After the publish, wait for the Publish button to be gone before leaving the page. Poshi's AssertElementNotPresent runs the full waitForElementNotPresent poll before asserting, and the published edit page renders no Publish button, so the button going away is the deferred reload landing — the page's own signal. The navigation that follows then has nothing left to race. The interim refresh loop is removed; the API status assertion stays, since it is what separates a lost publish from a lost render. Root cause is pinned in the commit message: 85784fcb2d13a (LPS-162430) deferred the reload the publish success handler used to perform synchronously to a one second timeout, hidden inside a commit titled as a pure rename.

## PR Check

**pr-check: PASS** — tested on `8f266fb9663d9dd50343ad52f63af590ba6f3c12`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Poshi Syntax | PASS |

Baseline matched by file pattern but is inapplicable to this Poshi-testcase-only diff (no exported API can change). The change passed fork `ci:test:object` runs: 61 out of 61, and 58 out of 62 after the rework where the sole unique failure is the deterministic LPD-102795 master test breakage (fix in review as LPD-103534) — CanPublishObjectWithPublishPermission itself passed with this fix aboard.

<!-- pr-check {"result": "success", "sha": "8f266fb9663d9dd50343ad52f63af590ba6f3c12"} -->
