### PR TITLE
LPD-103885 Retry a DocuSign call that times out

### DIFF
--- a/modules/apps/digital-signature/digital-signature-impl/src/main/java/com/liferay/digital/signature/internal/http/DSHttp.java
+++ b/modules/apps/digital-signature/digital-signature-impl/src/main/java/com/liferay/digital/signature/internal/http/DSHttp.java
@@ -8,16 +8,21 @@ package com.liferay.digital.signature.internal.http;
 import com.liferay.digital.signature.configuration.DigitalSignatureConfiguration;
 import com.liferay.digital.signature.configuration.DigitalSignatureConfigurationUtil;
 import com.liferay.digital.signature.internal.web.cache.DSAccessTokenWebCacheItem;
+import com.liferay.petra.function.RetryableUnsafeSupplier;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.Validator;
+
+import java.net.SocketTimeoutException;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -90,6 +95,11 @@ public class DSHttp {
 		return jsonObject.getString("access_token");
 	}
 
+	private int _getMaxRetries(int httpTimeout) {
+		return Math.max(
+			0, Math.min(_MAX_RETRIES, (httpTimeout / _MINIMUM_TIMEOUT) - 1));
+	}
+
 	private JSONObject _invoke(
 			long companyId, long groupId, String location, Http.Method method,
 			JSONObject bodyJSONObject)
@@ -137,10 +147,51 @@ public class DSHttp {
 				"/restapi/v2.1/accounts/",
 				digitalSignatureConfiguration.apiAccountId(), "/", location));
 		options.setMethod(method);
-		options.setTimeout(digitalSignatureConfiguration.httpTimeout());
 
-		return _http.URLtoByteArray(options);
+		int maxRetries = _getMaxRetries(
+			digitalSignatureConfiguration.httpTimeout());
+
+		options.setTimeout(
+			digitalSignatureConfiguration.httpTimeout() / (maxRetries + 1));
+
+		RetryableUnsafeSupplier<byte[], Exception> retryableUnsafeSupplier =
+			new RetryableUnsafeSupplier<>(
+				(exception, curMaxRetries, retryCount) -> {
+					if (!_isSocketTimeout(exception)) {
+						ReflectionUtil.throwException(exception);
+					}
+
+					if (_log.isWarnEnabled()) {
+						_log.warn(
+							StringBundler.concat(
+								"Retrying DocuSign call ",
+								options.getLocation(), " after attempt ",
+								retryCount, " of ", curMaxRetries + 1,
+								" timed out"));
+					}
+				},
+				true, maxRetries, 0, () -> _http.URLtoByteArray(options));
+
+		return retryableUnsafeSupplier.get();
 	}
+
+	private boolean _isSocketTimeout(Throwable throwable) {
+		while (throwable != null) {
+			if (throwable instanceof SocketTimeoutException) {
+				return true;
+			}
+
+			throwable = throwable.getCause();
+		}
+
+		return false;
+	}
+
+	private static final int _MAX_RETRIES = 2;
+
+	private static final int _MINIMUM_TIMEOUT = 20000;
+
+	private static final Log _log = LogFactoryUtil.getLog(DSHttp.class);
 
 	@Reference
 	private Http _http;

