### PR TITLE
LPD-104439 Generate Decimal values that Java renders in plain notation

### DIFF
--- a/modules/test/playwright/tests/object-web/utils/generateObjectEntry.ts
+++ b/modules/test/playwright/tests/object-web/utils/generateObjectEntry.ts
@@ -65,7 +65,9 @@ function generateObjectEntryValue({
 		case 'DateTime':
 			return getRandomDateTime(objectEntryFormat);
 		case 'Decimal':
-			return parseFloat(Math.random().toFixed(10)).toString();
+			return parseFloat(
+				(0.001 + Math.random() * 0.998).toFixed(10)
+			).toString();
 		case 'Encrypted':
 			return getRandomString();
 		case 'Integer':


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-104439

## What Is Being Fixed

The Playwright Decimal value generator for object entries returned `parseFloat(Math.random().toFixed(10)).toString()`, so about one run in a thousand drew a value below `0.001`. JavaScript prints such a value in plain notation (`0.000625421`), but the portal renders the stored double with Java's `Double.toString`, which switches to scientific notation below 10^-3 (`6.25421E-4`).

The content page integration test in `objectContentPageIntegration.spec.ts` creates an information template over an object that has a Decimal field, joins the generated values into a single `getByText` locator, and waits for it on the rendered page. On such a draw the locator can never match, so the test times out after 15 seconds. There is no retry, so the draw fails the run outright.

The failure is data dependent rather than a race: forcing the generator to `0.000625421` reproduces it on every run, and restoring the random draw makes the test pass.

Root cause: born broken on 2025-08-08 in `0faf120afc1bd` (LPD-62282), which created the information template test with a Decimal field and the joined `getByText` assertion while the generator had already produced JavaScript-formatted decimals since `daf66ddac96d6` (LPD-54630, 2025-07-22). The test later moved to `objectEntry.spec.ts` in `5354f141444bf` and to `objectContentPageIntegration.spec.ts` in `dc995c1c9f927` unchanged.

## How It Is Being Fixed

The generator now draws from `[0.001, 0.999]`, the range in which JavaScript and Java print the same shortest round-trip digits. The upper bound stays below 1 so no draw can round up to an integer, which Java would print as `1.0` while JavaScript prints `1`, and the ten decimal places of the original draw are kept.

## PR Check

**pr-check: PASS** — tested on `190fc41a521f9326ed60647b70058dc9bdd75b66`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| HTML Escaping | PASS |
| Per-Module Compile | NOT VERIFIED |
| Baseline | PASS (baseline-all + seven Ant projects + 0 changed exporting modules) |
| JavaScript Unit Tests | NOT VERIFIED |

Per-Module Compile: not verified. The branch's only change is `modules/test/playwright/tests/object-web/utils/generateObjectEntry.ts`. Resolving that file to a module by its nearest ancestor holding a `bnd.bnd` yields nothing — no `bnd.bnd` exists at any level from the file's directory up to `modules`, and `modules/test/playwright` is a standalone Gradle build (0-byte `settings.gradle`) rather than an OSGi module bundle. The deploy set is therefore empty and no module compile was exercised. The lockfile check passes vacuously: the diff changes no `package.json` and no lockfile. TypeScript in this tree is type-checked by Source Format's `portalYarnFormatCurrentBranch` step and exercised by the Playwright run, not by a module deploy.

Baseline: PASS (baseline-all + seven Ant projects + 0 changed exporting modules). The branch's only change is a TypeScript Playwright helper under `modules/test/playwright`, which has no `bnd.bnd` ancestor, so it exports no package and owes no version bump. All seven top level Ant projects were confirmed to have genuinely compared against Nexus by a standalone `baseline --rerun`, each reporting `1 executed`. `baseline-all` exited nonzero on one inherited finding in `modules/apps/design-library/design-library-api`, a module untouched by this branch: `Bundle Version Change Recommended: 1.2.0` against a released 1.1.0. Its in-place repair (`Bundle-Version` 1.1.1 to 1.2.0) was restored rather than committed, as that bump belongs to the owner of `design-library-api`. The Local Version Check passes.

JavaScript Unit Tests: not verified. The nearest `package.json` ancestor of the changed file is `modules/test/playwright`, whose `test` script is `playwright test` rather than Jest, and the module carries no Jest configuration or setup file. No other module declares its package name `@liferay/playwright` in `dependencies` or `devDependencies` (checked all 873 `package.json` files under `modules`), so there are no cross-module consumer snapshots to run, and every importer of the changed helper is a Playwright spec inside the same module. The diff adds no dependency and does not touch any `package.json`, lockfile, or `modules/node-scripts.config.js`, so the stale-stub-list sweep does not apply. Playwright execution is outside this validation's scope.

<!-- pr-check {"result":"success","sha":"190fc41a521f9326ed60647b70058dc9bdd75b66"} -->
