### PR TITLE
LPD-103836 Keep a reindex from reading a deleted definition's dropped column

### DIFF
--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/entry/util/ObjectEntryThreadLocal.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/entry/util/ObjectEntryThreadLocal.java
@@ -41,6 +41,10 @@ public class ObjectEntryThreadLocal {
 		return _disassociateRelatedModels.get();
 	}
 
+	public static boolean isSkipObjectDefinitionCache() {
+		return _skipObjectDefinitionCache.get();
+	}
+
 	public static boolean isSkipObjectEntryResourcePermission() {
 		return _skipObjectEntryResourcePermission.get();
 	}
@@ -78,6 +82,13 @@ public class ObjectEntryThreadLocal {
 		return _objectEntryFolderId.setWithSafeCloseable(objectEntryFolderId);
 	}
 
+	public static SafeCloseable setSkipObjectDefinitionCacheWithSafeCloseable(
+		boolean skipObjectDefinitionCache) {
+
+		return _skipObjectDefinitionCache.setWithSafeCloseable(
+			skipObjectDefinitionCache);
+	}
+
 	public static void setSkipObjectEntryResourcePermission(
 		boolean skipObjectEntryResourcePermission) {
 
@@ -107,6 +118,10 @@ public class ObjectEntryThreadLocal {
 	private static final CentralizedThreadLocal<Long> _objectEntryFolderId =
 		new CentralizedThreadLocal<>(
 			ObjectEntryThreadLocal.class + "._objectEntryFolderId", () -> null);
+	private static final CentralizedThreadLocal<Boolean>
+		_skipObjectDefinitionCache = new CentralizedThreadLocal<>(
+			ObjectEntryThreadLocal.class + "._skipObjectDefinitionCache",
+			() -> false);
 	private static final ThreadLocal<Boolean>
 		_skipObjectEntryResourcePermission = new CentralizedThreadLocal<>(
 			ObjectEntryThreadLocal.class +

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/entry/util/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/entry/util/packageinfo
@@ -1,1 +1,1 @@
-version 3.3.0
+version 3.4.0

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectEntryImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectEntryImpl.java
@@ -9,6 +9,7 @@ import com.liferay.exportimport.kernel.lar.StagedModelType;
 import com.liferay.friendly.url.model.FriendlyURLEntry;
 import com.liferay.friendly.url.service.FriendlyURLEntryLocalServiceUtil;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.entry.util.ObjectEntryThreadLocal;
 import com.liferay.object.entry.util.ObjectEntryValuesUtil;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
@@ -127,6 +128,13 @@ public class ObjectEntryImpl extends ObjectEntryBaseImpl {
 
 	@Override
 	public ObjectDefinition getObjectDefinition() {
+		if (ObjectEntryThreadLocal.isSkipObjectDefinitionCache()) {
+			_objectDefinition = null;
+
+			return ObjectDefinitionLocalServiceUtil.fetchObjectDefinition(
+				getObjectDefinitionId());
+		}
+
 		if (_objectDefinition == null) {
 			_objectDefinition =
 				ObjectDefinitionLocalServiceUtil.fetchObjectDefinition(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -3790,61 +3790,70 @@ public class ObjectEntryLocalServiceImpl
 			_objectRelationshipPersistence.findByObjectDefinitionId1(
 				objectDefinitionId);
 
-		for (ObjectRelationship objectRelationship : objectRelationships) {
-			ObjectDefinition objectDefinition2 =
-				_objectDefinitionPersistence.findByPrimaryKey(
-					objectRelationship.getObjectDefinitionId2());
+		try (SafeCloseable safeCloseable =
+				ObjectEntryThreadLocal.
+					setSkipObjectDefinitionCacheWithSafeCloseable(
+						ObjectDefinitionThreadLocal.isDeleteObjectDefinitionId(
+							objectDefinitionId))) {
 
-			if (WorkflowConstants.STATUS_DRAFT ==
-					objectDefinition2.getStatus()) {
+			for (ObjectRelationship objectRelationship : objectRelationships) {
+				ObjectDefinition objectDefinition2 =
+					_objectDefinitionPersistence.findByPrimaryKey(
+						objectRelationship.getObjectDefinitionId2());
 
-				continue;
-			}
+				if (WorkflowConstants.STATUS_DRAFT ==
+						objectDefinition2.getStatus()) {
 
-			ObjectRelatedModelsProvider objectRelatedModelsProvider =
-				_objectRelatedModelsProviderRegistry.
-					getObjectRelatedModelsProvider(
-						objectDefinition2.getClassName(),
-						objectDefinition2.getCompanyId(),
-						objectRelationship.getType());
-
-			try {
-				ObjectEntryThreadLocal.setSkipObjectEntryResourcePermission(
-					true);
-
-				String deletionType = objectRelationship.getDeletionType();
-
-				if (ObjectEntryThreadLocal.isDisassociateRelatedModels() ||
-					(Objects.equals(
-						deletionType,
-						ObjectRelationshipConstants.DELETION_TYPE_PREVENT) &&
-					 ObjectDefinitionThreadLocal.isDeleteObjectDefinitionId(
-						 objectDefinitionId))) {
-
-					deletionType =
-						ObjectRelationshipConstants.DELETION_TYPE_DISASSOCIATE;
+					continue;
 				}
 
-				if (moveToTrash) {
-					objectRelatedModelsProvider.moveRelatedModelToTrash(
-						PrincipalThreadLocal.getUserId(), groupId,
-						objectRelationship.getObjectRelationshipId(),
-						primaryKey, deletionType);
+				ObjectRelatedModelsProvider objectRelatedModelsProvider =
+					_objectRelatedModelsProviderRegistry.
+						getObjectRelatedModelsProvider(
+							objectDefinition2.getClassName(),
+							objectDefinition2.getCompanyId(),
+							objectRelationship.getType());
+
+				try {
+					ObjectEntryThreadLocal.setSkipObjectEntryResourcePermission(
+						true);
+
+					String deletionType = objectRelationship.getDeletionType();
+
+					if (ObjectEntryThreadLocal.isDisassociateRelatedModels() ||
+						(Objects.equals(
+							deletionType,
+							ObjectRelationshipConstants.
+								DELETION_TYPE_PREVENT) &&
+						 ObjectDefinitionThreadLocal.isDeleteObjectDefinitionId(
+							 objectDefinitionId))) {
+
+						deletionType =
+							ObjectRelationshipConstants.
+								DELETION_TYPE_DISASSOCIATE;
+					}
+
+					if (moveToTrash) {
+						objectRelatedModelsProvider.moveRelatedModelToTrash(
+							PrincipalThreadLocal.getUserId(), groupId,
+							objectRelationship.getObjectRelationshipId(),
+							primaryKey, deletionType);
+					}
+					else {
+						objectRelatedModelsProvider.deleteRelatedModel(
+							PrincipalThreadLocal.getUserId(), groupId,
+							objectRelationship.getObjectRelationshipId(),
+							primaryKey, deletionType);
+					}
 				}
-				else {
-					objectRelatedModelsProvider.deleteRelatedModel(
-						PrincipalThreadLocal.getUserId(), groupId,
-						objectRelationship.getObjectRelationshipId(),
-						primaryKey, deletionType);
+				catch (PrincipalException principalException) {
+					throw new ObjectRelationshipDeletionTypeException(
+						principalException.getMessage());
 				}
-			}
-			catch (PrincipalException principalException) {
-				throw new ObjectRelationshipDeletionTypeException(
-					principalException.getMessage());
-			}
-			finally {
-				ObjectEntryThreadLocal.setSkipObjectEntryResourcePermission(
-					false);
+				finally {
+					ObjectEntryThreadLocal.setSkipObjectEntryResourcePermission(
+						false);
+				}
 			}
 		}
 	}

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/buffer/IndexerRequest.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/buffer/IndexerRequest.java
@@ -29,7 +29,6 @@ public class IndexerRequest {
 
 		_indexer = new NoAutoCommitIndexer<>(indexer);
 
-		_modelClassName = classedModel.getModelClassName();
 		_modelPrimaryKey = (Long)classedModel.getPrimaryKeyObj();
 	}
 
@@ -63,7 +62,8 @@ public class IndexerRequest {
 				 _method.getName(), indexerRequest._method.getName()) &&
 			  Objects.equals(
 				  _modelPrimaryKey, indexerRequest._modelPrimaryKey))) &&
-			Objects.equals(_modelClassName, indexerRequest._modelClassName)) {
+			Objects.equals(
+				_getModelIdentity(), indexerRequest._getModelIdentity())) {
 
 			return true;
 		}
@@ -78,7 +78,7 @@ public class IndexerRequest {
 			_method.invoke(_indexer, _classedModel);
 		}
 		else {
-			_method.invoke(_indexer, _modelClassName, _modelPrimaryKey);
+			_method.invoke(_indexer, _getModelClassName(), _modelPrimaryKey);
 		}
 	}
 
@@ -86,10 +86,9 @@ public class IndexerRequest {
 	public int hashCode() {
 		int hashCode = HashUtil.hash(0, _method.getName());
 
-		hashCode = HashUtil.hash(hashCode, _modelClassName);
-		hashCode = HashUtil.hash(hashCode, _modelPrimaryKey);
+		hashCode = HashUtil.hash(hashCode, _getModelIdentity());
 
-		return hashCode;
+		return HashUtil.hash(hashCode, _modelPrimaryKey);
 	}
 
 	@Override
@@ -97,14 +96,29 @@ public class IndexerRequest {
 		return StringBundler.concat(
 			"{classModel=", _classedModel, ", indexer=",
 			ClassUtil.getClassName(_indexer), ", method=", _method,
-			", modelClassName=", _modelClassName, ", modelPrimaryKey=",
-			_modelPrimaryKey, "}");
+			", modelPrimaryKey=", _modelPrimaryKey, "}");
+	}
+
+	private String _getModelClassName() {
+		if (_modelClassName == null) {
+			_modelClassName = _classedModel.getModelClassName();
+		}
+
+		return _modelClassName;
+	}
+
+	private Object _getModelIdentity() {
+		if (_classedModel == null) {
+			return _modelClassName;
+		}
+
+		return _classedModel.getClass();
 	}
 
 	private final ClassedModel _classedModel;
 	private final Indexer<?> _indexer;
 	private final Method _method;
-	private final String _modelClassName;
+	private String _modelClassName;
 	private final Long _modelPrimaryKey;
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103836

## What Is Being Fixed

ci:test:object integration axes intermittently fail the portal log scan with SQLGrammarException: Unknown column 'O_..._x.r_<relationship>_c_<pk>Id' in 'field list'. When an object definition that participates in a relationship is deleted while a related entry reindexes, the reindex selects a relationship column the definition delete has already dropped. The buffered indexer captures the live ObjectEntry model at registration, ObjectEntryImpl memoizes its ObjectDefinition, and the definition memoizes its field bag, so the deferred commit-flush reindex builds SQL from the pre-delete schema.

## How It Is Being Fixed

Two halves. The delete side wraps the definition delete's related-models walk in ObjectEntryThreadLocal.setSkipObjectDefinitionCacheWithSafeCloseable, and ObjectEntryImpl.getObjectDefinition purges and bypasses its memo while the flag is on, so any model touched during the walk re-reads the live definition. The capture side stops IndexerRequest from reading the captured model in its constructor (class name and equality identity are computed lazily), so registering an index request can no longer repopulate the memo the delete side just purged. The exported package com.liferay.object.entry.util bumps 3.3.0 to 3.4.0.

Evidence: the failing axis clean on two consecutive object-suite runs with the fix, both previously failing log-scan axes clean in aggregate runs including a fully green 60 out of 60, ObjectEntryManagerImplTest 89/0 and ObjectEntryLocalServiceTest 84/0 locally with zero new ERROR logs, and ci:test:relevant regression-checked.

## PR Check

**pr-check: PASS** — tested on `53308b1d0566607d99cf7c3a3a66ea1da32989fc`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Baseline | PASS |
| Per-Module Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "53308b1d0566607d99cf7c3a3a66ea1da32989fc"} -->
