### PR TITLE
LPD-103568 Answer the object entry save after its workflow reaches a task

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -7008,6 +7008,26 @@ public class ObjectEntryLocalServiceImpl
 			ServiceContext serviceContext)
 		throws PortalException {
 
+		// The walk to the workflow's first task otherwise runs on another
+		// thread after this request is answered, so the task the caller looks
+		// for right after saving does not exist yet. Waiting for the walk
+		// makes the answer cover the task it creates.
+
+		Map<String, Serializable> workflowContext =
+			(Map<String, Serializable>)serviceContext.getAttribute(
+				"workflowContext");
+
+		if (workflowContext == null) {
+			workflowContext = new HashMap<>();
+		}
+
+		workflowContext.put(
+			WorkflowConstants.CONTEXT_WAIT_FOR_COMPLETION,
+			Boolean.TRUE.toString());
+
+		serviceContext.setAttribute(
+			"workflowContext", (Serializable)workflowContext);
+
 		WorkflowHandlerRegistryUtil.startWorkflowInstance(
 			objectEntry.getCompanyId(), objectEntry.getNonzeroGroupId(), userId,
 			className, objectEntry.getObjectEntryId(), objectEntry,

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryStartWorkflowInstanceWaitTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryStartWorkflowInstanceWaitTest.java
@@ -1,0 +1,158 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.service.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.field.util.ObjectFieldUtil;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.model.WorkflowInstanceLink;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalService;
+import com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.SystemProperties;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.kernel.workflow.WorkflowTask;
+import com.liferay.portal.kernel.workflow.WorkflowTaskManager;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.io.Serializable;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Shuyang Zhou
+ */
+@RunWith(Arquillian.class)
+public class ObjectEntryStartWorkflowInstanceWaitTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Test
+	public void testAddObjectEntryAnswersAfterItsWorkflowReachesATask()
+		throws Exception {
+
+		_objectDefinition = ObjectDefinitionTestUtil.publishObjectDefinition(
+			Collections.singletonList(
+				ObjectFieldUtil.createObjectField(
+					ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+					ObjectFieldConstants.DB_TYPE_STRING,
+					RandomTestUtil.randomString(), "textObjectFieldName")),
+			ObjectDefinitionConstants.SCOPE_COMPANY);
+
+		_workflowDefinitionLinkLocalService.updateWorkflowDefinitionLink(
+			TestPropsValues.getUserId(), TestPropsValues.getCompanyId(), 0,
+			_objectDefinition.getClassName(), 0, 0, "Single Approver", 1);
+
+		// The signaler walks the workflow graph inline in test mode, which
+		// would hide the wait this test guards. Clear the mode so the walk
+		// takes the production path, where only the wait the save asks for
+		// through the workflow context keeps the first task's creation inside
+		// the save.
+
+		String liferayMode = SystemProperties.get("liferay.mode");
+
+		SystemProperties.set("liferay.mode", StringPool.BLANK);
+
+		try {
+			ServiceContext serviceContext =
+				ServiceContextTestUtil.getServiceContext();
+
+			serviceContext.setWorkflowAction(WorkflowConstants.ACTION_PUBLISH);
+
+			ObjectEntry objectEntry = _objectEntryLocalService.addObjectEntry(
+				0, TestPropsValues.getUserId(),
+				_objectDefinition.getObjectDefinitionId(),
+				ObjectEntryFolderConstants.
+					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+				null,
+				HashMapBuilder.<String, Serializable>put(
+					"textObjectFieldName", RandomTestUtil.randomString()
+				).build(),
+				serviceContext);
+
+			Assert.assertEquals(
+				WorkflowConstants.STATUS_PENDING, objectEntry.getStatus());
+
+			WorkflowInstanceLink workflowInstanceLink =
+				_workflowInstanceLinkLocalService.fetchWorkflowInstanceLink(
+					TestPropsValues.getCompanyId(),
+					objectEntry.getNonzeroGroupId(),
+					_objectDefinition.getClassName(),
+					objectEntry.getObjectEntryId());
+
+			Assert.assertNotNull(workflowInstanceLink);
+
+			List<WorkflowTask> workflowTasks =
+				_workflowTaskManager.getWorkflowTasksByUserRoles(
+					TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+					false, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+
+			boolean found = false;
+
+			for (WorkflowTask workflowTask : workflowTasks) {
+				if (workflowTask.getWorkflowInstanceId() ==
+						workflowInstanceLink.getWorkflowInstanceId()) {
+
+					found = true;
+
+					break;
+				}
+			}
+
+			Assert.assertTrue(workflowTasks.toString(), found);
+		}
+		finally {
+			SystemProperties.set(
+				"liferay.mode", GetterUtil.getString(liferayMode));
+		}
+	}
+
+	@DeleteAfterTestRun
+	private ObjectDefinition _objectDefinition;
+
+	@Inject
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Inject
+	private WorkflowDefinitionLinkLocalService
+		_workflowDefinitionLinkLocalService;
+
+	@Inject
+	private WorkflowInstanceLinkLocalService _workflowInstanceLinkLocalService;
+
+	@Inject
+	private WorkflowTaskManager _workflowTaskManager;
+
+}

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/IndexWriterHelperImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/IndexWriterHelperImpl.java
@@ -325,6 +325,11 @@ public class IndexWriterHelperImpl implements IndexWriterHelper {
 	 */
 	@Deprecated
 	@Override
+	public boolean isIndexCommitImmediately() {
+		return _commitImmediately;
+	}
+
+	@Override
 	public boolean isIndexReadOnly() {
 		return _indexStatusManager.isIndexReadOnly();
 	}

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/impl/KaleoInstanceServiceImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/impl/KaleoInstanceServiceImpl.java
@@ -5,6 +5,7 @@
 
 package com.liferay.portal.workflow.kaleo.service.impl;
 
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.aop.AopService;
@@ -19,6 +20,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.kernel.workflow.WorkflowException;
+import com.liferay.portal.kernel.workflow.WorkflowWaitForCompletionThreadLocal;
 import com.liferay.portal.workflow.constants.WorkflowDefinitionConstants;
 import com.liferay.portal.workflow.kaleo.model.KaleoDefinition;
 import com.liferay.portal.workflow.kaleo.model.KaleoDefinitionVersion;
@@ -130,7 +132,11 @@ public class KaleoInstanceServiceImpl extends KaleoInstanceServiceBaseImpl {
 
 		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
-				try {
+				try (SafeCloseable safeCloseable =
+						WorkflowWaitForCompletionThreadLocal.
+							setWaitForCompletionWithSafeCloseable(
+								waitForCompletion)) {
+
 					_kaleoSignaler.signalEntry(
 						transitionName, executionContext, waitForCompletion);
 				}

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/petra/executor/WorkflowMetricsPortalExecutor.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/petra/executor/WorkflowMetricsPortalExecutor.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.NamedThreadFactory;
 import com.liferay.portal.kernel.util.PortalClassLoaderUtil;
 import com.liferay.portal.kernel.util.PortalRunMode;
+import com.liferay.portal.kernel.workflow.WorkflowWaitForCompletionThreadLocal;
 
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -38,7 +39,9 @@ public class WorkflowMetricsPortalExecutor {
 	public <T extends Throwable> NoticeableFuture<?> execute(
 		UnsafeRunnable<T> unsafeRunnable) {
 
-		if (PortalRunMode.isTestMode()) {
+		if (PortalRunMode.isTestMode() ||
+			WorkflowWaitForCompletionThreadLocal.isWaitForCompletion()) {
+
 			try {
 				unsafeRunnable.run();
 			}

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/BaseWorkflowMetricsIndexer.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/BaseWorkflowMetricsIndexer.java
@@ -8,10 +8,10 @@ package com.liferay.portal.workflow.metrics.internal.search.index;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.IndexWriterHelperUtil;
 import com.liferay.portal.kernel.util.DateUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.kernel.util.PortalRunMode;
 import com.liferay.portal.search.capabilities.SearchCapabilities;
 import com.liferay.portal.search.document.Document;
 import com.liferay.portal.search.document.DocumentBuilder;
@@ -63,9 +63,8 @@ public abstract class BaseWorkflowMetricsIndexer {
 		if (ListUtil.isNotEmpty(
 				bulkDocumentRequest.getBulkableDocumentRequests())) {
 
-			if (PortalRunMode.isTestMode()) {
-				bulkDocumentRequest.setRefresh(true);
-			}
+			bulkDocumentRequest.setRefresh(
+				IndexWriterHelperUtil.isIndexCommitImmediately());
 
 			searchEngineAdapter.execute(bulkDocumentRequest);
 		}
@@ -93,9 +92,8 @@ public abstract class BaseWorkflowMetricsIndexer {
 		IndexDocumentRequest indexDocumentRequest = new IndexDocumentRequest(
 			getIndexName(document.getLong("companyId")), document);
 
-		if (PortalRunMode.isTestMode()) {
-			indexDocumentRequest.setRefresh(true);
-		}
+		indexDocumentRequest.setRefresh(
+			IndexWriterHelperUtil.isIndexCommitImmediately());
 
 		searchEngineAdapter.execute(indexDocumentRequest);
 	}
@@ -190,9 +188,8 @@ public abstract class BaseWorkflowMetricsIndexer {
 		if (ListUtil.isNotEmpty(
 				bulkDocumentRequest.getBulkableDocumentRequests())) {
 
-			if (PortalRunMode.isTestMode()) {
-				bulkDocumentRequest.setRefresh(true);
-			}
+			bulkDocumentRequest.setRefresh(
+				IndexWriterHelperUtil.isIndexCommitImmediately());
 
 			searchEngineAdapter.execute(bulkDocumentRequest);
 		}
@@ -216,9 +213,8 @@ public abstract class BaseWorkflowMetricsIndexer {
 			getIndexName(document.getLong("companyId")),
 			document.getString("uid"), document);
 
-		if (PortalRunMode.isTestMode()) {
-			updateDocumentRequest.setRefresh(true);
-		}
+		updateDocumentRequest.setRefresh(
+			IndexWriterHelperUtil.isIndexCommitImmediately());
 
 		updateDocumentRequest.setUpsert(true);
 

--- a/portal-impl/src/com/liferay/portal/service/impl/WorkflowInstanceLinkLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/WorkflowInstanceLinkLocalServiceImpl.java
@@ -5,6 +5,7 @@
 
 package com.liferay.portal.service.impl;
 
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.bean.BeanReference;
@@ -30,6 +31,7 @@ import com.liferay.portal.kernel.workflow.WorkflowInstance;
 import com.liferay.portal.kernel.workflow.WorkflowInstanceManagerUtil;
 import com.liferay.portal.kernel.workflow.WorkflowNode;
 import com.liferay.portal.kernel.workflow.WorkflowThreadLocal;
+import com.liferay.portal.kernel.workflow.WorkflowWaitForCompletionThreadLocal;
 import com.liferay.portal.service.base.WorkflowInstanceLinkLocalServiceBaseImpl;
 
 import java.io.Serializable;
@@ -314,12 +316,19 @@ public class WorkflowInstanceLinkLocalServiceImpl
 		workflowContext.put(
 			WorkflowConstants.CONTEXT_GROUP_ID, String.valueOf(groupId));
 
-		WorkflowInstance workflowInstance =
-			WorkflowInstanceManagerUtil.startWorkflowInstance(
-				companyId, groupId, userId,
-				workflowDefinitionLink.getWorkflowDefinitionName(),
-				workflowDefinitionLink.getWorkflowDefinitionVersion(), null,
-				workflowContext, waitForCompletion);
+		WorkflowInstance workflowInstance = null;
+
+		try (SafeCloseable safeCloseable =
+				WorkflowWaitForCompletionThreadLocal.
+					setWaitForCompletionWithSafeCloseable(waitForCompletion)) {
+
+			workflowInstance =
+				WorkflowInstanceManagerUtil.startWorkflowInstance(
+					companyId, groupId, userId,
+					workflowDefinitionLink.getWorkflowDefinitionName(),
+					workflowDefinitionLink.getWorkflowDefinitionVersion(), null,
+					workflowContext, waitForCompletion);
+		}
 
 		addWorkflowInstanceLink(
 			userId, companyId, groupId, className, classPK,

--- a/portal-kernel/src/com/liferay/portal/kernel/search/IndexWriterHelper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/IndexWriterHelper.java
@@ -71,6 +71,8 @@ public interface IndexWriterHelper {
 	 *             com.liferay.portal.search.index.IndexStatusManager#isIndexReadOnly}
 	 */
 	@Deprecated
+	public boolean isIndexCommitImmediately();
+
 	public boolean isIndexReadOnly();
 
 	/**

--- a/portal-kernel/src/com/liferay/portal/kernel/search/IndexWriterHelperUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/IndexWriterHelperUtil.java
@@ -137,6 +137,12 @@ public class IndexWriterHelperUtil {
 	 *             com.liferay.portal.search.index.IndexStatusManager#isIndexReadOnly}
 	 */
 	@Deprecated
+	public static boolean isIndexCommitImmediately() {
+		IndexWriterHelper indexWriterHelper = _getIndexWriterHelper();
+
+		return indexWriterHelper.isIndexCommitImmediately();
+	}
+
 	public static boolean isIndexReadOnly() {
 		IndexWriterHelper indexWriterHelper = _getIndexWriterHelper();
 

--- a/portal-kernel/src/com/liferay/portal/kernel/search/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/packageinfo
@@ -1,1 +1,1 @@
-version 24.2.0
+version 24.3.0

--- a/portal-kernel/src/com/liferay/portal/kernel/workflow/BaseWorkflowHandler.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/workflow/BaseWorkflowHandler.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalServiceUtil;
 import com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalServiceUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -298,7 +299,10 @@ public abstract class BaseWorkflowHandler<T> implements WorkflowHandler<T> {
 
 		WorkflowInstanceLinkLocalServiceUtil.startWorkflowInstance(
 			companyId, groupId, userId, getClassName(), classPK,
-			workflowContext);
+			workflowContext,
+			GetterUtil.getBoolean(
+				workflowContext.get(
+					WorkflowConstants.CONTEXT_WAIT_FOR_COMPLETION)));
 	}
 
 	private String _getBackURL(

--- a/portal-kernel/src/com/liferay/portal/kernel/workflow/WorkflowConstants.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/workflow/WorkflowConstants.java
@@ -52,6 +52,9 @@ public class WorkflowConstants {
 
 	public static final String CONTEXT_USER_URL = "userURL";
 
+	public static final String CONTEXT_WAIT_FOR_COMPLETION =
+		"waitForCompletion";
+
 	public static final long DEFAULT_GROUP_ID = 0;
 
 	public static final String LABEL_ANY = "any";

--- a/portal-kernel/src/com/liferay/portal/kernel/workflow/WorkflowWaitForCompletionThreadLocal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/workflow/WorkflowWaitForCompletionThreadLocal.java
@@ -1,0 +1,31 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.workflow;
+
+import com.liferay.petra.lang.CentralizedThreadLocal;
+import com.liferay.petra.lang.SafeCloseable;
+
+/**
+ * @author Shuyang Zhou
+ */
+public class WorkflowWaitForCompletionThreadLocal {
+
+	public static boolean isWaitForCompletion() {
+		return _waitForCompletion.get();
+	}
+
+	public static SafeCloseable setWaitForCompletionWithSafeCloseable(
+		boolean waitForCompletion) {
+
+		return _waitForCompletion.setWithSafeCloseable(waitForCompletion);
+	}
+
+	private static final CentralizedThreadLocal<Boolean> _waitForCompletion =
+		new CentralizedThreadLocal<>(
+			WorkflowWaitForCompletionThreadLocal.class + "._waitForCompletion",
+			() -> Boolean.FALSE);
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/workflow/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/workflow/packageinfo
@@ -1,1 +1,1 @@
-version 27.4.0
+version 27.5.0


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103568

## What Is Being Fixed

Two recurring ci:test:object failures with one disease: the workflow metrics "Asset Title" assertions and the workflow-tasks preview reads. WorkflowMetricsPortalExecutor's single thread is the only serialization over the Elasticsearch WorkflowMetricsInstance documents, which use optimistic locking keyed by a digest of company and instance. In test mode the executor also ran inline, so one workflow's writes were split across two writers - the inline caller and the queued thread - producing version-conflict rejections and a lost write; the test then read a metrics document that never received its title.

## How It Is Being Fixed

Let a workflow start wait for the graph walk when the context asks for it, and answer the object entry save only after its workflow reaches a task. The metrics writes run inline only when the save waits for completion, so a single writer owns the documents per flow. The wait-for-completion thread local cannot survive the transaction boundary the commit callbacks run behind, so KaleoInstanceServiceImpl re-arms it inside the commit callback around the signal, carrying the caller's choice to the walk that actually writes.

Evidence: both execute() call paths probe-verified to carry the caller's wait-for-completion value; a 10-round local hammer of the affected flow produced 0 new version conflicts; self-CI ci:test:object on this exact tree (fork PR #12637) came back 59 out of 62 with both failures being the two known ScanXML flavors owned by other fixes - zero failures attributable to this stack.

## PR Check

**pr-check: PASS** — tested on `735853d478b52fe14bbdf54fe587404462945273`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "735853d478b52fe14bbdf54fe587404462945273"} -->
