### PR TITLE
LPD-104228 Look up display page templates across several groups

### DIFF
--- a/modules/apps/layout/layout-page-template-api/bnd.bnd
+++ b/modules/apps/layout/layout-page-template-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Layout Page Template API
 Bundle-SymbolicName: com.liferay.layout.page.template.api
-Bundle-Version: 38.0.1
+Bundle-Version: 38.1.0
 Export-Package:\
 	com.liferay.layout.page.template.constants,\
 	com.liferay.layout.page.template.exception,\

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateEntryService.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateEntryService.java
@@ -266,6 +266,23 @@ public interface LayoutPageTemplateEntryService extends BaseService {
 		OrderByComparator<LayoutPageTemplateEntry> orderByComparator);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<LayoutPageTemplateEntry> getLayoutPageTemplateEntries(
+		long[] groupIds, long classNameId, String classTypeKey, int type,
+		int status);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<LayoutPageTemplateEntry> getLayoutPageTemplateEntries(
+		long[] groupIds, long classNameId, String classTypeKey, int type,
+		int status, int start, int end,
+		OrderByComparator<LayoutPageTemplateEntry> orderByComparator);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<LayoutPageTemplateEntry> getLayoutPageTemplateEntries(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type, int status, int start, int end,
+		OrderByComparator<LayoutPageTemplateEntry> orderByComparator);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<LayoutPageTemplateEntry> getLayoutPageTemplateEntriesByType(
 		long groupId, long layoutPageTemplateCollectionId, int type, int start,
 		int end, OrderByComparator<LayoutPageTemplateEntry> orderByComparator);
@@ -336,6 +353,16 @@ public interface LayoutPageTemplateEntryService extends BaseService {
 		long groupId, String name, int[] types, int status);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public int getLayoutPageTemplateEntriesCount(
+		long[] groupIds, long classNameId, String classTypeKey, int type,
+		int status);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public int getLayoutPageTemplateEntriesCount(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type, int status);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getLayoutPageTemplateEntriesCountByType(
 		long groupId, long layoutPageTemplateCollectionId, int type);
 
@@ -389,4 +416,4 @@ public interface LayoutPageTemplateEntryService extends BaseService {
 		throws PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:220425949
+// LIFERAY-SERVICE-BUILDER-HASH:1740924047

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateEntryServiceUtil.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateEntryServiceUtil.java
@@ -412,6 +412,34 @@ public class LayoutPageTemplateEntryServiceUtil {
 			groupId, name, types, start, end, orderByComparator);
 	}
 
+	public static List<LayoutPageTemplateEntry> getLayoutPageTemplateEntries(
+		long[] groupIds, long classNameId, String classTypeKey, int type,
+		int status) {
+
+		return getService().getLayoutPageTemplateEntries(
+			groupIds, classNameId, classTypeKey, type, status);
+	}
+
+	public static List<LayoutPageTemplateEntry> getLayoutPageTemplateEntries(
+		long[] groupIds, long classNameId, String classTypeKey, int type,
+		int status, int start, int end,
+		OrderByComparator<LayoutPageTemplateEntry> orderByComparator) {
+
+		return getService().getLayoutPageTemplateEntries(
+			groupIds, classNameId, classTypeKey, type, status, start, end,
+			orderByComparator);
+	}
+
+	public static List<LayoutPageTemplateEntry> getLayoutPageTemplateEntries(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type, int status, int start, int end,
+		OrderByComparator<LayoutPageTemplateEntry> orderByComparator) {
+
+		return getService().getLayoutPageTemplateEntries(
+			groupIds, classNameId, classTypeKey, name, type, status, start, end,
+			orderByComparator);
+	}
+
 	public static List<LayoutPageTemplateEntry>
 		getLayoutPageTemplateEntriesByType(
 			long groupId, long layoutPageTemplateCollectionId, int type,
@@ -537,6 +565,22 @@ public class LayoutPageTemplateEntryServiceUtil {
 			groupId, name, types, status);
 	}
 
