### PR TITLE
LPD-103363 Let CMS admins publish structures with repeatable groups

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/model/listener/ObjectFolderModelListener.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/model/listener/ObjectFolderModelListener.java
@@ -23,9 +23,8 @@ import com.liferay.portal.kernel.search.IndexerRegistryUtil;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.util.PortalInstances;
-
-import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -115,13 +114,9 @@ public class ObjectFolderModelListener extends BaseModelListener<ObjectFolder> {
 	}
 
 	private void _onAfterCreate(ObjectFolder objectFolder) throws Exception {
-		if (!Objects.equals(
-				objectFolder.getExternalReferenceCode(),
-				ObjectFolderConstants.
-					EXTERNAL_REFERENCE_CODE_CONTENT_STRUCTURES) &&
-			!Objects.equals(
-				objectFolder.getExternalReferenceCode(),
-				ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_FILE_TYPES)) {
+		if (!ArrayUtil.contains(
+				_EXTERNAL_REFERENCE_CODES,
+				objectFolder.getExternalReferenceCode())) {
 
 			return;
 		}
@@ -139,6 +134,13 @@ public class ObjectFolderModelListener extends BaseModelListener<ObjectFolder> {
 					ObjectFolder.class.getName()),
 				ResourceAction::getActionId, String.class));
 	}
