### PR TITLE
LPD-104074 Wait for the model builder auto-save before the folder move test ends

### DIFF
--- a/modules/test/playwright/tests/object-web/folder/objectFolder.spec.ts
+++ b/modules/test/playwright/tests/object-web/folder/objectFolder.spec.ts
@@ -436,6 +436,15 @@ test.describe('manage object definitions through view object definitions', () =>
 					objectDefinition.label['en_US']
 				);
 
+				const objectFolderPutResponsePromise = page.waitForResponse(
+					(response) =>
+						response
+							.url()
+							.includes(
+								'/object-folders/by-external-reference-code/'
+							) && response.request().method() === 'PUT'
+				);
+
 				await page
 					.getByRole('menuitem', {name: 'Move to Current Folder'})
 					.click();
@@ -443,6 +452,8 @@ test.describe('manage object definitions through view object definitions', () =>
 				await expect(
 					page.locator('#ToastAlertContainer .alert-success')
 				).toBeVisible();
+
+				await objectFolderPutResponsePromise;
 			});
 
 			await test.step('Check that the object definition is visible in Folder B sidebar', async () => {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-104074

## What Is Being Fixed

objectFolder.spec.ts "object definitions can be moved to the current folder when the user is in the model builder view" intermittently fails in fixture teardown with HTTP 500 on DELETE /object-definitions/{id} (7 sightings incl. the upstream master routine, oldest 2026-06-19). The model builder saves node positions via a fire-and-forget folder PUT (since LPS-201415) that fires ~200ms after the success toast the test waits on, so the test ends with that PUT in flight while teardown deletes the same rows from a second browser context. Both transactions hit the same ObjectFolderItem row - one race, two shapes: an MVCC StaleStateException on the version-qualified delete, or the earlier-captured Postgres lock-order deadlock. LPD-104028 serialized the move PATCH but not this PUT.

## How It Is Being Fixed

Explicit wait at the producer: register waitForResponse for the folder auto-save PUT before the click that causes it and await it after the toast, so the test ends with no write in flight (the LPD-104066 listener-before-action idiom).

## PR Check

- Source Format: PASS (format-source-current-branch, incl. TypeScript checks and commit message validation)
- Local red/green: control probe 5/5 red with the byte-identical CI statement; fixed spec 5/5 green plain + 5/5 green under a 2s-delayed-PUT amplifier
- ci:test:object (solo): PASS 59/59, harvest clean, fixed test passed
- Aggregate ride: PASS 59/59 composed with every other pending fix

<!-- pr-check {"result": "success", "sha": "1465b1d2d2890fccaea546a928d34b0456597e59"} -->
