### PR TITLE
LPD-104410 Wait for the Model Builder to finish reloading after deleting a definition

### DIFF
--- a/modules/test/playwright/pages/object-web/model-builder/ModelBuilderObjectDefinitionNodePage.ts
+++ b/modules/test/playwright/pages/object-web/model-builder/ModelBuilderObjectDefinitionNodePage.ts
@@ -196,13 +196,26 @@ export class ModelBuilderObjectDefinitionNodePage {
 		return objectRelationship;
 	}
 
+	async deleteDraftObjectDefinition() {
+		const reloadedResponse = this._waitForModelBuilderReload();
+
+		await this.deleteObjectDefinitionOption.click();
+
+		await reloadedResponse;
+	}
+
 	async deleteObjectDefinition(objectDefinitionName: string) {
 		await this.deleteObjectDefinitionOption.click();
 		await this.modalDeleteObjectDefinitionTextField.click();
 		await this.modalDeleteObjectDefinitionTextField.fill(
 			objectDefinitionName
 		);
+
+		const reloadedResponse = this._waitForModelBuilderReload();
+
 		await this.modalDeleteObjectDefinitionConfirmationButton.click();
+
+		await reloadedResponse;
 	}
 
 	async fillObjectFieldLabelInput(objectFieldLabel: string) {
@@ -243,5 +256,17 @@ export class ModelBuilderObjectDefinitionNodePage {
 				name: String(objectFieldBusinessType),
 			})
 			.click();
+	}
+
+	private _waitForModelBuilderReload() {
+		return this.page.waitForResponse(
+			(response) =>
+				response.request().method() === 'PUT' &&
+				response
+					.url()
+					.includes(
+						'/o/object-admin/v1.0/object-folders/by-external-reference-code/'
+					)
+		);
 	}
 }

--- a/modules/test/playwright/tests/object-web/main/objectDefinition.spec.ts
+++ b/modules/test/playwright/tests/object-web/main/objectDefinition.spec.ts
@@ -260,7 +260,7 @@ test.describe('Manage object definitions through Model Builder', () => {
 			objectDefinition1.label['en_US']
 		);
 
-		await modelBuilderObjectDefinitionNodePage.deleteObjectDefinitionOption.click();
+		await modelBuilderObjectDefinitionNodePage.deleteDraftObjectDefinition();
 
 		apiHelpers.data.splice(
 			apiHelpers.data.findIndex(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-104410

## What Is Being Fixed

Deleting a definition in the Model Builder ends with a timed full page reload. The draft path in `objectDefinitionUtil.deleteObjectDefinition` and the confirmation path in `ModalDeleteObjectDefinition` both fall back to `setTimeout(() => window.location.reload(), 1000 or 1500)` because the Model Builder passes no `onAfterDeleteObjectDefinition`, and the reloaded page then fetches the folder, its definitions and every node before `EditObjectFolder`'s effect on `objectFolderItems.length` fires an un-awaited PUT of the whole folder.

A test that returns right after the delete click therefore hands control to the `apiHelpers` teardown while that reload is still a pending timer, and no drain can see a request a timer has not issued yet. On `ci:test:object` the fixture's DELETE of the second definition ran 34 ms into that PUT, whose per-item `updateObjectFolderItem` bumped the `ObjectFolderItem` row the delete had already queued for removal from a cached read: `StaleStateException` at the commit flush, the whole `deleteObjectDefinition` rolled back, HTTP 500 to the fixture, a draft definition left behind, and the next test's Select-All publish counting six check marks instead of five.

That is the recurring pair "can delete an object definition by model builder leftsidebar" 500 plus "can publish multiple object definitions" expecting 5 and receiving 6; it fired three times on the object suite between 2026-08-31 and 2026-09-01.

## How It Is Being Fixed

The page object's two delete methods now register a wait for the reloaded page's folder PUT response before triggering the delete and await it afterwards, so the delete step returns only once the Model Builder has finished its reload and nothing of the page's own is left to race the teardown. The draft path gets a method of its own, `deleteDraftObjectDefinition`, so the sidebar delete test can use it instead of clicking the raw menu item.

Reproduced locally against an isolated bundle with the page's CPU throttled six times and the reloaded page's folder request held for 1.5 s so the reload straddles the teardown: with the raw click the reload's PUT landed about three seconds after the teardown had started in 4 of 5 runs; with this wait it completed 0.6 s before the teardown began in 5 of 5, and the sibling published-definition delete plus the failing pair passed 6 of 6 without the amplifier.

## PR Check

**pr-check: PASS** — tested on `0c43bf021aa2b57a4488c7ad1d87ebdb2ccc766f`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| HTML Escaping | PASS |
| Per-Module Compile | NOT VERIFIED |
| Baseline | PASS (baseline-all + seven Ant projects + 0 changed exporting modules) |
| JavaScript Unit Tests | NOT VERIFIED |

Per-Module Compile verified nothing. Both changed files live under `modules/test/playwright`, which holds no `bnd.bnd` at any ancestor directory, so the deploy set derives empty and there is no OSGi bundle to build. The TypeScript in both files was still compiled, by Source Format's yarn side, which reported `Checking 1 TypeScript projects`. The lockfile check ran and had nothing to check: the diff changes no `package.json`, so no dependency was added or altered.

Baseline's one finding is inherited rather than this branch's. `portal-kernel` wants `com.liferay.portal.kernel.metadata` raised to `11.1.0` from `11.0.0` and its `Bundle-Version` raised to `190.1.0` from `190.0.1`. It is a local build-output artifact: a stale `RawMetadataProcessorUtil.class`, left behind by a source file deleted before the merge base, got packed into `portal-kernel.jar`, so baseline sees a phantom added class. Both repaired files were restored and neither is committed. The branch changed zero exporting modules and owes no bump.

JavaScript Unit Tests verified nothing. Both changed files resolve to `modules/test/playwright`, whose package is `@liferay/playwright` and whose `test` script is `playwright test` rather than a Jest suite; the module carries no Jest configuration, and Playwright runs are out of scope for pr-check. No other module declares `@liferay/playwright`, and the diff adds no dependency, so neither the cross-module consumer-snapshot sweep nor the stale stub-list sweep selected anything.

<!-- pr-check {"result":"success","sha":"0c43bf021aa2b57a4488c7ad1d87ebdb2ccc766f"} -->
