### PR TITLE
LPD-103632 Send the attachment download message where the download is granted

### DIFF
--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/action/trigger/test/ObjectActionAttachmentDownloadTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/action/trigger/test/ObjectActionAttachmentDownloadTest.java
@@ -1,0 +1,337 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.action.trigger.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.document.library.test.util.BaseWebServerTestCase;
+import com.liferay.object.action.executor.ObjectActionExecutor;
+import com.liferay.object.action.util.ObjectActionThreadLocal;
+import com.liferay.object.constants.ObjectActionTriggerConstants;
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.constants.ObjectFieldSettingConstants;
+import com.liferay.object.field.setting.builder.ObjectFieldSettingBuilder;
+import com.liferay.object.field.util.ObjectFieldUtil;
+import com.liferay.object.model.ObjectAction;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectField;
+import com.liferay.object.service.ObjectActionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.io.ByteArrayInputStream;
+import java.io.Serializable;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceRegistration;
+
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * @author Shuyang Zhou
+ */
+@RunWith(Arquillian.class)
+public class ObjectActionAttachmentDownloadTest extends BaseWebServerTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+
+		_executionCount = new AtomicInteger();
+
+		_objectField = ObjectFieldUtil.createObjectField(
+			ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT,
+			ObjectFieldConstants.DB_TYPE_LONG, true, false, null, "File",
+			"file",
+			Arrays.asList(
+				new ObjectFieldSettingBuilder(
+				).name(
+					ObjectFieldSettingConstants.NAME_ACCEPTED_FILE_EXTENSIONS
+				).value(
+					"txt"
+				).build(),
+				new ObjectFieldSettingBuilder(
+				).name(
+					ObjectFieldSettingConstants.NAME_FILE_SOURCE
+				).value(
+					ObjectFieldSettingConstants.VALUE_DOCS_AND_MEDIA
+				).build(),
+				new ObjectFieldSettingBuilder(
+				).name(
+					ObjectFieldSettingConstants.NAME_MAX_FILE_SIZE
+				).value(
+					"100"
+				).build()),
+			false);
+
+		_objectDefinition = ObjectDefinitionTestUtil.publishObjectDefinition(
+			ObjectDefinitionTestUtil.getRandomName(),
+			Collections.singletonList(_objectField),
+			ObjectDefinitionConstants.SCOPE_COMPANY,
+			TestPropsValues.getUserId());
+
+		_serviceRegistration = _registerObjectActionExecutor();
+
+		_objectAction = _objectActionLocalService.addObjectAction(
+			null, TestPropsValues.getUserId(),
+			_objectDefinition.getObjectDefinitionId(), true, StringPool.BLANK,
+			RandomTestUtil.randomString(),
+			Collections.<Locale, String>emptyMap(),
+			Collections.singletonMap(
+				LocaleUtil.US, RandomTestUtil.randomString()),
+			RandomTestUtil.randomString(), _KEY,
+			ObjectActionTriggerConstants.KEY_ON_AFTER_ATTACHMENT_DOWNLOAD,
+			UnicodePropertiesBuilder.create(
+				true
+			).build(),
+			false);
+	}
+
+	@After
+	@Override
+	public void tearDown() throws Exception {
+		if (_serviceRegistration != null) {
+			_serviceRegistration.unregister();
+		}
+
+		super.tearDown();
+	}
+
+	@Test
+	public void testRunsForItsOwnAttachment() throws Exception {
+		ObjectEntry objectEntry = _addObjectEntry();
+
+		MockHttpServletResponse mockHttpServletResponse = _download(
+			_getFileEntry(objectEntry),
+			_objectDefinition.getExternalReferenceCode(),
+			objectEntry.getExternalReferenceCode());
+
+		Assert.assertEquals(200, mockHttpServletResponse.getStatus());
+
+		Assert.assertEquals(1, _executionCount.get());
+	}
+
+	@Test
+	public void testRunsOncePerDownload() throws Exception {
+		ObjectEntry objectEntry = _addObjectEntry();
+
+		FileEntry fileEntry = _getFileEntry(objectEntry);
+
+		_download(
+			fileEntry, _objectDefinition.getExternalReferenceCode(),
+			objectEntry.getExternalReferenceCode());
+
+		Assert.assertEquals(1, _executionCount.get());
+
+		// The engine runs an action once per set of object entry IDs, recorded
+		// under the action's ID in a thread local, and a request filter clears
+		// those records between requests. This harness calls the servlet
+		// directly on one thread, so forget this action's record here to make
+		// the second download a second request rather than a repeat of the
+		// first.
+
+		Map<Long, Set<Long>> objectEntryIdsMap =
+			ObjectActionThreadLocal.getObjectEntryIdsMap();
+
+		objectEntryIdsMap.remove(_objectAction.getObjectActionId());
+
+		_download(
+			fileEntry, _objectDefinition.getExternalReferenceCode(),
+			objectEntry.getExternalReferenceCode());
+
+		Assert.assertEquals(2, _executionCount.get());
+	}
+
+	@Test
+	public void testSkipsUnknownObjectDefinitionExternalReferenceCode()
+		throws Exception {
+
+		ObjectEntry objectEntry = _addObjectEntry();
+
+		MockHttpServletResponse mockHttpServletResponse = _download(
+			_getFileEntry(objectEntry), RandomTestUtil.randomString(),
+			objectEntry.getExternalReferenceCode());
+
+		Assert.assertEquals(200, mockHttpServletResponse.getStatus());
+
+		Assert.assertEquals(0, _executionCount.get());
+	}
+
+	@Test
+	public void testSkipsWhenNoFileIsServed() throws Exception {
+		ObjectEntry objectEntry = _addObjectEntry();
+
+		FileEntry fileEntry = _getFileEntry(objectEntry);
+
+		fileEntry.setUuid(RandomTestUtil.randomString());
+
+		MockHttpServletResponse mockHttpServletResponse = _download(
+			fileEntry, _objectDefinition.getExternalReferenceCode(),
+			objectEntry.getExternalReferenceCode());
+
+		Assert.assertEquals(404, mockHttpServletResponse.getStatus());
+
+		Assert.assertEquals(0, _executionCount.get());
+	}
+
+	@Test
+	public void testSkipsWithoutObjectDefinitionExternalReferenceCode()
+		throws Exception {
+
+		ObjectEntry objectEntry = _addObjectEntry();
+
+		MockHttpServletResponse mockHttpServletResponse = _download(
+			_getFileEntry(objectEntry), null,
+			objectEntry.getExternalReferenceCode());
+
+		Assert.assertEquals(200, mockHttpServletResponse.getStatus());
+
+		Assert.assertEquals(0, _executionCount.get());
+	}
+
+	private ObjectEntry _addObjectEntry() throws Exception {
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext();
+
+		FileEntry fileEntry = dlAppService.addFileEntry(
+			null, group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			RandomTestUtil.randomString() + ".txt", ContentTypes.TEXT_PLAIN,
+			RandomTestUtil.randomString(), StringPool.BLANK, StringPool.BLANK,
+			StringPool.BLANK,
+			new ByteArrayInputStream(RandomTestUtil.randomBytes()), 0, null,
+			null, null, serviceContext);
+
+		return _objectEntryLocalService.addObjectEntry(
+			0, TestPropsValues.getUserId(),
+			_objectDefinition.getObjectDefinitionId(), 0,
+			LocaleUtil.toLanguageId(LocaleUtil.US),
+			HashMapBuilder.<String, Serializable>put(
+				"file", fileEntry.getFileEntryId()
+			).build(),
+			serviceContext);
+	}
+
+	private MockHttpServletResponse _download(
+			FileEntry fileEntry, String objectDefinitionExternalReferenceCode,
+			String objectEntryExternalReferenceCode)
+		throws Exception {
+
+		String path = StringBundler.concat(
+			StringPool.SLASH, fileEntry.getGroupId(), StringPool.SLASH,
+			fileEntry.getFolderId(), StringPool.SLASH, fileEntry.getFileName(),
+			StringPool.SLASH, fileEntry.getUuid());
+
+		return service(
+			"GET", path, Collections.emptyMap(),
+			HashMapBuilder.put(
+				"download", "true"
+			).put(
+				"objectDefinitionExternalReferenceCode",
+				() -> objectDefinitionExternalReferenceCode
+			).put(
+				"objectEntryExternalReferenceCode",
+				objectEntryExternalReferenceCode
+			).build(),
+			TestPropsValues.getUser(), null);
+	}
+
+	private FileEntry _getFileEntry(ObjectEntry objectEntry) throws Exception {
+		Map<String, Serializable> values = objectEntry.getValues();
+
+		long fileEntryId = (Long)values.get("file");
+
+		return dlAppService.getFileEntry(fileEntryId);
+	}
+
+	private ServiceRegistration<ObjectActionExecutor>
+		_registerObjectActionExecutor() {
+
+		Bundle bundle = FrameworkUtil.getBundle(
+			ObjectActionAttachmentDownloadTest.class);
+
+		BundleContext bundleContext = bundle.getBundleContext();
+
+		return bundleContext.registerService(
+			ObjectActionExecutor.class,
+			new ObjectActionExecutor() {
+
+				@Override
+				public void execute(
+					long companyId, long objectActionId,
+					UnicodeProperties parametersUnicodeProperties,
+					JSONObject payloadJSONObject, long userId) {
+
+					_executionCount.incrementAndGet();
+				}
+
+				@Override
+				public String getKey() {
+					return _KEY;
+				}
+
+			},
+			null);
+	}
+
+	private static final String _KEY = "test-attachment-download";
+
+	private AtomicInteger _executionCount;
+	private ObjectAction _objectAction;
+
+	@Inject
+	private ObjectActionLocalService _objectActionLocalService;
+
+	private ObjectDefinition _objectDefinition;
+
+	@Inject
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	private ObjectField _objectField;
+	private ServiceRegistration<ObjectActionExecutor> _serviceRegistration;
+
+}

