### PR TITLE
LPD-104415 Wait for the time zone save to complete before leaving Display Settings

### DIFF
--- a/modules/test/playwright/tests/object-web/entry/objectEntry.spec.ts
+++ b/modules/test/playwright/tests/object-web/entry/objectEntry.spec.ts
@@ -6914,6 +6914,8 @@ test.describe('Manage object entries through Workflow', () => {
 
 			await usersAndOrganizationsPage.saveTimeZoneButton.click();
 
+			await waitForAlert(page);
+
 			// Check if the time has changed
 
 			await viewObjectEntriesPage.goToObjectDefinitionEntry(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-104415

## What Is Being Fixed

"Date and time are adjusted to the user's time zone" saves the user's time zone with a plain form submit and immediately navigates to the object entry. Playwright's click returns as soon as the click is dispatched, before the browser has started the form's navigation, so the test's `goto` races the submit: when the submit's navigation starts first the `goto` dies with `ERR_ABORTED`, and when the `goto` starts first the submit is discarded and the time zone is never saved, so the entry still renders the unconverted time and the assertion for the converted one reports the element as not found.

The first shape was the dominant one until d52324d00380d (LPD-101755) made the `goto` retry on abort; the second shape is what remains, roughly one run in a hundred on `ci:test:object`. The product side is not involved: `EditDisplaySettingsMVCActionCommand` saves synchronously and redirects.

## How It Is Being Fixed

Waiting for the success alert after the Save click is the barrier the sibling `AccountSettingsPage.setTimeZone` already uses for the same form: the alert only renders on the page the redirect lands on, so by the time it is visible the time zone is persisted and no navigation is pending.

Reproduced against an isolated bundle by holding the Display Settings POST for 2.5 s: without the wait the entry showed 12:00 PM and the assertion failed with the CI signature in 4 of 4 runs; with the wait it showed 09:00 AM in 4 of 4.

## PR Check

**pr-check: PASS** — tested on `73ae89843cc68a8d2391bd27c88b28752da31a66`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| HTML Escaping | PASS |
| Per-Module Compile | NOT VERIFIED |
| Baseline | PASS (baseline-all + seven Ant projects + 0 changed exporting modules) |
| JavaScript Unit Tests | NOT VERIFIED |

Per-Module Compile verified nothing. The changed file lives under `modules/test/playwright`, which holds no `bnd.bnd` at any ancestor directory, so the deploy set derives empty and there is no OSGi bundle to build. The TypeScript was still compiled, by Source Format's yarn side, which reported `Checking 1 TypeScript projects`. The lockfile check ran and had nothing to check: the diff changes no `package.json`, so no dependency was added or altered.

Baseline's one finding is inherited rather than this branch's. `portal-kernel` wants `com.liferay.portal.kernel.metadata` raised to `11.1.0` from `11.0.0` and its `Bundle-Version` raised to `190.1.0` from `190.0.1`. It is a local build-output artifact: a stale `RawMetadataProcessorUtil.class`, left behind by a source file deleted before the merge base, got packed into `portal-kernel.jar`, so baseline sees a phantom added class. Both repaired files were restored and neither is committed. The branch changed zero exporting modules and owes no bump.

JavaScript Unit Tests verified nothing. The changed file resolves to `modules/test/playwright`, whose package is `@liferay/playwright` and whose `test` script is `playwright test` rather than a Jest suite; the module carries no Jest configuration, and Playwright runs are out of scope for pr-check. No other module declares `@liferay/playwright`, and the diff adds no dependency, so neither the cross-module consumer-snapshot sweep nor the stale stub-list sweep selected anything.

<!-- pr-check {"result":"success","sha":"73ae89843cc68a8d2391bd27c88b28752da31a66"} -->
