### PR TITLE
LPD-102052 Support HEAD requests for the GPC well-known endpoint

### DIFF
--- a/modules/apps/cookies/cookies-impl/src/main/java/com/liferay/cookies/internal/servlet/filter/GlobalPrivacyControlWellKnownFilter.java
+++ b/modules/apps/cookies/cookies-impl/src/main/java/com/liferay/cookies/internal/servlet/filter/GlobalPrivacyControlWellKnownFilter.java
@@ -59,8 +59,10 @@ public class GlobalPrivacyControlWellKnownFilter extends BaseFilter {
 			HttpServletResponse httpServletResponse, FilterChain filterChain)
 		throws Exception {
 
-		if (!Objects.equals(httpServletRequest.getMethod(), "GET")) {
-			httpServletResponse.setHeader("Allow", "GET");
+		String method = httpServletRequest.getMethod();
+
+		if (!Objects.equals(method, "GET") && !Objects.equals(method, "HEAD")) {
+			httpServletResponse.setHeader("Allow", "GET, HEAD");
 			httpServletResponse.sendError(
 				HttpServletResponse.SC_METHOD_NOT_ALLOWED);
 
@@ -77,7 +79,7 @@ public class GlobalPrivacyControlWellKnownFilter extends BaseFilter {
 		JSONObject jsonObject = JSONUtil.put("gpc", enabled);
 
 		if (!enabled) {
-			_writeJSON(httpServletResponse, jsonObject.toString());
+			_writeJSON(httpServletResponse, jsonObject.toString(), method);
 
 			return;
 		}
@@ -99,11 +101,11 @@ public class GlobalPrivacyControlWellKnownFilter extends BaseFilter {
 				localDate.format(DateTimeFormatter.ISO_LOCAL_DATE));
 		}
 
-		_writeJSON(httpServletResponse, jsonObject.toString());
+		_writeJSON(httpServletResponse, jsonObject.toString(), method);
 	}
 
 	private void _writeJSON(
-			HttpServletResponse httpServletResponse, String json)
+			HttpServletResponse httpServletResponse, String json, String method)
 		throws Exception {
 
 		httpServletResponse.setCharacterEncoding(StringPool.UTF8);
@@ -111,7 +113,9 @@ public class GlobalPrivacyControlWellKnownFilter extends BaseFilter {
 		httpServletResponse.setHeader(HttpHeaders.CACHE_CONTROL, "no-cache");
 		httpServletResponse.setStatus(HttpServletResponse.SC_OK);
 
-		ServletResponseUtil.write(httpServletResponse, json);
+		if (Objects.equals(method, "GET")) {
+			ServletResponseUtil.write(httpServletResponse, json);
+		}
 
 		httpServletResponse.flushBuffer();
 	}

--- a/modules/apps/cookies/cookies-test/src/testIntegration/java/com/liferay/cookies/internal/servlet/filter/test/GlobalPrivacyControlWellKnownFilterTest.java
+++ b/modules/apps/cookies/cookies-test/src/testIntegration/java/com/liferay/cookies/internal/servlet/filter/test/GlobalPrivacyControlWellKnownFilterTest.java
@@ -1,0 +1,123 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.cookies.internal.servlet.filter.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Christian Borges de Moura
+ */
+@RunWith(Arquillian.class)
+public class GlobalPrivacyControlWellKnownFilterTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testProcessFilter() throws Exception {
+		Company company = _companyLocalService.getCompany(
+			TestPropsValues.getCompanyId());
+
+		String urlString = StringBundler.concat(
+			Http.HTTP_WITH_SLASH, company.getVirtualHostname(), ":",
+			PortalUtil.getPortalServerPort(false), "/.well-known/gpc.json");
+
+		HttpResponse<String> getHttpResponse = _send(urlString, "GET");
+
+		Assert.assertEquals(
+			HttpServletResponse.SC_OK, getHttpResponse.statusCode());
+		Assert.assertNotEquals(StringPool.BLANK, getHttpResponse.body());
+
+		HttpResponse<String> headHttpResponse = _send(urlString, "HEAD");
+
+		Assert.assertEquals(
+			HttpServletResponse.SC_OK, headHttpResponse.statusCode());
+		Assert.assertEquals(StringPool.BLANK, headHttpResponse.body());
+
+		HttpHeaders getHttpHeaders = getHttpResponse.headers();
+
+		_assertHeader(
+			getHttpHeaders.firstValue(
+				"Cache-Control"
+			).get(),
+			"Cache-Control", headHttpResponse.headers());
+		_assertHeader(
+			getHttpHeaders.firstValue(
+				"Content-Type"
+			).get(),
+			"Content-Type", headHttpResponse.headers());
+
+		HttpResponse<String> postHttpResponse = _send(urlString, "POST");
+
+		Assert.assertEquals(
+			HttpServletResponse.SC_METHOD_NOT_ALLOWED,
+			postHttpResponse.statusCode());
+
+		_assertHeader("GET, HEAD", "Allow", postHttpResponse.headers());
+	}
+
+	private void _assertHeader(
+		String expectedHeaderValue, String headerName,
+		HttpHeaders httpHeaders) {
+
+		Map<String, List<String>> map = httpHeaders.map();
+
+		List<String> headerValues = map.get(headerName);
+
+		Assert.assertEquals(expectedHeaderValue, headerValues.get(0));
+	}
+
+	private HttpResponse<String> _send(String urlString, String method)
+		throws Exception {
+
+		return _httpClient.send(
+			HttpRequest.newBuilder(
+			).uri(
+				URI.create(urlString)
+			).method(
+				method, HttpRequest.BodyPublishers.noBody()
+			).build(),
+			HttpResponse.BodyHandlers.ofString());
+	}
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+	private final HttpClient _httpClient = HttpClient.newBuilder(
+	).followRedirects(
+		HttpClient.Redirect.NEVER
+	).build();
+
+}

--- a/modules/test/playwright/tests/cookies-banner-web/main/gpcWellKnownEndpoint.spec.ts
+++ b/modules/test/playwright/tests/cookies-banner-web/main/gpcWellKnownEndpoint.spec.ts
@@ -118,17 +118,48 @@ test(
 		const postResponse = await apiHelpers.postResponse(GPC_ENDPOINT);
 
 		expect(postResponse.status()).toBe(405);
-		expect(postResponse.headers()['allow']).toBe('GET');
+		expect(postResponse.headers()['allow']).toBe('GET, HEAD');
 
 		const putResponse = await apiHelpers.putResponse(GPC_ENDPOINT);
 
 		expect(putResponse.status()).toBe(405);
-		expect(putResponse.headers()['allow']).toBe('GET');
+		expect(putResponse.headers()['allow']).toBe('GET, HEAD');
 
 		const deleteResponse = await apiHelpers.delete(GPC_ENDPOINT);
 
 		expect(deleteResponse.status()).toBe(405);
-		expect(deleteResponse.headers()['allow']).toBe('GET');
+		expect(deleteResponse.headers()['allow']).toBe('GET, HEAD');
+	}
+);
+
+test(
+	'GPC well-known endpoint responds to HEAD like GET with an empty body',
+	{tag: '@LPD-102052'},
+	async ({browser}) => {
+		const context = await browser.newContext({storageState: undefined});
+
+		try {
+			const getResponse = await context.request.get(GPC_ENDPOINT);
+			const headResponse = await context.request.head(GPC_ENDPOINT);
+
+			expect(headResponse.status()).toBe(200);
+			expect(headResponse.headers()['content-type']).toContain(
+				'application/json'
+			);
+			expect(headResponse.headers()['content-type']).toBe(
+				getResponse.headers()['content-type']
+			);
+			expect(headResponse.headers()['cache-control']).toBe(
+				getResponse.headers()['cache-control']
+			);
+
+			const headResponseBody = await headResponse.body();
+
+			expect(headResponseBody.length).toBe(0);
+		}
+		finally {
+			await context.close();
+		}
 	}
 );
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102052