--- a/portal-impl/src/com/liferay/portal/servlet/filters/virtualhost/VirtualHostFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/virtualhost/VirtualHostFilter.java
@@ -317,9 +317,6 @@ public class VirtualHostFilter extends BasePortalFilter {
 				VirtualHostFilter.class.getName(), httpServletRequest,
 				httpServletResponse, filterChain);
 
-			WebServerServlet.sendMessageObjectEntryAttachmentDownload(
-				httpServletRequest, null);
-
 			return;
 		}
 

--- a/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
+++ b/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
@@ -237,8 +237,6 @@ public class WebServerServlet extends HttpServlet {
 					}
 				}
 			}
-
-			sendMessageObjectEntryAttachmentDownload(httpServletRequest, user);
 		}
 		catch (Exception exception) {
 			if (_log.isDebugEnabled()) {
@@ -253,53 +251,6 @@ public class WebServerServlet extends HttpServlet {
 		}
 
 		return true;
-	}
-
-	/**
-	 * @see com.liferay.portal.servlet.filters.virtualhost.VirtualHostFilter
-	 */
-	public static void sendMessageObjectEntryAttachmentDownload(
-		HttpServletRequest httpServletRequest, User user) {
-
-		String objectDefinitionExternalReferenceCode = ParamUtil.getString(
-			httpServletRequest, "objectDefinitionExternalReferenceCode");
-
-		if (Validator.isNull(objectDefinitionExternalReferenceCode)) {
-			return;
-		}
-
-		try {
-			MessageBus messageBus = _messageBusSnapshot.get();
-
-			Message message = new Message();
-
-			if (user == null) {
-				user = _getUser(httpServletRequest);
-			}
-
-			message.put("companyId", user.getCompanyId());
-
-			message.put(
-				"groupExternalReferenceCode",
-				ParamUtil.getString(
-					httpServletRequest, "groupExternalReferenceCode"));
-			message.put(
-				"objectDefinitionExternalReferenceCode",
-				objectDefinitionExternalReferenceCode);
-			message.put(
-				"objectEntryExternalReferenceCode",
-				ParamUtil.getString(
-					httpServletRequest, "objectEntryExternalReferenceCode"));
-			message.put("userId", user.getUserId());
-
-			messageBus.sendMessage(
-				DestinationNames.OBJECT_ENTRY_ATTACHMENT_DOWNLOAD, message);
-		}
-		catch (Exception exception) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(exception);
-			}
-		}
 	}
 
 	@Override
