### PR TITLE
LPD-96642 Fix two log entries breaking PortalLogAssertorTest on the stable smoke batches

### DIFF
--- a/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/portlet/FastLoginPortlet.java
+++ b/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/portlet/FastLoginPortlet.java
@@ -28,7 +28,6 @@ import org.osgi.service.component.annotations.Reference;
 		"com.liferay.portlet.private-session-attributes=false",
 		"com.liferay.portlet.render-weight=50",
 		"com.liferay.portlet.single-page-application=false",
-		"com.liferay.portlet.struts-path=plugins_admin",
 		"com.liferay.portlet.use-default-template=true",
 		"jakarta.portlet.display-name=Fast Sign In",
 		"jakarta.portlet.expiration-cache=0",

--- a/portal-impl/src/com/liferay/portal/spring/context/PortalContextLoaderListener.java
+++ b/portal-impl/src/com/liferay/portal/spring/context/PortalContextLoaderListener.java
@@ -19,9 +19,6 @@ import com.liferay.portal.events.StartupHelperUtil;
 import com.liferay.portal.kernel.bean.PortalBeanLocatorUtil;
 import com.liferay.portal.kernel.cache.thread.local.ThreadLocalCacheManager;
 import com.liferay.portal.kernel.concurrent.SystemExecutorServiceUtil;
-import com.liferay.portal.kernel.dao.db.DBManagerUtil;
-import com.liferay.portal.kernel.dao.db.DBType;
-import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.db.UpgradeExecutorServiceUtil;
 import com.liferay.portal.kernel.deploy.auto.AutoDeployDir;
 import com.liferay.portal.kernel.deploy.hot.HotDeployUtil;
@@ -72,9 +69,6 @@ import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-
-import java.sql.Connection;
-import java.sql.Statement;
 
 import java.util.List;
 import java.util.Map;
@@ -135,18 +129,6 @@ public class PortalContextLoaderListener extends ContextLoaderListener {
 		}
 		catch (Exception exception) {
 			_log.error(exception);
-		}
-
-		if (DBManagerUtil.getDBType() == DBType.HYPERSONIC) {
-			try (Connection connection = DataAccess.getConnection();
-
-				Statement statement = connection.createStatement()) {
-
-				statement.executeUpdate("SHUTDOWN");
-			}
-			catch (Exception exception) {
-				_log.error(exception);
-			}
 		}
 
 		DataSource dataSource = (DataSource)PortalBeanLocatorUtil.locate(

--- a/portal-impl/src/com/liferay/portal/util/InitUtil.java
+++ b/portal-impl/src/com/liferay/portal/util/InitUtil.java
@@ -14,6 +14,7 @@ import com.liferay.portal.kernel.bean.BeanLocator;
 import com.liferay.portal.kernel.bean.PortalBeanLocatorUtil;
 import com.liferay.portal.kernel.configuration.ConfigurationFactoryUtil;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
+import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.internal.configuration.ConfigurationFactoryImpl;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.log.Log;
@@ -47,9 +48,11 @@ import java.io.InputStream;
 
 import java.lang.reflect.Field;
 
+import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import java.sql.Statement;
 
 import java.util.Enumeration;
 import java.util.List;
@@ -74,6 +77,18 @@ import org.springframework.jdbc.datasource.DelegatingDataSource;
 public class InitUtil {
 
 	public static void cleanUpJDBC(DataSource dataSource) {
+		if (DBManagerUtil.getDBType() == DBType.HYPERSONIC) {
+			try (Connection connection = dataSource.getConnection();
+
+				Statement statement = connection.createStatement()) {
+
+				statement.executeUpdate("SHUTDOWN");
+			}
+			catch (Exception exception) {
+				_log.error(exception);
+			}
+		}
+
 		if (dataSource instanceof DelegatingDataSource) {
 			DelegatingDataSource delegatingDataSource =
 				(DelegatingDataSource)dataSource;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96642

## What Is Being Fixed

The upstream sync `test-portal-testsuite-upstream(master)` (build 1625) is red on both stable smoke Playwright batches, `playwright-js-smoke-tomcat101-hypersonic20` and `playwright-js-tomcat101-postgresql163_stable`. Every Playwright test passes; the failure is `PortalLogAssertorTest.testScanXMLLog`, which fails the build on any `WARN`/`ERROR`/`FATAL` event in the portal XML log.

Two pre-existing log entries fail it:

1. `WARN [PortletLocalServiceImpl] Duplicate Struts path plugins_admin` on both batches.
2. `ERROR [UserLocalServiceImpl] JDBCConnectionException: error executing work` at shutdown, on Hypersonic only.

## Cause

`ac2635c6e3dae` (LPD-96642, @javalosjr96) turned `PortalLogAssertorTest` on for the `smoke.main` / `ci:test:stable` batches by fixing a `build-test-batch.xml` gate that had matched the dead value `smoke` since the 2025 rename to `smoke.main`, so the assertor had not run on these batches for over a year. Enabling a build-failing log assertion on the stable batches without first running a stable or relevant batch against it let two long-standing log entries reach and break the `brianchandotcom` upstream sync. The change was forwarded to `brianchandotcom` on a `ci:forward` that ran only `ci:test:sf`, so no batch that the change actually affects was ever exercised before merge.

The log assertor itself is correct and worth keeping. This PR keeps it enabled and fixes the two entries it legitimately caught, rather than reverting the gate.

## How It Is Being Fixed

**Duplicate struts path.** `FastLoginPortlet` declared `com.liferay.portlet.struts-path=plugins_admin`, the same struts path `PluginsAdminPortlet` declares from another bundle, copied in when the portlet was created in 2015 (`e9ee61f50aef6`, LPS-57626). Nothing resolves `FastLoginPortlet` by struts path, and with the property gone the struts path defaults to the portlet id, exactly as `LoginPortlet` already relies on. `plugins_admin` was the only cross-bundle duplicate.

**Shutdown `ERROR`.** `PortalContextLoaderListener.contextDestroyed` issued the Hypersonic `SHUTDOWN` before `super.contextDestroyed`, so the embedded engine was stopped before Spring destroyed its beans. `UserLocalServiceImpl.destroy` flushes the pending last-login updates during bean destruction, which then ran against a stopped engine and logged the `ERROR`. This ordering gap is long-standing (the Hypersonic `SHUTDOWN` has run ahead of bean destruction since it entered shutdown handling in 2008); it was harmless until `LPD-36010` added the first destroy-time database write, which exposed it on Hypersonic. The `SHUTDOWN` needs a pooled connection and so can only run immediately before the pool closes: it now lives in `InitUtil.cleanUpJDBC`, right before the pool close, after the full Spring and Hibernate teardown. Both teardown paths that close the data source get it from there, so the engine stays alive as long as the data source and the two statements can no longer drift apart.

## PR Check

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile (portal-impl, login-web) | PASS |
| Baseline | PASS (no exported-API change) |

Tested SHA: `468501fda271632f56e75599bf71dcd2982e79af`
