### PR TITLE
LPD-103978 Delete the class name the test no longer gets for free

### DIFF
--- a/modules/apps/data-cleanup/data-cleanup-test/src/testIntegration/java/com/liferay/data/cleanup/internal/verify/test/ClassNamePostUpgradeDataCleanupProcessTest.java
+++ b/modules/apps/data-cleanup/data-cleanup-test/src/testIntegration/java/com/liferay/data/cleanup/internal/verify/test/ClassNamePostUpgradeDataCleanupProcessTest.java
@@ -177,6 +177,13 @@ public class ClassNamePostUpgradeDataCleanupProcessTest
 				if (objectDefinition != null) {
 					_objectDefinitionLocalService.deleteObjectDefinition(
 						objectDefinition);
+
+					ClassName className = _classNameLocalService.fetchClassName(
+						objectDefinition.getClassName());
+
+					if (className != null) {
+						_classNameLocalService.deleteClassName(className);
+					}
 				}
 			},
 			() -> {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103978

Follow-up to LPD-103978. That change deliberately stopped `deleteObjectDefinition` from deleting the class name, and this test's cleanup was the caller relying on the old cascade.

## What Is Being Fixed

`ClassNamePostUpgradeDataCleanupProcessTest` fails on **all 8** database axes of the `modules-integration` batch:

```
testFoundLiferayClassNameWithPoundIsNotDeleted   expected:<558> but was:<559>
testFoundSubscriptionClassNameIsNotDeleted       expected:<559> but was:<558>
```

Read from the raw per-axis consoles: db2111, mariadb102, mysql84, oracle193, postgresql144, postgresql153, postgresql163, sqlserver2019 — 2 assertions each, 16 in total.

## How It Is Being Fixed

Every test in this class runs inside a total class name row count invariant. `testFoundLiferayClassNameWithPoundIsNotDeleted` creates and publishes a custom object definition and deletes it in cleanup, and that cleanup relied on the delete taking the class name with it. It now leaks a row (**+1**), and the test that follows reads **-1**, because the orphan it inherits is exactly what the post upgrade cleanup process under test is there to sweep.

The production behaviour is correct and unchanged — a class name is an identity that must not be reused. Only the test cleanup was left incomplete, so it now deletes the class name itself.

A repo-wide sweep of `/src/test/` and `/src/testIntegration/` found no other test depending on the old cascade. Two production facts close off the class: the removed delete only ever ran inside the `isApproved()` branch, so deleting a draft never touched `ClassName_`; and both the uniqueness draw and the duplicate check query `ObjectDefinition`, never `ClassName_`, so a surviving tombstone cannot collide on re-create. `ObjectDefinitionLocalServiceTest` was the only other test asserting the old behaviour and was already flipped in the original commit.

## Testing

Local, against a bundle rebuilt so the tombstone is actually in the runtime:

- master's test on a clean database reproduces the exact pair — `expected:<518> but was:<519>` and `expected:<519> but was:<518>`
- with this fix, all 13 tests pass

CI on `3b0872da277d602197147868158bb4e0260ca21e`:

- `ci:test:relevant` — SUCCESS, 16 axes, 0 cached, 6576 tests, 0 failures. The test ran; both previously failing methods passed.
- `ci:test:upgrade` — the test ran on **all 8** database axes: 112 results, 104 passed, 8 skipped, **0 failures**. The suite's remaining 24 failures are the usual `LocalFile.*Upgrade` Poshi noise, in band with master's own nightly, and none are in data-cleanup.

Note this test is not selected by the `object` suite — `test.batch.class.names.includes[modules-integration-*][object]` covers only list-type, notification, object and portal-security-script-management-test, while `test.batch.class.names.includes[upgrade]` lists `**/data-cleanup-test/**/*Test.java`.
