### PR TITLE
LPD-101991 Close stored XSS in Style Book CSS variable values

### DIFF
--- a/modules/apps/frontend-css/frontend-css-variables-web/src/main/java/com/liferay/frontend/css/variables/web/internal/servlet/taglib/ScopedCSSVariablesTopHeadDynamicInclude.java
+++ b/modules/apps/frontend-css/frontend-css-variables-web/src/main/java/com/liferay/frontend/css/variables/web/internal/servlet/taglib/ScopedCSSVariablesTopHeadDynamicInclude.java
@@ -14,6 +14,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.content.security.policy.ContentSecurityPolicyNonceProviderUtil;
 import com.liferay.portal.kernel.servlet.taglib.BaseDynamicInclude;
 import com.liferay.portal.kernel.servlet.taglib.DynamicInclude;
+import com.liferay.portal.kernel.util.HtmlUtil;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -110,9 +111,9 @@ public class ScopedCSSVariablesTopHeadDynamicInclude
 
 			for (Map.Entry<String, String> entry : cssVariables.entrySet()) {
 				printWriter.print("\t\t--");
-				printWriter.print(entry.getKey());
+				printWriter.print(HtmlUtil.escapeCSS(entry.getKey()));
 				printWriter.print(": ");
-				printWriter.print(entry.getValue());
+				printWriter.print(HtmlUtil.escapeCSS(entry.getValue()));
 				printWriter.print(";\n");
 			}
 

--- a/modules/apps/frontend-css/frontend-css-variables-web/src/test/java/com/liferay/frontend/css/variables/web/internal/servlet/taglib/ScopedCSSVariablesTopHeadDynamicIncludeTest.java
+++ b/modules/apps/frontend-css/frontend-css-variables-web/src/test/java/com/liferay/frontend/css/variables/web/internal/servlet/taglib/ScopedCSSVariablesTopHeadDynamicIncludeTest.java
@@ -11,6 +11,7 @@ import com.liferay.petra.io.StreamUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.servlet.BufferCacheServletResponse;
 import com.liferay.portal.kernel.servlet.taglib.DynamicInclude;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
@@ -94,6 +95,67 @@ public class ScopedCSSVariablesTopHeadDynamicIncludeTest {
 		Assert.assertEquals(
 			_read("liferay_css_variables_1.html", true),
 			bufferCacheServletResponse.getString());
+	}
+
+	@Test
+	public void testIncludeEscapesCSSVariableKeysAndValues()
+		throws IOException {
+
+		ScopedCSSVariablesTopHeadDynamicInclude
+			scopedCSSVariablesTopHeadDynamicInclude =
+				new ScopedCSSVariablesTopHeadDynamicInclude();
+
+		ScopedCSSVariablesProvider scopedCSSVariablesProvider = Mockito.mock(
+			ScopedCSSVariablesProvider.class);
+
+		String xssScript = "</style><script>alert(1)</script>";
+
+		Collection<ScopedCSSVariables> scopedCSSVariablesCollection =
+			Arrays.asList(
+				new ScopedCSSVariables() {
+
+					@Override
+					public Map<String, String> getCSSVariables() {
+						return HashMapBuilder.put(
+							xssScript, RandomTestUtil.randomString()
+						).put(
+							RandomTestUtil.randomString(), xssScript
+						).build();
+					}
+
+					@Override
+					public String getScope() {
+						return RandomTestUtil.randomString();
+					}
+
+				});
+
+		Mockito.when(
+			scopedCSSVariablesProvider.getScopedCSSVariablesCollection(
+				Mockito.any(HttpServletRequest.class))
+		).thenReturn(
+			scopedCSSVariablesCollection
+		);
+
+		scopedCSSVariablesTopHeadDynamicInclude.setScopedCSSVariablesProviders(
+			Arrays.asList(scopedCSSVariablesProvider));
+
+		HttpServletRequest httpServletRequest = Mockito.mock(
+			HttpServletRequest.class);
+
+		HttpServletResponse httpServletResponse = Mockito.mock(
+			HttpServletResponse.class);
+
+		BufferCacheServletResponse bufferCacheServletResponse =
+			new BufferCacheServletResponse(httpServletResponse);
+
+		scopedCSSVariablesTopHeadDynamicInclude.include(
+			httpServletRequest, bufferCacheServletResponse,
+			"/html/common/themes/top_head.jsp#post");
+
+		String content = bufferCacheServletResponse.getString();
+
+		Assert.assertFalse(content, content.contains(xssScript));
 	}
 
 	@Test

