### PR TITLE
LPD-103923 Scope the Salesforce tests to the rows this run owns

### DIFF
--- a/modules/apps/object/object-storage-salesforce-test/src/testIntegration/java/com/liferay/object/storage/salesforce/internal/rest/manager/v1_0/test/SalesforceObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-storage-salesforce-test/src/testIntegration/java/com/liferay/object/storage/salesforce/internal/rest/manager/v1_0/test/SalesforceObjectEntryManagerImplTest.java
@@ -141,6 +141,8 @@ public class SalesforceObjectEntryManagerImplTest
 	public void setUp() throws Exception {
 		super.setUp();
 
+		_runId = RandomTestUtil.randomInt();
+
 		listTypeDefinition =
 			listTypeDefinitionLocalService.addListTypeDefinition(
 				"Status", TestPropsValues.getUserId(),
@@ -209,9 +211,9 @@ public class SalesforceObjectEntryManagerImplTest
 					).userId(
 						adminUser.getUserId()
 					).labelMap(
-						LocalizedMapUtil.getLocalizedMap("Object Definition ID")
+						LocalizedMapUtil.getLocalizedMap("Run ID")
 					).name(
-						"objectDefinitionId"
+						"runId"
 					).build(),
 					new DateTimeObjectFieldBuilder(
 					).externalReferenceCode(
@@ -373,8 +375,7 @@ public class SalesforceObjectEntryManagerImplTest
 			objectEntry1);
 
 		String filterString = StringBundler.concat(
-			"(objectDefinitionId eq ",
-			_objectDefinition.getObjectDefinitionId(), ") and ");
+			"(runId eq ", _runId, ") and ");
 
 		testGetObjectEntries(
 			HashMapBuilder.put(
@@ -641,8 +642,7 @@ public class SalesforceObjectEntryManagerImplTest
 					).put(
 						"flagged", flagged
 					).put(
-						"objectDefinitionId",
-						_objectDefinition.getObjectDefinitionId()
+						"runId", _runId
 					).put(
 						"startDate", startDate
 					).put(
@@ -709,5 +709,7 @@ public class SalesforceObjectEntryManagerImplTest
 
 	@Inject
 	private ObjectFieldSettingLocalService _objectFieldSettingLocalService;
+
+	private long _runId;
 
 }

--- a/modules/apps/object/object-storage-salesforce-test/src/testIntegration/java/com/liferay/object/storage/salesforce/internal/rest/manager/v1_0/test/SalesforceObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-storage-salesforce-test/src/testIntegration/java/com/liferay/object/storage/salesforce/internal/rest/manager/v1_0/test/SalesforceObjectEntryManagerImplTest.java
@@ -374,18 +374,13 @@ public class SalesforceObjectEntryManagerImplTest
 			).build(),
 			objectEntry1);
 
-		String filterString = StringBundler.concat(
-			"(runId eq ", _runId, ") and ");
-
 		testGetObjectEntries(
 			HashMapBuilder.put(
 				"filter",
 				StringBundler.concat(
-					filterString, "(",
 					buildEqualsExpressionFilterString("customStatus", "queued"),
 					" and ", buildEqualsExpressionFilterString("dueDate", date),
-					" and ", buildEqualsExpressionFilterString("title", title1),
-					")")
+					" and ", buildEqualsExpressionFilterString("title", title1))
 			).build(),
 			objectEntry1);
 
@@ -393,13 +388,12 @@ public class SalesforceObjectEntryManagerImplTest
 			HashMapBuilder.put(
 				"filter",
 				StringBundler.concat(
-					filterString, "(",
 					_buildNotEqualsExpressionFilterString(
 						"customStatus", "queued"),
 					" and ",
 					_buildNotEqualsExpressionFilterString("dueDate", date),
 					" and ",
-					_buildNotEqualsExpressionFilterString("title", title1), ")")
+					_buildNotEqualsExpressionFilterString("title", title1))
 			).build(),
 			objectEntry2, objectEntry3);
 
@@ -407,11 +401,9 @@ public class SalesforceObjectEntryManagerImplTest
 			HashMapBuilder.put(
 				"filter",
 				StringBundler.concat(
-					filterString, "(",
 					buildEqualsExpressionFilterString("customStatus", "queued"),
 					" or ", buildEqualsExpressionFilterString("dueDate", date),
-					" or ", buildEqualsExpressionFilterString("title", title1),
-					")")
+					" or ", buildEqualsExpressionFilterString("title", title1))
 			).build(),
 			objectEntry1, objectEntry4, objectEntry5);
 
