### PR TITLE
LPD-104521 Keep style book token values intact when rendering them

### DIFF
--- a/modules/apps/frontend-css/frontend-css-variables-web/src/main/java/com/liferay/frontend/css/variables/web/internal/servlet/taglib/ScopedCSSVariablesTopHeadDynamicInclude.java
+++ b/modules/apps/frontend-css/frontend-css-variables-web/src/main/java/com/liferay/frontend/css/variables/web/internal/servlet/taglib/ScopedCSSVariablesTopHeadDynamicInclude.java
@@ -10,11 +10,13 @@ import com.liferay.frontend.css.variables.ScopedCSSVariablesProvider;
 import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerList;
 import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerListFactory;
 import com.liferay.osgi.service.tracker.collections.map.PropertyServiceReferenceComparator;
+import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.content.security.policy.ContentSecurityPolicyNonceProviderUtil;
 import com.liferay.portal.kernel.servlet.taglib.BaseDynamicInclude;
 import com.liferay.portal.kernel.servlet.taglib.DynamicInclude;
 import com.liferay.portal.kernel.util.HtmlUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -113,7 +115,9 @@ public class ScopedCSSVariablesTopHeadDynamicInclude
 				printWriter.print("\t\t--");
 				printWriter.print(HtmlUtil.escapeCSS(entry.getKey()));
 				printWriter.print(": ");
-				printWriter.print(HtmlUtil.escapeCSS(entry.getValue()));
+				printWriter.print(
+					StringUtil.replace(
+						entry.getValue(), CharPool.LESS_THAN, "\\3c "));
 				printWriter.print(";\n");
 			}
 

--- a/modules/apps/frontend-css/frontend-css-variables-web/src/test/java/com/liferay/frontend/css/variables/web/internal/servlet/taglib/ScopedCSSVariablesTopHeadDynamicIncludeTest.java
+++ b/modules/apps/frontend-css/frontend-css-variables-web/src/test/java/com/liferay/frontend/css/variables/web/internal/servlet/taglib/ScopedCSSVariablesTopHeadDynamicIncludeTest.java
@@ -8,12 +8,12 @@ package com.liferay.frontend.css.variables.web.internal.servlet.taglib;
 import com.liferay.frontend.css.variables.ScopedCSSVariables;
 import com.liferay.frontend.css.variables.ScopedCSSVariablesProvider;
 import com.liferay.petra.io.StreamUtil;
-import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.servlet.BufferCacheServletResponse;
 import com.liferay.portal.kernel.servlet.taglib.DynamicInclude;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.TreeMapBuilder;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -25,7 +25,6 @@ import java.io.InputStream;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Map;
 
 import org.junit.Assert;
