### PR TITLE
LPD-104071 Keep the modal body from being remounted on every render

### DIFF
--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/modal/components/Modal.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/modal/components/Modal.tsx
@@ -82,6 +82,54 @@ export interface ModalProps {
 	zIndex?: number;
 }
 
+function Body({
+	component: BodyComponent,
+	html,
+	onOpen,
+	processClose,
+}: {
+	component?: typeof React.Component;
+	html?: string;
+	onOpen?: IframeOnOpen;
+	processClose: () => void;
+}) {
+	const bodyRef = useRef<HTMLDivElement>(null);
+	const onOpenRef = useRef(onOpen);
+	const processCloseRef = useRef(processClose);
+
+	useEffect(() => {
+		onOpenRef.current = onOpen;
+		processCloseRef.current = processClose;
+	}, [onOpen, processClose]);
+
+	useEffect(() => {
+		if (html) {
+			const fragment = document
+				.createRange()
+				.createContextualFragment(setCSPNonce(html));
+
+			if (bodyRef.current) {
+				bodyRef.current.innerHTML = '';
+
+				bodyRef.current.appendChild(fragment);
+			}
+		}
+
+		if (onOpenRef.current) {
+			onOpenRef.current({
+				container: bodyRef.current ?? undefined,
+				processClose: processCloseRef.current,
+			});
+		}
+	}, [html]);
+
+	return (
+		<div className="liferay-modal-body" ref={bodyRef}>
+			{BodyComponent && <BodyComponent closeModal={processClose} />}
+		</div>
+	);
+}
+
 export default function Modal({
 	bodyComponent,
 	bodyHTML,
@@ -210,43 +258,6 @@ export default function Modal({
 		if (onClick) {
 			onClick({processClose});
 		}
-	};
-
-	const Body = ({
-		component: BodyComponent,
-		html,
-	}: {
-		component?: typeof React.Component;
-		html?: string;
-	}) => {
-
-		/* eslint-disable-next-line react-compiler/react-compiler */
-		const bodyRef = useRef<HTMLDivElement>(null);
-
-		/* eslint-disable-next-line react-compiler/react-compiler */
-		useEffect(() => {
-			if (html) {
-				const fragment = document
-					.createRange()
-					.createContextualFragment(setCSPNonce(html));
-
-				if (bodyRef.current) {
-					bodyRef.current.innerHTML = '';
-
-					bodyRef.current.appendChild(fragment);
-				}
-			}
-
-			if (onOpen) {
-				onOpen({container: bodyRef.current ?? undefined, processClose});
-			}
-		}, [html]);
-
-		return (
-			<div className="liferay-modal-body" ref={bodyRef}>
-				{BodyComponent && <BodyComponent closeModal={processClose} />}
-			</div>
-		);
 	};
 
 	useEffect(() => {
@@ -380,10 +391,20 @@ export default function Modal({
 									</>
 								)}
 
-								{bodyHTML && <Body html={bodyHTML} />}
+								{bodyHTML && (
+									<Body
+										html={bodyHTML}
+										onOpen={onOpen}
+										processClose={processClose}
+									/>
+								)}
 
 								{bodyComponent && (
-									<Body component={bodyComponent} />
+									<Body
+										component={bodyComponent}
+										onOpen={onOpen}
+										processClose={processClose}
+									/>
 								)}
 							</div>
 

--- a/modules/apps/frontend-js/frontend-js-components-web/test/modal/components/Modal.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/test/modal/components/Modal.tsx
@@ -109,6 +109,62 @@ describe('Modal', () => {
 		expect(document.getElementById(sampleId)).toBeTruthy();
 	});
 
+	it('calls onOpen once, even when the modal rerenders', () => {
+		const onOpen = jest.fn();
+
+		const SampleBodyComponent = () => {
+			return <div />;
+		};
+
+		const {rerender} = render(
+			<Modal bodyComponent={SampleBodyComponent} onOpen={onOpen} />
+		);
+
+		act(() => {
+			jest.runAllTimers();
+		});
+
+		rerender(<Modal bodyComponent={SampleBodyComponent} onOpen={onOpen} />);
+
+		act(() => {
+			jest.runAllTimers();
+		});
+
+		expect(onOpen).toHaveBeenCalledTimes(1);
+	});
+
+	it('keeps the body state when the modal rerenders', () => {
+		const sampleId = 'sampleId';
+
+		const SampleBodyComponent = () => {
+			return <input id={sampleId} />;
+		};
+
+		const {baseElement, rerender} = render(
+			<Modal bodyComponent={SampleBodyComponent} />
+		);
+
+		act(() => {
+			jest.runAllTimers();
+		});
+
+		fireEvent.change(
+			baseElement.querySelector(`#${sampleId}`) as HTMLInputElement,
+			{target: {value: 'typed'}}
+		);
+
+		rerender(<Modal bodyComponent={SampleBodyComponent} />);
+
+		act(() => {
+			jest.runAllTimers();
+		});
+
+		expect(
+			(baseElement.querySelector(`#${sampleId}`) as HTMLInputElement)
+				.value
+		).toBe('typed');
+	});
+
 	it('renders given header HTML', () => {
 		const sampleId = 'sampleId';
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-104071

## What Is Being Fixed

`Modal` declared its `Body` component **inside** `Modal`, so every render created a new component type. React cannot reconcile a new type with the old one, so it unmounts the previous body and mounts a fresh one.

Two consequences: `onOpen` fires again on each remount, breaking the once-per-open contract callers rely on, and any state the body holds is discarded — text typed into a modal body can be lost when the parent re-renders.

## How It Is Being Fixed

Hoist `Body` to module scope so its identity is stable across renders, reaching the changing callbacks through refs rather than closure. The component type never changes, so React reconciles instead of remounting.

## Scope — please read

This is the **`onOpen`-twice contract violation** fix. It is **not** the fix for `objectPersonalData` "can anonymize object entries" — that test passes 5/5 on **both** arms, even with CDP CPU throttling widening the remount window from 19 ms to 313 ms. Its real cause is `performLogin` defaulting `rememberMe` to true, so `login.jsp` server-renders the field pre-populated with the previous user's email.

## Testing

| arm | result |
|---|---|
| control (master's `Modal.tsx`) | **2 FAILED** — `onOpen` called 2× instead of 1, body input value lost |
| fixed (hoisted `Body`) | **2 PASSED** — full module suite 191 passed, 22 suites |

Mechanism A/B on the live portal with an `innerHTML`-setter probe: master records **4 writes in two matched pairs**; fixed records **2**, `onOpen` once.

A design proposal to drive the second render from `useModal`'s internal 100 ms delay was **measured and refuted** — under `jest.runAllTimers` alone the diagnostic reports `mounts: 1, sameNode: true, value: "typed"`, so those tests would have passed on master and guarded nothing. `rerender` is what actually exercises it.

Both tests are confirmed to **run and pass on CI** in a non-cached `js-unit` axis of `ci:test:frontend-js`. This matters: `ci:test:object` and `ci:test:relevant` both pass their js-unit axes **without ever selecting** `frontend-js-components-web`, so a green there would have been vacuous.

Aggregate: carried alongside every other pending fix on `agg-2026-08-30-round5`, which produced two verified-genuine green runs.

## PR Check

| validation | result |
|---|---|
| Source Format | **PASS** — `format-source-current-branch` clean, 0 files modified |
| HTML Escaping | **PASS with note** — 2 added lines matched (`createContextualFragment`, `innerHTML = ''`). Both exist **once on master and once on the branch**: pre-existing code relocated by the hoist, no new HTML-rendering surface |
| JavaScript Unit Test | **PASS** — module suite 191 passed / 22 suites; the 2 new tests verified running on `ci:test:frontend-js` |
| Per-Module Compile | **PASS** — `frontend-js-components-web.assemble` succeeded on CI, so the change built into the bundle under test |
| Baseline | no exported-API change; `bnd.bnd` and `packageinfo` untouched |

Commits were renamed from `LPD-X` to the ticket; the amend was **message-only with the tree verified identical**, so the CI evidence above carries over unchanged.

<!-- pr-check {"result": "success", "sha": "781dcd5717d93cd18cb80cf7081038ca40cbda3c"} -->
