### PR TITLE
LPD-104511 Run semantic versioning in the stable suite

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -909,7 +909,6 @@
         modules-unit,\
         playwright-js-tomcat101-hypersonic20,\
         playwright-js-tomcat101-postgresql163,\
-        semantic-versioning,\
         unit
 
     test.relevant.changes[relevant]=true
@@ -6995,6 +6994,7 @@
         playwright-js-smoke-tomcat101-hypersonic20,\
         playwright-js-tomcat101-postgresql163_stable,\
         rest-builder-and-service-builder,\
+        semantic-versioning,\
         unit_stable
 
     workspaces.names[workspaces-compile][stable]=\


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-104511

## What Is Being Fixed

The stable suite is what the Brian origin syncing job (`test-portal-testsuite-upstream(master)`, `ci:test:stable`) and the forwarding gates run, and it carried no `semantic-versioning` batch. A missing version bump could therefore only be caught by `ci:test:relevant` or by a local baseline, so anything that forwarded without relevant reached master with no exported package ever compared.

Two misses landed in the same week, and both had to be repaired by hand after the fact:

- A protected method removal in the exported `com.liferay.portal.db.partition.test.util` package forwarded on `ci:test:sf` alone. The upstream gate then ran eleven batches against that tree without comparing a single exported package.

- A `design-library-api` `Bundle-Version` miss followed the next day.

Both reached master, and both broke `ant baseline-all` and the `ci:test:object` semantic versioning axis for everyone until they were fixed.

## How It Is Being Fixed

`semantic-versioning` is added to `test.batch.names[stable]`, which puts the check in front of every sync and every forward that runs stable. `test.batch.names[relevant]` inherits `${test.batch.names[stable]}`, so its own explicit `semantic-versioning` entry becomes a duplicate and is dropped, leaving the one-entry form every other stable batch already has. The net diff is a single line.

The relevant suite is unaffected either way: `test.batch.names[stable-rule][relevant]` also expands `${test.batch.names[stable]}`, and `semantic-versioning-rule` already contributes the batch unconditionally through `modified.files.includes[semantic-versioning-rule][relevant]=**`.

The batch measured sixteen minutes of parallel time for the six hundred module baselines against a forty-nine minute critical path, so it does not extend the suite.

The wiring was proven on a self-CI pull request (shuyangzhou/liferay-portal#12703), which ran `ci:test:stable` on this change five times. The new batch fired on real debt sitting on the tested base rather than on a synthetic case:

- Its first stable run failed *uniquely* on the new batch, with `com.liferay.semantic.versioning.SemanticVersioningTest` `testSemanticVersioning[/apps/portal/portal-db-partition-test-util]` — precisely the miss that motivated the change, caught by the batch that did not exist before this commit.

- Two later runs failed on the new batch again, with `[Baseline Warning] Bundle Version Change Recommended: 190.0.0` followed by `build.xml:277: Semantic versioning is incorrect.`, a further piece of version debt on the base.

- The most recent run has `semantic-versioning/0/0` passing, so the batch is not permanently red once the base is clean. That run's failures are a `js-unit` `object-web` spec and two Playwright `PortalLogAssertorTest` axes, none of them the new batch.

The other stable batches were unaffected throughout, and the syncing job is green again, so adding the batch now introduces no known noise.

## PR Check

**pr-check: PASS** — tested on `50f68d10bc1ef7a10d951cbeb5debbbf3636a6f1`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Baseline | PASS (baseline-all + seven Ant projects + 0 changed exporting modules) |
| PQL Validation | PASS |

Source Format ran the Java side clean (`BUILD SUCCESSFUL`, no `SourceCheck:` violations) and legitimately skipped the yarn side: `portal-impl/build.xml` sets `skip.node.task` when no changed file matches the frontend regex in `build.properties`, and this diff changes only `test.properties`.

Baseline compared the whole repository. `ant baseline-all` reported `BUILD SUCCESSFUL` with no `Baseline Warning`, `VERSION INCREASE`, `PACKAGE ADDED`, or `PACKAGE REMOVED` row, and each of the seven Ant projects was confirmed with a standalone `baseline --rerun` printing `1 executed`. The branch changes no `.java`, no `bnd.bnd`, and no `packageinfo`, so it owns zero exporting modules and the Local Version Check has nothing to require.

PQL Validation executed `testValidatePQL` (`tests="1" skipped="0" failures="0" errors="0"`), which validates every `test.batch.run.property.query` expression in every `test.properties` in the repository. It confirms the query behind the `semantic-versioning` batch is valid; it does not itself assert on the `test.batch.names` list edit.

<!-- pr-check {"result":"success","sha":"50f68d10bc1ef7a10d951cbeb5debbbf3636a6f1"} -->
