### PR TITLE
LPD-101231 Show FDS-specific CSV export modal text for filtered lists

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/download-report/DownloadStaticCSVReport.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/download-report/DownloadStaticCSVReport.tsx
@@ -69,6 +69,7 @@ export const DownloadStaticCSVReport: React.FC<IDownloadStaticCSVReport> = ({
 
 			{open && (
 				<Modal
+					isFDSExport={Boolean(getFDSQuery)}
 					observer={observer}
 					onClose={() => onOpenChange(false)}
 					onSubmit={async () => {
@@ -147,11 +148,13 @@ export const DownloadStaticCSVReport: React.FC<IDownloadStaticCSVReport> = ({
 };
 
 const Modal = ({
+	isFDSExport,
 	observer,
 	onClose,
 	onSubmit,
 	typeLang,
 }: {
+	isFDSExport: boolean;
 	observer: any;
 	onClose: () => void;
 	onSubmit: () => void;
@@ -173,9 +176,13 @@ const Modal = ({
 				<p>
 					{
 						sub(
-							Liferay.Language.get(
-								'the-generated-csv-file-supports-up-to-x-entries-per-export-and-it-will-respect-the-current-ordering-and-search-results.-please-ensure-that-any-desired-changes-have-been-successfully-applied-before-downloading-the-x-list'
-							),
+							isFDSExport
+								? Liferay.Language.get(
+										'the-generated-CSV-file-will-respect-the-current-filter-and-search-results,-with-a-maximum-of-x-entries-supported-per-export.-please-ensure-that-any-desired-changes-have-been-successfully-applied-before-downloading-the-x-list'
+									)
+								: Liferay.Language.get(
+										'the-generated-csv-file-supports-up-to-x-entries-per-export-and-it-will-respect-the-current-ordering-and-search-results.-please-ensure-that-any-desired-changes-have-been-successfully-applied-before-downloading-the-x-list'
+									),
 							[toLocale(MAX_CSV_ENTRIES), typeLang]
 						) as string
 					}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/download-report/__tests__/DownloadStaticCSVReport.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/download-report/__tests__/DownloadStaticCSVReport.tsx
@@ -136,6 +136,52 @@ describe('DownloadStaticCSVReport', () => {
 		});
 	});
 
+	it('displays the FDS-specific modal text when getFDSQuery is provided', async () => {
+		render(
+			<DefaultComponent getFDSQuery={() => ({filter: '', query: ''})} />
+		);
+
+		fireEvent.click(
+			screen.getByRole('button', {
+				name: /download report/i,
+			})
+		);
+
+		await waitFor(() => {
+			expect(
+				screen.getByText(
+					/The generated CSV file will respect the current filter and search results/
+				)
+			).toBeInTheDocument();
+		});
+
+		expect(
+			screen.queryByText(/The generated CSV file supports up to/)
+		).not.toBeInTheDocument();
+	});
+
+	it('displays the default modal text when getFDSQuery is not provided', async () => {
+		render(<DefaultComponent />);
+
+		fireEvent.click(
+			screen.getByRole('button', {
+				name: /download report/i,
+			})
+		);
+
+		await waitFor(() => {
+			expect(
+				screen.getByText(/The generated CSV file supports up to/)
+			).toBeInTheDocument();
+		});
+
+		expect(
+			screen.queryByText(
+				/The generated CSV file will respect the current filter and search results/
+			)
+		).not.toBeInTheDocument();
+	});
+
 	it('displays info alert about download CSV report', async () => {
 		(API.csv.fetchCSV as jest.Mock).mockReturnValue(
 			Promise.resolve({ok: true})


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101231

## What Is Being Fixed

The CSV export modal always showed the same generic text ("supports up to X entries per export ... respects the current ordering and search results"), even for lists backed by a FrontendDataSet, like the Asset List, where the export actually respects the currently applied filters and search, not just ordering.

## How It Is Being Fixed

`DownloadStaticCSVReport.tsx`'s modal now shows FDS-aware text when the export is FDS-backed, detected from the presence of the `getFDSQuery` prop (only FDS-driven callers pass it). The new text reuses a language key already used by the legacy `DownloadCSVReport.tsx` component for the same message, instead of introducing a duplicate. Each key is resolved through its own literal `Liferay.Language.get()` call so language-key extraction tooling can find both.

## PR Check

**pr-check: PASS** — tested on `140cad0377ff85df1e7e076d636bdbf28190e013`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| HTML Escaping | PASS |
| Baseline | PASS (baseline-all; branch changed no exporting module) |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "140cad0377ff85df1e7e076d636bdbf28190e013"} -->
