### PR TITLE
LPD-103957 Upgrade document library web after the repository framework

### DIFF
--- a/modules/apps/document-library/document-library-web-test/build.gradle
+++ b/modules/apps/document-library/document-library-web-test/build.gradle
@@ -2,6 +2,8 @@ dependencies {
 	testIntegrationImplementation group: "com.liferay.jakarta.portlet", name: "com.liferay.jakarta.portlet-api", version: "4.0.0"
 	testIntegrationImplementation group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	testIntegrationImplementation group: "jakarta.servlet", name: "jakarta.servlet-api", version: "6.0.0"
+	testIntegrationImplementation group: "org.osgi", name: "org.osgi.dto", version: "1.1.0"
+	testIntegrationImplementation group: "org.osgi", name: "org.osgi.service.component", version: "1.4.0"
 	testIntegrationImplementation project(":apps:depot:depot-api")
 	testIntegrationImplementation project(":apps:document-library:document-library-api")
 	testIntegrationImplementation project(":apps:document-library:document-library-test-util")

--- a/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/upgrade/registry/test/DLWebUpgradeStepRegistratorTest.java
+++ b/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/upgrade/registry/test/DLWebUpgradeStepRegistratorTest.java
@@ -1,0 +1,93 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.document.library.web.internal.upgrade.registry.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.module.util.SystemBundleUtil;
+import com.liferay.portal.kernel.repository.RepositoryFactory;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Objects;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.component.runtime.ServiceComponentRuntime;
+import org.osgi.service.component.runtime.dto.ComponentDescriptionDTO;
+import org.osgi.service.component.runtime.dto.ReferenceDTO;
+
+/**
+ * @author István András Dézsi
+ */
+@RunWith(Arquillian.class)
+public class DLWebUpgradeStepRegistratorTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testRegister() throws Exception {
+		BundleContext bundleContext = SystemBundleUtil.getBundleContext();
+
+		Collection<ServiceReference<UpgradeStepRegistrator>> serviceReferences =
+			bundleContext.getServiceReferences(
+				UpgradeStepRegistrator.class,
+				"(component.name=" + _CLASS_NAME + ")");
+
+		Assert.assertEquals(
+			serviceReferences.toString(), 1, serviceReferences.size());
+
+		for (ServiceReference<UpgradeStepRegistrator> serviceReference :
+				serviceReferences) {
+
+			ComponentDescriptionDTO componentDescriptionDTO =
+				_serviceComponentRuntime.getComponentDescriptionDTO(
+					serviceReference.getBundle(), _CLASS_NAME);
+
+			Assert.assertTrue(
+				Arrays.toString(componentDescriptionDTO.references),
+				_hasReference(
+					componentDescriptionDTO, RepositoryFactory.class.getName(),
+					"(class.name=com.liferay.portal.repository." +
+						"liferayrepository.LiferayRepository)"));
+		}
+	}
+
+	private boolean _hasReference(
+		ComponentDescriptionDTO componentDescriptionDTO, String interfaceName,
+		String target) {
+
+		for (ReferenceDTO referenceDTO : componentDescriptionDTO.references) {
+			if (Objects.equals(referenceDTO.interfaceName, interfaceName) &&
+				Objects.equals(referenceDTO.target, target)) {
+
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private static final String _CLASS_NAME =
+		"com.liferay.document.library.web.internal.upgrade.registry." +
+			"DLWebUpgradeStepRegistrator";
+
+	@Inject
+	private ServiceComponentRuntime _serviceComponentRuntime;
+
+}

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/upgrade/registry/DLWebUpgradeStepRegistrator.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/upgrade/registry/DLWebUpgradeStepRegistrator.java
@@ -10,6 +10,7 @@ import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.web.internal.upgrade.v1_0_0.UpgradeAdminPortlets;
 import com.liferay.document.library.web.internal.upgrade.v1_0_0.UpgradePortletPreferences;
 import com.liferay.document.library.web.internal.upgrade.v1_0_0.UpgradePortletSettings;
+import com.liferay.portal.kernel.repository.RepositoryFactory;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.RepositoryLocalService;
@@ -73,6 +74,11 @@ public class DLWebUpgradeStepRegistrator implements UpgradeStepRegistrator {
 
 	@Reference
 	private GroupLocalService _groupLocalService;
+
+	@Reference(
+		target = "(class.name=com.liferay.portal.repository.liferayrepository.LiferayRepository)"
+	)
+	private RepositoryFactory _liferayRepositoryFactory;
 
 	@Reference
 	private RepositoryLocalService _repositoryLocalService;

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -433,6 +433,7 @@
         modules/apps/document-library/document-library-repository-portlet-file-repository-impl,\
         modules/apps/document-library/document-library-service,\
         modules/apps/document-library/document-library-video,\
+        modules/apps/document-library/document-library-web,\
         modules/apps/document-library-google-docs/document-library-google-docs,\
         modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web,\
         modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-footers,\


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103957

Reopened from #181061 with the test method renamed as requested.

## What Is Being Fixed

The `com.liferay.document.library.web` module upgrade can run before the `com.liferay.document.library.service` module upgrade. The v1_1_0 `UpgradePortletPreferences` step calls `DLAppLocalService.getFolder`, which needs the `LiferayRepository` definition in the `RepositoryClassDefinitionCatalog`. That definition is only registered after the `com.liferay.document.library.service` module upgrade completes, because `PortalCapabilityLocatorImpl` depends on the Service Builder services of that module and those are gated on its `Release`. `DLWebUpgradeStepRegistrator` does not declare this dependency, so when the document library web upgrade runs first, it fails with `UndeployedExternalRepositoryException` and the whole module upgrade aborts. The failure surfaced in the upgrade test environment after LPD-100216 changed the module upgrade order, and it also reproduces from a 2024.Q4 database with a Documents and Media widget configured with a root folder.

## How It Is Being Fixed

`DLWebUpgradeStepRegistrator` declares a reference to the `RepositoryFactory` service registered for `com.liferay.portal.repository.liferayrepository.LiferayRepository`. `RepositoryClassDefinitionCatalogImpl` registers that service after it stores the repository class definition, so when the reference is satisfied, the definition the upgrade step needs is already in the catalog, independent of service listener ordering. A reference to `PortalCapabilityLocator` alone, the LPS-82746 approach used by `journal-service`, is not enough: it delays the upgrade until the repository framework starts initializing, but the upgrade can still run inside the same service event before `LiferayRepositoryDefiner` is registered. `PortletFileRepositoryImpl` already declares the same reference with the same target.

The reference is unused by design, which requires allowlisting the module for `UnusedVariableCheck` in `source-formatter.properties`, the same way `journal-service` is allowlisted. A new integration test asserts that the component declares the reference with this target. The upgrade test team verified the fix in their environment: the previously failing v1_1_0 step completes and the run contains no failed module upgrades.

## Why the Test Method Is Named testRegister

`register(Registry registry)` is the only method on `DLWebUpgradeStepRegistrator`, so it is the only method a test name can map to.

The test asserts a declaration rather than the return value of a call, which is why the previous name described the assertion instead of the method. Two things make `testRegister` the right mapping even so. Obtaining the `UpgradeStepRegistrator` service proves the component activated with every reference satisfied, which is the ordering guarantee this pull request adds, and `register` is the method whose upgrade steps depend on that guarantee holding. A reader who sees `testRegister` fail is therefore looking at the right method: its steps would run against a repository framework that is not ready.

If you would rather see this covered a different way, please say so and I will reshape it.

## PR Check

**pr-check: PASS** — tested on `325cfe46ffea49ed6bb9279d76f84c428a14f6b3`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | NOT VERIFIED |

Java Unit Tests exercised nothing. Neither changed Java file has a parallel name unit test counterpart, and the new `DLWebUpgradeStepRegistratorTest` is an integration test, covered by Integration Test Compile above.

<!-- pr-check {"result": "success", "sha": "325cfe46ffea49ed6bb9279d76f84c428a14f6b3"} -->
