### PR TITLE
LPD-103932 Deploy a portlet inline when a request waits on it

### DIFF
--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-tracker/src/main/java/com/liferay/portal/osgi/web/portlet/tracker/internal/osgi/util/tracker/PortletTracker.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-tracker/src/main/java/com/liferay/portal/osgi/web/portlet/tracker/internal/osgi/util/tracker/PortletTracker.java
@@ -39,6 +39,7 @@ import com.liferay.portal.kernel.portlet.LiferayWindowState;
 import com.liferay.portal.kernel.portlet.PortletIdCodec;
 import com.liferay.portal.kernel.portlet.PortletInstanceFactory;
 import com.liferay.portal.kernel.security.auth.CompanyInheritableThreadLocalCallable;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.security.permission.ResourceActions;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.PortletLocalService;
@@ -187,7 +188,7 @@ public class PortletTracker
 						return addedPortletModel;
 					}));
 
-		if (_parallel &&
+		if (_parallel && Validator.isNull(PrincipalThreadLocal.getName()) &&
 			GetterUtil.getBoolean(
 				serviceReference.getProperty(
 					"com.liferay.portlet.deploy.parallel"),


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103932

## What Is Being Fixed

Publishing an object definition redeploys its portlet synchronously, but PortletTracker defers all portlet processing - including the panel-category placement the add-widget panel reads - to the system executor once the database is warm (LPS-199018 parallelized deployment for startup speed). The update response therefore returns before the category tree contains the widget, and a user or test that opens the add-widget panel right after saving sees an empty or stale widget list. On CI this surfaced repeatedly as the Object Widget test finding no widget after publishing a definition.

## How It Is Being Fixed

Deploy a portlet inline when a request waits on it. The dispatch condition additionally requires an empty principal on the current thread: a named principal means the tracker is running on an application-server worker thread serving an authenticated request - object definition publishing being the canonical case - and that request needs the portlet fully placed before it responds. Background threads carry no principal, so every startup deployment keeps the parallel path. Instrumented boots across three flavors (cold, warm restart, warm database) measured hundreds of startup dispatches with zero named principals - startup parallelism is untouched - while the request-path deployment carries the publishing user's principal and now runs inline. The asymmetry is safe by construction: a background thread that somehow carried a principal would only pay a few milliseconds of serialization, while a request thread misclassified as background is impossible for deployments that require authentication.

## PR Check

**pr-check: PASS** — tested on `3f592fcca226394c4e4bec6de342a2738e41e820`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |

Source Format ran in current-branch mode with commit message validation; the change is one condition in an internal package with no exported-API, bnd, or dependency change, so no baseline or unit-test validation has a target. Self-CI on the fork: ci:test:stable passed 10 of 10 jobs and ci:test:relevant reported zero failures unique to the pull - each failed job was verified from the run artifacts to be pre-existing upstream change-tracking test debt (CTSQLTransformerTest classNameId drift, the over-2000-entry CT publish failure and its log-assertor echo, a session-factory verification) or build infrastructure.

<!-- pr-check {"result": "success", "sha": "3f592fcca226394c4e4bec6de342a2738e41e820"} -->
