### PR TITLE
Revert "LPD-103641 Fix excluding a value from a multiselect picklist filter"

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/field/predicate/provider/MultiselectPicklistFieldPredicateProvider.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/field/predicate/provider/MultiselectPicklistFieldPredicateProvider.java
@@ -40,19 +40,20 @@ public class MultiselectPicklistFieldPredicateProvider
 		Object left, long objectDefinitionId,
 		BinaryExpression.Operation operation, Object right) {
 
-		Expression<String> expression = DSLFunctionFactoryUtil.concat(
-			new Scalar<>(_SCALAR_EXPRESSION),
+		Expression<String> expression =
 			(Expression<String>)objectDefinitionColumnSupplier.apply(
-				String.valueOf(left)),
-			new Scalar<>(_SCALAR_EXPRESSION));
+				String.valueOf(left));
 
 		if (Objects.equals(operation, BinaryExpression.Operation.EQ)) {
+			expression = DSLFunctionFactoryUtil.concat(
+				new Scalar<>(_SCALAR_EXPRESSION), expression,
+				new Scalar<>(_SCALAR_EXPRESSION));
+
 			return expression.like(
 				_getFieldValueExpression(String.valueOf(right), null));
 		}
 		else if (Objects.equals(operation, BinaryExpression.Operation.NE)) {
-			return expression.notLike(
-				_getFieldValueExpression(String.valueOf(right), null));
+			return expression.neq(String.valueOf(right));
 		}
 
 		throw new UnsupportedOperationException(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -7068,17 +7068,17 @@ public class ObjectEntryResourceTest {
 				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
 				RandomTestUtil.randomString(), RandomTestUtil.randomString()));
 		_assertFilteredObjectEntries(
-			0,
+			2,
 			String.format(
 				"%s/any(k:k ne '%s')", _OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
 				_LIST_TYPE_ENTRY_KEY_1));
 		_assertFilteredObjectEntries(
-			1,
+			3,
 			String.format(
 				"%s/any(k:k ne '%s')", _OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
 				_LIST_TYPE_ENTRY_KEY_2));
 		_assertFilteredObjectEntries(
-			2,
+			3,
 			String.format(
 				"%s/any(k:k ne '%s')", _OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
 				_LIST_TYPE_ENTRY_KEY_3));
@@ -7087,24 +7087,6 @@ public class ObjectEntryResourceTest {
 			String.format(
 				"%s/any(k:k ne '%s')", _OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
 				RandomTestUtil.randomString()));
-		_assertFilteredObjectEntries(
-			0,
-			String.format(
-				"%s/any(k:(k ne '%s') and (k ne '%s'))",
-				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST, _LIST_TYPE_ENTRY_KEY_1,
-				_LIST_TYPE_ENTRY_KEY_2));
-		_assertFilteredObjectEntries(
-			1,
-			String.format(
-				"%s/any(k:(k ne '%s') and (k ne '%s'))",
-				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST, _LIST_TYPE_ENTRY_KEY_2,
-				_LIST_TYPE_ENTRY_KEY_3));
-		_assertFilteredObjectEntries(
-			3,
-			String.format(
-				"%s/any(k:(k ne '%s') and (k ne '%s'))",
-				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
-				RandomTestUtil.randomString(), RandomTestUtil.randomString()));
 		_assertFilteredObjectEntries(
 			3,
 			String.format(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103641

## What Is Being Fixed

Since 4835a9fba3ac5e021825c422d1f071f4771fadec merged, every ci:test:object run fails the same two ObjectEntryResourceTest methods deterministically. Three consecutive baseline runs on three different master tips, while the last tip without the commit was clean of them:

- https://test-1-47.liferay.com/job/test-portal-acceptance-pullrequest-downstream(master)/155023/testReport/com.liferay.object.rest.internal.resource.v1_0.test/ObjectEntryResourceTest
- https://test-1-42.liferay.com/job/test-portal-acceptance-pullrequest-downstream(master)/177557/testReport/com.liferay.object.rest.internal.resource.v1_0.test/ObjectEntryResourceTest
- https://test-1-47.liferay.com/job/test-portal-acceptance-pullrequest-downstream(master)/155037/testReport/com.liferay.object.rest.internal.resource.v1_0.test/ObjectEntryResourceTest

Failing in all three:

- `testGetObjectEntryFilteredByMultiselectPicklistObjectField` (the method the commit itself updated)
- `testFilterByLambdaOperatorsObjectEntriesByRelatedObjectEntriesFields`

## How It Is Being Fixed

Plain revert. Two independent problems need rework rather than a patch:

1. `testFilterByLambdaOperatorsObjectEntriesByRelatedObjectEntriesFields` still asserts the old behavior: the related entry holds the filtered key, so under the new semantics `any(k:k ne '<key>')` no longer returns it, and that method's expectations were not updated.
2. The new operator maps `any(k:k ne 'x')` to "x is not among the elements", which is `all(k:k ne 'x')` semantics; and the delimited match diverges across databases for entries with no value in the column - MySQL CONCAT of a NULL column yields NULL (row excluded) while PostgreSQL CONCAT ignores NULL arguments and yields ',,' (row included). The failing CI axis is PostgreSQL.

cc @antonio-ortega - the exclusion bug the original commit addresses is real and worth refixing; the CI failures above are the concrete rework targets.

## PR Check

**pr-check: PASS** — tested on `0bfe1ac1f73c1c50dc4ee4033d26a19e63b25fe1`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

Per-Module Compile ran ant compile install-portal-snapshots plus the object-rest-impl compile; Integration Test Compile is the object-rest-test testIntegration compile. The change is a pure revert of one merged commit.

<!-- pr-check {"result": "success", "sha": "0bfe1ac1f73c1c50dc4ee4033d26a19e63b25fe1"} -->
