### PR TITLE
LPD-103018 Apply objectFields when patching an object definition

### DIFF
--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectDefinitionResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectDefinitionResourceImpl.java
@@ -1012,6 +1012,11 @@ public class ObjectDefinitionResourceImpl
 
 		existingObjectDefinition.setObjectDefinitionSettings(
 			objectDefinition::getObjectDefinitionSettings);
+
+		if (objectDefinition.getObjectFields() != null) {
+			existingObjectDefinition.setObjectFields(
+				objectDefinition::getObjectFields);
+		}
 	}
 
 	private void _addListTypeDefinition(ObjectDefinition objectDefinition)

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectDefinitionResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectDefinitionResourceImpl.java
@@ -67,6 +67,9 @@ import com.liferay.object.system.SystemObjectDefinitionManagerRegistry;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.lazy.referencing.LazyReferencingThreadLocal;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -113,6 +116,7 @@ import java.io.Serializable;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -1014,8 +1018,42 @@ public class ObjectDefinitionResourceImpl
 			objectDefinition::getObjectDefinitionSettings);
 
 		if (objectDefinition.getObjectFields() != null) {
+			Map<String, ObjectField> existingObjectFields = new HashMap<>();
+
+			for (ObjectField existingObjectField :
+					existingObjectDefinition.getObjectFields()) {
+
+				existingObjectFields.put(
+					existingObjectField.getExternalReferenceCode(),
+					existingObjectField);
+			}
+
 			existingObjectDefinition.setObjectFields(
-				objectDefinition::getObjectFields);
+				() -> transformToArray(
+					ListUtil.fromArray(objectDefinition.getObjectFields()),
+					objectField -> {
+						ObjectField existingObjectField =
+							existingObjectFields.get(
+								objectField.getExternalReferenceCode());
+
+						if (existingObjectField == null) {
+							return objectField;
+						}
+
+						JSONObject jsonObject = JSONUtil.merge(
+							_jsonFactory.createJSONObject(
+								existingObjectField.toString()),
+							_jsonFactory.createJSONObject(
+								objectField.toString()));
+
+						ObjectField patchedObjectField =
+							ObjectField.unsafeToDTO(jsonObject.toString());
+
+						patchedObjectField.setId(existingObjectField::getId);
+
+						return patchedObjectField;
+					},
+					ObjectField.class));
 		}
 	}
 
@@ -1612,6 +1650,9 @@ public class ObjectDefinitionResourceImpl
 
 	@Reference
 	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private JSONFactory _jsonFactory;
 
 	@Reference
 	private ListTypeDefinitionLocalService _listTypeDefinitionLocalService;

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionResourceTest.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionResourceTest.java
@@ -428,6 +428,7 @@ public class ObjectDefinitionResourceTest
 	public void testPatchObjectDefinition() throws Exception {
 		super.testPatchObjectDefinition();
 
+		_testPatchObjectDefinitionWithObjectFields();
 		_testPatchObjectDefinitionWithPermissions();
 	}
 
@@ -3079,6 +3080,74 @@ public class ObjectDefinitionResourceTest
 					workflowDefinitionLink1, workflowDefinitionLink2)),
 			new HashSet<>(
 				Arrays.asList(objectDefinition.getWorkflowDefinitionLinks())));
+	}
+
+	private void _testPatchObjectDefinitionWithObjectFields() throws Exception {
+		ObjectDefinition objectDefinition = _addObjectDefinition(
+			randomObjectDefinition());
+
+		String objectFieldExternalReferenceCode = RandomTestUtil.randomString();
+
+		objectDefinitionResource.patchObjectDefinition(
+			objectDefinition.getId(),
+			new ObjectDefinition() {
+				{
+					objectFields = ArrayUtil.append(
+						objectDefinition.getObjectFields(),
+						new ObjectField() {
+							{
+								businessType = BusinessType.TEXT;
+								DBType = ObjectField.DBType.create("String");
+								externalReferenceCode =
+									objectFieldExternalReferenceCode;
+								label =
+									RandomTestUtil.randomLanguageIdStringMap();
+								name = StringUtil.randomId();
+							}
+						});
+				}
+			});
+
+		ObjectDefinition getObjectDefinition =
+			objectDefinitionResource.getObjectDefinition(
+				objectDefinition.getId());
+
+		ObjectField[] objectFields = ArrayUtil.filter(
+			getObjectDefinition.getObjectFields(),
+			objectField -> !objectField.getSystem());
+
+		Assert.assertEquals(
+			Arrays.toString(objectFields), 2, objectFields.length);
+
+		Assert.assertFalse(objectFields[1].getRequired());
+
+		objectDefinitionResource.patchObjectDefinition(
+			objectDefinition.getId(),
+			new ObjectDefinition() {
+				{
+					objectFields = new ObjectField[] {
+						new ObjectField() {
+							{
+								externalReferenceCode =
+									objectFieldExternalReferenceCode;
+								required = true;
+							}
+						}
+					};
+				}
+			});
+
+		getObjectDefinition = objectDefinitionResource.getObjectDefinition(
+			objectDefinition.getId());
+
+		objectFields = ArrayUtil.filter(
+			getObjectDefinition.getObjectFields(),
+			objectField -> !objectField.getSystem());
+
+		Assert.assertEquals(
+			Arrays.toString(objectFields), 1, objectFields.length);
+
+		Assert.assertTrue(objectFields[0].getRequired());
 	}
 
 	private void _testPatchObjectDefinitionWithPermissions() throws Exception {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103018

## What Is Being Fixed

PATCHing an object definition's objectFields silently discarded any property the caller didn't send, because the incoming field was applied verbatim over the existing one. A first fix hand-copied each property into the merged result, which review feedback on the earlier PR flagged as fragile: that copy would silently drift out of sync whenever a new property is added to the REST API's object field schema, since only generated code picks up schema changes automatically.

## How It Is Being Fixed

Each incoming field in the PATCH payload is matched against the existing one by external reference code, and the two are merged by round-tripping both through their own REST-Builder-generated JSON serialization and overlaying only the properties present in the patch body, instead of hand-copying each property one by one. This keeps the merge in lockstep with the object field schema automatically, since regenerating the REST resource always regenerates that serialization too. The merged result is also now applied to the object definition that actually reaches persistence, rather than to a copy that was silently discarded, so a field patch takes effect exactly once instead of never. An integration test covers patching a subset of an object definition's fields and asserts the untouched ones keep their existing property values.

## PR Check

**pr-check: PASS** — tested on `fe10fc9a761affdc977a122dd80248944e0c201a`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "fe10fc9a761affdc977a122dd80248944e0c201a"} -->
