### PR TITLE
LPD-103924 Revert the CMS sitemap space links until the new test passes on ci:test:object

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/site/provider/ObjectEntrySitemapURLProvider.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/site/provider/ObjectEntrySitemapURLProvider.java
@@ -21,24 +21,18 @@ import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectDefinitionSettingLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectEntryService;
-import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.petra.string.CharPool;
-import com.liferay.petra.string.StringBundler;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
-import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
-import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.GroupThreadLocal;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -257,33 +251,21 @@ public class ObjectEntrySitemapURLProvider implements SitemapURLProvider {
 	}
 
 	private String _getFriendlyURL(
-		boolean cms, long groupId, String languageId,
-		ObjectDefinition objectDefinition, ObjectEntry objectEntry) {
+		String languageId, ObjectDefinition objectDefinition,
+		ObjectEntry objectEntry) {
 
 		String urlTitle = objectEntry.getURLTitle(
 			LocaleUtil.fromLanguageId(languageId));
 
-		if (Validator.isNull(urlTitle)) {
-			if (!objectDefinition.isDefaultStorageType()) {
-				return objectEntry.getExternalReferenceCode();
-			}
-
-			return String.valueOf(objectEntry.getObjectEntryId());
-		}
-
-		if (!cms || (groupId == objectEntry.getGroupId())) {
+		if (Validator.isNotNull(urlTitle)) {
 			return urlTitle;
 		}
 
-		Group group = _groupLocalService.fetchGroup(objectEntry.getGroupId());
-
-		if (group == null) {
-			return urlTitle;
+		if (!objectDefinition.isDefaultStorageType()) {
+			return objectEntry.getExternalReferenceCode();
 		}
 
-		return StringBundler.concat(
-			StringUtil.removeFirst(group.getFriendlyURL(), StringPool.SLASH),
-			StringPool.SLASH, urlTitle);
+		return String.valueOf(objectEntry.getObjectEntryId());
 	}
 
 	private long[] _getGroupIds(long groupId) throws PortalException {
@@ -381,29 +363,22 @@ public class ObjectEntrySitemapURLProvider implements SitemapURLProvider {
 		String urlSeparator = StringUtil.quote(
 			objectDefinition.getFriendlyURLSeparator(), CharPool.SLASH);
 
-		try (SafeCloseable safeCloseable =
-				GroupThreadLocal.setGroupIdWithSafeCloseable(
-					layout.getGroupId())) {
+		for (ObjectEntry objectEntry : objectEntries) {
+			String friendlyURL = _getFriendlyURL(
+				themeDisplay.getLanguageId(), objectDefinition, objectEntry);
 
-			for (ObjectEntry objectEntry : objectEntries) {
-				String friendlyURL = _getFriendlyURL(
-					objectDefinition.isCMS(), layout.getGroupId(),
-					themeDisplay.getLanguageId(), objectDefinition,
-					objectEntry);
+			String canonicalURL = _portal.getCanonicalURL(
+				urlSeparator + friendlyURL, themeDisplay, layout);
 
-				String canonicalURL = _portal.getCanonicalURL(
-					urlSeparator + friendlyURL, themeDisplay, layout);
+			Map<Locale, String> alternateURLs = _portal.getAlternateURLs(
+				canonicalURL, themeDisplay, layout,
+				objectDefinitionAvailableLocales);
 
-				Map<Locale, String> alternateURLs = _portal.getAlternateURLs(
-					canonicalURL, themeDisplay, layout,
-					objectDefinitionAvailableLocales);
-
-				for (String alternateURL : alternateURLs.values()) {
-					_sitemapManager.addURLElement(
-						element, alternateURL, typeSettingsUnicodeProperties,
-						objectEntry.getModifiedDate(), canonicalURL,
-						alternateURLs, layout.getGroupId());
-				}
+			for (String alternateURL : alternateURLs.values()) {
+				_sitemapManager.addURLElement(
+					element, alternateURL, typeSettingsUnicodeProperties,
+					objectEntry.getModifiedDate(), canonicalURL, alternateURLs,
+					layout.getGroupId());
 			}
 		}
 	}
@@ -413,9 +388,6 @@ public class ObjectEntrySitemapURLProvider implements SitemapURLProvider {
 
 	@Reference
 	private DepotEntryLocalService _depotEntryLocalService;
-
-	@Reference
-	private GroupLocalService _groupLocalService;
 
 	@Reference
 	private Language _language;

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/site/provider/test/ObjectEntrySitemapURLProviderTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/site/provider/test/ObjectEntrySitemapURLProviderTest.java
@@ -17,18 +17,14 @@ import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectDefinitionSettingConstants;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
-import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.object.definition.setting.builder.ObjectDefinitionSettingBuilder;
 import com.liferay.object.field.builder.TextObjectFieldBuilder;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
-import com.liferay.object.model.ObjectFolder;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectDefinitionSettingLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
-import com.liferay.object.service.ObjectFolderLocalService;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
-import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -165,27 +161,6 @@ public class ObjectEntrySitemapURLProviderTest {
 	}
 
 	@Test
-	public void testVisitCMSObjectDefinition() throws Exception {
-		_testVisitCMSObjectDefinition(
-			(layout, objectDefinition, objectEntry) -> {
-				Group group = _depotEntry.getGroup();
-
-				_assertRootElement(
-					true, group.getFriendlyURL(), layout, objectDefinition,
-					objectEntry);
-			});
-
-		_testVisitCMSObjectDefinition(
-			(layout, objectDefinition, objectEntry) -> {
-				Group group = _depotEntry.getGroup();
-
-				_assertRootElement(
-					true, group.getFriendlyURL(), _layoutSet, objectDefinition,
-					objectEntry, _themeDisplay);
-			});
-	}
-
-	@Test
 	public void testVisitLayout() throws Exception {
 		_testVisitLayout(0, _companyObjectDefinition);
 		_testVisitLayout(_depotEntry.getGroupId(), _depotObjectDefinition);
@@ -227,27 +202,6 @@ public class ObjectEntrySitemapURLProviderTest {
 			ObjectDefinition objectDefinition, ObjectEntry objectEntry)
 		throws Exception {
 
-		_assertRootElement(
-			expectedHasContent, StringPool.BLANK, layout, objectDefinition,
-			objectEntry);
-	}
-
-	private void _assertRootElement(
-			boolean expectedHasContent, LayoutSet layoutSet,
-			ObjectDefinition objectDefinition, ObjectEntry objectEntry,
-			ThemeDisplay themeDisplay)
-		throws Exception {
-
-		_assertRootElement(
-			expectedHasContent, StringPool.BLANK, layoutSet, objectDefinition,
-			objectEntry, themeDisplay);
-	}
-
-	private void _assertRootElement(
-			boolean expectedHasContent, String friendlyURL, Layout layout,
-			ObjectDefinition objectDefinition, ObjectEntry objectEntry)
-		throws Exception {
-
 		Element rootElement = _getRootElement();
 
 		_objectEntrySitemapURLProvider.visitLayout(
@@ -260,11 +214,11 @@ public class ObjectEntrySitemapURLProviderTest {
 		}
 
 		_assertRootElements(
-			friendlyURL, objectDefinition, objectEntry, rootElement.elements());
+			objectDefinition, objectEntry, rootElement.elements());
 	}
 
 	private void _assertRootElement(
-			boolean expectedHasContent, String friendlyURL, LayoutSet layoutSet,
+			boolean expectedHasContent, LayoutSet layoutSet,
 			ObjectDefinition objectDefinition, ObjectEntry objectEntry,
 			ThemeDisplay themeDisplay)
 		throws Exception {
@@ -281,12 +235,12 @@ public class ObjectEntrySitemapURLProviderTest {
 		}
 
 		_assertRootElements(
-			friendlyURL, objectDefinition, objectEntry, rootElement.elements());
+			objectDefinition, objectEntry, rootElement.elements());
 	}
 
 	private void _assertRootElements(
-		String friendlyURL, ObjectDefinition objectDefinition,
-		ObjectEntry objectEntry, List<Element> rootElements) {
+		ObjectDefinition objectDefinition, ObjectEntry objectEntry,
+		List<Element> rootElements) {
 
 		Set<Locale> availableLocales = _language.getAvailableLocales();
 
@@ -310,8 +264,7 @@ public class ObjectEntrySitemapURLProviderTest {
 		String objectEntryFriendlyURL = StringUtil.toLowerCase(
 			StringBundler.concat(
 				StringPool.SLASH, objectDefinition.getFriendlyURLSeparator(),
-				friendlyURL, StringPool.SLASH,
-				objectEntry.getExternalReferenceCode()));
+				StringPool.SLASH, objectEntry.getExternalReferenceCode()));
 
 		for (Element rootElement : rootElements) {
 			String objectEntryLocalizedURL = rootElement.elementText("loc");
@@ -384,13 +337,11 @@ public class ObjectEntrySitemapURLProviderTest {
 		return themeDisplay;
 	}
 
-	private ObjectDefinition _publishObjectDefinition(
-			long objectFolderId, String scope)
+	private ObjectDefinition _publishObjectDefinition(String scope)
 		throws Exception {
 
 		ObjectDefinition objectDefinition =
 			ObjectDefinitionTestUtil.publishObjectDefinition(
-				ObjectDefinitionTestUtil.getRandomName(),
 				Collections.singletonList(
 					new TextObjectFieldBuilder(
 					).labelMap(
@@ -400,7 +351,7 @@ public class ObjectEntrySitemapURLProviderTest {
 					).objectFieldSettings(
 						Collections.emptyList()
 					).build()),
-				objectFolderId, scope, TestPropsValues.getUserId());
+				scope);
 
 		if (StringUtil.equals(scope, ObjectDefinitionConstants.SCOPE_DEPOT)) {
 			_objectDefinitionSettingLocalService.addObjectDefinitionSetting(
@@ -411,12 +362,6 @@ public class ObjectEntrySitemapURLProviderTest {
 		}
 
 		return objectDefinition;
-	}
-
-	private ObjectDefinition _publishObjectDefinition(String scope)
-		throws Exception {
-
-		return _publishObjectDefinition(0, scope);
 	}
 
 	private void _testGetModifiedDate(
@@ -445,42 +390,6 @@ public class ObjectEntrySitemapURLProviderTest {
 			Assert.assertNotNull(
 				_objectEntrySitemapURLProvider.getModifiedDate(
 					TestPropsValues.getCompanyId(), _group.getGroupId()));
-		}
-	}
-
-	private void _testVisitCMSObjectDefinition(
-			UnsafeTriConsumer<Layout, ObjectDefinition, ObjectEntry, Exception>
-				unsafeTriConsumer)
-		throws Exception {
-
-		ObjectFolder objectFolder =
-			_objectFolderLocalService.getOrAddEmptyObjectFolder(
-				ObjectFolderConstants.
-					EXTERNAL_REFERENCE_CODE_CONTENT_STRUCTURES,
-				TestPropsValues.getCompanyId(), TestPropsValues.getUserId());
-
-		ObjectDefinition objectDefinition = _publishObjectDefinition(
-			objectFolder.getObjectFolderId(),
-			ObjectDefinitionConstants.SCOPE_DEPOT);
-
-		try (CompanyConfigurationTemporarySwapper
-				companyConfigurationTemporarySwapper =
-					_getCompanyConfigurationTemporarySwapper(
-						objectDefinition)) {
-
-			_depotEntryGroupRelLocalService.addDepotEntryGroupRel(
-				_depotEntry.getDepotEntryId(), _group.getGroupId());
-
-			LayoutPageTemplateEntry layoutPageTemplateEntry =
-				_addDisplayPageTemplate(_group.getGroupId(), objectDefinition);
-
-			ObjectEntry objectEntry = _addObjectEntry(
-				_depotEntry.getGroupId(), objectDefinition);
-
-			unsafeTriConsumer.accept(
-				_layoutLocalService.getLayout(
-					layoutPageTemplateEntry.getPlid()),
-				objectDefinition, objectEntry);
 		}
 	}
 
@@ -675,9 +584,6 @@ public class ObjectEntrySitemapURLProviderTest {
 		type = SitemapURLProvider.class
 	)
 	private SitemapURLProvider _objectEntrySitemapURLProvider;
-
-	@Inject
-	private ObjectFolderLocalService _objectFolderLocalService;
 
 	@Inject
 	private Portal _portal;

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/site/provider/test/ObjectEntrySitemapURLProviderTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/site/provider/test/ObjectEntrySitemapURLProviderTest.java
@@ -171,16 +171,17 @@ public class ObjectEntrySitemapURLProviderTest {
 				Group group = _depotEntry.getGroup();
 
 				_assertRootElement(
-					true, group.getFriendlyURL(), _layoutSet, objectDefinition,
-					objectEntry, _themeDisplay);
+					true, group.getFriendlyURL(), layout, objectDefinition,
+					objectEntry);
 			});
+
 		_testVisitCMSObjectDefinition(
 			(layout, objectDefinition, objectEntry) -> {
 				Group group = _depotEntry.getGroup();
 
 				_assertRootElement(
-					true, group.getFriendlyURL(), layout, objectDefinition,
-					objectEntry);
+					true, group.getFriendlyURL(), _layoutSet, objectDefinition,
+					objectEntry, _themeDisplay);
 			});
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103924

## What Is Being Fixed

brianchandotcom#181159 (1dfb667192c1d, 8a8fd5ed2a1bd) plus the follow-up 56b4aa7211bdd landed on master at 2026-09-02 12:27Z without any `ci:test:object` run. The only CI on the change was `ci:test:sf` on an earlier generation of the branch, the forwarded PR skipped the PR Tester, and the merged SHAs themselves carried no CI.

Since the merge, `ObjectEntrySitemapURLProviderTest.testVisitCMSObjectDefinition` — the test 8a8fd5ed2a1bd added — fails in every `ci:test:object` run whose base contains it (6 of 6 so far, `modules-integration-postgresql163` axis 0/8) and passes in every run whose base does not.

It also reproduces locally on MySQL. With the assertion message added, the failing location is `http://localhost:8085/web/y8dt3isf`, which does not end with the expected `/c_as7brr5h8/asset-library-38155/0d9fed29-bad1-8f35-4400-8872a1a69431` — the per-layout `visitLayout` sub-case emits the bare site URL for the CMS entry, while the `visitLayoutSet` sub-case passes.

The failure is independent of the sub-case order. Re-running the class with the test file in its original order (56b4aa7211bdd reverted, same provider code deployed) fails identically, 2 of 2 runs: `http://localhost:8085/web/8ob7z7sg` does not end with `/c_a0doup299/asset-library-40271/db1b3e77-beed-d290-9349-af2606fc8374`. So the test never passed against its own product change in either order, and the reorder in 56b4aa7211bdd is not the cause.

## How It Is Being Fixed

Three clean `git revert`s, restoring `ObjectEntrySitemapURLProvider` and `ObjectEntrySitemapURLProviderTest` to their pre-change content byte for byte, so the object suite is green again. Nothing else on master has touched either file since. The change can be re-landed once `ci:test:object` passes on it.

## PR Check

**pr-check: PASS** — tested on `ee99110e9c48ab024f133f22ef638b11a60a210d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS (baseline-all + seven Ant projects + 0 changed exporting modules) |
| Java Unit Tests | NOT VERIFIED |

Source Format ran clean with `-Dvalidate.commit.messages=true` (confirmed present in the `SourceFormatter` argv under `ant -v`) and made no autocommit. The yarn half did not run at all: the diff is two `.java` files, none matching `source.formatter.frontend.file.regex`, so `skip.node.task` was set and `portalYarnFormatCurrentBranch` was bypassed — that is "never ran", not "ran clean".

Per-Module Compile deploys nothing in this environment: `:apps:object:object-service:deploy` was substituted with `:apps:object:object-service:compileJava` because a deploy writes into the developer's live portal. Java compilation of the changed module is verified (`> Task :apps:object:object-service:compileJava` executed, `BUILD SUCCESSFUL`), but bnd manifest and resource assembly went unexercised. The diff is a single internal Java class with no `bnd.bnd`, resource, or JSP change, so the unexercised portion has nothing in this diff to act on.

Integration Test Compile compiled all five sibling `-test` modules under `modules/apps/object` with `--rerun`, each task executing rather than reporting `UP-TO-DATE`: `object-test` (which holds the changed test file), `object-admin-rest-test`, `object-rest-test`, `object-storage-salesforce-test`, `object-storage-sugarcrm-test`.

Baseline found one **inherited** finding, in a module this branch never touched: `modules/apps/design-library/design-library-api/bnd.bnd` `Bundle-Version` `1.1.1` → `1.2.0` (`Bundle Version Change Recommended: 1.2.0`), which failed `:apps:design-library:design-library-api:baseline` and so made `ant baseline-all` exit nonzero. It is pre-existing master debt — `git diff master HEAD` on that file is empty. The repair was restored, not committed, and it does not fail the branch. All seven top-level Ant projects baselined standalone with `--rerun`, each printing `1 executed` and `BUILD SUCCESSFUL`. Neither changed module's `bnd.bnd` carries `Export-Package:`, so there were no changed exporting modules to compare and `baseline-all` never baselined either one. The Local Version Check passed: neither changed file is under an `*-api` module's `src/main/java`, `portal-impl/src`, or `portal-kernel/src`.

Java Unit Tests verified nothing. `ObjectEntrySitemapURLProvider` has no parallel-name unit test in `object-service/src/test/java` (the module has 13 unit tests, none of which loads the class), so no unit suite can exercise the change. The class is covered instead by the integration test this branch also reverts, `modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/site/provider/test/ObjectEntrySitemapURLProviderTest.java` — it is not an untested class, and Integration Test Compile above compiled that module.

<!-- pr-check {"result": "success", "sha": "ee99110e9c48ab024f133f22ef638b11a60a210d"} -->
