### PR TITLE
LPD-104496 Open the aggregation field through the hydration barrier before editing it

### DIFF
--- a/modules/test/playwright/tests/object-web/field/objectField.spec.ts
+++ b/modules/test/playwright/tests/object-web/field/objectField.spec.ts
@@ -1603,7 +1603,7 @@ test.describe('Manage objectFields through Objects Admin UI', () => {
 			objectFieldLabel,
 		});
 
-		await page.getByRole('link', {name: objectFieldLabel}).click();
+		await objectFieldsPage.openObjectField(objectFieldLabel);
 
 		await objectFieldsPage.iframeLocator
 			.getByLabel('LabelMandatory')


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-104496

## What Is Being Fixed

The `Manage objectFields through Objects Admin UI` aggregation field test failed intermittently on `ci:test:object`.

The edit object field side panel renders an empty, editable form on first paint and fills it in from a GET of the field once that response arrives, merging the whole server object over the form state. The test clicked the field's link and typed the new label straight away, so whenever the GET landed after the typing the label reverted to the server value while the relationship, function and field selections made afterwards survived. The save then sent the old label, the page reloaded without the renamed field, and the test timed out waiting for the renamed link.

Root cause: born racing the hydration in 5b6043aa6dd63 (LPD-82331, 2026-03-11), which moved the object field cases to Playwright and added this test with a raw link click, while the side panel had populated its form asynchronously since a3749d2f457f5 (LPS-180922, 2023-04-05).

## How It Is Being Fixed

Open the field through `ObjectFieldsPage.openObjectField` instead of clicking its link directly. That helper retries until `#objectFieldLabelInput` holds the field's label, which is exactly the wait for the hydration to land. This was the one open in the spec that bypassed it, and every other open already went through it, so after this change no raw field-label link click remains — the three surviving `getByRole('link', {name: objectFieldLabel})` references are `toBeVisible`/`toBeHidden` assertions rather than opens.

Reproduced against an isolated bundle by delaying the field GET by 2.5 seconds: the raw click failed three of three runs with the CI signature and the saved request carried the old label, while opening through the helper passed three of three under the same delay. The test then ran green on a self-CI `ci:test:object` run and carried green through four consecutive aggregate baseline rounds.

The product behavior that lets typed values be overwritten by a late hydration is left for the object team; this change only removes the test's exposure to it.

## PR Check

**pr-check: PASS** — tested on `9b2905a4835c5f96a9755c2265f8a8a3807b48ae`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| HTML Escaping | PASS |
| Per-Module Compile | NOT VERIFIED |
| Baseline | PASS (baseline-all + seven Ant projects + 0 changed exporting modules) |
| JavaScript Unit Tests | NOT VERIFIED |

Per-Module Compile verified nothing. The diff's only file is `modules/test/playwright/tests/object-web/field/objectField.spec.ts`, and no `bnd.bnd` exists anywhere in its ancestor chain, so the changed path belongs to no OSGi module and the deploy set is empty. The lockfile check, which runs regardless of a handoff, passed: the diff changes no `package.json`, `package-lock.json`, or `yarn.lock`, so there is no dependency range for the lockfile to match. No `public` or `protected` member was removed and neither `modules/frontend-sdk` nor `modules/node-scripts.config.js` changed, so nothing expanded the set either.

JavaScript Unit Tests verified nothing. The nearest ancestor holding a `package.json` is `modules/test/playwright`, whose `test` script is `playwright test`; the module declares no Jest dependency, carries no Jest config, and has no `jest` key, so no `Test Suites:` line can exist to judge the run by. Playwright coverage is out of pr-check's scope and is what `ci:test:object` provides. No other module declares `@liferay/playwright`, so there are no cross-module consumer snapshots to run, and the diff adds no dependency, so the stale stub list sweep does not apply.

Baseline produced one finding, and it is **inherited** rather than this branch's: `modules/apps/design-library/design-library-api`, a module the branch never touched, raised a `Bundle Version Change Recommended` warning and had its `bnd.bnd` `Bundle-Version` rewritten from `1.1.1` to `1.2.0` in the tree. That file was restored, nothing was committed, and the module's baseline was deliberately not rerun, since a second run compares the repaired tree and hides the finding. The branch itself changes no `.java`, `bnd.bnd`, `packageinfo`, or `.gradle` file and owns no exporting module, so it can own no baseline finding. The Local Version Check passed with every input empty. Each of the seven Ant projects was confirmed to have genuinely compared by a standalone `baseline --rerun` printing `1 executed`; the modules half of `baseline-all` runs without `--rerun`, so for untouched modules a cached `UP-TO-DATE` cannot be distinguished from a real comparison, which is why the universe is named as it is.

<!-- pr-check {"result":"success","sha":"9b2905a4835c5f96a9755c2265f8a8a3807b48ae"} -->
