### PR TITLE
LPD-104046 Let each picklist item edit finish before starting the next

### DIFF
--- a/modules/test/playwright/tests/object-web/upgrade/objectUpgrade.spec.ts
+++ b/modules/test/playwright/tests/object-web/upgrade/objectUpgrade.spec.ts
@@ -549,12 +549,14 @@ test.describe.serial('View Picklist after upgrade', () => {
 				);
 
 				await listTypeDefinitionPage.modalSaveButton.click();
-			}
 
-			for (const itemNumber of ['1', '2', '3']) {
+				await listTypeDefinitionPage.modalNameInput.waitFor({
+					state: 'hidden',
+				});
+
 				await expect(
 					listTypeDefinitionPage.frameLocator.getByRole('link', {
-						name: `Picklist Item ${itemNumber} Updated`,
+						name: `${itemName} Updated`,
 					})
 				).toBeVisible();
 			}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-104046

## What Is Being Fixed

`objectUpgrade.spec.ts` "Edit picklist items" times out after 90 seconds clicking the modal Save button. It has failed 73 times since 2026-07-15 and was never root caused, because Testray truncates the Playwright call log at exactly the token that distinguishes the possible causes.

The full trace was pulled from the CI artifacts. The truncated token is `element was detached from the DOM, retrying`. Nothing was obscured: there is no `hitTargetDescription` anywhere in the trace, no visibility failure, no strict mode violation, and after that line there are 85 seconds with no log line, no network request and no screencast frame.

The real failure is one action earlier. The click on the second item's link returned in **49 ms**, against **840 ms** for the first, and opened no modal at all: it landed at page coordinates inside the first iteration's still-open modal footer. Playwright did not report an interception because the item link lives in an `<iframe>` and the hit-target check runs in the link's own document, where the parent document's modal is invisible to `elementFromPoint`.

Three independent markers prove the following fill wrote into the **first** item's modal rather than a new one: the disabled Key field still read `picklistItem1`, the external reference code was still the first item's, and the Save button still carried the `__playwright_target__` marker Playwright wrote when it clicked the first item's Save.

## How It Is Being Fixed

Wait for the modal to go and for the renamed item to come back in the list before starting the next iteration. This is the shape the `Edit picklist` step directly above already uses, and the shape every `modalSaveButton.click()` in `listTypeDefinition.spec.ts` already follows. Asserting each rename inside the loop makes the separate trailing loop that re-checked all three redundant, so it is removed.

Root cause: created wrong in `6948bcac0656adb442f1e8cf4aff10fb9d72c696`, which moved these tests to Playwright with no barrier at the end of the loop body.

## PR Check

| Validation | Result |
|---|---|
| Source Format (with `validate.commit.messages`) | PASS |
| HTML Escaping | PASS — no added line renders a value as HTML |
| JavaScript Unit Test | N/A — `modules/test/playwright` has no Jest suite; its `test` script is `playwright test`, which is what `ci:test:object` ran |
| Per-Module Compile | N/A for deploy — no `bnd.bnd`, not an OSGi bundle. The TypeScript type check that applies to a `.ts` change ran as part of Source Format via `portalYarnFormatCurrentBranch` |
| Baseline | N/A — no Java, `bnd.bnd` or `packageinfo` in the diff, so there is no exported API to baseline |

`ci:test:object` on the fork: build `test-1-47 #1628`, tested SHA verified equal to the branch head, fully fresh with zero of fifty nine axes cached. 4170 tests, 4040 passed, **0 failed**, all 59 axes successful. All twelve `objectUpgrade` tests passed, including the picklist test containing the step this change touches, and none were skipped.

That run tested `6b4cf09bf65edc3af64b067096f65ba709891af0`, whose tree is byte-identical to this head — the only later change was renaming `LPD-X` to the ticket in the commit message.

A single green run does not prove the race is cured, since it fired once across the campaign and passed in every other run. It establishes that the barrier introduces no regression. The evidence for the fix itself is the trace and the existing sibling pattern.

<!-- pr-check {"result":"success","sha":"9ac0c4aea8785c622ce2f0d3b6bddee11bab1b79"} -->
