### PR TITLE
LPD-103887 Wait for the definition save before reading the new separator URL

### DIFF
--- a/modules/test/playwright/tests/object-web/entry/objectEntry.spec.ts
+++ b/modules/test/playwright/tests/object-web/entry/objectEntry.spec.ts
@@ -1583,7 +1583,7 @@ test.describe('Manage object entries through Friendly URL', () => {
 
 			await editObjectDetailsPage.saveObjectDefinition();
 
-			await page.waitForLoadState('networkidle');
+			await waitForAlert(page, 'The object was saved successfully');
 
 			await page.goto(
 				`/web${site.friendlyUrlPath}/${newObjectFriendlyURLSeparator}/` +


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103887

## What Is Being Fixed

The object entry friendly URL Playwright test intermittently fails at its last step: it changes the object definition's entry URL separator, saves, and loads the entry under the new separator, but the entry never renders. Three baseline sightings, including both ci:test:object baseline runs on 2026-08-27.

## How It Is Being Fixed

The save is a bare click followed by a networkidle wait, and network idleness can be satisfied in the gap before the save request has even started - so the navigation races the save and reads a separator the definition never received. The step now waits on the save's own success alert, which renders only after the update response is written, i.e. after the change is committed. The wait sits at this call site rather than in the shared save helper, because a helper-level wait was already tried and regressed ten callers that click Save in states which produce no alert.

Validated by a same-day natural A/B: the test failed in both baseline runs on unfixed master and passed in this branch's self-CI ci:test:object run, whose only test-failing job was a known unrelated flake (artifact-confirmed).

## PR Check

**pr-check: PASS** — tested on `5d4f5fe1497cef764a0f776348804369c3e88780`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

Source Format ran in current-branch mode with commit message validation. The diff is one Playwright spec file under modules/test/playwright, which is not an OSGi or Gradle module, so no compile, baseline, or unit-test validation has a target; TypeScript compilation and test listing were verified clean on this exact tree.

<!-- pr-check {"result": "success", "sha": "5d4f5fe1497cef764a0f776348804369c3e88780"} -->
