### PR TITLE
LPD-104206 Wait for the page reload before leaving addObjectField

### DIFF
--- a/modules/test/playwright/pages/object-web/object-fields/ObjectFieldsPage.ts
+++ b/modules/test/playwright/pages/object-web/object-fields/ObjectFieldsPage.ts
@@ -152,7 +152,14 @@ export class ObjectFieldsPage {
 				.click();
 		}
 
+		const navigation = this.page.waitForNavigation({
+			timeout: 10000,
+			waitUntil: 'load',
+		});
+
 		await this.saveButton.click();
+
+		await navigation;
 	}
 
 	async deleteObjectField(confirmDeletion: boolean, nth: number) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-104206

## What Is Being Fixed

`objectField.spec.ts` "can create object fields of all types" fails intermittently on ci:test:object: after a field save, the next Add Object Field click times out 90s waiting for `input[name="label"]` — the add-field panel never renders. The Fields screen calls `window.location.reload()` after a successful save, but `ObjectFieldsPage.addObjectField` returned as soon as the Save click was issued (~20ms before the reload's document request exists), so the next step interacts with the doomed document and the reload discards its work. The test loops 19 field types = 19 races per run. Born broken in `a88f35bf23c65` (LPD-24341).

## How It Is Being Fixed

Capture `page.waitForNavigation` before clicking Save in `addObjectField` and await it after — mirroring the sibling `saveObjectFieldReturningNavigation` idiom (and its 10s timeout, which also makes a non-navigating save fail fast at the Save line). A deterministic local red is structurally unobtainable (the reload document serves in 13–17ms and Playwright defers clicks while a navigation is pending), so verification is by ordering instrumentation: without the wait, the next iteration starts before the reload's document request 16/16; with it, strictly after the document response 16/16 — plus zero collateral on the full spec and solo ci:test:object green (target test passed retries-disabled; all 5 external call sites green).

## PR Check

**pr-check: PASS** — tested on `62086190bbb601a0b2f82b82fc5a94bb70088294`

| Validation | Result |
| --- | --- |
| Source Format (incl. frontend type check) | PASS |
| Solo ci:test:object (shuyangzhou#12693, content-clean vs external DS floor) | PASS |

<!-- pr-check {"result": "success", "sha": "62086190bbb601a0b2f82b82fc5a94bb70088294"} -->