+
+	private static final String[] _EXTERNAL_REFERENCE_CODES = {
+		ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENT_STRUCTURES,
+		ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_FILE_TYPES,
+		ObjectFolderConstants.
+			EXTERNAL_REFERENCE_CODE_STRUCTURE_REPEATABLE_GROUPS
+	};
 
 	@Reference
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/model/listener/test/ObjectFolderModelListenerTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/model/listener/test/ObjectFolderModelListenerTest.java
@@ -1,0 +1,108 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.model.listener.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.object.constants.ObjectActionKeys;
+import com.liferay.object.constants.ObjectFolderConstants;
+import com.liferay.object.model.ObjectFolder;
+import com.liferay.object.service.ObjectFolderLocalService;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.CompanyTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.util.PortalInstances;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Víctor Galán
+ */
+@RunWith(Arquillian.class)
+public class ObjectFolderModelListenerTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testOnAfterCreate() throws Exception {
+		Company company = CompanyTestUtil.addCompany();
+
+		PortalInstances.initCompany(company);
+
+		Role role = _roleLocalService.getRole(
+			company.getCompanyId(), RoleConstants.CMS_ADMINISTRATOR);
+
+		_assertResourcePermissions(
+			company,
+			ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENT_STRUCTURES,
+			role);
+		_assertResourcePermissions(
+			company, ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_FILE_TYPES,
+			role);
+		_assertResourcePermissions(
+			company,
+			ObjectFolderConstants.
+				EXTERNAL_REFERENCE_CODE_STRUCTURE_REPEATABLE_GROUPS,
+			role);
+	}
+
+	private void _assertResourcePermission(
+			String actionId, Company company, ObjectFolder objectFolder,
+			Role role)
+		throws Exception {
+
+		Assert.assertTrue(
+			_resourcePermissionLocalService.hasResourcePermission(
+				company.getCompanyId(), ObjectFolder.class.getName(),
+				ResourceConstants.SCOPE_INDIVIDUAL,
+				String.valueOf(objectFolder.getObjectFolderId()),
+				role.getRoleId(), actionId));
+	}
+
+	private void _assertResourcePermissions(
+			Company company, String externalReferenceCode, Role role)
+		throws Exception {
+
+		ObjectFolder objectFolder =
+			_objectFolderLocalService.getObjectFolderByExternalReferenceCode(
+				externalReferenceCode, company.getCompanyId());
+
+		_assertResourcePermission(
+			ObjectActionKeys.ADD_OBJECT_DEFINITION, company, objectFolder,
+			role);
+		_assertResourcePermission(
+			ActionKeys.DELETE, company, objectFolder, role);
+		_assertResourcePermission(
+			ActionKeys.PERMISSIONS, company, objectFolder, role);
+		_assertResourcePermission(
+			ActionKeys.UPDATE, company, objectFolder, role);
+		_assertResourcePermission(ActionKeys.VIEW, company, objectFolder, role);
+	}
+
+	@Inject
+	private ObjectFolderLocalService _objectFolderLocalService;
+
+	@Inject
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Inject
+	private RoleLocalService _roleLocalService;
+
+}

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/upgrade/v3_0_1/test/CMSObjectFolderPermissionsUpgradeProcessTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/upgrade/v3_0_1/test/CMSObjectFolderPermissionsUpgradeProcessTest.java
@@ -1,0 +1,112 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.upgrade.v3_0_1.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.object.constants.ObjectActionKeys;
+import com.liferay.object.constants.ObjectFolderConstants;
+import com.liferay.object.model.ObjectFolder;
+import com.liferay.object.service.ObjectFolderLocalService;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
+import com.liferay.site.cms.site.initializer.util.RoleUtil;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Víctor Galán
+ */
+@RunWith(Arquillian.class)
+public class CMSObjectFolderPermissionsUpgradeProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_objectFolder =
+			_objectFolderLocalService.fetchObjectFolderByExternalReferenceCode(
+				ObjectFolderConstants.
+					EXTERNAL_REFERENCE_CODE_STRUCTURE_REPEATABLE_GROUPS,
+				TestPropsValues.getCompanyId());
+
+		_role = RoleUtil.getOrAddCMSAdministratorRole(
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId());
+	}
+
+	@Test
+	public void testUpgrade() throws Exception {
+		Assert.assertNotNull(_objectFolder);
+
+		_resourcePermissionLocalService.setResourcePermissions(
+			TestPropsValues.getCompanyId(), ObjectFolder.class.getName(),
+			ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(_objectFolder.getObjectFolderId()),
+			_role.getRoleId(), new String[0]);
+
+		for (String actionId : _ACTION_IDS) {
+			Assert.assertFalse(actionId, _hasResourcePermission(actionId));
+		}
+
+		UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
+			_upgradeStepRegistrator, _CLASS_NAME);
+
+		upgradeProcess.upgrade();
+
+		for (String actionId : _ACTION_IDS) {
+			Assert.assertTrue(actionId, _hasResourcePermission(actionId));
+		}
+	}
+
+	private boolean _hasResourcePermission(String actionId) throws Exception {
+		return _resourcePermissionLocalService.hasResourcePermission(
+			TestPropsValues.getCompanyId(), ObjectFolder.class.getName(),
+			ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(_objectFolder.getObjectFolderId()),
+			_role.getRoleId(), actionId);
+	}
+
+	private static final String[] _ACTION_IDS = {
+		ObjectActionKeys.ADD_OBJECT_DEFINITION, ActionKeys.DELETE,
+		ActionKeys.PERMISSIONS, ActionKeys.UPDATE, ActionKeys.VIEW
+	};
+
+	private static final String _CLASS_NAME =
+		"com.liferay.site.cms.site.initializer.internal.upgrade.v3_0_1." +
+			"CMSObjectFolderPermissionsUpgradeProcess";
+
+	private ObjectFolder _objectFolder;
+
+	@Inject
+	private ObjectFolderLocalService _objectFolderLocalService;
+
+	@Inject
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	private Role _role;
+
+	@Inject(
+		filter = "component.name=com.liferay.site.cms.site.initializer.internal.upgrade.registry.SiteCMSSiteInitializerUpgradeStepRegistrator"
+	)
+	private UpgradeStepRegistrator _upgradeStepRegistrator;
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/upgrade/registry/SiteCMSSiteInitializerUpgradeStepRegistrator.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/upgrade/registry/SiteCMSSiteInitializerUpgradeStepRegistrator.java
@@ -15,10 +15,14 @@ import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 import com.liferay.site.cms.site.initializer.internal.upgrade.v1_0_0.CMSDefaultPermissionsUpgradeProcess;
 import com.liferay.site.cms.site.initializer.internal.upgrade.v1_0_0.CMSObjectRelationshipEdgeUpgradeProcess;
 import com.liferay.site.cms.site.initializer.internal.upgrade.v2_0_0.CMSBulkActionTaskTaskResultUpgradeProcess;
+import com.liferay.site.cms.site.initializer.internal.upgrade.v3_0_1.CMSObjectFolderPermissionsUpgradeProcess;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -52,6 +56,13 @@ public class SiteCMSSiteInitializerUpgradeStepRegistrator
 			new CMSBulkActionTaskTaskResultUpgradeProcess(
 				_companyLocalService, _objectDefinitionLocalService,
 				_objectFieldLocalService));
+
+		registry.register(
+			"3.0.0", "3.0.1",
+			new CMSObjectFolderPermissionsUpgradeProcess(
+				_companyLocalService, _objectFolderLocalService,
+				_resourceActionLocalService, _resourcePermissionLocalService,
+				_roleLocalService));
 	}
 
 	@Reference
@@ -79,5 +90,14 @@ public class SiteCMSSiteInitializerUpgradeStepRegistrator
 
 	@Reference
 	private ObjectRelationshipLocalService _objectRelationshipLocalService;