@@ -419,13 +411,12 @@ public class SalesforceObjectEntryManagerImplTest
 			HashMapBuilder.put(
 				"filter",
 				StringBundler.concat(
-					filterString, "(",
 					_buildNotEqualsExpressionFilterString(
 						"customStatus", "queued"),
 					" or ",
 					_buildNotEqualsExpressionFilterString("dueDate", date),
 					" or ",
-					_buildNotEqualsExpressionFilterString("title", title1), ")")
+					_buildNotEqualsExpressionFilterString("title", title1))
 			).build(),
 			objectEntry2, objectEntry3, objectEntry4, objectEntry5);
 
@@ -440,10 +431,9 @@ public class SalesforceObjectEntryManagerImplTest
 		testGetObjectEntries(
 			HashMapBuilder.put(
 				"filter",
-				filterString.concat(
-					StringBundler.concat(
-						"startDate ne ", dateTimeString1, " or startDate eq ",
-						dateTimeString2))
+				StringBundler.concat(
+					"startDate ne ", dateTimeString1, " or startDate eq ",
+					dateTimeString2)
 			).build(),
 			objectEntry1, objectEntry3, objectEntry4, objectEntry5);
 
@@ -452,41 +442,32 @@ public class SalesforceObjectEntryManagerImplTest
 		testGetObjectEntries(
 			HashMapBuilder.put(
 				"filter",
-				filterString.concat(
-					buildEqualsExpressionFilterString("customStatus", "queued"))
+				buildEqualsExpressionFilterString("customStatus", "queued")
 			).build(),
 			objectEntry1, objectEntry4, objectEntry5);
 
 		testGetObjectEntries(
 			HashMapBuilder.put(
 				"filter",
-				filterString.concat(
-					_buildNotEqualsExpressionFilterString(
-						"customStatus", "queued"))
+				_buildNotEqualsExpressionFilterString("customStatus", "queued")
 			).build(),
 			objectEntry2, objectEntry3);
 
 		testGetObjectEntries(
 			HashMapBuilder.put(
-				"filter",
-				filterString.concat(
-					buildEqualsExpressionFilterString("dueDate", date))
+				"filter", buildEqualsExpressionFilterString("dueDate", date)
 			).build(),
 			objectEntry1, objectEntry4, objectEntry5);
 
 		testGetObjectEntries(
 			HashMapBuilder.put(
-				"filter",
-				filterString.concat(
-					_buildNotEqualsExpressionFilterString("dueDate", date))
+				"filter", _buildNotEqualsExpressionFilterString("dueDate", date)
 			).build(),
 			objectEntry2, objectEntry3);
 
 		testGetObjectEntries(
 			HashMapBuilder.put(
-				"filter",
-				filterString.concat(
-					buildEqualsExpressionFilterString("flagged", true))
+				"filter", buildEqualsExpressionFilterString("flagged", true)
 			).build(),
 			objectEntry2, objectEntry4);
 
@@ -500,25 +481,20 @@ public class SalesforceObjectEntryManagerImplTest
 		testGetObjectEntries(
 			HashMapBuilder.put(
 				"filter",
-				filterString.concat(
-					_buildNotEqualsExpressionFilterString(
-						"startDate", localDateTime2))
+				_buildNotEqualsExpressionFilterString(
+					"startDate", localDateTime2)
 			).build(),
 			objectEntry1, objectEntry2, objectEntry4, objectEntry5);
 
 		testGetObjectEntries(
 			HashMapBuilder.put(
-				"filter",
-				filterString.concat(
-					buildEqualsExpressionFilterString("title", title1))
+				"filter", buildEqualsExpressionFilterString("title", title1)
 			).build(),
 			objectEntry1);
 
 		testGetObjectEntries(
 			HashMapBuilder.put(
-				"filter",
-				filterString.concat(
-					_buildNotEqualsExpressionFilterString("title", title1))
+				"filter", _buildNotEqualsExpressionFilterString("title", title1)
 			).build(),
 			objectEntry2, objectEntry3, objectEntry4, objectEntry5);
 