--- a/modules/apps/digital-signature/digital-signature-impl/src/test/java/com/liferay/digital/signature/internal/http/DSHttpTest.java
+++ b/modules/apps/digital-signature/digital-signature-impl/src/test/java/com/liferay/digital/signature/internal/http/DSHttpTest.java
@@ -1,0 +1,82 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.digital.signature.internal.http;
+
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.io.IOException;
+
+import java.net.SocketTimeoutException;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Shuyang Zhou
+ */
+public class DSHttpTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testGetMaxRetries() {
+		Assert.assertEquals(0, _getMaxRetries(-1));
+		Assert.assertEquals(0, _getMaxRetries(0));
+		Assert.assertEquals(0, _getMaxRetries(19999));
+		Assert.assertEquals(0, _getMaxRetries(20000));
+		Assert.assertEquals(0, _getMaxRetries(39999));
+		Assert.assertEquals(1, _getMaxRetries(40000));
+		Assert.assertEquals(1, _getMaxRetries(59999));
+		Assert.assertEquals(2, _getMaxRetries(60000));
+		Assert.assertEquals(2, _getMaxRetries(Integer.MAX_VALUE));
+	}
+
+	@Test
+	public void testIsSocketTimeout() {
+		Assert.assertTrue(
+			"A socket timeout is retryable",
+			_isSocketTimeout(new SocketTimeoutException()));
+		Assert.assertTrue(
+			"A wrapped socket timeout is retryable",
+			_isSocketTimeout(
+				new IOException(
+					"Wrapper",
+					new IOException("Inner", new SocketTimeoutException()))));
+	}
+
+	@Test
+	public void testIsSocketTimeoutIgnoresOtherFailures() {
+		Assert.assertFalse(
+			"A null throwable is not a socket timeout", _isSocketTimeout(null));
+		Assert.assertFalse(
+			"An unrelated failure is not a socket timeout",
+			_isSocketTimeout(new IOException("Host name may not be null")));
+		Assert.assertFalse(
+			"An unrelated cause chain is not a socket timeout",
+			_isSocketTimeout(
+				new IOException("Wrapper", new IllegalStateException())));
+	}
+
+	private int _getMaxRetries(int httpTimeout) {
+		return ReflectionTestUtil.invoke(
+			_dsHttp, "_getMaxRetries", new Class<?>[] {int.class}, httpTimeout);
+	}
+
+	private boolean _isSocketTimeout(Throwable throwable) {
+		return ReflectionTestUtil.invoke(
+			_dsHttp, "_isSocketTimeout", new Class<?>[] {Throwable.class},
+			throwable);
+	}
+
+	private final DSHttp _dsHttp = new DSHttp();
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103885

This supersedes #180926, which was closed without being applied. It is a rework addressing the review feedback there: the hand-rolled retry loop is replaced by the existing `RetryableUnsafeSupplier` from `petra-function`, and the change now ships with unit coverage.

## What Is Being Fixed

A DocuSign call that times out fails the whole request. The Digital Signature Poshi tests talk to a shared, real DocuSign org over the network, so an occasional slow response turns into a test failure that has nothing to do with Liferay. Retrying a timed-out read absorbs that.

## How It Is Being Fixed

`DSHttp` now wraps the `URLtoByteArray` call in a `RetryableUnsafeSupplier` rather than its own loop.

Two decisions govern the retry, and both are deliberately narrow:

- **How many attempts the budget affords.** The configured `httpTimeout` is divided across attempts instead of being spent afresh on each one, so the total wall clock a caller can wait is unchanged. `_getMaxRetries` allows one extra attempt per whole `_MINIMUM_TIMEOUT` (20s) in the budget, capped at 2 retries: below 40s there are no retries at all, so a short timeout is never sliced into uselessly small attempts.
- **Which failures qualify.** Only a socket timeout is retried, found by walking the cause chain. Anything else is rethrown immediately, so a genuine error (a bad host, a rejected credential) still fails fast rather than being retried three times.

## Testing

`DSHttpTest` covers both decisions directly. They are pure functions, so the test needs no DocuSign account and no portal:

- `testGetMaxRetries` pins the boundaries either side of every threshold (19999/20000, 39999/40000, 59999/60000) plus the negative and `Integer.MAX_VALUE` edges.
- `testIsSocketTimeout` covers a bare timeout and one nested two levels down a cause chain.
- `testIsSocketTimeoutIgnoresOtherFailures` covers `null` and unrelated exceptions.

I verified the test can actually fail rather than merely pass: mutating `_MINIMUM_TIMEOUT` from 20000 to 30000 turns `testGetMaxRetries` red while the two socket-timeout tests stay green.

Worth stating plainly about the functional suite: `ci:test:object` on my fork ran fully fresh (0 of 58 axes cached, 4160 tests) with all 21 Digital Signature Poshi tests passing against the deployed reworked bundle, and its only failure was the known, still-open `objectAction` download-notification flake covered by #180797. But no DocuSign call timed out during that run, so the retry branch itself never executed there — the unit test, not CI, is what covers the retry logic.

## PR Check

| Check | Result |
| --- | --- |
| Source Format | Passed (`format-source-current-branch -Dvalidate.commit.messages=true`, no modifications) |
| Baseline | Passed, no version bump — `DSHttp` is in an `internal` package and exports nothing |
| Per-Module Compile | Passed (`:apps:digital-signature:digital-signature-impl:deploy`) |
| Java Unit | Passed, 3 tests 0 failures |
| Integration Test Compile | Not applicable, no test module changed |
| Cross-Module Compile | Not applicable, no exported API changed |
