### PR TITLE
LPD-104065 Assert the schedule date the form wrote, not a freshly read clock

### DIFF
--- a/modules/test/playwright/tests/object-web/entry/objectEntry.spec.ts
+++ b/modules/test/playwright/tests/object-web/entry/objectEntry.spec.ts
@@ -899,19 +899,20 @@ cmsTest.describe('Manage object entries schedule properties', () => {
 
 			await page.keyboard.press('Escape');
 
+			const today =
+				await viewObjectEntriesPage.publishDateInput.inputValue();
+
 			await viewObjectEntriesPage.schedulePublicationButton.click();
 
 			await waitForAlert(page);
-
-			const date = new Date();
-
-			const today = getObjectEntryUIDateTimeFormat(date);
 
 			await viewObjectEntriesPage.choosePublicationOption('schedule');
 
 			await expect(viewObjectEntriesPage.publishDateInput).toHaveValue(
 				today
 			);
+
+			const date = new Date(today);
 
 			date.setDate(date.getDate() + 1);
 
@@ -1017,17 +1018,18 @@ cmsTest.describe('Manage object entries schedule properties', () => {
 
 			await page.keyboard.press('Escape');
 
+			const today =
+				await viewObjectEntriesPage.reviewDateInput.inputValue();
+
 			await viewObjectEntriesPage.choosePublicationOption('publish');
 
 			await waitForAlert(page);
 
-			const date = new Date();
-
-			const today = getObjectEntryUIDateTimeFormat(date);
-
 			await expect(viewObjectEntriesPage.reviewDateInput).toHaveValue(
 				today
 			);
+
+			const date = new Date(today);
 
 			date.setDate(date.getDate() + 1);
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-104065

## What Is Being Fixed

The review date and display date tests in `objectEntry.spec.ts` fail intermittently on CI, burning the full 15 second timeout without ever converging:

```
Error: Timed out 15000ms waiting for expect(locator).toHaveValue(expected)
Locator: getByLabel('Review DateMandatory', { exact: true })
Expected string: "08/26/2026 09:56 AM"
Received string: "08/26/2026 09:55 AM"
  - 19 x locator resolved to <input ... value="08/26/2026 09:55 AM" ...>
       - unexpected value "08/26/2026 09:55 AM"
```

Two recorded occurrences for the review date test, both on axis `playwright-js-tomcat101-postgresql163/1/0`: `test-1-47/1616` (2026-08-26) and `test-1-46/1811` (2026-08-27).

## How It Is Being Fixed

`scheduleForCurrentDate()` makes the **form** write the current date. The test then took a **second** clock reading, after `choosePublicationOption` and `waitForAlert`, and asserted the field equals that:

```ts
await viewObjectEntriesPage.scheduleForCurrentDate('Review');
await page.keyboard.press('Escape');
await viewObjectEntriesPage.choosePublicationOption('publish');
await waitForAlert(page);

const date = new Date();                          // second reading
const today = getObjectEntryUIDateTimeFormat(date);
await expect(reviewDateInput).toHaveValue(today); // compares two different clocks
```

When a minute boundary falls between the two readings the expectation is a minute ahead of the field. **The field is correct and already holds its final value; the expectation is wrong.** Nothing reconciles them, which is why the trace shows the same value on all 19 polls. That is the opposite of an ordinary slow-load flake, and it is why no retry or longer timeout would have helped.

The window is only the Escape, the publish and the alert wait — a couple of seconds out of sixty — so the trigger is roughly a 2 to 5 percent chance per run. That matches the observed rate: 2 failures across 4351 recorded results for the case.

Both tests now read the value the form wrote **before** publishing and assert that it survived, which is what they mean to check, and derive the next day by parsing that captured value rather than reading the clock again. The format was verified to round-trip through `new Date()` before relying on the parse, including the `12:05 AM` and `12:05 PM` edge cases.

## Root Cause

Born wrong in both tests, independently and six weeks apart:

| Commit | Date | Test |
| --- | --- | --- |
| `7db6108ac520d` | 2025-05-13 | LPD-54813 wrote the review date test with `waitForAlert` then a fresh `new Date()` and an equality assertion |
| `98265b66da2b9` | 2025-06-25 | LPD-56228 wrote the display date test the same way |

Neither ever read the value the form wrote, so both have been able to fail on a minute rollover since the day they were added.

A naive pickaxe search points at `5354f141444bf` (LPD-85191), but that commit only moved these tests into the entry subproject and is not the origin.

## Scope

`expirationDate` looks similar but is **not** affected — that test fills the value itself and compares against what it filled, so there is no second reading. The remaining `scheduleForCurrentDate` caller only asserts a validation message and never compares a date. Both were checked rather than assumed, and both are left unchanged.

## Verification

The amplifier spins until the wall-clock minute actually rolls over, converting the 2 to 5 percent trigger into a certainty. It is retained in **both** arms, so each comparison has a single variable.

| test | control | fixed |
|---|---|---|
| `reviewDate` | **5/5 failed** | **5/5 passed** |
| `displayDate` | **5/5 failed** | **5/5 passed** |

`displayDate` had no recorded CI failure. Rather than argue from the shared code shape, it was **proven with the same amplifier before being changed**.

Regression coverage: the full `object-web.entry` project passed **104/104**, with the untouched `expirationDate` test passing alongside as a control.

Self-CI `ci:test:object` on `06a865829a550` (tree identical to this head — `git diff --stat` between them is empty; only the commit message changed when the ticket was assigned): **46/59**, which diffs against the pure-master baseline `test-1-47/1632` as **empty in both directions** — nothing fails here that does not fail on baseline, nothing on baseline is missing here, and no shared failure changed its axis count. Both changed tests **ran and passed** in that build (`reviewDate` 14.4 s, `displayDate` 18.2 s), so the run is valid evidence rather than vacuous.

## PR Check

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| HTML Escaping | PASS |
| JavaScript Unit Test | N/A |
| Per-Module Compile | N/A |
| Baseline | N/A |

`Source Format` clean, twice (stable); the run includes `:portalYarnFormatCurrentBranch`, which type-checks the TypeScript. The three N/A results are by inspection: `modules/test/playwright` has no Jest config or dependency (its `test` script is `playwright test`), no `bnd.bnd` or `.lfrbuild-portal` so it is not deployable, and there is no Java, `packageinfo` or `.gradle` change.

<!-- pr-check {"result": "success", "sha": "92746be8627967df2f344be5e00a08048c47990d"} -->