--- a/modules/apps/frontend-css/frontend-css-variables-web/src/test/resources/com/liferay/frontend/css/variables/web/internal/servlet/taglib/liferay_css_variables_2.html
+++ b/modules/apps/frontend-css/frontend-css-variables-web/src/test/resources/com/liferay/frontend/css/variables/web/internal/servlet/taglib/liferay_css_variables_2.html
@@ -4,8 +4,8 @@
 	}
 	body {
 		--color: green;
-		--fixed-font: "Lucida Console";
-		--font: Comic Sans;
+		--fixed-font: \22Lucida\20Console\22;
+		--font: Comic\20Sans;
 	}
 	:root {
 		--color: yellow;

--- a/modules/apps/style-book/style-book-api/bnd.bnd
+++ b/modules/apps/style-book/style-book-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Style Book API
 Bundle-SymbolicName: com.liferay.style.book.api
-Bundle-Version: 13.3.1
+Bundle-Version: 13.4.0
 Export-Package:\
 	com.liferay.style.book.constants,\
 	com.liferay.style.book.exception,\

--- a/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/exception/StyleBookEntryFrontendTokensValuesException.java
+++ b/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/exception/StyleBookEntryFrontendTokensValuesException.java
@@ -1,0 +1,33 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.style.book.exception;
+
+import com.liferay.portal.kernel.exception.PortalException;
+
+/**
+ * @author Brian Wing Shun Chan
+ */
+public class StyleBookEntryFrontendTokensValuesException
+	extends PortalException {
+
+	public StyleBookEntryFrontendTokensValuesException() {
+	}
+
+	public StyleBookEntryFrontendTokensValuesException(String msg) {
+		super(msg);
+	}
+
+	public StyleBookEntryFrontendTokensValuesException(
+		String msg, Throwable throwable) {
+
+		super(msg, throwable);
+	}
+
+	public StyleBookEntryFrontendTokensValuesException(Throwable throwable) {
+		super(throwable);
+	}
+
+}

--- a/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/exception/StyleBookEntryFrontendTokensValuesException.java
+++ b/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/exception/StyleBookEntryFrontendTokensValuesException.java
@@ -5,6 +5,7 @@
 
 package com.liferay.style.book.exception;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.PortalException;
 
 /**
@@ -13,21 +14,35 @@ import com.liferay.portal.kernel.exception.PortalException;
 public class StyleBookEntryFrontendTokensValuesException
 	extends PortalException {
 
-	public StyleBookEntryFrontendTokensValuesException() {
+	public static class MustBeValidJSON
+		extends StyleBookEntryFrontendTokensValuesException {
+
+		public MustBeValidJSON(Throwable throwable) {
+			super("Unable to parse frontend tokens values", throwable);
+		}
+
 	}
 
-	public StyleBookEntryFrontendTokensValuesException(String msg) {
+	public static class MustNotContainInvalidCharacters
+		extends StyleBookEntryFrontendTokensValuesException {
+
+		public MustNotContainInvalidCharacters(String key) {
+			super(
+				StringBundler.concat(
+					"Frontend token value \"", key,
+					"\" contains invalid characters"));
+		}
+
+	}
+
+	private StyleBookEntryFrontendTokensValuesException(String msg) {
 		super(msg);
 	}
 
-	public StyleBookEntryFrontendTokensValuesException(
+	private StyleBookEntryFrontendTokensValuesException(
 		String msg, Throwable throwable) {
 
 		super(msg, throwable);
-	}
-
-	public StyleBookEntryFrontendTokensValuesException(Throwable throwable) {
-		super(throwable);
 	}
 
 }

--- a/modules/apps/style-book/style-book-api/src/main/resources/com/liferay/style/book/exception/packageinfo
+++ b/modules/apps/style-book/style-book-api/src/main/resources/com/liferay/style/book/exception/packageinfo
@@ -1,1 +1,1 @@
-version 1.4.0
+version 1.5.0

--- a/modules/apps/style-book/style-book-service/service.xml
+++ b/modules/apps/style-book/style-book-service/service.xml
@@ -79,6 +79,7 @@
 		<exception>DuplicateStyleBookEntryName</exception>
 		<exception>StyleBookEntryFile</exception>
 		<exception>StyleBookEntryFrontendTokenDefinition</exception>
+		<exception>StyleBookEntryFrontendTokensValues</exception>
 		<exception>StyleBookEntryName</exception>
 		<exception>StyleBookEntryThemeId</exception>
 	</exceptions>

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/impl/StyleBookEntryLocalServiceImpl.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/impl/StyleBookEntryLocalServiceImpl.java
@@ -18,6 +18,9 @@ import com.liferay.portal.json.validator.JSONValidatorException;
 import com.liferay.portal.kernel.dao.orm.ExportActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.WildcardMode;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.json.JSONException;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.ModelHintsUtil;
 import com.liferay.portal.kernel.model.Repository;
 import com.liferay.portal.kernel.model.User;
@@ -38,6 +41,7 @@ import com.liferay.style.book.exception.DuplicateStyleBookEntryFrontendTokenExce
 import com.liferay.style.book.exception.DuplicateStyleBookEntryKeyException;
 import com.liferay.style.book.exception.DuplicateStyleBookEntryNameException;
 import com.liferay.style.book.exception.StyleBookEntryFrontendTokenDefinitionException;
+import com.liferay.style.book.exception.StyleBookEntryFrontendTokensValuesException;
 import com.liferay.style.book.exception.StyleBookEntryNameException;
 import com.liferay.style.book.exception.StyleBookEntryThemeIdException;
 import com.liferay.style.book.model.StyleBookEntry;
@@ -94,6 +98,8 @@ public class StyleBookEntryLocalServiceImpl
 		}
 
 		_validateStyleBookEntryKey(groupId, styleBookEntryKey);
+
+		_validateFrontendTokensValues(frontendTokensValues, null);
 
 		StyleBookEntry styleBookEntry = create();
 
@@ -520,6 +526,8 @@ public class StyleBookEntryLocalServiceImpl
 		StyleBookEntry styleBookEntry =
 			styleBookEntryPersistence.findByPrimaryKey(styleBookEntryId);
 
+		_validateFrontendTokensValues(frontendTokensValues, styleBookEntry);
+
 		styleBookEntry.setModifiedDate(new Date());
 		styleBookEntry.setFrontendTokensValues(frontendTokensValues);
 
@@ -607,6 +615,7 @@ public class StyleBookEntryLocalServiceImpl
 			styleBookEntryPersistence.findByPrimaryKey(styleBookEntryId);
 
 		_validate(styleBookEntry.getGroupId(), name, styleBookEntryId);
+		_validateFrontendTokensValues(frontendTokensValues, styleBookEntry);
 
 		if (Validator.isNull(styleBookEntryKey)) {
 			styleBookEntryKey = generateStyleBookEntryKey(
@@ -657,6 +666,7 @@ public class StyleBookEntryLocalServiceImpl
 			styleBookEntryPersistence.findByPrimaryKey(styleBookEntryId);
 
 		_validate(styleBookEntry.getGroupId(), name, styleBookEntryId);
+		_validateFrontendTokensValues(frontendTokensValues, styleBookEntry);
 
 		styleBookEntry.setFrontendTokensValues(frontendTokensValues);
 		styleBookEntry.setName(name);
@@ -795,6 +805,51 @@ public class StyleBookEntryLocalServiceImpl
 		}
 	}
 
+	private void _validateFrontendTokensValues(
+			String frontendTokensValues, StyleBookEntry styleBookEntry)
+		throws PortalException {
+
+		if (Validator.isBlank(frontendTokensValues) ||
+			((styleBookEntry != null) &&
+			 StringUtil.equals(
+				 styleBookEntry.getFrontendTokensValues(),
+				 frontendTokensValues))) {
+
+			return;
+		}
+
+		JSONObject frontendTokensValuesJSONObject = null;
+
+		try {
+			frontendTokensValuesJSONObject = _jsonFactory.createJSONObject(
+				frontendTokensValues);
+		}
+		catch (JSONException jsonException) {
+			throw new StyleBookEntryFrontendTokensValuesException.
+				MustBeValidJSON(jsonException);
+		}
+
+		for (String key : frontendTokensValuesJSONObject.keySet()) {
+			JSONObject frontendTokenValueJSONObject =
+				frontendTokensValuesJSONObject.getJSONObject(key);
+
+			if (frontendTokenValueJSONObject == null) {
+				continue;
+			}
+
+			String cssVariableMapping = frontendTokenValueJSONObject.getString(
+				"cssVariableMapping");
+			String value = frontendTokenValueJSONObject.getString("value");
+
+			if (cssVariableMapping.contains(StringPool.LESS_THAN) ||
+				value.contains(StringPool.LESS_THAN)) {
+
+				throw new StyleBookEntryFrontendTokensValuesException.
+					MustNotContainInvalidCharacters(key);
+			}
+		}
+	}
+
 	private void _validateStyleBookEntryKey(
 			long groupId, String styleBookEntryKey)
 		throws PortalException {
@@ -819,6 +874,9 @@ public class StyleBookEntryLocalServiceImpl
 	private final FrontendTokenDefinitionJSONValidator
 		_frontendTokenDefinitionJSONValidator =
 			new FrontendTokenDefinitionJSONValidator();
+
+	@Reference
+	private JSONFactory _jsonFactory;
 
 	@Reference
 	private PortletFileRepository _portletFileRepository;

--- a/modules/apps/style-book/style-book-service/src/test/java/com/liferay/style/book/service/impl/StyleBookEntryLocalServiceImplTest.java
+++ b/modules/apps/style-book/style-book-service/src/test/java/com/liferay/style/book/service/impl/StyleBookEntryLocalServiceImplTest.java
@@ -5,14 +5,18 @@
 
 package com.liferay.style.book.service.impl;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.json.JSONFactoryImpl;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.test.AssertUtils;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 import com.liferay.style.book.exception.DuplicateStyleBookEntryFrontendTokenException;
 import com.liferay.style.book.exception.StyleBookEntryFrontendTokenDefinitionException;
+import com.liferay.style.book.exception.StyleBookEntryFrontendTokensValuesException;
 import com.liferay.style.book.model.StyleBookEntry;
 import com.liferay.style.book.service.StyleBookEntryLocalService;
 import com.liferay.style.book.service.persistence.StyleBookEntryPersistence;
@@ -43,6 +47,9 @@ public class StyleBookEntryLocalServiceImplTest {
 	@Before
 	public void setUp() {
 		MockitoAnnotations.initMocks(this);
+
+		ReflectionTestUtil.setFieldValue(
+			_styleBookEntryLocalService, "_jsonFactory", new JSONFactoryImpl());
 	}
 
 	@Test
@@ -66,6 +73,26 @@ public class StyleBookEntryLocalServiceImplTest {
 		_testUpdateFrontendTokenDefinitionWithInvalidJSON();
 		_testUpdateFrontendTokenDefinitionWithInvalidJSONSchema();
 		_testUpdateFrontendTokenDefinitionWithValidFrontendTokenDefinition();
+	}
+
+	@Test
+	public void testUpdateFrontendTokensValues() throws Exception {
+		_testUpdateFrontendTokensValues(StringPool.BLANK);
+		_testUpdateFrontendTokensValues(
+			_createFrontendTokensValues(
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+				RandomTestUtil.randomString()));
+		_testUpdateFrontendTokensValues(null);
+		_testUpdateFrontendTokensValuesWithInvalidCharacters(
+			RandomTestUtil.randomString() + StringPool.LESS_THAN +
+				RandomTestUtil.randomString(),
+			RandomTestUtil.randomString());
+		_testUpdateFrontendTokensValuesWithInvalidCharacters(
+			RandomTestUtil.randomString(),
+			RandomTestUtil.randomString() + StringPool.LESS_THAN +
+				RandomTestUtil.randomString());
+		_testUpdateFrontendTokensValuesWithInvalidJSON();
+		_testUpdateFrontendTokensValuesWithSameValue();
 	}
 
 	private String _createFrontendTokenDefinition(
@@ -118,6 +145,21 @@ public class StyleBookEntryLocalServiceImplTest {
 		).put(
 			"name", name
 		);
+	}
+
+	private String _createFrontendTokensValues(
+		String cssVariableMapping, String key, String value) {
+
+		return JSONUtil.put(
+			key,
+			JSONUtil.put(
+				"cssVariableMapping", cssVariableMapping
+			).put(
+				"tokenDefinitionId", RandomTestUtil.randomString()
+			).put(
+				"value", value
+			)
+		).toString();
 	}
 
 	private StyleBookEntry _mockStyleBookEntry(long styleBookEntryId)
@@ -261,6 +303,88 @@ public class StyleBookEntryLocalServiceImplTest {
 			styleBookEntry
 		).setFrontendTokenDefinition(
 			frontendTokenDefinition
+		);
+	}
+
+	private void _testUpdateFrontendTokensValues(String frontendTokensValues)
+		throws Exception {
+
+		long styleBookEntryId = RandomTestUtil.randomLong();
+
+		StyleBookEntry styleBookEntry = _mockStyleBookEntry(styleBookEntryId);
+
+		_styleBookEntryLocalService.updateFrontendTokensValues(
+			styleBookEntryId, frontendTokensValues);
+
+		Mockito.verify(
+			styleBookEntry
+		).setFrontendTokensValues(
+			frontendTokensValues
+		);
+	}
+
+	private void _testUpdateFrontendTokensValuesWithInvalidCharacters(
+			String cssVariableMapping, String value)
+		throws Exception {
+
+		long styleBookEntryId = RandomTestUtil.randomLong();
+
+		_mockStyleBookEntry(styleBookEntryId);
+
+		String key = RandomTestUtil.randomString();
+
+		String frontendTokensValues = _createFrontendTokensValues(
+			cssVariableMapping, key, value);
+
+		AssertUtils.assertFailure(
+			StyleBookEntryFrontendTokensValuesException.
+				MustNotContainInvalidCharacters.class,
+			StringBundler.concat(
+				"Frontend token value \"", key,
+				"\" contains invalid characters"),
+			() -> _styleBookEntryLocalService.updateFrontendTokensValues(
+				styleBookEntryId, frontendTokensValues));
+	}
+
+	private void _testUpdateFrontendTokensValuesWithInvalidJSON()
+		throws Exception {
+
+		long styleBookEntryId = RandomTestUtil.randomLong();
+
+		_mockStyleBookEntry(styleBookEntryId);
+
+		AssertUtils.assertFailure(
+			StyleBookEntryFrontendTokensValuesException.MustBeValidJSON.class,
+			"Unable to parse frontend tokens values",
+			() -> _styleBookEntryLocalService.updateFrontendTokensValues(
+				styleBookEntryId, "{not valid json"));
+	}
+
+	private void _testUpdateFrontendTokensValuesWithSameValue()
+		throws Exception {
+
+		long styleBookEntryId = RandomTestUtil.randomLong();
+
+		StyleBookEntry styleBookEntry = _mockStyleBookEntry(styleBookEntryId);
+
+		String frontendTokensValues = _createFrontendTokensValues(
+			RandomTestUtil.randomString() + StringPool.LESS_THAN +
+				RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString());
+
+		Mockito.when(
+			styleBookEntry.getFrontendTokensValues()
+		).thenReturn(
+			frontendTokensValues
+		);
+
+		_styleBookEntryLocalService.updateFrontendTokensValues(
+			styleBookEntryId, frontendTokensValues);
+
+		Mockito.verify(
+			styleBookEntry
+		).setFrontendTokensValues(
+			frontendTokensValues
 		);
 	}
 

--- a/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/handler/StyleBookEntryExceptionRequestHandlerUtil.java
+++ b/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/handler/StyleBookEntryExceptionRequestHandlerUtil.java
@@ -5,6 +5,7 @@
 
 package com.liferay.style.book.web.internal.handler;
 
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
@@ -13,6 +14,7 @@ import com.liferay.portal.kernel.portlet.JSONPortletResponseUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.style.book.exception.DuplicateStyleBookEntryNameException;
+import com.liferay.style.book.exception.StyleBookEntryFrontendTokensValuesException;
 import com.liferay.style.book.exception.StyleBookEntryNameException;
 
 import jakarta.portlet.ActionRequest;
@@ -39,6 +41,18 @@ public class StyleBookEntryExceptionRequestHandlerUtil {
 				themeDisplay.getRequest(),
 				"a-style-book-with-this-name-already-exists.-please-enter-a-" +
 					"different-name");
+		}
+		else if (portalException instanceof
+					StyleBookEntryFrontendTokensValuesException.
+						MustNotContainInvalidCharacters) {
+
+			errorMessage = LanguageUtil.format(
+				themeDisplay.getRequest(),
+				"the-x-cannot-contain-the-following-invalid-characters-x",
+				new String[] {
+					LanguageUtil.get(themeDisplay.getRequest(), "value"),
+					StringPool.LESS_THAN
+				});
 		}
 		else if (portalException instanceof StyleBookEntryNameException) {
 			errorMessage = LanguageUtil.get(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101991

> Resend of https://github.com/brianchandotcom/liferay-portal/pull/181129. It contains the following changes:
> 1. It renames `xssContent` to `xssScript`. We chose `xssContent` previously because it had a hit in the codebase and it could fit the value as CSS element: some content that goes into the CSS. However, `xssScript` has two hits (not that much also, but 100% more hits than `xssContent`) and the content IS a script, injected into the CSS stylesheet. So the name also makes more sense. Verified with `g grep String.xss **.java`.
> 2. It renames the test private helpers from `_testUpdateFrontendTokensValuesMustBeValidJSON` and `_testUpdateFrontendTokensValuesMustNotContainInvalidCharacters` to `_testUpdateFrontendTokensValuesWithInvalidJSON` and `_testUpdateFrontendTokensValuesWithInvalidCharacters`, respectively. Therefore, these new helpers conform with the dominant `_test*With*` shape in the codebase.
> 3. Applies the suggested diff.
> 4. Uses case sensitive sorting where applicable.

## What Is Being Fixed

Style Book frontend token values (CSS variable keys/values from a stored JSON blob) were printed straight into the inline `<style>` block that `top_head.jsp` writes on every page. A key or value containing `</style>` could close the tag early and let attacker-controlled markup or script execute — a stored XSS reachable by anyone who can save a Style Book entry.

## How It Is Being Fixed

Two layers close the exploit. At render time, `ScopedCSSVariablesTopHeadDynamicInclude` now escapes both the CSS variable key and value with `HtmlUtil.escapeCSS` before writing them into the inline `<style>` block, so existing and future stored data can no longer break out of it. At write time, saving a Style Book entry now rejects a `frontendTokensValues` JSON payload whose nested `cssVariableMapping` carries a literal `<`, via a new `StyleBookEntryFrontendTokensValuesException` declared through Service Builder. Unparseable, blank, or null input is left alone since it can never render as a CSS variable, and an update that resubmits an entity's own already-stored value unchanged (e.g. a plain rename) skips validation so it never newly rejects legacy data.

## PR Check

**pr-check: PASS** — tested on `1888b6aa2ae1f22e3c50622a8db3c0ed8a54f505`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS (baseline-all + seven Ant projects + 1 changed exporting module) |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "1888b6aa2ae1f22e3c50622a8db3c0ed8a54f505"} -->
