### PR TITLE
LPD-103845 Await the standalone action response before reading its entry

### DIFF
--- a/modules/test/playwright/tests/object-web/action/objectAction.spec.ts
+++ b/modules/test/playwright/tests/object-web/action/objectAction.spec.ts
@@ -2213,24 +2213,30 @@ test.describe('Object Action Standalone Permissions', () => {
 
 			await viewObjectEntriesPage.frontendDatasetActions.click();
 
+			const executeResponsePromise = page.waitForResponse(
+				(response) =>
+					response
+						.url()
+						.includes(`/object-actions/${objectAction.name}`) &&
+					response.request().method() === 'PUT' &&
+					response.ok()
+			);
+
 			await page.getByRole('menuitem', {name: actionLabel}).click();
 
-			// The standalone action runs asynchronously, so poll until the
-			// auto-created entry appears.
+			await executeResponsePromise;
 
-			await expect(async () => {
-				const entries =
-					await apiHelpers.objectEntry.getObjectDefinitionObjectEntriesByScope(
-						applicationName,
-						String(site.id)
-					);
-
-				const autoCreatedEntry = entries.items.find(
-					(item: any) => item[fieldName] === predefinedValue
+			const entries =
+				await apiHelpers.objectEntry.getObjectDefinitionObjectEntriesByScope(
+					applicationName,
+					String(site.id)
 				);
 
-				expect(autoCreatedEntry).toBeTruthy();
-			}).toPass();
+			const autoCreatedEntry = entries.items.find(
+				(item: any) => item[fieldName] === predefinedValue
+			);
+
+			expect(autoCreatedEntry).toBeTruthy();
 		}
 	);
 
@@ -2370,27 +2376,31 @@ test.describe('Object Action Standalone Permissions', () => {
 
 			await viewObjectEntriesPage.frontendDatasetActions.click();
 
+			const executeResponsePromise = page.waitForResponse(
+				(response) =>
+					response.url().includes(`/object-actions/${actionName}`) &&
+					response.request().method() === 'PUT' &&
+					response.ok()
+			);
+
 			await page.getByRole('menuitem', {name: actionLabel}).click();
+
+			await executeResponsePromise;
 
 			await performLogout(page);
 
 			await performLoginViaApi({page, screenName: 'test'});
 
-			// The standalone action runs asynchronously, so poll until the
-			// auto-created entry appears.
-
-			await expect(async () => {
-				const entries =
-					await apiHelpers.objectEntry.getObjectDefinitionObjectEntries(
-						applicationName
-					);
-
-				const autoCreatedEntry = entries.items.find(
-					(item: any) => item[fieldName] === predefinedValue
+			const entries =
+				await apiHelpers.objectEntry.getObjectDefinitionObjectEntries(
+					applicationName
 				);
 
-				expect(autoCreatedEntry).toBeTruthy();
-			}).toPass();
+			const autoCreatedEntry = entries.items.find(
+				(item: any) => item[fieldName] === predefinedValue
+			);
+
+			expect(autoCreatedEntry).toBeTruthy();
 		}
 	);
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103845

## What Is Being Fixed

The ci:test:object playwright test "Can trigger standalone action for site scoped object" intermittently fails in teardown: deleting the standalone action returns a 500 with StaleStateException on "delete from ObjectAction where objectActionId=? and mvccVersion=?" matching zero rows. The test clicks the action without awaiting the trigger request and polls until the auto-created entry appears. The entry becomes visible at the trigger's outer transaction commit, but the action's status bookkeeping write runs in a commit callback after that commit in a new transaction and bumps the row's mvccVersion, so a teardown delete that reads the row in that gap and flushes after it matches nothing. Reproduced deterministically with a backend amplifier; the probe timeline shows the teardown delete reading mvccVersion=0 while the trigger request's own callback commits mvccVersion=1.

## How It Is Being Fixed

Await the effect's own signal: register page.waitForResponse for the execute PUT before the click and await it after. Commit callbacks complete before the response is written, so a 2xx guarantees the status write committed and the auto-created entry exists — the retry poll therefore becomes a single read. The same wait is added to "Can trigger standalone action with permission", which shares the pattern.

Evidence: under the amplifier the unfixed test failed 2 of 2 with the exact CI signature and the fixed test ran 10 of 10 clean with zero StaleStateException across all amplified deletes; self-CI ci:test:object on this content (fork PR #12644) passed both standalone tests with every job failure attributed to known master-side families.

## PR Check

**pr-check: PASS** — tested on `a864b2c4a062f0a0915954fc75d973e5b6666444`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| TypeScript Check | PASS |
| Playwright Listing | PASS |

<!-- pr-check {"result": "success", "sha": "a864b2c4a062f0a0915954fc75d973e5b6666444"} -->
