### PR TITLE
LPD-103836 Rename the model identity to the model type key

### DIFF
--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/buffer/IndexerRequest.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/buffer/IndexerRequest.java
@@ -63,7 +63,7 @@ public class IndexerRequest {
 			  Objects.equals(
 				  _modelPrimaryKey, indexerRequest._modelPrimaryKey))) &&
 			Objects.equals(
-				_getModelIdentity(), indexerRequest._getModelIdentity())) {
+				_getModelTypeKey(), indexerRequest._getModelTypeKey())) {
 
 			return true;
 		}
@@ -86,7 +86,7 @@ public class IndexerRequest {
 	public int hashCode() {
 		int hashCode = HashUtil.hash(0, _method.getName());
 
-		hashCode = HashUtil.hash(hashCode, _getModelIdentity());
+		hashCode = HashUtil.hash(hashCode, _getModelTypeKey());
 
 		return HashUtil.hash(hashCode, _modelPrimaryKey);
 	}
@@ -107,7 +107,7 @@ public class IndexerRequest {
 		return _modelClassName;
 	}
 
-	private Object _getModelIdentity() {
+	private Object _getModelTypeKey() {
 		if (_classedModel == null) {
 			return _modelClassName;
 		}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103836

## What Is Being Fixed

Follow-up to the merged LPD-103836 change, per review on https://github.com/brianchandotcom/liferay-portal/pull/180872#issuecomment-5434322555: `_getModelIdentity` does not say what it means.

## How It Is Being Fixed

Renamed to `_getModelTypeKey`: the method stands in for the model's type in the request's equals and hashCode - the concrete class when a live model is held (deliberately not the model class name, whose read is what the buffered request must avoid) and the class name string for the name-and-primary-key form. The "key" suffix carries why the return type mixes Class and String: the value is only ever used as an equality and hash component.

## PR Check

**pr-check: PASS** — tested on `d8787fc02c8e72078cb8050173b116ddb21e7ca1`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Java Unit Tests | PASS |

Source Format ran in current-branch mode with commit message validation; Per-Module Compile is the portal-search module deploy; Java Unit Tests is the module's unit suite. The rename touches one private method with no API surface, so no baseline or cross-module validation has a target.

<!-- pr-check {"result": "success", "sha": "d8787fc02c8e72078cb8050173b116ddb21e7ca1"} -->
