### PR TITLE
LPD-103767 Wait for the relate the self relationship test's picker fires

### DIFF
--- a/modules/test/playwright/tests/object-web/relationship/objectRelationship.spec.ts
+++ b/modules/test/playwright/tests/object-web/relationship/objectRelationship.spec.ts
@@ -4259,6 +4259,14 @@ test.describe('Manage object relationship entries', () => {
 					.first()
 					.click();
 
+				await expect(
+					page.locator('iframe[title="Select"]')
+				).toBeHidden();
+
+				await expect(
+					page.getByRole('row').filter({hasText: 'Entry B'}).first()
+				).toBeVisible();
+
 				await viewObjectEntriesPage.goto(objectDefinition.className);
 
 				const entryARowRefreshed = page.getByRole('row', {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103767

## What Is Being Fixed

The playwright test "can view object entry title in the relationship tab for self relationship" is a recurring retry-masked flake in ci:test:object (three baseline sightings). Selecting the related entry in the picker fires the relate request and the test navigates away immediately; when the navigation wins the race it cancels the in-flight relate, the relationship is never created, and the row asserted after the revisit never appears.

## How It Is Being Fixed

After the picker click, wait for the picker frame to close and for the related entry's row to appear before navigating away — the same owned signal LPD-103434 gave the already-related block in this spec file. No retries, no timers.

Evidence: on a fresh CI-parity environment the unfixed test failed 5 of 5 runs at the exact traced assertion and the fixed test passed 10 of 10; self-CI ci:test:object came back 59 out of 62 with both failures being known unrelated issues owned by other fixes. The tree is byte-identical to the self-CI-tested commit.

## PR Check

**pr-check: PASS** — tested on `a469117ffa24137e720e925841aeb7a3b1b99847`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "a469117ffa24137e720e925841aeb7a3b1b99847"} -->
