### PR TITLE
LPD-103697 SF

### DIFF
--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/LayoutServiceContextHelperImpl.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/LayoutServiceContextHelperImpl.java
@@ -383,13 +383,13 @@ public class LayoutServiceContextHelperImpl
 				_portal.getPortalURL(
 					company.getVirtualHostname(), portalServerPort, secure));
 
-			themeDisplay.setSecure(secure);
-			themeDisplay.setServerName(company.getVirtualHostname());
-			themeDisplay.setServerPort(portalServerPort);
 			themeDisplay.setPathMain(_portal.getPathMain());
 			themeDisplay.setPermissionChecker(permissionChecker);
 			themeDisplay.setRealUser(user);
 			themeDisplay.setScopeGroupId(_group.getGroupId());
+			themeDisplay.setSecure(secure);
+			themeDisplay.setServerName(company.getVirtualHostname());
+			themeDisplay.setServerPort(portalServerPort);
 			themeDisplay.setSignedIn(!user.isGuestUser());
 			themeDisplay.setSiteGroupId(_group.getGroupId());
 			themeDisplay.setTimeZone(user.getTimeZone());


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103697

## What Is Being Fixed

`LayoutServiceContextHelperImpl` is not source formatter clean. `MethodCallsOrderCheck` wants `setSecure`, `setServerName` and `setServerPort` sorted into the run that follows them.

This is not introduced by anything on this branch. Checking out a2293c0b78f89d763edbfccaaeec3eb28610831b unmodified and running `formatSource` produces exactly the same three line reorder, so the next branch to touch this file picks it up whether it wants to or not.

## How It Is Being Fixed

The formatter's own output, committed as is. Nothing hand edited.

The setters stay above the `if (_layout != null)` branch that calls `setLookAndFeel`, so the ordering `getCDNBaseURL` and `setLookAndFeel` depend on is unaffected: sorting can only move them among themselves.

## Why Are There No Tests?

The commit is source formatter output. It reorders three consecutive setter calls on the same object and changes no behaviour, so there is nothing to assert that the existing tests do not already cover.

## PR Check

**pr-check: PASS** — tested on `82e1bf3b97e863458b182c02130281ecc0ffb258`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | NOT VERIFIED |
| Baseline | NOT VERIFIED |
| Java Unit Tests | PASS |

The diff baseline is `brian/master` rather than `liferay/master`. The file state this reorder applies to exists only on `brian/master`, which is 2043 commits ahead, so measuring against `liferay/master` would have reported on those commits rather than on this one.

Integration Test Compile verified nothing: the changed module, `layout-impl`, has no `src/testIntegration` sources, so there was nothing for it to compile.

Baseline verified nothing about this branch. The run aborted and its only repair was to `portal-kernel/bnd.bnd`, a file this branch does not touch, so the finding is pre-existing rather than introduced here and this branch's own modules went unexamined. That edit was reverted rather than committed.

Java Unit Tests ran `layout-impl`'s suite, 37 tests across 4 classes, 0 failures and 0 errors. No parallel-name counterpart exists for the changed class.

<!-- pr-check {"result": "success", "sha": "82e1bf3b97e863458b182c02130281ecc0ffb258"} -->
