### PR TITLE
LPD-101956 Stop two picker specs paging to the end of the list

### DIFF
--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/tests/ObjectRelationship/SelectObjectDefinition.spec.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/tests/ObjectRelationship/SelectObjectDefinition.spec.tsx
@@ -178,7 +178,7 @@ describe('SelectObjectDefinition', () => {
 	});
 
 	it('renders the hint while more object definitions can be loaded', async () => {
-		mockPage({lastPage: 10, once: false, totalCount: 200});
+		mockPage({lastPage: 2, once: false, totalCount: 200});
 
 		renderSelectObjectDefinition();
 
@@ -252,7 +252,7 @@ describe('SelectObjectDefinition', () => {
 	});
 
 	it('updates the hint when the search is cleared', async () => {
-		mockPage({items: [OBJECT_DEFINITION], lastPage: 10, totalCount: 200});
+		mockPage({items: [OBJECT_DEFINITION], lastPage: 2, totalCount: 200});
 
 		renderSelectObjectDefinition();
 
@@ -276,7 +276,7 @@ describe('SelectObjectDefinition', () => {
 
 		mockPage({
 			items: [OBJECT_DEFINITION],
-			lastPage: 10,
+			lastPage: 2,
 			once: false,
 			totalCount: 200,
 		});


### PR DESCRIPTION
follow up from: https://github.com/brianchandotcom/liferay-portal/pull/181152

https://liferay.atlassian.net/browse/LPD-101956

## What Is Being Fixed

Two specs covering the object definition picker's caption run close enough to Jest's five second budget to time out whenever the rest of the suite competes for the machine: "updates the hint when the search is cleared" and "renders the hint while more object definitions can be loaded".

## How It Is Being Fixed

The menu has no height under jsdom, so the infinite scroll reads the list as already scrolled to the bottom and keeps asking for another page until it reaches the last one. Both specs declared ten pages, so each one made ten sequential requests to prove something two pages already prove. Declaring two pages leaves every assertion untouched and bounds the walk. The object-web suite drops from about 86 seconds to 59.

## PR Check

**pr-check: PASS** — tested on `86ab856`

| Validation | Result |
| --- | --- |
| Source Format | PASS (module-scoped) |
| HTML Escaping | PASS |
| Per-Module Compile | PASS (1 module: `apps:object:object-web`) |
| Baseline | PASS |
| JavaScript Unit Tests | PASS |

Source Format ran module-scoped rather than in `current-branch` mode. This branch is stacked on Brian's integration branch, so `git merge-base HEAD master` resolves to 2505 commits across 3096 files, and `format-source-current-branch` would have reformatted all of them and autocommitted the result under this ticket. `gradlew formatSource` ran in `object-web` instead: `BUILD SUCCESSFUL`, no tree modifications.

Per-Module Compile ran `clean deploy` to avoid a cached verdict: `packageRunBuild`, `jar` and `deploy` all executed, `BUILD SUCCESSFUL in 55s`. `compileJava FROM-CACHE` is correct, since the commit changes no Java.

JavaScript Unit Tests: `Test Suites: 54 passed, 54 total`, `Tests: 348 passed, 348 total`.

<!-- pr-check {"result": "success", "sha": "86ab856b58115c3f94cb5ee83246ddd8356a179b"} -->