@@ -60,7 +59,22 @@ public class ScopedCSSVariablesTopHeadDynamicIncludeTest {
 
 					@Override
 					public Map<String, String> getCSSVariables() {
-						return Collections.singletonMap("color", "red");
+						return TreeMapBuilder.put(
+							"aspect-ratio-16-to-9", "56.25%"
+						).put(
+							"box-shadow", "0 0.5rem 1rem rgba(0, 0, 0, 0.15)"
+						).put(
+							"btn-link-color", "var(--primary)"
+						).put(
+							"color", "red"
+						).put(
+							"font-family-sans-serif",
+							"system-ui, -apple-system, 'Segoe UI', sans-serif"
+						).put(
+							"spacer-2", "0.5rem"
+						).put(
+							"white", "#fff"
+						).build();
 					}
 
 					@Override
@@ -157,80 +171,6 @@ public class ScopedCSSVariablesTopHeadDynamicIncludeTest {
 		String content = bufferCacheServletResponse.getString();
 
 		Assert.assertFalse(content, content.contains(xssScript));
-	}
-
-	@Test
-	public void testIncludeKeepsCSSVariableValuesIntact() throws IOException {
-		ScopedCSSVariablesTopHeadDynamicInclude
-			scopedCSSVariablesTopHeadDynamicInclude =
-				new ScopedCSSVariablesTopHeadDynamicInclude();
-
-		ScopedCSSVariablesProvider scopedCSSVariablesProvider = Mockito.mock(
-			ScopedCSSVariablesProvider.class);
-
-		Map<String, String> cssVariables = HashMapBuilder.put(
-			"aspect-ratio-16-to-9", "56.25%"
-		).put(
-			"box-shadow", "0 0.5rem 1rem rgba(0, 0, 0, 0.15)"
-		).put(
-			"btn-link-color", "var(--primary)"
-		).put(
-			"font-family-sans-serif",
-			"system-ui, -apple-system, 'Segoe UI', sans-serif"
-		).put(
-			"spacer-2", "0.5rem"
-		).put(
-			"white", "#fff"
-		).build();
-
-		Collection<ScopedCSSVariables> scopedCSSVariablesCollection =
-			Arrays.asList(
-				new ScopedCSSVariables() {
-
-					@Override
-					public Map<String, String> getCSSVariables() {
-						return cssVariables;
-					}
-
-					@Override
-					public String getScope() {
-						return ":root";
-					}
-
-				});
-
-		Mockito.when(
-			scopedCSSVariablesProvider.getScopedCSSVariablesCollection(
-				Mockito.any(HttpServletRequest.class))
-		).thenReturn(
-			scopedCSSVariablesCollection
-		);
-
-		scopedCSSVariablesTopHeadDynamicInclude.setScopedCSSVariablesProviders(
-			Arrays.asList(scopedCSSVariablesProvider));
-
-		HttpServletRequest httpServletRequest = Mockito.mock(
-			HttpServletRequest.class);
-
-		HttpServletResponse httpServletResponse = Mockito.mock(
-			HttpServletResponse.class);
-
-		BufferCacheServletResponse bufferCacheServletResponse =
-			new BufferCacheServletResponse(httpServletResponse);
-
-		scopedCSSVariablesTopHeadDynamicInclude.include(
-			httpServletRequest, bufferCacheServletResponse,
-			"/html/common/themes/top_head.jsp#post");
-
-		String content = bufferCacheServletResponse.getString();
-
-		for (Map.Entry<String, String> entry : cssVariables.entrySet()) {
-			String cssVariableDeclaration = StringBundler.concat(
-				"--", entry.getKey(), ": ", entry.getValue(), ";");
-
-			Assert.assertTrue(
-				content, content.contains(cssVariableDeclaration));
-		}
 	}
 
 	@Test

--- a/modules/apps/frontend-css/frontend-css-variables-web/src/test/java/com/liferay/frontend/css/variables/web/internal/servlet/taglib/ScopedCSSVariablesTopHeadDynamicIncludeTest.java
+++ b/modules/apps/frontend-css/frontend-css-variables-web/src/test/java/com/liferay/frontend/css/variables/web/internal/servlet/taglib/ScopedCSSVariablesTopHeadDynamicIncludeTest.java
@@ -8,6 +8,7 @@ package com.liferay.frontend.css.variables.web.internal.servlet.taglib;
 import com.liferay.frontend.css.variables.ScopedCSSVariables;
 import com.liferay.frontend.css.variables.ScopedCSSVariablesProvider;
 import com.liferay.petra.io.StreamUtil;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.servlet.BufferCacheServletResponse;
 import com.liferay.portal.kernel.servlet.taglib.DynamicInclude;
@@ -156,6 +157,80 @@ public class ScopedCSSVariablesTopHeadDynamicIncludeTest {
 		String content = bufferCacheServletResponse.getString();
 
 		Assert.assertFalse(content, content.contains(xssScript));
+	}
+
+	@Test
+	public void testIncludeKeepsCSSVariableValuesIntact() throws IOException {
+		ScopedCSSVariablesTopHeadDynamicInclude
+			scopedCSSVariablesTopHeadDynamicInclude =
+				new ScopedCSSVariablesTopHeadDynamicInclude();
+
+		ScopedCSSVariablesProvider scopedCSSVariablesProvider = Mockito.mock(
+			ScopedCSSVariablesProvider.class);
+
+		Map<String, String> cssVariables = HashMapBuilder.put(
+			"aspect-ratio-16-to-9", "56.25%"
+		).put(
+			"box-shadow", "0 0.5rem 1rem rgba(0, 0, 0, 0.15)"
+		).put(
+			"btn-link-color", "var(--primary)"
+		).put(
+			"font-family-sans-serif",
+			"system-ui, -apple-system, 'Segoe UI', sans-serif"
+		).put(
+			"spacer-2", "0.5rem"
+		).put(
+			"white", "#fff"
+		).build();
+
+		Collection<ScopedCSSVariables> scopedCSSVariablesCollection =
+			Arrays.asList(
+				new ScopedCSSVariables() {
+
+					@Override
+					public Map<String, String> getCSSVariables() {
+						return cssVariables;
+					}
+
+					@Override
+					public String getScope() {
+						return ":root";
+					}
+
+				});
+
+		Mockito.when(
+			scopedCSSVariablesProvider.getScopedCSSVariablesCollection(
+				Mockito.any(HttpServletRequest.class))
+		).thenReturn(
+			scopedCSSVariablesCollection
+		);
+
+		scopedCSSVariablesTopHeadDynamicInclude.setScopedCSSVariablesProviders(
+			Arrays.asList(scopedCSSVariablesProvider));
+
+		HttpServletRequest httpServletRequest = Mockito.mock(
+			HttpServletRequest.class);
+
+		HttpServletResponse httpServletResponse = Mockito.mock(
+			HttpServletResponse.class);
+
+		BufferCacheServletResponse bufferCacheServletResponse =
+			new BufferCacheServletResponse(httpServletResponse);
+
+		scopedCSSVariablesTopHeadDynamicInclude.include(
+			httpServletRequest, bufferCacheServletResponse,
+			"/html/common/themes/top_head.jsp#post");
+
+		String content = bufferCacheServletResponse.getString();
+
+		for (Map.Entry<String, String> entry : cssVariables.entrySet()) {
+			String cssVariableDeclaration = StringBundler.concat(
+				"--", entry.getKey(), ": ", entry.getValue(), ";");
+
+			Assert.assertTrue(
+				content, content.contains(cssVariableDeclaration));
+		}
 	}
 
 	@Test

--- a/modules/apps/frontend-css/frontend-css-variables-web/src/test/resources/com/liferay/frontend/css/variables/web/internal/servlet/taglib/liferay_css_variables_1.html
+++ b/modules/apps/frontend-css/frontend-css-variables-web/src/test/resources/com/liferay/frontend/css/variables/web/internal/servlet/taglib/liferay_css_variables_1.html
@@ -1,5 +1,11 @@
 <style data-senna-track="temporary" type="text/css">
 	:root {
+		--aspect-ratio-16-to-9: 56.25%;
+		--box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
+		--btn-link-color: var(--primary);
 		--color: red;
+		--font-family-sans-serif: system-ui, -apple-system, 'Segoe UI', sans-serif;
+		--spacer-2: 0.5rem;
+		--white: #fff;
 	}
 </style>

--- a/modules/apps/frontend-css/frontend-css-variables-web/src/test/resources/com/liferay/frontend/css/variables/web/internal/servlet/taglib/liferay_css_variables_2.html
+++ b/modules/apps/frontend-css/frontend-css-variables-web/src/test/resources/com/liferay/frontend/css/variables/web/internal/servlet/taglib/liferay_css_variables_2.html
@@ -4,8 +4,8 @@
 	}
 	body {
 		--color: green;
-		--fixed-font: \22Lucida\20Console\22;
-		--font: Comic\20Sans;
+		--fixed-font: "Lucida Console";
+		--font: Comic Sans;
 	}
 	:root {
 		--color: yellow;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-104521

## What Is Being Fixed

Resend of https://github.com/brianchandotcom/liferay-portal/pull/181266. Sample markup was out of order because it was compared against a `HashMap` instance, which doesn't guarantee input order.

## How It Is Being Fixed

We are able to sort the markup by using a `TreeMap`, which keeps order. Therefore, this resend swaps `HashMapBuilder` to `TreeMapBuilder` for this test specifically. The other tests are still using `HashMapBuilder` so we can have a minimal, focused change.

## PR Check

**pr-check: PASS** — tested on `4b8c3654c16ade422a2d2833dcadec3a700a2eea`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Service Registration | PASS |
| Transaction Usage | PASS |
| Integration Test Compile | NOT VERIFIED |
| Baseline | PASS (baseline-all + seven Ant projects + 0 changed exporting modules) |
| Java Unit Tests | PASS |

Integration Test Compile verified nothing. `modules/apps/frontend-css/frontend-css-variables-web` has no integration-test coverage — no sibling `-test` module under `modules/apps/frontend-css/`, no other module declares it as a project dependency, and it holds no `src/testIntegration` tree. Whether that gap is worth closing is the developer's call.

<!-- pr-check {"result": "success", "sha": "4b8c3654c16ade422a2d2833dcadec3a700a2eea"} -->
