### PR TITLE
LPD-101956 Partially revert the slow paginated picker hint tests

### DIFF
--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/tests/ObjectRelationship/SelectObjectDefinition.spec.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/tests/ObjectRelationship/SelectObjectDefinition.spec.tsx
@@ -4,7 +4,7 @@
  */
 
 import '@testing-library/jest-dom';
-import {fireEvent, render, screen, waitFor} from '@testing-library/react';
+import {render, screen, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
@@ -177,20 +177,6 @@ describe('SelectObjectDefinition', () => {
 		).toBeInTheDocument();
 	});
 
-	it('renders the hint while more object definitions can be loaded', async () => {
-		mockPage({lastPage: 10, once: false, totalCount: 200});
-
-		renderSelectObjectDefinition();
-
-		await waitFor(() => expect(global.fetch).toHaveBeenCalled());
-
-		await openMenu();
-
-		expect(
-			await screen.findByText(/Showing \d+ of 200 Items/)
-		).toBeInTheDocument();
-	});
-
 	it('requests object definitions with the context path prefixed', async () => {
 		(Liferay.ThemeDisplay.getPathContext as jest.Mock).mockReturnValueOnce(
 			'/myportal'
@@ -249,45 +235,5 @@ describe('SelectObjectDefinition', () => {
 		await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(3));
 
 		expect(getRequestedURL(2)).toContain('page=1');
-	});
-
-	it('updates the hint when the search is cleared', async () => {
-		mockPage({items: [OBJECT_DEFINITION], lastPage: 10, totalCount: 200});
-
-		renderSelectObjectDefinition();
-
-		await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
-
-		mockPage({
-			items: [OBJECT_DEFINITION],
-			lastPage: 1,
-			once: false,
-			totalCount: 1,
-		});
-
-		await userEvent.type(
-			screen.getByPlaceholderText('search-for-an-object-definition'),
-			'Alpha'
-		);
-
-		expect(
-			await screen.findByText('Showing 1 of 1 Items')
-		).toBeInTheDocument();
-
-		mockPage({
-			items: [OBJECT_DEFINITION],
-			lastPage: 10,
-			once: false,
-			totalCount: 200,
-		});
-
-		fireEvent.change(
-			screen.getByPlaceholderText('search-for-an-object-definition'),
-			{target: {value: ''}}
-		);
-
-		expect(
-			await screen.findByText(/Showing \d+ of 200 Items/)
-		).toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101956

## What Is Being Fixed

`411b4d887cc65` (LPD-101956) landed on master on 2026-09-02 at 12:50Z and grew `modules/apps/object/object-web/src/main/resources/META-INF/resources/js/tests/ObjectRelationship/SelectObjectDefinition.spec.tsx` from two tests to nine. Two of the seven new tests, `renders the hint while more object definitions can be loaded` and `updates the hint when the search is cleared`, wait out the picker's search debounce and then re-render the paginated autocomplete several times over. Each one costs over a second on an idle machine, where every other test in the spec costs a few hundred milliseconds.

On the shared js-unit axis every module's Jest suite runs in parallel against a single node, and there the two tests overrun Jest's 5000 ms per-test default in about half the runs. Of the thirteen pull request runs from 2026-09-02 whose build reports carry the new spec, seven failed on `Exceeded timeout of 5000 ms for a test` and six passed. The six that passed never passed comfortably: the two tests finished at 2928-3779 ms and 3668-4651 ms, leaving as little as 349 ms of headroom, while every other test in the spec finished in 205-1437 ms. Passing and failing runs differ only in how loaded the axis was — in the failing runs every test in the spec is slower, so these two are not flaky in isolation, they are simply sized too close to the limit.

This is not confined to PR branches. Testray imports the whole object-web Jest suite as one case, `:apps:object:object-web:packageRunTest`, and that case went from 51 passes and no failures on 2026-09-01 to 13 failures on 2026-09-02, with neither hint test title appearing anywhere in its history before that day — the first named occurrence is 2026-09-02T16:13:25Z.

The Brian origin syncing job is now blocked by the same timeout. `test-portal-testsuite-upstream(master)` runs ci:test:stable, and two of its runs have lost the hint tests: `test-1-43 #1332` at git hash `cc9401150b35` (16:08Z) failed both of them, at 5299 ms and 5581 ms, and `test-1-42 #1450` at git hash `f4d59b62550451` (started 19:09Z, downstream `test-1-47 #189069`) failed `updates the hint when the search is cleared` at 5813 ms. So this is holding up the syncing job on master code, not only individual pull requests.

Every failing run, the two syncing-job runs included. The seven-of-thirteen count above covers the pull request runs alone, so the two syncing-job rows are extra to it.

| Axis start (UTC) | Suite | PR | Build | Tested SHA | Failing tests |
| --- | --- | --- | --- | --- | --- |
| 2026-09-02 14:37Z | ci:test:object | 12613 | test-1-43 #1718 | `b6131fb89fb24` | both hint tests, 5271 / 6079 ms |
| 2026-09-02 14:41Z | ci:test:object | 12700 | test-1-41 #159 | `381c0c6778c2f` | both hint tests, 5960 / 5842 ms |
| 2026-09-02 14:47Z | ci:test:object | 12709 | test-1-48 #1568 | `5d790c0b75b44` | both hint tests, 5704 / 5910 ms |
| 2026-09-02 15:41Z | ci:test:object | 12718 | test-1-44 #1778 | `c8affd8425df6` | both hint tests, 5913 / 6381 ms |
| 2026-09-02 15:42Z | ci:test:stable | 12703 | test-1-45 #1733 | `a2de83f8b73fe` | `updates the hint when the search is cleared`, 5603 ms |
| 2026-09-02 16:08Z | ci:test:stable (syncing job) | — | test-1-43 #1332 | `cc9401150b35` | both hint tests, 5299 / 5581 ms |
| 2026-09-02 17:30Z | ci:test:object | 12720 | test-1-48 #1569 | `b530052703d40` | both hint tests, 5597 / 5543 ms |
| 2026-09-02 18:51Z | ci:test:stable | 12724 | test-1-48 #1570 | `013dd9a675621` | both hint tests, 5657 / 6078 ms |
| 2026-09-02 19:09Z | ci:test:stable (syncing job) | — | test-1-42 #1450 | `f4d59b62550451` | `updates the hint when the search is cleared`, 5813 ms |

## How It Is Being Fixed

This is a partial revert of `411b4d887cc65`. Only the two hint tests are removed, along with the `fireEvent` import they were the last user of. The other seven tests that commit added cover the same paginated picker and stay, as does its change to `modules/test/playwright/tests/object/relationship/objectRelationship.spec.ts`.

Two cheaper shapes were tried first and neither held. Fake timers made the two tests worse on the axis rather than better, and reducing the interactions still left them within a few hundred milliseconds of the limit once the axis was loaded, which is not enough headroom.

The seven remaining tests were measured alone and then again pinned to a single core against three busy loops, so roughly a 4x contention amplifier:

| Test | Alone | Amplified |
| --- | --- | --- |
| appends the next page when the menu asks for more | 504 ms | 1217 ms |
| discounts filtered object definitions from the hint | 337 ms | 467 ms |
| does not request more pages once the last page is loaded | 335 ms | 457 ms |
| keeps the hint once every object definition is loaded | 348 ms | 453 ms |
| requests object definitions with the context path prefixed | 310 ms | 328 ms |
| requests object definitions without a prefix at the root context | 308 ms | 318 ms |
| starts from the first page each time it is mounted | 722 ms | 1155 ms |

The slowest of them reaches 1217 ms under the amplifier, roughly a quarter of the budget, which is the headroom the two removed tests never had. The whole object-web Jest module passes locally: 54 suites, 346 tests. On CI, the `js-unit/0/0` axis of a self-CI run over this exact tree came back SUCCESS, completed 2026-09-02 at 20:45:59Z.

@larissacribeiro — the coverage these two tests add is worth having, so please redo them in a faster shape rather than leaving them out. What makes them expensive is the real debounce wait plus repeatedly re-rendering the paginated autocomplete to walk through pages; asserting the hint against a directly supplied page state, or driving the search through the component's own handler instead of a timed debounce, should get the same assertions well inside the 5000 ms budget even on a fully loaded shared axis. Aim for the few-hundred-millisecond range the other seven tests sit in, since anything above about two seconds alone has been overrunning under CI contention. Happy to hand over the measurements behind the tables above, including the per-test durations from each CI run and the local amplifier harness, if that helps you size the replacement.

## PR Check

**pr-check: PASS** — tested on `0fdaceba0ecec9ed8546de5b0ed5430e71a09d56`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| HTML Escaping | PASS |
| Per-Module Compile | PASS (packageRunBuild; deploy prohibited in this workspace) |
| Baseline | PASS (baseline-all + seven Ant projects + 0 changed exporting modules) |
| JavaScript Unit Tests | PASS |

Source Format ran both formatters clean. The yarn side ran rather than being skipped, since the diff is a `.tsx`: `Checking 2 TypeScript projects...` then `SUCCESS: Everything is correctly formatted.`, and `validate.commit.messages=true` was confirmed present in the `SourceFormatter` argv. Nothing was autocommitted because nothing needed fixing.

Per-Module Compile ran `:apps:object:object-web:packageRunBuild` in place of `:deploy`, which is prohibited in this workspace; the deploy set is the one module `apps:object:object-web`, derived from the changed file's nearest ancestor `bnd.bnd`. `BUILD SUCCESSFUL in 9s`, `3 actionable tasks: 3 executed`, with no `UP-TO-DATE` on the task. That the build genuinely re-read the branch content was proved rather than assumed: the staged copy under `build/node/packageRunBuild/resources` still contained a deleted test name before the run and no longer did after it. There is no consumer expansion to make, since the diff has no `.java` and removes no `public` or `protected` member, and no lockfile check to make, since the diff touches no `package.json` and no lockfile. The spec is staged as a verbatim source copy but is not in the production entry graph, so this validation covers the module still building and leaves the spec's own type-checking and execution to Source Format and JavaScript Unit Tests.

Baseline compared the whole repository and both halves it can be held to. `baseline-all` reported one finding, and it is **inherited** rather than the branch's: `apps:design-library:design-library-api` failed on `Semantic versioning is incorrect`, with `[Baseline Warning] Bundle Version Change Recommended: 1.2.0` against a `Bundle-Version` of `1.1.1` in `modules/apps/design-library/design-library-api/bnd.bnd`. That module is outside the branch diff, so the bump belongs to its owner; the file was restored to `1.1.1` and nothing was committed. All seven Ant projects were then confirmed standalone with `--rerun`, each printing `> Task :baseline` and `1 actionable task: 1 executed`. The count of changed exporting modules is 0, confirmed rather than assumed: the one changed file's nearest ancestor `bnd.bnd` is `modules/apps/object/object-web/bnd.bnd`, which carries no `Export-Package:` line. The Local Version Check passes with nothing to gate on — the diff has no `.java`, adds and removes no `public` or `protected` line, and touches no `packageinfo` or `bnd.bnd`.

JavaScript Unit Tests ran the changed module's full suite, `modules/apps/object/object-web`, all 54 `testMatch` specs and no spec selected by name: `Test Suites: 54 passed, 54 total` and `Tests: 346 passed, 346 total`. The spec this branch changes passes as `PASS src/main/resources/META-INF/resources/js/tests/ObjectRelationship/SelectObjectDefinition.spec.tsx`, and a verbose run of it confirms it now holds exactly seven tests, finishing at 311-739 ms each, with both deleted titles absent from the output. There are no cross-module consumers to sweep: nothing declares `@liferay/object-web` in its `dependencies` or `devDependencies`. The stale stub list sweep does not apply, confirmed rather than assumed, since the diff adds no dependency and touches no `package.json` or lockfile.

<!-- pr-check {"result": "success", "sha": "0fdaceba0ecec9ed8546de5b0ed5430e71a09d56"} -->
