### PR TITLE
LPD-103018 Revert LPD-103018 to unblock the master sync

### DIFF
--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectDefinitionResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectDefinitionResourceImpl.java
@@ -67,9 +67,6 @@ import com.liferay.object.system.SystemObjectDefinitionManagerRegistry;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
-import com.liferay.portal.kernel.json.JSONFactory;
-import com.liferay.portal.kernel.json.JSONObject;
-import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.lazy.referencing.LazyReferencingThreadLocal;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -116,7 +113,6 @@ import java.io.Serializable;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -1018,42 +1014,8 @@ public class ObjectDefinitionResourceImpl
 			objectDefinition::getObjectDefinitionSettings);
 
 		if (objectDefinition.getObjectFields() != null) {
-			Map<String, ObjectField> existingObjectFields = new HashMap<>();
-
-			for (ObjectField existingObjectField :
-					existingObjectDefinition.getObjectFields()) {
-
-				existingObjectFields.put(
-					existingObjectField.getExternalReferenceCode(),
-					existingObjectField);
-			}
-
 			existingObjectDefinition.setObjectFields(
-				() -> transformToArray(
-					ListUtil.fromArray(objectDefinition.getObjectFields()),
-					objectField -> {
-						ObjectField existingObjectField =
-							existingObjectFields.get(
-								objectField.getExternalReferenceCode());
-
-						if (existingObjectField == null) {
-							return objectField;
-						}
-
-						JSONObject jsonObject = JSONUtil.merge(
-							_jsonFactory.createJSONObject(
-								existingObjectField.toString()),
-							_jsonFactory.createJSONObject(
-								objectField.toString()));
-
-						ObjectField patchedObjectField =
-							ObjectField.unsafeToDTO(jsonObject.toString());
-
-						patchedObjectField.setId(existingObjectField::getId);
-
-						return patchedObjectField;
-					},
-					ObjectField.class));
+				objectDefinition::getObjectFields);
 		}
 	}
 
@@ -1650,9 +1612,6 @@ public class ObjectDefinitionResourceImpl
 
 	@Reference
 	private GroupLocalService _groupLocalService;
-
-	@Reference
-	private JSONFactory _jsonFactory;
 
 	@Reference
 	private ListTypeDefinitionLocalService _listTypeDefinitionLocalService;

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectDefinitionResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectDefinitionResourceImpl.java
@@ -1012,11 +1012,6 @@ public class ObjectDefinitionResourceImpl
 
 		existingObjectDefinition.setObjectDefinitionSettings(
 			objectDefinition::getObjectDefinitionSettings);
-
-		if (objectDefinition.getObjectFields() != null) {
-			existingObjectDefinition.setObjectFields(
-				objectDefinition::getObjectFields);
-		}
 	}
 
 	private void _addListTypeDefinition(ObjectDefinition objectDefinition)

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionResourceTest.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionResourceTest.java
@@ -3146,6 +3146,7 @@ public class ObjectDefinitionResourceTest
 
 		Assert.assertEquals(
 			Arrays.toString(objectFields), 1, objectFields.length);
+
 		Assert.assertTrue(objectFields[0].getRequired());
 	}
 

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionResourceTest.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionResourceTest.java
@@ -428,7 +428,6 @@ public class ObjectDefinitionResourceTest
 	public void testPatchObjectDefinition() throws Exception {
 		super.testPatchObjectDefinition();
 
-		_testPatchObjectDefinitionWithObjectFields();
 		_testPatchObjectDefinitionWithPermissions();
 	}
 
@@ -3080,74 +3079,6 @@ public class ObjectDefinitionResourceTest
 					workflowDefinitionLink1, workflowDefinitionLink2)),
 			new HashSet<>(
 				Arrays.asList(objectDefinition.getWorkflowDefinitionLinks())));
