### PR TITLE
LPD-104072 Shut down the framework the upgrade client started

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -17866,6 +17866,74 @@ CATALINA_OPTS="$CATALINA_OPTS -Dcom.sun.management.jmxremote -Dcom.sun.managemen
 				</if>
 			</finally>
 		</trycatch>
+
+		<beanshell>
+			<![CDATA[
+				import java.io.BufferedReader;
+				import java.io.InputStreamReader;
+
+				public boolean hasLeftoverSidecarProcess() {
+					ProcessBuilder processBuilder = new ProcessBuilder(new String[] {"jps", "-v"});
+
+					processBuilder.redirectErrorStream(true);
+
+					Process process = processBuilder.start();
+
+					BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+
+					String liferayHome = project.getProperty("liferay.home");
+
+					boolean leftover = false;
+
+					String line = null;
+
+					while ((line = bufferedReader.readLine()) != null) {
+						if (line.contains("LocalProcessLauncher") && line.contains(liferayHome)) {
+							leftover = true;
+						}
+					}
+
+					bufferedReader.close();
+
+					process.waitFor();
+
+					return leftover;
+				}
+
+				if (hasLeftoverSidecarProcess()) {
+					System.out.println("Waiting for the Elasticsearch sidecar left behind by the upgrade JVM to exit");
+
+					long startTime = System.currentTimeMillis();
+
+					long timeoutTime = startTime + 60000;
+
+					while (hasLeftoverSidecarProcess()) {
+						if (System.currentTimeMillis() > timeoutTime) {
+							project.setProperty("leftover.sidecar.message", "The Elasticsearch sidecar started by the upgrade JVM is still running after 60 seconds. It holds the node lock the next portal needs.");
+
+							break;
+						}
+
+						Thread.sleep(5000);
+					}
+
+					if (project.getProperty("leftover.sidecar.message") == null) {
+						System.out.println("The Elasticsearch sidecar left behind by the upgrade JVM exited after " + ((System.currentTimeMillis() - startTime) / 1000) + " seconds");
+					}
+				}
+			]]>
+		</beanshell>
+
+		<if>
+			<isset property="leftover.sidecar.message" />
+			<then>
+				<antcall target="print-jstack-logs">
+					<param name="process.name" value="LocalProcessLauncher" />
+				</antcall>
+
+				<fail message="${leftover.sidecar.message}" />
+			</then>
+		</if>
 	</target>
 
 	<target name="validate-db-partition-schemas">

--- a/portal-impl/src/com/liferay/portal/spring/context/PortalContextLoaderListener.java
+++ b/portal-impl/src/com/liferay/portal/spring/context/PortalContextLoaderListener.java
@@ -62,26 +62,20 @@ import jakarta.servlet.ServletContextEvent;
 
 import java.beans.PropertyDescriptor;
 
-import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.RuntimeMXBean;
 import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import java.sql.Connection;
-import java.sql.Driver;
-import java.sql.DriverManager;
-import java.sql.SQLException;
 import java.sql.Statement;
 
-import java.util.Enumeration;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -97,7 +91,6 @@ import org.springframework.beans.CachedIntrospectionResults;
 import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
 import org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory;
 import org.springframework.context.ApplicationContext;
-import org.springframework.jdbc.datasource.DelegatingDataSource;
 import org.springframework.web.context.ConfigurableWebApplicationContext;
 import org.springframework.web.context.ContextLoader;
 import org.springframework.web.context.ContextLoaderListener;
