### PR TITLE
LPD-104059 Click the workflow task asset by its row and stop forcing clicks

### DIFF
--- a/modules/test/playwright/pages/portal-workflow-kaleo-designer-web/ConfigurationTabPage.ts
+++ b/modules/test/playwright/pages/portal-workflow-kaleo-designer-web/ConfigurationTabPage.ts
@@ -27,8 +27,7 @@ export class ConfigurationTabPage {
 
 	async goTo() {
 		await this.processBuilderPage.goto();
-		await this.configurationTabLink.waitFor({state: 'visible'});
-		await this.configurationTabLink.click({force: true});
+		await this.configurationTabLink.click();
 		await this.page.waitForURL((url) =>
 			url.href.includes('=configuration')
 		);

--- a/modules/test/playwright/pages/portal-workflow-task-web/WorkflowTaskDetailsPage.ts
+++ b/modules/test/playwright/pages/portal-workflow-task-web/WorkflowTaskDetailsPage.ts
@@ -93,9 +93,10 @@ export class WorkflowTaskDetailsPage {
 		await this.selectAsset(assetTitle);
 	}
 
-	async selectAsset(assetTitle: string) {
-		const assetLink = this.page.getByRole('link', {name: assetTitle});
-		await assetLink.click();
+	async selectAsset(assetText: string) {
+		const row = this.page.getByRole('row').filter({hasText: assetText});
+
+		await row.locator('.lfr-asset-title-column').getByRole('link').click();
 	}
 
 	async selectAssignee(assignee: string) {

--- a/modules/test/playwright/pages/portal-workflow-task-web/WorkflowTaskDetailsPage.ts
+++ b/modules/test/playwright/pages/portal-workflow-task-web/WorkflowTaskDetailsPage.ts
@@ -95,7 +95,7 @@ export class WorkflowTaskDetailsPage {
 
 	async selectAsset(assetTitle: string) {
 		const assetLink = this.page.getByRole('link', {name: assetTitle});
-		await assetLink.click({force: true});
+		await assetLink.click();
 	}
 
 	async selectAssignee(assignee: string) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-104059

## What Is Being Fixed

`objectEntry.spec.ts` "friendly URL input is disabled when viewed inside workflow task detail" fails intermittently on `ci:test:object` with `locator.click: Element is not visible`, raised from `WorkflowTaskDetailsPage.selectAsset`, which clicked the asset link with `force: true`. The error arrives **after** `done scrolling` — the element was found and scrolled to, then had nothing to click.

`force: true` cannot help here. In playwright-core it gates exactly two things: the `visible, enabled and stable` actionability wait, and hit-target interception. It does **not** skip `scrollIntoViewIfNeeded` or the clickable-point calculation, so a layout box is still required. It also turns a recoverable state into a fatal one — without `force`, an element with no content quads is retried with backoff; with `force` it throws immediately. That is why the call died in 64 ms despite being given no timeout.

The history agrees. Both `force: true` usages were introduced by `df099ab16c0a556eebf71436463c5c5b3cc50540` with no stated rationale and no overlay to defeat. The second, in `ConfigurationTabPage.goTo`, sits directly after a `waitFor({state: 'visible'})` on the same element — a combination with no purpose, since the wait already establishes what `force` then declines to check.

## How It Is Being Fixed

Remove both `force: true` usages, partially reverting `df099ab16c0a556eebf71436463c5c5b3cc50540`. `ConfigurationTabPage.goTo` needs nothing in their place: the navigation it follows already waits for network idle, and `click()` already waits for actionability.

Then address the asset link **by the row that owns it** rather than by any link whose accessible name matches, so the locator names the one link the test means instead of resolving anywhere on the page.

## PR Check

| Validation | Result |
|---|---|
| Source Format (with `validate.commit.messages`) | PASS |
| HTML Escaping | PASS — no added line renders a value as HTML |
| JavaScript Unit Test | N/A — `modules/test/playwright` has no Jest suite; its `test` script is `playwright test` |
| Per-Module Compile | N/A — no `bnd.bnd`, not an OSGi bundle. The TypeScript check for a `.ts` change ran inside Source Format |
| Baseline | N/A — 0 non-Playwright files in the diff, so no exported API |

**CI**, on the verified head, fully uncached:

- `ci:test:object` test-1-45 #1701 — 0 of 59 axes cached, 4170 tests, **4040 passed, 0 failed**, 59/59 axes SUCCESS. The targeted test passed.
- `ci:test:bpm` test-1-43 #1690 — 0 of 703 axes cached. Red, but its failure population is the one master carries nightly (~510 cases); **no failure touches the changed code**, and the four specs exercising the changed navigation ran **10/10 on first attempt, no retries**.

**Local**, every affected project run on the branch and again on master — no regressions:

| project | branch | master |
|---|---|---|
| commerce/discounts, commerce/commerceAdminProductRelations | passed | — |
| e2e-cms-dxp/workflowNotificationReject | 3/3 passed | — |
| users-admin-web | 1 failed | 1 failed, same line |
| portal-workflow-task-web | 4 failed | 5 failed |
| notification-web + object-web.workflow + message-boards-web | 6 failed | 8 failed |

The one failure unique to the branch was a 500 from a site delete during fixture teardown; it passed 3/3 on re-run and appears nowhere near the changed code.

Together the runs execute **all 17 call sites** of the changed navigation method — 11 in CI, 6 locally — and the asset-selection method through its object-entry, object-workflow and workflow-notification callers.

Rebased onto `7160c531`; the two changed files are byte-identical to the CI-tested tree, and nothing landed upstream on them between the two bases.

<!-- pr-check {"result":"success","sha":"ee5e5ce27e6ed40cdffd2211bcbbcdbab9585fe7"} -->
