### PR TITLE
LPD-99377 Create the guest viewable blogs entry before fetching the page

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/AssetEntryResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/AssetEntryResourceTest.java
@@ -168,15 +168,15 @@ public class AssetEntryResourceTest extends BaseAssetEntryResourceTestCase {
 				"nestedFields", "permissions"
 			).build();
 
+		BlogsEntry guestViewableBlogsEntry = _addBlogsEntry(
+			testGroup.getGroupId());
+
 		Page<AssetEntry> page =
 			nestedFieldsAssetEntryResource.getAssetEntriesPage(
 				new Long[] {testGroup.getGroupId()}, null, null, null,
 				Pagination.of(1, 50), null);
 
 		List<AssetEntry> assetEntries = (List<AssetEntry>)page.getItems();
-
-		BlogsEntry guestViewableBlogsEntry = _addBlogsEntry(
-			testGroup.getGroupId());
 
 		AssetEntry guestViewableAssetEntry = _getAssetEntry(
 			assetEntries, guestViewableBlogsEntry.getEntryId());


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99377

## What Is Being Fixed

We sent https://github.com/brianchandotcom/liferay-portal/pull/181073 earlier. Commit 95bc6de7c2d18de7cb663beda6117cbd4d44d29a moved the `guestViewableBlogsEntry` declaration down next to its first use, which broke `AssetEntryResourceTest.testGetAssetEntriesPage`.

The declaration is also the statement that creates the blogs entry, so moving it past `getAssetEntriesPage` means the entry does not exist yet when the page is requested. The page never contains it, `_getAssetEntry` returns null, and the test fails with `java.lang.NullPointerException: Cannot invoke "AssetEntry.getPermissions()" because "guestViewableAssetEntry" is null`.

## How It Is Being Fixed

The creation moves back above the `getAssetEntriesPage` call, to the latest point the semantics allow: immediately before the page is requested, after the `AssetEntryResource` builder block that does not read it. The declaration stays as close to its first use as it legally can, and the rest of the reordering from 95bc6de is left untouched.

## PR Check

**pr-check: PASS** — tested on `5cc809bca0b6ab8edd98620f0c7f3346a7f57091`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

Java Unit Tests scheduled nothing. The branch's only changed file is itself an integration test under `src/testIntegration`, so the parallel-name rule has no production source to derive a counterpart from, and the `headless-delivery` module bundle has no `src/test/java` to fall back to.

<!-- pr-check {"result": "success", "sha": "5cc809bca0b6ab8edd98620f0c7f3346a7f57091"} -->
