### PR TITLE
LPD-104063 Wait for the layout save's deferred reload before navigating away

### DIFF
--- a/modules/test/playwright/tests/object-web/hierarchy/objectDefinitionHierarchy.spec.ts
+++ b/modules/test/playwright/tests/object-web/hierarchy/objectDefinitionHierarchy.spec.ts
@@ -1184,12 +1184,15 @@ test.describe('Manage root models elements through Objects Admin', () => {
 
 				await objectLayoutsPage.setObjectLayoutAsDefault();
 
-				await objectLayoutsPage.saveUpdateLayoutButton.click();
+				const {reload} =
+					await objectLayoutsPage.saveObjectLayoutReturningReload();
 
 				await waitForAlert(
 					page,
 					'Success:The object layout was updated successfully'
 				);
+
+				await reload;
 			});
 
 			await test.step('inheritance relationship field is omitted in object view', async () => {


### PR DESCRIPTION
> Resent from #181029, which the bot closed when the branch head moved. Code is unchanged — `git diff --stat e59bedc35 69a03f309` is empty; the amend only added the Root Cause section below.

https://liferay.atlassian.net/browse/LPD-104063

## What Is Being Fixed

`objectDefinitionHierarchy.spec.ts` › "cannot select inheritance relationships object field in object layout and object view" fails intermittently on CI. The step saves an object layout, waits for the success alert, then navigates on. The navigation is interrupted and the test fails downstream, away from its cause.

## How It Is Being Fixed

`SidePanelContent.tsx` `saveAndReload()` schedules the parent reload on a timer that starts **before** the success toast is raised:

```ts
setTimeout(() => {
    closeSidePanel();
    parentWindow.location.reload();
}, 300);
```

The toast the test waits on is therefore a starting gun, not a completion signal — waiting for it steers the test into the danger window rather than out of it. Playwright reports `navigations have finished` at that instant because the reload is not scheduled yet, so its auto-waiting cannot see the pending work.

`ObjectLayoutsPage` already owns `saveObjectLayoutReturningReload()`, which hands the reload promise back to the caller; **11 call sites in `objectRelationship.spec.ts` already use it**. This test was the one clicking the save button directly. It now uses the existing helper and awaits the reload before navigating away, so the step does not end with a navigation still pending.

Five sibling `saveUpdateLayoutButton.click()` call sites share the shape but have **no recorded failure**, so they are left unchanged and listed here rather than changed speculatively:

```
objectDefinitionHierarchy.spec.ts  — 5 further sites in other describes
```

## Root Cause

A lineage, not one commit.

**The emitter was born deferred.** `dcfca6f3abac89c` (LPS-147590, 2022-07-11) added `saveAndReload` by dropping it into the call slot `closeSidePanel()` already occupied — which was already ahead of `openToast(...)`. A synchronous close before a toast is harmless; a timer in the same slot turns the toast from a completion signal into a starting gun, and it did that **without moving a single call site**. `2c605fe504724` (LPS-158503, 2022-07-18) cut the delay from 1500 ms to 300 and is the only commit that has ever touched it.

**The failing call site was born direct.** `23dd8394fe43d` (LPD-62322, 2025-08-12) wrote `saveUpdateLayoutButton.click()` followed by `waitForAlert` and then a navigation. It was not converted away from a safe helper, because none existed: `ObjectLayoutsPage` had no `waitForNavigation` at all at that commit, and the direct click was the house idiom.

**The hazard was then pinned and swept, and this site was missed.** `591a9ec20f7ec` (LPD-102849, 2026-08-17) added `saveObjectLayoutReturningReload()` and converted three call sites; `0ad91a29197e6` (LPD-102865, same day) converted eight more. Those commits already describe this exact race. All eleven converted sites live in `objectRelationship.spec.ts` — `objectDefinitionHierarchy.spec.ts` was not in that sweep, which is why it still fails twelve days later.

Anyone re-deriving this should know that blaming the current line lands on `d60fad3fb6339` (LPD-85191), which git records as a **copy**: the hierarchy spec is byte-identical to the `rootModels` spec it was split from, so that commit moved the defect rather than authoring it.

## Verification

Reproduced with a deterministic control **before** the fix was written:

| arm | result |
|---|---|
| pristine, no amplifier | 5/5 passed (clean ground) |
| control | **5/5 failed**, CI signature |
| fixed, identical setup | **5/5 passed** |

Self-CI `ci:test:object`, build `test-1-42/1995`: the hierarchy spec passed **14/14**. Coverage was verified rather than assumed — `grep -cE '^\s*test\(' ` on the spec returns 14, matching the 14 testResults exactly, so the suite genuinely selected the changed test. The run was fully fresh (**0 of 58 axes cached**, `totalCachedDuration: 0`). That build's only failures are a pre-existing composite-key regression unrelated to this change.

That self-CI ran on `4b4a0f7a3b19df38aa2e3b9e007438b23da9dace`, whose tree is **identical** to this head — `git diff --stat 4b4a0f7a HEAD` is empty; only the commit message changed when the ticket was assigned.

## PR Check

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| HTML Escaping | PASS |
| JavaScript Unit Test | N/A |
| Per-Module Compile | N/A |
| Baseline | N/A |

`Source Format` — `ant format-source-current-branch -Dvalidate.commit.messages=true` clean, twice (stable). This also runs `:portalYarnFormatCurrentBranch`, which type-checks the TypeScript.
`HTML Escaping` — the three added lines emit no HTML.
`JavaScript Unit Test` — `modules/test/playwright` has no Jest config and no Jest dependency; its `test` script is `playwright test`.
`Per-Module Compile` — `modules/test/playwright` has no `bnd.bnd` and no `.lfrbuild-portal`; it is not a deployable module.
`Baseline` — no Java, `bnd.bnd`, `packageinfo`, or `.gradle` change, so no exported package surface is touched.

<!-- pr-check {"result": "success", "sha": "69a03f309e972507c739b746a82cef76d2e8368f"} -->


