### PR TITLE
LPD-104432 Give the PATCH schedule dates test an expiration the minute floor cannot pass

### DIFF
--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -9754,8 +9754,7 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_1);
 
 		Date displayDate = new Date();
-		Date expirationDate = new Date(
-			System.currentTimeMillis() + Time.MINUTE);
+		Date expirationDate = new Date(System.currentTimeMillis() + Time.HOUR);
 		Date reviewDate = new Date();
 
 		ObjectEntry objectEntry = ObjectEntryTestUtil.addObjectEntry(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-104432

## What Is Being Fixed

`ObjectEntryResourceTest#testPatchPutCustomObjectEntryWithScheduleDates` fails intermittently on `ci:test:object`. The test creates an object entry whose `expirationDate` is sixty seconds ahead of the clock and then PATCHes an unrelated field by external reference code. That PATCH rewrites the three schedule dates through `DefaultObjectEntryManagerImpl._toObjectValues`, which formats them as `yyyy-MM-dd HH:mm` and therefore floors them to the minute before `DateTimeObjectFieldBusinessType` parses them back, and the by-external-reference-code update runs as a full update in which `ObjectEntryLocalServiceImpl._setExpirationDate` re-validates the floored expiration against the clock.

When the entry happens to be created in the last seconds of a wall-clock minute, the floored expiration lands only a few seconds ahead, so the PATCH executing one to three seconds later finds it already in the past: `ObjectEntryExpirationDateException`, a 400 `Problem` body carrying no date fields, and the first assertion failing with the display date expected but `null` received. The window is the create-to-PATCH gap at the end of each wall-clock minute, and nothing appears in the log because the schedule date mapper logs at `DEBUG`.

## How It Is Being Fixed

The minute flooring is the product's chosen behavior since 7dab55acbcfe5 (LPD-55251), which routes the schedule dates through the date time business type so that REST shares the UI picker's minute precision and user-timezone interpretation. So the test adopts a margin the floor cannot consume instead: an expiration one hour ahead stays in the future for any create-to-PATCH delay CI can produce. The existing minute-truncated assertions are unchanged, and the product behavior is left exactly as it is.

## PR Check

**pr-check: PASS** — tested on `cd6f058774a466da6684269bdfff52b1e3d89ceb`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | NOT VERIFIED |
| Integration Test Compile | PASS |
| Baseline | PASS (baseline-all + seven Ant projects + 0 changed exporting modules) |
| Java Unit Tests | NOT VERIFIED |

Per-Module Compile verified nothing. The branch's only change is a Java file under `src/testIntegration`, and a module whose sole Java change lives there is excluded from the deploy set — Integration Test Compile compiles it instead, and a `-test` module deploys no runtime bundle. No consumer expansion applied, since the diff adds and removes no `public` or `protected` line, and the lockfile check was vacuous because the diff touches no `package.json`.

Java Unit Tests verified nothing. The one changed Java file is `ObjectEntryResourceTest.java` under `src/testIntegration`, which this validation's scope excludes, and `modules/apps/object/object-rest-test` has no `src/test` source set and declares no `testImplementation` dependencies, so no unit test counterpart exists. The changed file is itself the integration test that covers the behavior.

<!-- pr-check {"result":"success","sha":"cd6f058774a466da6684269bdfff52b1e3d89ceb"} -->
