### PR TITLE
LPD-103697 Mark the order setLookAndFeel depends on

### DIFF
--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/LayoutServiceContextHelperImpl.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/LayoutServiceContextHelperImpl.java
@@ -372,6 +372,9 @@ public class LayoutServiceContextHelperImpl
 
 			ThemeDisplay themeDisplay = ThemeDisplayFactory.create();
 
+			// Set attributes first that other methods (getCDNBaseURL and
+			// setLookAndFeel) depend on
+
 			themeDisplay.setCompany(company);
 			themeDisplay.setPortalDomain(company.getVirtualHostname());
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103697

## What Is Being Fixed

The fix itself is already in master. This adds only the comment that says why the order it depends on cannot change.

`getCDNBaseURL` memoises the CDN base URL, falling back to the portal URL built from the host fields when no CDN host is configured, and `setLookAndFeel` writes what it returns into the theme paths. Both read those fields at the moment they run, so a host assigned afterwards corrects neither the memo nor the paths derived from it. Nothing at the call site said so.

## How It Is Being Fixed

One comment, three lines, no code moved:

```java
ThemeDisplay themeDisplay = ThemeDisplayFactory.create();

// Set attributes first that other methods (getCDNBaseURL and
// setLookAndFeel) depend on

themeDisplay.setCompany(company);
themeDisplay.setPortalDomain(company.getVirtualHostname());
```

The wording is the comment `ServicePreAction` already carries above the same dependency, so both builders of a `ThemeDisplay` name it the same way.

## One Thing Worth Knowing

`MethodCallsOrderCheck` fires on this file and wants `setSecure`, `setServerName` and `setServerPort` sorted down into the run below. That is not caused by this change: checking out a2293c0b78f89d763edbfccaaeec3eb28610831b unmodified and running `formatSource` produces the same three-line reorder. It is left out of this branch deliberately so the diff is the comment alone, but whoever runs the formatter on this file next will pick it up.

Verified on this commit: `layout-impl` compiles and deploys, and the change adds no transaction usage. Source Format is the check above.