@@ -537,25 +513,25 @@ public class SalesforceObjectEntryManagerImplTest
 
 		testGetObjectEntries(
 			HashMapBuilder.put(
-				"filter", filterString.concat("startDate ge " + dateTimeString1)
+				"filter", "startDate ge " + dateTimeString1
 			).build(),
 			objectEntry2, objectEntry3);
 
 		testGetObjectEntries(
 			HashMapBuilder.put(
-				"filter", filterString.concat("startDate gt " + dateTimeString1)
+				"filter", "startDate gt " + dateTimeString1
 			).build(),
 			objectEntry3);
 
 		testGetObjectEntries(
 			HashMapBuilder.put(
-				"filter", filterString.concat("startDate le " + dateTimeString2)
+				"filter", "startDate le " + dateTimeString2
 			).build(),
 			objectEntry2, objectEntry3);
 
 		testGetObjectEntries(
 			HashMapBuilder.put(
-				"filter", filterString.concat("startDate lt " + dateTimeString2)
+				"filter", "startDate lt " + dateTimeString2
 			).build(),
 			objectEntry2);
 	}
@@ -608,8 +584,8 @@ public class SalesforceObjectEntryManagerImplTest
 
 		return _objectEntryManager.getObjectEntries(
 			companyId, _objectDefinition, null, null, dtoConverterContext,
-			context.get("filter"), Pagination.of(1, 4), context.get("search"),
-			sorts);
+			_buildRunFilterString(context.get("filter")), Pagination.of(1, 4),
+			context.get("search"), sorts);
 	}
 
 	private ObjectEntry _addObjectEntry(
@@ -680,6 +656,15 @@ public class SalesforceObjectEntryManagerImplTest
 		String fieldName, Object value) {
 
 		return StringBundler.concat(fieldName, " ne ", getValue(value));
+	}
+
+	private String _buildRunFilterString(String filterString) {
+		if (filterString == null) {
+			return "runId eq " + _runId;
+		}
+
+		return StringBundler.concat(
+			"(runId eq ", _runId, ") and (", filterString, ")");
 	}
 
 	private ObjectFieldSetting _createObjectFieldSetting(

--- a/modules/apps/object/object-storage-salesforce-test/src/testIntegration/java/com/liferay/object/storage/salesforce/internal/rest/manager/v1_0/test/SalesforceObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-storage-salesforce-test/src/testIntegration/java/com/liferay/object/storage/salesforce/internal/rest/manager/v1_0/test/SalesforceObjectEntryManagerImplTest.java
@@ -536,14 +536,14 @@ public class SalesforceObjectEntryManagerImplTest
 
 	@Test
 	public void testGetObjectEntry() throws Exception {
+		String description = "<p>" + RandomTestUtil.randomString() + "</p>";
 		String title = RandomTestUtil.randomString();
 
 		ObjectEntry objectEntry = _addObjectEntry(
-			null, "<p>Description</p>", null, false, null, title);
+			null, description, null, false, null, title);
 
 		_assertObjectEntry(
-			"<p>Description</p>", objectEntry.getExternalReferenceCode(),
-			title);
+			description, objectEntry.getExternalReferenceCode(), title);
 	}
 
 	@Test
@@ -552,23 +552,25 @@ public class SalesforceObjectEntryManagerImplTest
 			null, RandomTestUtil.randomString(), null, false, null,
 			RandomTestUtil.randomString());
 
+		String description = "<p>" + RandomTestUtil.randomString() + "</p>";
+		String title = RandomTestUtil.randomString();
+
 		_objectEntryManager.partialUpdateObjectEntry(
 			TestPropsValues.getCompanyId(), dtoConverterContext,
 			objectEntry.getExternalReferenceCode(), _objectDefinition,
 			new ObjectEntry() {
 				{
 					properties = HashMapBuilder.<String, Object>put(
-						"description", "<p>Description</p>"
+						"description", description
 					).put(
-						"title", "Able"
+						"title", title
 					).build();
 				}
 			},
 			null);
 
 		_assertObjectEntry(
-			"<p>Description</p>", objectEntry.getExternalReferenceCode(),
-			"Able");
+			description, objectEntry.getExternalReferenceCode(), title);
 	}
 
 	@Override

--- a/modules/apps/object/object-storage-salesforce-test/src/testIntegration/java/com/liferay/object/storage/salesforce/internal/rest/manager/v1_0/test/SalesforceObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-storage-salesforce-test/src/testIntegration/java/com/liferay/object/storage/salesforce/internal/rest/manager/v1_0/test/SalesforceObjectEntryManagerImplTest.java
@@ -57,11 +57,9 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
-import java.util.List;
 import java.util.Map;
 
 import org.junit.After;
