### PR TITLE
LPD-104208 Run the Digital Signature Poshi tests in the bpm suite instead of object

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -2913,6 +2913,7 @@
         (\
             (testray.main.component.name == "Calendar") OR \
             (testray.main.component.name == "Data Engine") OR \
+            (testray.main.component.name == "Digital Signature") OR \
             (testray.main.component.name == "Dynamic Data Mapping") OR \
             (testray.main.component.name == "Forms") OR \
             (testray.main.component.name == "Kaleo Designer") OR \
@@ -4874,10 +4875,7 @@
             (portal.acceptance != quarantine) AND \
             (portal.upstream == true)\
         ) AND \
-        (\
-            (testray.main.component.name == "Digital Signature") OR \
-            (testray.main.component.name == "Object")\
-        )
+        (testray.main.component.name == "Object")
 
     test.batch.run.property.query[functional-upgrade-*][object]=\
         (\


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-104208

## What Is Being Fixed

ci:test:object carried the 21 DigitalSignature Poshi tests because the suite's functional query selected the Digital Signature Testray component alongside Object, even though the four DigitalSignature testcase files declare `@component-name = "portal-bpm"`. Those tests depend on a shared external DocuSign demo account whose send quota CI's own volume can exhaust: since 2026-08-31 ~03:23 UTC the account refuses every envelope send with `RECIPIENT_LIMIT_EXCEEDED` (pinned by direct API probe: auth/reads/draft-create healthy, send deterministically refused, status page clean, rate-limit headroom ample), pinning every object run at a 10-test failure floor no portal change can lift.

## How It Is Being Fixed

Move the Digital Signature component from the ci:test:object functional query to ci:test:bpm in `test.properties`, matching the ownership the testcases already declare. DS coverage continues on the bpm daily runs; the object suite stops being gated by an external account quota.

## PR Check

**pr-check: PASS** — tested on `f5caf56d91a55608c041ee7b536eb9a481281f5a`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Solo ci:test:object (shuyangzhou#12695): 55/55 green; Testray delta vs stable baseline = exactly −21 DS tests / −4 functional axes, everything else byte-identical, failures 0 | PASS |

<!-- pr-check {"result": "success", "sha": "f5caf56d91a55608c041ee7b536eb9a481281f5a"} -->
