### PR TITLE
LPD-104508 Await the reloads that follow object saves and deletes in Playwright

### DIFF
--- a/modules/test/playwright/pages/object-web/ViewObjectDefinitionsPage.ts
+++ b/modules/test/playwright/pages/object-web/ViewObjectDefinitionsPage.ts
@@ -173,7 +173,20 @@ export class ViewObjectDefinitionsPage {
 
 		await modal.getByRole('textbox').fill(name);
 
+		const reloadResponse = this.page.waitForResponse(
+			(response) =>
+				response
+					.url()
+					.includes('/o/object-admin/v1.0/object-definitions?') &&
+				response.request().method() === 'GET' &&
+				response.status() === 200
+		);
+
 		await modal.getByRole('button', {exact: true, name: 'Delete'}).click();
+
+		const response = await reloadResponse;
+
+		await response.finished();
 	}
 
 	async deleteObjectFolder(objectFolderName: string) {

--- a/modules/test/playwright/pages/object-web/object-details/EditObjectDetailsPage.ts
+++ b/modules/test/playwright/pages/object-web/object-details/EditObjectDetailsPage.ts
@@ -130,6 +130,17 @@ export class EditObjectDetailsPage {
 		await this.saveButton.click();
 	}
 
+	async saveObjectDefinitionReturningReload() {
+		const reload = this.page.waitForNavigation({
+			timeout: 10000,
+			waitUntil: 'load',
+		});
+
+		await this.saveButton.click();
+
+		return {reload};
+	}
+
 	async selectEntryTitleField(fieldName: string) {
 		await this.entryTitleFieldCombobox.click();
 

--- a/modules/test/playwright/pages/object-web/object-relationship/ObjectRelationshipsPage.ts
+++ b/modules/test/playwright/pages/object-web/object-relationship/ObjectRelationshipsPage.ts
@@ -103,7 +103,11 @@ export class ObjectRelationshipsPage {
 
 		await modal.getByRole('textbox').fill(name);
 
+		const reload = this.page.waitForEvent('load', {timeout: 10000});
+
 		await modal.getByRole('button', {exact: true, name: 'Delete'}).click();
+
+		await reload;
 	}
 
 	async goto(objectDefinitionLabel: string, objectFolderLabel?: string) {

--- a/modules/test/playwright/tests/object-web/main/objectPermissions.spec.ts
+++ b/modules/test/playwright/tests/object-web/main/objectPermissions.spec.ts
@@ -229,12 +229,15 @@ test(
 
 			await editObjectDetailsPage.goto(parentObjectDefinition.name);
 
-			await editObjectDetailsPage.saveButton.click();
+			const {reload: detailsReload} =
+				await editObjectDetailsPage.saveObjectDefinitionReturningReload();
 
 			await waitForAlert(
 				page,
 				'Success:The object was saved successfully.'
 			);
+
+			await detailsReload;
 		});
 
 		const gotoRelationshipTab = async () => {

--- a/modules/test/playwright/tests/object-web/upgrade/objectUpgrade.spec.ts
+++ b/modules/test/playwright/tests/object-web/upgrade/objectUpgrade.spec.ts
@@ -97,7 +97,10 @@ test.describe.serial('View Custom Object1 after upgrade', () => {
 				'Custom Objects1 Updated'
 			);
 
-			await editObjectDetailsPage.saveObjectDefinition();
+			const {reload} =
+				await editObjectDetailsPage.saveObjectDefinitionReturningReload();
+
+			await reload;
 
 			await expect(editObjectDetailsPage.labelInput).toHaveValue(
 				'Custom Object1 Updated'


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-104508

## What Is Being Fixed

Three Playwright helpers under `modules/test/playwright` returned before the page they act on had finished its own asynchronous work, and every caller then either navigated away or ended the test while that work was still in flight.

Saving the object details form shows its success toast and then reloads the page from a one second timer. The permissions test that manages related entries without control panel access saved the parent definition, returned on the toast, created a user through the API, and navigated to the logout URL. When that navigation was still in flight as the timer fired, the reload cancelled it and the test failed at the logout with either `page.goto` `ERR_ABORTED` or a navigation to the details page interrupting the logout, depending on which phase of the race the browser was in.

The upgrade test that edits an object definition saved it with the same bare details save and returned on the input showing the new label, leaving the page's timed reload pending. The save's own response and the timed reload's requests were then cut off by the fixture teardown, and the portal logged the aborted response as an error: `ExceptionMapper` "Broken pipe" followed by `TransactionContainerRequestFilter` "Unable to roll back the transaction".

Deleting an object definition from the definitions list swaps the data set for a loading indicator, waits 200 ms and mounts the data set again, which fetches the definitions page anew. The delete helper returned as soon as the confirm button was clicked, so a test that asserted the deleted row is hidden passed against the loading indicator and ended while that fetch was still streaming. When the test was the last in its spec, the fixture teardown closed the page mid response and the portal logged the same aborted write. Deleting a relationship from the relationships tab has the same shape with a full page reload from a 1.5 second timer, and the upgrade spec navigates away right after it.

The upgrade batches now run the log assertor and fail on any error, so both aborted writes ended the axis red even though all twelve tests passed.

## How It Is Being Fixed

Three barriers, one per helper.

The details page object offers `saveObjectDefinitionReturningReload`, which arms the pending reload navigation before clicking save and hands it back, in the same shape as the object layouts page's save. The permissions test awaits that reload after the toast so the step ends with no navigation pending, and the upgrade spec saves through the same helper and awaits it, so nothing of the page's own is left when the test ends.

The definition delete helper arms the definitions page request before confirming and awaits the response to the end, so the row assertion runs against the reloaded data set and nothing of the page's own is in flight when the helper returns.

The relationship delete helper awaits the page load that the timer reload produces.

Verification: with the logout response delayed by 2.5 seconds so the timer always fires mid navigation, the permissions race failed three of three attempts before the change and passed three of three after it. The details save abort was modelled on an isolated bundle, where saving with the bare click and navigating away produced four "Broken pipe" errors and two HTTP 500 responses in four attempts, and saving through the reload helper produced none in four. The delete producer never reproduced locally, because the definitions listing completes in about 25 ms on an idle machine, and it was pinned from the upgrade axis log instead. With both fixes present the `playwright-js-tomcat101-postgresql163/10/0` upgrade axis is green on shuyangzhou#12709 and on shuyangzhou#12700 (55 of 55), and each branch was green on its own run, shuyangzhou#12715 and shuyangzhou#12726. Every run without both fixes failed that axis on `PortalLogAssertorTest` "Broken pipe".

## PR Check

**pr-check: PASS** — tested on `35360f1817a1f3dc7b99a0bab1cbf7ccc8a0c837`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| HTML Escaping | PASS |
| Per-Module Compile | PASS (TypeScript type-check, substituted for an empty OSGi deploy set) |
| Baseline | NOT VERIFIED |
| JavaScript Unit Tests | NOT VERIFIED |

Per-Module Compile derived an empty OSGi deploy set. Every changed file is a `.ts` under `modules/test/playwright`, which carries no `bnd.bnd` at any ancestor up to `modules/` and produces no runtime bundle, so `deploy` had nothing to run. A TypeScript type-check stood in for it: `tsc` 4.7.4 `--noEmit -p tsconfig.json` over a 2682 file program that includes all five changed files, exit 0 with no `error TS` line. A deliberately broken probe file in the same project exited 2 with `error TS2322`, which confirms the check can see an error rather than silently skipping. The diff changes no `package.json` and no lockfile, so the lockfile check had nothing to reconcile against `modules/yarn.lock`.

Baseline verified nothing. The diff is five `.ts` files and nothing else, with no `.java`, no `bnd.bnd`, no `packageinfo`, and no `.gradle`, so the branch changes no exported package and can own no finding, and the Local Version Check has no input to read. `baseline-all` was not run, so no inherited finding from the exporting modules the branch never touched is reported either.

JavaScript Unit Tests verified nothing. The changed module `modules/test/playwright` has no Jest suite and no Jest configuration; its `test` script is `playwright test`, and Playwright execution is outside pr-check's scope. No module declares `@liferay/playwright` in `dependencies` or `devDependencies`, so the cross module consumer sweep is empty, and with no `package.json` change the stale stub list sweep does not apply.

<!-- pr-check {"result":"success","sha":"35360f1817a1f3dc7b99a0bab1cbf7ccc8a0c837"} -->
