### PR TITLE
LPD-103924 Link CMS entries in the XML sitemap through their space

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/site/provider/ObjectEntrySitemapURLProvider.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/site/provider/ObjectEntrySitemapURLProvider.java
@@ -21,18 +21,24 @@ import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectDefinitionSettingLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectEntryService;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.GroupThreadLocal;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -251,21 +257,33 @@ public class ObjectEntrySitemapURLProvider implements SitemapURLProvider {
 	}
 
 	private String _getFriendlyURL(
-		String languageId, ObjectDefinition objectDefinition,
-		ObjectEntry objectEntry) {
+		boolean cms, long groupId, String languageId,
+		ObjectDefinition objectDefinition, ObjectEntry objectEntry) {
 
 		String urlTitle = objectEntry.getURLTitle(
 			LocaleUtil.fromLanguageId(languageId));
 
-		if (Validator.isNotNull(urlTitle)) {
+		if (Validator.isNull(urlTitle)) {
+			if (!objectDefinition.isDefaultStorageType()) {
+				return objectEntry.getExternalReferenceCode();
+			}
+
+			return String.valueOf(objectEntry.getObjectEntryId());
+		}
+
+		if (!cms || (groupId == objectEntry.getGroupId())) {
 			return urlTitle;
 		}
 
-		if (!objectDefinition.isDefaultStorageType()) {
-			return objectEntry.getExternalReferenceCode();
+		Group group = _groupLocalService.fetchGroup(objectEntry.getGroupId());
+
+		if (group == null) {
+			return urlTitle;
 		}
 
-		return String.valueOf(objectEntry.getObjectEntryId());
+		return StringBundler.concat(
+			StringUtil.removeFirst(group.getFriendlyURL(), StringPool.SLASH),
+			StringPool.SLASH, urlTitle);
 	}
 
 	private long[] _getGroupIds(long groupId) throws PortalException {
@@ -363,22 +381,29 @@ public class ObjectEntrySitemapURLProvider implements SitemapURLProvider {
 		String urlSeparator = StringUtil.quote(
 			objectDefinition.getFriendlyURLSeparator(), CharPool.SLASH);
 
-		for (ObjectEntry objectEntry : objectEntries) {
-			String friendlyURL = _getFriendlyURL(
-				themeDisplay.getLanguageId(), objectDefinition, objectEntry);
+		try (SafeCloseable safeCloseable =
+				GroupThreadLocal.setGroupIdWithSafeCloseable(
+					layout.getGroupId())) {
 
-			String canonicalURL = _portal.getCanonicalURL(
-				urlSeparator + friendlyURL, themeDisplay, layout);
+			for (ObjectEntry objectEntry : objectEntries) {
+				String friendlyURL = _getFriendlyURL(
+					objectDefinition.isCMS(), layout.getGroupId(),
+					themeDisplay.getLanguageId(), objectDefinition,
+					objectEntry);
 
-			Map<Locale, String> alternateURLs = _portal.getAlternateURLs(
-				canonicalURL, themeDisplay, layout,
-				objectDefinitionAvailableLocales);
+				String canonicalURL = _portal.getCanonicalURL(
+					urlSeparator + friendlyURL, themeDisplay, layout);
 
-			for (String alternateURL : alternateURLs.values()) {
-				_sitemapManager.addURLElement(
-					element, alternateURL, typeSettingsUnicodeProperties,
-					objectEntry.getModifiedDate(), canonicalURL, alternateURLs,
-					layout.getGroupId());
+				Map<Locale, String> alternateURLs = _portal.getAlternateURLs(
+					canonicalURL, themeDisplay, layout,
+					objectDefinitionAvailableLocales);
+
+				for (String alternateURL : alternateURLs.values()) {
+					_sitemapManager.addURLElement(
+						element, alternateURL, typeSettingsUnicodeProperties,
+						objectEntry.getModifiedDate(), canonicalURL,
+						alternateURLs, layout.getGroupId());
+				}
 			}
 		}
 	}
@@ -388,6 +413,9 @@ public class ObjectEntrySitemapURLProvider implements SitemapURLProvider {
 
 	@Reference
 	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
 
 	@Reference
 	private Language _language;

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/site/provider/test/ObjectEntrySitemapURLProviderTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/site/provider/test/ObjectEntrySitemapURLProviderTest.java
@@ -17,14 +17,18 @@ import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectDefinitionSettingConstants;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.object.definition.setting.builder.ObjectDefinitionSettingBuilder;
 import com.liferay.object.field.builder.TextObjectFieldBuilder;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectFolder;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectDefinitionSettingLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectFolderLocalService;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -161,6 +165,27 @@ public class ObjectEntrySitemapURLProviderTest {
 	}
 
 	@Test
+	public void testVisitCMSObjectDefinition() throws Exception {
+		_testVisitCMSObjectDefinition(
+			(layout, objectDefinition, objectEntry) -> {
+				Group group = _depotEntry.getGroup();
+
+				_assertRootElement(
+					true, group.getFriendlyURL(), layout, objectDefinition,
+					objectEntry);
+			});
+
+		_testVisitCMSObjectDefinition(
+			(layout, objectDefinition, objectEntry) -> {
+				Group group = _depotEntry.getGroup();
+
+				_assertRootElement(
+					true, group.getFriendlyURL(), _layoutSet, objectDefinition,
+					objectEntry, _themeDisplay);
+			});
+	}
+
+	@Test
 	public void testVisitLayout() throws Exception {
 		_testVisitLayout(0, _companyObjectDefinition);
 		_testVisitLayout(_depotEntry.getGroupId(), _depotObjectDefinition);
@@ -202,6 +227,27 @@ public class ObjectEntrySitemapURLProviderTest {
 			ObjectDefinition objectDefinition, ObjectEntry objectEntry)
 		throws Exception {
 
+		_assertRootElement(
+			expectedHasContent, StringPool.BLANK, layout, objectDefinition,
+			objectEntry);
+	}
+
+	private void _assertRootElement(
+			boolean expectedHasContent, LayoutSet layoutSet,
+			ObjectDefinition objectDefinition, ObjectEntry objectEntry,
+			ThemeDisplay themeDisplay)
+		throws Exception {
+
+		_assertRootElement(
+			expectedHasContent, StringPool.BLANK, layoutSet, objectDefinition,
+			objectEntry, themeDisplay);
+	}
+
+	private void _assertRootElement(
+			boolean expectedHasContent, String friendlyURL, Layout layout,
+			ObjectDefinition objectDefinition, ObjectEntry objectEntry)
+		throws Exception {
+
 		Element rootElement = _getRootElement();
 
 		_objectEntrySitemapURLProvider.visitLayout(
@@ -214,11 +260,11 @@ public class ObjectEntrySitemapURLProviderTest {
 		}
 
 		_assertRootElements(
-			objectDefinition, objectEntry, rootElement.elements());
+			friendlyURL, objectDefinition, objectEntry, rootElement.elements());
 	}
 
 	private void _assertRootElement(
-			boolean expectedHasContent, LayoutSet layoutSet,
+			boolean expectedHasContent, String friendlyURL, LayoutSet layoutSet,
 			ObjectDefinition objectDefinition, ObjectEntry objectEntry,
 			ThemeDisplay themeDisplay)
 		throws Exception {
@@ -235,12 +281,12 @@ public class ObjectEntrySitemapURLProviderTest {
 		}
 
 		_assertRootElements(
-			objectDefinition, objectEntry, rootElement.elements());
+			friendlyURL, objectDefinition, objectEntry, rootElement.elements());
 	}
 
 	private void _assertRootElements(
-		ObjectDefinition objectDefinition, ObjectEntry objectEntry,
-		List<Element> rootElements) {
+		String friendlyURL, ObjectDefinition objectDefinition,
+		ObjectEntry objectEntry, List<Element> rootElements) {
 
 		Set<Locale> availableLocales = _language.getAvailableLocales();
 
@@ -264,7 +310,8 @@ public class ObjectEntrySitemapURLProviderTest {
 		String objectEntryFriendlyURL = StringUtil.toLowerCase(
 			StringBundler.concat(
 				StringPool.SLASH, objectDefinition.getFriendlyURLSeparator(),
-				StringPool.SLASH, objectEntry.getExternalReferenceCode()));
+				friendlyURL, StringPool.SLASH,
+				objectEntry.getExternalReferenceCode()));
 
 		for (Element rootElement : rootElements) {
 			String objectEntryLocalizedURL = rootElement.elementText("loc");
@@ -337,11 +384,13 @@ public class ObjectEntrySitemapURLProviderTest {
 		return themeDisplay;
 	}
 
-	private ObjectDefinition _publishObjectDefinition(String scope)
+	private ObjectDefinition _publishObjectDefinition(
+			long objectFolderId, String scope)
 		throws Exception {
 
 		ObjectDefinition objectDefinition =
 			ObjectDefinitionTestUtil.publishObjectDefinition(
+				ObjectDefinitionTestUtil.getRandomName(),
 				Collections.singletonList(
 					new TextObjectFieldBuilder(
 					).labelMap(
@@ -351,7 +400,7 @@ public class ObjectEntrySitemapURLProviderTest {
 					).objectFieldSettings(
 						Collections.emptyList()
 					).build()),
-				scope);
+				objectFolderId, scope, TestPropsValues.getUserId());
 
 		if (StringUtil.equals(scope, ObjectDefinitionConstants.SCOPE_DEPOT)) {
 			_objectDefinitionSettingLocalService.addObjectDefinitionSetting(
@@ -362,6 +411,12 @@ public class ObjectEntrySitemapURLProviderTest {
 		}
 
 		return objectDefinition;
+	}
+
+	private ObjectDefinition _publishObjectDefinition(String scope)
+		throws Exception {
+
+		return _publishObjectDefinition(0, scope);
 	}
 
 	private void _testGetModifiedDate(
@@ -390,6 +445,42 @@ public class ObjectEntrySitemapURLProviderTest {
 			Assert.assertNotNull(
 				_objectEntrySitemapURLProvider.getModifiedDate(
 					TestPropsValues.getCompanyId(), _group.getGroupId()));
+		}
+	}
+
+	private void _testVisitCMSObjectDefinition(
+			UnsafeTriConsumer<Layout, ObjectDefinition, ObjectEntry, Exception>
+				unsafeTriConsumer)
+		throws Exception {
+
+		ObjectFolder objectFolder =
+			_objectFolderLocalService.getOrAddEmptyObjectFolder(
+				ObjectFolderConstants.
+					EXTERNAL_REFERENCE_CODE_CONTENT_STRUCTURES,
+				TestPropsValues.getCompanyId(), TestPropsValues.getUserId());
+
+		ObjectDefinition objectDefinition = _publishObjectDefinition(
+			objectFolder.getObjectFolderId(),
+			ObjectDefinitionConstants.SCOPE_DEPOT);
+
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					_getCompanyConfigurationTemporarySwapper(
+						objectDefinition)) {
+
+			_depotEntryGroupRelLocalService.addDepotEntryGroupRel(
+				_depotEntry.getDepotEntryId(), _group.getGroupId());
+
+			LayoutPageTemplateEntry layoutPageTemplateEntry =
+				_addDisplayPageTemplate(_group.getGroupId(), objectDefinition);
+
+			ObjectEntry objectEntry = _addObjectEntry(
+				_depotEntry.getGroupId(), objectDefinition);
+
+			unsafeTriConsumer.accept(
+				_layoutLocalService.getLayout(
+					layoutPageTemplateEntry.getPlid()),
+				objectDefinition, objectEntry);
 		}
 	}
 
@@ -584,6 +675,9 @@ public class ObjectEntrySitemapURLProviderTest {
 		type = SitemapURLProvider.class
 	)
 	private SitemapURLProvider _objectEntrySitemapURLProvider;
+
+	@Inject
+	private ObjectFolderLocalService _objectFolderLocalService;
 
 	@Inject
 	private Portal _portal;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103924

## What Is Being Fixed

A CMS object entry lives in a space, but the display page that renders it belongs to a site. The sitemap emitted the entry's URL title on its own, so the generated `loc` resolved against the site rather than the space and did not point at a real page.

## How It Is Being Fixed

`_getFriendlyURL` now receives the definition's CMS flag and the layout's group id. When a CMS entry's group differs from the layout's group, the entry group's friendly URL is prefixed onto the URL title, so the emitted location goes through the space. The visit loop is wrapped in `GroupThreadLocal.setGroupIdWithSafeCloseable(layout.getGroupId())` because `getAlternateURLs` re-derives each location and needs the layout's group to resolve it. The null URL title case was also turned into a guard clause so the new branch reads in one column.

## PR Check

**pr-check: PASS** — tested on `6cc06ccffd38c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

Baseline surfaced one inherited finding, in a module this branch does not touch. `com.liferay.portal.db.partition.test.util` is MAJOR / VERSION INCREASE REQUIRED (cur `6.0.0`, recommended `7.0.0`), caused by the removal of `protected static String getExportedPartitionName(long)` from `BaseDBPartitionTestCase`. The task rewrote `portal-db-partition-test-util/bnd.bnd` (`6.0.7` -> `7.0.0`) and its `packageinfo` (`6.0.0` -> `7.0.0`) in place; both were restored. The bump belongs to whoever removed that method. All seven Ant projects were confirmed to have genuinely baselined (`1 executed` each), and both branch-changed modules baselined clean.

Java Unit Tests ran `object-service`'s full unit suite as the fallback, since neither changed file has a parallel-name counterpart. 20 tests, 0 failures, 0 errors across 12 classes.

<!-- pr-check {"result": "success", "sha": "6cc06ccffd38c9dd1cabe036c46ad867f8375f11"} -->
