### PR TITLE
LPD-103931 Bind the Digital Signature tests to envelopes this run owns

### DIFF
--- a/modules/apps/digital-signature/digital-signature-test/src/testFunctional/macros/DigitalSignature.macro
+++ b/modules/apps/digital-signature/digital-signature-test/src/testFunctional/macros/DigitalSignature.macro
@@ -302,9 +302,11 @@ definition {
 	}
 
 	@summary = "Default summary"
-	macro enabledDigitalSignatureDownload(documentName = null) {
+	macro enabledDigitalSignatureDownload(envelopeName = null) {
+		DigitalSignature.waitForEnvelope(envelopeName = ${envelopeName});
+
 		Click(
-			envelopeName = ${documentName},
+			envelopeName = ${envelopeName},
 			locator1 = "DigitalSignatureListView#DIGITAL_SIGNATURE_ENVELOPE_NAME");
 
 		AssertElementPresent(locator1 = "DigitalSignatureListView#DIGITAL_SIGNATURE_DOWNLOAD_BUTTON");
@@ -458,18 +460,22 @@ definition {
 	}
 
 	@summary = "Default summary"
-	macro viewEnabledDownload(documentName = null) {
+	macro viewEnabledDownload(envelopeName = null) {
+		DigitalSignature.waitForEnvelope(envelopeName = ${envelopeName});
+
 		Click(
-			envelopeName = ${documentName},
+			envelopeName = ${envelopeName},
 			locator1 = "DigitalSignatureListView#DIGITAL_SIGNATURE_ELLIPSIS_BUTTON");
 
 		AssertElementPresent(locator1 = "DigitalSignatureListView#DIGITAL_SIGNATURE_DOWNLOAD_BY_LIST");
 	}
 
 	@summary = "Default summary"
-	macro viewEnvelopeDetails(documentName = null) {
+	macro viewEnvelopeDetails(envelopeName = null) {
+		DigitalSignature.waitForEnvelope(envelopeName = ${envelopeName});
+
 		Click(
-			envelopeName = ${documentName},
+			envelopeName = ${envelopeName},
 			locator1 = "DigitalSignatureListView#DIGITAL_SIGNATURE_ENVELOPE_NAME");
 
 		AssertElementPresent(locator1 = "DigitalSignatureListView#DIGITAL_SIGNATURE_ENVELOPE_ID");

--- a/modules/apps/digital-signature/digital-signature-test/src/testFunctional/macros/DigitalSignature.macro
+++ b/modules/apps/digital-signature/digital-signature-test/src/testFunctional/macros/DigitalSignature.macro
@@ -446,20 +446,6 @@ definition {
 	}
 
 	@summary = "Default summary"
-	macro viewDigitalSignatureEnabled(dsStatus = null) {
-		AssertElementPresent(
-			dsStatus = ${dsStatus},
-			locator1 = "DigitalSignatureListView#DIGITAL_SIGNATURE_STATUS");
-	}
-
-	@summary = "Default summary"
-	macro viewDigitalSignaturestatus(viewStatus = null) {
-		AssertElementPresent(
-			dsStatus = ${viewStatus},
-			locator1 = "DigitalSignatureListView#DIGITAL_SIGNATURE_STATUS");
-	}
-
-	@summary = "Default summary"
 	macro viewEnabledDownload(envelopeName = null) {
 		DigitalSignature.waitForEnvelope(envelopeName = ${envelopeName});
 
@@ -492,6 +478,16 @@ definition {
 		AssertElementNotPresent(
 			envelopeName = ${envelopeName},
 			locator1 = "DigitalSignatureListView#DIGITAL_SIGNATURE_ENVELOPE_NAME");
+	}
+
+	@summary = "Default summary"
+	macro viewEnvelopeStatus(dsStatus = null, envelopeName = null) {
+		DigitalSignature.waitForEnvelope(envelopeName = ${envelopeName});
+
+		AssertElementPresent(
+			dsStatus = ${dsStatus},
+			envelopeName = ${envelopeName},
+			locator1 = "DigitalSignatureListView#DIGITAL_SIGNATURE_ENVELOPE_STATUS");
 	}
 
 	@summary = "Default summary"

--- a/modules/apps/digital-signature/digital-signature-test/src/testFunctional/macros/DigitalSignature.macro
+++ b/modules/apps/digital-signature/digital-signature-test/src/testFunctional/macros/DigitalSignature.macro
@@ -272,19 +272,20 @@ definition {
 
 	@summary = "Default summary"
 	macro deleteEnvelope(envelopeName = null) {
-		DigitalSignature.waitForListViewLoad();
-
-		Refresh();
+		DigitalSignature.waitForEnvelope(envelopeName = ${envelopeName});
 
 		Click(
-			key_text = ${envelopeName},
-			locator1 = "Link#ANY");
+			envelopeName = ${envelopeName},
+			locator1 = "DigitalSignatureListView#DIGITAL_SIGNATURE_ENVELOPE_NAME");
 
-		AssertElementPresent(locator1 = "TextInput#HIDDEN");
+		DigitalSignature.deleteEnvelopeFromView();
+	}
 
-		DigitalSignature.waitForListViewLoad();
+	@summary = "Default summary"
+	macro deleteEnvelopeFromView() {
+		AssertElementPresent(locator1 = "DigitalSignatureListView#DIGITAL_SIGNATURE_ENVELOPE_DELETE_URL");
 
-		var value = selenium.getElementValue("TextInput#HIDDEN");
+		var value = selenium.getElementValue("DigitalSignatureListView#DIGITAL_SIGNATURE_ENVELOPE_DELETE_URL");
 
 		Navigator.openSpecificURL(url = ${value});
 	}
@@ -511,6 +512,21 @@ definition {
 		AssertElementPresent(
 			fileTitle = ${documentTitle},
 			locator1 = "DigitalSignatureEnvelopeSettings#DIGITAL_SIGNATURE_MODAL_UNSUPPORTED_FILE");
+	}
+
+	@summary = "Default summary"
+	macro waitForEnvelope(envelopeName = null) {
+		DigitalSignature.waitForListViewLoad();
+
+		while ((IsElementNotPresent(envelopeName = ${envelopeName}, locator1 = "DigitalSignatureListView#DIGITAL_SIGNATURE_ENVELOPE_NAME")) && (maxIterations = "10")) {
+			Refresh();
+
+			DigitalSignature.waitForListViewLoad();
+		}
+
+		AssertElementPresent(
+			envelopeName = ${envelopeName},
+			locator1 = "DigitalSignatureListView#DIGITAL_SIGNATURE_ENVELOPE_NAME");
 	}
 
 	@summary = "Default summary"

--- a/modules/apps/digital-signature/digital-signature-test/src/testFunctional/paths/DigitalSignatureListView.path
+++ b/modules/apps/digital-signature/digital-signature-test/src/testFunctional/paths/DigitalSignatureListView.path
@@ -11,8 +11,8 @@
 
 <tbody>
 <tr>
-	<td>DIGITAL_SIGNATURE_STATUS</td>
-	<td>//span[contains(@class,'label-item') and contains(.,'${dsStatus}')]</td>
+	<td>DIGITAL_SIGNATURE_ENVELOPE_STATUS</td>
+	<td>//tr[.//a[normalize-space(.) = '${envelopeName}']]//span[contains(@class, 'label-item') and contains(., '${dsStatus}')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/modules/apps/digital-signature/digital-signature-test/src/testFunctional/paths/DigitalSignatureListView.path
+++ b/modules/apps/digital-signature/digital-signature-test/src/testFunctional/paths/DigitalSignatureListView.path
@@ -41,6 +41,11 @@
 	<td></td>
 </tr>
 <tr>
+	<td>DIGITAL_SIGNATURE_ENVELOPE_DELETE_URL</td>
+	<td>//div[contains(@class, 'envelope-view')]//input[@type = 'hidden']</td>
+	<td></td>
+</tr>
+<tr>
 	<td>DIGITAL_SIGNATURE_ADD_RECIPIENT</td>
 	<td>//button[contains(@class, 'mb-4 btn btn-unstyled')]</td>
 	<td></td>
@@ -57,7 +62,7 @@
 </tr>
 <tr>
 	<td>DIGITAL_SIGNATURE_ENVELOPE_NAME</td>
-	<td>//a[contains(., '${envelopeName}')]</td>
+	<td>//a[normalize-space(.) = '${envelopeName}']</td>
 	<td></td>
 </tr>
 <tr>
@@ -67,12 +72,12 @@
 </tr>
 <tr>
 	<td>DIGITAL_SIGNATURE_ELLIPSIS_BUTTON</td>
-	<td>//tr[contains(@class, '') and contains(., '${envelopeName}')]//button[contains(@class, 'dropdown')]</td>
+	<td>//tr[.//a[normalize-space(.) = '${envelopeName}']]//button[contains(@class, 'dropdown')]</td>
 	<td></td>
 </tr>
 <tr>
 	<td>DIGITAL_SIGNATURE_DOWNLOAD_BY_LIST</td>
-	<td>//button[contains(., 'Download')]</td>
+	<td>//div[contains(@class, 'dropdown-menu')]//button[contains(., 'Download')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/modules/apps/digital-signature/digital-signature-test/src/testFunctional/tests/DigitalSignatureEnvelopeSettings.testcase
+++ b/modules/apps/digital-signature/digital-signature-test/src/testFunctional/tests/DigitalSignatureEnvelopeSettings.testcase
@@ -40,12 +40,16 @@ definition {
 	@description = "LPS-133105. Verify if its possible add more than 1 valid documents in a new Envelope"
 	@priority = 5
 	test CanAddMoreThan1Document {
+		var randomString = StringUtil.randomString(8);
+
+		var envelopeName = "Poshi Test CanAddMoreThan1Document ${randomString}";
+
 		task ("When a digital envelope is created with more than 1 valid document") {
 			DigitalSignature.createEnvelopeWithTwoDocuments(
 				addEmail = "test@liferay.com",
 				addFullName = "Recipient Full Name",
 				addMessage = "Email Message",
-				addName = "Poshi Test CanAddMoreThan1Document",
+				addName = ${envelopeName},
 				addSubject = "Email Subject");
 
 			Button.click(button = "Send");
@@ -54,7 +58,7 @@ definition {
 		task ("Then a message appears that the envelope was successfully created") {
 			Alert.viewSuccessMessageText(successMessage = "Your envelope was created successfully.");
 
-			DigitalSignature.deleteEnvelope(envelopeName = "Poshi Test CanAddMoreThan1Document");
+			DigitalSignature.deleteEnvelope(envelopeName = ${envelopeName});
 
 			DigitalSignature.deleteCreatedDM();
 
@@ -139,6 +143,8 @@ definition {
 	test CannotCreateEnvelopeWithUnsupportedFiles {
 		property solutions.acceptance = "true";
 
+		var randomString = StringUtil.randomString(8);
+
 		task ("When a Digital Envelope is created with an unsupported file type attached") {
 			Navigator.openURL();
 
@@ -146,7 +152,7 @@ definition {
 				addEmail = "test@liferay.com",
 				addFullName = "Recipient Full Name",
 				addMessage = "Email Message",
-				addName = "Poshi Test CannotCreateEnvelopeWithUnsupportedFiles",
+				addName = "Poshi Test CannotCreateEnvelopeWithUnsupportedFiles ${randomString}",
 				addSubject = "Email Subject",
 				dmDocumentFile = "Document_2.mp4");
 		}
@@ -185,12 +191,16 @@ definition {
 	test CanViewSuccessMessage {
 		property solutions.acceptance = "true";
 
+		var randomString = StringUtil.randomString(8);
+
+		var envelopeName = "Poshi Test CanViewSuccessMessage ${randomString}";
+
 		task ("When a digital envelope is created") {
 			DigitalSignature.createEnvelope(
 				addEmail = "test@liferay.com",
 				addFullName = "Recipient Full Name",
 				addMessage = "Email Message",
-				addName = "Poshi Test CanViewSuccessMessage",
+				addName = ${envelopeName},
 				addSubject = "Email Subject",
 				dmDocumentFile = "Alice's Adventures in Wonderland.pdf");
 
@@ -200,9 +210,7 @@ definition {
 		task ("Then a message appears that the envelope was successfully created") {
 			Alert.viewSuccessMessageText(successMessage = "Your envelope was created successfully.");
 
-			Refresh();
-
-			DigitalSignature.deleteEnvelope(envelopeName = "Poshi Test CanViewSuccessMessage");
+			DigitalSignature.deleteEnvelope(envelopeName = ${envelopeName});
 
 			DigitalSignature.deleteCreatedDM();
 

--- a/modules/apps/digital-signature/digital-signature-test/src/testFunctional/tests/DigitalSignatureListView.testcase
+++ b/modules/apps/digital-signature/digital-signature-test/src/testFunctional/tests/DigitalSignatureListView.testcase
@@ -40,12 +40,16 @@ definition {
 	@description = "LPS-131206. Verify if its possible download envelopes by Envelope Description "
 	@priority = 3
 	test CanDownloadEnvelopeByEnvelopeDescription {
+		var randomString = StringUtil.randomString(8);
+
+		var envelopeName = "Poshi Test CanDownloadEnvelopeByEnvelopeDescription ${randomString}";
+
 		task ("Given a digital signature envelope is created") {
 			DigitalSignature.createEnvelope(
 				addEmail = "test@liferay.com",
 				addFullName = "Recipient Full Name",
 				addMessage = "Email Message",
-				addName = "Test",
+				addName = ${envelopeName},
 				addSubject = "Email Subject",
 				dmDocumentFile = "Alice's Adventures in Wonderland.pdf");
 
@@ -63,13 +67,43 @@ definition {
 		}
 
 		task ("Then the digital signature's envelope can be downloaded") {
-			DigitalSignature.enabledDigitalSignatureDownload(documentName = "Test");
+			DigitalSignature.enabledDigitalSignatureDownload(envelopeName = ${envelopeName});
+		}
+
+		task ("Clean up the envelope and the document") {
+			DigitalSignature.deleteEnvelopeFromView();
+
+			DMNavigator.openDocumentsAndMediaAdmin(siteURLKey = "guest");
+
+			DMDocument.deleteCP(dmDocumentTitle = "DM Document Title");
+
+			RecycleBin.openRecycleBinAdmin(siteURLKey = "guest");
+
+			RecycleBin.emptyCP();
 		}
 	}
 
 	@description = "LPS-131206. Verify if its possible download envelopes by Envelope List"
 	@priority = 3
 	test CanDownloadEnvelopeByEnvelopeList {
+		var randomString = StringUtil.randomString(8);
+
+		var envelopeName = "Poshi Test CanDownloadEnvelopeByEnvelopeList ${randomString}";
+
+		task ("Given a digital signature envelope is created") {
+			DigitalSignature.createEnvelope(
+				addEmail = "test@liferay.com",
+				addFullName = "Recipient Full Name",
+				addMessage = "Email Message",
+				addName = ${envelopeName},
+				addSubject = "Email Subject",
+				dmDocumentFile = "Alice's Adventures in Wonderland.pdf");
+
+			Button.click(button = "Send");
+
+			Alert.viewSuccessMessageText(successMessage = "Your envelope was created successfully.");
+		}
+
 		task ("When a User Test Goes to Envelope List") {
 			Navigator.openURL();
 
@@ -79,13 +113,29 @@ definition {
 		}
 
 		task ("Then the digital signature can be downloaded") {
-			DigitalSignature.viewEnabledDownload(documentName = "Test");
+			DigitalSignature.viewEnabledDownload(envelopeName = ${envelopeName});
+		}
+
+		task ("Clean up the envelope and the document") {
+			DigitalSignature.deleteEnvelope(envelopeName = ${envelopeName});
+
+			DMNavigator.openDocumentsAndMediaAdmin(siteURLKey = "guest");
+
+			DMDocument.deleteCP(dmDocumentTitle = "DM Document Title");
+
+			RecycleBin.openRecycleBinAdmin(siteURLKey = "guest");
+
+			RecycleBin.emptyCP();
 		}
 	}
 
 	@description = "LPS-131206. Verify if is possible navigate between pages"
 	@priority = 3
 	test CanNavigateBetweenPages {
+		var randomString = StringUtil.randomString(8);
+
+		var envelopeNamePrefix = "Poshi Test CanNavigateBetweenPages ${randomString}";
+
 		task ("Given more envelopes exist than one page holds") {
 			DigitalSignature.addDMDocument(dmDocumentFile = "Alice's Adventures in Wonderland.pdf");
 
@@ -94,7 +144,7 @@ definition {
 					addEmail = "test@liferay.com",
 					addFullName = "Recipient Full Name",
 					addMessage = "Email Message",
-					addName = "Poshi Test CanNavigateBetweenPages ${envelopeNumber}",
+					addName = "${envelopeNamePrefix} ${envelopeNumber}",
 					addSubject = "Email Subject");
 
 				Button.click(button = "Send");
@@ -120,10 +170,10 @@ definition {
 		}
 
 		task ("Clean up the envelopes and the document") {
-			DigitalSignature.selectItemsPerPage(itemsPerPage = 20);
+			DigitalSignature.selectItemsPerPage(itemsPerPage = 60);
 
 			for (var envelopeNumber : list "1,2,3,4,5") {
-				DigitalSignature.deleteEnvelope(envelopeName = "Poshi Test CanNavigateBetweenPages ${envelopeNumber}");
+				DigitalSignature.deleteEnvelope(envelopeName = "${envelopeNamePrefix} ${envelopeNumber}");
 			}
 
 			DigitalSignature.deleteCreatedDM();
@@ -150,8 +200,6 @@ definition {
 		}
 
 		task ("Then the date the digital signature was created is shown") {
-			Refresh();
-
 			DigitalSignature.viewCreateDate(envelopeName = ${envelopeName});
 
 			DigitalSignature.deleteEnvelope(envelopeName = ${envelopeName});
@@ -169,6 +217,24 @@ definition {
 	@description = "LPS-131206. Verify if its possible view envelope details"
 	@priority = 4
 	test CanViewEnvelopeDetails {
+		var randomString = StringUtil.randomString(8);
+
+		var envelopeName = "Poshi Test CanViewEnvelopeDetails ${randomString}";
+
+		task ("Given a digital signature envelope is created") {
+			DigitalSignature.createEnvelope(
+				addEmail = "test@liferay.com",
+				addFullName = "Recipient Full Name",
+				addMessage = "Email Message",
+				addName = ${envelopeName},
+				addSubject = "Email Subject",
+				dmDocumentFile = "Alice's Adventures in Wonderland.pdf");
+
+			Button.click(button = "Send");
+
+			Alert.viewSuccessMessageText(successMessage = "Your envelope was created successfully.");
+		}
+
 		task ("When a User Test Goes to Digital Signature") {
 			Navigator.openURL();
 
@@ -178,7 +244,19 @@ definition {
 		}
 
 		task ("Then you can see details of the envelope") {
-			DigitalSignature.viewEnvelopeDetails(documentName = "Test");
+			DigitalSignature.viewEnvelopeDetails(envelopeName = ${envelopeName});
+		}
+
+		task ("Clean up the envelope and the document") {
+			DigitalSignature.deleteEnvelopeFromView();
+
+			DMNavigator.openDocumentsAndMediaAdmin(siteURLKey = "guest");
+
+			DMDocument.deleteCP(dmDocumentTitle = "DM Document Title");
+
+			RecycleBin.openRecycleBinAdmin(siteURLKey = "guest");
+
+			RecycleBin.emptyCP();
 		}
 	}
 
@@ -222,10 +300,6 @@ definition {
 		}
 
 		task ("Then the user can see that an envelope have more than one recipient on list") {
-			DigitalSignature.waitForListViewLoad();
-
-			Refresh();
-
 			DigitalSignature.viewMoreRecipient(envelopeName = ${envelopeName});
 
 			DigitalSignature.deleteEnvelope(envelopeName = ${envelopeName});

--- a/modules/apps/digital-signature/digital-signature-test/src/testFunctional/tests/DigitalSignatureListView.testcase
+++ b/modules/apps/digital-signature/digital-signature-test/src/testFunctional/tests/DigitalSignatureListView.testcase
@@ -183,7 +183,9 @@ definition {
 	@description = "LPS-131206. Verify if the Create Date column shows the date correctly after created one envelope in local Timezone "
 	@priority = 4
 	test CanViewCorrectDate {
-		var envelopeName = "Poshi Test CanViewCorrectDate ${StringUtil.randomString(8)}";
+		var randomString = StringUtil.randomString(8);
+
+		var envelopeName = "Poshi Test CanViewCorrectDate ${randomString}";
 
 		task ("When a digital envelope is created") {
 			DigitalSignature.createEnvelope(
@@ -311,7 +313,9 @@ definition {
 	@description = "LPS-131206. Verify if is possible view on list when an envelope have more recipients than one"
 	@priority = 4
 	test HaveMoreRecipientsThanOne {
-		var envelopeName = "Poshi Test HaveMoreRecipientsThanOne ${StringUtil.randomString(8)}";
+		var randomString = StringUtil.randomString(8);
+
+		var envelopeName = "Poshi Test HaveMoreRecipientsThanOne ${randomString}";
 
 		task ("Given a digital envelope is created") {
 			DigitalSignature.createEnvelope(

--- a/modules/apps/digital-signature/digital-signature-test/src/testFunctional/tests/DigitalSignatureListView.testcase
+++ b/modules/apps/digital-signature/digital-signature-test/src/testFunctional/tests/DigitalSignatureListView.testcase
@@ -263,6 +263,24 @@ definition {
 	@description = "LPS-131206. Verify if Digital Signature can be enabled"
 	@priority = 5
 	test DigitalSignatureCanBeEnabled {
+		var randomString = StringUtil.randomString(8);
+
+		var envelopeName = "Poshi Test DigitalSignatureCanBeEnabled ${randomString}";
+
+		task ("Given a digital signature envelope is created") {
+			DigitalSignature.createEnvelope(
+				addEmail = "test@liferay.com",
+				addFullName = "Recipient Full Name",
+				addMessage = "Email Message",
+				addName = ${envelopeName},
+				addSubject = "Email Subject",
+				dmDocumentFile = "Alice's Adventures in Wonderland.pdf");
+
+			Button.click(button = "Send");
+
+			Alert.viewSuccessMessageText(successMessage = "Your envelope was created successfully.");
+		}
+
 		task ("When a User Test Goes to Digital Signature") {
 			Navigator.openURL();
 
@@ -272,7 +290,21 @@ definition {
 		}
 
 		task ("Then the status is checked") {
-			DigitalSignature.viewDigitalSignaturestatus(viewStatus = "Sent");
+			DigitalSignature.viewEnvelopeStatus(
+				dsStatus = "Sent",
+				envelopeName = ${envelopeName});
+		}
+
+		task ("Clean up the envelope and the document") {
+			DigitalSignature.deleteEnvelope(envelopeName = ${envelopeName});
+
+			DMNavigator.openDocumentsAndMediaAdmin(siteURLKey = "guest");
+
+			DMDocument.deleteCP(dmDocumentTitle = "DM Document Title");
+
+			RecycleBin.openRecycleBinAdmin(siteURLKey = "guest");
+
+			RecycleBin.emptyCP();
 		}
 	}
 

--- a/modules/apps/digital-signature/digital-signature-test/src/testFunctional/tests/DigitalSignatureSiteSettings.testcase
+++ b/modules/apps/digital-signature/digital-signature-test/src/testFunctional/tests/DigitalSignatureSiteSettings.testcase
@@ -38,6 +38,10 @@ definition {
 	test CanEnableDigitalSignatureBySiteSettings {
 		property portal.release = "quarantine";
 
+		var randomString = StringUtil.randomString(8);
+
+		var envelopeName = "Poshi Test CanEnableDigitalSignatureBySiteSettings ${randomString}";
+
 		task ("Given that the digital signature site strategy is set as 'Always Override'") {
 			DigitalSignature.selectSiteStrategy(siteStrategy = "Always Override");
 
@@ -57,15 +61,31 @@ definition {
 				addEmail = "test@liferay.com",
 				addFullName = "Recipient Full Name",
 				addMessage = "Email Message",
-				addName = "Poshi Test CannotCreateEnvelopeWithUnsupportedFiles",
+				addName = ${envelopeName},
 				addSubject = "Email Subject",
 				dmDocumentFile = "Document_2.docx");
 
 			Button.click(button = "Send");
+
+			Alert.viewSuccessMessageText(successMessage = "Your envelope was created successfully.");
 		}
 
 		task ("Then the user can see that digital signature can be enabled using the Always Override strategy") {
-			DigitalSignature.viewDigitalSignatureEnabled(dsStatus = "Sent");
+			DigitalSignature.viewEnvelopeStatus(
+				dsStatus = "Sent",
+				envelopeName = ${envelopeName});
+		}
+
+		task ("Clean up the envelope and the document") {
+			DigitalSignature.deleteEnvelope(envelopeName = ${envelopeName});
+
+			DMNavigator.openDocumentsAndMediaAdmin(siteURLKey = "guest");
+
+			DMDocument.deleteCP(dmDocumentTitle = "DM Document Title");
+
+			RecycleBin.openRecycleBinAdmin(siteURLKey = "guest");
+
+			RecycleBin.emptyCP();
 		}
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103931

## What Is Being Fixed

Every CI run farm-wide shares one DocuSign sandbox account, so the envelope list any test reads is global and concurrent runs see each other's envelopes. The Digital Signature Poshi tests created envelopes under fixed literal names and then found, read, and deleted them by matching the first row with that name - a row that could belong to any concurrent run or to an envelope stranded by a dead one. The randomization the tests appeared to have was a silent no-op: an in-string ${StringUtil.randomString(8)} inside a quoted Poshi variable is never evaluated - the substitution engine only replaces defined-variable tokens - so the names stayed literal and identical across every run. The site-settings test also read the envelope list immediately after clicking Send with no wait on the send's effect, failing whenever the asynchronous submit paid the cold OAuth token fetch.

## How It Is Being Fixed

Five commits: delete and find an envelope through its own row rather than the first name match, reading the delete URL the envelope view carries; give each list view test its own envelope; bind the envelope status reads to an owned row and wait for the envelope-created success alert after Send so the status read has an effect signal; name the envelope settings tests' envelopes per run; and evaluate the random suffix the envelope names never got by assigning the random string to its own variable before composing the name.

## PR Check

**pr-check: PASS** — tested on `837918aaee0da6d765c3415c569fa789484aa5ac`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Poshi Syntax | PASS |

Source Format ran in current-branch mode with commit message validation; Poshi Syntax is the full run-poshi-validation pass. The diff touches only Poshi test sources, so no compile, baseline, or unit-test validation has a target. Three consecutive ci:test:object self-CI runs field-proved the changes: the run artifacts show locators carrying concrete evaluated random names, the send-wait fix passed in the final run, and that run's only remaining Digital Signature failure was afterward root-caused from its portal log to a pre-existing product defect: the envelope view's resource command resolves the DocuSign configuration with the company group while every sibling command uses the site group, so site-scope-only credentials yield a blank configuration and the envelope read fails composing its URL (Host name may not be null; born in LPS-133206). A separate one-line fix is in flight.

<!-- pr-check {"result": "success", "sha": "837918aaee0da6d765c3415c569fa789484aa5ac"} -->

