### PR TITLE
LPD-103768 Stop retrying the object playwright tests

### DIFF
--- a/modules/test/playwright/tests/object-web/action/config.ts
+++ b/modules/test/playwright/tests/object-web/action/config.ts
@@ -5,6 +5,7 @@
 
 export const config = {
 	name: 'object-web.action',
+	retries: 0,
 	testDir: 'tests/object-web/action',
 	use: {
 		testIdAttribute: 'data-qa-id',

--- a/modules/test/playwright/tests/object-web/client-extension/config.ts
+++ b/modules/test/playwright/tests/object-web/client-extension/config.ts
@@ -5,6 +5,7 @@
 
 export const config = {
 	name: 'object-web.client-extension',
+	retries: 0,
 	testDir: 'tests/object-web/client-extension',
 	use: {
 		testIdAttribute: 'data-qa-id',

--- a/modules/test/playwright/tests/object-web/content-page-integration/config.ts
+++ b/modules/test/playwright/tests/object-web/content-page-integration/config.ts
@@ -5,6 +5,7 @@
 
 export const config = {
 	name: 'object-web.content-page-integration',
+	retries: 0,
 	testDir: 'tests/object-web/content-page-integration',
 	use: {
 		testIdAttribute: 'data-qa-id',

--- a/modules/test/playwright/tests/object-web/entry/config.ts
+++ b/modules/test/playwright/tests/object-web/entry/config.ts
@@ -5,6 +5,7 @@
 
 export const config = {
 	name: 'object-web.entry',
+	retries: 0,
 	testDir: 'tests/object-web/entry',
 	use: {
 		testIdAttribute: 'data-qa-id',

--- a/modules/test/playwright/tests/object-web/export-import/config.ts
+++ b/modules/test/playwright/tests/object-web/export-import/config.ts
@@ -4,6 +4,7 @@
  */
 export const config = {
 	name: 'object-web.export-import',
+	retries: 0,
 	testDir: 'tests/object-web/export-import',
 	use: {
 		testIdAttribute: 'data-qa-id',

--- a/modules/test/playwright/tests/object-web/field/config.ts
+++ b/modules/test/playwright/tests/object-web/field/config.ts
@@ -5,6 +5,7 @@
 
 export const config = {
 	name: 'object-web.field',
+	retries: 0,
 	testDir: 'tests/object-web/field',
 	use: {
 		testIdAttribute: 'data-qa-id',

--- a/modules/test/playwright/tests/object-web/folder/config.ts
+++ b/modules/test/playwright/tests/object-web/folder/config.ts
@@ -5,6 +5,7 @@
 
 export const config = {
 	name: 'object-web.folder',
+	retries: 0,
 	testDir: 'tests/object-web/folder',
 	use: {
 		testIdAttribute: 'data-qa-id',

--- a/modules/test/playwright/tests/object-web/forms-integration/config.ts
+++ b/modules/test/playwright/tests/object-web/forms-integration/config.ts
@@ -5,6 +5,7 @@
 
 export const config = {
 	name: 'object-web.forms-integration',
+	retries: 0,
 	testDir: 'tests/object-web/forms-integration',
 	use: {
 		testIdAttribute: 'data-qa-id',

--- a/modules/test/playwright/tests/object-web/hierarchy/config.ts
+++ b/modules/test/playwright/tests/object-web/hierarchy/config.ts
@@ -5,6 +5,7 @@
 
 export const config = {
 	name: 'object-web.hierarchy',
+	retries: 0,
 	testDir: 'tests/object-web/hierarchy',
 	use: {
 		testIdAttribute: 'data-qa-id',

--- a/modules/test/playwright/tests/object-web/layout/config.ts
+++ b/modules/test/playwright/tests/object-web/layout/config.ts
@@ -5,6 +5,7 @@
 
 export const config = {
 	name: 'object-web.layout',
+	retries: 0,
 	testDir: 'tests/object-web/layout',
 	use: {
 		testIdAttribute: 'data-qa-id',

--- a/modules/test/playwright/tests/object-web/list-type-definition/config.ts
+++ b/modules/test/playwright/tests/object-web/list-type-definition/config.ts
@@ -5,6 +5,7 @@
 
 export const config = {
 	name: 'object-web.list-type-definition',
+	retries: 0,
 	testDir: 'tests/object-web/list-type-definition',
 	use: {
 		testIdAttribute: 'data-qa-id',

--- a/modules/test/playwright/tests/object-web/main/config.ts
+++ b/modules/test/playwright/tests/object-web/main/config.ts
@@ -5,6 +5,7 @@
 
 export const config = {
 	name: 'object-web.main',
+	retries: 0,
 	testDir: 'tests/object-web/main',
 	use: {
 		testIdAttribute: 'data-qa-id',

--- a/modules/test/playwright/tests/object-web/notification/config.ts
+++ b/modules/test/playwright/tests/object-web/notification/config.ts
@@ -5,6 +5,7 @@
 
 export const config = {
 	name: 'object-web.notification',
+	retries: 0,
 	testDir: 'tests/object-web/notification',
 	use: {
 		testIdAttribute: 'data-qa-id',

--- a/modules/test/playwright/tests/object-web/relationship/config.ts
+++ b/modules/test/playwright/tests/object-web/relationship/config.ts
@@ -5,6 +5,7 @@
 
 export const config = {
 	name: 'object-web.relationship',
+	retries: 0,
 	testDir: 'tests/object-web/relationship',
 	use: {
 		testIdAttribute: 'data-qa-id',

--- a/modules/test/playwright/tests/object-web/salesforce/config.ts
+++ b/modules/test/playwright/tests/object-web/salesforce/config.ts
@@ -5,6 +5,7 @@
 
 export const config = {
 	name: 'object-web.salesforce',
+	retries: 0,
 	testDir: 'tests/object-web/salesforce',
 	use: {
 		testIdAttribute: 'data-qa-id',

--- a/modules/test/playwright/tests/object-web/upgrade/config.ts
+++ b/modules/test/playwright/tests/object-web/upgrade/config.ts
@@ -5,6 +5,7 @@
 
 export const config = {
 	name: 'object-web.upgrade',
+	retries: 0,
 	testDir: 'tests/object-web/upgrade',
 	use: {
 		testIdAttribute: 'data-qa-id',

--- a/modules/test/playwright/tests/object-web/validation/config.ts
+++ b/modules/test/playwright/tests/object-web/validation/config.ts
@@ -5,6 +5,7 @@
 
 export const config = {
 	name: 'object-web.validation',
+	retries: 0,
 	testDir: 'tests/object-web/validation',
 	use: {
 		testIdAttribute: 'data-qa-id',

--- a/modules/test/playwright/tests/object-web/view/config.ts
+++ b/modules/test/playwright/tests/object-web/view/config.ts
@@ -5,6 +5,7 @@
 
 export const config = {
 	name: 'object-web.view',
+	retries: 0,
 	testDir: 'tests/object-web/view',
 	use: {
 		testIdAttribute: 'data-qa-id',

--- a/modules/test/playwright/tests/object-web/workflow/config.ts
+++ b/modules/test/playwright/tests/object-web/workflow/config.ts
@@ -5,6 +5,7 @@
 
 export const config = {
 	name: 'object-web.workflow',
+	retries: 0,
 	testDir: 'tests/object-web/workflow',
 	use: {
 		testIdAttribute: 'data-qa-id',


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103768

## What Is Being Fixed

The suite-wide playwright configuration retries every failed test once on CI, so whenever the retry wins, a real failure is reported as a flaky pass and never surfaces in the run's verdict. The object playwright projects are stabilized far enough that a failure is signal, not noise, and the retry now only hides regressions from ci:test:object.

## How It Is Being Fixed

Every object-web playwright project declares zero retries, overriding the suite-wide CI retry for exactly the nineteen projects the object suite runs and nothing else. The project set was verified three ways: it equals the suite's own property definition (test.properties object.playwright.projects), it equals the per-axis project names of a real ci:test:object run, and nothing outside object-web is touched.

Proof: locally under the CI environment flag, a deliberately failing test runs exactly once with no retry marker with the override, and retries without it. A CI proof run carrying two deliberately failing tests (dropped from this PR) showed both failing their jobs on a single attempt with no flaky classification, and a previously retry-masked flake failing its job outright.

## PR Check

**pr-check: PASS** — tested on `25e70126f5f0dd9c73a7d5c7d27c6d4974496b38`

| Validation | Result |
| --- | --- |
| TypeScript Compile | PASS |
| Playwright Project Listing | PASS |

<!-- pr-check {"result": "success", "sha": "25e70126f5f0dd9c73a7d5c7d27c6d4974496b38"} -->