@@ -1295,6 +1246,12 @@ public class WebServerServlet extends HttpServlet {
 			FileEntryHttpHeaderCustomizerUtil.getHttpHeaderValue(
 				fileEntry, HttpHeaders.CACHE_CONTROL, cacheControlValue));
 
+		// Everything that could refuse this download has already refused it
+		// and only the transfer is left, so the download is granted here
+
+		_sendObjectEntryAttachmentDownloadMessage(
+			fileEntry, httpServletRequest, user);
+
 		if (isSupportsRangeHeader(contentType)) {
 			ServletResponseUtil.sendFileWithRangeHeader(
 				httpServletRequest, httpServletResponse, fileName, inputStream,
@@ -2036,6 +1993,45 @@ public class WebServerServlet extends HttpServlet {
 			"this-site-is-inactive-please-contact-the-administrator");
 
 		return true;
+	}
+
+	private void _sendObjectEntryAttachmentDownloadMessage(
+		FileEntry fileEntry, HttpServletRequest httpServletRequest, User user) {
+
+		if (Validator.isNull(
+				ParamUtil.getString(
+					httpServletRequest,
+					"objectDefinitionExternalReferenceCode"))) {
+
+			return;
+		}
+
+		Message message = new Message();
+
+		message.put("companyId", fileEntry.getCompanyId());
+		message.put("fileEntryId", fileEntry.getFileEntryId());
+		message.put(
+			"groupExternalReferenceCode",
+			ParamUtil.getString(
+				httpServletRequest, "groupExternalReferenceCode"));
+		message.put(
+			"objectDefinitionExternalReferenceCode",
+			ParamUtil.getString(
+				httpServletRequest, "objectDefinitionExternalReferenceCode"));
+		message.put(
+			"objectEntryExternalReferenceCode",
+			ParamUtil.getString(
+				httpServletRequest, "objectEntryExternalReferenceCode"));
+		message.put(
+			"objectFieldExternalReferenceCode",
+			ParamUtil.getString(
+				httpServletRequest, "objectFieldExternalReferenceCode"));
+		message.put("userId", user.getUserId());
+
+		MessageBus messageBus = _messageBusSnapshot.get();
+
+		messageBus.sendMessage(
+			DestinationNames.OBJECT_ENTRY_ATTACHMENT_DOWNLOAD, message);
 	}
 
 	private static final String _PATH_SEPARATOR_FILE_ENTRY =

--- a/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
+++ b/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
@@ -88,8 +88,6 @@ import com.liferay.portal.kernel.template.TemplateManagerUtil;
 import com.liferay.portal.kernel.template.TemplateResource;
 import com.liferay.portal.kernel.template.URLTemplateResource;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.transaction.TransactionConfig;
-import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
 import com.liferay.portal.kernel.trash.helper.TrashHelper;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
@@ -374,14 +372,10 @@ public class WebServerServlet extends HttpServlet {
 				}
 			}
 
