### PR TITLE
LPD-104280 Wait for the relationship picker to repopulate before reading it back

### DIFF
--- a/modules/test/playwright/tests/object-web/entry/objectEntry.spec.ts
+++ b/modules/test/playwright/tests/object-web/entry/objectEntry.spec.ts
@@ -3718,11 +3718,9 @@ test.describe('Manage object entries through View Object Entries', () => {
 
 			await expect(viewObjectEntriesPage.successMessage).toBeVisible();
 
-			expect(
-				(
-					await page.getByPlaceholder('Search').inputValue()
-				).toLowerCase()
-			).toBe(userAccount.givenName.toLowerCase());
+			await expect(page.getByPlaceholder('Search')).toHaveValue(
+				new RegExp(`^${userAccount.givenName}$`, 'i')
+			);
 		}
 	);
 
@@ -3818,11 +3816,9 @@ test.describe('Manage object entries through View Object Entries', () => {
 					viewObjectEntriesPage.successMessage
 				).toBeVisible();
 
-				expect(
-					(
-						await page.getByPlaceholder('Search').inputValue()
-					).toLowerCase()
-				).toBe(userAccount.givenName.toLowerCase());
+				await expect(page.getByPlaceholder('Search')).toHaveValue(
+					new RegExp(`^${userAccount.givenName}$`, 'i')
+				);
 			}
 		}
 	);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-104280

## What Is Being Fixed

`objectEntry.spec.ts` intermittently reads an empty value from the relationship picker right after saving an entry. The success toast is not a completion barrier: it fires on the save response, but the picker's value is restored only by a later Senna re-navigation plus the user-accounts fetch that repopulates the freshly mounted input. A one-shot `inputValue()` read races that gap — the failure screenshot shows the correct value about twenty milliseconds after the empty read.

## How It Is Being Fixed

Both read-back sites are converted from one-shot `inputValue()` reads to the auto-retrying `expect(locator).toHaveValue(new RegExp(...))` form, which re-resolves the remounted input on every poll and waits through the repopulating fetch, keeping the original case-insensitive comparison. The one-shot pattern dates to the test's introduction in 6178dc43bf5dd (LPD-82349) — born racy rather than broken later.

A self ci:test:object run on this change was content-clean (the full objectEntry spec 86/86), and the commit is riding an aggregate hammer branch with consecutive content-clean runs.

## PR Check

**pr-check: PASS** — tested on `32cae1b4cb7184762673e23b20c1207919ae737b`

| Validation | Result |
| --- | --- |
| Source Format (with commit message validation) | PASS |
| Baseline | PASS |
| HTML Escaping | PASS |
| TypeScript Compile (tsc --noEmit, modules/test/playwright) | PASS |
| JavaScript Unit Tests | NOT VERIFIED |

- Baseline: one inherited finding on master (`portal-db-partition-test-util` 6.0.7/6.0.0 -> 7.0.0 major) in a module this branch does not touch; restored, not committed.
- JavaScript Unit Tests: the playwright module's `test` script is the Playwright runtime suite, not a unit suite; covered instead by the content-clean self ci:test:object run.

<!-- pr-check {"result": "success", "sha": "32cae1b4cb7184762673e23b20c1207919ae737b"} -->
