### PR TITLE
LPD-99284 Automate migration to the 4-arg fetchLayoutPageTemplateEntry

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -6059,6 +6059,15 @@
 		"to": "_sites.updateLayoutSetPrototypesLinks"
 	},
 	{
+		"classNames": [
+			"LayoutPageTemplateEntryLocalService",
+			"LayoutPageTemplateEntryLocalServiceUtil"
+		],
+		"from": "fetchLayoutPageTemplateEntry(long paramName, String paramName, int paramName)",
+		"issueKey": "LPD-99284",
+		"to": "fetchLayoutPageTemplateEntry(param#0#, 0L, param#1#, param#2#)"
+	},
+	{
 		"from": "regex:MultiVMPoolUtil\\s*.\\s*getPortalCache\\(\\s*(?<prefixMethodName>[\\s\\S]*?)\\)",
 		"issueKey": "LPS-153962",
 		"newImports": [

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_99284.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_99284.testjava
@@ -1,0 +1,26 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Liferay
+ */
+public class LPD_99284 {
+
+	public void method(long groupId, String name, int type) {
+		LayoutPageTemplateEntryLocalServiceUtil.fetchLayoutPageTemplateEntry(
+			123, name, type);
+		LayoutPageTemplateEntryLocalServiceUtil.fetchLayoutPageTemplateEntry(groupId, 0L, name, type);
+		_layoutPageTemplateEntryLocalService.fetchLayoutPageTemplateEntry(groupId, 0L, name, type);
+	}
+
+	@Reference
+	private LayoutPageTemplateEntryLocalService
+		_layoutPageTemplateEntryLocalService;
+
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_99284.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_99284.testjava
@@ -1,0 +1,28 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Liferay
+ */
+public class LPD_99284 {
+
+	public void method(long groupId, String name, int type) {
+		LayoutPageTemplateEntryLocalServiceUtil.fetchLayoutPageTemplateEntry(
+			123, name, type);
+		LayoutPageTemplateEntryLocalServiceUtil.fetchLayoutPageTemplateEntry(
+			groupId, name, type);
+		_layoutPageTemplateEntryLocalService.fetchLayoutPageTemplateEntry(
+			groupId, name, type);
+	}
+
+	@Reference
+	private LayoutPageTemplateEntryLocalService
+		_layoutPageTemplateEntryLocalService;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99284

## What Is Being Fixed

On 2026.q1.10-lts the `LayoutPageTemplateEntryLocalService.fetchLayoutPageTemplateEntry(long groupId, String name, int type)` overload was removed in favor of `fetchLayoutPageTemplateEntry(long groupId, long layoutPageTemplateCollectionId, String name, int type)`, where a caller with no collection context passes `0L`. The upgrade catalog carried no entry for the removed signature, so the source formatter's upgrade check could neither flag nor repair a stale call, leaving every caller to be found and edited by hand.

## How It Is Being Fixed

A replacement entry is added to the source formatter's `replacements.json`, the catalog `UpgradeCatchAllCheck` reads. It is scoped to `LayoutPageTemplateEntryLocalService` and `LayoutPageTemplateEntryLocalServiceUtil`, matches the removed call by its parameter shape rather than by text, and rewrites it as `param#0#, 0L, param#1#, param#2#` so the original arguments keep their positions and `0L` is injected as the new second argument.

Matching on parameter shape is what makes the rewrite safe to apply unattended: a call whose first argument is not a `long` variable does not match, so the check leaves it alone rather than guessing which argument became the collection id. The fixtures cover that case alongside the two that do get rewritten, one through the `Util` class and one through an injected `@Reference` service.

## PR Check

**pr-check: PASS** — tested on `b07526399514361f99c3dfec3918892afb82731b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

Source Format formatted the branch's 3 changed files and reported `SUCCESS: Everything is correctly formatted.` — no rewrites, so no `LPD-99284 SF` commit.

Baseline confirmed all seven Ant projects genuinely ran (`1 executed` each) and found 4 findings, none in a module the branch changed. All are inherited from master, reported and restored, and do not fail the branch: `portal-kernel` `com.liferay.exportimport.kernel.xstream` EXCESSIVE VERSION INCREASE (`3.0.0` → `2.0.0`); `portal-kernel` `com.liferay.portal.kernel.servlet` EXCESSIVE VERSION INCREASE (`18.0.0` → `17.3.0`); `portal-impl` `com.liferay.portal.dao.orm.hibernate` VERSION INCREASE REQUIRED, minor (`13.0.0` → `13.1.0`); `modules/apps/portal/portal-db-partition-test-util` VERSION INCREASE REQUIRED, major (`6.0.0`/`6.0.7` → `7.0.0`, from a removed `getExportedPartitionName(long)`). The Local Version Check passed: the diff touches no `*-api`, `portal-impl/src`, or `portal-kernel/src` Java and no `packageinfo` or `bnd.bnd`.

Java Unit Tests ran `:util:source-formatter:test --tests com.liferay.source.formatter.processor.UpgradeCatchAllCheckTest`: 271 tests, 2 failures. Both are pre-existing on master — `LPD_70233` is missing its `expected/` fixture entirely, and `LPD_61579` holds a stale `setServletContext`/`getRequest` expectation. A master baseline run in a throwaway worktree produced the same two fixtures with identical failure messages (270 tests, 2 failures), so the branch introduces no new failure. The new `LPD_99284` fixture case PASSED, and the count rising 270 → 271 confirms it was discovered rather than silently skipped.

<!-- pr-check {"result": "success", "sha": "b07526399514361f99c3dfec3918892afb82731b"} -->
