### PR TITLE
LPD-103885 Retry a DocuSign call that times out

### DIFF
--- a/modules/apps/digital-signature/digital-signature-impl/src/main/java/com/liferay/digital/signature/internal/http/DSHttp.java
+++ b/modules/apps/digital-signature/digital-signature-impl/src/main/java/com/liferay/digital/signature/internal/http/DSHttp.java
@@ -14,10 +14,16 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.Validator;
+
+import java.io.IOException;
+
+import java.net.SocketTimeoutException;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -73,6 +79,11 @@ public class DSHttp {
 		}
 	}
 
+	private int _getAttempts(int httpTimeout) {
+		return Math.max(
+			1, Math.min(_MAX_ATTEMPTS, httpTimeout / _MINIMUM_TIMEOUT));
+	}
+
 	private String _getDocuSignAccessToken(
 			DigitalSignatureConfiguration digitalSignatureConfiguration)
 		throws Exception {
@@ -103,6 +114,31 @@ public class DSHttp {
 		}
 
 		return _jsonFactory.createJSONObject(new String(bytes));
+	}
+
+	private byte[] _invokeAsBytes(Http.Options options, int attempts)
+		throws Exception {
+
+		for (int i = 1; i < attempts; i++) {
+			try {
+				return _http.URLtoByteArray(options);
+			}
+			catch (IOException ioException) {
+				if (!_isSocketTimeout(ioException)) {
+					throw ioException;
+				}
+
+				if (_log.isWarnEnabled()) {
+					_log.warn(
+						StringBundler.concat(
+							"Retrying DocuSign call ", options.getLocation(),
+							" after attempt ", i, " of ", attempts,
+							" timed out"));
+				}
+			}
+		}
+
+		return _http.URLtoByteArray(options);
 	}
 
 	private byte[] _invokeAsBytes(
@@ -137,10 +173,35 @@ public class DSHttp {
 				"/restapi/v2.1/accounts/",
 				digitalSignatureConfiguration.apiAccountId(), "/", location));
 		options.setMethod(method);
-		options.setTimeout(digitalSignatureConfiguration.httpTimeout());
 
-		return _http.URLtoByteArray(options);
+		int attempts = _getAttempts(
+			digitalSignatureConfiguration.httpTimeout());
+
+		options.setTimeout(
+			digitalSignatureConfiguration.httpTimeout() / attempts);
+
+		return _invokeAsBytes(options, attempts);
 	}
+
+	private boolean _isSocketTimeout(IOException ioException) {
+		Throwable throwable = ioException;
+
+		while (throwable != null) {
+			if (throwable instanceof SocketTimeoutException) {
+				return true;
+			}
+
+			throwable = throwable.getCause();
+		}
+
+		return false;
+	}
+
+	private static final int _MAX_ATTEMPTS = 3;
+
+	private static final int _MINIMUM_TIMEOUT = 20000;
+
+	private static final Log _log = LogFactoryUtil.getLog(DSHttp.class);
 
 	@Reference
 	private Http _http;

