### PR TITLE
LPD-103563 Prune stale sitemap pages after storing regenerated ones

### DIFF
--- a/modules/apps/site/site-api/bnd.bnd
+++ b/modules/apps/site/site-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Site API
 Bundle-SymbolicName: com.liferay.site.api
-Bundle-Version: 30.1.0
+Bundle-Version: 31.0.0
 Export-Package:\
 	com.liferay.site.configuration,\
 	com.liferay.site.configuration.manager,\

--- a/modules/apps/site/site-api/src/main/java/com/liferay/site/storage/helper/SitemapStorageHelper.java
+++ b/modules/apps/site/site-api/src/main/java/com/liferay/site/storage/helper/SitemapStorageHelper.java
@@ -19,13 +19,13 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface SitemapStorageHelper {
 
+	public void deleteSitemap(
+			long companyId, long groupId, String assetTypeKey, int page)
+		throws PortalException;
+
 	public void deleteSitemaps(long companyId) throws PortalException;
 
 	public void deleteSitemaps(long companyId, long groupId)
-		throws PortalException;
-
-	public void deleteSitemaps(
-			long companyId, long groupId, String assetTypeKey)
 		throws PortalException;
 
 	public Date getLastRegenerateSitemapDate(long companyId)

--- a/modules/apps/site/site-api/src/main/resources/com/liferay/site/storage/helper/packageinfo
+++ b/modules/apps/site/site-api/src/main/resources/com/liferay/site/storage/helper/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 2.0.0

--- a/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/manager/SitemapManagerImpl.java
+++ b/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/manager/SitemapManagerImpl.java
@@ -825,6 +825,20 @@ public class SitemapManagerImpl implements SitemapManager {
 		return themeDisplay;
 	}
 
+	private void _deleteAssetTypeSitemapsFromPage(
+			String assetTypeKey, long companyId, long groupId, int page)
+		throws PortalException {
+
+		while (_sitemapStorageHelper.hasSitemapFile(
+					companyId, groupId, assetTypeKey, page)) {
+
+			_sitemapStorageHelper.deleteSitemap(
+				companyId, groupId, assetTypeKey, page);
+
+			page++;
+		}
+	}
+
 	private void _generateAssetTypeSitemap(
 			long assetTypeClassNameId, long groupId, ThemeDisplay themeDisplay,
 			UnsafeBiConsumer<Integer, String, PortalException> unsafeBiConsumer)
@@ -1362,20 +1376,26 @@ public class SitemapManagerImpl implements SitemapManager {
 
 		String assetTypeKey = _assetTypeKeys.get(assetTypeClassNameId);
 
+		int[] pages = {0};
+
+		_generateAssetTypeSitemap(
+			assetTypeClassNameId, groupId, themeDisplay,
+			(page, xml) -> {
+				pages[0] = page;
+
+				_sitemapStorageHelper.storeSitemapFile(
+					companyId, groupId, assetTypeKey, page, xml);
+			});
+
 		try {
-			_sitemapStorageHelper.deleteSitemaps(
-				companyId, groupId, assetTypeKey);
+			_deleteAssetTypeSitemapsFromPage(
+				assetTypeKey, companyId, groupId, pages[0] + 1);
 		}
 		catch (Exception exception) {
 			if (_log.isWarnEnabled()) {
 				_log.warn(exception);
 			}
 		}
-
-		_generateAssetTypeSitemap(
-			assetTypeClassNameId, groupId, themeDisplay,
-			(page, xml) -> _sitemapStorageHelper.storeSitemapFile(
-				companyId, groupId, assetTypeKey, page, xml));
 	}
 
 	private void _removeAttribute(Element element, String name) {

--- a/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/storage/helper/SitemapStorageHelperImpl.java
+++ b/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/storage/helper/SitemapStorageHelperImpl.java
@@ -34,6 +34,16 @@ import org.osgi.service.component.annotations.Reference;
 public class SitemapStorageHelperImpl implements SitemapStorageHelper {
 
 	@Override
+	public void deleteSitemap(
+			long companyId, long groupId, String assetTypeKey, int page)
+		throws PortalException {
+
+		_dlStore.deleteFile(
+			companyId, CompanyConstants.SYSTEM,
+			_getSitemapFileName(groupId, assetTypeKey, page));
+	}
+
+	@Override
 	public void deleteSitemaps(long companyId) throws PortalException {
 		_dlStore.deleteDirectory(
 			companyId, CompanyConstants.SYSTEM, _getDirName());
@@ -57,16 +67,6 @@ public class SitemapStorageHelperImpl implements SitemapStorageHelper {
 
 		_dlStore.deleteDirectory(
 			companyId, CompanyConstants.SYSTEM, _getDirName(groupId));
-	}
-
-	@Override
-	public void deleteSitemaps(
-			long companyId, long groupId, String assetTypeKey)
-		throws PortalException {
-
-		_dlStore.deleteDirectory(
-			companyId, CompanyConstants.SYSTEM,
-			_getDirName(groupId, assetTypeKey));
 	}
 
 	@Override
@@ -185,11 +185,6 @@ public class SitemapStorageHelperImpl implements SitemapStorageHelper {
 
 	private String _getDirName(long groupId) {
 		return "sitemaps/" + groupId;
-	}
-
-	private String _getDirName(long groupId, String assetTypeKey) {
-		return StringBundler.concat(
-			"sitemaps/", groupId, StringPool.SLASH, assetTypeKey);
 	}
 
 	private String _getLastRegenerateSitemapDateFileName() {

--- a/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/manager/test/SitemapManagerTest.java
+++ b/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/manager/test/SitemapManagerTest.java
@@ -545,7 +545,7 @@ public class SitemapManagerTest {
 	}
 
 	@Test
-	public void testSitemapByAssetTypePaginationStoresMultiplePages()
+	public void testSitemapByAssetTypePaginationStoresAndPrunesPages()
 		throws Exception {
 
 		try (CompanyConfigurationTemporarySwapper
@@ -594,6 +594,27 @@ public class SitemapManagerTest {
 					_sitemapStorageHelper.hasSitemapFile(
 						companyId, groupId,
 						SitemapConstants.ASSET_TYPE_KEY_WEB_CONTENT, 4));
+
+				ReflectionTestUtil.setFieldValue(
+					_sitemapManager, "_maximumEntries",
+					SitemapManager.MAXIMUM_ENTRIES);
+
+				_sitemapManager.regenerateSitemap(
+					SitemapConstants.ASSET_TYPE_KEY_WEB_CONTENT, companyId,
+					groupId);
+
+				Assert.assertTrue(
+					_sitemapStorageHelper.hasSitemapFile(
+						companyId, groupId,
+						SitemapConstants.ASSET_TYPE_KEY_WEB_CONTENT, 1));
+				Assert.assertFalse(
+					_sitemapStorageHelper.hasSitemapFile(
+						companyId, groupId,
+						SitemapConstants.ASSET_TYPE_KEY_WEB_CONTENT, 2));
+				Assert.assertFalse(
+					_sitemapStorageHelper.hasSitemapFile(
+						companyId, groupId,
+						SitemapConstants.ASSET_TYPE_KEY_WEB_CONTENT, 3));
 			}
 			finally {
 				ReflectionTestUtil.setFieldValue(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103563

## What Is Being Fixed

Sitemap regeneration could delete the files it had just generated, leaving a site with an
empty or missing sitemap until the next regeneration.

`SitemapStorageHelperImpl.deleteSitemaps` removed cached files with `DLStore.deleteDirectory`,
which deletes nothing synchronously. `DLStoreImpl.deleteDirectory` only sends a message to
`DestinationNames.DOCUMENT_LIBRARY_DELETION`, a serial destination whose worker pool is a
single thread shared by every document library deletion in the portal. Regeneration issued
that delete and then wrote the new pages on the calling thread, so whenever the queued
deletion was processed after those writes it removed the sitemap that had just been
generated. The symptom matches LPD-102298, an absent or empty sitemap, but needs no attacker
and no concurrent reader, and it does not self-heal until the next regeneration.

The race is reachable whenever the queued delete outlives the generation: a remote store
where a LIST plus batch delete is slower than a small site's walk, or a deletion queue
already backed up behind other document library work.

## How It Is Being Fixed

Regeneration now writes first and prunes afterwards. `_regenerateAssetTypeSitemap` stores
pages one through N, records the last page reached, and then deletes any stale pages above it
through a new synchronous `SitemapStorageHelper.deleteSitemap` overload that takes a page and
delegates to `DLStore.deleteFile`. No queued deletion remains anywhere in the regeneration
path, so the fix is structural rather than a widened timing margin.

Moving the delete after the writes is safe because every store overwrites at the entry point
that `DLStore.addFile` funnels into. `DBStore` upserts through `fetchByC_R_P_V`,
`FileSystemStore` truncates, `S3Store` and `GCSStore` handle delete-then-put themselves, and
`AzureStore` uploads with overwrite enabled. The delete was therefore never required to make
a write land; its only job is removing stale pages left over when a regeneration produces
fewer pages than the previous one. The prune walks upward while a page exists, which is the
same contiguity assumption `_getAssetTypePageCount` already relies on, and it advances
unconditionally so a delete that fails cannot spin.

The page number is recorded before the store rather than after, so a store that throws
cannot leave the count at zero and have the prune delete every surviving page.

Because nothing called it any more, `deleteSitemaps(long, long, String)` is removed. That
also retires the last `deleteDirectory` call for an asset type directory in this helper, so
the asynchronous delete cannot be copied back into a path that writes afterwards. The removal
is a breaking change: the exported package goes from 1.1.0 to 2.0.0 and the bundle from
30.1.0 to 31.0.0, declared in the `# breaking` block on the versioning commit.

Beyond fixing the race, this also removes the window in which every page was absent for the
duration of a regeneration, and it fails safe: a regeneration that throws midway now leaves
servable pages rather than nothing.

## PR Check

**pr-check: PASS** — tested on `3d9f6d847ea3a677c59cd5096db9da172a309a43`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | NOT VERIFIED |

Java Unit Tests verified nothing. None of the four changed Java files has a parallel-name
counterpart, and none of `site-api`, `site-impl`, or `site-test` has a `src/test` source set
at all, so there was no unit test to exercise. Integration coverage for this change lives in
`SitemapManagerTest` under `src/testIntegration`, which is out of scope for this validation.

<!-- pr-check {"result": "success", "sha": "3d9f6d847ea3a677c59cd5096db9da172a309a43"} -->
