### PR TITLE
LPD-103738 Delete a catalog's content and row when its group is deleted

### DIFF
--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/model/listener/GroupModelListener.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/model/listener/GroupModelListener.java
@@ -5,8 +5,13 @@
 
 package com.liferay.commerce.product.internal.model.listener;
 
+import com.liferay.commerce.product.model.CPDefinition;
+import com.liferay.commerce.product.model.CommerceCatalog;
 import com.liferay.commerce.product.model.CommerceChannel;
+import com.liferay.commerce.product.service.CPDefinitionLocalService;
+import com.liferay.commerce.product.service.CommerceCatalogLocalService;
 import com.liferay.commerce.product.service.CommerceChannelLocalService;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -14,6 +19,7 @@ import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.ModelListener;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -26,10 +32,12 @@ public class GroupModelListener extends BaseModelListener<Group> {
 
 	@Override
 	public void onBeforeRemove(Group group) {
+		long groupId = group.getGroupId();
+
 		try {
 			CommerceChannel commerceChannel =
 				_commerceChannelLocalService.fetchCommerceChannelBySiteGroupId(
-					group.getGroupId());
+					groupId);
 
 			if (commerceChannel != null) {
 				_commerceChannelLocalService.updateCommerceChannel(
@@ -41,6 +49,23 @@ public class GroupModelListener extends BaseModelListener<Group> {
 					commerceChannel.getCommerceCurrencyCode(),
 					commerceChannel.getPriceDisplayType(),
 					commerceChannel.isDiscountsTargetNetPrice());
+			}
+
+			CommerceCatalog commerceCatalog =
+				_commerceCatalogLocalService.fetchCommerceCatalogByGroupId(
+					groupId);
+
+			if ((commerceCatalog != null) && !commerceCatalog.isSystem()) {
+				for (CPDefinition cpDefinition :
+						_cpDefinitionLocalService.getCPDefinitions(
+							groupId, WorkflowConstants.STATUS_ANY,
+							QueryUtil.ALL_POS, QueryUtil.ALL_POS)) {
+
+					_cpDefinitionLocalService.deleteCPDefinition(cpDefinition);
+				}
+
+				_commerceCatalogLocalService.deleteCommerceCatalog(
+					commerceCatalog);
 			}
 		}
 		catch (PortalException portalException) {
@@ -54,6 +79,12 @@ public class GroupModelListener extends BaseModelListener<Group> {
 		GroupModelListener.class);
 
 	@Reference
+	private CommerceCatalogLocalService _commerceCatalogLocalService;
+
+	@Reference
 	private CommerceChannelLocalService _commerceChannelLocalService;
+
+	@Reference
+	private CPDefinitionLocalService _cpDefinitionLocalService;
 
 }

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CommerceCatalogLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CommerceCatalogLocalServiceImpl.java
@@ -50,6 +50,7 @@ import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.util.CalendarFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.GroupThreadLocal;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
@@ -213,7 +214,9 @@ public class CommerceCatalogLocalServiceImpl
 
 		// Group
 
-		_groupLocalService.deleteGroup(groupId);
+		if (!GroupThreadLocal.isDeleteInProcess()) {
+			_groupLocalService.deleteGroup(groupId);
+		}
 
 		// Resources
 

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CommerceCatalogLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CommerceCatalogLocalServiceImpl.java
@@ -201,6 +201,16 @@ public class CommerceCatalogLocalServiceImpl
 
 		commerceCatalogPersistence.remove(commerceCatalog);
 
+		// Commerce product configuration lists
+
+		for (CPConfigurationList cpConfigurationList :
+				_cpConfigurationListLocalService.getCPConfigurationLists(
+					groupId, commerceCatalog.getCompanyId())) {
+
+			_cpConfigurationListLocalService.deleteCPConfigurationList(
+				cpConfigurationList, true);
+		}
+
 		// Group
 
 		_groupLocalService.deleteGroup(groupId);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103738

## What Is Being Fixed

Deleting a commerce catalog's group directly leaves the catalog's products, its master configuration list, and the catalog row itself behind, all pointing at a dead group: nothing cleans catalog-scoped content on group deletion, and the master configuration list additionally refuses non-forced deletion. In ci:test:object the test data guard sweeps leftovers in service registration order, which shifts with module composition, so runs whose order reached the group side first produced NoSuchGroupException errors from the orphaned rows' own cleanup paths and failed the modules-integration axis's log scan; the config-list rows fell back to silent raw row deletes on every run.

## How It Is Being Fixed

Two commits. First, deleteCommerceCatalog force-deletes its group's configuration lists before deleting the group, mirroring the company-deletion path. Second, group deletion cascades to the catalog: the commerce-product GroupModelListener deletes a dying catalog group's products and then the catalog through their own services, gated to skip system catalogs and empty lookups, while deleteCommerceCatalog skips its own group deletion when a group deletion is already in progress so the two entry points converge without recursion.

Local evidence: the affected notification test passes under CI's hostile sweep order with zero silent fallbacks, zero NoSuchGroupException, and zero log errors, and the full ObjectActionLocalServiceTest class passes 24 of 24. Self-CI ci:test:object: 59 out of 62, with both failures artifact-confirmed as known unrelated issues owned by other fixes.

## PR Check

**pr-check: PASS** — tested on `6814769ecd6d31e81e7184d13b2bc270993c2598`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |

<!-- pr-check {"result": "success", "sha": "6814769ecd6d31e81e7184d13b2bc270993c2598"} -->