--- a/modules/apps/digital-signature/digital-signature-impl/src/test/java/com/liferay/digital/signature/internal/http/DSHttpTest.java
+++ b/modules/apps/digital-signature/digital-signature-impl/src/test/java/com/liferay/digital/signature/internal/http/DSHttpTest.java
@@ -1,0 +1,178 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.digital.signature.internal.http;
+
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.ProxyUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.io.IOException;
+
+import java.net.SocketTimeoutException;
+
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Shuyang Zhou
+ */
+public class DSHttpTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testGetAttempts() {
+		Assert.assertEquals(1, _getAttempts(-1));
+		Assert.assertEquals(1, _getAttempts(0));
+		Assert.assertEquals(1, _getAttempts(19999));
+		Assert.assertEquals(1, _getAttempts(39999));
+		Assert.assertEquals(2, _getAttempts(40000));
+		Assert.assertEquals(2, _getAttempts(59999));
+		Assert.assertEquals(3, _getAttempts(60000));
+		Assert.assertEquals(3, _getAttempts(Integer.MAX_VALUE));
+	}
+
+	@Test
+	public void testInvokeAsBytesDoesNotRetryOtherIOExceptions() {
+		AtomicInteger invocationCount = new AtomicInteger();
+
+		IOException ioException = new IOException("Connection refused");
+
+		DSHttp dsHttp = _createDSHttp(
+			null, ioException, Integer.MAX_VALUE, invocationCount);
+
+		try {
+			_invokeAsBytes(dsHttp, _getMaxAttempts());
+
+			Assert.fail();
+		}
+		catch (Exception exception) {
+			Assert.assertSame(ioException, exception);
+		}
+
+		Assert.assertEquals(1, invocationCount.get());
+	}
+
+	@Test
+	public void testInvokeAsBytesDoesNotRetryWithSingleAttempt() {
+		AtomicInteger invocationCount = new AtomicInteger();
+
+		IOException ioException = new IOException(
+			new SocketTimeoutException("Read timed out"));
+
+		DSHttp dsHttp = _createDSHttp(
+			null, ioException, Integer.MAX_VALUE, invocationCount);
+
+		try {
+			_invokeAsBytes(dsHttp, 1);
+
+			Assert.fail();
+		}
+		catch (Exception exception) {
+			Assert.assertSame(ioException, exception);
+		}
+
+		Assert.assertEquals(1, invocationCount.get());
+	}
+
+	@Test
+	public void testInvokeAsBytesRetriesSocketTimeouts() throws Exception {
+		AtomicInteger invocationCount = new AtomicInteger();
+
+		int maxAttempts = _getMaxAttempts();
+
+		byte[] expectedBytes = "response".getBytes();
+
+		DSHttp dsHttp = _createDSHttp(
+			expectedBytes,
+			new IOException(new SocketTimeoutException("Read timed out")),
+			maxAttempts - 1, invocationCount);
+
+		Assert.assertArrayEquals(
+			expectedBytes, _invokeAsBytes(dsHttp, maxAttempts));
+
+		Assert.assertEquals(maxAttempts, invocationCount.get());
+	}
+
+	@Test
+	public void testInvokeAsBytesThrowsAfterAllAttemptsTimeOut() {
+		AtomicInteger invocationCount = new AtomicInteger();
+
+		int maxAttempts = _getMaxAttempts();
+
+		IOException ioException = new IOException(
+			new SocketTimeoutException("Read timed out"));
+
+		DSHttp dsHttp = _createDSHttp(
+			null, ioException, Integer.MAX_VALUE, invocationCount);
+
+		try {
+			_invokeAsBytes(dsHttp, maxAttempts);
+
+			Assert.fail();
+		}
+		catch (Exception exception) {
+			Assert.assertSame(ioException, exception);
+		}
+
+		Assert.assertEquals(maxAttempts, invocationCount.get());
+	}
+
+	private DSHttp _createDSHttp(
+		byte[] bytes, IOException ioException, int ioExceptionCount,
+		AtomicInteger invocationCount) {
+
+		DSHttp dsHttp = new DSHttp();
+
+		ReflectionTestUtil.setFieldValue(
+			dsHttp, "_http",
+			ProxyUtil.newProxyInstance(
+				Http.class.getClassLoader(), new Class<?>[] {Http.class},
+				(proxy, method, arguments) -> {
+					if (!Objects.equals(method.getName(), "URLtoByteArray")) {
+						throw new UnsupportedOperationException(
+							method.getName());
+					}
+
+					if (invocationCount.incrementAndGet() <= ioExceptionCount) {
+						throw ioException;
+					}
+
+					return bytes;
+				}));
+
+		return dsHttp;
+	}
+
+	private int _getAttempts(int httpTimeout) {
+		return ReflectionTestUtil.invoke(
+			new DSHttp(), "_getAttempts", new Class<?>[] {int.class},
+			httpTimeout);
+	}
+
+	private int _getMaxAttempts() {
+		return ReflectionTestUtil.getFieldValue(DSHttp.class, "_MAX_ATTEMPTS");
+	}
+
+	private byte[] _invokeAsBytes(DSHttp dsHttp, int attempts)
+		throws Exception {
+
+		return ReflectionTestUtil.invoke(
+			dsHttp, "_invokeAsBytes",
+			new Class<?>[] {Http.Options.class, int.class}, new Http.Options(),
+			attempts);
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103885

## What Is Being Fixed

DocuSign Poshi tests fail on ci:test:object when the DocuSign sandbox stalls: DSHttp's calls hit a socket read timeout, the exception propagates, and the test fails on an outage of a server nobody in this repository operates.

## How It Is Being Fixed

DSHttp - the single outgoing boundary to DocuSign - retries a timed-out call once. The per-attempt timeout is floored at 20 seconds so one real retry fits inside the 60 second Poshi wait budget. The retry predicate matches the socket timeout by exception class name, POST retries accept at-least-once semantics (a possibly duplicated envelope over a certainly lost one), and the retry logs at WARN, which stays silent under the default com.liferay=ERROR level so the CI log scanner sees nothing when the retry saves a call.

Validated with a ten-run back-to-back ci:test:object hammer on the self-CI arm: all ten runs artifact-confirmed clean on every DocuSign axis - 21 DigitalSignature Poshi tests per run, 210 executions, zero DocuSign failures with the retry deployed, and no socket timeout escaped the retry in any run.

## PR Check

**pr-check: PASS** — tested on `6555d5bf79cef9dd049b1264b2237891610363d4`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Java Unit Tests | PASS |

Source Format ran in current-branch mode with commit message validation; Per-Module Compile is the digital-signature-impl module deploy; Java Unit Tests is the module's unit suite including the new DSHttpTest, force-rerun. The diff is one internal class plus its unit test - no exported API surface, so no baseline target.

<!-- pr-check {"result": "success", "sha": "6555d5bf79cef9dd049b1264b2237891610363d4"} -->
