### PR TITLE
LPD-104127 Delete the composite key rule before the relationship

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -671,11 +671,11 @@ public class ObjectDefinitionLocalServiceImpl
 					_objectRelationshipPersistence.findByODI1_R(
 						objectDefinition.getObjectDefinitionId(), false)) {
 
-				_objectRelationshipLocalService.deleteObjectRelationship(
-					objectRelationship);
-
 				_deleteCompositeKeyObjectValidationRule(
 					objectRelationship.getObjectFieldId2());
+
+				_objectRelationshipLocalService.deleteObjectRelationship(
+					objectRelationship);
 			}
 
 			_objectValidationRuleLocalService.deleteObjectValidationRules(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-104127

Follows up on 469d303eb4202c57404ca02b653e9ae9e224fd91.

## What Is Being Fixed

`469d303` reordered two statements. Moving `deleteObjectValidationRules` below the `findByODI1_R` loop is fine. Moving `_deleteCompositeKeyObjectValidationRule` after `deleteObjectRelationship` is not, and it reintroduces the defect `LPD-103893` fixed.

`deleteObjectRelationship` calls `deleteRelationshipTypeObjectField`, and `_deleteObjectField` throws `RequiredObjectFieldException$MustNotDeleteObjectFieldCompositeKey` while a unique composite key validation still covers the field. The rule deletion placed after it never runs, because the exception aborts first. Inside `deleteCompanyObjectDefinitions` that also aborts the loop and leaves behind every object definition it had not yet reached, which is what `CompanyLocalServiceTest.testAddAndDeleteCompany` reports as leftover data.

Measured on `ObjectDefinitionLocalServiceTest`, with each ordering deployed in turn:

| Ordering | Result |
| --- | --- |
| `_deleteCompositeKeyObjectValidationRule` after `deleteObjectRelationship`, as in `469d303` | 32 tests, **1 failed** — `MustNotDeleteObjectFieldCompositeKey` |
| `_deleteCompositeKeyObjectValidationRule` before it, with `deleteObjectValidationRules` moved below the loop as in `469d303` | 32 tests, 0 failed |

The second row is the ordering this pull request restores, and it was verified on this base: a bundle built from this branch against a clean database, with `testDeleteObjectDefinitionWithCompositeKeyObjectValidationRule` passing. `formatSource` and `compileJava` also pass.

## How It Is Being Fixed

`_deleteCompositeKeyObjectValidationRule` moves back above `deleteObjectRelationship` inside the loop. The relocation of the bulk `deleteObjectValidationRules` call below the loop is kept, since that half of the sort is safe.

## PR Check

**pr-check: SKIPPED** — sent urgently to correct an ordering already on master; formatSource and compile were run and both pass.

<!-- pr-check {"reason": "sent urgently to correct an ordering already on master; formatSource and compile were run and both pass", "result": "skipped", "sha": "d3de524" } -->


