### PR TITLE
LPD-104240 Semantic versioning

### DIFF
--- a/modules/apps/design-library/design-library-api/bnd.bnd
+++ b/modules/apps/design-library/design-library-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Design Library API
 Bundle-SymbolicName: com.liferay.design.library.api
-Bundle-Version: 1.1.1
+Bundle-Version: 1.2.0
 Export-Package:\
 	com.liferay.design.library.constants,\
 	com.liferay.design.library.resource.type,\


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-104240

## What Is Being Fixed

`design-library-api` exports a new package, `com.liferay.design.library.util`, while its `Bundle-Version` is still `1.1.1`. Measured against the released `1.1.0`, that delta is one added package, so bnd reports `Bundle Version Change Recommended: 1.2.0` and refuses the module until the bump lands.

The effect is not local to this module. `ant baseline-all` fails for every branch, whatever it changed, and the `semantic-versioning` batch is red for everyone on `ci:test:object` and on `ci:test:relevant` — the latter because `modified.files.includes[semantic-versioning-rule][relevant]` is `**`, so any diff at all pulls the batch in. `ci:test:stable` carries no `semantic-versioning` batch and is unaffected.

## How It Is Being Fixed

`Bundle-Version` moves from `1.1.1` to `1.2.0`, which is exactly the value bnd recommends for an added package — not further and not less. Nothing else changes. The `packageinfo` that d592588b5155d added for the new package is already correct at `version 1.0.0` and is left untouched. A minor bump for an added package is not a breaking change, so there is no `# breaking` section.

@JavierMoral @liferay-page-management — worth recording why this was invisible on your side, because your `pr-check` Baseline result was truthful when it was produced. At the SHA you tested, the module sat at `1.1.0` and Nexus carried only the `1.0.1` release, so bnd compared the new export against `1.0.1` and found `1.1.0` sufficient. Some six and a half hours later the release bot published `1.1.0` and moved the module to `1.1.1` in f50cc7421b7c3, and it did so on `brianchandotcom/master` alone — upstream `master` carries neither that bump nor the new export yet, so nothing is broken there. The forward rebase is what combined the two, and only then does the comparison become "new export against the released `1.1.0`", which wants `1.2.0`. Nothing in the pre-merge path could have shown this: `ci:forward` skips the PR Tester, and the one suite that did run, `ci:test:sf`, is `test.batch.names[sf]=source-format-current-branch` and has no `semantic-versioning` batch to fail. `ci:test:relevant` would have caught it, but only after the rebase had produced the combination.

## PR Check

**pr-check: PASS** — tested on `a874413f463a6ddf3490659e2991e7b5e62b8508`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Baseline | PASS (baseline-all + seven Ant projects + 1 changed exporting module) |
| Structural Smoke | PASS |

Baseline was confirmed with a red/green pair rather than from silence. At the branch's `1.2.0` the `:apps:design-library:design-library-api:baseline` task compared and reported no warning of any kind. With master's `1.1.1` written back into the tree, the same standalone `--rerun` fails with `[Baseline Warning] Bundle Version Change Recommended: 1.2.0`, so the failure is real and this value is the exact fix. `baseline-all` was clean, and each of the seven top-level Ant projects reported `1 executed`.

Per-Module Compile ran `:apps:design-library:design-library-api:jar` rather than `:deploy`, which covers compilation, resource processing, and OSGi manifest generation from the changed `bnd.bnd` but not installation into a running bundle. The built jar's manifest carries `Bundle-Version: 1.2.0`.

Structural Smoke selected `ModulesStructureTest` alone, on the `bnd.bnd` basename, and reported `tests="8" failures="0" errors="0"`.

<!-- pr-check {"result":"success","sha":"a874413f463a6ddf3490659e2991e7b5e62b8508"} -->
