### PR TITLE
LPD-104028 Wait for the folder move to finish before the test ends

### DIFF
--- a/modules/test/playwright/tests/object-web/folder/objectFolder.spec.ts
+++ b/modules/test/playwright/tests/object-web/folder/objectFolder.spec.ts
@@ -439,6 +439,10 @@ test.describe('manage object definitions through view object definitions', () =>
 				await page
 					.getByRole('menuitem', {name: 'Move to Current Folder'})
 					.click();
+
+				await expect(
+					page.locator('#ToastAlertContainer .alert-success')
+				).toBeVisible();
 			});
 
 			await test.step('Check that the object definition is visible in Folder B sidebar', async () => {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-104028

## What Is Being Fixed

`objectFolder.spec.ts:378` fails intermittently on `ci:test:object`, and never in the test body — the failure is an HTTP 500 raised inside fixture teardown, at `clearData` -> `deleteObjectDefinition`. The PostgreSQL log shows a lock ordering deadlock: one transaction deletes `ResourcePermission` rows and waits on `ObjectField`, while the other updates `ObjectField` and waits on what the first holds.

The test clicks **Move to Current Folder** and then asserts only that the object definition is visible somewhere in the left sidebar. The sidebar already lists that definition before the move, because it nests other folders' definitions as tree children, so the assertion is satisfied by the pre-move DOM. The test therefore ends while the PATCH performing the move is still in flight, and teardown deletes the object definition concurrently with that request.

The move handler sends the whole definition including its `objectFields`, so the server re-saves every field before updating the resource permissions. That is what puts the `ObjectField` writes and the `ResourcePermission` delete into opposite orders between the two transactions.

## How It Is Being Fixed

Wait for the success toast after the click. The front end opens it only after the PATCH resolves, and it opens a **danger** toast on failure, so the wait cannot pass on a rejected move. This covers both interleavings: the test no longer ends before the move completes, so teardown cannot race it, and a move that is rejected now fails the test instead of passing silently.

## Testing

Local before/after on PostgreSQL 16.15, measured by PATCH status in the Tomcat access log rather than by the test verdict:

| | PATCH result | Test verdict |
| --- | --- | --- |
| before | 400 | passed (assertion vacuous) |
| before | 200 | **failed** in teardown |
| before | 400 | passed (assertion vacuous) |
| after | 200 | passed |
| after | 200 | passed |
| after | 200 | passed |

Two of three unfixed runs had the move **rejected with HTTP 400 while the test still passed** — that is the vacuous assertion, shown by HTTP status rather than inferred. After the change, three of three moves succeed with no teardown failure, and the runs are faster because the vacuous path had been spending time on retries.

All 9 tests in `objectFolder.spec.ts` pass locally on a clean environment. `ci:test:object` on the fork ran fully fresh (0 of 59 axes cached, 4159 tests): `objectFolder.spec.ts` 9/9 passed including the target test, with zero occurrences of `clearData`, `deleteObjectDefinition`, HTTP 500 or HTTP 400 anywhere in the build report. Its only failure is the `objectAction` download-notification test, whose cover (LPD-103632) landed on master after this branch's base and is provably not an ancestor of the tested SHA.

That fork run tested SHA `e738a651a4b7ba8850088146da6b489b314d1367`, before the commit was retitled with the ticket. The retitled head `d29e0482105305b36cc5a17cc8b295b5787ef024` has an identical tree hash (`b183f6c5e64e2dc10f2c3edd0b0bb3cfa5c8d5e7`), so the validated content is byte-identical and only the commit message differs.

Worth noting for anyone reproducing this on MySQL: the same race cannot surface as a deadlock there. `ObjectField` is `mvcc-enabled`, so the version-qualified delete matches zero rows and fails fast with a row count mismatch before any lock cycle can form.

## PR Check

| Check | Result |
| --- | --- |
| Source Format | Passed (`format-source-current-branch -Dvalidate.commit.messages=true`, no modifications; includes the TypeScript type-check) |
| Java Unit | Not applicable, no Java changed |
| Per-Module Compile | Not applicable, no compiled source changed |
| Baseline | Not applicable, no exported API changed |
| Integration Test Compile | Not applicable, no integration test module changed |
