### PR TITLE
LPD-104064 Stop re-navigating to the object details tab that is already open

### DIFF
--- a/modules/test/playwright/pages/object-web/object-details/EditObjectDetailsPage.ts
+++ b/modules/test/playwright/pages/object-web/object-details/EditObjectDetailsPage.ts
@@ -99,12 +99,27 @@ export class EditObjectDetailsPage {
 		await this.viewObjectDefinitionsPage.clickEditObjectDefinitionLink(
 			objectDefinitionLabel
 		);
+
+		await expect(this.detailsTabItem).toHaveAttribute(
+			'aria-current',
+			'page'
+		);
 	}
 
 	async goToDetailsTab() {
-		await this.detailsTabItem.click();
+		const ariaCurrent =
+			await this.detailsTabItem.getAttribute('aria-current');
 
-		await this.page.waitForLoadState('networkidle');
+		if (ariaCurrent !== 'page') {
+			await this.detailsTabItem.click();
+
+			await expect(this.detailsTabItem).toHaveAttribute(
+				'aria-current',
+				'page'
+			);
+		}
+
+		await this.waitForDetailsFormLoaded();
 	}
 
 	async waitForDetailsFormLoaded() {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-104064

## What Is Being Fixed

Two `objectDefinition.spec.ts` tests fail intermittently on CI with errors that look unrelated:

```
"can save changes when publishing"
  expected "UpdatedLabel386354200", received "ObjectDefinition2927753114"

"cannot save an object definition without a translation after changing the default language"
  strict mode violation: getByText('Required') resolved to 2 elements
```

They are the same bug.

## How It Is Being Fixed

Opening a definition already lands on the details tab, so `goToDetailsTab()` clicking it again is a **second SPA screen load**. Senna tears down and re-creates the portlet DOM, remounting `EditObjectDetails`, whose load effect refetches and calls `setValues` — replacing the whole form state including the label just typed.

From the CI trace (build `test-1-48/1541`, monotonic ms):

```
237684  click row link                        -> SPA nav #1
237874  click "Details"  (10 ms later, mid-transition)
238017    "element is not stable" -> retrying
238052    "element was detached from the DOM, retrying"
238104    resolved the NEW screen's Details link - aria-current="page", ALREADY ACTIVE
238244  GET ...&_screenNavigationCategoryKey=details   -> SPA nav #2 (REDUNDANT)
238269  expect(saveButton).toBeEnabled() PASSES        <- against the PRE-SWAP DOM
238319  fill label
238406  GET .../object-fields                          <- React mount #2
238464    response -> setValues() CLOBBERS the fill
238574  PUT -> sends the ORIGINAL label
```

Provable at the element level — same input node, adjacent snapshots:

```
238475.850  after@call@2231   value="UpdatedLabel386354200"
238499.901  before@call@2233  value="ObjectDefinition2927753114"
```

Neither existing wait can see it. `waitForLoadState('networkidle')` is a no-op against pushState — the trace logs `not waiting, "networkidle" event already fired`. `waitForDetailsFormLoaded()` is `expect(saveButton).toBeEnabled()`, which matched the pre-swap DOM.

The second failure is the same defect: with the label discarded the field is empty, so **both** Label and Plural Label report Required, the non-strict `getByText('Required')` matches two elements, and `toBeVisible()` throws.

`goto()` now waits for the details tab to become current before returning, so the screen is committed and the tab state readable. `goToDetailsTab()` returns instead of clicking when it is already current, removing the redundant load. Waiting harder in `goto()` alone would not fix it — clicking an active tab still triggers a reload and the gate would still pass pre-swap.

## Root Cause

Born wrong in `e5035a794b5eb` (LPD-28108, 2024-07-10), which created both helpers: `goto()` returned as soon as the row link was clicked, and `goToDetailsTab()` clicked unconditionally with **no wait at all**.

The product side could already clobber — the load effect keyed on `objectDefinitionId` predates the helpers by eighteen months, and `fbacbc4fe8ec9` (LPS-162430, 2022-12-28) only renamed the file it lives in.

`52d40abc2feb8` (LPD-32919, 2024-09-30) later added `waitForLoadState('networkidle')`, which is inert against pushState — it did not change behaviour, but made the helper look guarded.

## Verification

Local, on a bundle carrying all 12 of CI's `env/portal-ext.properties`. The amplifier recreates the CI conditions and is **retained in both arms**:

| test | control | fixed |
|---|---|---|
| can save changes when publishing | **5/5 failed** | **5/5 passed** |
| cannot save ... after changing the default language | **5/5 failed** (`Required` count 2 every run) | **5/5 passed** (count 1 every run) |

In the fixed arm the amplifier's held response is **never requested** — the redundant navigation is not issued at all, so the mechanism is removed rather than the symptom absorbed.

Shared helper with **24 call sites**, so the full `object-web.main` project was run: **62/62 passed**.

Self-CI `ci:test:object` on `2c5186ca48dc3` (tree identical to this head): **45/59**, against a pure-master baseline of 46/59 on build `test-1-47/1632`. Diffed test-by-test, the single delta is `objectContentPageIntegration` › "cannot add object portlet as widget when widget button is disabled" — a **step 2** widget-panel timeout. Step 1, the only part this change touches, passed with the new `aria-current` wait resolving in 179 ms and the redundant navigation skipped; the sibling test running the identical sequence passed in the same axis and run; and the timing-race alternative is refuted quantitatively (save→search window 2021 ms baseline vs 1991 ms here, −30 ms). That test has no prior failure in the four builds visible, so it is stated here as a **single unexplained occurrence** rather than a known flake.

## PR Check

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| HTML Escaping | PASS |
| JavaScript Unit Test | N/A |
| Per-Module Compile | N/A |
| Baseline | N/A |

`Source Format` clean, twice (stable); the run includes `:portalYarnFormatCurrentBranch`, which type-checks the TypeScript. `HTML Escaping` — the added lines emit no HTML. `JavaScript Unit Test` — `modules/test/playwright` has no Jest config or dependency; its `test` script is `playwright test`. `Per-Module Compile` — no `bnd.bnd`, no `.lfrbuild-portal`; not a deployable module. `Baseline` — no Java, `bnd.bnd`, `packageinfo` or `.gradle` change.

<!-- pr-check {"result": "success", "sha": "d721b38b47ed3806c7a7703319bff375f6802a1a"} -->