@@ -277,6 +275,8 @@ public class SalesforceObjectEntryManagerImplTest
 		catch (ObjectEntryManagerHttpException
 					objectEntryManagerHttpException) {
 
+			_assumeSkipped = true;
+
 			Assume.assumeNoException(
 				"Unable to authenticate with Salesforce",
 				objectEntryManagerHttpException);
@@ -285,21 +285,19 @@ public class SalesforceObjectEntryManagerImplTest
 
 	@After
 	public void tearDown() throws Exception {
-		for (ObjectEntry objectEntry : _objectEntries) {
-			_objectEntryManager.deleteObjectEntry(
-				companyId, dtoConverterContext,
-				objectEntry.getExternalReferenceCode(), _objectDefinition,
-				ObjectDefinitionConstants.SCOPE_COMPANY);
+		try {
+			_deleteObjectEntries();
 		}
+		finally {
+			if (_objectDefinition != null) {
+				objectDefinitionLocalService.deleteObjectDefinition(
+					_objectDefinition.getObjectDefinitionId());
+			}
 
-		if (_objectDefinition != null) {
-			objectDefinitionLocalService.deleteObjectDefinition(
-				_objectDefinition.getObjectDefinitionId());
-		}
-
-		if (listTypeDefinition != null) {
-			listTypeDefinitionLocalService.deleteListTypeDefinition(
-				listTypeDefinition.getListTypeDefinitionId());
+			if (listTypeDefinition != null) {
+				listTypeDefinitionLocalService.deleteListTypeDefinition(
+					listTypeDefinition.getListTypeDefinitionId());
+			}
 		}
 	}
 
@@ -603,7 +601,7 @@ public class SalesforceObjectEntryManagerImplTest
 			boolean flagged, LocalDateTime startDate, String title)
 		throws Exception {
 
-		ObjectEntry objectEntry = _objectEntryManager.addObjectEntry(
+		return _objectEntryManager.addObjectEntry(
 			dtoConverterContext, _objectDefinition,
 			new ObjectEntry() {
 				{
@@ -627,10 +625,6 @@ public class SalesforceObjectEntryManagerImplTest
 				}
 			},
 			ObjectDefinitionConstants.SCOPE_COMPANY);
-
-		_objectEntries.add(objectEntry);
-
-		return objectEntry;
 	}
 
 	private void _assertObjectEntry(
@@ -679,13 +673,30 @@ public class SalesforceObjectEntryManagerImplTest
 		return objectFieldSetting;
 	}
 
+	private void _deleteObjectEntries() throws Exception {
+		if (_assumeSkipped) {
+			return;
+		}
+
+		Page<ObjectEntry> page = _objectEntryManager.getObjectEntries(
+			companyId, _objectDefinition, null, null, dtoConverterContext,
+			_buildRunFilterString(null), Pagination.of(1, 200), null, null);
+
+		for (ObjectEntry objectEntry : page.getItems()) {
+			_objectEntryManager.deleteObjectEntry(
+				companyId, dtoConverterContext,
+				objectEntry.getExternalReferenceCode(), _objectDefinition,
+				ObjectDefinitionConstants.SCOPE_COMPANY);
+		}
+	}
+
 	@Inject
 	private static ConfigurationProvider _configurationProvider;
 
 	private static DateFormat _simpleDateFormat;
 
+	private boolean _assumeSkipped;
 	private ObjectDefinition _objectDefinition;
-	private final List<ObjectEntry> _objectEntries = new ArrayList<>();
 
 	@Inject(
 		filter = "object.entry.manager.storage.type=" + ObjectDefinitionConstants.STORAGE_TYPE_SALESFORCE

--- a/modules/test/playwright/tests/object-web/salesforce/objectSalesforce.spec.ts
+++ b/modules/test/playwright/tests/object-web/salesforce/objectSalesforce.spec.ts
@@ -18,6 +18,7 @@ import {objectPagesTest} from '../../../fixtures/objectPagesTest';
 import {pageEditorPagesTest} from '../../../fixtures/pageEditorPagesTest';
 import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
 import getRandomString from '../../../utils/getRandomString';
+import {normalizeRestPath} from '../../../utils/normalizeRestPath';
 import {waitForAlert} from '../../../utils/waitForAlert';
 import getFormContainerDefinition from '../../layout-content-page-editor-web/main/utils/getFormContainerDefinition';
 import getPageDefinition from '../../layout-content-page-editor-web/main/utils/getPageDefinition';
@@ -40,6 +41,46 @@ const test = mergeTests(
 	objectPagesTest,
 	pageEditorPagesTest
 );
+
+const createdSalesforceObjectEntries = [] as {
+	applicationName: string;
+	objectFieldValues: string[];
+}[];
+
+test.afterEach(async ({apiHelpers}) => {
+	for (const {
+		applicationName,
+		objectFieldValues,
+	} of createdSalesforceObjectEntries) {
+		try {
+			const {items} =
+				await apiHelpers.objectEntry.getObjectDefinitionObjectEntries(
+					applicationName,
+					new URLSearchParams({
+						filter: objectFieldValues
+							.map(
+								(objectFieldValue) =>
+									`title eq '${objectFieldValue}'`
+							)
+							.join(' or '),
+					})
+				);
+
+			for (const {externalReferenceCode} of items ?? []) {
+				await apiHelpers.delete(
+					`${apiHelpers.baseUrl}${applicationName}/by-external-reference-code/${externalReferenceCode}`
+				);
+			}
+		}
+		catch (error) {
+			console.error(
+				`Unable to delete the Salesforce object entries: ${error}`
+			);
+		}
+	}
+
+	createdSalesforceObjectEntries.length = 0;
+});
 
 test.beforeEach(async ({apiHelpers, instanceSettingsPage, page}) => {
 	test.skip(
@@ -148,6 +189,11 @@ test('Assert CRUD with created custom object using Salesforce storage type', asy
 
 	const objectFieldValue = getRandomString();
 	const objectFieldUpdatedValue = getRandomString();
+
+	createdSalesforceObjectEntries.push({
+		applicationName: normalizeRestPath(objectDefinition.restContextPath!),
+		objectFieldValues: [objectFieldValue, objectFieldUpdatedValue],
+	});
 
 	await test.step('Create Object Entry', async () => {
 		await viewObjectEntriesPage.goto(objectDefinition.className);
@@ -297,6 +343,11 @@ test('Assert CRUD with created custom object using Salesforce storage type in fo
 	});
 
 	const entryValue = getRandomString();
+
+	createdSalesforceObjectEntries.push({
+		applicationName: normalizeRestPath(objectDefinition.restContextPath!),
+		objectFieldValues: [entryValue],
+	});
 
 	await test.step('Submit an entry via the published form', async () => {
 		await page.goto(`/web${site.friendlyUrlPath}${layout.friendlyUrlPath}`);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103923

## What Is Being Fixed

Both Salesforce test surfaces share one sandbox org, and the storage manager adds no scope of its own - the caller's filter is the only partition and the asserted counts are global. The Java integration test tagged its rows with the object definition id, which identically seeded CI databases mint identically, so concurrent runs and rows stranded by dead runs collide; four of its twenty reads carried no scope at all or leaked it through OR precedence; its teardown deleted from an in-memory list that structurally misses a row whose post succeeded but whose read-back failed. The Playwright spec's only row cleanup was the last UI step of each test, so any earlier failure stranded rows in the shared sobject forever - the accumulated strays are what used to fill page one of every later run's entry list.

## How It Is Being Fixed

Five commits: a random per-run token replaces the definition id as the row tag; every read is scoped at the single override all reads pass through, wrapping the caller's filter as (runId eq token) and (filter); the teardown's delete list comes from the org by that token inside a try/finally, short-circuited when the authentication probe converted its failure into a skip so credential-less environments keep skipping cleanly; the fixed literal payloads become random; and the Playwright spec registers each test's run-unique titles and deletes the matching rows by external reference code in an afterEach, which gets a fresh timeout slot and runs before the fixture teardown that would strand them.

## PR Check

**pr-check: PASS** — tested on `abe0c5f19910e407807268a29f2076c4377fc3df`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |

Source Format ran in current-branch mode with commit message validation; Integration Test Compile is the object-storage-salesforce-test testIntegration compile. The Playwright half was verified with TypeScript compilation and test listing; the diff touches only test sources, so no baseline or unit-test validation has a target. Four consecutive ci:test:object self-CI runs had every branch-owned test clean, the last on these exact commits (35 owned results, 0 failures).

<!-- pr-check {"result": "success", "sha": "abe0c5f19910e407807268a29f2076c4377fc3df"} -->
