### PR TITLE
LPD-104207 Give every React component placeholder a unique id

### DIFF
--- a/modules/apps/portal-template/portal-template-react-renderer-impl/src/main/java/com/liferay/portal/template/react/renderer/internal/ReactRendererImpl.java
+++ b/modules/apps/portal-template/portal-template-react-renderer-impl/src/main/java/com/liferay/portal/template/react/renderer/internal/ReactRendererImpl.java
@@ -10,7 +10,6 @@ import com.liferay.frontend.js.loader.modules.extender.npm.NPMResolvedPackageNam
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.template.react.renderer.ComponentDescriptor;
 import com.liferay.portal.template.react.renderer.ReactRenderer;
 import com.liferay.portal.url.builder.AbsolutePortalURLBuilderFactory;
@@ -23,6 +22,7 @@ import java.io.Writer;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -39,7 +39,7 @@ public class ReactRendererImpl implements ReactRenderer {
 			HttpServletRequest httpServletRequest, Writer writer)
 		throws IOException {
 
-		String placeholderId = StringUtil.randomId();
+		String placeholderId = "reactComponent" + _counter.incrementAndGet();
 
 		_renderPlaceholder(writer, placeholderId);
 
@@ -122,6 +122,8 @@ public class ReactRendererImpl implements ReactRenderer {
 		writer.append(placeholderId);
 		writer.append("\"></div>");
 	}
+
+	private static final AtomicLong _counter = new AtomicLong();
 
 	@Reference
 	private AbsolutePortalURLBuilderFactory _absolutePortalURLBuilderFactory;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-104207

## What Is Being Fixed

Object admin screens intermittently render with a blank portlet body and zero console, network, or server errors — the Fields screen and the Objects definition list each blanked in a ci:test:object run, timing out on locators that never appeared. `ReactRendererImpl` assigns every `<react:component>` placeholder `StringUtil.randomId()` — four random lowercase letters with no uniqueness guarantee — so two placeholders on one page collide roughly once per 15,000–30,000 renders. `render.es.js` resolves the placeholder with `getElementById` and renders into its `parentElement`, so on a collision both components create React roots on the same container and the later render silently destroys the earlier component's tree. Both CI sightings were proven from the raw served documents (duplicate ids `ifpy` and `renm`) with the post-collision DOM shape in the trace snapshots. Born broken in `71fd3bae52079` (LPS-95524).

## How It Is Being Fixed

Replace the random id with a monotonic counter: `"reactComponent" + AtomicLong increment` — a counter cannot collide, which removes the precondition entirely. The id is a single-use, client-visible mount anchor (never used for auth, tokens, or URLs), and portal pages already carry fully deterministic ids (portlet namespaces, form ids), so predictability adds no exposure the page did not already have.

## PR Check

**pr-check: PASS** — tested on `654c31e0b4885346f98cab60686bd5c160321ed8`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile (portal-template-react-renderer-impl) | PASS |
| Solo ci:test:object (shuyangzhou#12694: non-passed set byte-identical to two fix-free control builds; 562 Playwright + 297 JUnit rows, zero failures) | PASS |
| Solo ci:test:relevant (same SHA content, clean) | PASS |

Live-portal A/B: forced constant id collides 3/3; fix yields distinct ids 3/3; pristine restored.

<!-- pr-check {"result": "success", "sha": "654c31e0b4885346f98cab60686bd5c160321ed8"} -->
