### PR TITLE
LPD-103630 Let the side panel save bracket the reload it schedules

### DIFF
--- a/modules/apps/object/object-test/src/testFunctional/macros/ObjectAdmin.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/ObjectAdmin.macro
@@ -1586,11 +1586,15 @@ definition {
 
 	@summary = "Default summary"
 	macro saveSidePanel() {
+		ExecuteJavaScript(value1 = "var markerElement = window.top.document.createElement('div'); markerElement.className = 'poshi-outgoing-document-marker'; window.top.document.body.appendChild(markerElement);");
+
 		Click(
 			key_text = "Save",
 			locator1 = "Button#ANY");
 
 		SelectFrame(value1 = "relative=top");
+
+		WaitForElementNotPresent(locator1 = "//div[@class='poshi-outgoing-document-marker']");
 
 		WaitForPageLoad();
 

--- a/modules/apps/object/object-test/src/testFunctional/macros/ObjectAdmin.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/ObjectAdmin.macro
@@ -1341,8 +1341,6 @@ definition {
 		if (isSet(click)) {
 			if ((${click} == "save") && (${notRefreshAttribute} == "true")) {
 				ObjectAdmin.saveSidePanel();
-
-				WaitForElementNotPresent(locator1 = "ObjectAdmin#SIDE_PANEL");
 			}
 			else if (${click} == "cancel") {
 				Button.clickCancel();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103630

## What Is Being Fixed

Saving the object side panel raises the success toast on the top document and then schedules a reload of that same document about three hundred milliseconds later. The `ObjectAdmin.saveSidePanel` Poshi macro drove a body-gated script call straight into that window: the script's second document lookup runs once, unretried, and when the reload swaps the document between the two lookups it throws element-not-present at the body itself. A second wait in the same flow could never match anything — it names the panel's in-iframe content container from the top frame, so it passes instantly without checking a thing.

## How It Is Being Fixed

Before clicking save, a marker node is planted on the top document from inside the panel iframe. The marker can only leave the DOM with the document it was planted on, so waiting for it to be gone after the click reads the reload landing from a signal armed before the click — it cannot be missed however late the waits run (Poshi waits are stateless 500ms polls, so a post-click poll alone cannot fully close the window). The page and event log waits that follow then run on the settled document. The dead top-frame wait is dropped. Root causes are pinned in the commit messages: the reload window was left unowned when saveSidePanel was introduced (LPD-101459, LPD-101466), and LPD-102457 fixed three sibling sites without reaching this macro; the dead wait was born functional (LPS-192841) and silenced when LPD-102457 moved this call site to the top frame.

## PR Check

**pr-check: PASS** — tested on `d01c690726595ef84b329d52f0f453c76c8f6842`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Poshi Syntax | PASS |

Baseline matched by file pattern but is inapplicable to this Poshi-macro-only diff (no exported API can change). Local Poshi run of ObjectFields#AllFieldsFromRelatedObjectAreDisplayedWhenFilteringLongIntegerFields (three saveSidePanel traversals): 116 of 116 steps passed with zero portal log errors. Fork `ci:test:object`: 61 out of 61 on the earlier polling shape, 58 out of 62 on the final marker shape with both failures being known master-wide externals (fixes in review).

<!-- pr-check {"result": "success", "sha": "d01c690726595ef84b329d52f0f453c76c8f6842"} -->
