### PR TITLE
LPD-103645 Require active bundles before running the data cleanup

### DIFF
--- a/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/PortletPreferencesPostUpgradeDataCleanupProcess.java
+++ b/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/PortletPreferencesPostUpgradeDataCleanupProcess.java
@@ -49,14 +49,14 @@ public class PortletPreferencesPostUpgradeDataCleanupProcess
 
 	@Override
 	public void cleanUp() throws Exception {
-		if (!PostUpgradeDataCleanupProcessUtil.isEveryLiferayBundleResolved()) {
+		if (!PostUpgradeDataCleanupProcessUtil.isEveryLiferayBundleActive()) {
 			if (_log.isWarnEnabled() && CompanyThreadLocal.isDefaultCompany()) {
 				_log.warn(
 					StringBundler.concat(
 						PortletPreferencesPostUpgradeDataCleanupProcess.class.
 							getSimpleName(),
-						" cannot be executed because there are modules with ",
-						"unsatisfied references"));
+						" cannot be executed because there are modules that ",
+						"are not active"));
 			}
 
 			return;

--- a/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/ResourceActionPostUpgradeDataCleanupProcess.java
+++ b/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/ResourceActionPostUpgradeDataCleanupProcess.java
@@ -55,14 +55,14 @@ public class ResourceActionPostUpgradeDataCleanupProcess
 
 	@Override
 	public void cleanUp() throws Exception {
-		if (!PostUpgradeDataCleanupProcessUtil.isEveryLiferayBundleResolved()) {
+		if (!PostUpgradeDataCleanupProcessUtil.isEveryLiferayBundleActive()) {
 			if (_log.isWarnEnabled() && CompanyThreadLocal.isDefaultCompany()) {
 				_log.warn(
 					StringBundler.concat(
 						ResourceActionPostUpgradeDataCleanupProcess.class.
 							getSimpleName(),
-						" cannot be executed because there are modules with ",
-						"unsatisfied references"));
+						" cannot be executed because there are modules that ",
+						"are not active"));
 			}
 
 			return;

--- a/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/ResourcePermissionPostupgradeDataCleanupProcess.java
+++ b/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/ResourcePermissionPostupgradeDataCleanupProcess.java
@@ -47,14 +47,14 @@ public class ResourcePermissionPostupgradeDataCleanupProcess
 
 	@Override
 	public void cleanUp() throws Exception {
-		if (!PostUpgradeDataCleanupProcessUtil.isEveryLiferayBundleResolved()) {
+		if (!PostUpgradeDataCleanupProcessUtil.isEveryLiferayBundleActive()) {
 			if (_log.isWarnEnabled() && CompanyThreadLocal.isDefaultCompany()) {
 				_log.warn(
 					StringBundler.concat(
 						ResourcePermissionPostupgradeDataCleanupProcess.class.
 							getSimpleName(),
-						" cannot be executed because there are modules with ",
-						"unsatisfied references"));
+						" cannot be executed because there are modules that ",
+						"are not active"));
 			}
 
 			return;

--- a/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/util/PostUpgradeDataCleanupProcessUtil.java
+++ b/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/util/PostUpgradeDataCleanupProcessUtil.java
@@ -7,30 +7,73 @@ package com.liferay.data.cleanup.internal.verify.util;
 
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 
+import java.util.function.Predicate;
+
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
+import org.osgi.framework.wiring.BundleRevision;
 
 /**
  * @author Luis Ortiz
  */
 public class PostUpgradeDataCleanupProcessUtil {
 
+	public static boolean isEveryLiferayBundleActive() {
+		return _isEveryLiferayBundle(
+			PostUpgradeDataCleanupProcessUtil::_isActive);
+	}
+
 	public static boolean isEveryLiferayBundleResolved() {
+		return _isEveryLiferayBundle(
+			PostUpgradeDataCleanupProcessUtil::_isResolved);
+	}
+
+	private static boolean _isActive(Bundle bundle) {
+		int state = bundle.getState();
+
+		if ((state == Bundle.ACTIVE) ||
+			((state == Bundle.RESOLVED) && _isFragment(bundle))) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	private static boolean _isEveryLiferayBundle(Predicate<Bundle> predicate) {
 		BundleContext bundleContext = SystemBundleUtil.getBundleContext();
 
 		for (Bundle bundle : bundleContext.getBundles()) {
 			String bundleSymbolicName = bundle.getSymbolicName();
 
-			if (!bundleSymbolicName.startsWith("com.liferay.")) {
-				continue;
-			}
+			if (bundleSymbolicName.startsWith("com.liferay.") &&
+				!predicate.test(bundle)) {
 
-			if (bundle.getState() == Bundle.INSTALLED) {
 				return false;
 			}
 		}
 
 		return true;
+	}
+
+	private static boolean _isFragment(Bundle bundle) {
+		BundleRevision bundleRevision = bundle.adapt(BundleRevision.class);
+
+		if ((bundleRevision != null) &&
+			((bundleRevision.getTypes() & BundleRevision.TYPE_FRAGMENT) != 0)) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	private static boolean _isResolved(Bundle bundle) {
+		if (bundle.getState() != Bundle.INSTALLED) {
+			return true;
+		}
+
+		return false;
 	}
 
 }

--- a/modules/apps/data-cleanup/data-cleanup-test/src/testIntegration/java/com/liferay/data/cleanup/internal/verify/test/BasePostUpgradeDataCleanupProcessTestCase.java
+++ b/modules/apps/data-cleanup/data-cleanup-test/src/testIntegration/java/com/liferay/data/cleanup/internal/verify/test/BasePostUpgradeDataCleanupProcessTestCase.java
@@ -90,6 +90,30 @@ public abstract class BasePostUpgradeDataCleanupProcessTestCase {
 		_waitForRegistries();
 	}
 
+	protected void startBundle(Bundle bundle) throws Exception {
+		bundle.start();
+
+		_waitForRegistries();
+	}
+
+	protected Bundle stopBundle(BundleContext bundleContext, String bundleName)
+		throws Exception {
+
+		for (Bundle bundle : bundleContext.getBundles()) {
+			if (Objects.equals(bundle.getSymbolicName(), bundleName) &&
+				(bundle.getState() == Bundle.ACTIVE)) {
+
+				_snapshotRegistries();
+
+				bundle.stop();
+
+				return bundle;
+			}
+		}
+
+		return null;
+	}
+
 	protected void test(
 			UnsafeConsumer<LogCapture, Exception> assertUnsafeConsumer,
 			UnsafeRunnable<Exception> cleanUpDataUnsafeRunnable,

--- a/modules/apps/data-cleanup/data-cleanup-test/src/testIntegration/java/com/liferay/data/cleanup/internal/verify/test/BasePostUpgradeDataCleanupProcessTestCase.java
+++ b/modules/apps/data-cleanup/data-cleanup-test/src/testIntegration/java/com/liferay/data/cleanup/internal/verify/test/BasePostUpgradeDataCleanupProcessTestCase.java
@@ -11,13 +11,19 @@ import com.liferay.object.test.util.ObjectDefinitionTestUtil;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeRunnable;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.dao.db.DBInspector;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.model.ClassName;
+import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.module.util.BundleUtil;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
+import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.ClassNameLocalServiceUtil;
+import com.liferay.portal.kernel.service.PortletLocalServiceUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.util.SetUtil;
+import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.lpkg.deployer.LPKGDeployer;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
@@ -30,7 +36,9 @@ import java.lang.reflect.Method;
 import java.sql.Connection;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.AfterClass;
@@ -78,6 +86,8 @@ public abstract class BasePostUpgradeDataCleanupProcessTestCase {
 
 		com.liferay.osgi.util.BundleUtil.refreshBundles(
 			bundleContext, Collections.singletonList(bundle));
+
+		_waitForRegistries();
 	}
 
 	protected void test(
@@ -180,6 +190,8 @@ public abstract class BasePostUpgradeDataCleanupProcessTestCase {
 			if (Objects.equals(bundle.getSymbolicName(), bundleName) &&
 				(bundle.getState() == Bundle.ACTIVE)) {
 
+				_snapshotRegistries();
+
 				bundle.uninstall();
 
 				com.liferay.osgi.util.BundleUtil.refreshBundles(
@@ -194,6 +206,16 @@ public abstract class BasePostUpgradeDataCleanupProcessTestCase {
 
 	protected static Connection connection;
 	protected static DBInspector dbInspector;
+
+	private Set<String> _getPortletIds() {
+		Set<String> portletIds = new HashSet<>();
+
+		for (Portlet portlet : PortletLocalServiceUtil.getPortlets()) {
+			portletIds.add(portlet.getPortletId());
+		}
+
+		return portletIds;
+	}
 
 	private void _runPostUpgradeDataCleanUpVerifyProcess() throws Exception {
 		Bundle bundle = BundleUtil.getBundle(
@@ -215,7 +237,50 @@ public abstract class BasePostUpgradeDataCleanupProcessTestCase {
 		method.invoke(object);
 	}
 
+	private void _snapshotRegistries() {
+		_modelNames = new HashSet<>(ResourceActionsUtil.getModelNames());
+		_portletIds = _getPortletIds();
+		_portletNames = new HashSet<>(ResourceActionsUtil.getPortletNames());
+	}
+
+	private void _waitForRegistries() throws Exception {
+		long startTime = System.currentTimeMillis();
+
+		while (true) {
+			Set<String> missingModelNames = SetUtil.asymmetricDifference(
+				_modelNames, ResourceActionsUtil.getModelNames());
+			Set<String> missingPortletIds = SetUtil.asymmetricDifference(
+				_portletIds, _getPortletIds());
+			Set<String> missingPortletNames = SetUtil.asymmetricDifference(
+				_portletNames, ResourceActionsUtil.getPortletNames());
+
+			if (missingModelNames.isEmpty() && missingPortletIds.isEmpty() &&
+				missingPortletNames.isEmpty()) {
+
+				return;
+			}
+
+			if ((System.currentTimeMillis() - startTime) > _TIMEOUT) {
+				throw new IllegalStateException(
+					StringBundler.concat(
+						"Unable to repopulate the resource action and portlet ",
+						"registries within ", _TIMEOUT / Time.SECOND,
+						" seconds: missing model names ", missingModelNames,
+						", missing portlet IDs ", missingPortletIds,
+						", and missing portlet names ", missingPortletNames));
+			}
+
+			Thread.sleep(500);
+		}
+	}
+
+	private static final long _TIMEOUT = Time.MINUTE * 5;
+
 	@Inject
 	private LPKGDeployer _lpkgDeployer;
+
+	private Set<String> _modelNames = Collections.emptySet();
+	private Set<String> _portletIds = Collections.emptySet();
+	private Set<String> _portletNames = Collections.emptySet();
 
 }

--- a/modules/apps/data-cleanup/data-cleanup-test/src/testIntegration/java/com/liferay/data/cleanup/internal/verify/test/PortletPreferencesPostUpgradeDataCleanupProcessTest.java
+++ b/modules/apps/data-cleanup/data-cleanup-test/src/testIntegration/java/com/liferay/data/cleanup/internal/verify/test/PortletPreferencesPostUpgradeDataCleanupProcessTest.java
@@ -507,7 +507,7 @@ public class PortletPreferencesPostUpgradeDataCleanupProcessTest
 					messages.contains(
 						"PortletPreferencesPostUpgradeDataCleanupProcess " +
 							"cannot be executed because there are modules " +
-								"with unsatisfied references"));
+								"that are not active"));
 			},
 			() -> {
 				Bundle bundle = bundleAtomicReference.get();

--- a/modules/apps/data-cleanup/data-cleanup-test/src/testIntegration/java/com/liferay/data/cleanup/internal/verify/test/ResourceActionPostUpgradeDataCleanupProcessTest.java
+++ b/modules/apps/data-cleanup/data-cleanup-test/src/testIntegration/java/com/liferay/data/cleanup/internal/verify/test/ResourceActionPostUpgradeDataCleanupProcessTest.java
@@ -49,6 +49,34 @@ public class ResourceActionPostUpgradeDataCleanupProcessTest
 	extends BasePostUpgradeDataCleanupProcessTestCase {
 
 	@Test
+	public void testCleanUpDoesNotRunIfBundleIsStopped() throws Exception {
+		AtomicReference<Bundle> bundleAtomicReference = new AtomicReference<>();
+
+		test(
+			logCapture -> {
+				List<String> messages = logCapture.getMessages();
+
+				Assert.assertTrue(
+					messages.toString(),
+					messages.contains(
+						"ResourceActionPostUpgradeDataCleanupProcess cannot " +
+							"be executed because there are modules that are " +
+								"not active"));
+			},
+			() -> {
+				Bundle bundle = bundleAtomicReference.get();
+
+				if (bundle != null) {
+					startBundle(bundle);
+				}
+			},
+			() -> bundleAtomicReference.set(
+				stopBundle(
+					SystemBundleUtil.getBundleContext(),
+					"com.liferay.dynamic.data.mapping.service")));
+	}
+
+	@Test
 	public void testFoundObjectDefinitionResourceActionsAreNotDeleted()
 		throws Exception {
 

--- a/modules/apps/data-cleanup/data-cleanup-test/src/testIntegration/java/com/liferay/data/cleanup/internal/verify/test/ResourceActionPostUpgradeDataCleanupProcessTest.java
+++ b/modules/apps/data-cleanup/data-cleanup-test/src/testIntegration/java/com/liferay/data/cleanup/internal/verify/test/ResourceActionPostUpgradeDataCleanupProcessTest.java
@@ -291,8 +291,8 @@ public class ResourceActionPostUpgradeDataCleanupProcessTest
 					messages.toString(),
 					messages.contains(
 						"ResourceActionPostUpgradeDataCleanupProcess cannot " +
-							"be executed because there are modules with " +
-								"unsatisfied references"));
+							"be executed because there are modules that are " +
+								"not active"));
 			},
 			() -> {
 				Bundle bundle = bundleAtomicReference.get();

--- a/modules/apps/data-cleanup/data-cleanup-test/src/testIntegration/java/com/liferay/data/cleanup/internal/verify/test/ResourcePermissionPostupgradeDataCleanupProcessTest.java
+++ b/modules/apps/data-cleanup/data-cleanup-test/src/testIntegration/java/com/liferay/data/cleanup/internal/verify/test/ResourcePermissionPostupgradeDataCleanupProcessTest.java
@@ -172,7 +172,7 @@ public class ResourcePermissionPostupgradeDataCleanupProcessTest
 					messages.contains(
 						"ResourcePermissionPostupgradeDataCleanupProcess " +
 							"cannot be executed because there are modules " +
-								"with unsatisfied references"));
+								"that are not active"));
 			},
 			() -> {
 				Bundle bundle = bundleAtomicReference.get();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103645

## What Is Being Fixed

The data cleanup can silently delete rows that belong to live modules. This is a data loss defect on a customer reachable path: `cleanUpAllSystemData` in Server Administration runs these cleanups on demand, and deleted portlet preferences do not come back.

The cleanups snapshot a live registry and delete every Liferay prefixed database row that is missing from the snapshot. Their only protection is a guard that rejects bundles in the `INSTALLED` state, and that is not enough. A bundle in `RESOLVED` or `STARTING` passes the guard before its services are registered, and a web application bundle (WAB), a WAR deployed as an OSGi bundle, is installed asynchronously and can be missing from the bundle list entirely. A cleanup that runs in such a moment sees an incomplete snapshot and deletes live rows.

CI confirmed this once, in the 2026-08-24 `ci:test:upgrade` build. One cleanup pass deleted 12 `resourceaction` rows, 13 `portletpreferences` rows, and 81 `Portlet` rows, including `BlogsPortlet`, `WikiPortlet`, and `SiteNavigationMenuPortlet`, which cannot be uninstalled. Two other failures in the same run show the same half registered state: a `NullPointerException` on an unregistered `persistedModelLocalService` and an "Unable to register portal instance" failure in `PortalLogAssertorTest`. Seven of the eight database vendors passed on the same SHA, so the trigger is timing, not a commit.

## How It Is Being Fixed

Two changes, one on each side of the race.

A second guard, `isEveryLiferayBundleActive`, requires every `com.liferay` bundle to be `ACTIVE`, and the three cleanups that read the resource action and portlet registries, `ResourceAction`, `PortletPreferences` and `ResourcePermission`, use it. A fragment never activates, so a fragment in `RESOLVED` is accepted through its `BundleRevision` type. `ClassName` keeps the existing `isEveryLiferayBundleResolved` guard, since it finds class names through the bundle wiring and `Bundle.loadClass`, which work on a resolved bundle. When the new guard fails, the cleanup skips with a warning, as the old one already does. This is a behavior change on a system where a `com.liferay` bundle failed to start: those three cleanups now skip where they used to run. For code whose only action is deleting rows, that is the intended direction; the worst case moves from deleting live rows to postponing an optional cleanup.

On the test side, `BasePostUpgradeDataCleanupProcessTestCase` snapshots the resource action and portlet registries before a bundle uninstall and waits until they refill after the reinstall. The names still missing are computed with `SetUtil.asymmetricDifference(snapshot, current)`, the kernel utility for the relative complement of two collections, in place of a private `_getMissingEntries` helper that reimplemented it. The helper named its parameters and result `entries`, which described none of the model names, portlet IDs and portlet names it compared, and the previous round of review flagged the name; the utility already exists and takes the registries' `List` and `Set` views directly, so the helper is removed together with the name and the test carries no set arithmetic of its own. This is the change that prevents the CI failure: in the failing run every bundle had already started when the deletions began, and the gap came from declarative services components that were still reregistering, which no bundle state check can see. A new test stops a bundle and asserts the cleanup refuses to run.

The guard covers the windows a state check can see, a stopped bundle and a refresh in flight, which is what the on demand production path crosses during a redeploy. A component still activating inside an `ACTIVE` bundle stays invisible to any state check, so the production window is narrowed rather than closed; closing it would need a registration quiescence signal OSGi does not provide.

Verified locally against master `b5f7105b51bf6`: the full `data-cleanup-test` suite (98 tests, 1 skipped by a nondefault company `Assume`) and the three `portal-upgrade-test` classes that load the data cleanup bundle (`DBUpgraderTest` and both `UpgradeLogAppender` variants, 66 tests) are green, and an end to end upgrade of a 2025.Q1 database (portal schema `31.11.0`, one company, partitioning disabled) to `39.0.0` was run twice on this change. `PostUpgradeDataCleanupVerifyProcess` executed its five cleanups both times with no `cannot be executed` warning, because `DependencyManagerSyncUtil.sync()` drains the WAB, portlet tracker and Spring extender initializations before the verify callable runs. The new test also proves the defect: it fails against the old guard and passes with the new one. A green CI run does not demonstrate the fix, since the race fired only once; the new test is the deterministic evidence.

## PR Check

**pr-check: PASS** — tested on `dbab16deb23a083dbcf171e8a08adf3200dc343d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

Java Unit Tests selected no test class. `data-cleanup-impl` has no `src/test` source tree, so no parallel-name counterpart exists for any of the four changed main sources and there is no unit suite to fall back to. The coverage for this change is integration level, in `data-cleanup-test`.

<!-- pr-check {"result": "success", "sha": "dbab16deb23a083dbcf171e8a08adf3200dc343d"} -->