### Problem

The Global Privacy Control support resource at `/.well-known/gpc.json` answered `GET` correctly (200 + `{"gpc":false}`) but rejected every other method, including `HEAD`, with `405 Allow: GET` and an HTML redirect body — and logged a WARN per rejected request.

### Root cause

`GlobalPrivacyControlWellKnownFilter.processFilter` guarded on `equals("GET")`, so `HEAD` fell through to `sendError(405)`.

### Fix

Accept `GET` **and** `HEAD` (advertising `Allow: GET, HEAD`), and thread the request method into `_writeJSON` so the status and all headers are written unconditionally while only the body write is guarded behind a `GET` check. `HEAD` now returns 200 with the same headers as `GET` and an empty body — identical to the pattern in the sibling `OAuth2WellKnownAuthorizationServerMetadataFilter`.

### Why HEAD

The [W3C GPC spec](https://w3c.github.io/gpc/) names only `GET` but is silent on `HEAD`; it anchors the resource to RFC 8615, i.e. an ordinary HTTP resource served under normal HTTP semantics. RFC 9110 §9.1 then makes `GET` and `HEAD` mandatory for a general-purpose server, and §9.3.2 defines `HEAD` as identical to `GET` with no body. The rest of the portal already conforms (`HEAD /web/guest/home` → 200). Scope is intentionally limited to `HEAD`; `OPTIONS`/CORS are not added.

### Testing

- New integration test `GlobalPrivacyControlWellKnownFilterTest` — asserts `GET` → 200 + body, `HEAD` → 200 + empty body with `GET`'s headers, `POST` → 405 `Allow: GET, HEAD`.
- Updated `gpcWellKnownEndpoint.spec.ts` — the non-`GET` assertions now expect `GET, HEAD`, plus a new `HEAD`-like-`GET`-empty-body test.
- Verified live against a running bundle: `HEAD` → 200 with `GET`'s headers, empty body, no WARN; `POST` → 405 `Allow: GET, HEAD`.
