### PR TITLE
LPD-103432 Delete the definition for real in the skip-delete-actions test

### DIFF
--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectActionLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectActionLocalServiceTest.java
@@ -55,7 +55,6 @@ import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.constants.ObjectFieldSettingConstants;
 import com.liferay.object.constants.ObjectRelationshipConstants;
-import com.liferay.object.definition.util.ObjectDefinitionThreadLocal;
 import com.liferay.object.exception.ObjectActionErrorMessageException;
 import com.liferay.object.exception.ObjectActionExecutorKeyException;
 import com.liferay.object.exception.ObjectActionNameException;
@@ -87,7 +86,6 @@ import com.liferay.object.test.util.ObjectRelationshipTestUtil;
 import com.liferay.object.test.util.TreeTestUtil;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
-import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
@@ -279,7 +277,10 @@ public class ObjectActionLocalServiceTest {
 				0, ObjectActionExecutorConstants.KEY_GROOVY),
 			"_objectScriptingExecutor", _originalObjectScriptingExecutor);
 
-		_objectDefinitionLocalService.deleteObjectDefinition(_objectDefinition);
+		if (_objectDefinition != null) {
+			_objectDefinitionLocalService.deleteObjectDefinition(
+				_objectDefinition);
+		}
 	}
 
 	@Test
@@ -2841,31 +2842,27 @@ public class ObjectActionLocalServiceTest {
 		ObjectEntry objectEntry = _addObjectEntry(
 			_objectDefinition,
 			HashMapBuilder.<String, Serializable>put(
-				"firstName", "John"
-			).build());
-
-		try (SafeCloseable safeCloseable =
-				ObjectDefinitionThreadLocal.
-					setDeleteObjectDefinitionIdWithSafeCloseable(
-						_objectDefinition.getObjectDefinitionId())) {
-
-			_objectEntryLocalService.deleteObjectEntry(objectEntry);
-		}
-
-		Assert.assertNull(
-			_objectEntryLocalService.fetchObjectEntry(
-				objectEntry.getObjectEntryId()));
-		Assert.assertEquals(0, _argumentsList.size());
-
-		objectEntry = _addObjectEntry(
-			_objectDefinition,
-			HashMapBuilder.<String, Serializable>put(
 				"firstName", "Paul"
 			).build());
 
 		_objectEntryLocalService.deleteObjectEntry(objectEntry);
 
 		_assertGroovyObjectActionExecutorArguments("Paul", objectEntry);
+
+		objectEntry = _addObjectEntry(
+			_objectDefinition,
+			HashMapBuilder.<String, Serializable>put(
+				"firstName", "John"
+			).build());
+
+		_objectDefinitionLocalService.deleteObjectDefinition(_objectDefinition);
+
+		_objectDefinition = null;
+
+		Assert.assertNull(
+			_objectEntryLocalService.fetchObjectEntry(
+				objectEntry.getObjectEntryId()));
+		Assert.assertEquals(0, _argumentsList.size());
 	}
 
 	@Test


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103432

## What Is Being Fixed

Follow-up to LPD-103432's guard test. The test simulates the definition delete by setting the definition-delete thread local around a bare entry delete, but the flag engages more than the action skip under test: the entry delete also skips the per-entry asset, resource, friendly URL, version, and sharing cleanup on the promise that the definition delete bulk-removes them — and with no definition delete ever running, the promise is never kept. The orphaned asset entry outlives the definition and its class name row, and the test data guard's leftover sweep dies reindexing it, failing the modules-integration axis's log scan on every run.

## How It Is Being Fixed

Delete the definition for real instead of simulating the flag: the skip under test then runs on the exact path that sets the flag in production, and the bulk cleanup it promises actually runs, leaving nothing behind. The test consumes the fixture the class tears down, so it clears the field and the teardown skips a fixture that is already gone.

Local: the test passes (1/0) and the full ObjectActionLocalServiceTest class passes (24/0) with zero portal-log ERRORs on a clean rebuilt bundle. Self-CI ci:test:object: 60 out of 62, with the reindex failure absent on the fix's run and present the same day on a run without it.

## PR Check

**pr-check: PASS** — tested on `789def25cfa07dce065c4855897b5258b480e6d5`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "789def25cfa07dce065c4855897b5258b480e6d5"} -->
