### PR TITLE
LPD-104064 Stop re-navigating to the object details tab that is already open

### DIFF
--- a/modules/test/playwright/pages/object-web/object-details/EditObjectDetailsPage.ts
+++ b/modules/test/playwright/pages/object-web/object-details/EditObjectDetailsPage.ts
@@ -99,12 +99,27 @@ export class EditObjectDetailsPage {
 		await this.viewObjectDefinitionsPage.clickEditObjectDefinitionLink(
 			objectDefinitionLabel
 		);
+
+		await expect(this.detailsTabItem).toHaveAttribute(
+			'aria-current',
+			'page'
+		);
 	}
 
 	async goToDetailsTab() {
-		await this.detailsTabItem.click();
+		const ariaCurrent =
+			await this.detailsTabItem.getAttribute('aria-current');
 
-		await this.page.waitForLoadState('networkidle');
+		if (ariaCurrent !== 'page') {
+			await this.detailsTabItem.click();
+
+			await expect(this.detailsTabItem).toHaveAttribute(
+				'aria-current',
+				'page'
+			);
+		}
+
+		await this.waitForDetailsFormLoaded();
 	}
 
 	async waitForDetailsFormLoaded() {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-104064

> **Resent from #181030, which was wrong.** That version removed the details-tab click without replacing the wait the click was incidentally providing, and it regressed `objectDefinition.spec.ts` "can set Title Field for a system object". This version keeps the redundant-navigation fix and makes that wait explicit. Detail under *Correction* below.

## What Is Being Fixed

Two `objectDefinition.spec.ts` tests fail intermittently on CI with errors that look unrelated:

```
"can save changes when publishing"
  expected "UpdatedLabel386354200", received "ObjectDefinition2927753114"

"cannot save an object definition without a translation after changing the default language"
  strict mode violation: getByText('Required') resolved to 2 elements
```

They are the same bug. Opening a definition already lands on the details tab, so `goToDetailsTab()` clicking it again is a **second SPA screen load**. Senna re-creates the portlet DOM, `EditObjectDetails` remounts, and its load effect calls `setValues` — replacing the form state including the label just typed. With the label discarded the field is empty, so both Label and Plural Label report Required, the non-strict `getByText('Required')` matches two elements, and `toBeVisible()` throws.

From the CI trace (`test-1-48/1541`), the clobber at element level — same input node, adjacent snapshots:

```
238475.850  after@call@2231   value="UpdatedLabel386354200"
238499.901  before@call@2233  value="ObjectDefinition2927753114"
```

Neither existing wait can see it. `waitForLoadState('networkidle')` is a no-op against pushState — the trace logs `not waiting, "networkidle" event already fired`. `waitForDetailsFormLoaded()` matched the pre-swap DOM.

## Correction over #181030

#181030 replaced the tab click with an `aria-current` assertion and returned. That was incomplete. **The click it removed was doing two jobs**: it navigated, and it auto-waited — retrying through "element is not stable" and "element was detached" — which absorbed the form's load. Callers that read the form without a wait of their own were relying on that incidental delay.

`aria-current="page"` is set when the screen *commits*, which is **before** the load effect refetches and calls `setValues`. So returning at that point hands control back **earlier** in the lifecycle than the old code did. `can set Title Field for a system object` then does a **non-retrying** `textContent()` read:

```ts
const originalEntryTitleField =
    (await editObjectDetailsPage.entryTitleField.textContent())?.trim() ?? '';
```

It captured the placeholder `'Select an Option'` and spent 90 s hunting for an option by that name. That test passed in **101 consecutive prior builds**, passed on the revert-only sibling branch on the same axis, and failed the first time it ran with #181030's change.

This version therefore waits for the details form on **both** paths, making the guarantee the click gave by accident an explicit one.

## Root Cause

Born wrong in `e5035a794b5eb` (LPD-28108, 2024-07-10), which created both helpers: `goto()` returned as soon as the row link was clicked, and `goToDetailsTab()` clicked unconditionally with **no wait at all**.

The product side could already clobber — the load effect keyed on `objectDefinitionId` predates the helpers by eighteen months, and `fbacbc4fe8ec9` (LPS-162430, 2022-12-28) only renamed the file it lives in.

`52d40abc2feb8` (LPD-32919, 2024-09-30) later added `waitForLoadState('networkidle')`, which is inert against pushState — it did not change behaviour, but made the helper look guarded.

## Verification

Amplifier recreates the CI conditions and is **retained in both arms**:

| test | control | fixed |
|---|---|---|
| can save changes when publishing | **5/5 failed** | **5/5 passed** |
| cannot save ... after changing the default language | **5/5 failed** (`Required` count 2 every run) | **5/5 passed** (count 1 every run) |

In the fixed arm the amplifier's held response is **never requested** — the redundant navigation is not issued, so the mechanism is removed rather than the symptom absorbed.

Regression coverage for the correction: `can set Title Field for a system object` now passes **3/3** (it is a system object, so this also confirms `waitForDetailsFormLoaded()` holds there). Full `object-web.main` project **61/62** — the one failure is `assert presence of selected node style ... after dragging an unselected one`, which never touches `EditObjectDetailsPage` (it uses `modelBuilderDiagramPage`), fails on a React Flow node click timeout, and passes 3/3 in isolation.

The helper is shared by **24 call sites**; 18 of them do not follow `goToDetailsTab()` with a readiness wait, which is why the incidental wait mattered and why it is now explicit.

## PR Check

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| HTML Escaping | PASS |
| JavaScript Unit Test | N/A |
| Per-Module Compile | N/A |
| Baseline | N/A |

`Source Format` clean, twice (stable); includes `:portalYarnFormatCurrentBranch`, which type-checks the TypeScript. The N/A results are by inspection: no Jest config or dependency in `modules/test/playwright` (its `test` script is `playwright test`), no `bnd.bnd` or `.lfrbuild-portal`, and no Java, `packageinfo` or `.gradle` change.

<!-- pr-check {"result": "success", "sha": "7894f5ae8f3a7e3bcdd3d1f73a20a910eb08e6e3"} -->
