### PR TITLE
LPD-103978 Keep the class name when its object definition is deleted

### DIFF
--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionLocalService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionLocalService.java
@@ -532,4 +532,4 @@ public interface ObjectDefinitionLocalService
 		throws PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-393345724
+// LIFERAY-SERVICE-BUILDER-HASH:-2069780434

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -141,7 +141,6 @@ import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.mass.delete.MassDeleteCacheThreadLocal;
-import com.liferay.portal.kernel.model.ClassName;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.SystemEventConstants;
@@ -727,14 +726,6 @@ public class ObjectDefinitionLocalServiceImpl
 			_dropTable(objectDefinition.getLocalizationDBTableName());
 
 			undeployObjectDefinition(objectDefinition);
-
-			// undeployObjectDefinition calls _invalidatePortalCache which calls
-			// _classNameLocalService#getClassNameId
-
-			ClassName className = _classNameLocalService.getClassName(
-				objectDefinition.getClassName());
-
-			_classNameLocalService.deleteClassName(className);
 
 			_registerTransactionCallbackForCluster(
 				_undeployObjectDefinitionMethodKey, objectDefinition);

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
@@ -2659,7 +2659,7 @@ public class ObjectDefinitionLocalServiceTest {
 		_objectDefinitionLocalService.deleteObjectDefinition(
 			objectDefinition.getObjectDefinitionId());
 
-		Assert.assertNull(
+		Assert.assertNotNull(
 			_classNameLocalService.fetchByClassNameId(
 				className.getClassNameId()));
 

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
@@ -668,6 +668,7 @@ public class DataGuardTestRuleUtil {
 
 	private static final Set<String> _blacklistedModelClassNames =
 		SetUtil.fromArray(
+			"com.liferay.portal.kernel.model.ClassName",
 			"com.liferay.portal.security.audit.storage.model.AuditEvent");
 	private static final ThreadLocal<Map<String, Map<Serializable, String>>>
 		_records = new ThreadLocal<>();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103978

## What Is Being Fixed

A class name row is an identity that has been issued. The table interns a model class name to give it a numeric identity, and DBInspector groups it with counter and resourceaction as a partitioned control table: identities are handed out monotonically, and the row is what keeps an issued one resolvable. Other tables store that identity by number, so deleting the row does not release a name, it strands every reference that already captured the number.

Deleting an object definition did exactly that, and it was the only runtime caller that recycled instead of issuing - a full run of the object integration suite performs about 4,500 class name deletions and every one comes from that call site. The deletion also sat in the middle of the definition's own removal, before the entity was removed and before its model listeners ran, so a consumer resolving the name afterwards republished the row it could still read and left the shared pool answering with an identity whose row was about to vanish. Instrumenting every pool mutation across a full run and replaying the operation order showed 99 values ending with the pool holding a binding whose row was deleted, all of them custom object definition class names, and 92 of the 99 entered through the company deletion cascade - the very cleanup the deletion was added to serve.

The consequence is product-wide, not test-only: the portal log assertor has failed its last 40 executions across nine different suites on the message that a class name id cannot be resolved, and the display page administration went blank on the same cause and had to grow null handling across nine of its own call sites.

The deletion was added so that a leftover class name row would stop failing the company service tests, on a ticket spun off from a test-infrastructure change that had reordered the test rule's own deletions. Fixing it in the tests was raised at the time and discarded.

## How It Is Being Fixed

Stop reporting class names as leftover test data, the way audit events already are, and keep the class name when its object definition is deleted; the test that asserted the row was gone now asserts it survives. The third commit is the pure regeneration the hand edit required, because the generated interface carries a hash computed over the implementation source.

## PR Check

**pr-check: PASS** — tested on `15eb02acf4c60ec4f25dda2ffd17b55c41fafede`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

Source Format ran in current-branch mode with commit message validation; Service Builder was re-run after the rebase and the committed regeneration still matches its output exactly. Self-CI on the fork: **ci:test:relevant 37/37 and ci:test:stable 10/10** on an uncached build - 8,590 results, 8,483 passed, 107 skipped, zero non-passed, including both build-services regeneration checks. The company service tests that the deleted behaviour was added for all pass with it removed. On ci:test:object the test name set is identical to two pure baselines of the same master, all 44 portal log assertor executions pass, and the two failures are a chronic foreign cover (LPD-103632) and a friendly-URL race fixed by LPD-103887, which was absent from this branch and has since merged.

<!-- pr-check {"result": "success", "sha": "15eb02acf4c60ec4f25dda2ffd17b55c41fafede"} -->
