### PR TITLE
LPD-104131 Keep random text file content from sniffing as another mime type

### DIFF
--- a/modules/apps/document-library/document-library-test-util/src/main/java/com/liferay/document/library/test/util/DLTestUtil.java
+++ b/modules/apps/document-library/document-library-test-util/src/main/java/com/liferay/document/library/test/util/DLTestUtil.java
@@ -18,11 +18,11 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.constants.TestDataConstants;
+import com.liferay.portal.kernel.test.randomizerbumpers.TikaSafeRandomizerBumper;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ContentTypes;
-import com.liferay.portal.kernel.util.StringUtil;
 
 import java.awt.image.BufferedImage;
 
@@ -120,7 +120,8 @@ public class DLTestUtil {
 	}
 
 	public static byte[] randomTextFileBytes(int length) {
-		String string = StringUtil.randomId(length);
+		String string = RandomTestUtil.randomString(
+			length, TikaSafeRandomizerBumper.INSTANCE);
 
 		return string.getBytes();
 	}

--- a/portal-test/src/com/liferay/portal/kernel/test/randomizerbumpers/TikaSafeRandomizerBumper.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/randomizerbumpers/TikaSafeRandomizerBumper.java
@@ -1,0 +1,36 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.test.randomizerbumpers;
+
+import com.liferay.petra.io.unsync.UnsyncByteArrayInputStream;
+import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.MimeTypesUtil;
+
+import java.util.Objects;
+
+/**
+ * @author Shuyang Zhou
+ */
+public class TikaSafeRandomizerBumper implements RandomizerBumper<String> {
+
+	public static final TikaSafeRandomizerBumper INSTANCE =
+		new TikaSafeRandomizerBumper(ContentTypes.TEXT_PLAIN);
+
+	public TikaSafeRandomizerBumper(String contentType) {
+		_contentType = contentType;
+	}
+
+	@Override
+	public boolean accept(String randomValue) {
+		return Objects.equals(
+			_contentType,
+			MimeTypesUtil.getContentType(
+				new UnsyncByteArrayInputStream(randomValue.getBytes()), null));
+	}
+
+	private final String _contentType;
+
+}

--- a/portal-test/src/com/liferay/portal/kernel/test/randomizerbumpers/packageinfo
+++ b/portal-test/src/com/liferay/portal/kernel/test/randomizerbumpers/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 1.2.0


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-104131

## What Is Being Fixed

`ObjectEntryResourceTest#testPostCustomObjectEntryWithAttachmentObjectField` fails intermittently on ci:test:object: the uploaded text attachment asserts `text/plain` but comes back as another type (observed `image/icns`). `DLTestUtil.randomTextFileBytes` builds content from `RandomTestUtil.randomString`, and Tika's magic-byte detection outranks the extension, so random content that happens to start with a known magic sequence ("icns" is a lowercase magic) gets sniffed and stored as a different content type. Forcing an icns prefix at the asserted upload call site reproduces the exact CI failure deterministically.

## How It Is Being Fixed

Add `TikaSafeRandomizerBumper` to portal-test's `randomizerbumpers` package: a `RandomizerBumper<String>` that accepts a candidate only when `MimeTypesUtil` sniffs it as the intended content type (`INSTANCE` = `text/plain`). `DLTestUtil.randomTextFileBytes` now generates through `RandomTestUtil.randomString(length, TikaSafeRandomizerBumper.INSTANCE)`, fixing every caller at the source with the existing RandomizerBumper retry pattern. The new exported class bumps the package to 1.2.0.

## PR Check

**pr-check: PASS** — tested on `bb51bfc139269200d969bf55e512d42ec0dacb6d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile (portal-test `ant compile install-portal-snapshot`; document-library-test-util `compileJava`) | PASS |
| Semantic Versioning (randomizerbumpers packageinfo 1.1.0 → 1.2.0) | PASS |

Notes: ci:test:object and ci:test:relevant ran on the self-PR (shuyangzhou#12690) with the target test green, 9 of 11 DLTestUtil caller files exercised green, and the semantic-versioning axis green; the 2 export-import caller files are not exercised by either suite.

<!-- pr-check {"result": "success", "sha": "bb51bfc139269200d969bf55e512d42ec0dacb6d"} -->