-	}
-
-	private void _testPatchObjectDefinitionWithObjectFields() throws Exception {
-		ObjectDefinition objectDefinition = _addObjectDefinition(
-			randomObjectDefinition());
-
-		String objectFieldExternalReferenceCode = RandomTestUtil.randomString();
-
-		objectDefinitionResource.patchObjectDefinition(
-			objectDefinition.getId(),
-			new ObjectDefinition() {
-				{
-					objectFields = ArrayUtil.append(
-						objectDefinition.getObjectFields(),
-						new ObjectField() {
-							{
-								businessType = BusinessType.TEXT;
-								DBType = ObjectField.DBType.create("String");
-								externalReferenceCode =
-									objectFieldExternalReferenceCode;
-								label =
-									RandomTestUtil.randomLanguageIdStringMap();
-								name = StringUtil.randomId();
-							}
-						});
-				}
-			});
-
-		ObjectDefinition getObjectDefinition =
-			objectDefinitionResource.getObjectDefinition(
-				objectDefinition.getId());
-
-		ObjectField[] objectFields = ArrayUtil.filter(
-			getObjectDefinition.getObjectFields(),
-			objectField -> !objectField.getSystem());
-
-		Assert.assertEquals(
-			Arrays.toString(objectFields), 2, objectFields.length);
-
-		Assert.assertFalse(objectFields[1].getRequired());
-
-		objectDefinitionResource.patchObjectDefinition(
-			objectDefinition.getId(),
-			new ObjectDefinition() {
-				{
-					objectFields = new ObjectField[] {
-						new ObjectField() {
-							{
-								externalReferenceCode =
-									objectFieldExternalReferenceCode;
-								required = true;
-							}
-						}
-					};
-				}
-			});
-
-		getObjectDefinition = objectDefinitionResource.getObjectDefinition(
-			objectDefinition.getId());
-
-		objectFields = ArrayUtil.filter(
-			getObjectDefinition.getObjectFields(),
-			objectField -> !objectField.getSystem());
-
-		Assert.assertEquals(
-			Arrays.toString(objectFields), 1, objectFields.length);
-
-		Assert.assertTrue(objectFields[0].getRequired());
 	}
 
 	private void _testPatchObjectDefinitionWithPermissions() throws Exception {


### PR DESCRIPTION
Reverts the four LPD-103018 commits. They break `test-portal-testsuite-upstream(master)`, which gates syncing master, and the failure is reproducible rather than flaky.

https://liferay.atlassian.net/browse/LPD-103018

## What Is Being Fixed

`test-portal-testsuite-upstream(master)/1313` failed on `2bfc476d344de9902b5300109a26c76f489ad268`, holding back 143 commits. Exactly one of its 14 downstream jobs was not SUCCESS: `modules-integration-postgresql163_stable/0/0`, running `portal-smoke-test`. `BundleSiteInitializerTest` failed 4 of its tests and `PortalLogAssertorTest#testScanXMLLog` failed on the ERROR that failure logged. The axis portal log holds exactly two `ERROR [` lines, both `BundleSiteInitializer:559`, and no FATAL or SEVERE, so there is a single cause.

```
ObjectFieldLocalServiceImpl._validateName(ObjectFieldLocalServiceImpl.java:2035)   <- MustNotBeDuplicate: Duplicate name field1
ObjectFieldLocalServiceImpl.addCustomObjectField(...:158)
ObjectFieldLocalServiceImpl.addOrUpdateCustomObjectField(...:200)
ObjectFieldLocalServiceImpl.updateObjectField(...:748)
ObjectDefinitionLocalServiceImpl._updateObjectFields(...:3078)
ObjectDefinitionServiceImpl.updateCustomObjectDefinition(...:288)
ObjectDefinitionResourceImpl.putObjectDefinition(ObjectDefinitionResourceImpl.java:681)
BaseObjectDefinitionResourceImpl.patchObjectDefinition(BaseObjectDefinitionResourceImpl.java:457)
BundleSiteInitializer._addObjectDefinitions(BundleSiteInitializer.java:1401)
```

`BaseObjectDefinitionResourceImpl` calls `preparePatch` at line 455 and `putObjectDefinition` at line 457. `preparePatch` is the method `fcec9b817dd94` changed.

`site-initializer-extender-test-bundle-1` and `-2` have shipped both `object-definitions/test-object-definition-3.json` and `test-object-definition-3-duplicate.json` since 2023 as an idempotency probe. All four files are byte-identical, declaring object definition `TestObjectDefinition3` with a field named `field1` and no `externalReferenceCode` on the field. `BundleSiteInitializer` resolves the definition by `name eq`, so whichever file is read second finds the first one's definition and takes the PATCH branch at `BundleSiteInitializer.java:1401`.

Before `fcec9b817dd94`, the REST-Builder-generated patch merge copied no collection property, so `preparePatch` left `objectFields` as the array read from the database, every element carrying a real `objectFieldId`, and the second file was a harmless update-by-primary-key. After it, PATCH replaces that array with the request body's. The body's `field1` has no `id` and no `externalReferenceCode`, so `addOrUpdateCustomObjectField` — which resolves identity by primary key and then by external reference code, never by name — routes it to `addCustomObjectField`, and `_validateName` rejects the already-existing name.

`e6e7cc817fd9f` is not a second cause; it narrowed the damage but did not close it. Its merge keys on `getExternalReferenceCode()`, and every persisted object field has a non-null one (`ObjectFieldPersistenceImpl` stamps the uuid when blank) while the incoming DTO's is null, so `existingObjectFields.get(null)` never matches and the `setId(existingObjectField::getId)` repair never runs.

## How It Is Being Fixed

All four commits are reverted, restoring both files byte-for-byte to their pre-ticket state:

- `404f9c052763edae71f46abc7805292dbcce6fa0` LPD-103018 SF
- `113501e8ffc8df1d0125999b3dda512561074c9f` LPD-103018 Add integration test
- `e6e7cc817fd9f784572f8643a5967dcdf273cb52` LPD-103018 Preserve existing objectField properties when patching
- `fcec9b817dd94b39eff02082ab5ea40502dac889` LPD-103018 Apply objectFields when patching an object definition

The integration test has to go with them because it asserts the new behavior, and the SF commit is a blank-line removal in that test.

This is a revert to unblock the sync, not a rejection of the goal. LPP-65217 (batch UPSERT with PARTIAL_UPDATE reporting success while adding nothing) reopens and should be relanded.

## Evidence

Attribution is bracketed by two `ci:test:stable` runs of the upstream testsuite, at test-class granularity in Testray:

| SHA | routine build | `BundleSiteInitializerTest` | `PortalLogAssertorTest` |
| --- | --- | --- | --- |
| `3bb5593ae86ef` (before the range) | 18829 | PASSED | no failure |
| `2bfc476d344de` (after the range) | 18835 | FAILED | FAILED |

Only 7 of the 143 commits touch `modules/apps/object/`; 4 are LPD-103018 and 3 are LPD-103669, which is independent (`6e83ac1ed655e` changes `com.liferay.object.field.util.ObjectFieldUtil` in `object-api`, a different class from the `admin.rest.internal.dto.v1_0.util` one on this stack, and only its object-entry value paths; `b2cdf483ae4e5` is a `packageinfo` minor bump). No commit in the range touches `modules/apps/object/object-service/`, `modules/apps/site-initializer/`, `modules/test/portal-smoke-test/`, or the fixtures, so every other file on the failing stack is byte-identical across the range. `git log -S "existingObjectDefinition.setObjectFields"` on `ObjectDefinitionResourceImpl.java` returns exactly one commit in the whole repository history, on any ref: `fcec9b817dd94`.

The revert was then verified on CI rather than argued: `ci:test:stable` on this branch, sender SHA `d01a3da3f59d309ad135389aba3cb2eed905a980` against base `3bb5593ae86ef82265517dd42ae7fc62feb36808`, returned **15 out of 15 jobs passed, 8247 tests, 0 failures**. On `modules-integration-postgresql163_stable/0/0` all four `BundleSiteInitializerTest` methods and both `PortalLogAssertorTest` methods PASSED.

## For The Reland

Two things to settle before LPD-103018 goes back in.

**Resolve object field identity by name when the incoming external reference code is blank.** `name` is the key `_validateName` actually enforces, and the surrounding code already treats it as identity — `ObjectDefinitionResourceImpl` matches deletion candidates on `getName()`, and `object-api`'s `ObjectFieldUtil.toObjectFieldsMap` keys fields by `getName()`. The map should also not be keyed on a blank external reference code. Changing the fixture is not the answer: it exists to assert exactly this dedup, and `"updateStrategy": "UPDATE"` does not help either, because `putObjectDefinition` skips `preparePatch` entirely and the id-less field reaches the same `addCustomObjectField`.

Worth checking alongside it: `site-initializer-extender-test-bundle-2`'s `test-object-definition-4.json` declares `field1` where bundle-1's declares `field4`, so a name fallback needs the full smoke test run before landing.

**Decide separately whether PATCH should delete fields.** Because `preparePatch` replaces the `objectFields` array instead of merging into it, a partial PATCH now reaches the pre-existing retain-by-name and delete pass in `putObjectDefinition` and deletes every non-system, non-relationship custom field absent from the body. Previously the array was always the full read array, so nothing was ever deleted. `113501e8ffc8d` asserts that deletion, but no commit message states the change. It was not reached in the failing run because the throw precedes the delete pass. That is a product decision, not something to infer from a test assertion.

The wider generator gap is already tracked as LPD-35202.

## Blast Radius

The exposure is not limited to the test fixture. Any site initializer whose object-definition JSON omits `externalReferenceCode` on its object fields hits this on re-initialization — `site-initializer-teaser-showcase/.../user-experience.json` and the Playwright setup fixtures `lemon.json` and `lemon-basket.json`. `site-initializer-pim` and `site-initializer-dsr` declare field external reference codes and are unaffected.
