### PR TITLE
LPD-104073 Stop reporting dispatch logs as leftover test data

### DIFF
--- a/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
@@ -668,6 +668,7 @@ public class DataGuardTestRuleUtil {
 
 	private static final Set<String> _blacklistedModelClassNames =
 		SetUtil.fromArray(
+			"com.liferay.dispatch.model.DispatchLog",
 			"com.liferay.portal.kernel.model.ClassName",
 			"com.liferay.portal.security.audit.storage.model.AuditEvent");
 	private static final ThreadLocal<Map<String, Map<Serializable, String>>>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-104073

## What Is Being Fixed

Any integration test class whose DataGuard window contains midnight is blamed for a DispatchLog row it never created. A ci:test:object run failed UserNotificationTypeTest with "caused leftover data for class :com.liferay.dispatch.model.DispatchLog" over a row stamped 00:00:00.029, guest-owned, SUCCESSFUL in 10ms — written by BaseDispatchTaskExecutor when the hidden scheduled-publications-conflict-checks trigger (LPD-17343, unconditional per portal instance, cron 0 0 0 * * ?) fired on the persisted Quartz thread, which runs during integration tests by design.

## How It Is Being Fixed

Blacklist the model in DataGuardTestRuleUtil the way AuditEvent (LPD-27214) and ClassName (LPD-103978) already are. Trigger deletion already cascades to its logs, so a test that leaks a DispatchTrigger is still caught; only the scheduler's own rows stop being blamed on bystanders.

## PR Check

- Source Format: PASS (format-source-current-branch, incl. commit message validation)
- Compile: PASS (portal-test ant compile)
- ci:test:object (solo): PASS 59/59, per-test harvest clean (UserNotificationTypeTest passed; zero leftover-data failures on all 21 integration axes)
- ci:test:relevant (solo): PASS (relevant 14/14 + stable 9/9)
- Aggregate ride: PASS 59/59 composed with every other pending fix

<!-- pr-check {"result": "success", "sha": "2edc5affb876fa171b254504f1f7d89323fe69fe"} -->
