### PR TITLE
LPD-103633 Fix the OpenSearch content compression test compilation

### DIFF
--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/connection/OpenSearchConnectionContentCompressionTest.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/connection/OpenSearchConnectionContentCompressionTest.java
@@ -71,7 +71,7 @@ public class OpenSearchConnectionContentCompressionTest {
 
 	@Test
 	public void testConnectWithCompressionEnabled() throws Exception {
-		_testConnect(true, _GZIP);
+		_testConnect(true, _ENCODING_GZIP);
 	}
 
 	private String _getCountJSON() {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103633

Quick follow-up to https://github.com/liferay-search/liferay-portal/pull/2167

https://github.com/brianchandotcom/liferay-portal/commit/cfcbe2a64fef152d015a9efebd954f2e491c342a changed a variable name but missed 1 instance