+
+	@Reference
+	private ResourceActionLocalService _resourceActionLocalService;
+
+	@Reference
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Reference
+	private RoleLocalService _roleLocalService;
 
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/upgrade/v3_0_1/CMSObjectFolderPermissionsUpgradeProcess.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/upgrade/v3_0_1/CMSObjectFolderPermissionsUpgradeProcess.java
@@ -1,0 +1,82 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.upgrade.v3_0_1;
+
+import com.liferay.object.constants.ObjectFolderConstants;
+import com.liferay.object.model.ObjectFolder;
+import com.liferay.object.service.ObjectFolderLocalService;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+
+/**
+ * @author Víctor Galán
+ */
+public class CMSObjectFolderPermissionsUpgradeProcess extends UpgradeProcess {
+
+	public CMSObjectFolderPermissionsUpgradeProcess(
+		CompanyLocalService companyLocalService,
+		ObjectFolderLocalService objectFolderLocalService,
+		ResourceActionLocalService resourceActionLocalService,
+		ResourcePermissionLocalService resourcePermissionLocalService,
+		RoleLocalService roleLocalService) {
+
+		_companyLocalService = companyLocalService;
+		_objectFolderLocalService = objectFolderLocalService;
+		_resourceActionLocalService = resourceActionLocalService;
+		_resourcePermissionLocalService = resourcePermissionLocalService;
+		_roleLocalService = roleLocalService;
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		_companyLocalService.forEachCompanyId(this::_upgradeCompany);
+	}
+
+	private void _upgradeCompany(long companyId) throws PortalException {
+		Role role = _roleLocalService.fetchRole(
+			companyId, RoleConstants.CMS_ADMINISTRATOR);
+
+		if (role == null) {
+			return;
+		}
+
+		ObjectFolder objectFolder =
+			_objectFolderLocalService.fetchObjectFolderByExternalReferenceCode(
+				ObjectFolderConstants.
+					EXTERNAL_REFERENCE_CODE_STRUCTURE_REPEATABLE_GROUPS,
+				companyId);
+
+		if (objectFolder == null) {
+			return;
+		}
+
+		_resourcePermissionLocalService.setResourcePermissions(
+			companyId, ObjectFolder.class.getName(),
+			ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(objectFolder.getObjectFolderId()), role.getRoleId(),
+			TransformUtil.transformToArray(
+				_resourceActionLocalService.getResourceActions(
+					ObjectFolder.class.getName()),
+				ResourceAction::getActionId, String.class));
+	}
+
+	private final CompanyLocalService _companyLocalService;
+	private final ObjectFolderLocalService _objectFolderLocalService;
+	private final ResourceActionLocalService _resourceActionLocalService;
+	private final ResourcePermissionLocalService
+		_resourcePermissionLocalService;
+	private final RoleLocalService _roleLocalService;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103363

## What Is Being Fixed

A user whose only role is CMS Administrator could not publish a content structure containing a repeatable group. Publishing failed with a generic "unexpected error" and the structure was never created.

Publishing a repeatable group creates a hidden object definition in the `L_CMS_STRUCTURE_REPEATABLE_GROUPS` object folder, and adding an object definition checks `ADD_OBJECT_DEFINITION` on the target folder. `ObjectFolderModelListener` grants the CMS Administrator role on the CMS object folders when they are created, but its list covered only `L_CMS_CONTENT_STRUCTURES` and `L_CMS_FILE_TYPES`, so no permission row ever existed for the repeatable groups folder. The request that creates the group definition returned 403 and the publish aborted before the main structure was written. Structures without a repeatable group were unaffected, which is why the failure looked specific to repeatable fields.

## How It Is Being Fixed

The listener now matches the folder external reference code against a constant that also includes `L_CMS_STRUCTURE_REPEATABLE_GROUPS`, so a fresh installation grants the role on all three CMS folders.

Because the listener only runs when the folder is created, installations that already deployed the CMS site initializer keep the missing permission. `CMSObjectFolderPermissionsUpgradeProcess` backfills it per company, tolerating a missing role or folder so it is a no-op where the listener has not run yet. The two paths cover disjoint cases: a fresh install skips the upgrade step through `registerInitialization` and relies on the listener, while an existing install already has the folder and relies on the upgrade. Granting is idempotent, so both firing is harmless.

Coverage is one integration test per path. `ObjectFolderModelListenerTest` creates a company so the CMS batch creates the folders and the listener fires, then asserts the role holds every `ObjectFolder` action on all three. `CMSObjectFolderPermissionsUpgradeProcessTest` clears the permissions, runs the upgrade step, and asserts they are restored.

## PR Check

**pr-check: PASS** — tested on `6843533e35050e51457e0407d55dd22eee1ff02e`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "6843533e35050e51457e0407d55dd22eee1ff02e"} -->
