### PR TITLE
LPD-103860 Assert the documentation links instead of the documentation site

### DIFF
--- a/modules/test/playwright/tests/object-web/field/objectField.spec.ts
+++ b/modules/test/playwright/tests/object-web/field/objectField.spec.ts
@@ -913,17 +913,9 @@ test.describe('Manage object fields through Model Builder', () => {
 
 		await page.getByText('Encrypted', {exact: true}).click();
 
-		const pagePromise = page.waitForEvent('popup');
-
-		await page.getByRole('link', {name: 'Learn more.'}).click();
-
-		const newPage = await pagePromise;
-
 		await expect(
-			newPage.getByRole('heading', {
-				name: 'Localizing Object Definitions',
-			})
-		).toBeVisible();
+			page.getByRole('link', {name: 'Learn more.'})
+		).toHaveAttribute('href', /localizing-object-definitions-and-entries/);
 	});
 
 	test('read only configuration is displayed in the fields advanced tab', async ({
@@ -2374,20 +2366,9 @@ test.describe('Manage objectFields through Objects Admin UI', () => {
 
 		await objectFieldsPage.openObjectField(objectFields[0].label['en_US']);
 
-		const pagePromise = page.waitForEvent('popup');
-
-		await page
-			.frameLocator('iframe')
-			.getByRole('link', {name: 'Learn more.'})
-			.click();
-
-		const newPage = await pagePromise;
-
 		await expect(
-			newPage.getByRole('heading', {
-				name: 'Localizing Object Definitions',
-			})
-		).toBeVisible();
+			page.frameLocator('iframe').getByRole('link', {name: 'Learn more.'})
+		).toHaveAttribute('href', /localizing-object-definitions-and-entries/);
 	});
 });
 

--- a/modules/test/playwright/tests/object-web/relationship/objectRelationship.spec.ts
+++ b/modules/test/playwright/tests/object-web/relationship/objectRelationship.spec.ts
@@ -1412,19 +1412,12 @@ test.describe('Manage object relationships through Model Builder', () => {
 			});
 
 			await test.step('assert that a "Learn more" link is displayed in the warning toast and leads to a learn recource', async () => {
-				const pagePromise = page.waitForEvent('popup');
-
-				await page.getByRole('link', {name: 'Learn more.'}).click();
-
-				const liferayLearnPage = await pagePromise;
-
-				await liferayLearnPage.waitForLoadState();
-
 				await expect(
-					liferayLearnPage.getByRole('heading', {
-						name: 'Accessing Accounts Data from Custom Object',
-					})
-				).toBeVisible();
+					page.getByRole('link', {name: 'Learn more.'})
+				).toHaveAttribute(
+					'href',
+					/accessing-accounts-data-from-custom-objects/
+				);
 			});
 		}
 	);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103860

## What Is Being Fixed

Three object Playwright tests assert the external documentation site instead of the portal's own output: the two "navigates to documentation from the 'unsupported translations' alert link" variants click through to learn.liferay.com and assert the rendered page heading, and the Postal Address relationship test clicks the warning toast's "Learn more." link and asserts the external page's heading. When the documentation site answers slowly, the heading assertion times out and the popup event sometimes never fires, failing ci:test:object on a server nobody in this repository operates. Five unsupported-translations failures and three Postal Address failures landed on 2026-08-26 alone.

## How It Is Being Fixed

The tests' contract is that the alert links to the right documentation, and the link's href is the portal's own observable output for that contract. Each site now asserts the href against the corresponding Learn resource URL and never opens the external site.

## PR Check

**pr-check: PASS** — tested on `a34b7cc2cae8b5d3015104e2710ebecf0169fb44`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

Source Format ran in current-branch mode with commit message validation. The diff is two Playwright spec files under modules/test/playwright, which is not an OSGi or Gradle module, so no compile, baseline, or unit-test validation has a target there; TypeScript compilation and test listing were verified clean on this exact tree, and the commits rode two consecutive fully green ci:test:object aggregate runs (60 out of 60 jobs each) on this same master base.

<!-- pr-check {"result": "success", "sha": "a34b7cc2cae8b5d3015104e2710ebecf0169fb44"} -->
