### PR TITLE
LPD-104263 Show and save schedule dates in the user time zone

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/ScheduleField.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/ScheduleField.tsx
@@ -98,6 +98,7 @@ export default React.forwardRef(function ScheduleField(
 				<ClayDatePicker
 					aria-describedby={error}
 					dateFormat={dateConfig.clayFormat}
+					defaultMonth={toUserTimeZoneDate(new Date())}
 					disabled={checked}
 					firstDayOfWeek={dateUtils.getFirstDayOfWeek(
 						locale as Parameters<
@@ -152,19 +153,25 @@ export default React.forwardRef(function ScheduleField(
 });
 
 export function isPastDate(value: string) {
-	const timeZone = Liferay.ThemeDisplay.getTimeZone();
+	const date = moment(value, dateConfig.momentFormat, true);
 
-	const timeZoneDateTime = new Date(
-		new Date().toLocaleString('en-US', {
-			timeZone,
-		})
-	);
+	if (!date.isValid()) {
+		return false;
+	}
 
-	return timeZoneDateTime >= new Date(toServerFormat(value));
+	return date.valueOf() <= toUserTimeZoneDate(new Date()).getTime();
 }
 
 export function toMomentDate(value: string) {
 	return value ? moment(value).format(dateConfig.momentFormat) : '';
+}
+
+export function toPickerDate(value: string) {
+	return value
+		? moment(toUserTimeZoneDate(new Date(value))).format(
+				dateConfig.momentFormat
+			)
+		: '';
 }
 
 export function toServerFormat(value: string) {
@@ -175,4 +182,24 @@ export function toServerFormat(value: string) {
 
 export function toServerISOFormat(value: string) {
 	return toServerFormat(value).replace(' ', 'T');
+}
+
+export function toUTCISOFormat(value: string) {
+	const date = moment(value, dateConfig.momentFormat, true).toDate();
+
+	const offsetAt = (instant: Date) =>
+		toUserTimeZoneDate(instant).getTime() - instant.getTime();
+
+	const firstGuess = new Date(date.getTime() - offsetAt(date));
+	const utcDate = new Date(date.getTime() - offsetAt(firstGuess));
+
+	return `${utcDate.toISOString().slice(0, 19)}Z`;
+}
+
+function toUserTimeZoneDate(date: Date) {
+	return new Date(
+		date.toLocaleString('en-US', {
+			timeZone: Liferay.ThemeDisplay.getTimeZone(),
+		})
+	);
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/dashboard/governance/components/GovernanceHealth.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/dashboard/governance/components/GovernanceHealth.tsx
@@ -102,7 +102,7 @@ export function GovernanceHealth() {
 				{loadingStatistics ? (
 					<ClayLoadingIndicator size="sm" />
 				) : health ? (
-					<div className="align-items-baseline d-flex">
+					<div className="align-items-baseline d-flex mb-1">
 						<Text size={9} weight="bold">
 							{health.score}
 						</Text>

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/dashboard/performance/components/InteractiveCard.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/dashboard/performance/components/InteractiveCard.tsx
@@ -105,7 +105,7 @@ export default function InteractiveCard({
 			<div className="mt-2">
 				<div className="cms-dashboard__interactive-card__metric d-flex flex-column justify-content-center">
 					{loading ? (
-						<ClayLoadingIndicator size="sm" />
+						<ClayLoadingIndicator className="my-3" size="sm" />
 					) : !isNullOrUndefined(value) ? (
 						<MetricValue
 							textWeight="bold"

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/modal/ScheduleDateModalContent.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/modal/ScheduleDateModalContent.tsx
@@ -11,7 +11,8 @@ import React, {useRef, useState} from 'react';
 import ScheduleField, {
 	dateConfig,
 	isPastDate,
-	toMomentDate,
+	toPickerDate,
+	toUTCISOFormat,
 } from '../../content_editor/components/ScheduleField';
 
 interface ScheduleFieldRef {
@@ -49,7 +50,7 @@ export default function ScheduleDateModalContent({
 	const [field, setField] = useState({
 		error: '',
 		never: false,
-		value: toMomentDate(date),
+		value: toPickerDate(date),
 	});
 	const [saving, setSaving] = useState(false);
 
@@ -73,11 +74,7 @@ export default function ScheduleDateModalContent({
 		setSaving(true);
 
 		const success = await onSave(
-			field.never
-				? ''
-				: `${moment(field.value, dateConfig.momentFormat)
-						.utc()
-						.format('YYYY-MM-DDTHH:mm:ss')}Z`
+			field.never ? '' : toUTCISOFormat(field.value)
 		);
 
 		setSaving(false);

--- a/modules/apps/site/site-cms-site-initializer/test/js/content_editor/components/ScheduleField.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/content_editor/components/ScheduleField.test.tsx
@@ -10,6 +10,8 @@ import React from 'react';
 
 import ScheduleField, {
 	isPastDate,
+	toPickerDate,
+	toUTCISOFormat,
 } from '../../../../src/main/resources/META-INF/resources/js/content_editor/components/ScheduleField';
 
 const DATE_CONFIG = {
@@ -190,5 +192,81 @@ describe('isPastDate', () => {
 
 	it('flags an earlier time on the current day as past', () => {
 		expect(isPastDate('07/10/2026 07:00 AM')).toBe(true);
+	});
+
+	it('flags an instant that already passed when the account time zone is ahead of the browser one', () => {
+		global.Liferay.ThemeDisplay.getTimeZone = jest
+			.fn()
+			.mockReturnValue('Europe/Madrid');
+
+		expect(isPastDate(toPickerDate('2026-07-10T07:55:00Z'))).toBe(true);
+	});
+
+	it('does not flag an instant still to come when the account time zone is ahead of the browser one', () => {
+		global.Liferay.ThemeDisplay.getTimeZone = jest
+			.fn()
+			.mockReturnValue('Europe/Madrid');
+
+		expect(isPastDate(toPickerDate('2026-07-10T08:05:00Z'))).toBe(false);
+	});
+});
+
+describe('toPickerDate', () => {
+	beforeEach(() => {
+		global.Liferay.ThemeDisplay.getTimeZone = jest
+			.fn()
+			.mockReturnValue('UTC');
+	});
+
+	it('shows the stored instant in the account time zone instead of the browser one', () => {
+		global.Liferay.ThemeDisplay.getTimeZone = jest
+			.fn()
+			.mockReturnValue('Europe/Madrid');
+
+		expect(toPickerDate('2026-07-10T08:00:00Z')).toBe(
+			'07/10/2026 10:00 AM'
+		);
+	});
+
+	it('shows no date when the content never expires', () => {
+		expect(toPickerDate('')).toBe('');
+	});
+});
+
+describe('toUTCISOFormat', () => {
+	beforeEach(() => {
+		global.Liferay.ThemeDisplay.getTimeZone = jest
+			.fn()
+			.mockReturnValue('UTC');
+	});
+
+	it('reads the entered value in the account time zone', () => {
+		global.Liferay.ThemeDisplay.getTimeZone = jest
+			.fn()
+			.mockReturnValue('Europe/Madrid');
+
+		expect(toUTCISOFormat('07/10/2026 10:00 AM')).toBe(
+			'2026-07-10T08:00:00Z'
+		);
+	});
+
+	it('keeps the stored instant untouched when the value is not edited', () => {
+		global.Liferay.ThemeDisplay.getTimeZone = jest
+			.fn()
+			.mockReturnValue('Asia/Tokyo');
+
+		expect(toUTCISOFormat(toPickerDate('2026-01-15T23:45:00Z'))).toBe(
+			'2026-01-15T23:45:00Z'
+		);
+	});
+
+	it('keeps the stored instant untouched across the account time zone DST change', () => {
+		global.Liferay.ThemeDisplay.getTimeZone = jest
+			.fn()
+			.mockReturnValue('Pacific/Auckland');
+
+		expect(toUTCISOFormat(toPickerDate('2026-09-26T13:30:00Z'))).toBe(
+			'2026-09-26T13:30:00Z'
+		);
 	});
 });

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/governanceDashboard.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/governanceDashboard.spec.ts
@@ -30,9 +30,10 @@ const DATE_INPUT = '12/31/2099 10:00 AM';
 const DUE_DATE_INPUT = '2099-12-31';
 const DUE_TIME_INPUT = '10:00';
 const PAST_DATE = '2020-01-01T00:00:00Z';
-const TIME_ZONE = 'America/Los_Angeles';
+const TIME_ZONE_BROWSER = 'America/Los_Angeles';
+const TIME_ZONE_USER = 'UTC';
 
-test.use({timezoneId: TIME_ZONE});
+test.use({timezoneId: TIME_ZONE_BROWSER});
 
 async function fillScheduleDateModal(page: Page, date: string) {
 	const dateInput = page.locator('.modal input.form-control').first();
@@ -85,14 +86,14 @@ function getUpcomingDate(hour: number) {
 	return date.toISOString().replace(/\.\d{3}Z$/, 'Z');
 }
 
-function formatInTimeZone(date: string) {
+function formatInTimeZone(date: string, timeZone: string) {
 	return new Date(date).toLocaleString('en-US', {
 		day: '2-digit',
 		hour: '2-digit',
 		hour12: true,
 		minute: '2-digit',
 		month: '2-digit',
-		timeZone: TIME_ZONE,
+		timeZone,
 		year: 'numeric',
 	});
 }
@@ -138,7 +139,7 @@ async function pollDate(
 						String(objectEntryId)
 					);
 
-				return formatInTimeZone(objectEntry[fieldName]);
+				return formatInTimeZone(objectEntry[fieldName], TIME_ZONE_USER);
 			},
 			{timeout: 3000}
 		)
@@ -187,8 +188,8 @@ test.beforeEach(async ({apiHelpers, page}) => {
 
 test.describe('Attention Required section', () => {
 	test(
-		'Stores the review date the user picked in their own time zone',
-		{tag: '@LPD-98462'},
+		'Stores the review date the user picked in their account time zone rather than the browser one',
+		{tag: ['@LPD-98462', '@LPD-104263']},
 		async ({apiHelpers, page}) => {
 			const spaceName = `space ${getRandomString()}`;
 			const title = `overdue ${getRandomString()}`;
@@ -690,7 +691,10 @@ test.describe('Attention Required section', () => {
 							);
 
 						return workflowTask?.dateDue
-							? formatInTimeZone(workflowTask.dateDue)
+							? formatInTimeZone(
+									workflowTask.dateDue,
+									TIME_ZONE_BROWSER
+								)
 							: null;
 					})
 					.toBe(DATE_DISPLAYED);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-104263

Resent from https://github.com/brianchandotcom/liferay-portal/pull/181191, closed over the ordering and naming of the time zone constants in `governanceDashboard.spec.ts`. The only change since then is renaming `BROWSER_TIME_ZONE` and `USER_TIME_ZONE` to `TIME_ZONE_BROWSER` and `TIME_ZONE_USER`, so the block sorts alphabetically and both constants share their prefix.

## What Is Being Fixed

The Update Expiration Date and Update Review Date actions of the CMS lists worked in the browser's time zone while the content editor works in the account's time zone, which is also what the classic Web Content does and what `DateTimeObjectFieldBusinessType` applies on the server. The same content showed two different hours depending on the entry point, a date typed in the modal was stored shifted by the offset between both zones, and the past date validation compared "now" in one zone against a value typed in the other, so with a two hour offset it let a past date through and the bulk task failed afterwards with `ObjectEntryExpirationDateException`, which is the unexpected error reported in the ticket. Clay's "Select current date" button also wrote the browser's clock into the content editor field, which saved an expiration two hours in the future without any error.

## How It Is Being Fixed

The modals now convert between the stored instant and the account's wall clock in both directions: `toPickerDate` shows the stored date in the account's time zone and `toUTCISOFormat` reads the typed value in that same zone before sending it as UTC, measuring the offset twice so that a DST transition of the account's zone between the typed clock and the real instant does not shift the result by an hour. `isPastDate` compares the typed clock against the current clock in the account's time zone, so the inline error and the disabled Save button appear whenever the date is not in the future, before anything reaches the server. The content editor helpers (`toMomentDate`, `toServerFormat`, `toServerISOFormat`) are untouched, since the server already renders and parses that value in the account's zone. The picker receives `defaultMonth` with the current time in the account's zone, which is what Clay reads for the "Select current date" button, so it stops writing the browser's clock; that button still yields a value the validation rejects, because it truncates to the minute and an expiration date must be in the future, which matches how the classic Web Content refuses a past date. A second commit keeps the governance dashboard cards from changing height while they load.

The last commit adjusts the governance dashboard Playwright tests, which typed a date in these modals and expected the stored instant in the browser's time zone, to expect it in the account's time zone while the browser stays in America/Los_Angeles, so they now guard the difference between both. It also adds unit tests for the conversions, for the past date check when both zones differ, and for a stored instant that crosses the account's DST change.

## PR Check

**pr-check: PASS** — tested on `af5466cf25ad4`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| HTML Escaping | PASS |
| Per-Module Compile | PASS |
| Baseline | PASS |
| JavaScript Unit Tests | PASS |

Per-Module Compile built `apps:site:site-cms-site-initializer` with the `jar` task in place of `deploy`, since a live bundle is attached to the checkout; the resulting jar carries the change. The Playwright spec has no ancestor `bnd.bnd` and is not an OSGi module.

Baseline found one inherited warning outside the branch: `apps:portal:portal-db-partition-test-util` reports `VERSION INCREASE REQUIRED` 6.0.0 → 7.0.0 and `Bundle Version Change Recommended` 7.0.0, from a removed `protected static String getExportedPartitionName(long)` in `BaseDBPartitionTestCase` already on master. The repair was restored and not committed. The seven Ant projects each printed `1 executed`; `site-cms-site-initializer` exports no packages.

JavaScript Unit Tests ran the module's full suite (183 suites, 1086 tests) plus the three consumers whose specs import it: `site-pim-site-initializer` (16), `site-cmp-site-initializer` (298) and `site-dsr-site-initializer` (134).

<!-- pr-check {"result": "success", "sha": "af5466cf25ad4cb672a20fde0e519c990ad1037f"} -->