+	public static int getLayoutPageTemplateEntriesCount(
+		long[] groupIds, long classNameId, String classTypeKey, int type,
+		int status) {
+
+		return getService().getLayoutPageTemplateEntriesCount(
+			groupIds, classNameId, classTypeKey, type, status);
+	}
+
+	public static int getLayoutPageTemplateEntriesCount(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type, int status) {
+
+		return getService().getLayoutPageTemplateEntriesCount(
+			groupIds, classNameId, classTypeKey, name, type, status);
+	}
+
 	public static int getLayoutPageTemplateEntriesCountByType(
 		long groupId, long layoutPageTemplateCollectionId, int type) {
 
@@ -637,4 +681,4 @@ public class LayoutPageTemplateEntryServiceUtil {
 			LayoutPageTemplateEntryService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1008902933
+// LIFERAY-SERVICE-BUILDER-HASH:322937130

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateEntryServiceWrapper.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateEntryServiceWrapper.java
@@ -476,6 +476,39 @@ public class LayoutPageTemplateEntryServiceWrapper
 	}
 
 	@Override
+	public java.util.List<LayoutPageTemplateEntry> getLayoutPageTemplateEntries(
+		long[] groupIds, long classNameId, String classTypeKey, int type,
+		int status) {
+
+		return _layoutPageTemplateEntryService.getLayoutPageTemplateEntries(
+			groupIds, classNameId, classTypeKey, type, status);
+	}
+
+	@Override
+	public java.util.List<LayoutPageTemplateEntry> getLayoutPageTemplateEntries(
+		long[] groupIds, long classNameId, String classTypeKey, int type,
+		int status, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator
+			<LayoutPageTemplateEntry> orderByComparator) {
+
+		return _layoutPageTemplateEntryService.getLayoutPageTemplateEntries(
+			groupIds, classNameId, classTypeKey, type, status, start, end,
+			orderByComparator);
+	}
+
+	@Override
+	public java.util.List<LayoutPageTemplateEntry> getLayoutPageTemplateEntries(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type, int status, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator
+			<LayoutPageTemplateEntry> orderByComparator) {
+
+		return _layoutPageTemplateEntryService.getLayoutPageTemplateEntries(
+			groupIds, classNameId, classTypeKey, name, type, status, start, end,
+			orderByComparator);
+	}
+
+	@Override
 	public java.util.List<LayoutPageTemplateEntry>
 		getLayoutPageTemplateEntriesByType(
 			long groupId, long layoutPageTemplateCollectionId, int type,
@@ -626,6 +659,26 @@ public class LayoutPageTemplateEntryServiceWrapper
 	}
 
 	@Override
+	public int getLayoutPageTemplateEntriesCount(
+		long[] groupIds, long classNameId, String classTypeKey, int type,
+		int status) {
+
+		return _layoutPageTemplateEntryService.
+			getLayoutPageTemplateEntriesCount(
+				groupIds, classNameId, classTypeKey, type, status);
+	}
+
+	@Override
+	public int getLayoutPageTemplateEntriesCount(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type, int status) {
+
+		return _layoutPageTemplateEntryService.
+			getLayoutPageTemplateEntriesCount(
+				groupIds, classNameId, classTypeKey, name, type, status);
+	}
+
+	@Override
 	public int getLayoutPageTemplateEntriesCountByType(
 		long groupId, long layoutPageTemplateCollectionId, int type) {
 
@@ -744,4 +797,4 @@ public class LayoutPageTemplateEntryServiceWrapper
 	private LayoutPageTemplateEntryService _layoutPageTemplateEntryService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1502575075
+// LIFERAY-SERVICE-BUILDER-HASH:-1836737670

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/persistence/LayoutPageTemplateEntryPersistence.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/persistence/LayoutPageTemplateEntryPersistence.java
@@ -2185,6 +2185,52 @@ public interface LayoutPageTemplateEntryPersistence
 			<LayoutPageTemplateEntry> orderByComparator);
 
 	/**
+	 * Returns an ordered range of all the layout page template entries that the user has permission to view where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and type = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param type the type
+	 * @param start the lower bound of the range of layout page template entries
+	 * @param end the upper bound of the range of layout page template entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching layout page template entries that the user has permission to view
+	 */
+	public java.util.List<LayoutPageTemplateEntry> filterFindByG_C_C_T(
+		long[] groupIds, long classNameId, String classTypeKey, int type,
+		int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator
+			<LayoutPageTemplateEntry> orderByComparator);
+
+	/**
+	 * Returns an ordered range of all the layout page template entries where groupId = &#63; and classNameId = &#63; and classTypeKey = &#63; and type = &#63;, optionally using the finder cache.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param type the type
+	 * @param start the lower bound of the range of layout page template entries
+	 * @param end the upper bound of the range of layout page template entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching layout page template entries
+	 */
+	public java.util.List<LayoutPageTemplateEntry> findByG_C_C_T(
+		long[] groupIds, long classNameId, String classTypeKey, int type,
+		int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator
+			<LayoutPageTemplateEntry> orderByComparator,
+		boolean useFinderCache);
+
+	/**
 	 * Removes all the layout page template entries where groupId = &#63; and classNameId = &#63; and classTypeKey = &#63; and type = &#63; from the database.
 	 *
 	 * @param groupId the group ID
@@ -2208,6 +2254,18 @@ public interface LayoutPageTemplateEntryPersistence
 		long groupId, long classNameId, String classTypeKey, int type);
 
 	/**
+	 * Returns the number of layout page template entries where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and type = &#63;.
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param type the type
+	 * @return the number of matching layout page template entries
+	 */
+	public int countByG_C_C_T(
+		long[] groupIds, long classNameId, String classTypeKey, int type);
+
+	/**
 	 * Returns the number of layout page template entries that the user has permission to view where groupId = &#63; and classNameId = &#63; and classTypeKey = &#63; and type = &#63;.
 	 *
 	 * @param groupId the group ID
@@ -2218,6 +2276,18 @@ public interface LayoutPageTemplateEntryPersistence
 	 */
 	public int filterCountByG_C_C_T(
 		long groupId, long classNameId, String classTypeKey, int type);
+
+	/**
+	 * Returns the number of layout page template entries that the user has permission to view where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and type = &#63;.
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param type the type
+	 * @return the number of matching layout page template entries that the user has permission to view
+	 */
+	public int filterCountByG_C_C_T(
+		long[] groupIds, long classNameId, String classTypeKey, int type);
 
 	/**
 	 * Returns an ordered range of all the layout page template entries where groupId = &#63; and classNameId = &#63; and classTypeKey = &#63; and defaultTemplate = &#63;.
@@ -3084,6 +3154,149 @@ public interface LayoutPageTemplateEntryPersistence
 			<LayoutPageTemplateEntry> orderByComparator);
 
 	/**
+	 * Returns all the layout page template entries that the user has permission to view where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63;.
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param name the name
+	 * @param type the type
+	 * @return the matching layout page template entries that the user has permission to view
+	 */
+	public java.util.List<LayoutPageTemplateEntry> filterFindByG_C_C_LikeN_T(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type);
+
+	/**
+	 * Returns a range of all the layout page template entries that the user has permission to view where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param name the name
+	 * @param type the type
+	 * @param start the lower bound of the range of layout page template entries
+	 * @param end the upper bound of the range of layout page template entries (not inclusive)
+	 * @return the range of matching layout page template entries that the user has permission to view
+	 */
+	public java.util.List<LayoutPageTemplateEntry> filterFindByG_C_C_LikeN_T(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the layout page template entries that the user has permission to view where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param name the name
+	 * @param type the type
+	 * @param start the lower bound of the range of layout page template entries
+	 * @param end the upper bound of the range of layout page template entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching layout page template entries that the user has permission to view
+	 */
+	public java.util.List<LayoutPageTemplateEntry> filterFindByG_C_C_LikeN_T(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator
+			<LayoutPageTemplateEntry> orderByComparator);
+
+	/**
+	 * Returns all the layout page template entries where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param name the name
+	 * @param type the type
+	 * @return the matching layout page template entries
+	 */
+	public java.util.List<LayoutPageTemplateEntry> findByG_C_C_LikeN_T(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type);
+
+	/**
+	 * Returns a range of all the layout page template entries where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param name the name
+	 * @param type the type
+	 * @param start the lower bound of the range of layout page template entries
+	 * @param end the upper bound of the range of layout page template entries (not inclusive)
+	 * @return the range of matching layout page template entries
+	 */
+	public java.util.List<LayoutPageTemplateEntry> findByG_C_C_LikeN_T(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the layout page template entries where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param name the name
+	 * @param type the type
+	 * @param start the lower bound of the range of layout page template entries
+	 * @param end the upper bound of the range of layout page template entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching layout page template entries
+	 */
+	public java.util.List<LayoutPageTemplateEntry> findByG_C_C_LikeN_T(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator
+			<LayoutPageTemplateEntry> orderByComparator);
+
+	/**
+	 * Returns an ordered range of all the layout page template entries where groupId = &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63;, optionally using the finder cache.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param name the name
+	 * @param type the type
+	 * @param start the lower bound of the range of layout page template entries
+	 * @param end the upper bound of the range of layout page template entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching layout page template entries
+	 */
+	public java.util.List<LayoutPageTemplateEntry> findByG_C_C_LikeN_T(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator
+			<LayoutPageTemplateEntry> orderByComparator,
+		boolean useFinderCache);
+
+	/**
 	 * Removes all the layout page template entries where groupId = &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63; from the database.
 	 *
 	 * @param groupId the group ID
@@ -3111,6 +3324,20 @@ public interface LayoutPageTemplateEntryPersistence
 		int type);
 
 	/**
+	 * Returns the number of layout page template entries where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63;.
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param name the name
+	 * @param type the type
+	 * @return the number of matching layout page template entries
+	 */
+	public int countByG_C_C_LikeN_T(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type);
+
+	/**
 	 * Returns the number of layout page template entries that the user has permission to view where groupId = &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63;.
 	 *
 	 * @param groupId the group ID
@@ -3122,6 +3349,20 @@ public interface LayoutPageTemplateEntryPersistence
 	 */
 	public int filterCountByG_C_C_LikeN_T(
 		long groupId, long classNameId, String classTypeKey, String name,
+		int type);
+
+	/**
+	 * Returns the number of layout page template entries that the user has permission to view where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63;.
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param name the name
+	 * @param type the type
+	 * @return the number of matching layout page template entries that the user has permission to view
+	 */
+	public int filterCountByG_C_C_LikeN_T(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
 		int type);
 
 	/**
@@ -3209,6 +3450,54 @@ public interface LayoutPageTemplateEntryPersistence
 			<LayoutPageTemplateEntry> orderByComparator);
 
 	/**
+	 * Returns an ordered range of all the layout page template entries that the user has permission to view where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and type = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param type the type
+	 * @param status the status
+	 * @param start the lower bound of the range of layout page template entries
+	 * @param end the upper bound of the range of layout page template entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching layout page template entries that the user has permission to view
+	 */
+	public java.util.List<LayoutPageTemplateEntry> filterFindByG_C_C_T_S(
+		long[] groupIds, long classNameId, String classTypeKey, int type,
+		int status, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator
+			<LayoutPageTemplateEntry> orderByComparator);
+
+	/**
+	 * Returns an ordered range of all the layout page template entries where groupId = &#63; and classNameId = &#63; and classTypeKey = &#63; and type = &#63; and status = &#63;, optionally using the finder cache.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param type the type
+	 * @param status the status
+	 * @param start the lower bound of the range of layout page template entries
+	 * @param end the upper bound of the range of layout page template entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching layout page template entries
+	 */
+	public java.util.List<LayoutPageTemplateEntry> findByG_C_C_T_S(
+		long[] groupIds, long classNameId, String classTypeKey, int type,
+		int status, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator
+			<LayoutPageTemplateEntry> orderByComparator,
+		boolean useFinderCache);
+
+	/**
 	 * Removes all the layout page template entries where groupId = &#63; and classNameId = &#63; and classTypeKey = &#63; and type = &#63; and status = &#63; from the database.
 	 *
 	 * @param groupId the group ID
@@ -3236,6 +3525,20 @@ public interface LayoutPageTemplateEntryPersistence
 		int status);
 
 	/**
+	 * Returns the number of layout page template entries where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and type = &#63; and status = &#63;.
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param type the type
+	 * @param status the status
+	 * @return the number of matching layout page template entries
+	 */
+	public int countByG_C_C_T_S(
+		long[] groupIds, long classNameId, String classTypeKey, int type,
+		int status);
+
+	/**
 	 * Returns the number of layout page template entries that the user has permission to view where groupId = &#63; and classNameId = &#63; and classTypeKey = &#63; and type = &#63; and status = &#63;.
 	 *
 	 * @param groupId the group ID
@@ -3247,6 +3550,20 @@ public interface LayoutPageTemplateEntryPersistence
 	 */
 	public int filterCountByG_C_C_T_S(
 		long groupId, long classNameId, String classTypeKey, int type,
+		int status);
+
+	/**
+	 * Returns the number of layout page template entries that the user has permission to view where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and type = &#63; and status = &#63;.
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param type the type
+	 * @param status the status
+	 * @return the number of matching layout page template entries that the user has permission to view
+	 */
+	public int filterCountByG_C_C_T_S(
+		long[] groupIds, long classNameId, String classTypeKey, int type,
 		int status);
 
 	/**
@@ -3559,6 +3876,156 @@ public interface LayoutPageTemplateEntryPersistence
 			<LayoutPageTemplateEntry> orderByComparator);
 
 	/**
+	 * Returns all the layout page template entries that the user has permission to view where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63; and status = &#63;.
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param name the name
+	 * @param type the type
+	 * @param status the status
+	 * @return the matching layout page template entries that the user has permission to view
+	 */
+	public java.util.List<LayoutPageTemplateEntry> filterFindByG_C_C_LikeN_T_S(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type, int status);
+
+	/**
+	 * Returns a range of all the layout page template entries that the user has permission to view where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param name the name
+	 * @param type the type
+	 * @param status the status
+	 * @param start the lower bound of the range of layout page template entries
+	 * @param end the upper bound of the range of layout page template entries (not inclusive)
+	 * @return the range of matching layout page template entries that the user has permission to view
+	 */
+	public java.util.List<LayoutPageTemplateEntry> filterFindByG_C_C_LikeN_T_S(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type, int status, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the layout page template entries that the user has permission to view where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param name the name
+	 * @param type the type
+	 * @param status the status
+	 * @param start the lower bound of the range of layout page template entries
+	 * @param end the upper bound of the range of layout page template entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching layout page template entries that the user has permission to view
+	 */
+	public java.util.List<LayoutPageTemplateEntry> filterFindByG_C_C_LikeN_T_S(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type, int status, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator
+			<LayoutPageTemplateEntry> orderByComparator);
+
+	/**
+	 * Returns all the layout page template entries where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param name the name
+	 * @param type the type
+	 * @param status the status
+	 * @return the matching layout page template entries
+	 */
+	public java.util.List<LayoutPageTemplateEntry> findByG_C_C_LikeN_T_S(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type, int status);
+
+	/**
+	 * Returns a range of all the layout page template entries where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param name the name
+	 * @param type the type
+	 * @param status the status
+	 * @param start the lower bound of the range of layout page template entries
+	 * @param end the upper bound of the range of layout page template entries (not inclusive)
+	 * @return the range of matching layout page template entries
+	 */
+	public java.util.List<LayoutPageTemplateEntry> findByG_C_C_LikeN_T_S(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type, int status, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the layout page template entries where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param name the name
+	 * @param type the type
+	 * @param status the status
+	 * @param start the lower bound of the range of layout page template entries
+	 * @param end the upper bound of the range of layout page template entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching layout page template entries
+	 */
+	public java.util.List<LayoutPageTemplateEntry> findByG_C_C_LikeN_T_S(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type, int status, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator
+			<LayoutPageTemplateEntry> orderByComparator);
+
+	/**
+	 * Returns an ordered range of all the layout page template entries where groupId = &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63; and status = &#63;, optionally using the finder cache.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param name the name
+	 * @param type the type
+	 * @param status the status
+	 * @param start the lower bound of the range of layout page template entries
+	 * @param end the upper bound of the range of layout page template entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching layout page template entries
+	 */
+	public java.util.List<LayoutPageTemplateEntry> findByG_C_C_LikeN_T_S(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type, int status, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator
+			<LayoutPageTemplateEntry> orderByComparator,
+		boolean useFinderCache);
+
+	/**
 	 * Removes all the layout page template entries where groupId = &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63; and status = &#63; from the database.
 	 *
 	 * @param groupId the group ID
@@ -3588,6 +4055,21 @@ public interface LayoutPageTemplateEntryPersistence
 		int type, int status);
 
 	/**
+	 * Returns the number of layout page template entries where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63; and status = &#63;.
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param name the name
+	 * @param type the type
+	 * @param status the status
+	 * @return the number of matching layout page template entries
+	 */
+	public int countByG_C_C_LikeN_T_S(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type, int status);
+
+	/**
 	 * Returns the number of layout page template entries that the user has permission to view where groupId = &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63; and status = &#63;.
 	 *
 	 * @param groupId the group ID
@@ -3600,6 +4082,21 @@ public interface LayoutPageTemplateEntryPersistence
 	 */
 	public int filterCountByG_C_C_LikeN_T_S(
 		long groupId, long classNameId, String classTypeKey, String name,
+		int type, int status);
+
+	/**
+	 * Returns the number of layout page template entries that the user has permission to view where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63; and status = &#63;.
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param name the name
+	 * @param type the type
+	 * @param status the status
+	 * @return the number of matching layout page template entries that the user has permission to view
+	 */
+	public int filterCountByG_C_C_LikeN_T_S(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
 		int type, int status);
 
 	/**
@@ -5036,6 +5533,74 @@ public interface LayoutPageTemplateEntryPersistence
 	}
 
 	/**
+	 * Returns all the layout page template entries where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and type = &#63;.
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param type the type
+	 * @return the matching layout page template entries
+	 */
+	public default java.util.List<LayoutPageTemplateEntry> findByG_C_C_T(
+		long[] groupIds, long classNameId, String classTypeKey, int type) {
+
+		return findByG_C_C_T(
+			groupIds, classNameId, classTypeKey, type,
+			com.liferay.portal.kernel.dao.orm.QueryUtil.ALL_POS,
+			com.liferay.portal.kernel.dao.orm.QueryUtil.ALL_POS, null, true);
+	}
+
+	/**
+	 * Returns a range of all the layout page template entries where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and type = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param type the type
+	 * @param start the lower bound of the range of layout page template entries
+	 * @param end the upper bound of the range of layout page template entries (not inclusive)
+	 * @return the range of matching layout page template entries
+	 */
+	public default java.util.List<LayoutPageTemplateEntry> findByG_C_C_T(
+		long[] groupIds, long classNameId, String classTypeKey, int type,
+		int start, int end) {
+
+		return findByG_C_C_T(
+			groupIds, classNameId, classTypeKey, type, start, end, null, true);
+	}
+
+	/**
+	 * Returns an ordered range of all the layout page template entries where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and type = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param type the type
+	 * @param start the lower bound of the range of layout page template entries
+	 * @param end the upper bound of the range of layout page template entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching layout page template entries
+	 */
+	public default java.util.List<LayoutPageTemplateEntry> findByG_C_C_T(
+		long[] groupIds, long classNameId, String classTypeKey, int type,
+		int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator
+			<LayoutPageTemplateEntry> orderByComparator) {
+
+		return findByG_C_C_T(
+			groupIds, classNameId, classTypeKey, type, start, end,
+			orderByComparator, true);
+	}
+
+	/**
 	 * Returns all the layout page template entries that the user has permission to view where groupId = &#63; and classNameId = &#63; and classTypeKey = &#63; and type = &#63;.
 	 *
 	 * @param groupId the group ID
@@ -5074,6 +5639,47 @@ public interface LayoutPageTemplateEntryPersistence
 
 		return filterFindByG_C_C_T(
 			groupId, classNameId, classTypeKey, type, start, end, null);
+	}
+
+	/**
+	 * Returns all the layout page template entries that the user has permission to view where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and type = &#63;.
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param type the type
+	 * @return the matching layout page template entries that the user has permission to view
+	 */
+	public default java.util.List<LayoutPageTemplateEntry> filterFindByG_C_C_T(
+		long[] groupIds, long classNameId, String classTypeKey, int type) {
+
+		return filterFindByG_C_C_T(
+			groupIds, classNameId, classTypeKey, type,
+			com.liferay.portal.kernel.dao.orm.QueryUtil.ALL_POS,
+			com.liferay.portal.kernel.dao.orm.QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the layout page template entries that the user has permission to view where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and type = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param type the type
+	 * @param start the lower bound of the range of layout page template entries
+	 * @param end the upper bound of the range of layout page template entries (not inclusive)
+	 * @return the range of matching layout page template entries that the user has permission to view
+	 */
+	public default java.util.List<LayoutPageTemplateEntry> filterFindByG_C_C_T(
+		long[] groupIds, long classNameId, String classTypeKey, int type,
+		int start, int end) {
+
+		return filterFindByG_C_C_T(
+			groupIds, classNameId, classTypeKey, type, start, end, null);
 	}
 
 	/**
@@ -5482,6 +6088,79 @@ public interface LayoutPageTemplateEntryPersistence
 	}
 
 	/**
+	 * Returns all the layout page template entries where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and type = &#63; and status = &#63;.
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param type the type
+	 * @param status the status
+	 * @return the matching layout page template entries
+	 */
+	public default java.util.List<LayoutPageTemplateEntry> findByG_C_C_T_S(
+		long[] groupIds, long classNameId, String classTypeKey, int type,
+		int status) {
+
+		return findByG_C_C_T_S(
+			groupIds, classNameId, classTypeKey, type, status,
+			com.liferay.portal.kernel.dao.orm.QueryUtil.ALL_POS,
+			com.liferay.portal.kernel.dao.orm.QueryUtil.ALL_POS, null, true);
+	}
+
+	/**
+	 * Returns a range of all the layout page template entries where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and type = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param type the type
+	 * @param status the status
+	 * @param start the lower bound of the range of layout page template entries
+	 * @param end the upper bound of the range of layout page template entries (not inclusive)
+	 * @return the range of matching layout page template entries
+	 */
+	public default java.util.List<LayoutPageTemplateEntry> findByG_C_C_T_S(
+		long[] groupIds, long classNameId, String classTypeKey, int type,
+		int status, int start, int end) {
+
+		return findByG_C_C_T_S(
+			groupIds, classNameId, classTypeKey, type, status, start, end, null,
+			true);
+	}
+
+	/**
+	 * Returns an ordered range of all the layout page template entries where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and type = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param type the type
+	 * @param status the status
+	 * @param start the lower bound of the range of layout page template entries
+	 * @param end the upper bound of the range of layout page template entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching layout page template entries
+	 */
+	public default java.util.List<LayoutPageTemplateEntry> findByG_C_C_T_S(
+		long[] groupIds, long classNameId, String classTypeKey, int type,
+		int status, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator
+			<LayoutPageTemplateEntry> orderByComparator) {
+
+		return findByG_C_C_T_S(
+			groupIds, classNameId, classTypeKey, type, status, start, end,
+			orderByComparator, true);
+	}
+
+	/**
 	 * Returns all the layout page template entries that the user has permission to view where groupId = &#63; and classNameId = &#63; and classTypeKey = &#63; and type = &#63; and status = &#63;.
 	 *
 	 * @param groupId the group ID
@@ -5525,6 +6204,53 @@ public interface LayoutPageTemplateEntryPersistence
 
 		return filterFindByG_C_C_T_S(
 			groupId, classNameId, classTypeKey, type, status, start, end, null);
+	}
+
+	/**
+	 * Returns all the layout page template entries that the user has permission to view where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and type = &#63; and status = &#63;.
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param type the type
+	 * @param status the status
+	 * @return the matching layout page template entries that the user has permission to view
+	 */
+	public default java.util.List<LayoutPageTemplateEntry>
+		filterFindByG_C_C_T_S(
+			long[] groupIds, long classNameId, String classTypeKey, int type,
+			int status) {
+
+		return filterFindByG_C_C_T_S(
+			groupIds, classNameId, classTypeKey, type, status,
+			com.liferay.portal.kernel.dao.orm.QueryUtil.ALL_POS,
+			com.liferay.portal.kernel.dao.orm.QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the layout page template entries that the user has permission to view where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and type = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param type the type
+	 * @param status the status
+	 * @param start the lower bound of the range of layout page template entries
+	 * @param end the upper bound of the range of layout page template entries (not inclusive)
+	 * @return the range of matching layout page template entries that the user has permission to view
+	 */
+	public default java.util.List<LayoutPageTemplateEntry>
+		filterFindByG_C_C_T_S(
+			long[] groupIds, long classNameId, String classTypeKey, int type,
+			int status, int start, int end) {
+
+		return filterFindByG_C_C_T_S(
+			groupIds, classNameId, classTypeKey, type, status, start, end,
+			null);
 	}
 
 	/**
@@ -5648,4 +6374,4 @@ public interface LayoutPageTemplateEntryPersistence
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-709730791
+// LIFERAY-SERVICE-BUILDER-HASH:1553252830

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/persistence/LayoutPageTemplateEntryUtil.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/persistence/LayoutPageTemplateEntryUtil.java
@@ -2786,6 +2786,60 @@ public class LayoutPageTemplateEntryUtil {
 	}
 
 	/**
+	 * Returns an ordered range of all the layout page template entries that the user has permission to view where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and type = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param type the type
+	 * @param start the lower bound of the range of layout page template entries
+	 * @param end the upper bound of the range of layout page template entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching layout page template entries that the user has permission to view
+	 */
+	public static List<LayoutPageTemplateEntry> filterFindByG_C_C_T(
+		long[] groupIds, long classNameId, String classTypeKey, int type,
+		int start, int end,
+		OrderByComparator<LayoutPageTemplateEntry> orderByComparator) {
+
+		return getPersistence().filterFindByG_C_C_T(
+			groupIds, classNameId, classTypeKey, type, start, end,
+			orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the layout page template entries where groupId = &#63; and classNameId = &#63; and classTypeKey = &#63; and type = &#63;, optionally using the finder cache.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param type the type
+	 * @param start the lower bound of the range of layout page template entries
+	 * @param end the upper bound of the range of layout page template entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching layout page template entries
+	 */
+	public static List<LayoutPageTemplateEntry> findByG_C_C_T(
+		long[] groupIds, long classNameId, String classTypeKey, int type,
+		int start, int end,
+		OrderByComparator<LayoutPageTemplateEntry> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByG_C_C_T(
+			groupIds, classNameId, classTypeKey, type, start, end,
+			orderByComparator, useFinderCache);
+	}
+
+	/**
 	 * Removes all the layout page template entries where groupId = &#63; and classNameId = &#63; and classTypeKey = &#63; and type = &#63; from the database.
 	 *
 	 * @param groupId the group ID
@@ -2817,6 +2871,22 @@ public class LayoutPageTemplateEntryUtil {
 	}
 
 	/**
+	 * Returns the number of layout page template entries where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and type = &#63;.
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param type the type
+	 * @return the number of matching layout page template entries
+	 */
+	public static int countByG_C_C_T(
+		long[] groupIds, long classNameId, String classTypeKey, int type) {
+
+		return getPersistence().countByG_C_C_T(
+			groupIds, classNameId, classTypeKey, type);
+	}
+
+	/**
 	 * Returns the number of layout page template entries that the user has permission to view where groupId = &#63; and classNameId = &#63; and classTypeKey = &#63; and type = &#63;.
 	 *
 	 * @param groupId the group ID
@@ -2830,6 +2900,22 @@ public class LayoutPageTemplateEntryUtil {
 
 		return getPersistence().filterCountByG_C_C_T(
 			groupId, classNameId, classTypeKey, type);
+	}
+
+	/**
+	 * Returns the number of layout page template entries that the user has permission to view where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and type = &#63;.
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param type the type
+	 * @return the number of matching layout page template entries that the user has permission to view
+	 */
+	public static int filterCountByG_C_C_T(
+		long[] groupIds, long classNameId, String classTypeKey, int type) {
+
+		return getPersistence().filterCountByG_C_C_T(
+			groupIds, classNameId, classTypeKey, type);
 	}
 
 	/**
@@ -3890,6 +3976,177 @@ public class LayoutPageTemplateEntryUtil {
 	}
 
 	/**
+	 * Returns all the layout page template entries that the user has permission to view where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63;.
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param name the name
+	 * @param type the type
+	 * @return the matching layout page template entries that the user has permission to view
+	 */
+	public static List<LayoutPageTemplateEntry> filterFindByG_C_C_LikeN_T(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type) {
+
+		return getPersistence().filterFindByG_C_C_LikeN_T(
+			groupIds, classNameId, classTypeKey, name, type);
+	}
+
+	/**
+	 * Returns a range of all the layout page template entries that the user has permission to view where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param name the name
+	 * @param type the type
+	 * @param start the lower bound of the range of layout page template entries
+	 * @param end the upper bound of the range of layout page template entries (not inclusive)
+	 * @return the range of matching layout page template entries that the user has permission to view
+	 */
+	public static List<LayoutPageTemplateEntry> filterFindByG_C_C_LikeN_T(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type, int start, int end) {
+
+		return getPersistence().filterFindByG_C_C_LikeN_T(
+			groupIds, classNameId, classTypeKey, name, type, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the layout page template entries that the user has permission to view where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param name the name
+	 * @param type the type
+	 * @param start the lower bound of the range of layout page template entries
+	 * @param end the upper bound of the range of layout page template entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching layout page template entries that the user has permission to view
+	 */
+	public static List<LayoutPageTemplateEntry> filterFindByG_C_C_LikeN_T(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type, int start, int end,
+		OrderByComparator<LayoutPageTemplateEntry> orderByComparator) {
+
+		return getPersistence().filterFindByG_C_C_LikeN_T(
+			groupIds, classNameId, classTypeKey, name, type, start, end,
+			orderByComparator);
+	}
+
+	/**
+	 * Returns all the layout page template entries where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param name the name
+	 * @param type the type
+	 * @return the matching layout page template entries
+	 */
+	public static List<LayoutPageTemplateEntry> findByG_C_C_LikeN_T(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type) {
+
+		return getPersistence().findByG_C_C_LikeN_T(
+			groupIds, classNameId, classTypeKey, name, type);
+	}
+
+	/**
+	 * Returns a range of all the layout page template entries where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param name the name
+	 * @param type the type
+	 * @param start the lower bound of the range of layout page template entries
+	 * @param end the upper bound of the range of layout page template entries (not inclusive)
+	 * @return the range of matching layout page template entries
+	 */
+	public static List<LayoutPageTemplateEntry> findByG_C_C_LikeN_T(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type, int start, int end) {
+
+		return getPersistence().findByG_C_C_LikeN_T(
+			groupIds, classNameId, classTypeKey, name, type, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the layout page template entries where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param name the name
+	 * @param type the type
+	 * @param start the lower bound of the range of layout page template entries
+	 * @param end the upper bound of the range of layout page template entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching layout page template entries
+	 */
+	public static List<LayoutPageTemplateEntry> findByG_C_C_LikeN_T(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type, int start, int end,
+		OrderByComparator<LayoutPageTemplateEntry> orderByComparator) {
+
+		return getPersistence().findByG_C_C_LikeN_T(
+			groupIds, classNameId, classTypeKey, name, type, start, end,
+			orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the layout page template entries where groupId = &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63;, optionally using the finder cache.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param name the name
+	 * @param type the type
+	 * @param start the lower bound of the range of layout page template entries
+	 * @param end the upper bound of the range of layout page template entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching layout page template entries
+	 */
+	public static List<LayoutPageTemplateEntry> findByG_C_C_LikeN_T(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type, int start, int end,
+		OrderByComparator<LayoutPageTemplateEntry> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByG_C_C_LikeN_T(
+			groupIds, classNameId, classTypeKey, name, type, start, end,
+			orderByComparator, useFinderCache);
+	}
+
+	/**
 	 * Removes all the layout page template entries where groupId = &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63; from the database.
 	 *
 	 * @param groupId the group ID
@@ -3925,6 +4182,24 @@ public class LayoutPageTemplateEntryUtil {
 	}
 
 	/**
+	 * Returns the number of layout page template entries where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63;.
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param name the name
+	 * @param type the type
+	 * @return the number of matching layout page template entries
+	 */
+	public static int countByG_C_C_LikeN_T(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type) {
+
+		return getPersistence().countByG_C_C_LikeN_T(
+			groupIds, classNameId, classTypeKey, name, type);
+	}
+
+	/**
 	 * Returns the number of layout page template entries that the user has permission to view where groupId = &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63;.
 	 *
 	 * @param groupId the group ID
@@ -3940,6 +4215,24 @@ public class LayoutPageTemplateEntryUtil {
 
 		return getPersistence().filterCountByG_C_C_LikeN_T(
 			groupId, classNameId, classTypeKey, name, type);
+	}
+
+	/**
+	 * Returns the number of layout page template entries that the user has permission to view where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63;.
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param name the name
+	 * @param type the type
+	 * @return the number of matching layout page template entries that the user has permission to view
+	 */
+	public static int filterCountByG_C_C_LikeN_T(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type) {
+
+		return getPersistence().filterCountByG_C_C_LikeN_T(
+			groupIds, classNameId, classTypeKey, name, type);
 	}
 
 	/**
@@ -4044,6 +4337,62 @@ public class LayoutPageTemplateEntryUtil {
 	}
 
 	/**
+	 * Returns an ordered range of all the layout page template entries that the user has permission to view where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and type = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param type the type
+	 * @param status the status
+	 * @param start the lower bound of the range of layout page template entries
+	 * @param end the upper bound of the range of layout page template entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching layout page template entries that the user has permission to view
+	 */
+	public static List<LayoutPageTemplateEntry> filterFindByG_C_C_T_S(
+		long[] groupIds, long classNameId, String classTypeKey, int type,
+		int status, int start, int end,
+		OrderByComparator<LayoutPageTemplateEntry> orderByComparator) {
+
+		return getPersistence().filterFindByG_C_C_T_S(
+			groupIds, classNameId, classTypeKey, type, status, start, end,
+			orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the layout page template entries where groupId = &#63; and classNameId = &#63; and classTypeKey = &#63; and type = &#63; and status = &#63;, optionally using the finder cache.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param type the type
+	 * @param status the status
+	 * @param start the lower bound of the range of layout page template entries
+	 * @param end the upper bound of the range of layout page template entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching layout page template entries
+	 */
+	public static List<LayoutPageTemplateEntry> findByG_C_C_T_S(
+		long[] groupIds, long classNameId, String classTypeKey, int type,
+		int status, int start, int end,
+		OrderByComparator<LayoutPageTemplateEntry> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByG_C_C_T_S(
+			groupIds, classNameId, classTypeKey, type, status, start, end,
+			orderByComparator, useFinderCache);
+	}
+
+	/**
 	 * Removes all the layout page template entries where groupId = &#63; and classNameId = &#63; and classTypeKey = &#63; and type = &#63; and status = &#63; from the database.
 	 *
 	 * @param groupId the group ID
@@ -4079,6 +4428,24 @@ public class LayoutPageTemplateEntryUtil {
 	}
 
 	/**
+	 * Returns the number of layout page template entries where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and type = &#63; and status = &#63;.
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param type the type
+	 * @param status the status
+	 * @return the number of matching layout page template entries
+	 */
+	public static int countByG_C_C_T_S(
+		long[] groupIds, long classNameId, String classTypeKey, int type,
+		int status) {
+
+		return getPersistence().countByG_C_C_T_S(
+			groupIds, classNameId, classTypeKey, type, status);
+	}
+
+	/**
 	 * Returns the number of layout page template entries that the user has permission to view where groupId = &#63; and classNameId = &#63; and classTypeKey = &#63; and type = &#63; and status = &#63;.
 	 *
 	 * @param groupId the group ID
@@ -4094,6 +4461,24 @@ public class LayoutPageTemplateEntryUtil {
 
 		return getPersistence().filterCountByG_C_C_T_S(
 			groupId, classNameId, classTypeKey, type, status);
+	}
+
+	/**
+	 * Returns the number of layout page template entries that the user has permission to view where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and type = &#63; and status = &#63;.
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param type the type
+	 * @param status the status
+	 * @return the number of matching layout page template entries that the user has permission to view
+	 */
+	public static int filterCountByG_C_C_T_S(
+		long[] groupIds, long classNameId, String classTypeKey, int type,
+		int status) {
+
+		return getPersistence().filterCountByG_C_C_T_S(
+			groupIds, classNameId, classTypeKey, type, status);
 	}
 
 	/**
@@ -4472,6 +4857,186 @@ public class LayoutPageTemplateEntryUtil {
 	}
 
 	/**
+	 * Returns all the layout page template entries that the user has permission to view where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63; and status = &#63;.
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param name the name
+	 * @param type the type
+	 * @param status the status
+	 * @return the matching layout page template entries that the user has permission to view
+	 */
+	public static List<LayoutPageTemplateEntry> filterFindByG_C_C_LikeN_T_S(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type, int status) {
+
+		return getPersistence().filterFindByG_C_C_LikeN_T_S(
+			groupIds, classNameId, classTypeKey, name, type, status);
+	}
+
+	/**
+	 * Returns a range of all the layout page template entries that the user has permission to view where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param name the name
+	 * @param type the type
+	 * @param status the status
+	 * @param start the lower bound of the range of layout page template entries
+	 * @param end the upper bound of the range of layout page template entries (not inclusive)
+	 * @return the range of matching layout page template entries that the user has permission to view
+	 */
+	public static List<LayoutPageTemplateEntry> filterFindByG_C_C_LikeN_T_S(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type, int status, int start, int end) {
+
+		return getPersistence().filterFindByG_C_C_LikeN_T_S(
+			groupIds, classNameId, classTypeKey, name, type, status, start,
+			end);
+	}
+
+	/**
+	 * Returns an ordered range of all the layout page template entries that the user has permission to view where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param name the name
+	 * @param type the type
+	 * @param status the status
+	 * @param start the lower bound of the range of layout page template entries
+	 * @param end the upper bound of the range of layout page template entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching layout page template entries that the user has permission to view
+	 */
+	public static List<LayoutPageTemplateEntry> filterFindByG_C_C_LikeN_T_S(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type, int status, int start, int end,
+		OrderByComparator<LayoutPageTemplateEntry> orderByComparator) {
+
+		return getPersistence().filterFindByG_C_C_LikeN_T_S(
+			groupIds, classNameId, classTypeKey, name, type, status, start, end,
+			orderByComparator);
+	}
+
+	/**
+	 * Returns all the layout page template entries where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param name the name
+	 * @param type the type
+	 * @param status the status
+	 * @return the matching layout page template entries
+	 */
+	public static List<LayoutPageTemplateEntry> findByG_C_C_LikeN_T_S(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type, int status) {
+
+		return getPersistence().findByG_C_C_LikeN_T_S(
+			groupIds, classNameId, classTypeKey, name, type, status);
+	}
+
+	/**
+	 * Returns a range of all the layout page template entries where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param name the name
+	 * @param type the type
+	 * @param status the status
+	 * @param start the lower bound of the range of layout page template entries
+	 * @param end the upper bound of the range of layout page template entries (not inclusive)
+	 * @return the range of matching layout page template entries
+	 */
+	public static List<LayoutPageTemplateEntry> findByG_C_C_LikeN_T_S(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type, int status, int start, int end) {
+
+		return getPersistence().findByG_C_C_LikeN_T_S(
+			groupIds, classNameId, classTypeKey, name, type, status, start,
+			end);
+	}
+
+	/**
+	 * Returns an ordered range of all the layout page template entries where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param name the name
+	 * @param type the type
+	 * @param status the status
+	 * @param start the lower bound of the range of layout page template entries
+	 * @param end the upper bound of the range of layout page template entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching layout page template entries
+	 */
+	public static List<LayoutPageTemplateEntry> findByG_C_C_LikeN_T_S(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type, int status, int start, int end,
+		OrderByComparator<LayoutPageTemplateEntry> orderByComparator) {
+
+		return getPersistence().findByG_C_C_LikeN_T_S(
+			groupIds, classNameId, classTypeKey, name, type, status, start, end,
+			orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the layout page template entries where groupId = &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63; and status = &#63;, optionally using the finder cache.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param name the name
+	 * @param type the type
+	 * @param status the status
+	 * @param start the lower bound of the range of layout page template entries
+	 * @param end the upper bound of the range of layout page template entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching layout page template entries
+	 */
+	public static List<LayoutPageTemplateEntry> findByG_C_C_LikeN_T_S(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type, int status, int start, int end,
+		OrderByComparator<LayoutPageTemplateEntry> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByG_C_C_LikeN_T_S(
+			groupIds, classNameId, classTypeKey, name, type, status, start, end,
+			orderByComparator, useFinderCache);
+	}
+
+	/**
 	 * Removes all the layout page template entries where groupId = &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63; and status = &#63; from the database.
 	 *
 	 * @param groupId the group ID
@@ -4509,6 +5074,25 @@ public class LayoutPageTemplateEntryUtil {
 	}
 
 	/**
+	 * Returns the number of layout page template entries where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63; and status = &#63;.
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param name the name
+	 * @param type the type
+	 * @param status the status
+	 * @return the number of matching layout page template entries
+	 */
+	public static int countByG_C_C_LikeN_T_S(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type, int status) {
+
+		return getPersistence().countByG_C_C_LikeN_T_S(
+			groupIds, classNameId, classTypeKey, name, type, status);
+	}
+
+	/**
 	 * Returns the number of layout page template entries that the user has permission to view where groupId = &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63; and status = &#63;.
 	 *
 	 * @param groupId the group ID
@@ -4525,6 +5109,25 @@ public class LayoutPageTemplateEntryUtil {
 
 		return getPersistence().filterCountByG_C_C_LikeN_T_S(
 			groupId, classNameId, classTypeKey, name, type, status);
+	}
+
+	/**
+	 * Returns the number of layout page template entries that the user has permission to view where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63; and status = &#63;.
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param name the name
+	 * @param type the type
+	 * @param status the status
+	 * @return the number of matching layout page template entries that the user has permission to view
+	 */
+	public static int filterCountByG_C_C_LikeN_T_S(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type, int status) {
+
+		return getPersistence().filterCountByG_C_C_LikeN_T_S(
+			groupIds, classNameId, classTypeKey, name, type, status);
 	}
 
 	/**
@@ -5917,6 +6520,71 @@ public class LayoutPageTemplateEntryUtil {
 	}
 
 	/**
+	 * Returns all the layout page template entries where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and type = &#63;.
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param type the type
+	 * @return the matching layout page template entries
+	 */
+	public static List<LayoutPageTemplateEntry> findByG_C_C_T(
+		long[] groupIds, long classNameId, String classTypeKey, int type) {
+
+		return getPersistence().findByG_C_C_T(
+			groupIds, classNameId, classTypeKey, type);
+	}
+
+	/**
+	 * Returns a range of all the layout page template entries where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and type = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param type the type
+	 * @param start the lower bound of the range of layout page template entries
+	 * @param end the upper bound of the range of layout page template entries (not inclusive)
+	 * @return the range of matching layout page template entries
+	 */
+	public static List<LayoutPageTemplateEntry> findByG_C_C_T(
+		long[] groupIds, long classNameId, String classTypeKey, int type,
+		int start, int end) {
+
+		return getPersistence().findByG_C_C_T(
+			groupIds, classNameId, classTypeKey, type, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the layout page template entries where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and type = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param type the type
+	 * @param start the lower bound of the range of layout page template entries
+	 * @param end the upper bound of the range of layout page template entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching layout page template entries
+	 */
+	public static List<LayoutPageTemplateEntry> findByG_C_C_T(
+		long[] groupIds, long classNameId, String classTypeKey, int type,
+		int start, int end,
+		OrderByComparator<LayoutPageTemplateEntry> orderByComparator) {
+
+		return getPersistence().findByG_C_C_T(
+			groupIds, classNameId, classTypeKey, type, start, end,
+			orderByComparator);
+	}
+
+	/**
 	 * Returns all the layout page template entries that the user has permission to view where groupId = &#63; and classNameId = &#63; and classTypeKey = &#63; and type = &#63;.
 	 *
 	 * @param groupId the group ID
@@ -5953,6 +6621,45 @@ public class LayoutPageTemplateEntryUtil {
 
 		return getPersistence().filterFindByG_C_C_T(
 			groupId, classNameId, classTypeKey, type, start, end);
+	}
+
+	/**
+	 * Returns all the layout page template entries that the user has permission to view where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and type = &#63;.
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param type the type
+	 * @return the matching layout page template entries that the user has permission to view
+	 */
+	public static List<LayoutPageTemplateEntry> filterFindByG_C_C_T(
+		long[] groupIds, long classNameId, String classTypeKey, int type) {
+
+		return getPersistence().filterFindByG_C_C_T(
+			groupIds, classNameId, classTypeKey, type);
+	}
+
+	/**
+	 * Returns a range of all the layout page template entries that the user has permission to view where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and type = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param type the type
+	 * @param start the lower bound of the range of layout page template entries
+	 * @param end the upper bound of the range of layout page template entries (not inclusive)
+	 * @return the range of matching layout page template entries that the user has permission to view
+	 */
+	public static List<LayoutPageTemplateEntry> filterFindByG_C_C_T(
+		long[] groupIds, long classNameId, String classTypeKey, int type,
+		int start, int end) {
+
+		return getPersistence().filterFindByG_C_C_T(
+			groupIds, classNameId, classTypeKey, type, start, end);
 	}
 
 	/**
@@ -6338,6 +7045,75 @@ public class LayoutPageTemplateEntryUtil {
 	}
 
 	/**
+	 * Returns all the layout page template entries where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and type = &#63; and status = &#63;.
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param type the type
+	 * @param status the status
+	 * @return the matching layout page template entries
+	 */
+	public static List<LayoutPageTemplateEntry> findByG_C_C_T_S(
+		long[] groupIds, long classNameId, String classTypeKey, int type,
+		int status) {
+
+		return getPersistence().findByG_C_C_T_S(
+			groupIds, classNameId, classTypeKey, type, status);
+	}
+
+	/**
+	 * Returns a range of all the layout page template entries where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and type = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param type the type
+	 * @param status the status
+	 * @param start the lower bound of the range of layout page template entries
+	 * @param end the upper bound of the range of layout page template entries (not inclusive)
+	 * @return the range of matching layout page template entries
+	 */
+	public static List<LayoutPageTemplateEntry> findByG_C_C_T_S(
+		long[] groupIds, long classNameId, String classTypeKey, int type,
+		int status, int start, int end) {
+
+		return getPersistence().findByG_C_C_T_S(
+			groupIds, classNameId, classTypeKey, type, status, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the layout page template entries where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and type = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param type the type
+	 * @param status the status
+	 * @param start the lower bound of the range of layout page template entries
+	 * @param end the upper bound of the range of layout page template entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching layout page template entries
+	 */
+	public static List<LayoutPageTemplateEntry> findByG_C_C_T_S(
+		long[] groupIds, long classNameId, String classTypeKey, int type,
+		int status, int start, int end,
+		OrderByComparator<LayoutPageTemplateEntry> orderByComparator) {
+
+		return getPersistence().findByG_C_C_T_S(
+			groupIds, classNameId, classTypeKey, type, status, start, end,
+			orderByComparator);
+	}
+
+	/**
 	 * Returns all the layout page template entries that the user has permission to view where groupId = &#63; and classNameId = &#63; and classTypeKey = &#63; and type = &#63; and status = &#63;.
 	 *
 	 * @param groupId the group ID
@@ -6377,6 +7153,48 @@ public class LayoutPageTemplateEntryUtil {
 
 		return getPersistence().filterFindByG_C_C_T_S(
 			groupId, classNameId, classTypeKey, type, status, start, end);
+	}
+
+	/**
+	 * Returns all the layout page template entries that the user has permission to view where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and type = &#63; and status = &#63;.
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param type the type
+	 * @param status the status
+	 * @return the matching layout page template entries that the user has permission to view
+	 */
+	public static List<LayoutPageTemplateEntry> filterFindByG_C_C_T_S(
+		long[] groupIds, long classNameId, String classTypeKey, int type,
+		int status) {
+
+		return getPersistence().filterFindByG_C_C_T_S(
+			groupIds, classNameId, classTypeKey, type, status);
+	}
+
+	/**
+	 * Returns a range of all the layout page template entries that the user has permission to view where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and type = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.layout.page.template.model.impl.LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param type the type
+	 * @param status the status
+	 * @param start the lower bound of the range of layout page template entries
+	 * @param end the upper bound of the range of layout page template entries (not inclusive)
+	 * @return the range of matching layout page template entries that the user has permission to view
+	 */
+	public static List<LayoutPageTemplateEntry> filterFindByG_C_C_T_S(
+		long[] groupIds, long classNameId, String classTypeKey, int type,
+		int status, int start, int end) {
+
+		return getPersistence().filterFindByG_C_C_T_S(
+			groupIds, classNameId, classTypeKey, type, status, start, end);
 	}
 
 	/**
@@ -6505,4 +7323,4 @@ public class LayoutPageTemplateEntryUtil {
 	private static volatile LayoutPageTemplateEntryPersistence _persistence;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-452288564
+// LIFERAY-SERVICE-BUILDER-HASH:-1575587438

--- a/modules/apps/layout/layout-page-template-api/src/main/resources/com/liferay/layout/page/template/service/packageinfo
+++ b/modules/apps/layout/layout-page-template-api/src/main/resources/com/liferay/layout/page/template/service/packageinfo
@@ -1,1 +1,1 @@
-version 19.0.0
+version 19.1.0

--- a/modules/apps/layout/layout-page-template-api/src/main/resources/com/liferay/layout/page/template/service/persistence/packageinfo
+++ b/modules/apps/layout/layout-page-template-api/src/main/resources/com/liferay/layout/page/template/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 10.0.0
+version 10.1.0

--- a/modules/apps/layout/layout-page-template-service/service.xml
+++ b/modules/apps/layout/layout-page-template-service/service.xml
@@ -193,7 +193,7 @@
 			<finder-column name="status" />
 		</finder>
 		<finder name="G_C_C_T" return-type="Collection">
-			<finder-column name="groupId" />
+			<finder-column arrayable-operator="OR" name="groupId" />
 			<finder-column name="classNameId" />
 			<finder-column name="classTypeKey" />
 			<finder-column name="type" />
@@ -223,14 +223,14 @@
 			<finder-column name="status" />
 		</finder>
 		<finder name="G_C_C_LikeN_T" return-type="Collection">
-			<finder-column name="groupId" />
+			<finder-column arrayable-operator="OR" name="groupId" />
 			<finder-column name="classNameId" />
 			<finder-column name="classTypeKey" />
 			<finder-column comparator="LIKE" name="name" />
 			<finder-column name="type" />
 		</finder>
 		<finder name="G_C_C_T_S" return-type="Collection">
-			<finder-column name="groupId" />
+			<finder-column arrayable-operator="OR" name="groupId" />
 			<finder-column name="classNameId" />
 			<finder-column name="classTypeKey" />
 			<finder-column name="type" />
@@ -244,7 +244,7 @@
 			<finder-column name="status" />
 		</finder>
 		<finder name="G_C_C_LikeN_T_S" return-type="Collection">
-			<finder-column name="groupId" />
+			<finder-column arrayable-operator="OR" name="groupId" />
 			<finder-column name="classNameId" />
 			<finder-column name="classTypeKey" />
 			<finder-column comparator="LIKE" name="name" />

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/http/LayoutPageTemplateEntryServiceHttp.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/http/LayoutPageTemplateEntryServiceHttp.java
@@ -1776,6 +1776,129 @@ public class LayoutPageTemplateEntryServiceHttp {
 
 	public static java.util.List
 		<com.liferay.layout.page.template.model.LayoutPageTemplateEntry>
+			getLayoutPageTemplateEntries(
+				HttpPrincipal httpPrincipal, long[] groupIds, long classNameId,
+				String classTypeKey, int type, int status) {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				LayoutPageTemplateEntryServiceUtil.class,
+				"getLayoutPageTemplateEntries",
+				_getLayoutPageTemplateEntriesParameterTypes42);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, groupIds, classNameId, classTypeKey, type, status);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (java.util.List
+				<com.liferay.layout.page.template.model.
+					LayoutPageTemplateEntry>)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static java.util.List
+		<com.liferay.layout.page.template.model.LayoutPageTemplateEntry>
+			getLayoutPageTemplateEntries(
+				HttpPrincipal httpPrincipal, long[] groupIds, long classNameId,
+				String classTypeKey, int type, int status, int start, int end,
+				com.liferay.portal.kernel.util.OrderByComparator
+					<com.liferay.layout.page.template.model.
+						LayoutPageTemplateEntry> orderByComparator) {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				LayoutPageTemplateEntryServiceUtil.class,
+				"getLayoutPageTemplateEntries",
+				_getLayoutPageTemplateEntriesParameterTypes43);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, groupIds, classNameId, classTypeKey, type, status,
+				start, end, orderByComparator);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (java.util.List
+				<com.liferay.layout.page.template.model.
+					LayoutPageTemplateEntry>)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static java.util.List
+		<com.liferay.layout.page.template.model.LayoutPageTemplateEntry>
+			getLayoutPageTemplateEntries(
+				HttpPrincipal httpPrincipal, long[] groupIds, long classNameId,
+				String classTypeKey, String name, int type, int status,
+				int start, int end,
+				com.liferay.portal.kernel.util.OrderByComparator
+					<com.liferay.layout.page.template.model.
+						LayoutPageTemplateEntry> orderByComparator) {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				LayoutPageTemplateEntryServiceUtil.class,
+				"getLayoutPageTemplateEntries",
+				_getLayoutPageTemplateEntriesParameterTypes44);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, groupIds, classNameId, classTypeKey, name, type,
+				status, start, end, orderByComparator);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (java.util.List
+				<com.liferay.layout.page.template.model.
+					LayoutPageTemplateEntry>)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static java.util.List
+		<com.liferay.layout.page.template.model.LayoutPageTemplateEntry>
 			getLayoutPageTemplateEntriesByType(
 				HttpPrincipal httpPrincipal, long groupId,
 				long layoutPageTemplateCollectionId, int type, int start,
@@ -1788,7 +1911,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntriesByType",
-				_getLayoutPageTemplateEntriesByTypeParameterTypes42);
+				_getLayoutPageTemplateEntriesByTypeParameterTypes45);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, layoutPageTemplateCollectionId, type, start,
@@ -1824,7 +1947,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntriesCount",
-				_getLayoutPageTemplateEntriesCountParameterTypes43);
+				_getLayoutPageTemplateEntriesCountParameterTypes46);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, type);
@@ -1857,7 +1980,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntriesCount",
-				_getLayoutPageTemplateEntriesCountParameterTypes44);
+				_getLayoutPageTemplateEntriesCountParameterTypes47);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, type, status);
@@ -1890,7 +2013,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntriesCount",
-				_getLayoutPageTemplateEntriesCountParameterTypes45);
+				_getLayoutPageTemplateEntriesCountParameterTypes48);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, types);
@@ -1923,7 +2046,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntriesCount",
-				_getLayoutPageTemplateEntriesCountParameterTypes46);
+				_getLayoutPageTemplateEntriesCountParameterTypes49);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, types, status);
@@ -1957,7 +2080,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntriesCount",
-				_getLayoutPageTemplateEntriesCountParameterTypes47);
+				_getLayoutPageTemplateEntriesCountParameterTypes50);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, layoutPageTemplateCollectionId);
@@ -1991,7 +2114,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntriesCount",
-				_getLayoutPageTemplateEntriesCountParameterTypes48);
+				_getLayoutPageTemplateEntriesCountParameterTypes51);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, layoutPageTemplateCollectionId, status);
@@ -2025,7 +2148,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntriesCount",
-				_getLayoutPageTemplateEntriesCountParameterTypes49);
+				_getLayoutPageTemplateEntriesCountParameterTypes52);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, classNameId, classTypeId, type);
@@ -2059,7 +2182,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntriesCount",
-				_getLayoutPageTemplateEntriesCountParameterTypes50);
+				_getLayoutPageTemplateEntriesCountParameterTypes53);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, classNameId, classTypeId, type, status);
@@ -2093,7 +2216,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntriesCount",
-				_getLayoutPageTemplateEntriesCountParameterTypes51);
+				_getLayoutPageTemplateEntriesCountParameterTypes54);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, classNameId, classTypeId, name, type);
@@ -2127,7 +2250,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntriesCount",
-				_getLayoutPageTemplateEntriesCountParameterTypes52);
+				_getLayoutPageTemplateEntriesCountParameterTypes55);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, classNameId, classTypeId, name, type,
@@ -2162,7 +2285,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntriesCount",
-				_getLayoutPageTemplateEntriesCountParameterTypes53);
+				_getLayoutPageTemplateEntriesCountParameterTypes56);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, layoutPageTemplateCollectionId, name);
@@ -2196,7 +2319,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntriesCount",
-				_getLayoutPageTemplateEntriesCountParameterTypes54);
+				_getLayoutPageTemplateEntriesCountParameterTypes57);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, layoutPageTemplateCollectionId, name,
@@ -2230,7 +2353,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntriesCount",
-				_getLayoutPageTemplateEntriesCountParameterTypes55);
+				_getLayoutPageTemplateEntriesCountParameterTypes58);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, name, type);
@@ -2264,7 +2387,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntriesCount",
-				_getLayoutPageTemplateEntriesCountParameterTypes56);
+				_getLayoutPageTemplateEntriesCountParameterTypes59);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, name, type, status);
@@ -2297,7 +2420,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntriesCount",
-				_getLayoutPageTemplateEntriesCountParameterTypes57);
+				_getLayoutPageTemplateEntriesCountParameterTypes60);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, name, types);
@@ -2331,10 +2454,79 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntriesCount",
-				_getLayoutPageTemplateEntriesCountParameterTypes58);
+				_getLayoutPageTemplateEntriesCountParameterTypes61);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, name, types, status);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return ((Integer)returnObj).intValue();
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static int getLayoutPageTemplateEntriesCount(
+		HttpPrincipal httpPrincipal, long[] groupIds, long classNameId,
+		String classTypeKey, int type, int status) {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				LayoutPageTemplateEntryServiceUtil.class,
+				"getLayoutPageTemplateEntriesCount",
+				_getLayoutPageTemplateEntriesCountParameterTypes62);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, groupIds, classNameId, classTypeKey, type, status);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return ((Integer)returnObj).intValue();
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static int getLayoutPageTemplateEntriesCount(
+		HttpPrincipal httpPrincipal, long[] groupIds, long classNameId,
+		String classTypeKey, String name, int type, int status) {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				LayoutPageTemplateEntryServiceUtil.class,
+				"getLayoutPageTemplateEntriesCount",
+				_getLayoutPageTemplateEntriesCountParameterTypes63);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, groupIds, classNameId, classTypeKey, name, type,
+				status);
 
 			Object returnObj = null;
 
@@ -2365,7 +2557,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntriesCountByType",
-				_getLayoutPageTemplateEntriesCountByTypeParameterTypes59);
+				_getLayoutPageTemplateEntriesCountByTypeParameterTypes64);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, layoutPageTemplateCollectionId, type);
@@ -2400,7 +2592,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntry",
-				_getLayoutPageTemplateEntryParameterTypes60);
+				_getLayoutPageTemplateEntryParameterTypes65);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, layoutPageTemplateEntryId);
@@ -2444,7 +2636,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntry",
-				_getLayoutPageTemplateEntryParameterTypes61);
+				_getLayoutPageTemplateEntryParameterTypes66);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, layoutPageTemplateEntryKey);
@@ -2488,7 +2680,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntryByExternalReferenceCode",
-				_getLayoutPageTemplateEntryByExternalReferenceCodeParameterTypes62);
+				_getLayoutPageTemplateEntryByExternalReferenceCodeParameterTypes67);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, externalReferenceCode, groupId);
@@ -2532,7 +2724,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"moveLayoutPageTemplateEntry",
-				_moveLayoutPageTemplateEntryParameterTypes63);
+				_moveLayoutPageTemplateEntryParameterTypes68);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, layoutPageTemplateEntryId,
@@ -2577,7 +2769,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"updateLayoutPageTemplateEntry",
-				_updateLayoutPageTemplateEntryParameterTypes64);
+				_updateLayoutPageTemplateEntryParameterTypes69);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, layoutPageTemplateEntryId, defaultTemplate);
@@ -2621,7 +2813,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"updateLayoutPageTemplateEntry",
-				_updateLayoutPageTemplateEntryParameterTypes65);
+				_updateLayoutPageTemplateEntryParameterTypes70);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, layoutPageTemplateEntryId, previewFileEntryId);
@@ -2665,7 +2857,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"updateLayoutPageTemplateEntry",
-				_updateLayoutPageTemplateEntryParameterTypes66);
+				_updateLayoutPageTemplateEntryParameterTypes71);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, layoutPageTemplateEntryId, classNameId,
@@ -2710,7 +2902,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"updateLayoutPageTemplateEntry",
-				_updateLayoutPageTemplateEntryParameterTypes67);
+				_updateLayoutPageTemplateEntryParameterTypes72);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, layoutPageTemplateEntryId, name);
@@ -2753,7 +2945,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class, "updateStatus",
-				_updateStatusParameterTypes68);
+				_updateStatusParameterTypes73);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, layoutPageTemplateEntryId, status);
@@ -2991,110 +3183,135 @@ public class LayoutPageTemplateEntryServiceHttp {
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
 	private static final Class<?>[]
-		_getLayoutPageTemplateEntriesByTypeParameterTypes42 = new Class[] {
+		_getLayoutPageTemplateEntriesParameterTypes42 = new Class[] {
+			long[].class, long.class, String.class, int.class, int.class
+		};
+	private static final Class<?>[]
+		_getLayoutPageTemplateEntriesParameterTypes43 = new Class[] {
+			long[].class, long.class, String.class, int.class, int.class,
+			int.class, int.class,
+			com.liferay.portal.kernel.util.OrderByComparator.class
+		};
+	private static final Class<?>[]
+		_getLayoutPageTemplateEntriesParameterTypes44 = new Class[] {
+			long[].class, long.class, String.class, String.class, int.class,
+			int.class, int.class, int.class,
+			com.liferay.portal.kernel.util.OrderByComparator.class
+		};
+	private static final Class<?>[]
+		_getLayoutPageTemplateEntriesByTypeParameterTypes45 = new Class[] {
 			long.class, long.class, int.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
 	private static final Class<?>[]
-		_getLayoutPageTemplateEntriesCountParameterTypes43 = new Class[] {
+		_getLayoutPageTemplateEntriesCountParameterTypes46 = new Class[] {
 			long.class, int.class
 		};
 	private static final Class<?>[]
-		_getLayoutPageTemplateEntriesCountParameterTypes44 = new Class[] {
+		_getLayoutPageTemplateEntriesCountParameterTypes47 = new Class[] {
 			long.class, int.class, int.class
 		};
 	private static final Class<?>[]
-		_getLayoutPageTemplateEntriesCountParameterTypes45 = new Class[] {
+		_getLayoutPageTemplateEntriesCountParameterTypes48 = new Class[] {
 			long.class, int[].class
 		};
 	private static final Class<?>[]
-		_getLayoutPageTemplateEntriesCountParameterTypes46 = new Class[] {
+		_getLayoutPageTemplateEntriesCountParameterTypes49 = new Class[] {
 			long.class, int[].class, int.class
 		};
 	private static final Class<?>[]
-		_getLayoutPageTemplateEntriesCountParameterTypes47 = new Class[] {
+		_getLayoutPageTemplateEntriesCountParameterTypes50 = new Class[] {
 			long.class, long.class
 		};
 	private static final Class<?>[]
-		_getLayoutPageTemplateEntriesCountParameterTypes48 = new Class[] {
+		_getLayoutPageTemplateEntriesCountParameterTypes51 = new Class[] {
 			long.class, long.class, int.class
 		};
 	private static final Class<?>[]
-		_getLayoutPageTemplateEntriesCountParameterTypes49 = new Class[] {
+		_getLayoutPageTemplateEntriesCountParameterTypes52 = new Class[] {
 			long.class, long.class, long.class, int.class
 		};
 	private static final Class<?>[]
-		_getLayoutPageTemplateEntriesCountParameterTypes50 = new Class[] {
+		_getLayoutPageTemplateEntriesCountParameterTypes53 = new Class[] {
 			long.class, long.class, long.class, int.class, int.class
 		};
 	private static final Class<?>[]
-		_getLayoutPageTemplateEntriesCountParameterTypes51 = new Class[] {
+		_getLayoutPageTemplateEntriesCountParameterTypes54 = new Class[] {
 			long.class, long.class, long.class, String.class, int.class
 		};
 	private static final Class<?>[]
-		_getLayoutPageTemplateEntriesCountParameterTypes52 = new Class[] {
+		_getLayoutPageTemplateEntriesCountParameterTypes55 = new Class[] {
 			long.class, long.class, long.class, String.class, int.class,
 			int.class
 		};
 	private static final Class<?>[]
-		_getLayoutPageTemplateEntriesCountParameterTypes53 = new Class[] {
-			long.class, long.class, String.class
-		};
-	private static final Class<?>[]
-		_getLayoutPageTemplateEntriesCountParameterTypes54 = new Class[] {
-			long.class, long.class, String.class, int.class
-		};
-	private static final Class<?>[]
-		_getLayoutPageTemplateEntriesCountParameterTypes55 = new Class[] {
-			long.class, String.class, int.class
-		};
-	private static final Class<?>[]
 		_getLayoutPageTemplateEntriesCountParameterTypes56 = new Class[] {
-			long.class, String.class, int.class, int.class
+			long.class, long.class, String.class
 		};
 	private static final Class<?>[]
 		_getLayoutPageTemplateEntriesCountParameterTypes57 = new Class[] {
-			long.class, String.class, int[].class
+			long.class, long.class, String.class, int.class
 		};
 	private static final Class<?>[]
 		_getLayoutPageTemplateEntriesCountParameterTypes58 = new Class[] {
+			long.class, String.class, int.class
+		};
+	private static final Class<?>[]
+		_getLayoutPageTemplateEntriesCountParameterTypes59 = new Class[] {
+			long.class, String.class, int.class, int.class
+		};
+	private static final Class<?>[]
+		_getLayoutPageTemplateEntriesCountParameterTypes60 = new Class[] {
+			long.class, String.class, int[].class
+		};
+	private static final Class<?>[]
+		_getLayoutPageTemplateEntriesCountParameterTypes61 = new Class[] {
 			long.class, String.class, int[].class, int.class
 		};
 	private static final Class<?>[]
-		_getLayoutPageTemplateEntriesCountByTypeParameterTypes59 = new Class[] {
+		_getLayoutPageTemplateEntriesCountParameterTypes62 = new Class[] {
+			long[].class, long.class, String.class, int.class, int.class
+		};
+	private static final Class<?>[]
+		_getLayoutPageTemplateEntriesCountParameterTypes63 = new Class[] {
+			long[].class, long.class, String.class, String.class, int.class,
+			int.class
+		};
+	private static final Class<?>[]
+		_getLayoutPageTemplateEntriesCountByTypeParameterTypes64 = new Class[] {
 			long.class, long.class, int.class
 		};
 	private static final Class<?>[]
-		_getLayoutPageTemplateEntryParameterTypes60 = new Class[] {long.class};
+		_getLayoutPageTemplateEntryParameterTypes65 = new Class[] {long.class};
 	private static final Class<?>[]
-		_getLayoutPageTemplateEntryParameterTypes61 = new Class[] {
+		_getLayoutPageTemplateEntryParameterTypes66 = new Class[] {
 			long.class, String.class
 		};
 	private static final Class<?>[]
-		_getLayoutPageTemplateEntryByExternalReferenceCodeParameterTypes62 =
+		_getLayoutPageTemplateEntryByExternalReferenceCodeParameterTypes67 =
 			new Class[] {String.class, long.class};
 	private static final Class<?>[]
-		_moveLayoutPageTemplateEntryParameterTypes63 = new Class[] {
+		_moveLayoutPageTemplateEntryParameterTypes68 = new Class[] {
 			long.class, long.class
 		};
 	private static final Class<?>[]
-		_updateLayoutPageTemplateEntryParameterTypes64 = new Class[] {
+		_updateLayoutPageTemplateEntryParameterTypes69 = new Class[] {
 			long.class, boolean.class
 		};
 	private static final Class<?>[]
-		_updateLayoutPageTemplateEntryParameterTypes65 = new Class[] {
+		_updateLayoutPageTemplateEntryParameterTypes70 = new Class[] {
 			long.class, long.class
 		};
 	private static final Class<?>[]
-		_updateLayoutPageTemplateEntryParameterTypes66 = new Class[] {
+		_updateLayoutPageTemplateEntryParameterTypes71 = new Class[] {
 			long.class, long.class, String.class
 		};
 	private static final Class<?>[]
-		_updateLayoutPageTemplateEntryParameterTypes67 = new Class[] {
+		_updateLayoutPageTemplateEntryParameterTypes72 = new Class[] {
 			long.class, String.class
 		};
-	private static final Class<?>[] _updateStatusParameterTypes68 =
+	private static final Class<?>[] _updateStatusParameterTypes73 =
 		new Class[] {long.class, int.class};
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1106706765
+// LIFERAY-SERVICE-BUILDER-HASH:-235848567

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateEntryServiceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateEntryServiceImpl.java
@@ -35,6 +35,7 @@ import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermi
 import com.liferay.portal.kernel.security.permission.resource.PortletResourcePermission;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -46,6 +47,7 @@ import com.liferay.segments.service.SegmentsExperienceLocalService;
 import java.sql.Types;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
@@ -724,6 +726,68 @@ public class LayoutPageTemplateEntryServiceImpl
 	}
 
 	@Override
+	public List<LayoutPageTemplateEntry> getLayoutPageTemplateEntries(
+		long[] groupIds, long classNameId, String classTypeKey, int type,
+		int status) {
+
+		if (ArrayUtil.isEmpty(groupIds)) {
+			return Collections.emptyList();
+		}
+
+		if (status == WorkflowConstants.STATUS_ANY) {
+			return layoutPageTemplateEntryPersistence.filterFindByG_C_C_T(
+				groupIds, classNameId, classTypeKey, type);
+		}
+
+		return layoutPageTemplateEntryPersistence.filterFindByG_C_C_T_S(
+			groupIds, classNameId, classTypeKey, type, status);
+	}
+
+	@Override
+	public List<LayoutPageTemplateEntry> getLayoutPageTemplateEntries(
+		long[] groupIds, long classNameId, String classTypeKey, int type,
+		int status, int start, int end,
+		OrderByComparator<LayoutPageTemplateEntry> orderByComparator) {
+
+		if (ArrayUtil.isEmpty(groupIds)) {
+			return Collections.emptyList();
+		}
+
+		if (status == WorkflowConstants.STATUS_ANY) {
+			return layoutPageTemplateEntryPersistence.filterFindByG_C_C_T(
+				groupIds, classNameId, classTypeKey, type, start, end,
+				orderByComparator);
+		}
+
+		return layoutPageTemplateEntryPersistence.filterFindByG_C_C_T_S(
+			groupIds, classNameId, classTypeKey, type, status, start, end,
+			orderByComparator);
+	}
+
+	@Override
+	public List<LayoutPageTemplateEntry> getLayoutPageTemplateEntries(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type, int status, int start, int end,
+		OrderByComparator<LayoutPageTemplateEntry> orderByComparator) {
+
+		if (ArrayUtil.isEmpty(groupIds)) {
+			return Collections.emptyList();
+		}
+
+		if (status == WorkflowConstants.STATUS_ANY) {
+			return layoutPageTemplateEntryPersistence.filterFindByG_C_C_LikeN_T(
+				groupIds, classNameId, classTypeKey,
+				_customSQL.keywords(name, false, WildcardMode.SURROUND)[0],
+				type, start, end, orderByComparator);
+		}
+
+		return layoutPageTemplateEntryPersistence.filterFindByG_C_C_LikeN_T_S(
+			groupIds, classNameId, classTypeKey,
+			_customSQL.keywords(name, false, WildcardMode.SURROUND)[0], type,
+			status, start, end, orderByComparator);
+	}
+
+	@Override
 	public List<LayoutPageTemplateEntry> getLayoutPageTemplateEntriesByType(
 		long groupId, long layoutPageTemplateCollectionId, int type, int start,
 		int end, OrderByComparator<LayoutPageTemplateEntry> orderByComparator) {
@@ -913,6 +977,47 @@ public class LayoutPageTemplateEntryServiceImpl
 		return layoutPageTemplateEntryPersistence.filterCountByG_T_LikeN_S(
 			groupId, _customSQL.keywords(name, false, WildcardMode.SURROUND)[0],
 			types, status);
+	}
+
+	@Override
+	public int getLayoutPageTemplateEntriesCount(
+		long[] groupIds, long classNameId, String classTypeKey, int type,
+		int status) {
+
+		if (ArrayUtil.isEmpty(groupIds)) {
+			return 0;
+		}
+
+		if (status == WorkflowConstants.STATUS_ANY) {
+			return layoutPageTemplateEntryPersistence.filterCountByG_C_C_T(
+				groupIds, classNameId, classTypeKey, type);
+		}
+
+		return layoutPageTemplateEntryPersistence.filterCountByG_C_C_T_S(
+			groupIds, classNameId, classTypeKey, type, status);
+	}
+
+	@Override
+	public int getLayoutPageTemplateEntriesCount(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type, int status) {
+
+		if (ArrayUtil.isEmpty(groupIds)) {
+			return 0;
+		}
+
+		if (status == WorkflowConstants.STATUS_ANY) {
+			return layoutPageTemplateEntryPersistence.
+				filterCountByG_C_C_LikeN_T(
+					groupIds, classNameId, classTypeKey,
+					_customSQL.keywords(name, false, WildcardMode.SURROUND)[0],
+					type);
+		}
+
+		return layoutPageTemplateEntryPersistence.filterCountByG_C_C_LikeN_T_S(
+			groupIds, classNameId, classTypeKey,
+			_customSQL.keywords(name, false, WildcardMode.SURROUND)[0], type,
+			status);
 	}
 
 	@Override

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/persistence/impl/LayoutPageTemplateEntryPersistenceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/persistence/impl/LayoutPageTemplateEntryPersistenceImpl.java
@@ -3031,8 +3031,10 @@ public class LayoutPageTemplateEntryPersistenceImpl
 
 		return _collectionPersistenceFinderByG_C_C_T.find(
 			finderCache,
-			new Object[] {groupId, classNameId, classTypeKey, type}, start, end,
-			orderByComparator, useFinderCache);
+			new Object[] {
+				new long[] {groupId}, classNameId, classTypeKey, type
+			},
+			start, end, orderByComparator, useFinderCache);
 	}
 
 	/**
@@ -3054,7 +3056,9 @@ public class LayoutPageTemplateEntryPersistenceImpl
 
 		return _collectionPersistenceFinderByG_C_C_T.findFirst(
 			finderCache,
-			new Object[] {groupId, classNameId, classTypeKey, type},
+			new Object[] {
+				new long[] {groupId}, classNameId, classTypeKey, type
+			},
 			orderByComparator);
 	}
 
@@ -3075,7 +3079,9 @@ public class LayoutPageTemplateEntryPersistenceImpl
 
 		return _collectionPersistenceFinderByG_C_C_T.fetchFirst(
 			finderCache,
-			new Object[] {groupId, classNameId, classTypeKey, type},
+			new Object[] {
+				new long[] {groupId}, classNameId, classTypeKey, type
+			},
 			orderByComparator);
 	}
 
@@ -3103,8 +3109,73 @@ public class LayoutPageTemplateEntryPersistenceImpl
 
 		return _collectionPersistenceFinderByG_C_C_T.filterFind(
 			finderCache,
-			new Object[] {groupId, classNameId, classTypeKey, type}, start, end,
-			orderByComparator, groupId);
+			new Object[] {
+				new long[] {groupId}, classNameId, classTypeKey, type
+			},
+			start, end, orderByComparator, groupId);
+	}
+
+	/**
+	 * Returns an ordered range of all the layout page template entries that the user has permission to view where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and type = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param type the type
+	 * @param start the lower bound of the range of layout page template entries
+	 * @param end the upper bound of the range of layout page template entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching layout page template entries that the user has permission to view
+	 */
+	@Override
+	public List<LayoutPageTemplateEntry> filterFindByG_C_C_T(
+		long[] groupIds, long classNameId, String classTypeKey, int type,
+		int start, int end,
+		OrderByComparator<LayoutPageTemplateEntry> orderByComparator) {
+
+		groupIds = ArrayUtil.sortedUnique(groupIds);
+
+		return _collectionPersistenceFinderByG_C_C_T.filterFind(
+			finderCache,
+			new Object[] {groupIds, classNameId, classTypeKey, type}, start,
+			end, orderByComparator, groupIds);
+	}
+
+	/**
+	 * Returns an ordered range of all the layout page template entries where groupId = &#63; and classNameId = &#63; and classTypeKey = &#63; and type = &#63;, optionally using the finder cache.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param type the type
+	 * @param start the lower bound of the range of layout page template entries
+	 * @param end the upper bound of the range of layout page template entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching layout page template entries
+	 */
+	@Override
+	public List<LayoutPageTemplateEntry> findByG_C_C_T(
+		long[] groupIds, long classNameId, String classTypeKey, int type,
+		int start, int end,
+		OrderByComparator<LayoutPageTemplateEntry> orderByComparator,
+		boolean useFinderCache) {
+
+		return _collectionPersistenceFinderByG_C_C_T.find(
+			finderCache,
+			new Object[] {
+				ArrayUtil.sortedUnique(groupIds), classNameId, classTypeKey,
+				type
+			},
+			start, end, orderByComparator, useFinderCache);
 	}
 
 	/**
@@ -3121,7 +3192,9 @@ public class LayoutPageTemplateEntryPersistenceImpl
 
 		_collectionPersistenceFinderByG_C_C_T.remove(
 			finderCache,
-			new Object[] {groupId, classNameId, classTypeKey, type});
+			new Object[] {
+				new long[] {groupId}, classNameId, classTypeKey, type
+			});
 	}
 
 	/**
@@ -3139,7 +3212,30 @@ public class LayoutPageTemplateEntryPersistenceImpl
 
 		return _collectionPersistenceFinderByG_C_C_T.count(
 			finderCache,
-			new Object[] {groupId, classNameId, classTypeKey, type});
+			new Object[] {
+				new long[] {groupId}, classNameId, classTypeKey, type
+			});
+	}
+
+	/**
+	 * Returns the number of layout page template entries where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and type = &#63;.
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param type the type
+	 * @return the number of matching layout page template entries
+	 */
+	@Override
+	public int countByG_C_C_T(
+		long[] groupIds, long classNameId, String classTypeKey, int type) {
+
+		return _collectionPersistenceFinderByG_C_C_T.count(
+			finderCache,
+			new Object[] {
+				ArrayUtil.sortedUnique(groupIds), classNameId, classTypeKey,
+				type
+			});
 	}
 
 	/**
@@ -3157,7 +3253,30 @@ public class LayoutPageTemplateEntryPersistenceImpl
 
 		return _collectionPersistenceFinderByG_C_C_T.filterCount(
 			finderCache,
-			new Object[] {groupId, classNameId, classTypeKey, type}, groupId);
+			new Object[] {
+				new long[] {groupId}, classNameId, classTypeKey, type
+			},
+			groupId);
+	}
+
+	/**
+	 * Returns the number of layout page template entries that the user has permission to view where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and type = &#63;.
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param type the type
+	 * @return the number of matching layout page template entries that the user has permission to view
+	 */
+	@Override
+	public int filterCountByG_C_C_T(
+		long[] groupIds, long classNameId, String classTypeKey, int type) {
+
+		groupIds = ArrayUtil.sortedUnique(groupIds);
+
+		return _collectionPersistenceFinderByG_C_C_T.filterCount(
+			finderCache,
+			new Object[] {groupIds, classNameId, classTypeKey, type}, groupIds);
 	}
 
 	private FilterCollectionPersistenceFinder
@@ -4207,7 +4326,9 @@ public class LayoutPageTemplateEntryPersistenceImpl
 
 		return _collectionPersistenceFinderByG_C_C_LikeN_T.find(
 			finderCache,
-			new Object[] {groupId, classNameId, classTypeKey, name, type},
+			new Object[] {
+				new long[] {groupId}, classNameId, classTypeKey, name, type
+			},
 			start, end, orderByComparator, useFinderCache);
 	}
 
@@ -4232,7 +4353,9 @@ public class LayoutPageTemplateEntryPersistenceImpl
 
 		return _collectionPersistenceFinderByG_C_C_LikeN_T.findFirst(
 			finderCache,
-			new Object[] {groupId, classNameId, classTypeKey, name, type},
+			new Object[] {
+				new long[] {groupId}, classNameId, classTypeKey, name, type
+			},
 			orderByComparator);
 	}
 
@@ -4255,7 +4378,9 @@ public class LayoutPageTemplateEntryPersistenceImpl
 
 		return _collectionPersistenceFinderByG_C_C_LikeN_T.fetchFirst(
 			finderCache,
-			new Object[] {groupId, classNameId, classTypeKey, name, type},
+			new Object[] {
+				new long[] {groupId}, classNameId, classTypeKey, name, type
+			},
 			orderByComparator);
 	}
 
@@ -4329,8 +4454,197 @@ public class LayoutPageTemplateEntryPersistenceImpl
 
 		return _collectionPersistenceFinderByG_C_C_LikeN_T.filterFind(
 			finderCache,
-			new Object[] {groupId, classNameId, classTypeKey, name, type},
+			new Object[] {
+				new long[] {groupId}, classNameId, classTypeKey, name, type
+			},
 			start, end, orderByComparator, groupId);
+	}
+
+	/**
+	 * Returns all the layout page template entries that the user has permission to view where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63;.
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param name the name
+	 * @param type the type
+	 * @return the matching layout page template entries that the user has permission to view
+	 */
+	@Override
+	public List<LayoutPageTemplateEntry> filterFindByG_C_C_LikeN_T(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type) {
+
+		return filterFindByG_C_C_LikeN_T(
+			groupIds, classNameId, classTypeKey, name, type, QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the layout page template entries that the user has permission to view where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param name the name
+	 * @param type the type
+	 * @param start the lower bound of the range of layout page template entries
+	 * @param end the upper bound of the range of layout page template entries (not inclusive)
+	 * @return the range of matching layout page template entries that the user has permission to view
+	 */
+	@Override
+	public List<LayoutPageTemplateEntry> filterFindByG_C_C_LikeN_T(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type, int start, int end) {
+
+		return filterFindByG_C_C_LikeN_T(
+			groupIds, classNameId, classTypeKey, name, type, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the layout page template entries that the user has permission to view where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param name the name
+	 * @param type the type
+	 * @param start the lower bound of the range of layout page template entries
+	 * @param end the upper bound of the range of layout page template entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching layout page template entries that the user has permission to view
+	 */
+	@Override
+	public List<LayoutPageTemplateEntry> filterFindByG_C_C_LikeN_T(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type, int start, int end,
+		OrderByComparator<LayoutPageTemplateEntry> orderByComparator) {
+
+		groupIds = ArrayUtil.sortedUnique(groupIds);
+
+		return _collectionPersistenceFinderByG_C_C_LikeN_T.filterFind(
+			finderCache,
+			new Object[] {groupIds, classNameId, classTypeKey, name, type},
+			start, end, orderByComparator, groupIds);
+	}
+
+	/**
+	 * Returns all the layout page template entries where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param name the name
+	 * @param type the type
+	 * @return the matching layout page template entries
+	 */
+	@Override
+	public List<LayoutPageTemplateEntry> findByG_C_C_LikeN_T(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type) {
+
+		return findByG_C_C_LikeN_T(
+			groupIds, classNameId, classTypeKey, name, type, QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the layout page template entries where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param name the name
+	 * @param type the type
+	 * @param start the lower bound of the range of layout page template entries
+	 * @param end the upper bound of the range of layout page template entries (not inclusive)
+	 * @return the range of matching layout page template entries
+	 */
+	@Override
+	public List<LayoutPageTemplateEntry> findByG_C_C_LikeN_T(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type, int start, int end) {
+
+		return findByG_C_C_LikeN_T(
+			groupIds, classNameId, classTypeKey, name, type, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the layout page template entries where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param name the name
+	 * @param type the type
+	 * @param start the lower bound of the range of layout page template entries
+	 * @param end the upper bound of the range of layout page template entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching layout page template entries
+	 */
+	@Override
+	public List<LayoutPageTemplateEntry> findByG_C_C_LikeN_T(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type, int start, int end,
+		OrderByComparator<LayoutPageTemplateEntry> orderByComparator) {
+
+		return findByG_C_C_LikeN_T(
+			groupIds, classNameId, classTypeKey, name, type, start, end,
+			orderByComparator, true);
+	}
+
+	/**
+	 * Returns an ordered range of all the layout page template entries where groupId = &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63;, optionally using the finder cache.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param name the name
+	 * @param type the type
+	 * @param start the lower bound of the range of layout page template entries
+	 * @param end the upper bound of the range of layout page template entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching layout page template entries
+	 */
+	@Override
+	public List<LayoutPageTemplateEntry> findByG_C_C_LikeN_T(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type, int start, int end,
+		OrderByComparator<LayoutPageTemplateEntry> orderByComparator,
+		boolean useFinderCache) {
+
+		return _collectionPersistenceFinderByG_C_C_LikeN_T.find(
+			finderCache,
+			new Object[] {
+				ArrayUtil.sortedUnique(groupIds), classNameId, classTypeKey,
+				name, type
+			},
+			start, end, orderByComparator, useFinderCache);
 	}
 
 	/**
@@ -4349,7 +4663,9 @@ public class LayoutPageTemplateEntryPersistenceImpl
 
 		_collectionPersistenceFinderByG_C_C_LikeN_T.remove(
 			finderCache,
-			new Object[] {groupId, classNameId, classTypeKey, name, type});
+			new Object[] {
+				new long[] {groupId}, classNameId, classTypeKey, name, type
+			});
 	}
 
 	/**
@@ -4369,7 +4685,32 @@ public class LayoutPageTemplateEntryPersistenceImpl
 
 		return _collectionPersistenceFinderByG_C_C_LikeN_T.count(
 			finderCache,
-			new Object[] {groupId, classNameId, classTypeKey, name, type});
+			new Object[] {
+				new long[] {groupId}, classNameId, classTypeKey, name, type
+			});
+	}
+
+	/**
+	 * Returns the number of layout page template entries where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63;.
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param name the name
+	 * @param type the type
+	 * @return the number of matching layout page template entries
+	 */
+	@Override
+	public int countByG_C_C_LikeN_T(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type) {
+
+		return _collectionPersistenceFinderByG_C_C_LikeN_T.count(
+			finderCache,
+			new Object[] {
+				ArrayUtil.sortedUnique(groupIds), classNameId, classTypeKey,
+				name, type
+			});
 	}
 
 	/**
@@ -4389,8 +4730,33 @@ public class LayoutPageTemplateEntryPersistenceImpl
 
 		return _collectionPersistenceFinderByG_C_C_LikeN_T.filterCount(
 			finderCache,
-			new Object[] {groupId, classNameId, classTypeKey, name, type},
+			new Object[] {
+				new long[] {groupId}, classNameId, classTypeKey, name, type
+			},
 			groupId);
+	}
+
+	/**
+	 * Returns the number of layout page template entries that the user has permission to view where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63;.
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param name the name
+	 * @param type the type
+	 * @return the number of matching layout page template entries that the user has permission to view
+	 */
+	@Override
+	public int filterCountByG_C_C_LikeN_T(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type) {
+
+		groupIds = ArrayUtil.sortedUnique(groupIds);
+
+		return _collectionPersistenceFinderByG_C_C_LikeN_T.filterCount(
+			finderCache,
+			new Object[] {groupIds, classNameId, classTypeKey, name, type},
+			groupIds);
 	}
 
 	private FilterCollectionPersistenceFinder
@@ -4424,7 +4790,9 @@ public class LayoutPageTemplateEntryPersistenceImpl
 
 		return _collectionPersistenceFinderByG_C_C_T_S.find(
 			finderCache,
-			new Object[] {groupId, classNameId, classTypeKey, type, status},
+			new Object[] {
+				new long[] {groupId}, classNameId, classTypeKey, type, status
+			},
 			start, end, orderByComparator, useFinderCache);
 	}
 
@@ -4449,7 +4817,9 @@ public class LayoutPageTemplateEntryPersistenceImpl
 
 		return _collectionPersistenceFinderByG_C_C_T_S.findFirst(
 			finderCache,
-			new Object[] {groupId, classNameId, classTypeKey, type, status},
+			new Object[] {
+				new long[] {groupId}, classNameId, classTypeKey, type, status
+			},
 			orderByComparator);
 	}
 
@@ -4472,7 +4842,9 @@ public class LayoutPageTemplateEntryPersistenceImpl
 
 		return _collectionPersistenceFinderByG_C_C_T_S.fetchFirst(
 			finderCache,
-			new Object[] {groupId, classNameId, classTypeKey, type, status},
+			new Object[] {
+				new long[] {groupId}, classNameId, classTypeKey, type, status
+			},
 			orderByComparator);
 	}
 
@@ -4501,8 +4873,75 @@ public class LayoutPageTemplateEntryPersistenceImpl
 
 		return _collectionPersistenceFinderByG_C_C_T_S.filterFind(
 			finderCache,
-			new Object[] {groupId, classNameId, classTypeKey, type, status},
+			new Object[] {
+				new long[] {groupId}, classNameId, classTypeKey, type, status
+			},
 			start, end, orderByComparator, groupId);
+	}
+
+	/**
+	 * Returns an ordered range of all the layout page template entries that the user has permission to view where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and type = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param type the type
+	 * @param status the status
+	 * @param start the lower bound of the range of layout page template entries
+	 * @param end the upper bound of the range of layout page template entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching layout page template entries that the user has permission to view
+	 */
+	@Override
+	public List<LayoutPageTemplateEntry> filterFindByG_C_C_T_S(
+		long[] groupIds, long classNameId, String classTypeKey, int type,
+		int status, int start, int end,
+		OrderByComparator<LayoutPageTemplateEntry> orderByComparator) {
+
+		groupIds = ArrayUtil.sortedUnique(groupIds);
+
+		return _collectionPersistenceFinderByG_C_C_T_S.filterFind(
+			finderCache,
+			new Object[] {groupIds, classNameId, classTypeKey, type, status},
+			start, end, orderByComparator, groupIds);
+	}
+
+	/**
+	 * Returns an ordered range of all the layout page template entries where groupId = &#63; and classNameId = &#63; and classTypeKey = &#63; and type = &#63; and status = &#63;, optionally using the finder cache.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param type the type
+	 * @param status the status
+	 * @param start the lower bound of the range of layout page template entries
+	 * @param end the upper bound of the range of layout page template entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching layout page template entries
+	 */
+	@Override
+	public List<LayoutPageTemplateEntry> findByG_C_C_T_S(
+		long[] groupIds, long classNameId, String classTypeKey, int type,
+		int status, int start, int end,
+		OrderByComparator<LayoutPageTemplateEntry> orderByComparator,
+		boolean useFinderCache) {
+
+		return _collectionPersistenceFinderByG_C_C_T_S.find(
+			finderCache,
+			new Object[] {
+				ArrayUtil.sortedUnique(groupIds), classNameId, classTypeKey,
+				type, status
+			},
+			start, end, orderByComparator, useFinderCache);
 	}
 
 	/**
@@ -4521,7 +4960,9 @@ public class LayoutPageTemplateEntryPersistenceImpl
 
 		_collectionPersistenceFinderByG_C_C_T_S.remove(
 			finderCache,
-			new Object[] {groupId, classNameId, classTypeKey, type, status});
+			new Object[] {
+				new long[] {groupId}, classNameId, classTypeKey, type, status
+			});
 	}
 
 	/**
@@ -4541,7 +4982,32 @@ public class LayoutPageTemplateEntryPersistenceImpl
 
 		return _collectionPersistenceFinderByG_C_C_T_S.count(
 			finderCache,
-			new Object[] {groupId, classNameId, classTypeKey, type, status});
+			new Object[] {
+				new long[] {groupId}, classNameId, classTypeKey, type, status
+			});
+	}
+
+	/**
+	 * Returns the number of layout page template entries where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and type = &#63; and status = &#63;.
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param type the type
+	 * @param status the status
+	 * @return the number of matching layout page template entries
+	 */
+	@Override
+	public int countByG_C_C_T_S(
+		long[] groupIds, long classNameId, String classTypeKey, int type,
+		int status) {
+
+		return _collectionPersistenceFinderByG_C_C_T_S.count(
+			finderCache,
+			new Object[] {
+				ArrayUtil.sortedUnique(groupIds), classNameId, classTypeKey,
+				type, status
+			});
 	}
 
 	/**
@@ -4561,8 +5027,33 @@ public class LayoutPageTemplateEntryPersistenceImpl
 
 		return _collectionPersistenceFinderByG_C_C_T_S.filterCount(
 			finderCache,
-			new Object[] {groupId, classNameId, classTypeKey, type, status},
+			new Object[] {
+				new long[] {groupId}, classNameId, classTypeKey, type, status
+			},
 			groupId);
+	}
+
+	/**
+	 * Returns the number of layout page template entries that the user has permission to view where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and type = &#63; and status = &#63;.
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param type the type
+	 * @param status the status
+	 * @return the number of matching layout page template entries that the user has permission to view
+	 */
+	@Override
+	public int filterCountByG_C_C_T_S(
+		long[] groupIds, long classNameId, String classTypeKey, int type,
+		int status) {
+
+		groupIds = ArrayUtil.sortedUnique(groupIds);
+
+		return _collectionPersistenceFinderByG_C_C_T_S.filterCount(
+			finderCache,
+			new Object[] {groupIds, classNameId, classTypeKey, type, status},
+			groupIds);
 	}
 
 	private FilterCollectionPersistenceFinder
@@ -4861,7 +5352,8 @@ public class LayoutPageTemplateEntryPersistenceImpl
 		return _collectionPersistenceFinderByG_C_C_LikeN_T_S.find(
 			finderCache,
 			new Object[] {
-				groupId, classNameId, classTypeKey, name, type, status
+				new long[] {groupId}, classNameId, classTypeKey, name, type,
+				status
 			},
 			start, end, orderByComparator, useFinderCache);
 	}
@@ -4889,7 +5381,8 @@ public class LayoutPageTemplateEntryPersistenceImpl
 		return _collectionPersistenceFinderByG_C_C_LikeN_T_S.findFirst(
 			finderCache,
 			new Object[] {
-				groupId, classNameId, classTypeKey, name, type, status
+				new long[] {groupId}, classNameId, classTypeKey, name, type,
+				status
 			},
 			orderByComparator);
 	}
@@ -4915,7 +5408,8 @@ public class LayoutPageTemplateEntryPersistenceImpl
 		return _collectionPersistenceFinderByG_C_C_LikeN_T_S.fetchFirst(
 			finderCache,
 			new Object[] {
-				groupId, classNameId, classTypeKey, name, type, status
+				new long[] {groupId}, classNameId, classTypeKey, name, type,
+				status
 			},
 			orderByComparator);
 	}
@@ -4995,9 +5489,208 @@ public class LayoutPageTemplateEntryPersistenceImpl
 		return _collectionPersistenceFinderByG_C_C_LikeN_T_S.filterFind(
 			finderCache,
 			new Object[] {
-				groupId, classNameId, classTypeKey, name, type, status
+				new long[] {groupId}, classNameId, classTypeKey, name, type,
+				status
 			},
 			start, end, orderByComparator, groupId);
+	}
+
+	/**
+	 * Returns all the layout page template entries that the user has permission to view where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63; and status = &#63;.
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param name the name
+	 * @param type the type
+	 * @param status the status
+	 * @return the matching layout page template entries that the user has permission to view
+	 */
+	@Override
+	public List<LayoutPageTemplateEntry> filterFindByG_C_C_LikeN_T_S(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type, int status) {
+
+		return filterFindByG_C_C_LikeN_T_S(
+			groupIds, classNameId, classTypeKey, name, type, status,
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the layout page template entries that the user has permission to view where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param name the name
+	 * @param type the type
+	 * @param status the status
+	 * @param start the lower bound of the range of layout page template entries
+	 * @param end the upper bound of the range of layout page template entries (not inclusive)
+	 * @return the range of matching layout page template entries that the user has permission to view
+	 */
+	@Override
+	public List<LayoutPageTemplateEntry> filterFindByG_C_C_LikeN_T_S(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type, int status, int start, int end) {
+
+		return filterFindByG_C_C_LikeN_T_S(
+			groupIds, classNameId, classTypeKey, name, type, status, start, end,
+			null);
+	}
+
+	/**
+	 * Returns an ordered range of all the layout page template entries that the user has permission to view where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param name the name
+	 * @param type the type
+	 * @param status the status
+	 * @param start the lower bound of the range of layout page template entries
+	 * @param end the upper bound of the range of layout page template entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching layout page template entries that the user has permission to view
+	 */
+	@Override
+	public List<LayoutPageTemplateEntry> filterFindByG_C_C_LikeN_T_S(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type, int status, int start, int end,
+		OrderByComparator<LayoutPageTemplateEntry> orderByComparator) {
+
+		groupIds = ArrayUtil.sortedUnique(groupIds);
+
+		return _collectionPersistenceFinderByG_C_C_LikeN_T_S.filterFind(
+			finderCache,
+			new Object[] {
+				groupIds, classNameId, classTypeKey, name, type, status
+			},
+			start, end, orderByComparator, groupIds);
+	}
+
+	/**
+	 * Returns all the layout page template entries where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param name the name
+	 * @param type the type
+	 * @param status the status
+	 * @return the matching layout page template entries
+	 */
+	@Override
+	public List<LayoutPageTemplateEntry> findByG_C_C_LikeN_T_S(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type, int status) {
+
+		return findByG_C_C_LikeN_T_S(
+			groupIds, classNameId, classTypeKey, name, type, status,
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the layout page template entries where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param name the name
+	 * @param type the type
+	 * @param status the status
+	 * @param start the lower bound of the range of layout page template entries
+	 * @param end the upper bound of the range of layout page template entries (not inclusive)
+	 * @return the range of matching layout page template entries
+	 */
+	@Override
+	public List<LayoutPageTemplateEntry> findByG_C_C_LikeN_T_S(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type, int status, int start, int end) {
+
+		return findByG_C_C_LikeN_T_S(
+			groupIds, classNameId, classTypeKey, name, type, status, start, end,
+			null);
+	}
+
+	/**
+	 * Returns an ordered range of all the layout page template entries where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param name the name
+	 * @param type the type
+	 * @param status the status
+	 * @param start the lower bound of the range of layout page template entries
+	 * @param end the upper bound of the range of layout page template entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching layout page template entries
+	 */
+	@Override
+	public List<LayoutPageTemplateEntry> findByG_C_C_LikeN_T_S(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type, int status, int start, int end,
+		OrderByComparator<LayoutPageTemplateEntry> orderByComparator) {
+
+		return findByG_C_C_LikeN_T_S(
+			groupIds, classNameId, classTypeKey, name, type, status, start, end,
+			orderByComparator, true);
+	}
+
+	/**
+	 * Returns an ordered range of all the layout page template entries where groupId = &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63; and status = &#63;, optionally using the finder cache.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>LayoutPageTemplateEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param name the name
+	 * @param type the type
+	 * @param status the status
+	 * @param start the lower bound of the range of layout page template entries
+	 * @param end the upper bound of the range of layout page template entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching layout page template entries
+	 */
+	@Override
+	public List<LayoutPageTemplateEntry> findByG_C_C_LikeN_T_S(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type, int status, int start, int end,
+		OrderByComparator<LayoutPageTemplateEntry> orderByComparator,
+		boolean useFinderCache) {
+
+		return _collectionPersistenceFinderByG_C_C_LikeN_T_S.find(
+			finderCache,
+			new Object[] {
+				ArrayUtil.sortedUnique(groupIds), classNameId, classTypeKey,
+				name, type, status
+			},
+			start, end, orderByComparator, useFinderCache);
 	}
 
 	/**
@@ -5018,7 +5711,8 @@ public class LayoutPageTemplateEntryPersistenceImpl
 		_collectionPersistenceFinderByG_C_C_LikeN_T_S.remove(
 			finderCache,
 			new Object[] {
-				groupId, classNameId, classTypeKey, name, type, status
+				new long[] {groupId}, classNameId, classTypeKey, name, type,
+				status
 			});
 	}
 
@@ -5041,7 +5735,32 @@ public class LayoutPageTemplateEntryPersistenceImpl
 		return _collectionPersistenceFinderByG_C_C_LikeN_T_S.count(
 			finderCache,
 			new Object[] {
-				groupId, classNameId, classTypeKey, name, type, status
+				new long[] {groupId}, classNameId, classTypeKey, name, type,
+				status
+			});
+	}
+
+	/**
+	 * Returns the number of layout page template entries where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63; and status = &#63;.
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param name the name
+	 * @param type the type
+	 * @param status the status
+	 * @return the number of matching layout page template entries
+	 */
+	@Override
+	public int countByG_C_C_LikeN_T_S(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type, int status) {
+
+		return _collectionPersistenceFinderByG_C_C_LikeN_T_S.count(
+			finderCache,
+			new Object[] {
+				ArrayUtil.sortedUnique(groupIds), classNameId, classTypeKey,
+				name, type, status
 			});
 	}
 
@@ -5064,9 +5783,36 @@ public class LayoutPageTemplateEntryPersistenceImpl
 		return _collectionPersistenceFinderByG_C_C_LikeN_T_S.filterCount(
 			finderCache,
 			new Object[] {
-				groupId, classNameId, classTypeKey, name, type, status
+				new long[] {groupId}, classNameId, classTypeKey, name, type,
+				status
 			},
 			groupId);
+	}
+
+	/**
+	 * Returns the number of layout page template entries that the user has permission to view where groupId = any &#63; and classNameId = &#63; and classTypeKey = &#63; and name LIKE &#63; and type = &#63; and status = &#63;.
+	 *
+	 * @param groupIds the group IDs
+	 * @param classNameId the class name ID
+	 * @param classTypeKey the class type key
+	 * @param name the name
+	 * @param type the type
+	 * @param status the status
+	 * @return the number of matching layout page template entries that the user has permission to view
+	 */
+	@Override
+	public int filterCountByG_C_C_LikeN_T_S(
+		long[] groupIds, long classNameId, String classTypeKey, String name,
+		int type, int status) {
+
+		groupIds = ArrayUtil.sortedUnique(groupIds);
+
+		return _collectionPersistenceFinderByG_C_C_LikeN_T_S.filterCount(
+			finderCache,
+			new Object[] {
+				groupIds, classNameId, classTypeKey, name, type, status
+			},
+			groupIds);
 	}
 
 	private UniquePersistenceFinder
@@ -6235,7 +6981,7 @@ public class LayoutPageTemplateEntryPersistenceImpl
 					},
 					0, 4, true, null),
 				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_C_C_T",
+					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByG_C_C_T",
 					new String[] {
 						Long.class.getName(), Long.class.getName(),
 						String.class.getName(), Integer.class.getName()
@@ -6248,9 +6994,9 @@ public class LayoutPageTemplateEntryPersistenceImpl
 				_SQL_COUNT_LAYOUTPAGETEMPLATEENTRY_WHERE,
 				LayoutPageTemplateEntryModelImpl.ORDER_BY_JPQL,
 				_ENTITY_ALIAS_PREFIX, "", "", null,
-				new FinderColumn<>(
+				new ArrayableFinderColumn<>(
 					"layoutPageTemplateEntry.", "groupId",
-					FinderColumn.Type.LONG, "=", true, true,
+					FinderColumn.Type.LONG, "=", false, true, true,
 					LayoutPageTemplateEntry::getGroupId),
 				new FinderColumn<>(
 					"layoutPageTemplateEntry.", "classNameId",
@@ -6514,9 +7260,9 @@ public class LayoutPageTemplateEntryPersistenceImpl
 				_SQL_COUNT_LAYOUTPAGETEMPLATEENTRY_WHERE,
 				LayoutPageTemplateEntryModelImpl.ORDER_BY_JPQL,
 				_ENTITY_ALIAS_PREFIX, "", "", null,
-				new FinderColumn<>(
+				new ArrayableFinderColumn<>(
 					"layoutPageTemplateEntry.", "groupId",
-					FinderColumn.Type.LONG, "=", true, true,
+					FinderColumn.Type.LONG, "=", false, true, true,
 					LayoutPageTemplateEntry::getGroupId),
 				new FinderColumn<>(
 					"layoutPageTemplateEntry.", "classNameId",
@@ -6566,8 +7312,7 @@ public class LayoutPageTemplateEntryPersistenceImpl
 					},
 					0, 4, true, null),
 				new FinderPath(
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
-					"countByG_C_C_T_S",
+					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByG_C_C_T_S",
 					new String[] {
 						Long.class.getName(), Long.class.getName(),
 						String.class.getName(), Integer.class.getName(),
@@ -6582,9 +7327,9 @@ public class LayoutPageTemplateEntryPersistenceImpl
 				_SQL_COUNT_LAYOUTPAGETEMPLATEENTRY_WHERE,
 				LayoutPageTemplateEntryModelImpl.ORDER_BY_JPQL,
 				_ENTITY_ALIAS_PREFIX, "", "", null,
-				new FinderColumn<>(
+				new ArrayableFinderColumn<>(
 					"layoutPageTemplateEntry.", "groupId",
-					FinderColumn.Type.LONG, "=", true, true,
+					FinderColumn.Type.LONG, "=", false, true, true,
 					LayoutPageTemplateEntry::getGroupId),
 				new FinderColumn<>(
 					"layoutPageTemplateEntry.", "classNameId",
@@ -6707,9 +7452,9 @@ public class LayoutPageTemplateEntryPersistenceImpl
 				_SQL_COUNT_LAYOUTPAGETEMPLATEENTRY_WHERE,
 				LayoutPageTemplateEntryModelImpl.ORDER_BY_JPQL,
 				_ENTITY_ALIAS_PREFIX, "", "", null,
-				new FinderColumn<>(
+				new ArrayableFinderColumn<>(
 					"layoutPageTemplateEntry.", "groupId",
-					FinderColumn.Type.LONG, "=", true, true,
+					FinderColumn.Type.LONG, "=", false, true, true,
 					LayoutPageTemplateEntry::getGroupId),
 				new FinderColumn<>(
 					"layoutPageTemplateEntry.", "classNameId",
@@ -6816,4 +7561,4 @@ public class LayoutPageTemplateEntryPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:556193239
+// LIFERAY-SERVICE-BUILDER-HASH:524244426

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/persistence/test/LayoutPageTemplateEntryPersistenceTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/persistence/test/LayoutPageTemplateEntryPersistenceTest.java
@@ -508,6 +508,14 @@ public class LayoutPageTemplateEntryPersistenceTest {
 	}
 
 	@Test
+	public void testCountByG_C_C_TArrayable() throws Exception {
+		_persistence.countByG_C_C_T(
+			new long[] {RandomTestUtil.nextLong(), 0L},
+			RandomTestUtil.nextLong(), RandomTestUtil.randomString(),
+			RandomTestUtil.nextInt());
+	}
+
+	@Test
 	public void testCountByG_C_C_D() throws Exception {
 		_persistence.countByG_C_C_D(
 			RandomTestUtil.nextLong(), RandomTestUtil.nextLong(), "",
@@ -569,6 +577,14 @@ public class LayoutPageTemplateEntryPersistenceTest {
 	}
 
 	@Test
+	public void testCountByG_C_C_LikeN_TArrayable() throws Exception {
+		_persistence.countByG_C_C_LikeN_T(
+			new long[] {RandomTestUtil.nextLong(), 0L},
+			RandomTestUtil.nextLong(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), RandomTestUtil.nextInt());
+	}
+
+	@Test
 	public void testCountByG_C_C_T_S() throws Exception {
 		_persistence.countByG_C_C_T_S(
 			RandomTestUtil.nextLong(), RandomTestUtil.nextLong(), "",
@@ -577,6 +593,14 @@ public class LayoutPageTemplateEntryPersistenceTest {
 		_persistence.countByG_C_C_T_S(0L, 0L, "null", 0, 0);
 
 		_persistence.countByG_C_C_T_S(0L, 0L, (String)null, 0, 0);
+	}
+
+	@Test
+	public void testCountByG_C_C_T_SArrayable() throws Exception {
+		_persistence.countByG_C_C_T_S(
+			new long[] {RandomTestUtil.nextLong(), 0L},
+			RandomTestUtil.nextLong(), RandomTestUtil.randomString(),
+			RandomTestUtil.nextInt(), RandomTestUtil.nextInt());
 	}
 
 	@Test
@@ -602,6 +626,15 @@ public class LayoutPageTemplateEntryPersistenceTest {
 
 		_persistence.countByG_C_C_LikeN_T_S(
 			0L, 0L, (String)null, (String)null, 0, 0);
+	}
+
+	@Test
+	public void testCountByG_C_C_LikeN_T_SArrayable() throws Exception {
+		_persistence.countByG_C_C_LikeN_T_S(
+			new long[] {RandomTestUtil.nextLong(), 0L},
+			RandomTestUtil.nextLong(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), RandomTestUtil.nextInt(),
+			RandomTestUtil.nextInt());
 	}
 
 	@Test
@@ -1112,4 +1145,4 @@ public class LayoutPageTemplateEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1732224641
+// LIFERAY-SERVICE-BUILDER-HASH:1613404101

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/test/DisplayPageTemplateServiceTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/test/DisplayPageTemplateServiceTest.java
@@ -53,7 +53,7 @@ public class DisplayPageTemplateServiceTest {
 	public void testAddDisplayPageTemplate() throws PortalException {
 		String name = RandomTestUtil.randomString();
 
-		LayoutPageTemplateEntry displayPageTemplate =
+		LayoutPageTemplateEntry layoutPageTemplateEntry =
 			_layoutPageTemplateEntryService.addLayoutPageTemplateEntry(
 				null, _group.getGroupId(), 0, null, name,
 				LayoutPageTemplateEntryTypeConstants.DISPLAY_PAGE, 0,
@@ -61,11 +61,11 @@ public class DisplayPageTemplateServiceTest {
 				ServiceContextTestUtil.getServiceContext(
 					_group.getGroupId(), TestPropsValues.getUserId()));
 
-		LayoutPageTemplateEntry persistedDisplayPageTemplate =
+		LayoutPageTemplateEntry persistedLayoutPageTemplateEntry =
 			_layoutPageTemplateEntryService.fetchLayoutPageTemplateEntry(
-				displayPageTemplate.getLayoutPageTemplateEntryId());
+				layoutPageTemplateEntry.getLayoutPageTemplateEntryId());
 
-		Assert.assertEquals(name, persistedDisplayPageTemplate.getName());
+		Assert.assertEquals(name, persistedLayoutPageTemplateEntry.getName());
 	}
 
 	@Test(expected = NoSuchClassNameException.class)
@@ -77,16 +77,16 @@ public class DisplayPageTemplateServiceTest {
 
 	@Test
 	public void testDeleteDisplayPageTemplate() throws PortalException {
-		LayoutPageTemplateEntry displayPageTemplate =
+		LayoutPageTemplateEntry layoutPageTemplateEntry =
 			DisplayPageTemplateTestUtil.addDisplayPageTemplate(
 				_group.getGroupId());
 
 		_layoutPageTemplateEntryService.deleteLayoutPageTemplateEntry(
-			displayPageTemplate.getLayoutPageTemplateEntryId());
+			layoutPageTemplateEntry.getLayoutPageTemplateEntryId());
 
 		Assert.assertNull(
 			_layoutPageTemplateEntryService.fetchLayoutPageTemplateEntry(
-				displayPageTemplate.getLayoutPageTemplateEntryId()));
+				layoutPageTemplateEntry.getLayoutPageTemplateEntryId()));
 	}
 
 	private LayoutPageTemplateEntry _createDisplayPageEntry(

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/test/DisplayPageTemplateServiceTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/test/DisplayPageTemplateServiceTest.java
@@ -54,10 +54,57 @@ public class DisplayPageTemplateServiceTest {
 	@Before
 	public void setUp() throws Exception {
 		_group1 = GroupTestUtil.addGroup();
+		_group2 = GroupTestUtil.addGroup();
 	}
 
 	@Test
-	public void testAddDisplayPageTemplate() throws PortalException {
+	public void testAddLayoutPageTemplateEntry() throws Exception {
+		_testAddLayoutPageTemplateEntry();
+
+		_testAddLayoutPageTemplateEntryWithInvalidClassNameId();
+	}
+
+	@Test
+	public void testDeleteLayoutPageTemplateEntry() throws Exception {
+		LayoutPageTemplateEntry layoutPageTemplateEntry =
+			DisplayPageTemplateTestUtil.addDisplayPageTemplate(
+				_group1.getGroupId());
+
+		_layoutPageTemplateEntryService.deleteLayoutPageTemplateEntry(
+			layoutPageTemplateEntry.getLayoutPageTemplateEntryId());
+
+		Assert.assertNull(
+			_layoutPageTemplateEntryService.fetchLayoutPageTemplateEntry(
+				layoutPageTemplateEntry.getLayoutPageTemplateEntryId()));
+	}
+
+	@Test
+	public void testGetLayoutPageTemplateEntries() throws Exception {
+		_testGetLayoutPageTemplateEntriesAcrossGroups();
+		_testGetLayoutPageTemplateEntriesAcrossGroupsWithName();
+		_testGetLayoutPageTemplateEntriesAcrossGroupsWithPagination();
+		_testGetLayoutPageTemplateEntriesWithoutGroups();
+	}
+
+	@Test
+	public void testGetLayoutPageTemplateEntriesCount() throws Exception {
+		_testGetLayoutPageTemplateEntriesCountAcrossGroups();
+		_testGetLayoutPageTemplateEntriesCountAcrossGroupsWithName();
+		_testGetLayoutPageTemplateEntriesCountWithoutGroups();
+	}
+
+	private LayoutPageTemplateEntry _createDisplayPageEntry(
+			long classNameId, String classTypeKey)
+		throws PortalException {
+
+		return _layoutPageTemplateEntryService.addLayoutPageTemplateEntry(
+			null, _group1.getGroupId(), 0, null, classNameId, classTypeKey,
+			RandomTestUtil.randomString(), 0, WorkflowConstants.STATUS_DRAFT,
+			ServiceContextTestUtil.getServiceContext(
+				_group1.getGroupId(), TestPropsValues.getUserId()));
+	}
+
+	private void _testAddLayoutPageTemplateEntry() throws Exception {
 		String name = RandomTestUtil.randomString();
 
 		LayoutPageTemplateEntry layoutPageTemplateEntry =
@@ -75,32 +122,16 @@ public class DisplayPageTemplateServiceTest {
 		Assert.assertEquals(name, persistedLayoutPageTemplateEntry.getName());
 	}
 
-	@Test(expected = NoSuchClassNameException.class)
-	public void testAddDisplayPageWithInvalidClassNameId()
-		throws PortalException {
-
-		_createDisplayPageEntry(0, RandomTestUtil.randomString());
-	}
-
-	@Test
-	public void testDeleteDisplayPageTemplate() throws PortalException {
-		LayoutPageTemplateEntry layoutPageTemplateEntry =
-			DisplayPageTemplateTestUtil.addDisplayPageTemplate(
-				_group1.getGroupId());
-
-		_layoutPageTemplateEntryService.deleteLayoutPageTemplateEntry(
-			layoutPageTemplateEntry.getLayoutPageTemplateEntryId());
-
-		Assert.assertNull(
-			_layoutPageTemplateEntryService.fetchLayoutPageTemplateEntry(
-				layoutPageTemplateEntry.getLayoutPageTemplateEntryId()));
-	}
-
-	@Test
-	public void testGetLayoutPageTemplateEntriesAcrossGroups()
+	private void _testAddLayoutPageTemplateEntryWithInvalidClassNameId()
 		throws Exception {
 
-		_group2 = GroupTestUtil.addGroup();
+		Assert.assertThrows(
+			NoSuchClassNameException.class,
+			() -> _createDisplayPageEntry(0, RandomTestUtil.randomString()));
+	}
+
+	private void _testGetLayoutPageTemplateEntriesAcrossGroups()
+		throws Exception {
 
 		DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
 			_group1.getGroupId(), JournalArticle.class.getName());
@@ -169,11 +200,8 @@ public class DisplayPageTemplateServiceTest {
 			layoutPageTemplateEntry1, layoutPageTemplateEntries.get(0));
 	}
 
-	@Test
-	public void testGetLayoutPageTemplateEntriesAcrossGroupsWithName()
+	private void _testGetLayoutPageTemplateEntriesAcrossGroupsWithName()
 		throws Exception {
-
-		_group2 = GroupTestUtil.addGroup();
 
 		DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
 			_group1.getGroupId(), JournalArticle.class.getName());
@@ -256,11 +284,8 @@ public class DisplayPageTemplateServiceTest {
 			layoutPageTemplateEntry1, layoutPageTemplateEntries.get(0));
 	}
 
-	@Test
-	public void testGetLayoutPageTemplateEntriesAcrossGroupsWithPagination()
+	private void _testGetLayoutPageTemplateEntriesAcrossGroupsWithPagination()
 		throws Exception {
-
-		_group2 = GroupTestUtil.addGroup();
 
 		DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
 			_group1.getGroupId(), JournalArticle.class.getName());
@@ -320,11 +345,8 @@ public class DisplayPageTemplateServiceTest {
 			layoutPageTemplateEntries.size());
 	}
 
-	@Test
-	public void testGetLayoutPageTemplateEntriesCountAcrossGroups()
+	private void _testGetLayoutPageTemplateEntriesCountAcrossGroups()
 		throws Exception {
-
-		_group2 = GroupTestUtil.addGroup();
 
 		DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
 			_group1.getGroupId(), JournalArticle.class.getName());
@@ -371,11 +393,8 @@ public class DisplayPageTemplateServiceTest {
 				WorkflowConstants.STATUS_APPROVED));
 	}
 
-	@Test
-	public void testGetLayoutPageTemplateEntriesCountAcrossGroupsWithName()
+	private void _testGetLayoutPageTemplateEntriesCountAcrossGroupsWithName()
 		throws Exception {
-
-		_group2 = GroupTestUtil.addGroup();
 
 		DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
 			_group1.getGroupId(), JournalArticle.class.getName());
@@ -433,8 +452,36 @@ public class DisplayPageTemplateServiceTest {
 				WorkflowConstants.STATUS_APPROVED));
 	}
 
-	@Test
-	public void testGetLayoutPageTemplateEntriesWithoutGroups()
+	private void _testGetLayoutPageTemplateEntriesCountWithoutGroups()
+		throws Exception {
+
+		DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
+			_group1.getGroupId(), JournalArticle.class.getName());
+
+		DisplayPageTemplateTestUtil.addDisplayPageTemplate(
+			_group1.getGroupId(),
+			_portal.getClassNameId(JournalArticle.class.getName()),
+			ddmStructure.getStructureKey());
+
+		Assert.assertEquals(
+			0,
+			_layoutPageTemplateEntryService.getLayoutPageTemplateEntriesCount(
+				new long[0],
+				_portal.getClassNameId(JournalArticle.class.getName()),
+				ddmStructure.getStructureKey(),
+				LayoutPageTemplateEntryTypeConstants.DISPLAY_PAGE,
+				WorkflowConstants.STATUS_APPROVED));
+		Assert.assertEquals(
+			0,
+			_layoutPageTemplateEntryService.getLayoutPageTemplateEntriesCount(
+				new long[0],
+				_portal.getClassNameId(JournalArticle.class.getName()),
+				ddmStructure.getStructureKey(), RandomTestUtil.randomString(),
+				LayoutPageTemplateEntryTypeConstants.DISPLAY_PAGE,
+				WorkflowConstants.STATUS_APPROVED));
+	}
+
+	private void _testGetLayoutPageTemplateEntriesWithoutGroups()
 		throws Exception {
 
 		DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
@@ -482,34 +529,6 @@ public class DisplayPageTemplateServiceTest {
 		Assert.assertEquals(
 			layoutPageTemplateEntries.toString(), 0,
 			layoutPageTemplateEntries.size());
-
-		Assert.assertEquals(
-			0,
-			_layoutPageTemplateEntryService.getLayoutPageTemplateEntriesCount(
-				new long[0],
-				_portal.getClassNameId(JournalArticle.class.getName()),
-				ddmStructure.getStructureKey(),
-				LayoutPageTemplateEntryTypeConstants.DISPLAY_PAGE,
-				WorkflowConstants.STATUS_APPROVED));
-		Assert.assertEquals(
-			0,
-			_layoutPageTemplateEntryService.getLayoutPageTemplateEntriesCount(
-				new long[0],
-				_portal.getClassNameId(JournalArticle.class.getName()),
-				ddmStructure.getStructureKey(), RandomTestUtil.randomString(),
-				LayoutPageTemplateEntryTypeConstants.DISPLAY_PAGE,
-				WorkflowConstants.STATUS_APPROVED));
-	}
-
-	private LayoutPageTemplateEntry _createDisplayPageEntry(
-			long classNameId, String classTypeKey)
-		throws PortalException {
-
-		return _layoutPageTemplateEntryService.addLayoutPageTemplateEntry(
-			null, _group1.getGroupId(), 0, null, classNameId, classTypeKey,
-			RandomTestUtil.randomString(), 0, WorkflowConstants.STATUS_DRAFT,
-			ServiceContextTestUtil.getServiceContext(
-				_group1.getGroupId(), TestPropsValues.getUserId()));
 	}
 
 	@DeleteAfterTestRun

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/test/DisplayPageTemplateServiceTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/test/DisplayPageTemplateServiceTest.java
@@ -6,10 +6,14 @@
 package com.liferay.layout.page.template.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.dynamic.data.mapping.test.util.DDMStructureTestUtil;
+import com.liferay.journal.model.JournalArticle;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryService;
 import com.liferay.layout.page.template.test.util.DisplayPageTemplateTestUtil;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.NoSuchClassNameException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
@@ -19,10 +23,13 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -46,7 +53,7 @@ public class DisplayPageTemplateServiceTest {
 
 	@Before
 	public void setUp() throws Exception {
-		_group = GroupTestUtil.addGroup();
+		_group1 = GroupTestUtil.addGroup();
 	}
 
 	@Test
@@ -55,11 +62,11 @@ public class DisplayPageTemplateServiceTest {
 
 		LayoutPageTemplateEntry layoutPageTemplateEntry =
 			_layoutPageTemplateEntryService.addLayoutPageTemplateEntry(
-				null, _group.getGroupId(), 0, null, name,
+				null, _group1.getGroupId(), 0, null, name,
 				LayoutPageTemplateEntryTypeConstants.DISPLAY_PAGE, 0,
 				WorkflowConstants.STATUS_DRAFT,
 				ServiceContextTestUtil.getServiceContext(
-					_group.getGroupId(), TestPropsValues.getUserId()));
+					_group1.getGroupId(), TestPropsValues.getUserId()));
 
 		LayoutPageTemplateEntry persistedLayoutPageTemplateEntry =
 			_layoutPageTemplateEntryService.fetchLayoutPageTemplateEntry(
@@ -79,7 +86,7 @@ public class DisplayPageTemplateServiceTest {
 	public void testDeleteDisplayPageTemplate() throws PortalException {
 		LayoutPageTemplateEntry layoutPageTemplateEntry =
 			DisplayPageTemplateTestUtil.addDisplayPageTemplate(
-				_group.getGroupId());
+				_group1.getGroupId());
 
 		_layoutPageTemplateEntryService.deleteLayoutPageTemplateEntry(
 			layoutPageTemplateEntry.getLayoutPageTemplateEntryId());
@@ -89,21 +96,432 @@ public class DisplayPageTemplateServiceTest {
 				layoutPageTemplateEntry.getLayoutPageTemplateEntryId()));
 	}
 
+	@Test
+	public void testGetLayoutPageTemplateEntriesAcrossGroups()
+		throws Exception {
+
+		_group2 = GroupTestUtil.addGroup();
+
+		DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
+			_group1.getGroupId(), JournalArticle.class.getName());
+
+		LayoutPageTemplateEntry layoutPageTemplateEntry1 =
+			DisplayPageTemplateTestUtil.addDisplayPageTemplate(
+				_group1.getGroupId(),
+				_portal.getClassNameId(JournalArticle.class.getName()),
+				ddmStructure.getStructureKey());
+
+		LayoutPageTemplateEntry layoutPageTemplateEntry2 =
+			DisplayPageTemplateTestUtil.addDisplayPageTemplate(
+				_group2.getGroupId(),
+				_portal.getClassNameId(JournalArticle.class.getName()),
+				ddmStructure.getStructureKey());
+
+		LayoutPageTemplateEntry layoutPageTemplateEntry3 =
+			DisplayPageTemplateTestUtil.addDisplayPageTemplate(
+				_group2.getGroupId(),
+				_portal.getClassNameId(JournalArticle.class.getName()),
+				ddmStructure.getStructureKey(), false,
+				WorkflowConstants.STATUS_DRAFT);
+
+		List<LayoutPageTemplateEntry> layoutPageTemplateEntries =
+			_layoutPageTemplateEntryService.getLayoutPageTemplateEntries(
+				new long[] {_group1.getGroupId(), _group2.getGroupId()},
+				_portal.getClassNameId(JournalArticle.class.getName()),
+				ddmStructure.getStructureKey(),
+				LayoutPageTemplateEntryTypeConstants.DISPLAY_PAGE,
+				WorkflowConstants.STATUS_APPROVED);
+
+		Assert.assertEquals(
+			layoutPageTemplateEntries.toString(), 2,
+			layoutPageTemplateEntries.size());
+		Assert.assertTrue(
+			layoutPageTemplateEntries.contains(layoutPageTemplateEntry1));
+		Assert.assertTrue(
+			layoutPageTemplateEntries.contains(layoutPageTemplateEntry2));
+
+		layoutPageTemplateEntries =
+			_layoutPageTemplateEntryService.getLayoutPageTemplateEntries(
+				new long[] {_group1.getGroupId(), _group2.getGroupId()},
+				_portal.getClassNameId(JournalArticle.class.getName()),
+				ddmStructure.getStructureKey(),
+				LayoutPageTemplateEntryTypeConstants.DISPLAY_PAGE,
+				WorkflowConstants.STATUS_ANY);
+
+		Assert.assertEquals(
+			layoutPageTemplateEntries.toString(), 3,
+			layoutPageTemplateEntries.size());
+		Assert.assertTrue(
+			layoutPageTemplateEntries.contains(layoutPageTemplateEntry3));
+
+		layoutPageTemplateEntries =
+			_layoutPageTemplateEntryService.getLayoutPageTemplateEntries(
+				new long[] {_group1.getGroupId()},
+				_portal.getClassNameId(JournalArticle.class.getName()),
+				ddmStructure.getStructureKey(),
+				LayoutPageTemplateEntryTypeConstants.DISPLAY_PAGE,
+				WorkflowConstants.STATUS_APPROVED);
+
+		Assert.assertEquals(
+			layoutPageTemplateEntries.toString(), 1,
+			layoutPageTemplateEntries.size());
+		Assert.assertEquals(
+			layoutPageTemplateEntry1, layoutPageTemplateEntries.get(0));
+	}
+
+	@Test
+	public void testGetLayoutPageTemplateEntriesAcrossGroupsWithName()
+		throws Exception {
+
+		_group2 = GroupTestUtil.addGroup();
+
+		DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
+			_group1.getGroupId(), JournalArticle.class.getName());
+
+		String name = RandomTestUtil.randomString();
+
+		LayoutPageTemplateEntry layoutPageTemplateEntry1 =
+			DisplayPageTemplateTestUtil.addDisplayPageTemplate(
+				_group1.getGroupId(),
+				_portal.getClassNameId(JournalArticle.class.getName()),
+				ddmStructure.getStructureKey(), false, null, name,
+				WorkflowConstants.STATUS_APPROVED);
+
+		LayoutPageTemplateEntry layoutPageTemplateEntry2 =
+			DisplayPageTemplateTestUtil.addDisplayPageTemplate(
+				_group2.getGroupId(),
+				_portal.getClassNameId(JournalArticle.class.getName()),
+				ddmStructure.getStructureKey(), false, null, name,
+				WorkflowConstants.STATUS_APPROVED);
+
+		LayoutPageTemplateEntry layoutPageTemplateEntry3 =
+			DisplayPageTemplateTestUtil.addDisplayPageTemplate(
+				_group1.getGroupId(),
+				_portal.getClassNameId(JournalArticle.class.getName()),
+				ddmStructure.getStructureKey(), false, null,
+				name + RandomTestUtil.randomString(),
+				WorkflowConstants.STATUS_DRAFT);
+
+		DisplayPageTemplateTestUtil.addDisplayPageTemplate(
+			_group2.getGroupId(),
+			_portal.getClassNameId(JournalArticle.class.getName()),
+			ddmStructure.getStructureKey(), false, null,
+			RandomTestUtil.randomString(), WorkflowConstants.STATUS_APPROVED);
+
+		List<LayoutPageTemplateEntry> layoutPageTemplateEntries =
+			_layoutPageTemplateEntryService.getLayoutPageTemplateEntries(
+				new long[] {_group1.getGroupId(), _group2.getGroupId()},
+				_portal.getClassNameId(JournalArticle.class.getName()),
+				ddmStructure.getStructureKey(), name,
+				LayoutPageTemplateEntryTypeConstants.DISPLAY_PAGE,
+				WorkflowConstants.STATUS_APPROVED, QueryUtil.ALL_POS,
+				QueryUtil.ALL_POS, null);
+
+		Assert.assertEquals(
+			layoutPageTemplateEntries.toString(), 2,
+			layoutPageTemplateEntries.size());
+		Assert.assertTrue(
+			layoutPageTemplateEntries.contains(layoutPageTemplateEntry1));
+		Assert.assertTrue(
+			layoutPageTemplateEntries.contains(layoutPageTemplateEntry2));
+
+		layoutPageTemplateEntries =
+			_layoutPageTemplateEntryService.getLayoutPageTemplateEntries(
+				new long[] {_group1.getGroupId(), _group2.getGroupId()},
+				_portal.getClassNameId(JournalArticle.class.getName()),
+				ddmStructure.getStructureKey(), name,
+				LayoutPageTemplateEntryTypeConstants.DISPLAY_PAGE,
+				WorkflowConstants.STATUS_ANY, QueryUtil.ALL_POS,
+				QueryUtil.ALL_POS, null);
+
+		Assert.assertEquals(
+			layoutPageTemplateEntries.toString(), 3,
+			layoutPageTemplateEntries.size());
+		Assert.assertTrue(
+			layoutPageTemplateEntries.contains(layoutPageTemplateEntry3));
+
+		layoutPageTemplateEntries =
+			_layoutPageTemplateEntryService.getLayoutPageTemplateEntries(
+				new long[] {_group1.getGroupId()},
+				_portal.getClassNameId(JournalArticle.class.getName()),
+				ddmStructure.getStructureKey(), name,
+				LayoutPageTemplateEntryTypeConstants.DISPLAY_PAGE,
+				WorkflowConstants.STATUS_APPROVED, QueryUtil.ALL_POS,
+				QueryUtil.ALL_POS, null);
+
+		Assert.assertEquals(
+			layoutPageTemplateEntries.toString(), 1,
+			layoutPageTemplateEntries.size());
+		Assert.assertEquals(
+			layoutPageTemplateEntry1, layoutPageTemplateEntries.get(0));
+	}
+
+	@Test
+	public void testGetLayoutPageTemplateEntriesAcrossGroupsWithPagination()
+		throws Exception {
+
+		_group2 = GroupTestUtil.addGroup();
+
+		DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
+			_group1.getGroupId(), JournalArticle.class.getName());
+
+		DisplayPageTemplateTestUtil.addDisplayPageTemplate(
+			_group1.getGroupId(),
+			_portal.getClassNameId(JournalArticle.class.getName()),
+			ddmStructure.getStructureKey());
+
+		DisplayPageTemplateTestUtil.addDisplayPageTemplate(
+			_group2.getGroupId(),
+			_portal.getClassNameId(JournalArticle.class.getName()),
+			ddmStructure.getStructureKey());
+
+		DisplayPageTemplateTestUtil.addDisplayPageTemplate(
+			_group2.getGroupId(),
+			_portal.getClassNameId(JournalArticle.class.getName()),
+			ddmStructure.getStructureKey(), false,
+			WorkflowConstants.STATUS_DRAFT);
+
+		List<LayoutPageTemplateEntry> layoutPageTemplateEntries =
+			_layoutPageTemplateEntryService.getLayoutPageTemplateEntries(
+				new long[] {_group1.getGroupId(), _group2.getGroupId()},
+				_portal.getClassNameId(JournalArticle.class.getName()),
+				ddmStructure.getStructureKey(),
+				LayoutPageTemplateEntryTypeConstants.DISPLAY_PAGE,
+				WorkflowConstants.STATUS_APPROVED, QueryUtil.ALL_POS,
+				QueryUtil.ALL_POS, null);
+
+		Assert.assertEquals(
+			layoutPageTemplateEntries.toString(), 2,
+			layoutPageTemplateEntries.size());
+
+		layoutPageTemplateEntries =
+			_layoutPageTemplateEntryService.getLayoutPageTemplateEntries(
+				new long[] {_group1.getGroupId(), _group2.getGroupId()},
+				_portal.getClassNameId(JournalArticle.class.getName()),
+				ddmStructure.getStructureKey(),
+				LayoutPageTemplateEntryTypeConstants.DISPLAY_PAGE,
+				WorkflowConstants.STATUS_ANY, QueryUtil.ALL_POS,
+				QueryUtil.ALL_POS, null);
+
+		Assert.assertEquals(
+			layoutPageTemplateEntries.toString(), 3,
+			layoutPageTemplateEntries.size());
+
+		layoutPageTemplateEntries =
+			_layoutPageTemplateEntryService.getLayoutPageTemplateEntries(
+				new long[] {_group1.getGroupId(), _group2.getGroupId()},
+				_portal.getClassNameId(JournalArticle.class.getName()),
+				ddmStructure.getStructureKey(),
+				LayoutPageTemplateEntryTypeConstants.DISPLAY_PAGE,
+				WorkflowConstants.STATUS_APPROVED, 0, 1, null);
+
+		Assert.assertEquals(
+			layoutPageTemplateEntries.toString(), 1,
+			layoutPageTemplateEntries.size());
+	}
+
+	@Test
+	public void testGetLayoutPageTemplateEntriesCountAcrossGroups()
+		throws Exception {
+
+		_group2 = GroupTestUtil.addGroup();
+
+		DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
+			_group1.getGroupId(), JournalArticle.class.getName());
+
+		DisplayPageTemplateTestUtil.addDisplayPageTemplate(
+			_group1.getGroupId(),
+			_portal.getClassNameId(JournalArticle.class.getName()),
+			ddmStructure.getStructureKey());
+
+		DisplayPageTemplateTestUtil.addDisplayPageTemplate(
+			_group2.getGroupId(),
+			_portal.getClassNameId(JournalArticle.class.getName()),
+			ddmStructure.getStructureKey());
+
+		DisplayPageTemplateTestUtil.addDisplayPageTemplate(
+			_group2.getGroupId(),
+			_portal.getClassNameId(JournalArticle.class.getName()),
+			ddmStructure.getStructureKey(), false,
+			WorkflowConstants.STATUS_DRAFT);
+
+		Assert.assertEquals(
+			2,
+			_layoutPageTemplateEntryService.getLayoutPageTemplateEntriesCount(
+				new long[] {_group1.getGroupId(), _group2.getGroupId()},
+				_portal.getClassNameId(JournalArticle.class.getName()),
+				ddmStructure.getStructureKey(),
+				LayoutPageTemplateEntryTypeConstants.DISPLAY_PAGE,
+				WorkflowConstants.STATUS_APPROVED));
+		Assert.assertEquals(
+			3,
+			_layoutPageTemplateEntryService.getLayoutPageTemplateEntriesCount(
+				new long[] {_group1.getGroupId(), _group2.getGroupId()},
+				_portal.getClassNameId(JournalArticle.class.getName()),
+				ddmStructure.getStructureKey(),
+				LayoutPageTemplateEntryTypeConstants.DISPLAY_PAGE,
+				WorkflowConstants.STATUS_ANY));
+		Assert.assertEquals(
+			1,
+			_layoutPageTemplateEntryService.getLayoutPageTemplateEntriesCount(
+				new long[] {_group1.getGroupId()},
+				_portal.getClassNameId(JournalArticle.class.getName()),
+				ddmStructure.getStructureKey(),
+				LayoutPageTemplateEntryTypeConstants.DISPLAY_PAGE,
+				WorkflowConstants.STATUS_APPROVED));
+	}
+
+	@Test
+	public void testGetLayoutPageTemplateEntriesCountAcrossGroupsWithName()
+		throws Exception {
+
+		_group2 = GroupTestUtil.addGroup();
+
+		DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
+			_group1.getGroupId(), JournalArticle.class.getName());
+
+		String name = RandomTestUtil.randomString();
+
+		DisplayPageTemplateTestUtil.addDisplayPageTemplate(
+			_group1.getGroupId(),
+			_portal.getClassNameId(JournalArticle.class.getName()),
+			ddmStructure.getStructureKey(), false, null, name,
+			WorkflowConstants.STATUS_APPROVED);
+
+		DisplayPageTemplateTestUtil.addDisplayPageTemplate(
+			_group2.getGroupId(),
+			_portal.getClassNameId(JournalArticle.class.getName()),
+			ddmStructure.getStructureKey(), false, null, name,
+			WorkflowConstants.STATUS_APPROVED);
+
+		DisplayPageTemplateTestUtil.addDisplayPageTemplate(
+			_group1.getGroupId(),
+			_portal.getClassNameId(JournalArticle.class.getName()),
+			ddmStructure.getStructureKey(), false, null,
+			name + RandomTestUtil.randomString(),
+			WorkflowConstants.STATUS_DRAFT);
+
+		DisplayPageTemplateTestUtil.addDisplayPageTemplate(
+			_group2.getGroupId(),
+			_portal.getClassNameId(JournalArticle.class.getName()),
+			ddmStructure.getStructureKey(), false, null,
+			RandomTestUtil.randomString(), WorkflowConstants.STATUS_APPROVED);
+
+		Assert.assertEquals(
+			2,
+			_layoutPageTemplateEntryService.getLayoutPageTemplateEntriesCount(
+				new long[] {_group1.getGroupId(), _group2.getGroupId()},
+				_portal.getClassNameId(JournalArticle.class.getName()),
+				ddmStructure.getStructureKey(), name,
+				LayoutPageTemplateEntryTypeConstants.DISPLAY_PAGE,
+				WorkflowConstants.STATUS_APPROVED));
+		Assert.assertEquals(
+			3,
+			_layoutPageTemplateEntryService.getLayoutPageTemplateEntriesCount(
+				new long[] {_group1.getGroupId(), _group2.getGroupId()},
+				_portal.getClassNameId(JournalArticle.class.getName()),
+				ddmStructure.getStructureKey(), name,
+				LayoutPageTemplateEntryTypeConstants.DISPLAY_PAGE,
+				WorkflowConstants.STATUS_ANY));
+		Assert.assertEquals(
+			1,
+			_layoutPageTemplateEntryService.getLayoutPageTemplateEntriesCount(
+				new long[] {_group1.getGroupId()},
+				_portal.getClassNameId(JournalArticle.class.getName()),
+				ddmStructure.getStructureKey(), name,
+				LayoutPageTemplateEntryTypeConstants.DISPLAY_PAGE,
+				WorkflowConstants.STATUS_APPROVED));
+	}
+
+	@Test
+	public void testGetLayoutPageTemplateEntriesWithoutGroups()
+		throws Exception {
+
+		DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
+			_group1.getGroupId(), JournalArticle.class.getName());
+
+		DisplayPageTemplateTestUtil.addDisplayPageTemplate(
+			_group1.getGroupId(),
+			_portal.getClassNameId(JournalArticle.class.getName()),
+			ddmStructure.getStructureKey());
+
+		List<LayoutPageTemplateEntry> layoutPageTemplateEntries =
+			_layoutPageTemplateEntryService.getLayoutPageTemplateEntries(
+				new long[0],
+				_portal.getClassNameId(JournalArticle.class.getName()),
+				ddmStructure.getStructureKey(),
+				LayoutPageTemplateEntryTypeConstants.DISPLAY_PAGE,
+				WorkflowConstants.STATUS_APPROVED);
+
+		Assert.assertEquals(
+			layoutPageTemplateEntries.toString(), 0,
+			layoutPageTemplateEntries.size());
+
+		layoutPageTemplateEntries =
+			_layoutPageTemplateEntryService.getLayoutPageTemplateEntries(
+				new long[0],
+				_portal.getClassNameId(JournalArticle.class.getName()),
+				ddmStructure.getStructureKey(),
+				LayoutPageTemplateEntryTypeConstants.DISPLAY_PAGE,
+				WorkflowConstants.STATUS_APPROVED, QueryUtil.ALL_POS,
+				QueryUtil.ALL_POS, null);
+
+		Assert.assertEquals(
+			layoutPageTemplateEntries.toString(), 0,
+			layoutPageTemplateEntries.size());
+
+		layoutPageTemplateEntries =
+			_layoutPageTemplateEntryService.getLayoutPageTemplateEntries(
+				new long[0],
+				_portal.getClassNameId(JournalArticle.class.getName()),
+				ddmStructure.getStructureKey(), RandomTestUtil.randomString(),
+				LayoutPageTemplateEntryTypeConstants.DISPLAY_PAGE,
+				WorkflowConstants.STATUS_APPROVED, QueryUtil.ALL_POS,
+				QueryUtil.ALL_POS, null);
+
+		Assert.assertEquals(
+			layoutPageTemplateEntries.toString(), 0,
+			layoutPageTemplateEntries.size());
+
+		Assert.assertEquals(
+			0,
+			_layoutPageTemplateEntryService.getLayoutPageTemplateEntriesCount(
+				new long[0],
+				_portal.getClassNameId(JournalArticle.class.getName()),
+				ddmStructure.getStructureKey(),
+				LayoutPageTemplateEntryTypeConstants.DISPLAY_PAGE,
+				WorkflowConstants.STATUS_APPROVED));
+		Assert.assertEquals(
+			0,
+			_layoutPageTemplateEntryService.getLayoutPageTemplateEntriesCount(
+				new long[0],
+				_portal.getClassNameId(JournalArticle.class.getName()),
+				ddmStructure.getStructureKey(), RandomTestUtil.randomString(),
+				LayoutPageTemplateEntryTypeConstants.DISPLAY_PAGE,
+				WorkflowConstants.STATUS_APPROVED));
+	}
+
 	private LayoutPageTemplateEntry _createDisplayPageEntry(
 			long classNameId, String classTypeKey)
 		throws PortalException {
 
 		return _layoutPageTemplateEntryService.addLayoutPageTemplateEntry(
-			null, _group.getGroupId(), 0, null, classNameId, classTypeKey,
+			null, _group1.getGroupId(), 0, null, classNameId, classTypeKey,
 			RandomTestUtil.randomString(), 0, WorkflowConstants.STATUS_DRAFT,
 			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), TestPropsValues.getUserId()));
+				_group1.getGroupId(), TestPropsValues.getUserId()));
 	}
 
 	@DeleteAfterTestRun
-	private Group _group;
+	private Group _group1;
+
+	@DeleteAfterTestRun
+	private Group _group2;
 
 	@Inject
 	private LayoutPageTemplateEntryService _layoutPageTemplateEntryService;
+
+	@Inject
+	private Portal _portal;
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-104228

## What Is Being Fixed

Every display page template lookup on `LayoutPageTemplateEntryService` took a single `groupId`, so a caller could only ever see the templates of one group. A display page template hosted in a Design Library and installed via marketplace lives in a different group from the site that renders it, and there was no way to ask for both at once.

## How It Is Being Fixed

The four `service.xml` finders that already filter by group, class name, class type and type — `G_C_C_T`, `G_C_C_LikeN_T`, `G_C_C_T_S` and `G_C_C_LikeN_T_S` — get `arrayable-operator="OR"` on their `groupId` column, so Service Builder generates `long[] groupIds` variants alongside the existing scalar ones. `LayoutPageTemplateEntryServiceImpl` then exposes five `long[] groupIds` overloads of `getLayoutPageTemplateEntries` and `getLayoutPageTemplateEntriesCount`, each applying the same permission filtering as its single group counterpart.

Nothing is removed. The scalar overloads stay exactly as they were, so the change is source and binary compatible for the 154 modules that depend on `layout-page-template-api` and no existing caller has to change. The consumers that will use the new overloads — the display page selector, the mapping field set provider and the friendly URL resolver — are later tasks of LPD-103977; this one opens the door for them at the service layer.

The integration tests exercise the arrayable behavior directly: several groups at once, a single group, an empty `long[]`, and the name and pagination variants.

## PR Check

**pr-check: PASS** — tested on `9c4ba6780205e3d49f82cab9c509d7339334de38`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Service Registration | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS (baseline-all + seven Ant projects + 1 changed exporting module) |
| Structural Smoke | PASS |
| Java Unit Tests | NOT VERIFIED |

Java Unit Tests verified nothing about the branch. No changed class has a parallel-name unit counterpart — `layout-page-template-api` has no `src/test/java` at all, and `layout-page-template-service` holds only `EditableValuesTransformerUtilTest`, unrelated to the change. That suite was run anyway and passed (`tests="7" failures="0" errors="0"`), which catches an unrelated break but cannot speak for the change. Two of the changed classes are covered by integration tests in the sibling `-test` module — `LayoutPageTemplateEntryServiceTest.java` and `LayoutPageTemplateEntryPersistenceTest.java` — which this validation does not run.

Baseline made a commit. On a clean tree, `ant baseline-all` reported `com.liferay.layout.page.template.service` MINOR `19.0.0 → 19.1.0` and `com.liferay.layout.page.template.service.persistence` MINOR `10.0.0 → 10.1.0`, both `VERSION INCREASE REQUIRED`, plus `[Baseline Warning] Bundle Version Change Recommended: 38.1.0`. All three files belong to a module the branch changed and are minor rises, so they were committed as `LPD-104228 Semantic versioning`. No other module was repaired. Re-baselining the module afterwards gave `BUILD SUCCESSFUL`, the task executed, zero findings and zero tree drift; the seven Ant projects each reported `1 executed` with no findings.

Structural Smoke only became applicable after that commit — the ledger recompute picked up the new `bnd.bnd` path, which Pass 1 could not have seen. `ModulesStructureTest` reported `tests="8" failures="0" errors="0"` and changed nothing in the tree.

<!-- pr-check {"result": "success", "sha": "9c4ba6780205e3d49f82cab9c509d7339334de38"} -->
