### PR TITLE
LPD-104281 Pass the relationship name and type in the swapped parameter order

### DIFF
--- a/modules/apps/object/object-rest-test-util/src/main/java/com/liferay/object/rest/test/util/ObjectRelationshipTestUtil.java
+++ b/modules/apps/object/object-rest-test-util/src/main/java/com/liferay/object/rest/test/util/ObjectRelationshipTestUtil.java
@@ -37,7 +37,7 @@ public class ObjectRelationshipTestUtil {
 
 		return addObjectRelationship(
 			deletionType, objectDefinition, relatedObjectDefinition, userId,
-			type, StringUtil.randomId());
+			StringUtil.randomId(), type);
 	}
 
 	public static ObjectRelationship addObjectRelationship(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-104281

## What Is Being Fixed

Since 98706e3ece718 ("LPD-104281 Match usage") swapped the six-argument `ObjectRelationshipTestUtil.addObjectRelationship` overload's parameters to `(…, String name, String type)`, the five-argument overload has still delegated to it positionally as `(type, StringUtil.randomId())`. Both parameters are Strings, so it compiled, and every five-argument caller sends the type constant as the relationship name and a random four-letter id as the type; `ObjectRelationshipLocalServiceImpl._validateType` rejects it with `ObjectRelationshipTypeException: Invalid type <randomId>`. On ci:test:object this fails 115 integration tests deterministically across four axes (`ObjectEntryResourceTest`, `ObjectEntryRelatedObjectsResourceTest`, `RelatedObjectEntryResourceTest`, `SystemObjectRelatedObjectEntriesTest`, `DefaultObjectEntryManagerImplTest`) on every master tip that contains that commit; all 115 traces pass through the five-argument overload's delegation.

## How It Is Being Fixed

The five-argument overload delegates as `(StringUtil.randomId(), type)`, matching the swapped signature. One line; no signature changes, so no consumer is affected and no version bump is owed. A self ci:test:object run on this fix was **55 out of 55 green**, the four axes recovered.

## PR Check

**pr-check: PASS** — tested on `526fca90dae74f302a4680b806a1cbe5aa3c051d`

| Validation | Result |
| --- | --- |
| Source Format (with commit message validation) | PASS |
| Baseline | PASS (baseline-all + 7 Ant projects + 1 changed exporting module) |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | NOT VERIFIED |
| Java Unit Tests | PASS |
| Transaction Usage | PASS |

- Baseline: `ant baseline-all` clean (no warning rows, no repairs); the seven Ant projects printed `1 executed` standalone; `> Task :apps:object:object-rest-test-util:baseline` printed standalone with no findings — a method-body change owes no bump.
- Per-Module Compile: `:apps:object:object-rest-test-util:deploy`. Integration Test Compile: `:apps:object:object-rest-test:compileTestIntegrationJava`.
- Cross-Module Compile: `ObjectRelationshipTestUtil` has 15 testIntegration consumers, above the expansion cap of 8; no signature changed, and the self ci:test:object run built and ran the full tree green.
- Java Unit Tests: no parallel-name counterpart exists. Transaction Usage: no new transaction usage.

<!-- pr-check {"result": "success", "sha": "526fca90dae74f302a4680b806a1cbe5aa3c051d"} -->
