### PR TITLE
LPD-103246 Stable fix PR for the ThemeDisplay.getTimeZone Jest mock

### DIFF
--- a/modules/frontend-sdk/node-scripts/package.json
+++ b/modules/frontend-sdk/node-scripts/package.json
@@ -4,7 +4,7 @@
 		"node-scripts": "./bin.js"
 	},
 	"com.liferay": {
-		"sha256": "1d4b284b69d918b578997b22a3eefd61e72c8220c14a3a7db68aeadeca8beff8"
+		"sha256": "55321f1c645abee6ca2dc7ad80ea435b84ace39860770103f0a0f3dd9d5c21fc"
 	},
 	"dependencies": {
 		"@babel/preset-env": "7.24.7",

--- a/modules/frontend-sdk/node-scripts/util/jest/mocks/Liferay.js
+++ b/modules/frontend-sdk/node-scripts/util/jest/mocks/Liferay.js
@@ -300,6 +300,8 @@ const ThemeDisplay = {
 
 	getScopeGroupId: jest.fn(() => '20126'),
 
+	getTimeZone: jest.fn(() => 'UTC'),
+
 	getUserId: jest.fn(() => '20164'),
 
 	isSignedIn: jest.fn(() => true),


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103246

## What Is Being Fixed

LPD-103246 added a module-scope call to `Liferay.ThemeDisplay.getTimeZone()` in `ReviewDuplicateTopicsModal.tsx`. The shared Jest `ThemeDisplay` mock does not implement that method, so every suite that transitively imports the component throws at import time. Stable build 1586 failed with 15 such suites across `site-cmp-site-initializer` and `site-dsr-site-initializer`.

## How It Is Being Fixed

`getTimeZone` is added to the shared mock returning `'UTC'`, matching the local stub `site-cms-site-initializer` already defines (which is why its own suites pass today). Fixing the shared mock rather than each consumer keeps it aligned with `liferay.d.ts`, which declares the method. The formatter updated `com.liferay.sha256` as a required companion change.

## Why Are There No Tests?

The change is itself test infrastructure. Its effect is that 15 previously dead suites now execute: 253 suites and 1441 tests pass across the three affected modules, 69 more tests than ran before.

## PR Check

**pr-check: PASS** — tested on `ada7c9ae91d348e6d3e9a27bbba9f45ee22269a9`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

Per-Module Compile and JavaScript Unit Tests matched on the owning module, `modules/frontend-sdk/node-scripts`, which has no `build.gradle` and no `test` script, so neither had a target to run. The three consumer module suites were run in their place.

<!-- pr-check {"result": "success", "sha": "ada7c9ae91d348e6d3e9a27bbba9f45ee22269a9"} -->
