### PR TITLE
LPD-104491 Make the scheduled object entry test independent of workflow approval speed

### DIFF
--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -9907,6 +9907,14 @@ public class ObjectEntryLocalServiceTest {
 		return serviceRegistration::unregister;
 	}
 
+	private ObjectEntry _rewindDisplayDate(ObjectEntry objectEntry) {
+		objectEntry.setDisplayDate(
+			new java.sql.Date(
+				System.currentTimeMillis() - TimeUnit.MINUTE.toMillis(1)));
+
+		return _objectEntryLocalService.updateObjectEntry(objectEntry);
+	}
+
 	private void _testAddObjectEntry(
 			String expectedValue, String fieldName,
 			ObjectDefinition objectDefinition, String value)
@@ -10367,8 +10375,7 @@ public class ObjectEntryLocalServiceTest {
 			HashMapBuilder.<String, Serializable>put(
 				"displayDate",
 				new java.sql.Date(
-					System.currentTimeMillis() +
-						TimeUnit.MILLISECOND.toMillis(1000))
+					System.currentTimeMillis() + TimeUnit.HOUR.toMillis(1))
 			).putAll(
 				requiredValues
 			).build(),
@@ -10385,7 +10392,7 @@ public class ObjectEntryLocalServiceTest {
 		Assert.assertEquals(
 			WorkflowConstants.STATUS_SCHEDULED, objectEntry3.getStatus());
 
-		Thread.sleep(1000);
+		objectEntry3 = _rewindDisplayDate(objectEntry3);
 
 		jobExecutorUnsafeRunnable.run();
 
@@ -10442,8 +10449,7 @@ public class ObjectEntryLocalServiceTest {
 			HashMapBuilder.<String, Serializable>put(
 				"displayDate",
 				new java.sql.Date(
-					System.currentTimeMillis() +
-						TimeUnit.MILLISECOND.toMillis(1000))
+					System.currentTimeMillis() + TimeUnit.HOUR.toMillis(1))
 			).putAll(
 				requiredValues
 			).build(),
@@ -10460,7 +10466,7 @@ public class ObjectEntryLocalServiceTest {
 		Assert.assertEquals(
 			WorkflowConstants.STATUS_DENIED, objectEntry5.getStatus());
 
-		Thread.sleep(1000);
+		objectEntry5 = _rewindDisplayDate(objectEntry5);
 
 		jobExecutorUnsafeRunnable.run();
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-104491

## What Is Being Fixed

`ObjectEntryLocalServiceTest` adds an object entry whose display date is one second in the future, approves its pending workflow task, and expects the entry to become scheduled. Approving the task goes through the workflow engine and takes longer than a second on a loaded CI axis, so by the time the status is derived the display date is already in the past and the entry is approved instead of scheduled. The same one second margin also sat on the rejected entry, and both were followed by a one second sleep so the scheduler job would find the display date passed.

Root cause: born broken on 2025-07-23 in 945e68f11d27d (LPD-58624), which introduced the entries with a one second display date margin and the one second sleeps.

## How It Is Being Fixed

Both entries now get a display date one hour in the future, so the status derived at approval or rejection time cannot depend on how long the workflow engine took. To exercise the scheduler job, the test rewinds each entry's display date into the past through the plain model update before running the job, instead of sleeping until the wall clock passes the date.

The fix was confirmed with a red/green arm pair on self CI. The green arm ran `ci:test:object` with this change and `ObjectEntryLocalServiceTest` passed (shuyangzhou/liferay-portal#12713). The red arm, the same tree with a one millisecond margin, failed with `expected:<7> but was:<0>`, the exact shape seen in the campaign baseline run (shuyangzhou/liferay-portal#12714). The commit has since been carried green through four consecutive aggregate `ci:test:object` rounds.

## PR Check

**pr-check: PASS** — tested on `d4b0f3a05c551805af8d164fda99a843ee2de819`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | NOT VERIFIED |
| Integration Test Compile | PASS |
| Baseline | PASS (baseline-all + seven Ant projects + 0 changed exporting modules) |
| Java Unit Tests | NOT VERIFIED |

Per-Module Compile verified nothing. The branch's only change is a Java file under `modules/apps/object/object-test/src/testIntegration`, and the validation excludes a module whose only Java change is under `src/testIntegration` because a `-test` module deploys no runtime bundle. Integration Test Compile covers it instead. No `package.json` changed, so the lockfile check had nothing to compare.

Java Unit Tests verified nothing. `object-test` has no `src/test` tree at all, and the changed file is itself an integration test under `src/testIntegration`, which this validation holds out of scope. The changed class is covered by `ObjectEntryLocalServiceTest` as an integration test, whose execution is out of pr-check scope.

Baseline reports one inherited finding, not this branch's. `:apps:design-library:design-library-api:baseline` fails with `Semantic versioning is incorrect` comparing `com.liferay.design.library.api-1.1.1.jar` against the released `1.1.0`, and recommends `Bundle Version Change Recommended: 1.2.0`. `modules/apps/design-library/design-library-api/bnd.bnd` is not in the branch diff, so the repair the task wrote into the tree (`Bundle-Version: 1.1.1` raised to `1.2.0`) was restored and left uncommitted. All seven Ant projects reported `1 actionable task: 1 executed`, and `object-test/bnd.bnd` carries no `Export-Package:`, so the branch contributes no exporting module to compare.

<!-- pr-check {"result":"success","sha":"d4b0f3a05c551805af8d164fda99a843ee2de819"} -->
