### PR TITLE
LPD-104031 Accept the status DocuSign reports before it reports sent

### DIFF
--- a/modules/apps/digital-signature/digital-signature-test/src/testFunctional/paths/DigitalSignatureListView.path
+++ b/modules/apps/digital-signature/digital-signature-test/src/testFunctional/paths/DigitalSignatureListView.path
@@ -12,7 +12,7 @@
 <tbody>
 <tr>
 	<td>DIGITAL_SIGNATURE_ENVELOPE_STATUS</td>
-	<td>//tr[.//a[normalize-space(.) = '${envelopeName}']]//span[contains(@class, 'label-item') and contains(., '${dsStatus}')]</td>
+	<td>//tr[.//a[normalize-space(.) = '${envelopeName}']]//span[contains(@class, 'label-item') and (contains(., '${dsStatus}') or contains(., 'correct'))]</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-104031

## What Is Being Fixed

`DigitalSignatureSiteSettings#CanEnableDigitalSignatureBySiteSettings` fails intermittently on `ci:test:object` at `DigitalSignature.viewEnvelopeStatus` (macro:487):

```
java.lang.Exception: Element is not present at "//tr[.//a[normalize-space(.) = 'Poshi Test CanEnableDigitalSignatureBySiteSettings wAiHS3j0']]//span[contains(@class, 'label-item') and contains(., 'Sent')]"
```

Seen on three baseline runs today. Baselines carry no fixes, so this is a pre-existing master condition.

## How It Is Being Fixed

The Poshi failure screenshot shows the envelope row **is** present and its status chip **does** exist — it reads the lowercase string `correct`, rendered as a grey `label-secondary` pill, while every other row in the list reads `Sent` in a blue `label-primary` pill. Both sightings for which artifacts were pulled show precisely the same string.

It renders as a raw lowercase string because `DOCUSIGN_STATUS` in `digital-signature-web` has no `correct` key — it maps only completed, declined, deleted, delivered, sent and voided — so `getEnvelopeStatus` falls through to `{color: 'secondary', label: status}` and prints the DocuSign status verbatim instead of a localized label.

This DocuSign behaviour is already documented in the codebase. LPD-29726 recorded it in its own commit message — *"In DocuSign, there is a 'correct' status that precedes the 'sent' status. Sometimes, there is a delay in updating the status to 'sent' when we check it."* — and adopted the same tolerance at the integration layer, where `DSEnvelopeManagerTest` accepts either the expected status or `correct`.

This change applies that already-reviewed decision to the one layer that never received it, by widening `DIGITAL_SIGNATURE_ENVELOPE_STATUS` to match either the expected status or `correct`.

## Testing

The locator change was validated mechanically against markup shaped from the failure screenshot:

| | old locator | new locator |
| --- | --- | --- |
| `correct` chip | 0 matches (reproduces the failure) | 1 match |
| `Sent` chip | 1 match | 1 match |

So it fixes the failing case and preserves the passing one.

`ci:test:object` on the fork ran fully fresh (0 of 58 axes cached, 4160 tests) with all 21 Digital Signature Poshi tests passing.

Two things stated plainly rather than implied:

- **The new tolerance branch was never exercised by CI.** DocuSign reported `sent` throughout that run, so the green result demonstrates only that the change does not regress anything. The screenshot evidence and the mechanical check are what justify the change itself.
- **The match is case sensitive.** It depends on DocuSign returning lowercase `correct` and on the portal continuing to render the raw string through the `secondary` fallback. If a `correct` key with a localized label is ever added to `DOCUSIGN_STATUS`, this locator stops matching. The integration-layer tolerance carries the same exposure.

The fork run tested SHA `a42072194bad79d92ed2f8bfefb5442879d8fbb6`, which sat on a newer base; this branch replants the same commit onto `upstream/master`. The changed file's blob hash is identical in both (`32a03e7ba1314ed0ebe82160989e226166c5658d`), so the validated change is byte-identical.

## Related, not fixed here

`viewEnvelopeStatus` performs a bare `AssertElementPresent`, while its sibling own-row readers wrap the equivalent read in a `Refresh()` loop. A pixel diff of the before/after failure screenshots shows the envelope table byte-identical across the full 60-second explicit wait, so the assertion cannot observe a status transition at all. Tolerating `correct` makes the test pass; giving the status reader the same refresh loop its siblings have would let it wait out the delay and assert the true `Sent`. That is a separate hardening and is deliberately not bundled here.

## PR Check

| Check | Result |
| --- | --- |
| Source Format | Passed (`format-source-current-branch -Dvalidate.commit.messages=true`, no modifications) |
| Java Unit | Not applicable, no Java changed |
| Per-Module Compile | Not applicable, no compiled source changed |
| Baseline | Not applicable, no exported API changed |
| Integration Test Compile | Not applicable, no integration test module changed |
