### PR TITLE
LPD-104514 Never draw the string "null" as a four letter random id

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/util/StringUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/StringUtil.java
@@ -2179,9 +2179,11 @@ public class StringUtil {
 	}
 
 	/**
-	 * Returns a randomized string of four lower case, alphabetic characters.
+	 * Returns a randomized string of four lower case, alphabetic characters
+	 * that is never the literal <code>null</code>.
 	 *
 	 * @return a randomized string of four lower case, alphabetic characters
+	 *         that is never the literal <code>null</code>
 	 */
 	public static String randomId() {
 		return randomId(4);
@@ -2189,21 +2191,14 @@ public class StringUtil {
 
 	/**
 	 * Returns a randomized string with the length informed and only alphabetic
-	 * characters.
+	 * characters. A four character result is never the literal
+	 * <code>null</code>.
 	 *
 	 * @return a randomized string with the length informed and only alphabetic
 	 *         characters.
 	 */
 	public static String randomId(int length) {
-		Random random = new Random();
-
-		char[] chars = new char[length];
-
-		for (int i = 0; i < length; i++) {
-			chars[i] = (char)(CharPool.LOWER_CASE_A + random.nextInt(26));
-		}
-
-		return new String(chars);
+		return _randomId(length, new Random());
 	}
 
 	/**
@@ -4966,6 +4961,24 @@ public class StringUtil {
 		}
 
 		return Character.isWhitespace(c);
+	}
+
+	private static String _randomId(int length, Random random) {
+		char[] chars = new char[length];
+
+		while (true) {
+			for (int i = 0; i < length; i++) {
+				chars[i] = (char)(CharPool.LOWER_CASE_A + random.nextInt(26));
+			}
+
+			String randomId = new String(chars);
+
+			if ((length == 4) && randomId.equals(StringPool.NULL)) {
+				continue;
+			}
+
+			return randomId;
+		}
 	}
 
 	private static String _read(InputStream inputStream) throws IOException {

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/util/StringUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/util/StringUtilTest.java
@@ -8,6 +8,7 @@ package com.liferay.portal.kernel.util;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.randomizerbumpers.RandomizerBumper;
 import com.liferay.portal.kernel.test.rule.CodeCoverageAssertor;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -325,6 +326,46 @@ public class StringUtilTest {
 		Assert.assertEquals("%PATH%", StringUtil.quote("PATH", '%'));
 		Assert.assertEquals(
 			"Hello World Hello", StringUtil.quote(" World ", "Hello"));
+	}
+
+	@Test
+	public void testRandomIdNeverReturnsNull() {
+		int[] offsets = {
+			_getOffset('n'), _getOffset('u'), _getOffset('l'), _getOffset('l'),
+			_getOffset('a'), _getOffset('b'), _getOffset('c'), _getOffset('d')
+		};
+		int[] index = new int[1];
+
+		Random random = new Random() {
+
+			@Override
+			public int nextInt(int bound) {
+				return offsets[index[0]++];
+			}
+
+		};
+
+		String randomId = ReflectionTestUtil.invoke(
+			StringUtil.class, "_randomId",
+			new Class<?>[] {int.class, Random.class}, 4, random);
+
+		Assert.assertEquals(randomId, "abcd", randomId);
+
+		Assert.assertEquals(String.valueOf(index[0]), 8, index[0]);
+
+		index[0] = 0;
+
+		randomId = ReflectionTestUtil.invoke(
+			StringUtil.class, "_randomId",
+			new Class<?>[] {int.class, Random.class}, 5, random);
+
+		Assert.assertEquals(randomId, "nulla", randomId);
+
+		Assert.assertEquals(String.valueOf(index[0]), 5, index[0]);
+
+		randomId = StringUtil.randomId(4);
+
+		Assert.assertEquals(randomId, 4, randomId.length());
 	}
 
 	@Test
@@ -1271,6 +1312,10 @@ public class StringUtilTest {
 			StringUtil.wildcardMatches(
 				s, wildcard, CharPool.UNDERLINE, CharPool.PERCENT,
 				CharPool.BACK_SLASH, true));
+	}
+
+	private int _getOffset(char c) {
+		return c - CharPool.LOWER_CASE_A;
 	}
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-104514

## What Is Being Fixed

`StringUtil.randomId` draws a string of random lower case letters of the requested length, four by default, and `Validator.isNull` treats the literal string `null` as null. A four letter draw therefore spells `null` once in 456,976 draws, and any caller that hands the bare id to a `Validator.isNull` check sees it as absent.

An audit of the 383 `randomId` call sites found the four letter default used as a bare identifier in production, not only in tests:

- `PortalImpl.generateRandomKey` returns it on AJAX and isolated renders, and the captcha servlet declines to draw an image when the id spells `null`.
- `PortletIdCodec.encode` drops the instance separator for an instance id that spells `null`, so preferences and permissions land under the non instanced portlet id.
- The headless page definition resource puts it in a layout name that the layout name validation rejects.

The bare four letter default is also used at 228 test call sites. On the test side the same draw produced `ListTypeEntryKeyException` "Key is null" and `ObjectRelationshipNameException` "Name is null" in `ci:test:object` on 2026-09-02, and the same family appears on `release-2026.q3` on 2026-08-28.

Root cause: born broken in `ea5292b2e3aad` (LPS-35724, 2013-08-09), which introduced `randomId` without excluding the one four letter draw that `Validator.isNull` has treated as null since the repository's initial import `1175ea90c7156` (2006-04-21).

## How It Is Being Fixed

`randomId(int)` delegates to a private `_randomId(int, Random)` that redraws only when the length is four and the draw equals `StringPool.NULL`. A result of any other length cannot equal `null` and is returned exactly as drawn, so the contract changes for the default length alone, and the Javadoc on both overloads now documents it. No public or protected signature changes. Fixing it in `StringUtil` rather than at the call sites covers all of them at once.

`StringUtilTest.testRandomIdNeverReturnsNull` drives the draw with a `Random` that spells `n`, `u`, `l`, `l` on the first four draws and `a`, `b`, `c`, `d` on the next four, asserting the redraw discards the rejected draw, returns `abcd`, and consulted the `Random` eight times. It then resets the draw index and asserts a five letter id is returned exactly as drawn (`nulla`, five draws), so the redraw is pinned to the default length only. Red and green: with the guard disabled the test fails with `expected:<[abcd]> but was:<[null]>`; with the fix `StringUtilTest` runs 57 of 57 green.

The self CI run of the identical implementation, with an earlier test shape, on shuyangzhou/liferay-portal#12728 showed no failures beyond known master items.

## PR Check

**pr-check: PASS** — tested on `72e770f3c7965bc20de373f6bb1f72189ac5e42c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Service Registration | PASS |
| Transaction Usage | PASS |
| Full Portal Build | NOT VERIFIED |
| Cross-Module Compile | NOT VERIFIED |
| Baseline | PASS (baseline-all + seven Ant projects + 0 changed exporting modules) |
| Java Unit Tests | PASS |

Java Unit Tests ran the changed class's counterpart, `StringUtilTest`, from a deleted `test-results` tree against a freshly recompiled class: `Tests run: 57, Failures: 0, Errors: 0, Skipped: 0`, with `testRandomIdNeverReturnsNull` present and carrying no failure node. Disabling the guard and rerunning the same suite gives `Tests run: 57, Failures: 1` with `expected:<[abcd]> but was:<[null]>`, so the test is proven able to see the defect it guards.

Full Portal Build verified nothing. Its command is `ant all` (`clean` + `compile` + `deploy`), which cannot run in this checkout because its deploy pass writes into the bundle backing a live portal; the repository-root `ant compile` target is out of scope for the same reason, since it itself invokes `install-portal-snapshot` and a Gradle `deploy`. Substituted in its place: `portal-kernel` and `portal-impl` each compiled with their own `ant compile` (`Compiling 2 source files`, `BUILD SUCCESSFUL`, after the changed source's class file and the up-to-date stamp were removed so the compile could not be skipped), `javap` confirming the compiled class carries `private static java.lang.String _randomId(int, java.util.Random)` alongside both unchanged public `randomId` overloads, and `ant baseline-all` rebuilding all seven top-level Ant project jars through their `jar` target. The two modules carrying `.lfrbuild-portal-deprecated` were not compiled.

Cross-Module Compile verified nothing. `StringUtil` has 246 consumers on the two surfaces this validation compiles — 2 modules carrying `.lfrbuild-portal-deprecated` and 244 `-test` modules with `testIntegration` sources — so the cap of 8 skipped the expansion for every symbol; `StringUtilTest` has no module consumers. The cap rule recommends Full Portal Build plus Integration Test Compile, and neither ran: the former is unavailable here for the reason above, and the latter never fired because the diff touches no `modules/` path. What that leaves unexamined is bounded, since the change adds no public or protected member and so presents no consumer with a changed signature.

<!-- pr-check {"result": "success", "sha": "72e770f3c7965bc20de373f6bb1f72189ac5e42c"} -->