-			TransactionConfig.Builder builder = new TransactionConfig.Builder();
+			Callable<Void> fileServingCallable = _createFileServingCallable(
+				httpServletRequest, httpServletResponse, user);
 
-			builder.setRollbackForClasses(Exception.class);
-
-			TransactionInvokerUtil.invoke(
-				builder.build(),
-				_createFileServingCallable(
-					httpServletRequest, httpServletResponse, user));
+			fileServingCallable.call();
 		}
 		catch (FileEntryExpiredException | NoSuchFileEntryException |
 			   NoSuchFolderException exception) {

--- a/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
+++ b/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
@@ -137,7 +137,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.Callable;
 
 /**
  * @author Alexander Chow
@@ -372,10 +371,66 @@ public class WebServerServlet extends HttpServlet {
 				}
 			}
 
-			Callable<Void> fileServingCallable = _createFileServingCallable(
-				httpServletRequest, httpServletResponse, user);
+			String path = _getPath(httpServletRequest);
 
-			fileServingCallable.call();
+			String[] pathArray = StringUtil.split(
+				_getPath(httpServletRequest), CharPool.SLASH);
+
+			if (pathArray.length == 0) {
+				sendGroups(
+					httpServletResponse, user,
+					httpServletRequest.getServletPath() + StringPool.SLASH +
+						path);
+			}
+			else {
+				if (Validator.isNumber(pathArray[0])) {
+					sendFile(
+						httpServletRequest, httpServletResponse, user,
+						pathArray);
+				}
+				else if (_PATH_SEPARATOR_FILE_ENTRY.equals(pathArray[0])) {
+					sendFile(
+						httpServletRequest, httpServletResponse, user,
+						pathArray);
+				}
+				else if (PATH_PORTLET_FILE_ENTRY.equals(pathArray[0])) {
+					sendPortletFileEntry(
+						httpServletRequest, httpServletResponse, path,
+						pathArray);
+				}
+				else {
+					if (PropsValues.WEB_SERVER_SERVLET_CHECK_IMAGE_GALLERY &&
+						isLegacyImageGalleryImageId(
+							httpServletRequest, httpServletResponse)) {
+
+						return;
+					}
+
+					Image image = getImage(httpServletRequest, true);
+
+					if (image != null) {
+						if ((image.getCompanyId() != user.getCompanyId()) &&
+							_processCompanyInactiveRequest(
+								httpServletRequest, httpServletResponse,
+								image.getCompanyId())) {
+
+							return;
+						}
+
+						writeImage(
+							image, httpServletRequest, httpServletResponse);
+					}
+					else {
+						sendDocumentLibrary(
+							httpServletRequest, httpServletResponse, user,
+							StringBundler.concat(
+								PortalUtil.getPathContext(),
+								httpServletRequest.getServletPath(),
+								StringPool.SLASH, path),
+							pathArray);
+					}
+				}
+			}
 		}
 		catch (FileEntryExpiredException | NoSuchFileEntryException |
 			   NoSuchFolderException exception) {
@@ -1746,76 +1801,6 @@ public class WebServerServlet extends HttpServlet {
 					ActionKeys.ACCESS_IN_CONTROL_PANEL);
 			}
 		}
-	}
-
-	private Callable<Void> _createFileServingCallable(
-		HttpServletRequest httpServletRequest,
-		HttpServletResponse httpServletResponse, User user) {
-
-		return () -> {
-			String path = _getPath(httpServletRequest);
-
-			String[] pathArray = StringUtil.split(
-				_getPath(httpServletRequest), CharPool.SLASH);
-
-			if (pathArray.length == 0) {
-				sendGroups(
-					httpServletResponse, user,
-					httpServletRequest.getServletPath() + StringPool.SLASH +
-						path);
-			}
-			else {
-				if (Validator.isNumber(pathArray[0])) {
-					sendFile(
-						httpServletRequest, httpServletResponse, user,
-						pathArray);
-				}
-				else if (_PATH_SEPARATOR_FILE_ENTRY.equals(pathArray[0])) {
-					sendFile(
-						httpServletRequest, httpServletResponse, user,
-						pathArray);
-				}
-				else if (PATH_PORTLET_FILE_ENTRY.equals(pathArray[0])) {
-					sendPortletFileEntry(
-						httpServletRequest, httpServletResponse, path,
-						pathArray);
-				}
-				else {
-					if (PropsValues.WEB_SERVER_SERVLET_CHECK_IMAGE_GALLERY &&
-						isLegacyImageGalleryImageId(
-							httpServletRequest, httpServletResponse)) {
-
-						return null;
-					}
-
-					Image image = getImage(httpServletRequest, true);
-
-					if (image != null) {
-						if ((image.getCompanyId() != user.getCompanyId()) &&
-							_processCompanyInactiveRequest(
-								httpServletRequest, httpServletResponse,
-								image.getCompanyId())) {
-
-							return null;
-						}
-
-						writeImage(
-							image, httpServletRequest, httpServletResponse);
-					}
-					else {
-						sendDocumentLibrary(
-							httpServletRequest, httpServletResponse, user,
-							StringBundler.concat(
-								PortalUtil.getPathContext(),
-								httpServletRequest.getServletPath(),
-								StringPool.SLASH, path),
-							pathArray);
-					}
-				}
-			}
-
-			return null;
-		};
 	}
 
 	private String _getActionId(HttpServletRequest httpServletRequest) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103632

## What Is Being Fixed

The test "can send notification email via download action" is the most frequent retry-masked flake in ci:test:object. The message that runs an object's after-attachment-download actions was sent from two places, and which one a request reached depended on whether a layout set resolved for it: a routing predicate that runs before the servlet, or a filter epilogue that runs after the whole response. Neither place could tell whether a download had actually happened, so on the CI configuration the actions ran only after the full response body, racing the test's inbox check.

## How It Is Being Fixed

Serve the file without a transaction around it (the transaction existed for live JDBC blob streaming that no longer happens), inline the file serving into the servlet, and send the attachment download message at the single point where the download is granted — after every permission and business check has passed and before the first byte of the body. A request answered with anything other than a file sends nothing. A new integration test drives the servlet directly and covers five cases: actions run on a download, run twice on two downloads, and run zero times for a not-found answer, an unresolvable definition name, and a request naming no definition.

Self-CI ci:test:object on this branch: 61 out of 61 jobs passed.

## PR Check

**pr-check: PASS** — tested on `ef45c49c7e6495c23f1e6ad5f876e8102288e3a4`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "ef45c49c7e6495c23f1e6ad5f876e8102288e3a4"} -->
