### PR TITLE
LPD-104281 Interpolate exception message arguments verbatim

### DIFF
--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/jaxrs/exception/mapper/util/ObjectExceptionMapperUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/jaxrs/exception/mapper/util/ObjectExceptionMapperUtil.java
@@ -30,7 +30,8 @@ public class ObjectExceptionMapperUtil {
 		}
 
 		return language.format(
-			acceptLanguage.getPreferredLocale(), messageKey, arguments);
+			acceptLanguage.getPreferredLocale(), messageKey,
+			arguments.toArray(), false);
 	}
 
 }

--- a/modules/apps/object/object-rest-test-util/bnd.bnd
+++ b/modules/apps/object/object-rest-test-util/bnd.bnd
@@ -1,4 +1,4 @@
 Bundle-Name: Liferay Object REST Test Utilities
 Bundle-SymbolicName: com.liferay.object.rest.test.util
-Bundle-Version: 3.2.3
+Bundle-Version: 3.3.0
 Export-Package: com.liferay.object.rest.test.util

--- a/modules/apps/object/object-rest-test-util/src/main/java/com/liferay/object/rest/test/util/ObjectRelationshipTestUtil.java
+++ b/modules/apps/object/object-rest-test-util/src/main/java/com/liferay/object/rest/test/util/ObjectRelationshipTestUtil.java
@@ -35,12 +35,23 @@ public class ObjectRelationshipTestUtil {
 			ObjectDefinition relatedObjectDefinition, long userId, String type)
 		throws Exception {
 
+		return addObjectRelationship(
+			deletionType, objectDefinition, relatedObjectDefinition, userId,
+			type, StringUtil.randomId());
+	}
+
+	public static ObjectRelationship addObjectRelationship(
+			String deletionType, ObjectDefinition objectDefinition,
+			ObjectDefinition relatedObjectDefinition, long userId, String type,
+			String name)
+		throws Exception {
+
 		return ObjectRelationshipLocalServiceUtil.addObjectRelationship(
 			null, userId, objectDefinition.getObjectDefinitionId(),
 			relatedObjectDefinition.getObjectDefinitionId(), 0, deletionType,
 			false,
 			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
-			StringUtil.randomId(), false, type, null);
+			name, false, type, null);
 	}
 
 	public static void relateObjectEntries(

--- a/modules/apps/object/object-rest-test-util/src/main/resources/com/liferay/object/rest/test/util/packageinfo
+++ b/modules/apps/object/object-rest-test-util/src/main/resources/com/liferay/object/rest/test/util/packageinfo
@@ -1,1 +1,1 @@
-version 3.2.0
+version 3.3.0

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryRelatedObjectsResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryRelatedObjectsResourceTest.java
@@ -666,6 +666,43 @@ public class ObjectEntryRelatedObjectsResourceTest {
 	}
 
 	@Test
+	public void testDeleteCustomObjectEntryWithObjectRelationshipNamedAsLanguageKey()
+		throws Exception {
+
+		_objectRelationship = ObjectRelationshipTestUtil.addObjectRelationship(
+			ObjectRelationshipConstants.DELETION_TYPE_PREVENT,
+			_objectDefinition1, _objectDefinition2, TestPropsValues.getUserId(),
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY, "data");
+
+		_objectRelationships.add(_objectRelationship);
+
+		ObjectRelationshipTestUtil.relateObjectEntries(
+			_objectEntry1.getPrimaryKey(), _objectEntry2.getPrimaryKey(),
+			_objectRelationship, TestPropsValues.getUserId());
+
+		JSONAssert.assertEquals(
+			JSONUtil.put(
+				"status", "BAD_REQUEST"
+			).put(
+				"title",
+				StringBundler.concat(
+					"The prevent deletion type in the object relationship ",
+					"data with object definition ",
+					_objectDefinition2.getShortName(),
+					" is preventing this object entry from being deleted.")
+			).toString(),
+			HTTPTestUtil.invokeToJSONObject(
+				null,
+				StringBundler.concat(
+					_objectDefinition1.getRESTContextPath(),
+					"/by-external-reference-code/",
+					_objectEntry1.getExternalReferenceCode()),
+				Http.Method.DELETE
+			).toString(),
+			JSONCompareMode.LENIENT);
+	}
+
+	@Test
 	public void testDeleteObjectEntryWithHierarchy() throws Exception {
 
 		// Modifiable system as child


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-104281

## What Is Being Fixed

Object REST error titles pass their arguments through language translation: `Language.format(locale, key, arguments)` defaults `translateArguments` to true, so any entity or field name that equals an existing language key is silently replaced by that key's translation. A relationship named `data` renders as `Data` in the error title, which made `ObjectEntryRelatedObjectsResourceTest` fail whenever `StringUtil.randomId()` collided with one of the ~204 four-letter language keys (about one run in 2240; observed as `days` on 2026-05-08 and `data` on 2026-08-31). All 18 object REST exception mappers funnel through this method, and every argument their exceptions carry is an entity value, never a language key. Born broken in ca5c5362985b1 (LPS-194407).

## How It Is Being Fixed

`ObjectExceptionMapperUtil.getTitle` now formats with `language.format(locale, key, arguments.toArray(), false)`, interpolating arguments verbatim. A new exposure test creates a relationship literally named `data` via a new name-accepting `ObjectRelationshipTestUtil.addObjectRelationship` overload (exported package bumped to 3.3.0) and asserts the exact raw name in the title — the test fails without the fix and passes with it.

Known accepted cosmetic effect: three existing call sites whose argument is itself a language key (`name` twice, `external-reference-code` once) now show the raw key in error titles; those arguments are field identifiers, so rendering them verbatim is more correct than the accidental translation.

Local red/green on an isolated bundle: 2/2 red reproducing data-to-Data verbatim before the fix, 2/2 green after (deployed jar verified by javap), 36/36 collateral tests green. The self ci:test:object run was certified clean including the semantic-versioning axis and the new exposure test.

## PR Check

**pr-check: PASS** — tested on `c2088386a25ea7251d350b08d9c7c1c671b74972`

| Validation | Result |
| --- | --- |
| Source Format (with commit message validation) | PASS |
| Baseline | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | NOT VERIFIED |
| Java Unit Tests | PASS |
| Transaction Usage | PASS |
| Structural Smoke | PASS |

- Baseline: `object-rest-test-util` 3.3.0 bump verified by a genuine `--rerun` baseline (executed, no warnings); `object-api` clean; the seven Ant projects baselined individually, all clean. One inherited master finding (`portal-db-partition-test-util` 6.0.7/6.0.0 -> 7.0.0 major) in a module this branch does not touch; restored, not committed.
- Per-Module Compile: `:apps:object:object-api:deploy`, `:apps:object:object-rest-test-util:deploy`.
- Integration Test Compile: `object-rest-test`, `object-test` `compileTestIntegrationJava`.
- Cross-Module Compile: 15 testIntegration consumers of `ObjectRelationshipTestUtil` exceed the expansion cap of 8. The change is a purely additive overload (existing signatures untouched), and the self ci:test:object run built the full tree green.
- Java Unit Tests: no parallel-name counterpart test classes exist for the changed sources.
- Structural Smoke: `ModulesStructureTest` 8/8.

<!-- pr-check {"result": "success", "sha": "c2088386a25ea7251d350b08d9c7c1c671b74972"} -->
