### PR TITLE
LPD-100542 Rename group2 to layoutGroup and referencedArticleGroup

### DIFF
--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/exportimport/data/handler/test/JournalExportImportTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/exportimport/data/handler/test/JournalExportImportTest.java
@@ -408,33 +408,34 @@ public class JournalExportImportTest extends BasePortletExportImportTestCase {
 	public void testExportImportJournalArticleWithLayoutURLLayoutAndGroupDoesNotExistOnImportSide()
 		throws Exception {
 
-		Group group2 = GroupTestUtil.addGroup();
+		Group layoutGroup = GroupTestUtil.addGroup();
 
-		Layout parentLayout = LayoutTestUtil.addTypePortletLayout(group2);
+		Layout parentLayout = LayoutTestUtil.addTypePortletLayout(layoutGroup);
 
 		Layout childLayout = LayoutTestUtil.addTypePortletLayout(
-			group2, parentLayout.getPlid());
+			layoutGroup, parentLayout.getPlid());
 
 		String content = StringUtil.replace(
 			_read("journal_article_content.xml"),
 			new String[] {"[$GROUP_NAME$]", "[[$LAYOUT_FRIENDLY_URL$]$]"},
 			new String[] {
-				StringUtil.toLowerCase(group2.getName("en_US")),
+				StringUtil.toLowerCase(layoutGroup.getName("en_US")),
 				StringUtil.toLowerCase(childLayout.getFriendlyURL())
 			});
 
 		DataDefinition dataDefinition =
 			DataDefinitionTestUtil.addDataDefinition(
-				"journal", _dataDefinitionResourceFactory, group2.getGroupId(),
-				_read("data_definition.json"), TestPropsValues.getUser());
+				"journal", _dataDefinitionResourceFactory,
+				layoutGroup.getGroupId(), _read("data_definition.json"),
+				TestPropsValues.getUser());
 
 		JournalArticle article = JournalTestUtil.addArticleWithXMLContent(
-			group2.getGroupId(), content, dataDefinition.getDataDefinitionKey(),
-			null);
+			layoutGroup.getGroupId(), content,
+			dataDefinition.getDataDefinitionKey(), null);
 
 		exportPortlet(JournalPortletKeys.JOURNAL, parentLayout);
 
-		GroupTestUtil.deleteGroup(group2);
+		GroupTestUtil.deleteGroup(layoutGroup);
 
 		ExportImportConfiguration exportImportConfiguration = importPortlet(
 			JournalPortletKeys.JOURNAL, parentLayout);
@@ -454,7 +455,7 @@ public class JournalExportImportTest extends BasePortletExportImportTestCase {
 		Assert.assertEquals(
 			StringBundler.concat(
 				"Warning: The referenced Layout group reference ('/",
-				StringUtil.toLowerCase(group2.getName("en_US")),
+				StringUtil.toLowerCase(layoutGroup.getName("en_US")),
 				"') was not found. Defaulting to the current '",
 				importedGroup.getGroupKey(), "' group"),
 			exportImportReportEntry.getErrorMessage());
@@ -1647,17 +1648,17 @@ public class JournalExportImportTest extends BasePortletExportImportTestCase {
 	private JournalArticle _exportPortletWithMissingArticleReference()
 		throws Exception {
 
-		Group group2 = GroupTestUtil.addGroup();
+		Group referencedArticleGroup = GroupTestUtil.addGroup();
 
 		try {
 			JournalArticle referencedArticle =
 				JournalTestUtil.addArticleWithXMLContent(
-					group2.getGroupId(),
+					referencedArticleGroup.getGroupId(),
 					JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 					JournalArticleConstants.CLASS_NAME_ID_DEFAULT,
 					_buildXMLContent("{}"),
-					_addDataDefinition(group2.getGroupId()), null,
-					LocaleUtil.US);
+					_addDataDefinition(referencedArticleGroup.getGroupId()),
+					null, LocaleUtil.US);
 
 			JournalArticle article = JournalTestUtil.addArticleWithXMLContent(
 				group.getGroupId(),
@@ -1678,7 +1679,7 @@ public class JournalExportImportTest extends BasePortletExportImportTestCase {
 			return article;
 		}
 		finally {
-			GroupTestUtil.deleteGroup(group2);
+			GroupTestUtil.deleteGroup(referencedArticleGroup);
 		}
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100542

## What Is Being Fixed

A prior commit under LPD-100542 renamed a throwaway `Group` local from `randomGroup` to `group2` in `JournalExportImportTest`, but the class has no `group1` — only an inherited `group` field from `BaseExportImportTestCase` — so `group2` didn't communicate why the variable existed. A reviewer flagged this after the original PR (#4157) merged.

## How It Is Being Fixed

Renamed each occurrence to describe what the created group is actually used for: `layoutGroup` for the group that hosts the layout referenced by the exported article's URL in `testExportImportJournalArticleWithLayoutURLLayoutAndGroupDoesNotExistOnImportSide`, and `referencedArticleGroup` for the group that hosts the article referenced by, but deliberately excluded from, the export in `_exportPortletWithMissingArticleReference`.

## Why Are There No Tests?

Pure rename, no behavior change — existing test coverage for these methods is unchanged and still exercises the same assertions.

## PR Check

**pr-check: PASS** — tested on `dd95fddfec37d3b5feec32865542d61f51417718`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS (baseline-all + seven Ant projects + 0 changed exporting modules) |

Source Format: Java SourceCheck clean; yarn/node formatter skipped (no frontend file in the diff).

Integration Test Compile: apps:journal:journal-test and apps:journal:journal-web-test both BUILD SUCCESSFUL.

Baseline: journal-test carries no Export-Package, so zero exporting modules from this branch were in scope; baseline-all and the seven Ant projects all ran clean. One inherited minor-version finding in portal-kernel (unrelated to this branch) was reported and reverted, not committed.

<!-- pr-check {"result": "success", "sha": "dd95fddfec37d3b5feec32865542d61f51417718"} -->
