### PR TITLE
LPD-104130 Commit the toast to the DOM before openToast returns

### DIFF
--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/toast/openToast.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/toast/openToast.tsx
@@ -82,6 +82,7 @@ const rootsMap = new Map();
 
 export interface OpenToastProps {
 	autoClose?: number | boolean;
+	autoFocus?: boolean;
 	container?: HTMLElement;
 	containerId?: string;
 	message?: string;
@@ -123,6 +124,7 @@ export interface OpenToastProps {
 
 function openToast({
 	autoClose = TOAST_AUTO_CLOSE_INTERVAL,
+	autoFocus = false,
 	container,
 	containerId,
 	message = '',
@@ -191,14 +193,14 @@ function openToast({
 				}}
 			/>
 		</ClayAlert>,
-		renderData,
+		{...renderData, __reactDOMFlushSync: true},
 		rootElement
 	);
 
 	const alertElement =
 		rootElement.querySelector<HTMLElement>('[role="alert"]');
 
-	if (alertElement) {
+	if (autoFocus && alertElement) {
 		alertElement.setAttribute('tabindex', '-1');
 		alertElement.focus();
 	}

--- a/modules/apps/frontend-js/frontend-js-components-web/test/toast/openToast.test.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/test/toast/openToast.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import openToast from '../../src/main/resources/META-INF/resources/toast/openToast';
+
+jest.mock('frontend-js-web', () => ({
+	buildFragment: (html: string) => {
+		const template = globalThis.document.createElement('template');
+
+		template.innerHTML = html;
+
+		return template.content;
+	},
+}));
+
+describe('openToast', () => {
+	beforeEach(() => {
+		document.body.innerHTML = '';
+
+		(globalThis as any).Liferay = {
+			...(globalThis as any).Liferay,
+			Icons: {spritemap: '/spritemap.svg'},
+			component: () => {},
+		};
+	});
+
+	it('does not move focus unless asked to', () => {
+		openToast({message: 'saved', type: 'success'});
+
+		expect(document.activeElement).not.toBe(
+			document.querySelector('#ToastAlertContainer [role="alert"]')
+		);
+	});
+
+	it('focuses the alert when autoFocus is set', () => {
+		openToast({autoFocus: true, message: 'saved', type: 'success'});
+
+		expect(document.activeElement).toBe(
+			document.querySelector('#ToastAlertContainer [role="alert"]')
+		);
+	});
+
+	it('renders the alert before returning', () => {
+		openToast({message: 'saved', type: 'success'});
+
+		expect(
+			document.querySelector('#ToastAlertContainer .alert-success')
+		).not.toBeNull();
+	});
+});

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/session.ts
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/session.ts
@@ -193,6 +193,7 @@ export class Session {
 			const openToast = this.openToast;
 
 			const toastDefaultConfig = {
+				autoFocus: true,
 				onClick: ({event}: any) => {
 					if (event.target.classList.contains('alert-link')) {
 						this.extend();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-104130

## What Is Being Fixed

`objectDefinitionHierarchy.spec.ts` "assert management of object entries that are account restricted" fails intermittently on ci:test:object with a 15s timeout waiting for the success toast after Save. `openToast` renders the alert on a React 18 concurrent root without `__reactDOMFlushSync`, so the alert commits one macrotask after `openToast` returns; callers that pair the toast with a wall-clock timer (`EditObjectDetails` schedules `setTimeout(reload, 1000)` in the same tick) race that gap, and under CI load the toast can be wiped before it ever paints. A second latent bug: the focus block reading `[role="alert"]` right after render has been dead since the React 18 upgrade, so toasts were never focused or announced.

## How It Is Being Fixed

Pass `__reactDOMFlushSync: true` at `openToast`'s render call so the alert is committed to the DOM before `openToast` returns, and gate the focus block behind a new `autoFocus` option defaulting to `false` — today's observable behavior for every existing call site. The session-timeout toast in `session.ts` opts in, keeping its asserted accessibility focus. An earlier version that revived focus unconditionally regressed `objectRelationship.spec.ts` (focus steal closes the open Clay dropdown) and was refuted by a three-arm A/B: unconditional-focus arm 5/5 red, pristine 5/5 green, this version 5/5 green. Jest control: alert-exists-on-return fails 5/5 on master, passes 5/5 with the fix.

## PR Check

**pr-check: PASS** — tested on `bbff5872a39a14169f6d02e3f93891f3693d13fa`

| Validation | Result |
| --- | --- |
| Source Format (incl. frontend type check) | PASS |
| Frontend Unit Tests (frontend-js-components-web: 23 suites, 194 passed, 2 skipped) | PASS |

Notes: ci:test:frontend-js 9/9 and ci:test:object ran green for this change on the self-PR (shuyangzhou#12686); the aggregate rides show the hierarchy target 14/14 and objectRelationship 53/53 green.

<!-- pr-check {"result": "success", "sha": "bbff5872a39a14169f6d02e3f93891f3693d13fa"} -->