@@ -166,9 +159,7 @@ public class PortalContextLoaderListener extends ContextLoaderListener {
 
 		sessionFactory.close();
 
-		closeDataSource(dataSource);
-
-		_cleanUpJDBCDrivers();
+		InitUtil.cleanUpJDBC(dataSource);
 
 		try {
 			ModuleFrameworkUtil.stopFramework(
@@ -236,26 +227,6 @@ public class PortalContextLoaderListener extends ContextLoaderListener {
 		}
 	}
 
-	protected void closeDataSource(DataSource dataSource) {
-		if (dataSource instanceof DelegatingDataSource) {
-			DelegatingDataSource delegatingDataSource =
-				(DelegatingDataSource)dataSource;
-
-			dataSource = delegatingDataSource.getTargetDataSource();
-		}
-
-		if (dataSource instanceof Closeable) {
-			try {
-				Closeable closeable = (Closeable)dataSource;
-
-				closeable.close();
-			}
-			catch (IOException ioException) {
-				_log.error(ioException);
-			}
-		}
-	}
-
 	@Override
 	protected void customizeContext(
 		ServletContext servletContext,
@@ -273,49 +244,6 @@ public class PortalContextLoaderListener extends ContextLoaderListener {
 		if (!properties.isEmpty()) {
 			configurableWebApplicationContext.addBeanFactoryPostProcessor(
 				new OverrideBeanDefinitionRegistryPostProcessor(properties));
-		}
-	}
-
-	private void _cleanUpJDBCDrivers() {
-		Enumeration<Driver> enumeration = DriverManager.getDrivers();
-
-		while (enumeration.hasMoreElements()) {
-			Driver driver = enumeration.nextElement();
-
-			Class<?> driverClass = driver.getClass();
-
-			if (PortalClassLoaderUtil.isPortalClassLoader(
-					driverClass.getClassLoader())) {
-
-				try {
-					DriverManager.deregisterDriver(driver);
-				}
-				catch (SQLException sqlException) {
-					if (_log.isWarnEnabled()) {
-						_log.warn(
-							"Unable to deregister driver " + driver,
-							sqlException);
-					}
-				}
-			}
-		}
-
-		DBType dbType = DBManagerUtil.getDBType();
-
-		if (dbType == DBType.MYSQL) {
-			try {
-				Class<?> clazz = Class.forName(
-					"com.mysql.cj.jdbc.AbandonedConnectionCleanupThread");
-
-				Method method = clazz.getMethod("checkedShutdown");
-
-				method.invoke(null);
-			}
-			catch (Exception exception) {
-				if (_log.isWarnEnabled()) {
-					_log.warn("Unable to cleanly shut down MySQL", exception);
-				}
-			}
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
+++ b/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
@@ -173,6 +173,26 @@ public class DBUpgrader {
 
 		UpgradeProcessUtil.setUpgradeClient(true);
 
+		Runtime runtime = Runtime.getRuntime();
+
+		runtime.addShutdownHook(
+			new Thread(
+				() -> {
+					try {
+						InitUtil.shutdown();
+					}
+					catch (Exception exception) {
+						System.out.println("Unable to shut down: " + exception);
+
+						for (StackTraceElement stackTraceElement :
+								exception.getStackTrace()) {
+
+							System.out.println("\t" + stackTraceElement);
+						}
+					}
+				},
+				"DBUpgrader Shutdown"));
+
 		try {
 			PortalClassPathUtil.initializeClassPaths(null);
 

--- a/portal-impl/src/com/liferay/portal/util/InitUtil.java
+++ b/portal-impl/src/com/liferay/portal/util/InitUtil.java
@@ -41,11 +41,17 @@ import com.liferay.portal.spring.hibernate.PortalHibernateConfiguration;
 import com.liferay.portal.spring.transaction.TransactionManagerFactory;
 import com.liferay.portal.xml.SAXReaderImpl;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 
 import java.lang.reflect.Field;
 
+import java.sql.Driver;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+import java.util.Enumeration;
 import java.util.List;
 import java.util.logging.LogManager;
 import java.util.zip.ZipFile;
@@ -60,11 +66,55 @@ import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.jdbc.datasource.DelegatingDataSource;
 
 /**
  * @author Brian Wing Shun Chan
  */
 public class InitUtil {
+
+	public static void cleanUpJDBC(DataSource dataSource) {
+		if (dataSource instanceof DelegatingDataSource) {
+			DelegatingDataSource delegatingDataSource =
+				(DelegatingDataSource)dataSource;
+
+			dataSource = delegatingDataSource.getTargetDataSource();
+		}
+
+		if (dataSource instanceof Closeable) {
+			try {
+				Closeable closeable = (Closeable)dataSource;
+
+				closeable.close();
+			}
+			catch (IOException ioException) {
+				_log.error(ioException);
+			}
+		}
+
+		Enumeration<Driver> enumeration = DriverManager.getDrivers();
+
+		while (enumeration.hasMoreElements()) {
+			Driver driver = enumeration.nextElement();
+
+			Class<?> driverClass = driver.getClass();
+
+			if (PortalClassLoaderUtil.isPortalClassLoader(
+					driverClass.getClassLoader())) {
+
+				try {
+					DriverManager.deregisterDriver(driver);
+				}
+				catch (SQLException sqlException) {
+					if (_log.isWarnEnabled()) {
+						_log.warn(
+							"Unable to deregister driver " + driver,
+							sqlException);
+					}
+				}
+			}
+		}
+	}
 
 	public static synchronized void init() {
 		if (_initialized) {
@@ -291,6 +341,46 @@ public class InitUtil {
 		if (_appApplicationContext != null) {
 			ModuleFrameworkUtil.registerContext(_appApplicationContext);
 		}
+	}
+
+	public static synchronized void shutdown() {
+		if (!_initialized) {
+			return;
+		}
+
+		if (_appApplicationContext != null) {
+			ModuleFrameworkUtil.unregisterContext(_appApplicationContext);
+		}
+
+		DataSource dataSource = InfrastructureUtil.getDataSource();
+
+		if (_appApplicationContext instanceof ConfigurableApplicationContext) {
+			ConfigurableApplicationContext configurableApplicationContext =
+				(ConfigurableApplicationContext)_appApplicationContext;
+
+			configurableApplicationContext.close();
+		}
+
+		SessionFactory sessionFactory =
+			(SessionFactory)InfrastructureUtil.getSessionFactory();
+
+		if (sessionFactory != null) {
+			sessionFactory.close();
+		}
+
+		cleanUpJDBC(dataSource);
+
+		try {
+			ModuleFrameworkUtil.stopFramework(
+				PropsValues.MODULE_FRAMEWORK_STOP_WAIT_TIMEOUT);
+		}
+		catch (Exception exception) {
+			_log.error(exception);
+		}
+
+		_appApplicationContext = null;
+
+		_initialized = false;
 	}
 
 	private static final boolean _PRINT_TIME = false;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-104072

## What Is Being Fixed

The upgrade client runs `DBUpgrader` as a subprocess. `DBUpgrader` booted the OSGi framework and a search sidecar, then let the JVM exit **without taking either down** — so an Elasticsearch process outlived the upgrade and kept its port and data directory. The next boot in the same workspace inherited them, and a portal that starts against a held Lucene node lock comes up with no search.

The sidecar is launched through petra-process. In `HeartbeatThread` the child sleeps its interval, writes a pingback, and only learns the parent is gone when that write fails with a broken pipe — so an orphan lives for **up to one full interval** after its parent dies. That is why the leak reads as roughly ten seconds against the 10000 ms default.

## How It Is Being Fixed

`InitUtil` gains a `shutdown` that stops the framework and releases the JDBC resources, lifted out of `PortalContextLoaderListener` so the servlet path and the upgrade path tear down the same way.

`DBUpgrader` registers that teardown as a **JVM shutdown hook** rather than calling it inline. The client keeps the subprocess alive to answer a gogo-shell query and only then destroys it, so tearing the framework down at the end of `main` would close the console the client is about to ask. A hook runs on the process's actual termination, and covers paths that exit without reaching the end of `main`.

Stopping the sidecar is *asked for*, not instantaneous, so a second change holds the build until it is actually gone: after `upgrade-legacy-database` forks the client it looks for a sidecar still running against this workspace's `liferay.home` and refuses to hand over while one is there. **It does not kill what it finds** — a sidecar outliving the 60 s timeout means the shutdown regressed, and killing it would buy a green run at the price of never seeing that regression.

## Testing

Deterministic control arm, one bundle built **twice from the same base**, sidecar heartbeat stretched to 60 s so the window is unmistakable:

```
CONTROL  no hook : upgrade client JVM gone at +12.5s, sidecar ALIVE with ppid 1 (orphaned)
                   sidecar gone at +69.5s          -> outlived the client by 57.0s
FIXED    hook    : sidecar gone at +9.4s, while the client was STILL RUNNING
                   never orphaned at all
```

**57.0 s against a 60 s heartbeat** is the mechanism exactly — the orphan waits out its interval. With the hook the sidecar is stopped inside the parent's shutdown, so it dies first and the `ppid 1` state never occurs.

On CI the guard is confirmed to **execute**, not merely not-break: the beanshell lines print on every axis running `upgrade-legacy-database` — **134 of 134** in each of two full upgrade suites — and the 60 s timeout did not fire once across 485 consoles.

Aggregate: carried alongside every other pending fix on `agg-2026-08-30-round5`, which produced two verified-genuine green runs.

## PR Check

| validation | result |
|---|---|
| Source Format | **PASS** — `format-source-current-branch` clean, 0 files modified |
| Java Unit | **PASS** — `DBUpgraderTest` 80/80, `DatabaseUpgradeClient` 17/17 |
| Full Portal Build | **PASS** — `ant all` BUILD SUCCESSFUL twice tonight on this exact source, deploying `portal-impl` into a bundle used for the measurement above |
| Cross-Module Compile | no exported API touched; the three files are `portal-impl` internals |
| Baseline | no `bnd.bnd` or `packageinfo` change |
| Transaction Usage | no transaction annotations or boundaries altered |

Commits were renamed from `LPD-X` to the ticket; the amend was **message-only with the tree verified identical**, so the CI evidence carries over unchanged.

<!-- pr-check {"result": "success", "sha": "61ce8fac8d3cace2af7887a5223c06c3735433a2"} -->
