### PR TITLE
LPD-34688 Regenerate translation-web snapshots for the editor change

### DIFF
--- a/modules/apps/translation/translation-web/test/js/translate/__snapshots__/Translate.js.snap
+++ b/modules/apps/translation/translation-web/test/js/translate/__snapshots__/Translate.js.snap
@@ -312,7 +312,6 @@ exports[`Translate renders with auto-translate disabled 1`] = `
               </label>
               <div
                 id="_mock_TranslationPortlet_infoField--description--0Container"
-                role="textbox"
               >
                 <div
                   id="_mock_TranslationPortlet_infoField--description--0"
@@ -386,7 +385,6 @@ exports[`Translate renders with auto-translate disabled 1`] = `
               </label>
               <div
                 id="_mock_TranslationPortlet_infoField--content--0Container"
-                role="textbox"
               >
                 <div
                   id="_mock_TranslationPortlet_infoField--content--0"
@@ -438,7 +436,6 @@ exports[`Translate renders with auto-translate disabled 1`] = `
               </label>
               <div
                 id="_mock_TranslationPortlet_infoField--repeteableContent--0Container"
-                role="textbox"
               >
                 <div
                   id="_mock_TranslationPortlet_infoField--repeteableContent--0"
@@ -490,7 +487,6 @@ exports[`Translate renders with auto-translate disabled 1`] = `
               </label>
               <div
                 id="_mock_TranslationPortlet_infoField--repeteableContent--1Container"
-                role="textbox"
               >
                 <div
                   id="_mock_TranslationPortlet_infoField--repeteableContent--1"
@@ -542,7 +538,6 @@ exports[`Translate renders with auto-translate disabled 1`] = `
               </label>
               <div
                 id="_mock_TranslationPortlet_infoField--repeteableContent--2Container"
-                role="textbox"
               >
                 <div
                   id="_mock_TranslationPortlet_infoField--repeteableContent--2"
@@ -987,7 +982,6 @@ exports[`Translate renders with auto-translate enabled 1`] = `
                   </label>
                   <div
                     id="_mock_TranslationPortlet_infoField--description--0Container"
-                    role="textbox"
                   >
                     <div
                       id="_mock_TranslationPortlet_infoField--description--0"
@@ -1092,7 +1086,6 @@ exports[`Translate renders with auto-translate enabled 1`] = `
                   </label>
                   <div
                     id="_mock_TranslationPortlet_infoField--content--0Container"
-                    role="textbox"
                   >
                     <div
                       id="_mock_TranslationPortlet_infoField--content--0"
@@ -1175,7 +1168,6 @@ exports[`Translate renders with auto-translate enabled 1`] = `
                   </label>
                   <div
                     id="_mock_TranslationPortlet_infoField--repeteableContent--0Container"
-                    role="textbox"
                   >
                     <div
                       id="_mock_TranslationPortlet_infoField--repeteableContent--0"
@@ -1258,7 +1250,6 @@ exports[`Translate renders with auto-translate enabled 1`] = `
                   </label>
                   <div
                     id="_mock_TranslationPortlet_infoField--repeteableContent--1Container"
-                    role="textbox"
                   >
                     <div
                       id="_mock_TranslationPortlet_infoField--repeteableContent--1"
@@ -1341,7 +1332,6 @@ exports[`Translate renders with auto-translate enabled 1`] = `
                   </label>
                   <div
                     id="_mock_TranslationPortlet_infoField--repeteableContent--2Container"
-                    role="textbox"
                   >
                     <div
                       id="_mock_TranslationPortlet_infoField--repeteableContent--2"
@@ -1879,7 +1869,6 @@ exports[`Translate renders with experiences selector 1`] = `
                   </label>
                   <div
                     id="_mock_TranslationPortlet_infoField--description--0Container"
-                    role="textbox"
                   >
                     <div
                       id="_mock_TranslationPortlet_infoField--description--0"
@@ -1984,7 +1973,6 @@ exports[`Translate renders with experiences selector 1`] = `
                   </label>
                   <div
                     id="_mock_TranslationPortlet_infoField--content--0Container"
-                    role="textbox"
                   >
                     <div
                       id="_mock_TranslationPortlet_infoField--content--0"
@@ -2067,7 +2055,6 @@ exports[`Translate renders with experiences selector 1`] = `
                   </label>
                   <div
                     id="_mock_TranslationPortlet_infoField--repeteableContent--0Container"
-                    role="textbox"
                   >
                     <div
                       id="_mock_TranslationPortlet_infoField--repeteableContent--0"
@@ -2150,7 +2137,6 @@ exports[`Translate renders with experiences selector 1`] = `
                   </label>
                   <div
                     id="_mock_TranslationPortlet_infoField--repeteableContent--1Container"
-                    role="textbox"
                   >
                     <div
                       id="_mock_TranslationPortlet_infoField--repeteableContent--1"
@@ -2233,7 +2219,6 @@ exports[`Translate renders with experiences selector 1`] = `
                   </label>
                   <div
                     id="_mock_TranslationPortlet_infoField--repeteableContent--2Container"
-                    role="textbox"
                   >
                     <div
                       id="_mock_TranslationPortlet_infoField--repeteableContent--2"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-34688

## What Is Being Fixed

The upstream sync gate `test-portal-testsuite-upstream(master)` is red (first failure: build 1619 on test-1-48, portal SHA `0ab73e981ccfa`): the `js-unit/0/0` axis fails on three `translation-web` Jest snapshot tests, blocking every merge from reaching liferay/liferay-portal.

Root cause: 932c2a88b8d0e (LPD-34688) moved the CKEditor ClassicEditor ARIA attributes (`role="textbox"`, `aria-label`, `aria-invalid`) off the React container div onto the live editable element, but did not regenerate the snapshots of `translation-web`, a consumer that renders ClassicEditor in its Translate tests. The committed snapshots still expect `role="textbox"` on the infoField containers, so the suite fails deterministically.

## How It Is Being Fixed

Regenerated the `translation-web` snapshots with `jest -u`. The only delta is the removal of the five stale attribute lines per snapshot (15 lines total). Red reproduced locally at the current master tip (3 failed / 24 passed, identical to CI), and after the regen the module suite passes 27/27. A repo-wide scan shows `translation-web` holds the only committed snapshot containing `role="textbox"`, so no other consumer needs the same regen.

## PR Check

**pr-check: PASS** — tested on `953da56d0ee63f8b173ff09749a88b95c713b846`

| Validation | Result |
| --- | --- |
| Source Format (with commit message validation) | PASS |
| JavaScript Unit Tests (translation-web full suite) | PASS (27/27; red 3/27 before the regen, identical to the CI failure) |

<!-- pr-check {"result": "success", "sha": "953da56d0ee63f8b173ff09749a88b95c713b846"} -->
