### PR TITLE
LPD-104066 Wait for the model builder sidebar's fetch before reading the sidebar

### DIFF
--- a/modules/test/playwright/tests/object-web/main/objectDefinition.spec.ts
+++ b/modules/test/playwright/tests/object-web/main/objectDefinition.spec.ts
@@ -133,7 +133,16 @@ test.describe('Manage object definitions through Model Builder', () => {
 			const objectDefinitionLabel =
 				'ObjectDefinitionLabel' + getRandomInt();
 
-			modelBuilderLeftSidebarPage.createNewObjectDefinitionButton.click();
+			await modelBuilderLeftSidebarPage.createNewObjectDefinitionButton.click();
+
+			const objectDefinitionResponsePromise =
+				modelBuilderDiagramPage.page.waitForResponse((response) =>
+					response
+						.url()
+						.includes(
+							'/object-definitions/by-external-reference-code/'
+						)
+				);
 
 			const objectDefinition =
 				await modalAddObjectDefinitionPage.createObjectDefinition(
@@ -144,6 +153,8 @@ test.describe('Manage object definitions through Model Builder', () => {
 				id: objectDefinition.id,
 				type: 'objectDefinition',
 			});
+
+			await objectDefinitionResponsePromise;
 
 			const rightSidebar =
 				modelBuilderRightSidebarPage.getRightSidebarLocator(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-104066

## What Is Being Fixed

`objectDefinition.spec.ts` "can create an object definition by model builder" fails intermittently on `ci:test:object` with:

```
Received: <element(s) not found>
```

The test creates an object definition through the Model Builder and then asserts the right sidebar shows its label. The sidebar does not arrive with the modal — after the modal closes the page issues a `GET /object-definitions/by-external-reference-code/…` and the sidebar renders from that response. Nothing waited for it, so a slow fetch leaves the assertion reading an empty sidebar.

Playwright's auto-waiting does not cover this: `toBeVisible()` retries the locator, but the content only appears once that one response lands, so retrying the DOM does not make the fetch arrive sooner.

A second, quieter defect sat on the line above — the click that opens the modal was never awaited, so its promise floated and the modal was driven while the click was still resolving, inside a four-iteration loop.

## How It Is Being Fixed

Await the click; register the `waitForResponse` **before** the create and await it after the create, before reading the sidebar.

The ordering is load-bearing: registering the listener after `createObjectDefinition` would let a fast response land before anything was listening, and the wait would hang until timeout. Register early, await late.

This is a wait at the producer rather than a retry at the assertion, so the sidebar is read once — when it is actually populated.

## Root Cause

`56911ed6931c5` (LPD-21496, 2024-04-24) added this test with the unawaited click and no wait for the fetch that fills the sidebar. Born broken.

A naive pickaxe lands on `57faa628b5331`, which is only a project **move**; the origin was confirmed by reading the added lines in the original commit.

## Testing

| arm | result |
|---|---|
| control | **5/5 failed**, exact CI signature |
| fixed | **5/5 passed** |

One-shot route holding the `by-external-reference-code` response 20 s, armed immediately before the create. The amplifier fired 5x in **both** arms.

- Owning project `object-web.main`: **62/62 passed**.
- Solo self-CI (`test-1-45/1707`): **0 of 58 axes cached**, 4194 test results, failure set **identical** to the four-times-verified bare-master reference. The fixed test **ran and passed** (16.4 s); all 43 tests in the spec passed; Playwright 566/567, 0 failed.
- Aggregate: carried in `agg-2026-08-30-round4` alongside every other pending fix — **three consecutive verified greens**, each 0 cached axes, 4194 = 4064 passed / 130 skipped / 0 failed.

## PR Check

| validation | result |
|---|---|
| Source Format | **PASS** — `format-source-current-branch`, clean (includes the TypeScript check) |
| HTML Escaping | **PASS** — no added line renders a value as HTML |
| JavaScript Unit Test | **N/A as Jest** — `modules/test/playwright`'s `test` script is the Playwright runner, not a Jest suite. Satisfied instead by the owning-project run, `object-web.main` 62/62 |
| Per-Module Compile | **Does not fire** — no `bnd.bnd` and no `.lfrbuild-portal`; not a deployable bundle, nothing to compile or deploy |
| Baseline | **Not applicable** — the diff is one Playwright spec: no Java, no exported package, no `bnd.bnd`/`packageinfo`. Only an inherited finding is possible, which does not fail the branch |

Diff is a single file: `modules/test/playwright/tests/object-web/main/objectDefinition.spec.ts`, +12 / −1.

<!-- pr-check {"result": "success", "sha": "ffa169a71078b485ebb48f9ea7b8d151673551bb"} -->
