### PR TITLE
LPD-104279 Wait for the page's pending API requests before clearing test data

### DIFF
--- a/modules/test/playwright/fixtures/dataApiHelpersTest.ts
+++ b/modules/test/playwright/fixtures/dataApiHelpersTest.ts
@@ -6,6 +6,7 @@
 import {mergeTests} from '@playwright/test';
 
 import {DataApiHelpers} from '../helpers/ApiHelpers';
+import {trackPendingApiRequests} from '../utils/trackPendingApiRequests';
 import {BackendPage, backendPageTest} from './backendPageTest';
 
 const test = mergeTests(backendPageTest);
@@ -17,10 +18,13 @@ const dataApiHelpersTest = test.extend<{
 	apiHelpers: async ({backendPage, page}, use) => {
 		const dataApiHelpers = new DataApiHelpers(page);
 
+		const waitForPendingApiRequests = trackPendingApiRequests(page);
+
 		try {
 			await use(dataApiHelpers);
 		}
 		finally {
+			await waitForPendingApiRequests();
 
 			// @ts-ignore
 

--- a/modules/test/playwright/fixtures/dataRemoteApiHelpersTest.ts
+++ b/modules/test/playwright/fixtures/dataRemoteApiHelpersTest.ts
@@ -5,6 +5,7 @@
 
 import {DataApiHelpers} from '../helpers/ApiHelpers';
 import {liferayConfig} from '../liferay.config';
+import {trackPendingApiRequests} from '../utils/trackPendingApiRequests';
 
 import type {Page, TestType} from '@playwright/test';
 
@@ -24,10 +25,14 @@ function dataRemoteApiHelpersTest(
 
 			const dataApiHelpers = new DataApiHelpers(remotePage, remoteUrl);
 
+			const waitForPendingApiRequests =
+				trackPendingApiRequests(remotePage);
+
 			try {
 				await use(dataApiHelpers);
 			}
 			finally {
+				await waitForPendingApiRequests();
 
 				// @ts-ignore
 

--- a/modules/test/playwright/utils/trackPendingApiRequests.ts
+++ b/modules/test/playwright/utils/trackPendingApiRequests.ts
@@ -1,0 +1,42 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import type {Page, Request, Response} from '@playwright/test';
+
+export function trackPendingApiRequests(page: Page) {
+	const pendingRequests = new Set<Request>();
+
+	const add = (request: Request) => {
+		const resourceType = request.resourceType();
+
+		if (resourceType === 'fetch' || resourceType === 'xhr') {
+			pendingRequests.add(request);
+		}
+	};
+
+	const remove = (request: Request) => {
+		pendingRequests.delete(request);
+	};
+
+	const removeResponse = (response: Response) => {
+		pendingRequests.delete(response.request());
+	};
+
+	page.on('request', add);
+	page.on('requestfailed', remove);
+	page.on('response', removeResponse);
+
+	return async () => {
+		const startTime = Date.now();
+
+		while (pendingRequests.size && Date.now() - startTime < 10000) {
+			await new Promise((resolve) => setTimeout(resolve, 100));
+		}
+
+		page.off('request', add);
+		page.off('requestfailed', remove);
+		page.off('response', removeResponse);
+	};
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-104279

## What Is Being Fixed

Playwright object-web tests fail intermittently because the apiHelpers fixtures start deleting the test's data the moment the test body returns, while the browser page still has its own fetch/XHR requests in flight (model-builder auto-saves and linking calls that nothing awaits). The overlap produces concurrent mutations no real user flow issues: a folder auto-save PUT racing the teardown DELETE ends in a StaleStateException 500 that orphans a draft and breaks later tests, and a relationship create landing while teardown deletes its partner definition leaves a permanently dangling ObjectRelationship row that 404s the object definition list for the rest of the run — the mechanism behind the recurring 16-test object-web failure clusters.

## How It Is Being Fixed

A new `trackPendingApiRequests` utility records every fetch/XHR request the page issues and returns a drain function that waits (bounded at ten seconds) until they settle, called as the first step of teardown — before `clearData` — in both `dataApiHelpersTest` and `dataRemoteApiHelpersTest`. A request settles on its `response` or `requestfailed` event rather than `requestfinished`: fire-and-forget saves never emit `requestfinished`, so a body-completion barrier would silently degenerate into the full cap, while the response event marks the server transaction complete — exactly the boundary teardown must not cross.

Verified with a deterministic amplifier: control 5/5 red with the exact CI signature, fixed 5/5 green with real observed drains of 1.7-1.8s. A self ci:test:object run on this change was content-clean, and the commit is riding an aggregate hammer branch with consecutive content-clean runs.

## PR Check

**pr-check: PASS** — tested on `25bac6f4bf539179daa13490d05c470eaf402c1f`

| Validation | Result |
| --- | --- |
| Source Format (with commit message validation) | PASS |
| Baseline | PASS |
| HTML Escaping | PASS |
| TypeScript Compile (tsc --noEmit, modules/test/playwright) | PASS |
| JavaScript Unit Tests | NOT VERIFIED |

- Baseline: one inherited finding on master (`portal-db-partition-test-util` 6.0.7/6.0.0 -> 7.0.0 major) in a module this branch does not touch; restored, not committed.
- JavaScript Unit Tests: the playwright module's `test` script is the Playwright runtime suite, not a unit suite; covered instead by the content-clean self ci:test:object run.

<!-- pr-check {"result": "success", "sha": "25bac6f4bf539179daa13490d05c470eaf402c1f"} -->
