### PR TITLE
LPD-99790 Semantic versioning

### DIFF
--- a/modules/apps/portal/portal-db-partition-test-util/bnd.bnd
+++ b/modules/apps/portal/portal-db-partition-test-util/bnd.bnd
@@ -1,4 +1,4 @@
 Bundle-Name: Liferay Portal DB Partition Test Utilities
 Bundle-SymbolicName: com.liferay.portal.db.partition.test.util
-Bundle-Version: 6.0.7
+Bundle-Version: 7.0.0
 Export-Package: com.liferay.portal.db.partition.test.util

--- a/modules/apps/portal/portal-db-partition-test-util/src/main/resources/com/liferay/portal/db/partition/test/util/packageinfo
+++ b/modules/apps/portal/portal-db-partition-test-util/src/main/resources/com/liferay/portal/db/partition/test/util/packageinfo
@@ -1,1 +1,1 @@
-version 6.0.0
+version 7.0.0


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99790

## What Is Being Fixed

`semantic-versioning/0/0` has failed on every master-based ci:test run since 2026-09-01T12:21Z with `testSemanticVersioning[/apps/portal/portal-db-partition-test-util]`: 243a5bb156aeb ("LPD-99790 Inline the second getExportedPartitionName test delegate") removed `protected static getExportedPartitionName(long)` from `BaseDBPartitionTestCase` in the exported package `com.liferay.portal.db.partition.test.util`, released in 6.0.6, without the MAJOR bump that removal requires. The baseline reports `VERSION INCREASE REQUIRED` 6.0.0 -> 7.0.0 and `Bundle Version Change Recommended: 7.0.0`.

## How It Is Being Fixed

`packageinfo` 6.0.0 -> 7.0.0 and `Bundle-Version` 6.0.7 -> 7.0.0, as a semantic versioning commit carrying the breaking-change section for the removed method. Verified: a self ci:test:object run on this bump was 55/55 green with the semantic-versioning axis passing, and a standalone `--rerun` baseline of the module on this branch reports nothing.

How it slipped through is being followed up separately with the original PR's author — see the forensic request at https://github.com/liferay-database-infra/liferay-portal/pull/3911#issuecomment-5499768272 : the change forwarded on ci:test:sf plus a pr-check status whose Baseline row read PASS although its own notes state `ant baseline-all` was not run, and the PR Tester does not run for forwarded pull requests, so no semantic-versioning check executed before merge.

## PR Check

**pr-check: PASS** — tested on `59c1ebe24a73cc5c055cbe1c9d4338425fcdc520`

| Validation | Result |
| --- | --- |
| Source Format (with commit message validation) | PASS |
| Baseline | PASS (baseline-all + 7 Ant projects + 1 changed exporting module) |
| Structural Smoke | PASS |

- Baseline: `ant baseline-all` ran clean for this branch's module (bump verified sufficient); the seven Ant projects each printed `1 executed` standalone with `--rerun`; `> Task :apps:portal:portal-db-partition-test-util:baseline` printed standalone. No inherited findings. (A first pass reported a `portal-test` `randomizerbumpers` 1.2.0 -> 1.3.0 rise; it was an orphan pre-rename `TikaSafeRandomizerBumper.class` left in the local `portal-test/classes` and swept into the jar by `ant jar` — after `ant clean jar` the standalone `portal-test` baseline against released 32.8.0 is clean, so master owes nothing there.)
- Structural Smoke: `ModulesStructureTest` 8/8 (bnd.bnd changed).

<!-- pr-check {"result": "success", "sha": "59c1ebe24a73cc5c055cbe1c9d4338425fcdc520"} -->
