### PR TITLE
LPD-97867 Group similar CMS content into similar asset sets

### DIFF
--- a/modules/apps/headless/headless-cms/headless-cms-api/bnd.bnd
+++ b/modules/apps/headless/headless-cms/headless-cms-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless CMS API
 Bundle-SymbolicName: com.liferay.headless.cms.api
-Bundle-Version: 3.1.1
+Bundle-Version: 3.2.0
 Export-Package:\
 	com.liferay.headless.cms.dto.v1_0,\
 	com.liferay.headless.cms.resource.v1_0

--- a/modules/apps/headless/headless-cms/headless-cms-api/src/main/java/com/liferay/headless/cms/dto/v1_0/SimilarAsset.java
+++ b/modules/apps/headless/headless-cms/headless-cms-api/src/main/java/com/liferay/headless/cms/dto/v1_0/SimilarAsset.java
@@ -1,0 +1,416 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.dto.v1_0;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.util.ObjectMapperUtil;
+
+import jakarta.annotation.Generated;
+
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+import java.io.Serializable;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+
+import java.util.Date;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Generated("")
+@GraphQLName(
+	description = "A CMS content asset that belongs to a similar asset set.",
+	value = "SimilarAsset"
+)
+@io.swagger.v3.oas.annotations.media.Schema(
+	description = "A CMS content asset that belongs to a similar asset set."
+)
+@JsonFilter("Liferay.Vulcan")
+@XmlRootElement(name = "SimilarAsset")
+public class SimilarAsset implements Serializable {
+
+	public static SimilarAsset toDTO(String json) {
+		return ObjectMapperUtil.readValue(SimilarAsset.class, json);
+	}
+
+	public static SimilarAsset unsafeToDTO(String json) {
+		return ObjectMapperUtil.unsafeReadValue(SimilarAsset.class, json);
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The localized label of the asset's content type."
+	)
+	public String getContentType() {
+		if (_contentTypeSupplier != null) {
+			contentType = _contentTypeSupplier.get();
+
+			_contentTypeSupplier = null;
+		}
+
+		return contentType;
+	}
+
+	public void setContentType(String contentType) {
+		this.contentType = contentType;
+
+		_contentTypeSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setContentType(
+		UnsafeSupplier<String, Exception> contentTypeUnsafeSupplier) {
+
+		_contentTypeSupplier = () -> {
+			try {
+				return contentTypeUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(
+		description = "The localized label of the asset's content type."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String contentType;
+
+	@JsonIgnore
+	private Supplier<String> _contentTypeSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public Date getDateModified() {
+		if (_dateModifiedSupplier != null) {
+			dateModified = _dateModifiedSupplier.get();
+
+			_dateModifiedSupplier = null;
+		}
+
+		return dateModified;
+	}
+
+	public void setDateModified(Date dateModified) {
+		this.dateModified = dateModified;
+
+		_dateModifiedSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setDateModified(
+		UnsafeSupplier<Date, Exception> dateModifiedUnsafeSupplier) {
+
+		_dateModifiedSupplier = () -> {
+			try {
+				return dateModifiedUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Date dateModified;
+
+	@JsonIgnore
+	private Supplier<Date> _dateModifiedSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public Long getId() {
+		if (_idSupplier != null) {
+			id = _idSupplier.get();
+
+			_idSupplier = null;
+		}
+
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+
+		_idSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setId(UnsafeSupplier<Long, Exception> idUnsafeSupplier) {
+		_idSupplier = () -> {
+			try {
+				return idUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Long id;
+
+	@JsonIgnore
+	private Supplier<Long> _idSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public String getTitle() {
+		if (_titleSupplier != null) {
+			title = _titleSupplier.get();
+
+			_titleSupplier = null;
+		}
+
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+
+		_titleSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setTitle(
+		UnsafeSupplier<String, Exception> titleUnsafeSupplier) {
+
+		_titleSupplier = () -> {
+			try {
+				return titleUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String title;
+
+	@JsonIgnore
+	private Supplier<String> _titleSupplier;
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof SimilarAsset)) {
+			return false;
+		}
+
+		SimilarAsset similarAsset = (SimilarAsset)object;
+
+		return Objects.equals(toString(), similarAsset.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("{");
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		String contentType = getContentType();
+
+		if (contentType != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"contentType\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(contentType));
+
+			sb.append("\"");
+		}
+
+		Date dateModified = getDateModified();
+
+		if (dateModified != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"dateModified\": ");
+
+			sb.append("\"");
+
+			sb.append(liferayToJSONDateFormat.format(dateModified));
+
+			sb.append("\"");
+		}
+
+		Long id = getId();
+
+		if (id != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"id\": ");
+
+			sb.append(id);
+		}
+
+		String title = getTitle();
+
+		if (title != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"title\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(title));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		accessMode = io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY,
+		defaultValue = "com.liferay.headless.cms.dto.v1_0.SimilarAsset",
+		name = "x-class-name"
+	)
+	public String xClassName;
+
+	private static String _escape(Object object) {
+		return StringUtil.replace(
+			String.valueOf(object), _JSON_ESCAPE_STRINGS[0],
+			_JSON_ESCAPE_STRINGS[1]);
+	}
+
+	private static boolean _isArray(Object value) {
+		if (value == null) {
+			return false;
+		}
+
+		Class<?> clazz = value.getClass();
+
+		return clazz.isArray();
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(_escape(entry.getKey()));
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			if (_isArray(value)) {
+				sb.append("[");
+
+				Object[] valueArray = (Object[])value;
+
+				for (int i = 0; i < valueArray.length; i++) {
+					if (valueArray[i] instanceof Map) {
+						sb.append(_toJSON((Map<String, ?>)valueArray[i]));
+					}
+					else if (valueArray[i] instanceof String) {
+						sb.append("\"");
+						sb.append(valueArray[i]);
+						sb.append("\"");
+					}
+					else {
+						sb.append(valueArray[i]);
+					}
+
+					if ((i + 1) < valueArray.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof Map) {
+				sb.append(_toJSON((Map<String, ?>)value));
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(value));
+				sb.append("\"");
+			}
+			else {
+				sb.append(value);
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static final String[][] _JSON_ESCAPE_STRINGS = {
+		{"\\", "\"", "\b", "\f", "\n", "\r", "\t"},
+		{"\\\\", "\\\"", "\\b", "\\f", "\\n", "\\r", "\\t"}
+	};
+
+	private Map<String, Serializable> _extendedProperties;
+
+}
+// LIFERAY-REST-BUILDER-HASH:-1011653456

--- a/modules/apps/headless/headless-cms/headless-cms-api/src/main/java/com/liferay/headless/cms/dto/v1_0/SimilarAssetSet.java
+++ b/modules/apps/headless/headless-cms/headless-cms-api/src/main/java/com/liferay/headless/cms/dto/v1_0/SimilarAssetSet.java
@@ -1,0 +1,308 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.dto.v1_0;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.util.ObjectMapperUtil;
+
+import jakarta.annotation.Generated;
+
+import jakarta.validation.Valid;
+
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+import java.io.Serializable;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Generated("")
+@GraphQLName(
+	description = "A set of CMS content assets detected as similar to one another.",
+	value = "SimilarAssetSet"
+)
+@io.swagger.v3.oas.annotations.media.Schema(
+	description = "A set of CMS content assets detected as similar to one another."
+)
+@JsonFilter("Liferay.Vulcan")
+@XmlRootElement(name = "SimilarAssetSet")
+public class SimilarAssetSet implements Serializable {
+
+	public static SimilarAssetSet toDTO(String json) {
+		return ObjectMapperUtil.readValue(SimilarAssetSet.class, json);
+	}
+
+	public static SimilarAssetSet unsafeToDTO(String json) {
+		return ObjectMapperUtil.unsafeReadValue(SimilarAssetSet.class, json);
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The set's assets that fall inside the requested page. A set split across pages repeats in the next page with the remaining assets."
+	)
+	@Valid
+	public SimilarAsset[] getSimilarAssets() {
+		if (_similarAssetsSupplier != null) {
+			similarAssets = _similarAssetsSupplier.get();
+
+			_similarAssetsSupplier = null;
+		}
+
+		return similarAssets;
+	}
+
+	public void setSimilarAssets(SimilarAsset[] similarAssets) {
+		this.similarAssets = similarAssets;
+
+		_similarAssetsSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setSimilarAssets(
+		UnsafeSupplier<SimilarAsset[], Exception> similarAssetsUnsafeSupplier) {
+
+		_similarAssetsSupplier = () -> {
+			try {
+				return similarAssetsUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(
+		description = "The set's assets that fall inside the requested page. A set split across pages repeats in the next page with the remaining assets."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected SimilarAsset[] similarAssets;
+
+	@JsonIgnore
+	private Supplier<SimilarAsset[]> _similarAssetsSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The total number of assets in the set, independent of the requested page."
+	)
+	public Integer getSize() {
+		if (_sizeSupplier != null) {
+			size = _sizeSupplier.get();
+
+			_sizeSupplier = null;
+		}
+
+		return size;
+	}
+
+	public void setSize(Integer size) {
+		this.size = size;
+
+		_sizeSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setSize(UnsafeSupplier<Integer, Exception> sizeUnsafeSupplier) {
+		_sizeSupplier = () -> {
+			try {
+				return sizeUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(
+		description = "The total number of assets in the set, independent of the requested page."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Integer size;
+
+	@JsonIgnore
+	private Supplier<Integer> _sizeSupplier;
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof SimilarAssetSet)) {
+			return false;
+		}
+
+		SimilarAssetSet similarAssetSet = (SimilarAssetSet)object;
+
+		return Objects.equals(toString(), similarAssetSet.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("{");
+
+		SimilarAsset[] similarAssets = getSimilarAssets();
+
+		if (similarAssets != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"similarAssets\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < similarAssets.length; i++) {
+				sb.append(String.valueOf(similarAssets[i]));
+
+				if ((i + 1) < similarAssets.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
+		Integer size = getSize();
+
+		if (size != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"size\": ");
+
+			sb.append(size);
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		accessMode = io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY,
+		defaultValue = "com.liferay.headless.cms.dto.v1_0.SimilarAssetSet",
+		name = "x-class-name"
+	)
+	public String xClassName;
+
+	private static String _escape(Object object) {
+		return StringUtil.replace(
+			String.valueOf(object), _JSON_ESCAPE_STRINGS[0],
+			_JSON_ESCAPE_STRINGS[1]);
+	}
+
+	private static boolean _isArray(Object value) {
+		if (value == null) {
+			return false;
+		}
+
+		Class<?> clazz = value.getClass();
+
+		return clazz.isArray();
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(_escape(entry.getKey()));
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			if (_isArray(value)) {
+				sb.append("[");
+
+				Object[] valueArray = (Object[])value;
+
+				for (int i = 0; i < valueArray.length; i++) {
+					if (valueArray[i] instanceof Map) {
+						sb.append(_toJSON((Map<String, ?>)valueArray[i]));
+					}
+					else if (valueArray[i] instanceof String) {
+						sb.append("\"");
+						sb.append(valueArray[i]);
+						sb.append("\"");
+					}
+					else {
+						sb.append(valueArray[i]);
+					}
+
+					if ((i + 1) < valueArray.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof Map) {
+				sb.append(_toJSON((Map<String, ?>)value));
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(value));
+				sb.append("\"");
+			}
+			else {
+				sb.append(value);
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static final String[][] _JSON_ESCAPE_STRINGS = {
+		{"\\", "\"", "\b", "\f", "\n", "\r", "\t"},
+		{"\\\\", "\\\"", "\\b", "\\f", "\\n", "\\r", "\\t"}
+	};
+
+	private Map<String, Serializable> _extendedProperties;
+
+}
+// LIFERAY-REST-BUILDER-HASH:1029558369

--- a/modules/apps/headless/headless-cms/headless-cms-api/src/main/java/com/liferay/headless/cms/resource/v1_0/SimilarAssetSetResource.java
+++ b/modules/apps/headless/headless-cms/headless-cms-api/src/main/java/com/liferay/headless/cms/resource/v1_0/SimilarAssetSetResource.java
@@ -1,0 +1,140 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.resource.v1_0;
+
+import com.liferay.headless.cms.dto.v1_0.SimilarAssetSet;
+import com.liferay.portal.kernel.change.tracking.CTAware;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
+
+import jakarta.annotation.Generated;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import jakarta.ws.rs.core.UriInfo;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.osgi.annotation.versioning.ProviderType;
+
+/**
+ * To access this resource, run:
+ *
+ *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/headless-cms/v1.0
+ *
+ * @author Crescenzo Rega
+ * @generated
+ */
+@CTAware
+@Generated("")
+@ProviderType
+public interface SimilarAssetSetResource {
+
+	public Page<SimilarAssetSet> getSimilarAssetSetsPage(
+			Long assetLibraryId, Pagination pagination)
+		throws Exception;
+
+	public default void setContextAcceptLanguage(
+		AcceptLanguage contextAcceptLanguage) {
+	}
+
+	public void setContextCompany(
+		com.liferay.portal.kernel.model.Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
+
+	public void setContextUser(
+		com.liferay.portal.kernel.model.User contextUser);
+
+	public void setExpressionConvert(
+		ExpressionConvert<com.liferay.portal.kernel.search.filter.Filter>
+			expressionConvert);
+
+	public void setFilterParserProvider(
+		FilterParserProvider filterParserProvider);
+
+	public void setGroupLocalService(GroupLocalService groupLocalService);
+
+	public void setResourceActionLocalService(
+		ResourceActionLocalService resourceActionLocalService);
+
+	public void setResourcePermissionLocalService(
+		ResourcePermissionLocalService resourcePermissionLocalService);
+
+	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setSortParserProvider(SortParserProvider sortParserProvider);
+
+	public default com.liferay.portal.kernel.search.filter.Filter toFilter(
+		String filterString) {
+
+		return toFilter(
+			filterString, Collections.<String, List<String>>emptyMap());
+	}
+
+	public default com.liferay.portal.kernel.search.filter.Filter toFilter(
+		String filterString, Map<String, List<String>> multivaluedMap) {
+
+		return null;
+	}
+
+	public default com.liferay.portal.kernel.search.Sort[] toSorts(
+		String sortsString) {
+
+		return new com.liferay.portal.kernel.search.Sort[0];
+	}
+
+	@ProviderType
+	public interface Builder {
+
+		public SimilarAssetSetResource build();
+
+		public Builder checkPermissions(boolean checkPermissions);
+
+		public Builder httpServletRequest(
+			HttpServletRequest httpServletRequest);
+
+		public Builder httpServletResponse(
+			HttpServletResponse httpServletResponse);
+
+		public Builder preferredLocale(Locale preferredLocale);
+
+		public Builder uriInfo(UriInfo uriInfo);
+
+		public Builder user(com.liferay.portal.kernel.model.User user);
+
+	}
+
+	@ProviderType
+	public interface Factory {
+
+		public Builder create();
+
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:1088551045

--- a/modules/apps/headless/headless-cms/headless-cms-api/src/main/resources/com/liferay/headless/cms/dto/v1_0/packageinfo
+++ b/modules/apps/headless/headless-cms/headless-cms-api/src/main/resources/com/liferay/headless/cms/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 2.3.0
+version 2.4.0

--- a/modules/apps/headless/headless-cms/headless-cms-api/src/main/resources/com/liferay/headless/cms/resource/v1_0/packageinfo
+++ b/modules/apps/headless/headless-cms/headless-cms-api/src/main/resources/com/liferay/headless/cms/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 3.1.0
+version 3.2.0

--- a/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/dto/v1_0/SimilarAsset.java
+++ b/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/dto/v1_0/SimilarAsset.java
@@ -1,0 +1,143 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.client.dto.v1_0;
+
+import com.liferay.headless.cms.client.function.UnsafeSupplier;
+import com.liferay.headless.cms.client.serdes.v1_0.SimilarAssetSerDes;
+
+import jakarta.annotation.Generated;
+
+import java.io.Serializable;
+
+import java.util.Date;
+import java.util.Objects;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Generated("")
+public class SimilarAsset implements Cloneable, Serializable {
+
+	public static SimilarAsset toDTO(String json) {
+		return SimilarAssetSerDes.toDTO(json);
+	}
+
+	public String getContentType() {
+		return contentType;
+	}
+
+	public void setContentType(String contentType) {
+		this.contentType = contentType;
+	}
+
+	public void setContentType(
+		UnsafeSupplier<String, Exception> contentTypeUnsafeSupplier) {
+
+		try {
+			contentType = contentTypeUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String contentType;
+
+	public Date getDateModified() {
+		return dateModified;
+	}
+
+	public void setDateModified(Date dateModified) {
+		this.dateModified = dateModified;
+	}
+
+	public void setDateModified(
+		UnsafeSupplier<Date, Exception> dateModifiedUnsafeSupplier) {
+
+		try {
+			dateModified = dateModifiedUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Date dateModified;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public void setId(UnsafeSupplier<Long, Exception> idUnsafeSupplier) {
+		try {
+			id = idUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Long id;
+
+	public String getTitle() {
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+	}
+
+	public void setTitle(
+		UnsafeSupplier<String, Exception> titleUnsafeSupplier) {
+
+		try {
+			title = titleUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String title;
+
+	@Override
+	public SimilarAsset clone() throws CloneNotSupportedException {
+		return (SimilarAsset)super.clone();
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof SimilarAsset)) {
+			return false;
+		}
+
+		SimilarAsset similarAsset = (SimilarAsset)object;
+
+		return Objects.equals(toString(), similarAsset.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		return SimilarAssetSerDes.toJSON(this);
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:-522998368

--- a/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/dto/v1_0/SimilarAssetSet.java
+++ b/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/dto/v1_0/SimilarAssetSet.java
@@ -1,0 +1,100 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.client.dto.v1_0;
+
+import com.liferay.headless.cms.client.function.UnsafeSupplier;
+import com.liferay.headless.cms.client.serdes.v1_0.SimilarAssetSetSerDes;
+
+import jakarta.annotation.Generated;
+
+import java.io.Serializable;
+
+import java.util.Objects;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Generated("")
+public class SimilarAssetSet implements Cloneable, Serializable {
+
+	public static SimilarAssetSet toDTO(String json) {
+		return SimilarAssetSetSerDes.toDTO(json);
+	}
+
+	public SimilarAsset[] getSimilarAssets() {
+		return similarAssets;
+	}
+
+	public void setSimilarAssets(SimilarAsset[] similarAssets) {
+		this.similarAssets = similarAssets;
+	}
+
+	public void setSimilarAssets(
+		UnsafeSupplier<SimilarAsset[], Exception> similarAssetsUnsafeSupplier) {
+
+		try {
+			similarAssets = similarAssetsUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected SimilarAsset[] similarAssets;
+
+	public Integer getSize() {
+		return size;
+	}
+
+	public void setSize(Integer size) {
+		this.size = size;
+	}
+
+	public void setSize(UnsafeSupplier<Integer, Exception> sizeUnsafeSupplier) {
+		try {
+			size = sizeUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Integer size;
+
+	@Override
+	public SimilarAssetSet clone() throws CloneNotSupportedException {
+		return (SimilarAssetSet)super.clone();
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof SimilarAssetSet)) {
+			return false;
+		}
+
+		SimilarAssetSet similarAssetSet = (SimilarAssetSet)object;
+
+		return Objects.equals(toString(), similarAssetSet.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		return SimilarAssetSetSerDes.toJSON(this);
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:-697577447

--- a/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/resource/v1_0/SimilarAssetSetResource.java
+++ b/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/resource/v1_0/SimilarAssetSetResource.java
@@ -1,0 +1,282 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.client.resource.v1_0;
+
+import com.liferay.headless.cms.client.dto.v1_0.SimilarAssetSet;
+import com.liferay.headless.cms.client.http.HttpInvoker;
+import com.liferay.headless.cms.client.pagination.Page;
+import com.liferay.headless.cms.client.pagination.Pagination;
+import com.liferay.headless.cms.client.problem.Problem;
+import com.liferay.headless.cms.client.serdes.v1_0.SimilarAssetSetSerDes;
+
+import jakarta.annotation.Generated;
+
+import java.net.URL;
+
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Generated("")
+public interface SimilarAssetSetResource {
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public Page<SimilarAssetSet> getSimilarAssetSetsPage(
+			Long assetLibraryId, Pagination pagination)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse getSimilarAssetSetsPageHttpResponse(
+			Long assetLibraryId, Pagination pagination)
+		throws Exception;
+
+	public static class Builder {
+
+		public Builder authentication(String login, String password) {
+			_login = login;
+			_password = password;
+
+			return this;
+		}
+
+		public Builder bearerToken(String token) {
+			return header("Authorization", "Bearer " + token);
+		}
+
+		public SimilarAssetSetResource build() {
+			return new SimilarAssetSetResourceImpl(this);
+		}
+
+		public Builder contextPath(String contextPath) {
+			_contextPath = contextPath;
+
+			return this;
+		}
+
+		public Builder endpoint(String address, String scheme) {
+			String[] addressParts = address.split(":");
+
+			String host = addressParts[0];
+
+			int port = 443;
+
+			if (addressParts.length > 1) {
+				String portString = addressParts[1];
+
+				try {
+					port = Integer.parseInt(portString);
+				}
+				catch (NumberFormatException numberFormatException) {
+					throw new IllegalArgumentException(
+						"Unable to parse port from " + portString);
+				}
+			}
+
+			return endpoint(host, port, scheme);
+		}
+
+		public Builder endpoint(String host, int port, String scheme) {
+			_host = host;
+			_port = port;
+			_scheme = scheme;
+
+			return this;
+		}
+
+		public Builder endpoint(URL url) {
+			return endpoint(url.getHost(), url.getPort(), url.getProtocol());
+		}
+
+		public Builder header(String key, String value) {
+			_headers.put(key, value);
+
+			return this;
+		}
+
+		public Builder locale(Locale locale) {
+			_locale = locale;
+
+			return this;
+		}
+
+		public Builder parameter(String key, String value) {
+			_parameters.put(key, value);
+
+			return this;
+		}
+
+		public Builder parameters(String... parameters) {
+			if ((parameters.length % 2) != 0) {
+				throw new IllegalArgumentException(
+					"Parameters length is not an even number");
+			}
+
+			for (int i = 0; i < parameters.length; i += 2) {
+				String parameterName = String.valueOf(parameters[i]);
+				String parameterValue = String.valueOf(parameters[i + 1]);
+
+				_parameters.put(parameterName, parameterValue);
+			}
+
+			return this;
+		}
+
+		private Builder() {
+		}
+
+		private String _contextPath = "";
+		private Map<String, String> _headers = new LinkedHashMap<>();
+		private String _host = "localhost";
+		private Locale _locale;
+		private String _login;
+		private String _password;
+		private Map<String, String> _parameters = new LinkedHashMap<>();
+		private int _port = 8080;
+		private String _scheme = "http";
+
+	}
+
+	public static class SimilarAssetSetResourceImpl
+		implements SimilarAssetSetResource {
+
+		public Page<SimilarAssetSet> getSimilarAssetSetsPage(
+				Long assetLibraryId, Pagination pagination)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				getSimilarAssetSetsPageHttpResponse(assetLibraryId, pagination);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return Page.of(content, SimilarAssetSetSerDes::toDTO);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse getSimilarAssetSetsPageHttpResponse(
+				Long assetLibraryId, Pagination pagination)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+			if (assetLibraryId != null) {
+				httpInvoker.parameter(
+					"assetLibraryId", String.valueOf(assetLibraryId));
+			}
+
+			if (pagination != null) {
+				httpInvoker.parameter(
+					"page", String.valueOf(pagination.getPage()));
+				httpInvoker.parameter(
+					"pageSize", String.valueOf(pagination.getPageSize()));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-cms/v1.0/similar-asset-sets");
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		private SimilarAssetSetResourceImpl(Builder builder) {
+			_builder = builder;
+		}
+
+		private static final Logger _logger = Logger.getLogger(
+			SimilarAssetSetResource.class.getName());
+
+		private Builder _builder;
+
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:-1724568166

--- a/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/serdes/v1_0/SimilarAssetSerDes.java
+++ b/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/serdes/v1_0/SimilarAssetSerDes.java
@@ -1,0 +1,303 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.client.serdes.v1_0;
+
+import com.liferay.headless.cms.client.dto.v1_0.SimilarAsset;
+import com.liferay.headless.cms.client.json.BaseJSONParser;
+
+import jakarta.annotation.Generated;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Generated("")
+public class SimilarAssetSerDes {
+
+	public static SimilarAsset toDTO(String json) {
+		SimilarAssetJSONParser similarAssetJSONParser =
+			new SimilarAssetJSONParser();
+
+		return similarAssetJSONParser.parseToDTO(json);
+	}
+
+	public static SimilarAsset[] toDTOs(String json) {
+		SimilarAssetJSONParser similarAssetJSONParser =
+			new SimilarAssetJSONParser();
+
+		return similarAssetJSONParser.parseToDTOs(json);
+	}
+
+	public static String toJSON(SimilarAsset similarAsset) {
+		if (similarAsset == null) {
+			return "null";
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ssXX");
+
+		if (similarAsset.getContentType() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"contentType\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(similarAsset.getContentType()));
+
+			sb.append("\"");
+		}
+
+		if (similarAsset.getDateModified() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"dateModified\": ");
+
+			sb.append("\"");
+
+			sb.append(
+				liferayToJSONDateFormat.format(similarAsset.getDateModified()));
+
+			sb.append("\"");
+		}
+
+		if (similarAsset.getId() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"id\": ");
+
+			sb.append(similarAsset.getId());
+		}
+
+		if (similarAsset.getTitle() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"title\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(similarAsset.getTitle()));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	public static Map<String, Object> toMap(String json) {
+		SimilarAssetJSONParser similarAssetJSONParser =
+			new SimilarAssetJSONParser();
+
+		return similarAssetJSONParser.parseToMap(json);
+	}
+
+	public static Map<String, String> toMap(SimilarAsset similarAsset) {
+		if (similarAsset == null) {
+			return null;
+		}
+
+		Map<String, String> map = new TreeMap<>();
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ssXX");
+
+		if (similarAsset.getContentType() == null) {
+			map.put("contentType", null);
+		}
+		else {
+			map.put(
+				"contentType", String.valueOf(similarAsset.getContentType()));
+		}
+
+		if (similarAsset.getDateModified() == null) {
+			map.put("dateModified", null);
+		}
+		else {
+			map.put(
+				"dateModified",
+				liferayToJSONDateFormat.format(similarAsset.getDateModified()));
+		}
+
+		if (similarAsset.getId() == null) {
+			map.put("id", null);
+		}
+		else {
+			map.put("id", String.valueOf(similarAsset.getId()));
+		}
+
+		if (similarAsset.getTitle() == null) {
+			map.put("title", null);
+		}
+		else {
+			map.put("title", String.valueOf(similarAsset.getTitle()));
+		}
+
+		return map;
+	}
+
+	public static class SimilarAssetJSONParser
+		extends BaseJSONParser<SimilarAsset> {
+
+		@Override
+		protected SimilarAsset createDTO() {
+			return new SimilarAsset();
+		}
+
+		@Override
+		protected SimilarAsset[] createDTOArray(int size) {
+			return new SimilarAsset[size];
+		}
+
+		@Override
+		protected boolean parseMaps(String jsonParserFieldName) {
+			if (Objects.equals(jsonParserFieldName, "contentType")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "dateModified")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "id")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "title")) {
+				return false;
+			}
+
+			return false;
+		}
+
+		@Override
+		protected void setField(
+			SimilarAsset similarAsset, String jsonParserFieldName,
+			Object jsonParserFieldValue) {
+
+			if (Objects.equals(jsonParserFieldName, "contentType")) {
+				if (jsonParserFieldValue != null) {
+					similarAsset.setContentType((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "dateModified")) {
+				if (jsonParserFieldValue != null) {
+					similarAsset.setDateModified(
+						toDate((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "id")) {
+				if (jsonParserFieldValue != null) {
+					similarAsset.setId(
+						Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "title")) {
+				if (jsonParserFieldValue != null) {
+					similarAsset.setTitle((String)jsonParserFieldValue);
+				}
+			}
+		}
+
+	}
+
+	private static String _escape(Object object) {
+		String string = String.valueOf(object);
+
+		for (String[] strings : BaseJSONParser.JSON_ESCAPE_STRINGS) {
+			string = string.replace(strings[0], strings[1]);
+		}
+
+		return string;
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(entry.getKey());
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			sb.append(_toJSON(value));
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static String _toJSON(Object value) {
+		if (value == null) {
+			return "null";
+		}
+
+		if (value instanceof Map) {
+			return _toJSON((Map)value);
+		}
+
+		Class<?> clazz = value.getClass();
+
+		if (clazz.isArray()) {
+			StringBuilder sb = new StringBuilder("[");
+
+			Object[] values = (Object[])value;
+
+			for (int i = 0; i < values.length; i++) {
+				sb.append(_toJSON(values[i]));
+
+				if ((i + 1) < values.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+
+			return sb.toString();
+		}
+
+		if (value instanceof String) {
+			return "\"" + _escape(value) + "\"";
+		}
+
+		return String.valueOf(value);
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:2041123751

--- a/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/serdes/v1_0/SimilarAssetSetSerDes.java
+++ b/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/serdes/v1_0/SimilarAssetSetSerDes.java
@@ -1,0 +1,254 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.client.serdes.v1_0;
+
+import com.liferay.headless.cms.client.dto.v1_0.SimilarAsset;
+import com.liferay.headless.cms.client.dto.v1_0.SimilarAssetSet;
+import com.liferay.headless.cms.client.json.BaseJSONParser;
+
+import jakarta.annotation.Generated;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Generated("")
+public class SimilarAssetSetSerDes {
+
+	public static SimilarAssetSet toDTO(String json) {
+		SimilarAssetSetJSONParser similarAssetSetJSONParser =
+			new SimilarAssetSetJSONParser();
+
+		return similarAssetSetJSONParser.parseToDTO(json);
+	}
+
+	public static SimilarAssetSet[] toDTOs(String json) {
+		SimilarAssetSetJSONParser similarAssetSetJSONParser =
+			new SimilarAssetSetJSONParser();
+
+		return similarAssetSetJSONParser.parseToDTOs(json);
+	}
+
+	public static String toJSON(SimilarAssetSet similarAssetSet) {
+		if (similarAssetSet == null) {
+			return "null";
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		if (similarAssetSet.getSimilarAssets() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"similarAssets\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < similarAssetSet.getSimilarAssets().length;
+				 i++) {
+
+				sb.append(
+					String.valueOf(similarAssetSet.getSimilarAssets()[i]));
+
+				if ((i + 1) < similarAssetSet.getSimilarAssets().length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
+		if (similarAssetSet.getSize() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"size\": ");
+
+			sb.append(similarAssetSet.getSize());
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	public static Map<String, Object> toMap(String json) {
+		SimilarAssetSetJSONParser similarAssetSetJSONParser =
+			new SimilarAssetSetJSONParser();
+
+		return similarAssetSetJSONParser.parseToMap(json);
+	}
+
+	public static Map<String, String> toMap(SimilarAssetSet similarAssetSet) {
+		if (similarAssetSet == null) {
+			return null;
+		}
+
+		Map<String, String> map = new TreeMap<>();
+
+		if (similarAssetSet.getSimilarAssets() == null) {
+			map.put("similarAssets", null);
+		}
+		else {
+			map.put(
+				"similarAssets",
+				String.valueOf(similarAssetSet.getSimilarAssets()));
+		}
+
+		if (similarAssetSet.getSize() == null) {
+			map.put("size", null);
+		}
+		else {
+			map.put("size", String.valueOf(similarAssetSet.getSize()));
+		}
+
+		return map;
+	}
+
+	public static class SimilarAssetSetJSONParser
+		extends BaseJSONParser<SimilarAssetSet> {
+
+		@Override
+		protected SimilarAssetSet createDTO() {
+			return new SimilarAssetSet();
+		}
+
+		@Override
+		protected SimilarAssetSet[] createDTOArray(int size) {
+			return new SimilarAssetSet[size];
+		}
+
+		@Override
+		protected boolean parseMaps(String jsonParserFieldName) {
+			if (Objects.equals(jsonParserFieldName, "similarAssets")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "size")) {
+				return false;
+			}
+
+			return false;
+		}
+
+		@Override
+		protected void setField(
+			SimilarAssetSet similarAssetSet, String jsonParserFieldName,
+			Object jsonParserFieldValue) {
+
+			if (Objects.equals(jsonParserFieldName, "similarAssets")) {
+				if (jsonParserFieldValue != null) {
+					Object[] jsonParserFieldValues =
+						(Object[])jsonParserFieldValue;
+
+					SimilarAsset[] similarAssetsArray =
+						new SimilarAsset[jsonParserFieldValues.length];
+
+					for (int i = 0; i < similarAssetsArray.length; i++) {
+						similarAssetsArray[i] = SimilarAssetSerDes.toDTO(
+							(String)jsonParserFieldValues[i]);
+					}
+
+					similarAssetSet.setSimilarAssets(similarAssetsArray);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "size")) {
+				if (jsonParserFieldValue != null) {
+					similarAssetSet.setSize(
+						Integer.valueOf((String)jsonParserFieldValue));
+				}
+			}
+		}
+
+	}
+
+	private static String _escape(Object object) {
+		String string = String.valueOf(object);
+
+		for (String[] strings : BaseJSONParser.JSON_ESCAPE_STRINGS) {
+			string = string.replace(strings[0], strings[1]);
+		}
+
+		return string;
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(entry.getKey());
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			sb.append(_toJSON(value));
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static String _toJSON(Object value) {
+		if (value == null) {
+			return "null";
+		}
+
+		if (value instanceof Map) {
+			return _toJSON((Map)value);
+		}
+
+		Class<?> clazz = value.getClass();
+
+		if (clazz.isArray()) {
+			StringBuilder sb = new StringBuilder("[");
+
+			Object[] values = (Object[])value;
+
+			for (int i = 0; i < values.length; i++) {
+				sb.append(_toJSON(values[i]));
+
+				if ((i + 1) < values.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+
+			return sb.toString();
+		}
+
+		if (value instanceof String) {
+			return "\"" + _escape(value) + "\"";
+		}
+
+		return String.valueOf(value);
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:-182401492

--- a/modules/apps/headless/headless-cms/headless-cms-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/rest-openapi.yaml
@@ -97,6 +97,42 @@ components:
         ResetAssetPermissionAction:
             allOf:
                 -   $ref: "#/components/schemas/AssetPermissionAction"
+        SimilarAsset:
+            description:
+                A CMS content asset that belongs to a similar asset set.
+            properties:
+                contentType:
+                    description:
+                        The localized label of the asset's content type.
+                    readOnly: true
+                    type: string
+                dateModified:
+                    format: date-time
+                    readOnly: true
+                    type: string
+                id:
+                    format: int64
+                    readOnly: true
+                    type: integer
+                title:
+                    readOnly: true
+                    type: string
+        SimilarAssetSet:
+            description:
+                A set of CMS content assets detected as similar to one another.
+            properties:
+                similarAssets:
+                    description:
+                        The set's assets that fall inside the requested page. A set split across pages repeats in the next page with the remaining assets.
+                    items:
+                        $ref: "#/components/schemas/SimilarAsset"
+                    readOnly: true
+                    type: array
+                size:
+                    description:
+                        The total number of assets in the set, independent of the requested page.
+                    readOnly: true
+                    type: integer
 info:
     license:
         name: Apache 2.0
@@ -226,3 +262,36 @@ paths:
                                     $ref: "#/components/schemas/BrokenLinkAsset"
                                 type: array
             tags: ["BrokenLinkAsset"]
+    "/similar-asset-sets":
+        get:
+            description:
+                List the sets of CMS content whose main text overlaps significantly, paginated by asset. Content is compared within one language, so a translation is only ever compared against the same translation of other content, and a set always spans the whole space, so its size never depends on the requested page. Omit assetLibraryId to span all accessible spaces. Note that totalCount counts the assets that belong to a set while the items are the sets that hold them, so it is the number of assets that have a similar asset rather than a page count, and a set that straddles a page boundary is returned on both pages with its full size.
+            operationId: getSimilarAssetSetsPage
+            parameters:
+                -   in: query
+                    name: assetLibraryId
+                    schema:
+                        format: int64
+                        type: integer
+                -   in: query
+                    name: page
+                    schema:
+                        type: integer
+                -   in: query
+                    name: pageSize
+                    schema:
+                        type: integer
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/SimilarAssetSet"
+                                type: array
+                        application/xml:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/SimilarAssetSet"
+                                type: array
+            tags: ["SimilarAssetSet"]

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/graphql/query/v1_0/Query.java
@@ -8,9 +8,11 @@ package com.liferay.headless.cms.internal.graphql.query.v1_0;
 import com.liferay.headless.cms.dto.v1_0.AssetStatistics;
 import com.liferay.headless.cms.dto.v1_0.AssetUsage;
 import com.liferay.headless.cms.dto.v1_0.BrokenLinkAsset;
+import com.liferay.headless.cms.dto.v1_0.SimilarAssetSet;
 import com.liferay.headless.cms.resource.v1_0.AssetStatisticsResource;
 import com.liferay.headless.cms.resource.v1_0.AssetUsageResource;
 import com.liferay.headless.cms.resource.v1_0.BrokenLinkAssetResource;
+import com.liferay.headless.cms.resource.v1_0.SimilarAssetSetResource;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.portal.kernel.service.GroupLocalService;
@@ -66,6 +68,14 @@ public class Query {
 
 		_brokenLinkAssetResourceComponentServiceObjects =
 			brokenLinkAssetResourceComponentServiceObjects;
+	}
+
+	public static void setSimilarAssetSetResourceComponentServiceObjects(
+		ComponentServiceObjects<SimilarAssetSetResource>
+			similarAssetSetResourceComponentServiceObjects) {
+
+		_similarAssetSetResourceComponentServiceObjects =
+			similarAssetSetResourceComponentServiceObjects;
 	}
 
 	/**
@@ -132,6 +142,29 @@ public class Query {
 					Pagination.of(page, pageSize),
 					_sortsBiFunction.apply(
 						brokenLinkAssetResource, sortsString))));
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {similarAssetSets(assetLibraryId: ___, page: ___, pageSize: ___){items {__}, page, pageSize, totalCount}}"}' -u 'test@liferay.com:test'
+	 */
+	@GraphQLField(
+		description = "List the sets of CMS content whose main text overlaps significantly, paginated by asset. Content is compared within one language, so a translation is only ever compared against the same translation of other content, and a set always spans the whole space, so its size never depends on the requested page. Omit assetLibraryId to span all accessible spaces. Note that totalCount counts the assets that belong to a set while the items are the sets that hold them, so it is the number of assets that have a similar asset rather than a page count, and a set that straddles a page boundary is returned on both pages with its full size."
+	)
+	public SimilarAssetSetPage similarAssetSets(
+			@GraphQLName("assetLibraryId") @NotEmpty String assetLibraryId,
+			@GraphQLName("pageSize") int pageSize,
+			@GraphQLName("page") int page)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_similarAssetSetResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			similarAssetSetResource -> new SimilarAssetSetPage(
+				similarAssetSetResource.getSimilarAssetSetsPage(
+					Long.valueOf(assetLibraryId),
+					Pagination.of(page, pageSize))));
 	}
 
 	@GraphQLName("AssetStatisticsPage")
@@ -233,6 +266,39 @@ public class Query {
 
 	}
 
+	@GraphQLName("SimilarAssetSetPage")
+	public class SimilarAssetSetPage {
+
+		public SimilarAssetSetPage(Page similarAssetSetPage) {
+			actions = similarAssetSetPage.getActions();
+
+			items = similarAssetSetPage.getItems();
+			lastPage = similarAssetSetPage.getLastPage();
+			page = similarAssetSetPage.getPage();
+			pageSize = similarAssetSetPage.getPageSize();
+			totalCount = similarAssetSetPage.getTotalCount();
+		}
+
+		@GraphQLField
+		protected Map<String, Map<String, String>> actions;
+
+		@GraphQLField
+		protected java.util.Collection<SimilarAssetSet> items;
+
+		@GraphQLField
+		protected long lastPage;
+
+		@GraphQLField
+		protected long page;
+
+		@GraphQLField
+		protected long pageSize;
+
+		@GraphQLField
+		protected long totalCount;
+
+	}
+
 	private <T, R, E1 extends Throwable, E2 extends Throwable> R
 			_applyComponentServiceObjects(
 				ComponentServiceObjects<T> componentServiceObjects,
@@ -309,12 +375,34 @@ public class Query {
 		brokenLinkAssetResource.setRoleLocalService(_roleLocalService);
 	}
 
+	private void _populateResourceContext(
+			SimilarAssetSetResource similarAssetSetResource)
+		throws Exception {
+
+		similarAssetSetResource.setContextAcceptLanguage(_acceptLanguage);
+		similarAssetSetResource.setContextCompany(_company);
+		similarAssetSetResource.setContextHttpServletRequest(
+			_httpServletRequest);
+		similarAssetSetResource.setContextHttpServletResponse(
+			_httpServletResponse);
+		similarAssetSetResource.setContextUriInfo(_uriInfo);
+		similarAssetSetResource.setContextUser(_user);
+		similarAssetSetResource.setGroupLocalService(_groupLocalService);
+		similarAssetSetResource.setResourceActionLocalService(
+			_resourceActionLocalService);
+		similarAssetSetResource.setResourcePermissionLocalService(
+			_resourcePermissionLocalService);
+		similarAssetSetResource.setRoleLocalService(_roleLocalService);
+	}
+
 	private static ComponentServiceObjects<AssetStatisticsResource>
 		_assetStatisticsResourceComponentServiceObjects;
 	private static ComponentServiceObjects<AssetUsageResource>
 		_assetUsageResourceComponentServiceObjects;
 	private static ComponentServiceObjects<BrokenLinkAssetResource>
 		_brokenLinkAssetResourceComponentServiceObjects;
+	private static ComponentServiceObjects<SimilarAssetSetResource>
+		_similarAssetSetResourceComponentServiceObjects;
 
 	private AcceptLanguage _acceptLanguage;
 	private com.liferay.portal.kernel.model.Company _company;
@@ -333,4 +421,4 @@ public class Query {
 	private com.liferay.portal.kernel.model.User _user;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-802839611
+// LIFERAY-REST-BUILDER-HASH:205050445

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -11,10 +11,12 @@ import com.liferay.headless.cms.internal.resource.v1_0.AssetPermissionActionReso
 import com.liferay.headless.cms.internal.resource.v1_0.AssetStatisticsResourceImpl;
 import com.liferay.headless.cms.internal.resource.v1_0.AssetUsageResourceImpl;
 import com.liferay.headless.cms.internal.resource.v1_0.BrokenLinkAssetResourceImpl;
+import com.liferay.headless.cms.internal.resource.v1_0.SimilarAssetSetResourceImpl;
 import com.liferay.headless.cms.resource.v1_0.AssetPermissionActionResource;
 import com.liferay.headless.cms.resource.v1_0.AssetStatisticsResource;
 import com.liferay.headless.cms.resource.v1_0.AssetUsageResource;
 import com.liferay.headless.cms.resource.v1_0.BrokenLinkAssetResource;
+import com.liferay.headless.cms.resource.v1_0.SimilarAssetSetResource;
 import com.liferay.portal.kernel.util.ObjectValuePair;
 import com.liferay.portal.vulcan.graphql.servlet.ServletData;
 
@@ -49,6 +51,8 @@ public class ServletDataImpl implements ServletData {
 			_assetUsageResourceComponentServiceObjects);
 		Query.setBrokenLinkAssetResourceComponentServiceObjects(
 			_brokenLinkAssetResourceComponentServiceObjects);
+		Query.setSimilarAssetSetResourceComponentServiceObjects(
+			_similarAssetSetResourceComponentServiceObjects);
 	}
 
 	public String getApplicationName() {
@@ -106,6 +110,11 @@ public class ServletDataImpl implements ServletData {
 						new ObjectValuePair<>(
 							BrokenLinkAssetResourceImpl.class,
 							"getBrokenLinkAssetsPage"));
+					put(
+						"query#similarAssetSets",
+						new ObjectValuePair<>(
+							SimilarAssetSetResourceImpl.class,
+							"getSimilarAssetSetsPage"));
 				}
 			};
 
@@ -125,5 +134,9 @@ public class ServletDataImpl implements ServletData {
 	private ComponentServiceObjects<BrokenLinkAssetResource>
 		_brokenLinkAssetResourceComponentServiceObjects;
 
+	@Reference(scope = ReferenceScope.PROTOTYPE_REQUIRED)
+	private ComponentServiceObjects<SimilarAssetSetResource>
+		_similarAssetSetResourceComponentServiceObjects;
+
 }
-// LIFERAY-REST-BUILDER-HASH:1309969940
+// LIFERAY-REST-BUILDER-HASH:-1384675289

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/BaseSimilarAssetSetResourceImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/BaseSimilarAssetSetResourceImpl.java
@@ -1,0 +1,536 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.internal.resource.v1_0;
+
+import com.liferay.headless.cms.dto.v1_0.SimilarAssetSet;
+import com.liferay.headless.cms.resource.v1_0.SimilarAssetSetResource;
+import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.util.ActionUtil;
+import com.liferay.portal.vulcan.util.UriInfoUtil;
+
+import jakarta.annotation.Generated;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import jakarta.ws.rs.core.UriInfo;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Generated("")
+@jakarta.ws.rs.Path("/v1.0")
+public abstract class BaseSimilarAssetSetResourceImpl
+	implements SimilarAssetSetResource {
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'GET' 'http://localhost:8080/o/headless-cms/v1.0/similar-asset-sets'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "List the sets of CMS content whose main text overlaps significantly, paginated by asset. Content is compared within one language, so a translation is only ever compared against the same translation of other content, and a set always spans the whole space, so its size never depends on the requested page. Omit assetLibraryId to span all accessible spaces. Note that totalCount counts the assets that belong to a set while the items are the sets that hold them, so it is the number of assets that have a similar asset rather than a page count, and a set that straddles a page boundary is returned on both pages with its full size."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "assetLibraryId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "page"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "pageSize"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(name = "SimilarAssetSet")
+		}
+	)
+	@jakarta.ws.rs.GET
+	@jakarta.ws.rs.Path("/similar-asset-sets")
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public Page<SimilarAssetSet> getSimilarAssetSetsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("assetLibraryId")
+			Long assetLibraryId,
+			@jakarta.ws.rs.core.Context Pagination pagination)
+		throws Exception {
+
+		return Page.of(Collections.emptyList());
+	}
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
+	public void setContextCompany(
+		com.liferay.portal.kernel.model.Company contextCompany) {
+
+		this.contextCompany = contextCompany;
+	}
+
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = UriInfoUtil.getVulcanUriInfo(
+			getApplicationPath(), contextUriInfo);
+	}
+
+	public void setContextUser(
+		com.liferay.portal.kernel.model.User contextUser) {
+
+		this.contextUser = contextUser;
+	}
+
+	public void setExpressionConvert(
+		ExpressionConvert<com.liferay.portal.kernel.search.filter.Filter>
+			expressionConvert) {
+
+		this.expressionConvert = expressionConvert;
+	}
+
+	public void setFilterParserProvider(
+		FilterParserProvider filterParserProvider) {
+
+		this.filterParserProvider = filterParserProvider;
+	}
+
+	public void setGroupLocalService(GroupLocalService groupLocalService) {
+		this.groupLocalService = groupLocalService;
+	}
+
+	public void setResourceActionLocalService(
+		ResourceActionLocalService resourceActionLocalService) {
+
+		this.resourceActionLocalService = resourceActionLocalService;
+	}
+
+	public void setResourcePermissionLocalService(
+		ResourcePermissionLocalService resourcePermissionLocalService) {
+
+		this.resourcePermissionLocalService = resourcePermissionLocalService;
+	}
+
+	public void setRoleLocalService(RoleLocalService roleLocalService) {
+		this.roleLocalService = roleLocalService;
+	}
+
+	public void setSortParserProvider(SortParserProvider sortParserProvider) {
+		this.sortParserProvider = sortParserProvider;
+	}
+
+	protected String getApplicationPath() {
+		return "headless-cms";
+	}
+
+	protected Map<String, String> addAction(
+		String actionName,
+		com.liferay.portal.kernel.model.GroupedModel groupedModel,
+		String methodName) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), groupedModel, methodName,
+			contextScopeChecker, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, Long id, String methodName, Long ownerId,
+		String permissionName, Long siteId) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), id, methodName, contextScopeChecker,
+			ownerId, permissionName, siteId, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, Long id, String methodName,
+		ModelResourcePermission modelResourcePermission) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), id, methodName, contextScopeChecker,
+			modelResourcePermission, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, String methodName, String permissionName,
+		Long siteId) {
+
+		return addAction(
+			actionName, siteId, methodName, null, permissionName, siteId);
+	}
+
+	protected <T, R, E extends Throwable> List<R> transform(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transform(collection, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> R[] transform(
+		int[] array, UnsafeFunction<Integer, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transform(array, unsafeFunction, clazz);
+	}
+
+	public static <R, E extends Throwable> R[] transform(
+		long[] array, UnsafeFunction<Long, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] transform(
+		T[] array, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] transformToArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transformToArray(
+			collection, unsafeFunction, clazz);
+	}
+
+	public static <T, E extends Throwable> boolean[] transformToBooleanArray(
+		Collection<T> collection,
+		UnsafeFunction<T, Boolean, E> unsafeFunction) {
+
+		return TransformUtil.transformToBooleanArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> boolean[] transformToBooleanArray(
+		T[] array, UnsafeFunction<T, Boolean, E> unsafeFunction) {
+
+		return TransformUtil.transformToBooleanArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] transformToByteArray(
+		Collection<T> collection, UnsafeFunction<T, Byte, E> unsafeFunction) {
+
+		return TransformUtil.transformToByteArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] transformToByteArray(
+		T[] array, UnsafeFunction<T, Byte, E> unsafeFunction) {
+
+		return TransformUtil.transformToByteArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[] transformToDoubleArray(
+		Collection<T> collection, UnsafeFunction<T, Double, E> unsafeFunction) {
+
+		return TransformUtil.transformToDoubleArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[] transformToDoubleArray(
+		T[] array, UnsafeFunction<T, Double, E> unsafeFunction) {
+
+		return TransformUtil.transformToDoubleArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] transformToFloatArray(
+		Collection<T> collection, UnsafeFunction<T, Float, E> unsafeFunction) {
+
+		return TransformUtil.transformToFloatArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] transformToFloatArray(
+		T[] array, UnsafeFunction<T, Float, E> unsafeFunction) {
+
+		return TransformUtil.transformToFloatArray(array, unsafeFunction);
+	}
+
+	public static <T, R, E extends Throwable> int[] transformToIntArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToIntArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> int[] transformToIntArray(
+		T[] array, UnsafeFunction<T, Integer, E> unsafeFunction) {
+
+		return TransformUtil.transformToIntArray(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> transformToList(
+		int[] array, UnsafeFunction<Integer, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToList(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> transformToList(
+		long[] array, UnsafeFunction<Long, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> List<R> transformToList(
+		T[] array, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> long[] transformToLongArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToLongArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> long[] transformToLongArray(
+		T[] array, UnsafeFunction<T, Long, E> unsafeFunction) {
+
+		return TransformUtil.transformToLongArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] transformToShortArray(
+		Collection<T> collection, UnsafeFunction<T, Short, E> unsafeFunction) {
+
+		return TransformUtil.transformToShortArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] transformToShortArray(
+		T[] array, UnsafeFunction<T, Short, E> unsafeFunction) {
+
+		return TransformUtil.transformToShortArray(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> List<R> unsafeTransform(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransform(collection, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> R[] unsafeTransform(
+			int[] array, UnsafeFunction<Integer, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransform(array, unsafeFunction, clazz);
+	}
+
+	public static <R, E extends Throwable> R[] unsafeTransform(
+			long[] array, UnsafeFunction<Long, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] unsafeTransform(
+			T[] array, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransformToArray(
+			collection, unsafeFunction, clazz);
+	}
+
+	public static <T, E extends Throwable> boolean[]
+			unsafeTransformToBooleanArray(
+				Collection<T> collection,
+				UnsafeFunction<T, Boolean, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToBooleanArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> boolean[]
+			unsafeTransformToBooleanArray(
+				T[] array, UnsafeFunction<T, Boolean, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToBooleanArray(
+			array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] unsafeTransformToByteArray(
+			Collection<T> collection, UnsafeFunction<T, Byte, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToByteArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] unsafeTransformToByteArray(
+			T[] array, UnsafeFunction<T, Byte, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToByteArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[]
+			unsafeTransformToDoubleArray(
+				Collection<T> collection,
+				UnsafeFunction<T, Double, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToDoubleArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[]
+			unsafeTransformToDoubleArray(
+				T[] array, UnsafeFunction<T, Double, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToDoubleArray(
+			array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] unsafeTransformToFloatArray(
+			Collection<T> collection,
+			UnsafeFunction<T, Float, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToFloatArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] unsafeTransformToFloatArray(
+			T[] array, UnsafeFunction<T, Float, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToFloatArray(array, unsafeFunction);
+	}
+
+	public static <T, R, E extends Throwable> int[] unsafeTransformToIntArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToIntArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> int[] unsafeTransformToIntArray(
+			T[] array, UnsafeFunction<T, Integer, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToIntArray(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> unsafeTransformToList(
+			int[] array, UnsafeFunction<Integer, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToList(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> unsafeTransformToList(
+			long[] array, UnsafeFunction<Long, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> List<R> unsafeTransformToList(
+			T[] array, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> long[] unsafeTransformToLongArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToLongArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> long[] unsafeTransformToLongArray(
+			T[] array, UnsafeFunction<T, Long, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToLongArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] unsafeTransformToShortArray(
+			Collection<T> collection,
+			UnsafeFunction<T, Short, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToShortArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] unsafeTransformToShortArray(
+			T[] array, UnsafeFunction<T, Short, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToShortArray(array, unsafeFunction);
+	}
+
+	protected AcceptLanguage contextAcceptLanguage;
+	protected com.liferay.portal.kernel.model.Company contextCompany;
+	protected HttpServletRequest contextHttpServletRequest;
+	protected HttpServletResponse contextHttpServletResponse;
+	protected Object contextScopeChecker;
+	protected UriInfo contextUriInfo;
+	protected com.liferay.portal.kernel.model.User contextUser;
+	protected ExpressionConvert<com.liferay.portal.kernel.search.filter.Filter>
+		expressionConvert;
+	protected FilterParserProvider filterParserProvider;
+	protected GroupLocalService groupLocalService;
+	protected ResourceActionLocalService resourceActionLocalService;
+	protected ResourcePermissionLocalService resourcePermissionLocalService;
+	protected RoleLocalService roleLocalService;
+	protected SortParserProvider sortParserProvider;
+
+	private static final com.liferay.portal.kernel.log.Log _log =
+		LogFactoryUtil.getLog(BaseSimilarAssetSetResourceImpl.class);
+
+}
+// LIFERAY-REST-BUILDER-HASH:-1273675676

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -93,9 +93,11 @@ public class OpenAPIResourceImpl {
 
 			add(BrokenLinkAssetResourceImpl.class);
 
+			add(SimilarAssetSetResourceImpl.class);
+
 			add(OpenAPIResourceImpl.class);
 		}
 	};
 
 }
-// LIFERAY-REST-BUILDER-HASH:-529876021
+// LIFERAY-REST-BUILDER-HASH:-1311847398

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/SimilarAssetSetResourceImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/SimilarAssetSetResourceImpl.java
@@ -87,13 +87,13 @@ public class SimilarAssetSetResourceImpl
 		String[] entryClassNames = ArrayUtil.toStringArray(
 			ListUtil.toList(objectDefinitions, ObjectDefinition::getClassName));
 
-		List<String> sharedSimilarAssets = _searchSharedSimilarAssets(
+		List<String> sharedSimilarAssetHashes = _searchSharedSimilarAssetHashes(
 			entryClassNames, groupIds);
 
 		Map<Long, List<Long>> objectEntryIdsMap = _getObjectEntryIdsMap(
-			_searchSharedSimilarAssetDocuments(
-				entryClassNames, groupIds, sharedSimilarAssets),
-			new HashSet<>(sharedSimilarAssets));
+			_searchSharedSimilarAssetHashDocuments(
+				entryClassNames, groupIds, sharedSimilarAssetHashes),
+			new HashSet<>(sharedSimilarAssetHashes));
 
 		long totalCount = 0;
 
@@ -174,7 +174,7 @@ public class SimilarAssetSetResourceImpl
 	}
 
 	private Map<Long, List<Long>> _getObjectEntryIdsMap(
-		List<Document> documents, Set<String> sharedSimilarAssets) {
+		List<Document> documents, Set<String> sharedSimilarAssetHashes) {
 
 		Map<Long, Long> parentObjectEntryIds = new LinkedHashMap<>();
 		Map<String, List<Long>> objectEntryIdsMap = new HashMap<>();
@@ -188,16 +188,18 @@ public class SimilarAssetSetResourceImpl
 
 			parentObjectEntryIds.putIfAbsent(objectEntryId, objectEntryId);
 
-			for (String similarAsset : document.getStrings("similarAssets")) {
-				if (!sharedSimilarAssets.contains(similarAsset)) {
+			for (String similarAssetHash :
+					document.getStrings("similarAssetHashes")) {
+
+				if (!sharedSimilarAssetHashes.contains(similarAssetHash)) {
 					continue;
 				}
 
-				List<Long> similarAssetObjectEntryIds =
+				List<Long> similarAssetHashObjectEntryIds =
 					objectEntryIdsMap.computeIfAbsent(
-						similarAsset, key -> new ArrayList<>());
+						similarAssetHash, key -> new ArrayList<>());
 
-				similarAssetObjectEntryIds.add(objectEntryId);
+				similarAssetHashObjectEntryIds.add(objectEntryId);
 			}
 		}
 
@@ -333,22 +335,22 @@ public class SimilarAssetSetResourceImpl
 	}
 
 	private void _mergeObjectEntryIds(
-		Map<Long, List<String>> similarAssetsMap,
+		Map<Long, List<String>> similarAssetHashesMap,
 		Map<Long, Long> parentObjectEntryIds) {
 
 		Map<String, Long> objectEntryIdsMap = new HashMap<>();
 
 		for (Map.Entry<Long, List<String>> entry :
-				similarAssetsMap.entrySet()) {
+				similarAssetHashesMap.entrySet()) {
 
-			List<String> similarAssets = entry.getValue();
+			List<String> similarAssetHashes = entry.getValue();
 
-			if (similarAssets.size() < _MIN_SHARED_SIMILAR_ASSETS) {
+			if (similarAssetHashes.size() < _MIN_SHARED_SIMILAR_ASSET_HASHES) {
 				continue;
 			}
 
 			Long objectEntryId = objectEntryIdsMap.putIfAbsent(
-				StringUtil.merge(similarAssets), entry.getKey());
+				StringUtil.merge(similarAssetHashes), entry.getKey());
 
 			if (objectEntryId != null) {
 				_mergeObjectEntryIds(
@@ -361,8 +363,8 @@ public class SimilarAssetSetResourceImpl
 		Map<String, List<Long>> objectEntryIdsMap,
 		Map<Long, Long> parentObjectEntryIds) {
 
-		Map<Long, List<String>> similarAssetsMap = new LinkedHashMap<>();
-		Map<Long, Map<Long, Integer>> sharedSimilarAssetCounts =
+		Map<Long, List<String>> similarAssetHashesMap = new LinkedHashMap<>();
+		Map<Long, Map<Long, Integer>> sharedSimilarAssetHashCounts =
 			new HashMap<>();
 
 		for (Map.Entry<String, List<Long>> entry :
@@ -370,13 +372,13 @@ public class SimilarAssetSetResourceImpl
 
 			List<Long> objectEntryIds = entry.getValue();
 
-			if (objectEntryIds.size() > _MAX_ASSETS_PER_SIMILAR_ASSET) {
+			if (objectEntryIds.size() > _MAX_ASSETS_PER_SIMILAR_ASSET_HASH) {
 				for (Long objectEntryId : objectEntryIds) {
-					List<String> similarAssets =
-						similarAssetsMap.computeIfAbsent(
+					List<String> similarAssetHashes =
+						similarAssetHashesMap.computeIfAbsent(
 							objectEntryId, key -> new ArrayList<>());
 
-					similarAssets.add(entry.getKey());
+					similarAssetHashes.add(entry.getKey());
 				}
 
 				continue;
@@ -397,7 +399,7 @@ public class SimilarAssetSetResourceImpl
 					}
 
 					Map<Long, Integer> counts =
-						sharedSimilarAssetCounts.computeIfAbsent(
+						sharedSimilarAssetHashCounts.computeIfAbsent(
 							Math.min(objectEntryId1, objectEntryId2),
 							objectEntryId -> new HashMap<>());
 
@@ -405,7 +407,7 @@ public class SimilarAssetSetResourceImpl
 						Math.max(objectEntryId1, objectEntryId2), 1,
 						Integer::sum);
 
-					if (count >= _MIN_SHARED_SIMILAR_ASSETS) {
+					if (count >= _MIN_SHARED_SIMILAR_ASSET_HASHES) {
 						_mergeObjectEntryIds(
 							objectEntryId1, objectEntryId2,
 							parentObjectEntryIds);
@@ -414,22 +416,22 @@ public class SimilarAssetSetResourceImpl
 			}
 		}
 
-		_mergeObjectEntryIds(similarAssetsMap, parentObjectEntryIds);
+		_mergeObjectEntryIds(similarAssetHashesMap, parentObjectEntryIds);
 	}
 
-	private List<Document> _searchSharedSimilarAssetDocuments(
+	private List<Document> _searchSharedSimilarAssetHashDocuments(
 		String[] entryClassNames, Long[] groupIds,
-		List<String> sharedSimilarAssets) {
+		List<String> sharedSimilarAssetHashes) {
 
 		List<Document> documents = new ArrayList<>();
 
-		if (sharedSimilarAssets.isEmpty()) {
+		if (sharedSimilarAssetHashes.isEmpty()) {
 			return documents;
 		}
 
-		TermsQuery termsQuery = QueriesUtil.terms("similarAssets");
+		TermsQuery termsQuery = QueriesUtil.terms("similarAssetHashes");
 
-		termsQuery.addValues(sharedSimilarAssets.toArray());
+		termsQuery.addValues(sharedSimilarAssetHashes.toArray());
 
 		SearchResponse searchResponse = _searcher.search(
 			_searchRequestBuilderFactory.builder(
@@ -447,7 +449,7 @@ public class SimilarAssetSetResourceImpl
 			).entryClassNames(
 				entryClassNames
 			).fetchSourceIncludes(
-				new String[] {"objectEntryId", "similarAssets"}
+				new String[] {"objectEntryId", "similarAssetHashes"}
 			).size(
 				_MAX_DOCUMENTS
 			).withSearchContext(
@@ -463,19 +465,19 @@ public class SimilarAssetSetResourceImpl
 		return documents;
 	}
 
-	private List<String> _searchSharedSimilarAssets(
+	private List<String> _searchSharedSimilarAssetHashes(
 		String[] entryClassNames, Long[] groupIds) {
 
-		List<String> sharedSimilarAssets = new ArrayList<>();
+		List<String> sharedSimilarAssetHashes = new ArrayList<>();
 
 		TermsAggregation termsAggregation = _aggregations.terms(
-			_SIMILAR_ASSETS_AGGREGATION_NAME, "similarAssets");
+			_SIMILAR_ASSET_HASHES_AGGREGATION_NAME, "similarAssetHashes");
 
 		termsAggregation.setMinDocCount(2);
 		termsAggregation.setIncludeExcludeClause(
 			new IncludeExcludeClauseImpl(
 				contextAcceptLanguage.getPreferredLanguageId() + "_.*", null));
-		termsAggregation.setSize(_MAX_SIMILAR_ASSETS);
+		termsAggregation.setSize(_MAX_SIMILAR_ASSET_HASHES);
 
 		SearchResponse searchResponse = _searcher.search(
 			_searchRequestBuilderFactory.builder(
@@ -495,17 +497,17 @@ public class SimilarAssetSetResourceImpl
 
 		TermsAggregationResult termsAggregationResult =
 			(TermsAggregationResult)searchResponse.getAggregationResult(
-				_SIMILAR_ASSETS_AGGREGATION_NAME);
+				_SIMILAR_ASSET_HASHES_AGGREGATION_NAME);
 
 		if (termsAggregationResult == null) {
-			return sharedSimilarAssets;
+			return sharedSimilarAssetHashes;
 		}
 
 		for (Bucket bucket : termsAggregationResult.getBuckets()) {
-			sharedSimilarAssets.add(bucket.getKey());
+			sharedSimilarAssetHashes.add(bucket.getKey());
 		}
 
-		return sharedSimilarAssets;
+		return sharedSimilarAssetHashes;
 	}
 
 	private SimilarAssetSet _toSimilarAssetSet(
@@ -554,16 +556,16 @@ public class SimilarAssetSetResourceImpl
 		return similarAssetSet;
 	}
 
-	private static final int _MAX_ASSETS_PER_SIMILAR_ASSET = 500;
+	private static final int _MAX_ASSETS_PER_SIMILAR_ASSET_HASH = 500;
 
 	private static final int _MAX_DOCUMENTS = 10000;
 
-	private static final int _MAX_SIMILAR_ASSETS = 10000;
+	private static final int _MAX_SIMILAR_ASSET_HASHES = 10000;
 
-	private static final int _MIN_SHARED_SIMILAR_ASSETS = 3;
+	private static final int _MIN_SHARED_SIMILAR_ASSET_HASHES = 3;
 
-	private static final String _SIMILAR_ASSETS_AGGREGATION_NAME =
-		"similarAssets";
+	private static final String _SIMILAR_ASSET_HASHES_AGGREGATION_NAME =
+		"similarAssetHashes";
 
 	@Reference
 	private Aggregations _aggregations;

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/SimilarAssetSetResourceImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/SimilarAssetSetResourceImpl.java
@@ -1,0 +1,627 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.internal.resource.v1_0;
+
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.depot.service.DepotEntryService;
+import com.liferay.headless.cms.dto.v1_0.SimilarAsset;
+import com.liferay.headless.cms.dto.v1_0.SimilarAssetSet;
+import com.liferay.headless.cms.resource.v1_0.SimilarAssetSetResource;
+import com.liferay.object.constants.ObjectFolderConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.service.ObjectDefinitionService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.search.aggregation.Aggregations;
+import com.liferay.portal.search.aggregation.bucket.Bucket;
+import com.liferay.portal.search.aggregation.bucket.IncludeExcludeClause;
+import com.liferay.portal.search.aggregation.bucket.TermsAggregation;
+import com.liferay.portal.search.aggregation.bucket.TermsAggregationResult;
+import com.liferay.portal.search.document.Document;
+import com.liferay.portal.search.filter.ComplexQueryPartBuilderFactory;
+import com.liferay.portal.search.hits.SearchHit;
+import com.liferay.portal.search.hits.SearchHits;
+import com.liferay.portal.search.query.QueriesUtil;
+import com.liferay.portal.search.query.TermsQuery;
+import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
+import com.liferay.portal.search.searcher.SearchResponse;
+import com.liferay.portal.search.searcher.Searcher;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.util.GroupUtil;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ServiceScope;
+
+/**
+ * @author Mikel Lorza
+ */
+@Component(
+	properties = "OSGI-INF/liferay/rest/v1_0/similar-asset-set.properties",
+	scope = ServiceScope.PROTOTYPE, service = SimilarAssetSetResource.class
+)
+public class SimilarAssetSetResourceImpl
+	extends BaseSimilarAssetSetResourceImpl {
+
+	@Override
+	public Page<SimilarAssetSet> getSimilarAssetSetsPage(
+			Long assetLibraryId, Pagination pagination)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled(
+				contextCompany.getCompanyId(), "LPD-82226")) {
+
+			return Page.of(new ArrayList<>(), pagination, 0);
+		}
+
+		Long[] groupIds = _getGroupIds(assetLibraryId);
+		List<ObjectDefinition> objectDefinitions = _getCMSObjectDefinitions();
+
+		if (ArrayUtil.isEmpty(groupIds) || objectDefinitions.isEmpty()) {
+			return Page.of(new ArrayList<>(), pagination, 0);
+		}
+
+		String[] entryClassNames = ArrayUtil.toStringArray(
+			ListUtil.toList(objectDefinitions, ObjectDefinition::getClassName));
+
+		List<String> sharedSimilarAssets = _searchSharedSimilarAssets(
+			entryClassNames, groupIds);
+
+		Map<Long, List<Long>> objectEntryIdsMap = _getObjectEntryIdsMap(
+			_searchSharedSimilarAssetDocuments(
+				entryClassNames, groupIds, sharedSimilarAssets),
+			new HashSet<>(sharedSimilarAssets));
+
+		long totalCount = 0;
+
+		for (List<Long> objectEntryIds : objectEntryIdsMap.values()) {
+			totalCount += objectEntryIds.size();
+		}
+
+		Map<Long, ObjectDefinition> objectDefinitionsMap = new HashMap<>();
+
+		for (ObjectDefinition objectDefinition : objectDefinitions) {
+			objectDefinitionsMap.put(
+				objectDefinition.getObjectDefinitionId(), objectDefinition);
+		}
+
+		return Page.of(
+			_getSimilarAssetSets(
+				objectDefinitionsMap, objectEntryIdsMap, pagination),
+			pagination, totalCount);
+	}
+
+	private List<ObjectDefinition> _getCMSObjectDefinitions() throws Exception {
+		return _objectDefinitionService.getCMSObjectDefinitions(
+			contextCompany.getCompanyId(),
+			new String[] {
+				ObjectFolderConstants.
+					EXTERNAL_REFERENCE_CODE_CONTENT_STRUCTURES,
+				ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_FILE_TYPES
+			});
+	}
+
+	private Map<Long, List<Long>> _getGroupedObjectEntryIdsMap(
+		Map<Long, Long> parentObjectEntryIds) {
+
+		Map<Long, List<Long>> objectEntryIdsMap = new LinkedHashMap<>();
+
+		for (Long objectEntryId : parentObjectEntryIds.keySet()) {
+			List<Long> rootObjectEntryIds = objectEntryIdsMap.computeIfAbsent(
+				_getRootObjectEntryId(objectEntryId, parentObjectEntryIds),
+				rootObjectEntryId -> new ArrayList<>());
+
+			rootObjectEntryIds.add(objectEntryId);
+		}
+
+		Map<Long, List<Long>> groupedObjectEntryIdsMap = new HashMap<>();
+
+		for (List<Long> objectEntryIds : objectEntryIdsMap.values()) {
+			if (objectEntryIds.size() < 2) {
+				continue;
+			}
+
+			Collections.sort(objectEntryIds);
+
+			groupedObjectEntryIdsMap.put(objectEntryIds.get(0), objectEntryIds);
+		}
+
+		return _getSortedObjectEntryIdsMap(groupedObjectEntryIdsMap);
+	}
+
+	private Long[] _getGroupIds(Long assetLibraryId) {
+		List<Long> depotEntryGroupIds =
+			_depotEntryService.getDepotEntryGroupIds(
+				contextCompany.getCompanyId(), contextUser.getUserId(),
+				DepotConstants.TYPE_SPACE);
+
+		if (assetLibraryId == null) {
+			return depotEntryGroupIds.toArray(new Long[0]);
+		}
+
+		Long groupId = GroupUtil.getDepotGroupId(
+			String.valueOf(assetLibraryId), contextCompany.getCompanyId(),
+			_depotEntryLocalService, groupLocalService);
+
+		if ((groupId == null) || !depotEntryGroupIds.contains(groupId)) {
+			return new Long[0];
+		}
+
+		return new Long[] {groupId};
+	}
+
+	private Map<Long, List<Long>> _getObjectEntryIdsMap(
+		List<Document> documents, Set<String> sharedSimilarAssets) {
+
+		Map<Long, Long> parentObjectEntryIds = new LinkedHashMap<>();
+		Map<String, List<Long>> objectEntryIdsMap = new HashMap<>();
+
+		for (Document document : documents) {
+			Long objectEntryId = document.getLong("objectEntryId");
+
+			if (objectEntryId == null) {
+				continue;
+			}
+
+			parentObjectEntryIds.putIfAbsent(objectEntryId, objectEntryId);
+
+			for (String similarAsset : document.getStrings("similarAssets")) {
+				if (!sharedSimilarAssets.contains(similarAsset)) {
+					continue;
+				}
+
+				List<Long> similarAssetObjectEntryIds =
+					objectEntryIdsMap.computeIfAbsent(
+						similarAsset, key -> new ArrayList<>());
+
+				similarAssetObjectEntryIds.add(objectEntryId);
+			}
+		}
+
+		_mergeSimilarObjectEntryIds(objectEntryIdsMap, parentObjectEntryIds);
+
+		return _getGroupedObjectEntryIdsMap(parentObjectEntryIds);
+	}
+
+	private Long _getRootObjectEntryId(
+		Long objectEntryId, Map<Long, Long> parentObjectEntryIds) {
+
+		Long rootObjectEntryId = objectEntryId;
+
+		Long parentObjectEntryId = parentObjectEntryIds.get(rootObjectEntryId);
+
+		while (!parentObjectEntryId.equals(rootObjectEntryId)) {
+			rootObjectEntryId = parentObjectEntryId;
+
+			parentObjectEntryId = parentObjectEntryIds.get(rootObjectEntryId);
+		}
+
+		while (!objectEntryId.equals(rootObjectEntryId)) {
+			objectEntryId = parentObjectEntryIds.put(
+				objectEntryId, rootObjectEntryId);
+		}
+
+		return rootObjectEntryId;
+	}
+
+	private Consumer<SearchContext> _getSearchContextConsumer(Long[] groupIds) {
+		long[] scopedGroupIds = ArrayUtil.toArray(groupIds);
+
+		return searchContext -> {
+			searchContext.setAttribute(
+				Field.STATUS, WorkflowConstants.STATUS_APPROVED);
+			searchContext.setGroupIds(scopedGroupIds);
+
+			searchContext.setUserId(contextUser.getUserId());
+		};
+	}
+
+	private List<SimilarAssetSet> _getSimilarAssetSets(
+			Map<Long, ObjectDefinition> objectDefinitionsMap,
+			Map<Long, List<Long>> objectEntryIdsMap, Pagination pagination)
+		throws Exception {
+
+		List<SimilarAssetSet> similarAssetSets = new ArrayList<>();
+
+		int endPosition = -1;
+		int startPosition = -1;
+
+		if (pagination != null) {
+			endPosition = pagination.getEndPosition();
+			startPosition = pagination.getStartPosition();
+		}
+
+		int position = 0;
+
+		for (List<Long> objectEntryIds : objectEntryIdsMap.values()) {
+			int groupStartPosition = position;
+
+			position += objectEntryIds.size();
+
+			List<Long> pageObjectEntryIds = objectEntryIds;
+
+			if ((endPosition >= 0) && (startPosition >= 0)) {
+				if (position <= startPosition) {
+					continue;
+				}
+
+				if (groupStartPosition >= endPosition) {
+					break;
+				}
+
+				pageObjectEntryIds = objectEntryIds.subList(
+					Math.max(startPosition - groupStartPosition, 0),
+					Math.min(
+						endPosition - groupStartPosition,
+						objectEntryIds.size()));
+			}
+
+			similarAssetSets.add(
+				_toSimilarAssetSet(
+					objectDefinitionsMap, pageObjectEntryIds,
+					objectEntryIds.size()));
+		}
+
+		return similarAssetSets;
+	}
+
+	private Map<Long, List<Long>> _getSortedObjectEntryIdsMap(
+		Map<Long, List<Long>> objectEntryIdsMap) {
+
+		List<Long> lowestObjectEntryIds = ListUtil.fromMapKeys(
+			objectEntryIdsMap);
+
+		lowestObjectEntryIds.sort(
+			Comparator.comparingInt(
+				(Long lowestObjectEntryId) -> {
+					List<Long> objectEntryIds = objectEntryIdsMap.get(
+						lowestObjectEntryId);
+
+					return objectEntryIds.size();
+				}
+			).reversed(
+			).thenComparing(
+				Comparator.naturalOrder()
+			));
+
+		Map<Long, List<Long>> sortedObjectEntryIdsMap = new LinkedHashMap<>();
+
+		for (Long lowestObjectEntryId : lowestObjectEntryIds) {
+			sortedObjectEntryIdsMap.put(
+				lowestObjectEntryId,
+				objectEntryIdsMap.get(lowestObjectEntryId));
+		}
+
+		return sortedObjectEntryIdsMap;
+	}
+
+	private void _mergeObjectEntryIds(
+		Long objectEntryId1, Long objectEntryId2,
+		Map<Long, Long> parentObjectEntryIds) {
+
+		Long rootObjectEntryId1 = _getRootObjectEntryId(
+			objectEntryId1, parentObjectEntryIds);
+		Long rootObjectEntryId2 = _getRootObjectEntryId(
+			objectEntryId2, parentObjectEntryIds);
+
+		if (!rootObjectEntryId1.equals(rootObjectEntryId2)) {
+			parentObjectEntryIds.put(rootObjectEntryId1, rootObjectEntryId2);
+		}
+	}
+
+	private void _mergeObjectEntryIds(
+		Map<Long, List<String>> similarAssetsMap,
+		Map<Long, Long> parentObjectEntryIds) {
+
+		Map<String, Long> objectEntryIdsMap = new HashMap<>();
+
+		for (Map.Entry<Long, List<String>> entry :
+				similarAssetsMap.entrySet()) {
+
+			List<String> similarAssets = entry.getValue();
+
+			if (similarAssets.size() < _MIN_SHARED_SIMILAR_ASSETS) {
+				continue;
+			}
+
+			Long objectEntryId = objectEntryIdsMap.putIfAbsent(
+				StringUtil.merge(similarAssets), entry.getKey());
+
+			if (objectEntryId != null) {
+				_mergeObjectEntryIds(
+					objectEntryId, entry.getKey(), parentObjectEntryIds);
+			}
+		}
+	}
+
+	private void _mergeSimilarObjectEntryIds(
+		Map<String, List<Long>> objectEntryIdsMap,
+		Map<Long, Long> parentObjectEntryIds) {
+
+		Map<Long, List<String>> similarAssetsMap = new LinkedHashMap<>();
+		Map<Long, Map<Long, Integer>> sharedSimilarAssetCounts =
+			new HashMap<>();
+
+		for (Map.Entry<String, List<Long>> entry :
+				objectEntryIdsMap.entrySet()) {
+
+			List<Long> objectEntryIds = entry.getValue();
+
+			if (objectEntryIds.size() > _MAX_ASSETS_PER_SIMILAR_ASSET) {
+				for (Long objectEntryId : objectEntryIds) {
+					List<String> similarAssets =
+						similarAssetsMap.computeIfAbsent(
+							objectEntryId, key -> new ArrayList<>());
+
+					similarAssets.add(entry.getKey());
+				}
+
+				continue;
+			}
+
+			for (int i = 0; i < objectEntryIds.size(); i++) {
+				for (int j = i + 1; j < objectEntryIds.size(); j++) {
+					Long objectEntryId1 = objectEntryIds.get(i);
+					Long objectEntryId2 = objectEntryIds.get(j);
+
+					Long rootObjectEntryId1 = _getRootObjectEntryId(
+						objectEntryId1, parentObjectEntryIds);
+					Long rootObjectEntryId2 = _getRootObjectEntryId(
+						objectEntryId2, parentObjectEntryIds);
+
+					if (rootObjectEntryId1.equals(rootObjectEntryId2)) {
+						continue;
+					}
+
+					Map<Long, Integer> counts =
+						sharedSimilarAssetCounts.computeIfAbsent(
+							Math.min(objectEntryId1, objectEntryId2),
+							objectEntryId -> new HashMap<>());
+
+					int count = counts.merge(
+						Math.max(objectEntryId1, objectEntryId2), 1,
+						Integer::sum);
+
+					if (count >= _MIN_SHARED_SIMILAR_ASSETS) {
+						_mergeObjectEntryIds(
+							objectEntryId1, objectEntryId2,
+							parentObjectEntryIds);
+					}
+				}
+			}
+		}
+
+		_mergeObjectEntryIds(similarAssetsMap, parentObjectEntryIds);
+	}
+
+	private List<Document> _searchSharedSimilarAssetDocuments(
+		String[] entryClassNames, Long[] groupIds,
+		List<String> sharedSimilarAssets) {
+
+		List<Document> documents = new ArrayList<>();
+
+		if (sharedSimilarAssets.isEmpty()) {
+			return documents;
+		}
+
+		TermsQuery termsQuery = QueriesUtil.terms("similarAssets");
+
+		termsQuery.addValues(sharedSimilarAssets.toArray());
+
+		SearchResponse searchResponse = _searcher.search(
+			_searchRequestBuilderFactory.builder(
+			).addComplexQueryPart(
+				_complexQueryPartBuilderFactory.builder(
+				).occur(
+					"must"
+				).query(
+					termsQuery
+				).build()
+			).companyId(
+				contextCompany.getCompanyId()
+			).emptySearchEnabled(
+				true
+			).entryClassNames(
+				entryClassNames
+			).fetchSourceIncludes(
+				new String[] {"objectEntryId", "similarAssets"}
+			).size(
+				_MAX_DOCUMENTS
+			).withSearchContext(
+				_getSearchContextConsumer(groupIds)
+			).build());
+
+		SearchHits searchHits = searchResponse.getSearchHits();
+
+		for (SearchHit searchHit : searchHits.getSearchHits()) {
+			documents.add(searchHit.getDocument());
+		}
+
+		return documents;
+	}
+
+	private List<String> _searchSharedSimilarAssets(
+		String[] entryClassNames, Long[] groupIds) {
+
+		List<String> sharedSimilarAssets = new ArrayList<>();
+
+		TermsAggregation termsAggregation = _aggregations.terms(
+			_SIMILAR_ASSETS_AGGREGATION_NAME, "similarAssets");
+
+		termsAggregation.setMinDocCount(2);
+		termsAggregation.setIncludeExcludeClause(
+			new IncludeExcludeClauseImpl(
+				contextAcceptLanguage.getPreferredLanguageId() + "_.*", null));
+		termsAggregation.setSize(_MAX_SIMILAR_ASSETS);
+
+		SearchResponse searchResponse = _searcher.search(
+			_searchRequestBuilderFactory.builder(
+			).addAggregation(
+				termsAggregation
+			).companyId(
+				contextCompany.getCompanyId()
+			).emptySearchEnabled(
+				true
+			).entryClassNames(
+				entryClassNames
+			).size(
+				0
+			).withSearchContext(
+				_getSearchContextConsumer(groupIds)
+			).build());
+
+		TermsAggregationResult termsAggregationResult =
+			(TermsAggregationResult)searchResponse.getAggregationResult(
+				_SIMILAR_ASSETS_AGGREGATION_NAME);
+
+		if (termsAggregationResult == null) {
+			return sharedSimilarAssets;
+		}
+
+		for (Bucket bucket : termsAggregationResult.getBuckets()) {
+			sharedSimilarAssets.add(bucket.getKey());
+		}
+
+		return sharedSimilarAssets;
+	}
+
+	private SimilarAssetSet _toSimilarAssetSet(
+			Map<Long, ObjectDefinition> objectDefinitionsMap,
+			List<Long> objectEntryIds, int size)
+		throws Exception {
+
+		SimilarAssetSet similarAssetSet = new SimilarAssetSet();
+
+		SimilarAsset[] similarAssets = transformToArray(
+			objectEntryIds,
+			objectEntryId -> {
+				ObjectEntry objectEntry =
+					_objectEntryLocalService.fetchObjectEntry(objectEntryId);
+
+				if (objectEntry == null) {
+					return null;
+				}
+
+				SimilarAsset similarAsset = new SimilarAsset();
+
+				similarAsset.setDateModified(objectEntry::getModifiedDate);
+				similarAsset.setId(() -> objectEntryId);
+				similarAsset.setTitle(
+					() -> objectEntry.getTitleValue(
+						contextAcceptLanguage.getPreferredLanguageId(), true));
+
+				ObjectDefinition objectDefinition = objectDefinitionsMap.get(
+					objectEntry.getObjectDefinitionId());
+
+				if (objectDefinition != null) {
+					similarAsset.setContentType(
+						() -> objectDefinition.getLabel(
+							contextAcceptLanguage.getPreferredLanguageId(),
+							true));
+				}
+
+				return similarAsset;
+			},
+			SimilarAsset.class);
+
+		similarAssetSet.setSimilarAssets(() -> similarAssets);
+
+		similarAssetSet.setSize(() -> size);
+
+		return similarAssetSet;
+	}
+
+	private static final int _MAX_ASSETS_PER_SIMILAR_ASSET = 500;
+
+	private static final int _MAX_DOCUMENTS = 10000;
+
+	private static final int _MAX_SIMILAR_ASSETS = 10000;
+
+	private static final int _MIN_SHARED_SIMILAR_ASSETS = 3;
+
+	private static final String _SIMILAR_ASSETS_AGGREGATION_NAME =
+		"similarAssets";
+
+	@Reference
+	private Aggregations _aggregations;
+
+	@Reference
+	private ComplexQueryPartBuilderFactory _complexQueryPartBuilderFactory;
+
+	@Reference
+	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Reference
+	private DepotEntryService _depotEntryService;
+
+	@Reference
+	private ObjectDefinitionService _objectDefinitionService;
+
+	@Reference
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Reference
+	private Searcher _searcher;
+
+	@Reference
+	private SearchRequestBuilderFactory _searchRequestBuilderFactory;
+
+	private static class IncludeExcludeClauseImpl
+		implements IncludeExcludeClause {
+
+		public IncludeExcludeClauseImpl(
+			String includeRegex, String excludeRegex) {
+
+			_includeRegex = includeRegex;
+			_excludeRegex = excludeRegex;
+		}
+
+		@Override
+		public String[] getExcludedValues() {
+			return null;
+		}
+
+		@Override
+		public String getExcludeRegex() {
+			return _excludeRegex;
+		}
+
+		@Override
+		public String[] getIncludedValues() {
+			return null;
+		}
+
+		@Override
+		public String getIncludeRegex() {
+			return _includeRegex;
+		}
+
+		private final String _excludeRegex;
+		private final String _includeRegex;
+
+	}
+
+}

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/factory/SimilarAssetSetResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/factory/SimilarAssetSetResourceFactoryImpl.java
@@ -1,0 +1,335 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.internal.resource.v1_0.factory;
+
+import com.liferay.headless.cms.internal.security.permission.LiberalPermissionChecker;
+import com.liferay.headless.cms.resource.v1_0.SimilarAssetSetResource;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.ProxyUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+
+import jakarta.annotation.Generated;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import jakarta.ws.rs.core.UriInfo;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Function;
+
+import org.osgi.service.component.ComponentServiceObjects;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceScope;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Component(
+	property = "resource.locator.key=/headless-cms/v1.0/SimilarAssetSet",
+	service = SimilarAssetSetResource.Factory.class
+)
+@Generated("")
+public class SimilarAssetSetResourceFactoryImpl
+	implements SimilarAssetSetResource.Factory {
+
+	@Override
+	public SimilarAssetSetResource.Builder create() {
+		return new SimilarAssetSetResource.Builder() {
+
+			@Override
+			public SimilarAssetSetResource build() {
+				if (_user == null) {
+					throw new IllegalArgumentException("User is not set");
+				}
+
+				Function<InvocationHandler, SimilarAssetSetResource>
+					similarAssetSetResourceProxyProviderFunction =
+						ResourceProxyProviderFunctionHolder.
+							_similarAssetSetResourceProxyProviderFunction;
+
+				return similarAssetSetResourceProxyProviderFunction.apply(
+					(proxy, method, arguments) -> _invoke(
+						method, arguments, _checkPermissions,
+						_httpServletRequest, _httpServletResponse,
+						_preferredLocale, _uriInfo, _user));
+			}
+
+			@Override
+			public SimilarAssetSetResource.Builder checkPermissions(
+				boolean checkPermissions) {
+
+				_checkPermissions = checkPermissions;
+
+				return this;
+			}
+
+			@Override
+			public SimilarAssetSetResource.Builder httpServletRequest(
+				HttpServletRequest httpServletRequest) {
+
+				_httpServletRequest = httpServletRequest;
+
+				return this;
+			}
+
+			@Override
+			public SimilarAssetSetResource.Builder httpServletResponse(
+				HttpServletResponse httpServletResponse) {
+
+				_httpServletResponse = httpServletResponse;
+
+				return this;
+			}
+
+			@Override
+			public SimilarAssetSetResource.Builder preferredLocale(
+				Locale preferredLocale) {
+
+				_preferredLocale = preferredLocale;
+
+				return this;
+			}
+
+			@Override
+			public SimilarAssetSetResource.Builder uriInfo(UriInfo uriInfo) {
+				_uriInfo = uriInfo;
+
+				return this;
+			}
+
+			@Override
+			public SimilarAssetSetResource.Builder user(User user) {
+				_user = user;
+
+				return this;
+			}
+
+			private boolean _checkPermissions = true;
+			private HttpServletRequest _httpServletRequest;
+			private HttpServletResponse _httpServletResponse;
+			private Locale _preferredLocale;
+			private UriInfo _uriInfo;
+			private User _user;
+
+		};
+	}
+
+	private static Function<InvocationHandler, SimilarAssetSetResource>
+		_getProxyProviderFunction() {
+
+		Class<?> proxyClass = ProxyUtil.getProxyClass(
+			SimilarAssetSetResource.class.getClassLoader(),
+			SimilarAssetSetResource.class);
+
+		try {
+			Constructor<SimilarAssetSetResource> constructor =
+				(Constructor<SimilarAssetSetResource>)proxyClass.getConstructor(
+					InvocationHandler.class);
+
+			return invocationHandler -> {
+				try {
+					return constructor.newInstance(invocationHandler);
+				}
+				catch (ReflectiveOperationException
+							reflectiveOperationException) {
+
+					throw new InternalError(reflectiveOperationException);
+				}
+			};
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			throw new InternalError(noSuchMethodException);
+		}
+	}
+
+	private Object _invoke(
+			Method method, Object[] arguments, boolean checkPermissions,
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse, Locale preferredLocale,
+			UriInfo uriInfo, User user)
+		throws Throwable {
+
+		String name = PrincipalThreadLocal.getName();
+
+		PrincipalThreadLocal.setName(user.getUserId());
+
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		if (checkPermissions) {
+			PermissionThreadLocal.setPermissionChecker(
+				_defaultPermissionCheckerFactory.create(user));
+		}
+		else {
+			PermissionThreadLocal.setPermissionChecker(
+				new LiberalPermissionChecker(user));
+		}
+
+		SimilarAssetSetResource similarAssetSetResource =
+			_componentServiceObjects.getService();
+
+		similarAssetSetResource.setContextAcceptLanguage(
+			new AcceptLanguageImpl(httpServletRequest, preferredLocale, user));
+
+		Company company = _companyLocalService.getCompany(user.getCompanyId());
+
+		similarAssetSetResource.setContextCompany(company);
+
+		similarAssetSetResource.setContextHttpServletRequest(
+			httpServletRequest);
+		similarAssetSetResource.setContextHttpServletResponse(
+			httpServletResponse);
+		similarAssetSetResource.setContextUriInfo(uriInfo);
+		similarAssetSetResource.setContextUser(user);
+		similarAssetSetResource.setExpressionConvert(_expressionConvert);
+		similarAssetSetResource.setFilterParserProvider(_filterParserProvider);
+		similarAssetSetResource.setGroupLocalService(_groupLocalService);
+		similarAssetSetResource.setResourceActionLocalService(
+			_resourceActionLocalService);
+		similarAssetSetResource.setResourcePermissionLocalService(
+			_resourcePermissionLocalService);
+		similarAssetSetResource.setRoleLocalService(_roleLocalService);
+		similarAssetSetResource.setSortParserProvider(_sortParserProvider);
+
+		try {
+			return method.invoke(similarAssetSetResource, arguments);
+		}
+		catch (InvocationTargetException invocationTargetException) {
+			throw invocationTargetException.getTargetException();
+		}
+		finally {
+			_componentServiceObjects.ungetService(similarAssetSetResource);
+
+			PrincipalThreadLocal.setName(name);
+
+			PermissionThreadLocal.setPermissionChecker(permissionChecker);
+		}
+	}
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
+
+	@Reference(scope = ReferenceScope.PROTOTYPE_REQUIRED)
+	private ComponentServiceObjects<SimilarAssetSetResource>
+		_componentServiceObjects;
+
+	@Reference
+	private PermissionCheckerFactory _defaultPermissionCheckerFactory;
+
+	@Reference(
+		target = "(result.class.name=com.liferay.portal.kernel.search.filter.Filter)"
+	)
+	private ExpressionConvert<Filter> _expressionConvert;
+
+	@Reference
+	private FilterParserProvider _filterParserProvider;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private ResourceActionLocalService _resourceActionLocalService;
+
+	@Reference
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Reference
+	private RoleLocalService _roleLocalService;
+
+	@Reference
+	private SortParserProvider _sortParserProvider;
+
+	@Reference
+	private UserLocalService _userLocalService;
+
+	private static class ResourceProxyProviderFunctionHolder {
+
+		private static final Function
+			<InvocationHandler, SimilarAssetSetResource>
+				_similarAssetSetResourceProxyProviderFunction =
+					_getProxyProviderFunction();
+
+	}
+
+	private class AcceptLanguageImpl implements AcceptLanguage {
+
+		public AcceptLanguageImpl(
+			HttpServletRequest httpServletRequest, Locale preferredLocale,
+			User user) {
+
+			_httpServletRequest = httpServletRequest;
+			_preferredLocale = preferredLocale;
+			_user = user;
+		}
+
+		@Override
+		public List<Locale> getLocales() {
+			return Arrays.asList(getPreferredLocale());
+		}
+
+		@Override
+		public String getPreferredLanguageId() {
+			return LocaleUtil.toLanguageId(getPreferredLocale());
+		}
+
+		@Override
+		public Locale getPreferredLocale() {
+			if (_preferredLocale != null) {
+				return _preferredLocale;
+			}
+
+			if (_httpServletRequest != null) {
+				Locale locale = (Locale)_httpServletRequest.getAttribute(
+					WebKeys.LOCALE);
+
+				if (locale != null) {
+					return locale;
+				}
+			}
+
+			return _user.getLocale();
+		}
+
+		@Override
+		public boolean isAcceptAllLanguages() {
+			return false;
+		}
+
+		private final HttpServletRequest _httpServletRequest;
+		private final Locale _preferredLocale;
+		private final User _user;
+
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:141834606

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/similar-asset-set.properties
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/similar-asset-set.properties
@@ -1,0 +1,8 @@
+#
+# This is a generated file.
+#
+
+api.version=v1.0
+entity.class.name=com.liferay.headless.cms.dto.v1_0.SimilarAssetSet
+osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.CMS)
+osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/BaseSimilarAssetSetResourceTestCase.java
+++ b/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/BaseSimilarAssetSetResourceTestCase.java
@@ -1,0 +1,952 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.resource.v1_0.test;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
+
+import com.liferay.headless.cms.client.dto.v1_0.SimilarAssetSet;
+import com.liferay.headless.cms.client.http.HttpInvoker;
+import com.liferay.headless.cms.client.pagination.Page;
+import com.liferay.headless.cms.client.pagination.Pagination;
+import com.liferay.headless.cms.client.resource.v1_0.SimilarAssetSetResource;
+import com.liferay.headless.cms.client.serdes.v1_0.SimilarAssetSetSerDes;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.JAXRSWhiteboardTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.odata.entity.EntityField;
+import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.vulcan.resource.EntityModelResource;
+
+import jakarta.annotation.Generated;
+
+import jakarta.ws.rs.core.MultivaluedHashMap;
+
+import java.lang.reflect.Method;
+
+import java.text.Format;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Generated("")
+public abstract class BaseSimilarAssetSetResourceTestCase {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_format = FastDateFormatFactoryUtil.getSimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		JAXRSWhiteboardTestUtil.ensureReady();
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		irrelevantGroup = GroupTestUtil.addGroup();
+		testGroup = GroupTestUtil.addGroup();
+
+		testCompany = CompanyLocalServiceUtil.getCompany(
+			testGroup.getCompanyId());
+
+		_similarAssetSetResource.setContextCompany(testCompany);
+
+		_testCompanyAdminUser = UserTestUtil.getAdminUser(
+			testCompany.getCompanyId());
+
+		similarAssetSetResource = SimilarAssetSetResource.builder(
+		).authentication(
+			_testCompanyAdminUser.getEmailAddress(),
+			PropsValues.DEFAULT_ADMIN_PASSWORD
+		).endpoint(
+			testCompany.getVirtualHostname(),
+			PortalUtil.getPortalServerPort(false), "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		GroupTestUtil.deleteGroup(irrelevantGroup);
+		GroupTestUtil.deleteGroup(testGroup);
+	}
+
+	@Test
+	public void testClientSerDesToDTO() throws Exception {
+		ObjectMapper objectMapper = getClientSerDesObjectMapper();
+
+		SimilarAssetSet similarAssetSet1 = randomSimilarAssetSet();
+
+		String json = objectMapper.writeValueAsString(similarAssetSet1);
+
+		SimilarAssetSet similarAssetSet2 = SimilarAssetSetSerDes.toDTO(json);
+
+		Assert.assertTrue(equals(similarAssetSet1, similarAssetSet2));
+	}
+
+	@Test
+	public void testClientSerDesToJSON() throws Exception {
+		ObjectMapper objectMapper = getClientSerDesObjectMapper();
+
+		SimilarAssetSet similarAssetSet = randomSimilarAssetSet();
+
+		String json1 = objectMapper.writeValueAsString(similarAssetSet);
+		String json2 = SimilarAssetSetSerDes.toJSON(similarAssetSet);
+
+		Assert.assertEquals(
+			objectMapper.readTree(json1), objectMapper.readTree(json2));
+	}
+
+	protected ObjectMapper getClientSerDesObjectMapper() {
+		return new ObjectMapper() {
+			{
+				configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
+				configure(
+					SerializationFeature.WRITE_ENUMS_USING_TO_STRING, true);
+				enable(SerializationFeature.INDENT_OUTPUT);
+				setDateFormat(new ISO8601DateFormat());
+				setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+				setSerializationInclusion(JsonInclude.Include.NON_NULL);
+				setVisibility(
+					PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+				setVisibility(
+					PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE);
+			}
+		};
+	}
+
+	@Test
+	public void testEscapeRegexInStringFields() throws Exception {
+		String regex = "^[0-9]+(\\.[0-9]{1,2})\"?";
+
+		SimilarAssetSet similarAssetSet = randomSimilarAssetSet();
+
+		String json = SimilarAssetSetSerDes.toJSON(similarAssetSet);
+
+		Assert.assertFalse(json.contains(regex));
+
+		similarAssetSet = SimilarAssetSetSerDes.toDTO(json);
+	}
+
+	@Test
+	public void testGetSimilarAssetSetsPage() throws Exception {
+		Page<SimilarAssetSet> page =
+			similarAssetSetResource.getSimilarAssetSetsPage(
+				null, Pagination.of(1, 10));
+
+		long totalCount = page.getTotalCount();
+
+		SimilarAssetSet similarAssetSet1 =
+			testGetSimilarAssetSetsPage_addSimilarAssetSet(
+				randomSimilarAssetSet());
+
+		SimilarAssetSet similarAssetSet2 =
+			testGetSimilarAssetSetsPage_addSimilarAssetSet(
+				randomSimilarAssetSet());
+
+		page = similarAssetSetResource.getSimilarAssetSetsPage(
+			null, Pagination.of(1, (int)totalCount + 2));
+
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
+
+		assertContains(
+			similarAssetSet1, (List<SimilarAssetSet>)page.getItems());
+		assertContains(
+			similarAssetSet2, (List<SimilarAssetSet>)page.getItems());
+		assertValid(page, testGetSimilarAssetSetsPage_getExpectedActions());
+	}
+
+	protected Map<String, Map<String, String>>
+			testGetSimilarAssetSetsPage_getExpectedActions()
+		throws Exception {
+
+		Map<String, Map<String, String>> expectedActions = new HashMap<>();
+
+		return expectedActions;
+	}
+
+	@Test
+	public void testGetSimilarAssetSetsPageWithPagination() throws Exception {
+		Page<SimilarAssetSet> similarAssetSetsPage =
+			similarAssetSetResource.getSimilarAssetSetsPage(null, null);
+
+		int totalCount = GetterUtil.getInteger(
+			similarAssetSetsPage.getTotalCount());
+
+		SimilarAssetSet similarAssetSet1 =
+			testGetSimilarAssetSetsPage_addSimilarAssetSet(
+				randomSimilarAssetSet());
+
+		SimilarAssetSet similarAssetSet2 =
+			testGetSimilarAssetSetsPage_addSimilarAssetSet(
+				randomSimilarAssetSet());
+
+		SimilarAssetSet similarAssetSet3 =
+			testGetSimilarAssetSetsPage_addSimilarAssetSet(
+				randomSimilarAssetSet());
+
+		// See com.liferay.portal.vulcan.internal.configuration.HeadlessAPICompanyConfiguration#pageSizeLimit
+
+		int pageSizeLimit = 500;
+
+		if (totalCount >= (pageSizeLimit - 2)) {
+			Page<SimilarAssetSet> page1 =
+				similarAssetSetResource.getSimilarAssetSetsPage(
+					null,
+					Pagination.of(
+						(int)Math.ceil((totalCount + 1.0) / pageSizeLimit),
+						pageSizeLimit));
+
+			Assert.assertEquals(totalCount + 3, page1.getTotalCount());
+
+			assertContains(
+				similarAssetSet1, (List<SimilarAssetSet>)page1.getItems());
+
+			Page<SimilarAssetSet> page2 =
+				similarAssetSetResource.getSimilarAssetSetsPage(
+					null,
+					Pagination.of(
+						(int)Math.ceil((totalCount + 2.0) / pageSizeLimit),
+						pageSizeLimit));
+
+			assertContains(
+				similarAssetSet2, (List<SimilarAssetSet>)page2.getItems());
+
+			Page<SimilarAssetSet> page3 =
+				similarAssetSetResource.getSimilarAssetSetsPage(
+					null,
+					Pagination.of(
+						(int)Math.ceil((totalCount + 3.0) / pageSizeLimit),
+						pageSizeLimit));
+
+			assertContains(
+				similarAssetSet3, (List<SimilarAssetSet>)page3.getItems());
+		}
+		else {
+			Page<SimilarAssetSet> page1 =
+				similarAssetSetResource.getSimilarAssetSetsPage(
+					null, Pagination.of(1, totalCount + 2));
+
+			List<SimilarAssetSet> similarAssetSets1 =
+				(List<SimilarAssetSet>)page1.getItems();
+
+			Assert.assertEquals(
+				similarAssetSets1.toString(), totalCount + 2,
+				similarAssetSets1.size());
+
+			Page<SimilarAssetSet> page2 =
+				similarAssetSetResource.getSimilarAssetSetsPage(
+					null, Pagination.of(2, totalCount + 2));
+
+			Assert.assertEquals(totalCount + 3, page2.getTotalCount());
+
+			List<SimilarAssetSet> similarAssetSets2 =
+				(List<SimilarAssetSet>)page2.getItems();
+
+			Assert.assertEquals(
+				similarAssetSets2.toString(), 1, similarAssetSets2.size());
+
+			Page<SimilarAssetSet> page3 =
+				similarAssetSetResource.getSimilarAssetSetsPage(
+					null, Pagination.of(1, (int)totalCount + 3));
+
+			assertContains(
+				similarAssetSet1, (List<SimilarAssetSet>)page3.getItems());
+			assertContains(
+				similarAssetSet2, (List<SimilarAssetSet>)page3.getItems());
+			assertContains(
+				similarAssetSet3, (List<SimilarAssetSet>)page3.getItems());
+		}
+	}
+
+	protected SimilarAssetSet testGetSimilarAssetSetsPage_addSimilarAssetSet(
+			SimilarAssetSet similarAssetSet)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected void assertContains(
+		SimilarAssetSet similarAssetSet,
+		List<SimilarAssetSet> similarAssetSets) {
+
+		boolean contains = false;
+
+		for (SimilarAssetSet item : similarAssetSets) {
+			if (equals(similarAssetSet, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			similarAssetSets + " does not contain " + similarAssetSet,
+			contains);
+	}
+
+	protected void assertHttpResponseStatusCode(
+		int expectedHttpResponseStatusCode,
+		HttpInvoker.HttpResponse actualHttpResponse) {
+
+		Assert.assertEquals(
+			expectedHttpResponseStatusCode, actualHttpResponse.getStatusCode());
+	}
+
+	protected void assertEquals(
+		SimilarAssetSet similarAssetSet1, SimilarAssetSet similarAssetSet2) {
+
+		Assert.assertTrue(
+			similarAssetSet1 + " does not equal " + similarAssetSet2,
+			equals(similarAssetSet1, similarAssetSet2));
+	}
+
+	protected void assertEquals(
+		List<SimilarAssetSet> similarAssetSets1,
+		List<SimilarAssetSet> similarAssetSets2) {
+
+		Assert.assertEquals(similarAssetSets1.size(), similarAssetSets2.size());
+
+		for (int i = 0; i < similarAssetSets1.size(); i++) {
+			SimilarAssetSet similarAssetSet1 = similarAssetSets1.get(i);
+			SimilarAssetSet similarAssetSet2 = similarAssetSets2.get(i);
+
+			assertEquals(similarAssetSet1, similarAssetSet2);
+		}
+	}
+
+	protected void assertEqualsIgnoringOrder(
+		List<SimilarAssetSet> similarAssetSets1,
+		List<SimilarAssetSet> similarAssetSets2) {
+
+		Assert.assertEquals(similarAssetSets1.size(), similarAssetSets2.size());
+
+		for (SimilarAssetSet similarAssetSet1 : similarAssetSets1) {
+			boolean contains = false;
+
+			for (SimilarAssetSet similarAssetSet2 : similarAssetSets2) {
+				if (equals(similarAssetSet1, similarAssetSet2)) {
+					contains = true;
+
+					break;
+				}
+			}
+
+			Assert.assertTrue(
+				similarAssetSets2 + " does not contain " + similarAssetSet1,
+				contains);
+		}
+	}
+
+	protected void assertValid(SimilarAssetSet similarAssetSet)
+		throws Exception {
+
+		boolean valid = true;
+
+		for (String additionalAssertFieldName :
+				getAdditionalAssertFieldNames()) {
+
+			if (Objects.equals("similarAssets", additionalAssertFieldName)) {
+				if (similarAssetSet.getSimilarAssets() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("size", additionalAssertFieldName)) {
+				if (similarAssetSet.getSize() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			throw new IllegalArgumentException(
+				"Invalid additional assert field name " +
+					additionalAssertFieldName);
+		}
+
+		Assert.assertTrue(valid);
+	}
+
+	protected void assertValid(Page<SimilarAssetSet> page) {
+		assertValid(page, Collections.emptyMap());
+	}
+
+	protected void assertValid(
+		Page<SimilarAssetSet> page,
+		Map<String, Map<String, String>> expectedActions) {
+
+		boolean valid = false;
+
+		java.util.Collection<SimilarAssetSet> similarAssetSets =
+			page.getItems();
+
+		int size = similarAssetSets.size();
+
+		if ((page.getLastPage() > 0) && (page.getPage() > 0) &&
+			(page.getPageSize() > 0) && (page.getTotalCount() > 0) &&
+			(size > 0)) {
+
+			valid = true;
+		}
+
+		Assert.assertTrue(valid);
+
+		assertValid(page.getActions(), expectedActions);
+	}
+
+	protected void assertValid(
+		Map<String, Map<String, String>> actions1,
+		Map<String, Map<String, String>> actions2) {
+
+		for (String key : actions2.keySet()) {
+			Map action = actions1.get(key);
+
+			Assert.assertNotNull(key + " does not contain an action", action);
+
+			Map<String, String> expectedAction = actions2.get(key);
+
+			Assert.assertEquals(
+				expectedAction.get("method"), action.get("method"));
+			Assert.assertEquals(expectedAction.get("href"), action.get("href"));
+		}
+	}
+
+	protected String[] getAdditionalAssertFieldNames() {
+		return new String[0];
+	}
+
+	protected List<GraphQLField> getGraphQLFields() throws Exception {
+		List<GraphQLField> graphQLFields = new ArrayList<>();
+
+		for (java.lang.reflect.Field field :
+				getDeclaredFields(
+					com.liferay.headless.cms.dto.v1_0.SimilarAssetSet.class)) {
+
+			if (!ArrayUtil.contains(
+					getAdditionalAssertFieldNames(), field.getName())) {
+
+				continue;
+			}
+
+			graphQLFields.addAll(getGraphQLFields(field));
+		}
+
+		return graphQLFields;
+	}
+
+	protected List<GraphQLField> getGraphQLFields(
+			java.lang.reflect.Field... fields)
+		throws Exception {
+
+		List<GraphQLField> graphQLFields = new ArrayList<>();
+
+		for (java.lang.reflect.Field field : fields) {
+			com.liferay.portal.vulcan.graphql.annotation.GraphQLField
+				vulcanGraphQLField = field.getAnnotation(
+					com.liferay.portal.vulcan.graphql.annotation.GraphQLField.
+						class);
+
+			if (vulcanGraphQLField != null) {
+				Class<?> clazz = field.getType();
+
+				if (clazz.isArray()) {
+					clazz = clazz.getComponentType();
+				}
+
+				List<GraphQLField> childrenGraphQLFields = getGraphQLFields(
+					getDeclaredFields(clazz));
+
+				graphQLFields.add(
+					new GraphQLField(field.getName(), childrenGraphQLFields));
+			}
+		}
+
+		return graphQLFields;
+	}
+
+	protected String[] getIgnoredEntityFieldNames() {
+		return new String[0];
+	}
+
+	protected boolean equals(
+		SimilarAssetSet similarAssetSet1, SimilarAssetSet similarAssetSet2) {
+
+		if (similarAssetSet1 == similarAssetSet2) {
+			return true;
+		}
+
+		for (String additionalAssertFieldName :
+				getAdditionalAssertFieldNames()) {
+
+			if (Objects.equals("similarAssets", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						similarAssetSet1.getSimilarAssets(),
+						similarAssetSet2.getSimilarAssets())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("size", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						similarAssetSet1.getSize(),
+						similarAssetSet2.getSize())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			throw new IllegalArgumentException(
+				"Invalid additional assert field name " +
+					additionalAssertFieldName);
+		}
+
+		return true;
+	}
+
+	protected boolean equals(
+		Map<String, Object> map1, Map<String, Object> map2) {
+
+		if (Objects.equals(map1.keySet(), map2.keySet())) {
+			for (Map.Entry<String, Object> entry : map1.entrySet()) {
+				if (entry.getValue() instanceof Map) {
+					if (!equals(
+							(Map)entry.getValue(),
+							(Map)map2.get(entry.getKey()))) {
+
+						return false;
+					}
+				}
+				else if (!Objects.deepEquals(
+							entry.getValue(), map2.get(entry.getKey()))) {
+
+					return false;
+				}
+			}
+
+			return true;
+		}
+
+		return false;
+	}
+
+	protected java.lang.reflect.Field[] getDeclaredFields(Class clazz)
+		throws Exception {
+
+		if (clazz.getClassLoader() == null) {
+			return new java.lang.reflect.Field[0];
+		}
+
+		return TransformUtil.transform(
+			ReflectionUtil.getDeclaredFields(clazz),
+			field -> {
+				if (field.isSynthetic()) {
+					return null;
+				}
+
+				return field;
+			},
+			java.lang.reflect.Field.class);
+	}
+
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
+		if (!(_similarAssetSetResource instanceof EntityModelResource)) {
+			throw new UnsupportedOperationException(
+				"Resource is not an instance of EntityModelResource");
+		}
+
+		EntityModelResource entityModelResource =
+			(EntityModelResource)_similarAssetSetResource;
+
+		EntityModel entityModel = entityModelResource.getEntityModel(
+			new MultivaluedHashMap());
+
+		if (entityModel == null) {
+			return Collections.emptyList();
+		}
+
+		Map<String, EntityField> entityFieldsMap =
+			entityModel.getEntityFieldsMap();
+
+		return entityFieldsMap.values();
+	}
+
+	protected List<EntityField> getEntityFields(EntityField.Type type)
+		throws Exception {
+
+		return TransformUtil.transform(
+			getEntityFields(),
+			entityField -> {
+				if (!Objects.equals(entityField.getType(), type) ||
+					ArrayUtil.contains(
+						getIgnoredEntityFieldNames(), entityField.getName())) {
+
+					return null;
+				}
+
+				return entityField;
+			});
+	}
+
+	protected String getFilterString(
+		EntityField entityField, String operator,
+		SimilarAssetSet similarAssetSet) {
+
+		StringBundler sb = new StringBundler();
+
+		String entityFieldName = entityField.getName();
+
+		sb.append(entityFieldName);
+
+		sb.append(" ");
+		sb.append(operator);
+		sb.append(" ");
+
+		if (entityFieldName.equals("similarAssets")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("size")) {
+			sb.append(String.valueOf(similarAssetSet.getSize()));
+
+			return sb.toString();
+		}
+
+		throw new IllegalArgumentException(
+			"Invalid entity field " + entityFieldName);
+	}
+
+	protected String invoke(String query) throws Exception {
+		HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+		httpInvoker.body(
+			JSONUtil.put(
+				"query", query
+			).toString(),
+			"application/json");
+		httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+		httpInvoker.path(
+			"http://localhost:" + PortalUtil.getPortalServerPort(false) +
+				"/o/graphql");
+		httpInvoker.userNameAndPassword(
+			"test@liferay.com:" + PropsValues.DEFAULT_ADMIN_PASSWORD);
+
+		HttpInvoker.HttpResponse httpResponse = httpInvoker.invoke();
+
+		return httpResponse.getContent();
+	}
+
+	protected JSONObject invokeGraphQLMutation(GraphQLField graphQLField)
+		throws Exception {
+
+		GraphQLField mutationGraphQLField = new GraphQLField(
+			"mutation", graphQLField);
+
+		return JSONFactoryUtil.createJSONObject(
+			invoke(mutationGraphQLField.toString()));
+	}
+
+	protected JSONObject invokeGraphQLQuery(GraphQLField graphQLField)
+		throws Exception {
+
+		GraphQLField queryGraphQLField = new GraphQLField(
+			"query", graphQLField);
+
+		return JSONFactoryUtil.createJSONObject(
+			invoke(queryGraphQLField.toString()));
+	}
+
+	protected SimilarAssetSet randomSimilarAssetSet() throws Exception {
+		return new SimilarAssetSet() {
+			{
+				size = RandomTestUtil.randomInt();
+			}
+		};
+	}
+
+	protected SimilarAssetSet randomIrrelevantSimilarAssetSet()
+		throws Exception {
+
+		SimilarAssetSet randomIrrelevantSimilarAssetSet =
+			randomSimilarAssetSet();
+
+		return randomIrrelevantSimilarAssetSet;
+	}
+
+	protected SimilarAssetSet randomPatchSimilarAssetSet() throws Exception {
+		return randomSimilarAssetSet();
+	}
+
+	protected SimilarAssetSetResource similarAssetSetResource;
+	protected com.liferay.portal.kernel.model.Group irrelevantGroup;
+	protected com.liferay.portal.kernel.model.Company testCompany;
+	protected com.liferay.portal.kernel.model.Group testGroup;
+
+	protected static class BeanTestUtil {
+
+		public static void copyProperties(Object source, Object target)
+			throws Exception {
+
+			Class<?> sourceClass = source.getClass();
+
+			Class<?> targetClass = target.getClass();
+
+			for (java.lang.reflect.Field field :
+					_getAllDeclaredFields(sourceClass)) {
+
+				if (field.isSynthetic()) {
+					continue;
+				}
+
+				Method getMethod = _getMethod(
+					sourceClass, field.getName(), "get");
+
+				try {
+					Method setMethod = _getMethod(
+						targetClass, field.getName(), "set",
+						getMethod.getReturnType());
+
+					setMethod.invoke(target, getMethod.invoke(source));
+				}
+				catch (Exception e) {
+					continue;
+				}
+			}
+		}
+
+		public static boolean hasProperty(Object bean, String name) {
+			Method setMethod = _getMethod(
+				bean.getClass(), "set" + StringUtil.upperCaseFirstLetter(name));
+
+			if (setMethod != null) {
+				return true;
+			}
+
+			return false;
+		}
+
+		public static void setProperty(Object bean, String name, Object value)
+			throws Exception {
+
+			Class<?> clazz = bean.getClass();
+
+			Method setMethod = _getMethod(
+				clazz, "set" + StringUtil.upperCaseFirstLetter(name));
+
+			if (setMethod == null) {
+				throw new NoSuchMethodException();
+			}
+
+			Class<?>[] parameterTypes = setMethod.getParameterTypes();
+
+			setMethod.invoke(bean, _translateValue(parameterTypes[0], value));
+		}
+
+		private static List<java.lang.reflect.Field> _getAllDeclaredFields(
+			Class<?> clazz) {
+
+			List<java.lang.reflect.Field> fields = new ArrayList<>();
+
+			while ((clazz != null) && (clazz != Object.class)) {
+				for (java.lang.reflect.Field field :
+						clazz.getDeclaredFields()) {
+
+					fields.add(field);
+				}
+
+				clazz = clazz.getSuperclass();
+			}
+
+			return fields;
+		}
+
+		private static Method _getMethod(Class<?> clazz, String name) {
+			for (Method method : clazz.getMethods()) {
+				if (name.equals(method.getName()) &&
+					(method.getParameterCount() == 1) &&
+					_parameterTypes.contains(method.getParameterTypes()[0])) {
+
+					return method;
+				}
+			}
+
+			return null;
+		}
+
+		private static Method _getMethod(
+				Class<?> clazz, String fieldName, String prefix,
+				Class<?>... parameterTypes)
+			throws Exception {
+
+			return clazz.getMethod(
+				prefix + StringUtil.upperCaseFirstLetter(fieldName),
+				parameterTypes);
+		}
+
+		private static Object _translateValue(
+			Class<?> parameterType, Object value) {
+
+			if ((value instanceof Integer) &&
+				parameterType.equals(Long.class)) {
+
+				Integer intValue = (Integer)value;
+
+				return intValue.longValue();
+			}
+
+			return value;
+		}
+
+		private static final Set<Class<?>> _parameterTypes = new HashSet<>(
+			Arrays.asList(
+				Boolean.class, Date.class, Double.class, Integer.class,
+				Long.class, Map.class, String.class));
+
+	}
+
+	protected class GraphQLField {
+
+		public GraphQLField(String key, GraphQLField... graphQLFields) {
+			this(key, new HashMap<>(), graphQLFields);
+		}
+
+		public GraphQLField(String key, List<GraphQLField> graphQLFields) {
+			this(key, new HashMap<>(), graphQLFields);
+		}
+
+		public GraphQLField(
+			String key, Map<String, Object> parameterMap,
+			GraphQLField... graphQLFields) {
+
+			_key = key;
+			_parameterMap = parameterMap;
+			_graphQLFields = Arrays.asList(graphQLFields);
+		}
+
+		public GraphQLField(
+			String key, Map<String, Object> parameterMap,
+			List<GraphQLField> graphQLFields) {
+
+			_key = key;
+			_parameterMap = parameterMap;
+			_graphQLFields = graphQLFields;
+		}
+
+		@Override
+		public String toString() {
+			StringBuilder sb = new StringBuilder(_key);
+
+			if (!_parameterMap.isEmpty()) {
+				sb.append("(");
+
+				for (Map.Entry<String, Object> entry :
+						_parameterMap.entrySet()) {
+
+					sb.append(entry.getKey());
+					sb.append(": ");
+					sb.append(entry.getValue());
+					sb.append(", ");
+				}
+
+				sb.setLength(sb.length() - 2);
+
+				sb.append(")");
+			}
+
+			if (!_graphQLFields.isEmpty()) {
+				sb.append("{");
+
+				for (GraphQLField graphQLField : _graphQLFields) {
+					sb.append(graphQLField.toString());
+					sb.append(", ");
+				}
+
+				sb.setLength(sb.length() - 2);
+
+				sb.append("}");
+			}
+
+			return sb.toString();
+		}
+
+		private final List<GraphQLField> _graphQLFields;
+		private final String _key;
+		private final Map<String, Object> _parameterMap;
+
+	}
+
+	private static final com.liferay.portal.kernel.log.Log _log =
+		LogFactoryUtil.getLog(BaseSimilarAssetSetResourceTestCase.class);
+
+	private static Format _format;
+
+	private com.liferay.portal.kernel.model.User _testCompanyAdminUser;
+
+	@Inject
+	private com.liferay.headless.cms.resource.v1_0.SimilarAssetSetResource
+		_similarAssetSetResource;
+
+}
+// LIFERAY-REST-BUILDER-HASH:1318741929

--- a/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/SimilarAssetSetResourceTest.java
+++ b/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/SimilarAssetSetResourceTest.java
@@ -1,0 +1,607 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.resource.v1_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.constants.DepotRolesConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.headless.cms.client.dto.v1_0.SimilarAsset;
+import com.liferay.headless.cms.client.dto.v1_0.SimilarAssetSet;
+import com.liferay.headless.cms.client.pagination.Page;
+import com.liferay.headless.cms.client.pagination.Pagination;
+import com.liferay.headless.cms.client.resource.v1_0.SimilarAssetSetResource;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectEntryFolder;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryFolderLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.RoleConstants;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.io.Serializable;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Mikel Lorza
+ */
+@FeatureFlag("LPD-82226")
+@RunWith(Arquillian.class)
+public class SimilarAssetSetResourceTest
+	extends BaseSimilarAssetSetResourceTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Override
+	@Test
+	public void testGetSimilarAssetSetsPage() throws Exception {
+		DepotEntry depotEntry = _addSpaceDepotEntry(
+			ServiceContextTestUtil.getServiceContext());
+
+		long groupId = depotEntry.getGroupId();
+
+		ObjectDefinition objectDefinition =
+			_getBasicWebContentObjectDefinition();
+
+		Page<SimilarAssetSet> similarAssetSetsPage = _getSimilarAssetSetsPage(
+			groupId, null);
+
+		Assert.assertEquals(0, similarAssetSetsPage.getTotalCount());
+
+		List<SimilarAssetSet> similarAssetSets =
+			(List<SimilarAssetSet>)similarAssetSetsPage.getItems();
+
+		Assert.assertEquals(
+			similarAssetSets.toString(), 0, similarAssetSets.size());
+
+		ObjectEntry duplicateObjectEntry1 = _addObjectEntry(
+			depotEntry, objectDefinition, _SIMILAR_TITLE, _SIMILAR_CONTENT);
+		ObjectEntry duplicateObjectEntry2 = _addObjectEntry(
+			depotEntry, objectDefinition, _SIMILAR_TITLE,
+			_SIMILAR_CONTENT + " You can also contact support for help.");
+
+		_addObjectEntry(
+			depotEntry, objectDefinition, RandomTestUtil.randomString(),
+			_DISTINCT_CONTENT);
+
+		similarAssetSetsPage = _getSimilarAssetSetsPage(groupId, null);
+
+		Assert.assertEquals(2, similarAssetSetsPage.getTotalCount());
+
+		similarAssetSets =
+			(List<SimilarAssetSet>)similarAssetSetsPage.getItems();
+
+		Assert.assertEquals(
+			similarAssetSets.toString(), 1, similarAssetSets.size());
+
+		SimilarAssetSet similarAssetSet = similarAssetSets.get(0);
+
+		Assert.assertEquals(
+			2, GetterUtil.getInteger(similarAssetSet.getSize()));
+
+		SimilarAsset[] similarAssets = similarAssetSet.getSimilarAssets();
+
+		Assert.assertEquals(
+			Arrays.toString(similarAssets), 2, similarAssets.length);
+
+		List<Long> objectEntryIds = new ArrayList<>();
+
+		for (SimilarAsset similarAssetSetAsset : similarAssets) {
+			objectEntryIds.add(similarAssetSetAsset.getId());
+
+			Assert.assertEquals(
+				_SIMILAR_TITLE, similarAssetSetAsset.getTitle());
+			Assert.assertNotNull(similarAssetSetAsset.getContentType());
+			Assert.assertNotNull(similarAssetSetAsset.getDateModified());
+		}
+
+		Assert.assertTrue(
+			objectEntryIds.contains(duplicateObjectEntry1.getObjectEntryId()));
+		Assert.assertTrue(
+			objectEntryIds.contains(duplicateObjectEntry2.getObjectEntryId()));
+
+		_depotEntryLocalService.deleteDepotEntry(depotEntry.getDepotEntryId());
+
+		_testGetSimilarAssetSetsPageGraphQL();
+		_testGetSimilarAssetSetsPagePermissions();
+		_testGetSimilarAssetSetsPageTranslation();
+	}
+
+	@Override
+	@Test
+	public void testGetSimilarAssetSetsPageWithPagination() throws Exception {
+		DepotEntry depotEntry = _addSpaceDepotEntry(
+			ServiceContextTestUtil.getServiceContext());
+
+		long groupId = depotEntry.getGroupId();
+
+		_addObjectEntries(depotEntry);
+
+		Page<SimilarAssetSet> similarAssetSetsPage = _getSimilarAssetSetsPage(
+			groupId, Pagination.of(1, 2));
+
+		Assert.assertEquals(5, similarAssetSetsPage.getTotalCount());
+
+		List<SimilarAssetSet> similarAssetSets =
+			(List<SimilarAssetSet>)similarAssetSetsPage.getItems();
+
+		Assert.assertEquals(
+			similarAssetSets.toString(), 1, similarAssetSets.size());
+
+		_assertSimilarAssetSet(
+			similarAssetSets.get(0), 3,
+			new String[] {"Big Summer Sale", "Summer Sale 2026"});
+
+		similarAssetSetsPage = _getSimilarAssetSetsPage(
+			groupId, Pagination.of(2, 2));
+
+		Assert.assertEquals(5, similarAssetSetsPage.getTotalCount());
+
+		similarAssetSets =
+			(List<SimilarAssetSet>)similarAssetSetsPage.getItems();
+
+		Assert.assertEquals(
+			similarAssetSets.toString(), 2, similarAssetSets.size());
+
+		_assertSimilarAssetSet(
+			similarAssetSets.get(0), 3,
+			new String[] {"Summer Sale Highlights"});
+		_assertSimilarAssetSet(
+			similarAssetSets.get(1), 2, new String[] {_PRODUCT_LAUNCH_TITLE});
+
+		similarAssetSetsPage = _getSimilarAssetSetsPage(
+			groupId, Pagination.of(3, 2));
+
+		Assert.assertEquals(5, similarAssetSetsPage.getTotalCount());
+
+		similarAssetSets =
+			(List<SimilarAssetSet>)similarAssetSetsPage.getItems();
+
+		Assert.assertEquals(
+			similarAssetSets.toString(), 1, similarAssetSets.size());
+
+		_assertSimilarAssetSet(
+			similarAssetSets.get(0), 2, new String[] {_PRODUCT_LAUNCH_TITLE});
+
+		_depotEntryLocalService.deleteDepotEntry(depotEntry.getDepotEntryId());
+	}
+
+	private void _addObjectEntries(DepotEntry depotEntry) throws Exception {
+		ObjectDefinition objectDefinition =
+			_getBasicWebContentObjectDefinition();
+
+		_addObjectEntry(
+			depotEntry, objectDefinition, "Big Summer Sale",
+			_SUMMER_SALE_CONTENT);
+		_addObjectEntry(
+			depotEntry, objectDefinition, "Summer Sale 2026",
+			_SUMMER_SALE_CONTENT + " The offer ends this Sunday.");
+		_addObjectEntry(
+			depotEntry, objectDefinition, "Summer Sale Highlights",
+			_SUMMER_SALE_CONTENT +
+				" The offer ends this Sunday and stock is limited.");
+
+		_addObjectEntry(
+			depotEntry, objectDefinition, _PRODUCT_LAUNCH_TITLE,
+			_PRODUCT_LAUNCH_CONTENT);
+		_addObjectEntry(
+			depotEntry, objectDefinition, _PRODUCT_LAUNCH_TITLE,
+			_PRODUCT_LAUNCH_CONTENT +
+				" Contact the press office for further details.");
+
+		_addObjectEntry(
+			depotEntry, objectDefinition, RandomTestUtil.randomString(),
+			_DISTINCT_CONTENT);
+	}
+
+	private ObjectEntry _addObjectEntry(
+			DepotEntry depotEntry, ObjectDefinition objectDefinition,
+			String title, String content)
+		throws Exception {
+
+		return _addObjectEntry(
+			depotEntry, objectDefinition, title, content,
+			ServiceContextTestUtil.getServiceContext());
+	}
+
+	private ObjectEntry _addObjectEntry(
+			DepotEntry depotEntry, ObjectDefinition objectDefinition,
+			String title, String content, ServiceContext serviceContext)
+		throws Exception {
+
+		ObjectEntryFolder objectEntryFolder =
+			_objectEntryFolderLocalService.
+				getObjectEntryFolderByExternalReferenceCode(
+					"L_CONTENTS", depotEntry.getGroupId(),
+					depotEntry.getCompanyId());
+
+		return _objectEntryLocalService.addObjectEntry(
+			depotEntry.getGroupId(), depotEntry.getUserId(),
+			objectDefinition.getObjectDefinitionId(),
+			objectEntryFolder.getObjectEntryFolderId(), "en_US",
+			HashMapBuilder.<String, Serializable>put(
+				"content_i18n",
+				HashMapBuilder.put(
+					"en_US", (Serializable)content
+				).build()
+			).put(
+				"title_i18n",
+				HashMapBuilder.put(
+					"en_US", (Serializable)title
+				).build()
+			).build(),
+			serviceContext);
+	}
+
+	private DepotEntry _addSpaceDepotEntry(ServiceContext serviceContext)
+		throws Exception {
+
+		return _depotEntryLocalService.addDepotEntry(
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), StringUtil.randomString()
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), StringUtil.randomString()
+			).build(),
+			DepotConstants.TYPE_SPACE, serviceContext);
+	}
+
+	private ObjectEntry _addTranslatedObjectEntry(
+			DepotEntry depotEntry, ObjectDefinition objectDefinition,
+			String title, String content, String spanishTitle,
+			String spanishContent)
+		throws Exception {
+
+		ObjectEntryFolder objectEntryFolder =
+			_objectEntryFolderLocalService.
+				getObjectEntryFolderByExternalReferenceCode(
+					"L_CONTENTS", depotEntry.getGroupId(),
+					depotEntry.getCompanyId());
+
+		return _objectEntryLocalService.addObjectEntry(
+			depotEntry.getGroupId(), depotEntry.getUserId(),
+			objectDefinition.getObjectDefinitionId(),
+			objectEntryFolder.getObjectEntryFolderId(), "en_US",
+			HashMapBuilder.<String, Serializable>put(
+				"content_i18n",
+				HashMapBuilder.put(
+					"en_US", content
+				).put(
+					"es_ES", spanishContent
+				).build()
+			).put(
+				"title_i18n",
+				HashMapBuilder.put(
+					"en_US", title
+				).put(
+					"es_ES", spanishTitle
+				).build()
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+	}
+
+	private void _assertSimilarAssetSet(
+		SimilarAssetSet similarAssetSet, int size, String[] titles) {
+
+		Assert.assertEquals(
+			size, GetterUtil.getInteger(similarAssetSet.getSize()));
+
+		SimilarAsset[] similarAssets = similarAssetSet.getSimilarAssets();
+
+		Assert.assertEquals(
+			Arrays.toString(similarAssets), titles.length,
+			similarAssets.length);
+
+		for (int i = 0; i < titles.length; i++) {
+			SimilarAsset similarAssetSetAsset = similarAssets[i];
+
+			Assert.assertEquals(titles[i], similarAssetSetAsset.getTitle());
+		}
+	}
+
+	private String _getAdminUserEmailAddress() throws Exception {
+		User user = UserTestUtil.getAdminUser(testCompany.getCompanyId());
+
+		return user.getEmailAddress();
+	}
+
+	private ObjectDefinition _getBasicWebContentObjectDefinition()
+		throws Exception {
+
+		Group cmsGroup = _groupLocalService.getGroup(
+			TestPropsValues.getCompanyId(), GroupConstants.CMS);
+
+		return _objectDefinitionLocalService.
+			getObjectDefinitionByExternalReferenceCode(
+				"L_CMS_BASIC_WEB_CONTENT", cmsGroup.getCompanyId());
+	}
+
+	private Page<SimilarAssetSet> _getSimilarAssetSetsPage(
+			long groupId, Pagination pagination)
+		throws Exception {
+
+		return similarAssetSetResource.getSimilarAssetSetsPage(
+			groupId, pagination);
+	}
+
+	private void _testGetSimilarAssetSetsPageGraphQL() throws Exception {
+		DepotEntry depotEntry = _addSpaceDepotEntry(
+			ServiceContextTestUtil.getServiceContext());
+
+		ObjectDefinition objectDefinition =
+			_getBasicWebContentObjectDefinition();
+
+		_addObjectEntry(
+			depotEntry, objectDefinition, _SIMILAR_TITLE, _SIMILAR_CONTENT);
+		_addObjectEntry(
+			depotEntry, objectDefinition, _SIMILAR_TITLE,
+			_SIMILAR_CONTENT + " You can also contact support for help.");
+
+		GraphQLField graphQLField = new GraphQLField(
+			"similarAssetSets",
+			HashMapBuilder.<String, Object>put(
+				"assetLibraryId", "\"" + depotEntry.getGroupId() + "\""
+			).build(),
+			new GraphQLField("items", new GraphQLField("size")),
+			new GraphQLField("totalCount"));
+
+		JSONObject similarAssetSetsPageJSONObject =
+			JSONUtil.getValueAsJSONObject(
+				invokeGraphQLQuery(graphQLField), "JSONObject/data",
+				"JSONObject/similarAssetSets");
+
+		Assert.assertEquals(
+			2, similarAssetSetsPageJSONObject.getLong("totalCount"));
+
+		JSONArray similarAssetSetsJSONArray =
+			similarAssetSetsPageJSONObject.getJSONArray("items");
+
+		Assert.assertEquals(
+			similarAssetSetsJSONArray.toString(), 1,
+			similarAssetSetsJSONArray.length());
+
+		JSONObject similarAssetSetJSONObject =
+			similarAssetSetsJSONArray.getJSONObject(0);
+
+		Assert.assertEquals(2, similarAssetSetJSONObject.getInt("size"));
+
+		_depotEntryLocalService.deleteDepotEntry(depotEntry.getDepotEntryId());
+	}
+
+	private void _testGetSimilarAssetSetsPagePermissions() throws Exception {
+		DepotEntry depotEntry = _addSpaceDepotEntry(
+			ServiceContextTestUtil.getServiceContext());
+
+		long groupId = depotEntry.getGroupId();
+
+		ObjectDefinition objectDefinition =
+			_getBasicWebContentObjectDefinition();
+
+		ObjectEntry objectEntry = _addObjectEntry(
+			depotEntry, objectDefinition, _SIMILAR_TITLE, _SIMILAR_CONTENT);
+
+		_addObjectEntry(
+			depotEntry, objectDefinition, _SIMILAR_TITLE,
+			_SIMILAR_CONTENT + " You can also contact support for help.");
+
+		Page<SimilarAssetSet> similarAssetSetsPage = _getSimilarAssetSetsPage(
+			groupId, null);
+
+		Assert.assertEquals(2, similarAssetSetsPage.getTotalCount());
+
+		List<SimilarAssetSet> similarAssetSets =
+			(List<SimilarAssetSet>)similarAssetSetsPage.getItems();
+
+		_assertSimilarAssetSet(
+			similarAssetSets.get(0), 2,
+			new String[] {_SIMILAR_TITLE, _SIMILAR_TITLE});
+
+		// The CMS grants VIEW on every content to the user role and to the
+		// space member role, so hiding one asset takes revoking both
+
+		for (String name :
+				new String[] {
+					DepotRolesConstants.ASSET_LIBRARY_MEMBER, RoleConstants.USER
+				}) {
+
+			Role role = _roleLocalService.getRole(
+				testCompany.getCompanyId(), name);
+
+			_resourcePermissionLocalService.setResourcePermissions(
+				testCompany.getCompanyId(), objectDefinition.getClassName(),
+				ResourceConstants.SCOPE_INDIVIDUAL,
+				String.valueOf(objectEntry.getObjectEntryId()),
+				role.getRoleId(), new String[0]);
+		}
+
+		String password = RandomTestUtil.randomString();
+
+		User user = UserTestUtil.addUser(testCompany, password);
+
+		_userLocalService.addGroupUser(groupId, user.getUserId());
+
+		SimilarAssetSetResource userSimilarAssetSetResource =
+			SimilarAssetSetResource.builder(
+			).authentication(
+				user.getEmailAddress(), password
+			).endpoint(
+				testCompany.getVirtualHostname(),
+				PortalUtil.getPortalServerPort(false), "http"
+			).locale(
+				LocaleUtil.getDefault()
+			).build();
+
+		similarAssetSetsPage =
+			userSimilarAssetSetResource.getSimilarAssetSetsPage(groupId, null);
+
+		Assert.assertEquals(0, similarAssetSetsPage.getTotalCount());
+
+		similarAssetSets =
+			(List<SimilarAssetSet>)similarAssetSetsPage.getItems();
+
+		Assert.assertEquals(
+			similarAssetSets.toString(), 0, similarAssetSets.size());
+
+		_userLocalService.deleteUser(user);
+
+		_depotEntryLocalService.deleteDepotEntry(depotEntry.getDepotEntryId());
+	}
+
+	private void _testGetSimilarAssetSetsPageTranslation() throws Exception {
+		DepotEntry depotEntry = _addSpaceDepotEntry(
+			ServiceContextTestUtil.getServiceContext());
+
+		long groupId = depotEntry.getGroupId();
+
+		ObjectDefinition objectDefinition =
+			_getBasicWebContentObjectDefinition();
+
+		_addTranslatedObjectEntry(
+			depotEntry, objectDefinition, _SIMILAR_TITLE, _SIMILAR_CONTENT,
+			"Oferta de Verano Grande", _SPANISH_SUMMER_SALE_CONTENT);
+		_addTranslatedObjectEntry(
+			depotEntry, objectDefinition, RandomTestUtil.randomString(),
+			_DISTINCT_CONTENT, "Oferta de Verano 2026",
+			_SPANISH_SUMMER_SALE_CONTENT + " La oferta acaba el domingo.");
+
+		SimilarAssetSetResource spanishSimilarAssetSetResource =
+			SimilarAssetSetResource.builder(
+			).authentication(
+				_getAdminUserEmailAddress(), PropsValues.DEFAULT_ADMIN_PASSWORD
+			).endpoint(
+				testCompany.getVirtualHostname(),
+				PortalUtil.getPortalServerPort(false), "http"
+			).locale(
+				LocaleUtil.SPAIN
+			).build();
+
+		Page<SimilarAssetSet> similarAssetSetsPage =
+			spanishSimilarAssetSetResource.getSimilarAssetSetsPage(
+				groupId, null);
+
+		Assert.assertEquals(2, similarAssetSetsPage.getTotalCount());
+
+		List<SimilarAssetSet> similarAssetSets =
+			(List<SimilarAssetSet>)similarAssetSetsPage.getItems();
+
+		Assert.assertEquals(
+			similarAssetSets.toString(), 1, similarAssetSets.size());
+
+		_assertSimilarAssetSet(
+			similarAssetSets.get(0), 2,
+			new String[] {"Oferta de Verano Grande", "Oferta de Verano 2026"});
+
+		similarAssetSetsPage = _getSimilarAssetSetsPage(groupId, null);
+
+		Assert.assertEquals(0, similarAssetSetsPage.getTotalCount());
+
+		similarAssetSets =
+			(List<SimilarAssetSet>)similarAssetSetsPage.getItems();
+
+		Assert.assertEquals(
+			similarAssetSets.toString(), 0, similarAssetSets.size());
+
+		_depotEntryLocalService.deleteDepotEntry(depotEntry.getDepotEntryId());
+	}
+
+	private static final String _DISTINCT_CONTENT =
+		"The quarterly sales report shows strong revenue growth across the " +
+			"European market with product categories in retail and wholesale " +
+				"increasing during the last fiscal period.";
+
+	private static final String _PRODUCT_LAUNCH_CONTENT =
+		"The new generation of our platform is available today with a " +
+			"redesigned workspace faster search and a set of integrations " +
+				"that our customers have been asking for during this year.";
+
+	private static final String _PRODUCT_LAUNCH_TITLE =
+		"Product Launch Press Release";
+
+	private static final String _SIMILAR_CONTENT =
+		"If you forgot your password go to the login page and click the " +
+			"forgot password link enter your email address and you will " +
+				"receive an email with instructions to create a new password.";
+
+	private static final String _SIMILAR_TITLE = "Reset Your Password";
+
+	private static final String _SPANISH_SUMMER_SALE_CONTENT =
+		"Nuestras rebajas de verano traen descuentos de hasta el cincuenta " +
+			"por ciento en toda la coleccion de exterior incluidas tiendas " +
+				"mochilas y botas de montana mientras queden existencias.";
+
+	private static final String _SUMMER_SALE_CONTENT =
+		"Our summer sale brings discounts of up to fifty percent on every " +
+			"outdoor collection including tents backpacks and hiking boots " +
+				"while stock lasts in all of our stores.";
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Inject
+	private GroupLocalService _groupLocalService;
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Inject
+	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
+
+	@Inject
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Inject
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Inject
+	private RoleLocalService _roleLocalService;
+
+	@Inject
+	private UserLocalService _userLocalService;
+
+}

--- a/modules/apps/site/site-cms-site-initializer/bnd.bnd
+++ b/modules/apps/site/site-cms-site-initializer/bnd.bnd
@@ -3,3 +3,4 @@ Bundle-SymbolicName: com.liferay.site.cms.site.initializer
 Bundle-Version: 1.0.38
 Web-ContextPath: /site-cms-site-initializer
 -dsannotations-options: inherit
+-fixupmessages: Classes found in the wrong directory: ...;is:=ignore

--- a/modules/apps/site/site-cms-site-initializer/build.gradle
+++ b/modules/apps/site/site-cms-site-initializer/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+	compileInclude group: "com.dynatrace.hash4j", name: "hash4j", version: "0.30.0"
 	compileOnly group: "com.liferay", name: "biz.aQute.bnd.annotation", version: "4.2.0.LIFERAY-PATCHED-2"
 	compileOnly group: "com.liferay", name: "jakarta.ws.rs", version: "3.1.0.LIFERAY-PATCHED-1"
 	compileOnly group: "com.liferay.jakarta.portlet", name: "com.liferay.jakarta.portlet-api", version: "4.0.0"

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/search/similar/asset/CMSContentSimilarAssetTextExtractor.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/search/similar/asset/CMSContentSimilarAssetTextExtractor.java
@@ -1,0 +1,164 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.search.similar.asset;
+
+import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectField;
+import com.liferay.object.model.bag.ObjectFieldBag;
+import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.HtmlParser;
+
+import java.io.Serializable;
+
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * @author Mikel Lorza
+ */
+public class CMSContentSimilarAssetTextExtractor {
+
+	public CMSContentSimilarAssetTextExtractor(HtmlParser htmlParser) {
+		_htmlParser = htmlParser;
+	}
+
+	public Set<String> getLanguageIds(ObjectEntry objectEntry)
+		throws Exception {
+
+		Set<String> languageIds = new LinkedHashSet<>();
+
+		languageIds.add(objectEntry.getDefaultLanguageId());
+
+		Map<String, Serializable> indexedValues =
+			objectEntry.getIndexedValues();
+
+		ObjectDefinition objectDefinition = objectEntry.getObjectDefinition();
+
+		for (ObjectField objectField : _getObjectFields(objectDefinition)) {
+			if (!objectField.isLocalized()) {
+				continue;
+			}
+
+			Object localizedValues = indexedValues.get(
+				objectField.getI18nObjectFieldName());
+
+			if (!(localizedValues instanceof Map)) {
+				continue;
+			}
+
+			Map<?, ?> localizedValuesMap = (Map<?, ?>)localizedValues;
+
+			for (Object languageId : localizedValuesMap.keySet()) {
+				languageIds.add(String.valueOf(languageId));
+			}
+		}
+
+		return languageIds;
+	}
+
+	public String getText(String languageId, ObjectEntry objectEntry)
+		throws Exception {
+
+		Map<String, Serializable> indexedValues =
+			objectEntry.getIndexedValues();
+
+		ObjectDefinition objectDefinition = objectEntry.getObjectDefinition();
+
+		StringBundler sb = new StringBundler();
+
+		for (ObjectField objectField : _getObjectFields(objectDefinition)) {
+			Object indexedValue = null;
+
+			if (objectField.isLocalized()) {
+				Object localizedValues = indexedValues.get(
+					objectField.getI18nObjectFieldName());
+
+				if (localizedValues instanceof Map) {
+					Map<?, ?> localizedValuesMap = (Map<?, ?>)localizedValues;
+
+					indexedValue = localizedValuesMap.get(languageId);
+				}
+			}
+			else {
+				indexedValue = indexedValues.get(objectField.getName());
+			}
+
+			if (indexedValue == null) {
+				continue;
+			}
+
+			String indexedValueString = String.valueOf(indexedValue);
+
+			if (Objects.equals(
+					objectField.getBusinessType(),
+					ObjectFieldConstants.BUSINESS_TYPE_RICH_TEXT)) {
+
+				indexedValueString = _htmlParser.extractText(
+					indexedValueString);
+			}
+
+			sb.append(indexedValueString);
+			sb.append(CharPool.SPACE);
+		}
+
+		return sb.toString();
+	}
+
+	private Iterable<ObjectField> _getObjectFields(
+		ObjectDefinition objectDefinition) {
+
+		ObjectFieldBag objectFieldBag = objectDefinition.getObjectFieldBag();
+
+		Set<ObjectField> objectFields = new LinkedHashSet<>();
+
+		for (ObjectField objectField :
+				objectFieldBag.getIndexedObjectFields()) {
+
+			if (_isTitleObjectField(objectDefinition, objectField)) {
+				continue;
+			}
+
+			if (_isTextObjectField(objectField)) {
+				objectFields.add(objectField);
+			}
+		}
+
+		return objectFields;
+	}
+
+	private boolean _isTextObjectField(ObjectField objectField) {
+		String businessType = objectField.getBusinessType();
+
+		if (businessType.equals(ObjectFieldConstants.BUSINESS_TYPE_TEXT) ||
+			businessType.equals(ObjectFieldConstants.BUSINESS_TYPE_LONG_TEXT) ||
+			businessType.equals(ObjectFieldConstants.BUSINESS_TYPE_RICH_TEXT)) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	private boolean _isTitleObjectField(
+		ObjectDefinition objectDefinition, ObjectField objectField) {
+
+		if (objectField.getObjectFieldId() ==
+				objectDefinition.getTitleObjectFieldId()) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	private final HtmlParser _htmlParser;
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/search/similar/asset/SimilarAssetHashUtil.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/search/similar/asset/SimilarAssetHashUtil.java
@@ -21,11 +21,23 @@ import java.util.HashSet;
 import java.util.Set;
 
 /**
+ * Reduces a CMS content to the hashes two near duplicates literally share, so
+ * that an index which only matches equal values can answer which contents are
+ * similar.
+ *
+ * <p>
+ * The text is cut into sequences of three consecutive keywords, each hashed,
+ * and the set is condensed into one fixed length fingerprint estimating how
+ * much two sets overlap. The fingerprint is then split into 32 hashes: two
+ * contents that share one are candidates, and how many they share is what
+ * decides whether they are grouped.
+ * </p>
+ *
  * @author Mikel Lorza
  */
-public class SimilarAssetUtil {
+public class SimilarAssetHashUtil {
 
-	public static String[] getSimilarAssets(String text) {
+	public static String[] getHashes(String text) {
 		if (text == null) {
 			return new String[0];
 		}
@@ -42,26 +54,25 @@ public class SimilarAssetUtil {
 				keywordSequences, _hasher64::hashCharsToLong)
 		);
 
-		String[] similarAssets = new String[_SIMILAR_ASSETS];
+		String[] hashes = new String[_HASHES];
 
-		for (int i = 0; i < _SIMILAR_ASSETS; i++) {
-			StringBundler sb = new StringBundler(
-				(_SAMPLES_PER_SIMILAR_ASSET * 2) + 2);
+		for (int i = 0; i < _HASHES; i++) {
+			StringBundler sb = new StringBundler((_SAMPLES_PER_HASH * 2) + 2);
 
 			sb.append("b");
 			sb.append(i);
 
-			for (int j = 0; j < _SAMPLES_PER_SIMILAR_ASSET; j++) {
+			for (int j = 0; j < _SAMPLES_PER_HASH; j++) {
 				sb.append(StringPool.UNDERLINE);
 				sb.append(
 					_similarityHashPolicy.getComponent(
-						similarityHash, (i * _SAMPLES_PER_SIMILAR_ASSET) + j));
+						similarityHash, (i * _SAMPLES_PER_HASH) + j));
 			}
 
-			similarAssets[i] = sb.toString();
+			hashes[i] = sb.toString();
 		}
 
-		return similarAssets;
+		return hashes;
 	}
 
 	private static Set<String> _getKeywordSequences(String text) {
@@ -107,16 +118,16 @@ public class SimilarAssetUtil {
 
 	private static final int _BITS_PER_SAMPLE = 8;
 
+	private static final int _HASHES = 32;
+
 	private static final int _KEYWORD_SEQUENCE_SIZE = 3;
 
-	private static final int _SAMPLES_PER_SIMILAR_ASSET = 4;
-
-	private static final int _SIMILAR_ASSETS = 32;
+	private static final int _SAMPLES_PER_HASH = 4;
 
 	private static final Hasher64 _hasher64 = Hashing.murmur3_128();
 	private static final SimilarityHashPolicy _similarityHashPolicy =
 		SimilarityHashing.superMinHash(
-			_SIMILAR_ASSETS * _SAMPLES_PER_SIMILAR_ASSET, _BITS_PER_SAMPLE,
+			_HASHES * _SAMPLES_PER_HASH, _BITS_PER_SAMPLE,
 			SuperMinHashVersion.V1);
 
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/search/similar/asset/SimilarAssetUtil.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/search/similar/asset/SimilarAssetUtil.java
@@ -1,0 +1,122 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.search.similar.asset;
+
+import com.dynatrace.hash4j.hashing.Hasher64;
+import com.dynatrace.hash4j.hashing.Hashing;
+import com.dynatrace.hash4j.similarity.ElementHashProvider;
+import com.dynatrace.hash4j.similarity.SimilarityHashPolicy;
+import com.dynatrace.hash4j.similarity.SimilarityHashing;
+import com.dynatrace.hash4j.similarity.SuperMinHashVersion;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * @author Mikel Lorza
+ */
+public class SimilarAssetUtil {
+
+	public static String[] getSimilarAssets(String text) {
+		if (text == null) {
+			return new String[0];
+		}
+
+		Set<String> keywordSequences = _getKeywordSequences(text);
+
+		if (keywordSequences.isEmpty()) {
+			return new String[0];
+		}
+
+		byte[] similarityHash = _similarityHashPolicy.createHasher(
+		).compute(
+			ElementHashProvider.ofCollection(
+				keywordSequences, _hasher64::hashCharsToLong)
+		);
+
+		String[] similarAssets = new String[_SIMILAR_ASSETS];
+
+		for (int i = 0; i < _SIMILAR_ASSETS; i++) {
+			StringBundler sb = new StringBundler(
+				(_SAMPLES_PER_SIMILAR_ASSET * 2) + 2);
+
+			sb.append("b");
+			sb.append(i);
+
+			for (int j = 0; j < _SAMPLES_PER_SIMILAR_ASSET; j++) {
+				sb.append(StringPool.UNDERLINE);
+				sb.append(
+					_similarityHashPolicy.getComponent(
+						similarityHash, (i * _SAMPLES_PER_SIMILAR_ASSET) + j));
+			}
+
+			similarAssets[i] = sb.toString();
+		}
+
+		return similarAssets;
+	}
+
+	private static Set<String> _getKeywordSequences(String text) {
+		Set<String> keywordSequences = new HashSet<>();
+
+		String[] words = StringUtil.toLowerCase(
+			text, LocaleUtil.ENGLISH
+		).replaceAll(
+			"[^\\p{L}\\p{Nd}]+", " "
+		).trim(
+		).split(
+			"\\s+"
+		);
+
+		if ((words.length == 1) && words[0].isEmpty()) {
+			return keywordSequences;
+		}
+
+		if (words.length < _KEYWORD_SEQUENCE_SIZE) {
+			for (String word : words) {
+				keywordSequences.add(word);
+			}
+
+			return keywordSequences;
+		}
+
+		for (int i = 0; i <= (words.length - _KEYWORD_SEQUENCE_SIZE); i++) {
+			StringBundler sb = new StringBundler();
+
+			for (int j = 0; j < _KEYWORD_SEQUENCE_SIZE; j++) {
+				if (j > 0) {
+					sb.append(StringPool.SPACE);
+				}
+
+				sb.append(words[i + j]);
+			}
+
+			keywordSequences.add(sb.toString());
+		}
+
+		return keywordSequences;
+	}
+
+	private static final int _BITS_PER_SAMPLE = 8;
+
+	private static final int _KEYWORD_SEQUENCE_SIZE = 3;
+
+	private static final int _SAMPLES_PER_SIMILAR_ASSET = 4;
+
+	private static final int _SIMILAR_ASSETS = 32;
+
+	private static final Hasher64 _hasher64 = Hashing.murmur3_128();
+	private static final SimilarityHashPolicy _similarityHashPolicy =
+		SimilarityHashing.superMinHash(
+			_SIMILAR_ASSETS * _SAMPLES_PER_SIMILAR_ASSET, _BITS_PER_SAMPLE,
+			SuperMinHashVersion.V1);
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/search/spi/index/configuration/contributor/CMSSimilarAssetCompanyIndexConfigurationContributor.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/search/spi/index/configuration/contributor/CMSSimilarAssetCompanyIndexConfigurationContributor.java
@@ -1,0 +1,36 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.search.spi.index.configuration.contributor;
+
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.search.spi.index.configuration.contributor.CompanyIndexConfigurationContributor;
+import com.liferay.portal.search.spi.index.configuration.contributor.helper.MappingsHelper;
+import com.liferay.portal.search.spi.index.configuration.contributor.helper.SettingsHelper;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Mikel Lorza
+ */
+@Component(service = CompanyIndexConfigurationContributor.class)
+public class CMSSimilarAssetCompanyIndexConfigurationContributor
+	implements CompanyIndexConfigurationContributor {
+
+	@Override
+	public void contributeMappings(
+		long companyId, MappingsHelper mappingsHelper) {
+
+		mappingsHelper.putMappings(
+			StringUtil.read(
+				getClass(), "dependencies/similar-asset-type-mappings.json"));
+	}
+
+	@Override
+	public void contributeSettings(
+		long companyId, SettingsHelper settingsHelper) {
+	}
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/search/spi/model/index/contributor/CMSContentSimilarAssetDocumentContributor.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/search/spi/model/index/contributor/CMSContentSimilarAssetDocumentContributor.java
@@ -18,7 +18,7 @@ import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.DocumentContributor;
 import com.liferay.portal.kernel.util.HtmlParser;
 import com.liferay.site.cms.site.initializer.internal.search.similar.asset.CMSContentSimilarAssetTextExtractor;
-import com.liferay.site.cms.site.initializer.internal.search.similar.asset.SimilarAssetUtil;
+import com.liferay.site.cms.site.initializer.internal.search.similar.asset.SimilarAssetHashUtil;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -58,32 +58,35 @@ public class CMSContentSimilarAssetDocumentContributor
 				return;
 			}
 
-			List<String> similarAssets = new ArrayList<>();
+			List<String> similarAssetHashes = new ArrayList<>();
 
 			for (String languageId :
 					_cmsContentSimilarAssetTextExtractor.getLanguageIds(
 						objectEntry)) {
 
-				similarAssets.addAll(
+				similarAssetHashes.addAll(
 					TransformUtil.transformToList(
-						SimilarAssetUtil.getSimilarAssets(
+						SimilarAssetHashUtil.getHashes(
 							_cmsContentSimilarAssetTextExtractor.getText(
 								languageId, objectEntry)),
-						similarAsset -> StringBundler.concat(
-							languageId, StringPool.UNDERLINE, similarAsset)));
+						similarAssetHash -> StringBundler.concat(
+							languageId, StringPool.UNDERLINE,
+							similarAssetHash)));
 			}
 
-			if (similarAssets.isEmpty()) {
+			if (similarAssetHashes.isEmpty()) {
 				return;
 			}
 
 			document.addKeyword(
-				"similarAssets", similarAssets.toArray(new String[0]));
+				"similarAssetHashes",
+				similarAssetHashes.toArray(new String[0]));
 		}
 		catch (Exception exception) {
 			if (_log.isWarnEnabled()) {
 				_log.warn(
-					"Unable to contribute similar assets for object entry " +
+					"Unable to contribute similar asset hashes for object " +
+						"entry " +
 						objectEntry.getObjectEntryId(),
 					exception);
 			}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/search/spi/model/index/contributor/CMSContentSimilarAssetDocumentContributor.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/search/spi/model/index/contributor/CMSContentSimilarAssetDocumentContributor.java
@@ -1,0 +1,108 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.search.spi.model.index.contributor;
+
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.DocumentContributor;
+import com.liferay.portal.kernel.util.HtmlParser;
+import com.liferay.site.cms.site.initializer.internal.search.similar.asset.CMSContentSimilarAssetTextExtractor;
+import com.liferay.site.cms.site.initializer.internal.search.similar.asset.SimilarAssetUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Mikel Lorza
+ */
+@Component(service = DocumentContributor.class)
+public class CMSContentSimilarAssetDocumentContributor
+	implements DocumentContributor<ObjectEntry> {
+
+	@Override
+	public void contribute(
+		Document document, BaseModel<ObjectEntry> baseModel) {
+
+		if (!(baseModel instanceof ObjectEntry)) {
+			return;
+		}
+
+		ObjectEntry objectEntry = (ObjectEntry)baseModel;
+
+		try {
+			if (!FeatureFlagManagerUtil.isEnabled(
+					objectEntry.getCompanyId(), "LPD-82226")) {
+
+				return;
+			}
+
+			ObjectDefinition objectDefinition =
+				objectEntry.getObjectDefinition();
+
+			if (!objectDefinition.isCMS()) {
+				return;
+			}
+
+			List<String> similarAssets = new ArrayList<>();
+
+			for (String languageId :
+					_cmsContentSimilarAssetTextExtractor.getLanguageIds(
+						objectEntry)) {
+
+				similarAssets.addAll(
+					TransformUtil.transformToList(
+						SimilarAssetUtil.getSimilarAssets(
+							_cmsContentSimilarAssetTextExtractor.getText(
+								languageId, objectEntry)),
+						similarAsset -> StringBundler.concat(
+							languageId, StringPool.UNDERLINE, similarAsset)));
+			}
+
+			if (similarAssets.isEmpty()) {
+				return;
+			}
+
+			document.addKeyword(
+				"similarAssets", similarAssets.toArray(new String[0]));
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Unable to contribute similar assets for object entry " +
+						objectEntry.getObjectEntryId(),
+					exception);
+			}
+		}
+	}
+
+	@Activate
+	protected void activate() {
+		_cmsContentSimilarAssetTextExtractor =
+			new CMSContentSimilarAssetTextExtractor(_htmlParser);
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		CMSContentSimilarAssetDocumentContributor.class);
+
+	private CMSContentSimilarAssetTextExtractor
+		_cmsContentSimilarAssetTextExtractor;
+
+	@Reference
+	private HtmlParser _htmlParser;
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/dashboard/governance/GovernanceService.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/dashboard/governance/GovernanceService.ts
@@ -55,13 +55,13 @@ async function getAssetStatistics(
 ) {
 	const scope = assetLibraryId ? `assetLibraryId=${assetLibraryId}&` : '';
 
-	const [statistics, similarityClusters] = await Promise.all([
+	const [statistics, similarAssetSets] = await Promise.all([
 		ApiHelper.get<AssetStatistics>(
 			`/o/headless-cms/v1.0/asset-statistics?${scope}`,
 			signal
 		),
 		ApiHelper.get<{totalCount: number}>(
-			`/o/headless-cms/v1.0/similarity-clusters?${scope}pageSize=1`,
+			`/o/headless-cms/v1.0/similar-asset-sets?${scope}pageSize=1`,
 			signal
 		),
 	]);
@@ -74,7 +74,7 @@ async function getAssetStatistics(
 		...statistics,
 		data: {
 			...statistics.data,
-			duplicatedCount: similarityClusters.data?.totalCount,
+			duplicatedCount: similarAssetSets.data?.totalCount,
 		},
 	};
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/com/liferay/site/cms/site/initializer/internal/search/spi/index/configuration/contributor/dependencies/similar-asset-type-mappings.json
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/com/liferay/site/cms/site/initializer/internal/search/spi/index/configuration/contributor/dependencies/similar-asset-type-mappings.json
@@ -1,6 +1,6 @@
 {
 	"properties": {
-		"similarAssets": {
+		"similarAssetHashes": {
 			"type": "keyword"
 		}
 	}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/com/liferay/site/cms/site/initializer/internal/search/spi/index/configuration/contributor/dependencies/similar-asset-type-mappings.json
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/com/liferay/site/cms/site/initializer/internal/search/spi/index/configuration/contributor/dependencies/similar-asset-type-mappings.json
@@ -1,0 +1,7 @@
+{
+	"properties": {
+		"similarAssets": {
+			"type": "keyword"
+		}
+	}
+}

--- a/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/search/similar/asset/CMSContentSimilarAssetTextExtractorTest.java
+++ b/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/search/similar/asset/CMSContentSimilarAssetTextExtractorTest.java
@@ -1,0 +1,267 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.search.similar.asset;
+
+import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectField;
+import com.liferay.object.model.bag.ObjectFieldBag;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.HtmlParser;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.io.Serializable;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Mikel Lorza
+ */
+public class CMSContentSimilarAssetTextExtractorTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		HtmlParser htmlParser = Mockito.mock(HtmlParser.class);
+
+		Mockito.when(
+			htmlParser.extractText(Mockito.anyString())
+		).thenAnswer(
+			invocation -> {
+				String html = invocation.getArgument(0, String.class);
+
+				return html.replaceAll("<[^>]+>", "");
+			}
+		);
+
+		_cmsContentSimilarAssetTextExtractor =
+			new CMSContentSimilarAssetTextExtractor(htmlParser);
+	}
+
+	@Test
+	public void testGetLanguageIds() throws Exception {
+		Assert.assertEquals(
+			Arrays.asList("en_US", "es_ES"),
+			ListUtil.fromCollection(
+				_cmsContentSimilarAssetTextExtractor.getLanguageIds(
+					_mockObjectEntry(
+						HashMapBuilder.<String, Serializable>put(
+							"i18nContent",
+							HashMapBuilder.put(
+								"en_US", "<p>Body</p>"
+							).put(
+								"es_ES", "<p>Cuerpo</p>"
+							).build()
+						).build()))));
+	}
+
+	@Test
+	public void testGetLanguageIdsWithTitleOnlyTranslation() throws Exception {
+		Assert.assertEquals(
+			Arrays.asList("en_US"),
+			ListUtil.fromCollection(
+				_cmsContentSimilarAssetTextExtractor.getLanguageIds(
+					_mockObjectEntry(
+						HashMapBuilder.<String, Serializable>put(
+							"i18nContent",
+							HashMapBuilder.put(
+								"en_US", "<p>Body</p>"
+							).build()
+						).put(
+							"i18nTitle",
+							HashMapBuilder.put(
+								"en_US", "Title"
+							).put(
+								"ja_JP", "タイトル"
+							).build()
+						).build()))));
+	}
+
+	@Test
+	public void testGetTextWithNonlocalizedField() throws Exception {
+		Assert.assertEquals(
+			"The body ACME-1234 ",
+			_cmsContentSimilarAssetTextExtractor.getText(
+				"en_US",
+				_mockObjectEntry(
+					HashMapBuilder.<String, Serializable>put(
+						"i18nContent",
+						HashMapBuilder.put(
+							"en_US", "<p>The body</p>"
+						).build()
+					).put(
+						"reference", "ACME-1234"
+					).build())));
+	}
+
+	@Test
+	public void testGetTextWithoutTranslation() throws Exception {
+		Assert.assertEquals(
+			"",
+			_cmsContentSimilarAssetTextExtractor.getText(
+				"es_ES",
+				_mockObjectEntry(
+					HashMapBuilder.<String, Serializable>put(
+						"i18nContent",
+						HashMapBuilder.put(
+							"en_US", "<p>The body</p>"
+						).build()
+					).put(
+						"i18nTitle",
+						HashMapBuilder.put(
+							"es_ES", "Solo el titulo"
+						).build()
+					).build())));
+	}
+
+	@Test
+	public void testGetTextWithTitle() throws Exception {
+		Assert.assertEquals(
+			"The body of the content ",
+			_cmsContentSimilarAssetTextExtractor.getText(
+				"en_US",
+				_mockObjectEntry(
+					HashMapBuilder.<String, Serializable>put(
+						"i18nContent",
+						HashMapBuilder.put(
+							"en_US", "<p>The body of the content</p>"
+						).build()
+					).put(
+						"i18nTitle",
+						HashMapBuilder.put(
+							"en_US", "Zeta Quarterly Report Alpha"
+						).build()
+					).build())));
+	}
+
+	private ObjectEntry _mockObjectEntry(
+			Map<String, Serializable> indexedValues)
+		throws Exception {
+
+		ObjectField contentObjectField = _mockObjectField(
+			ObjectFieldConstants.BUSINESS_TYPE_RICH_TEXT, "i18nContent", true,
+			_OBJECT_FIELD_ID_CONTENT, "content");
+		ObjectField referenceObjectField = _mockObjectField(
+			ObjectFieldConstants.BUSINESS_TYPE_TEXT, null, false,
+			_OBJECT_FIELD_ID_REFERENCE, "reference");
+		ObjectField titleObjectField = _mockObjectField(
+			ObjectFieldConstants.BUSINESS_TYPE_TEXT, "i18nTitle", true,
+			_OBJECT_FIELD_ID_TITLE, "title");
+
+		List<ObjectField> objectFields = Arrays.asList(
+			contentObjectField, referenceObjectField, titleObjectField);
+
+		ObjectFieldBag objectFieldBag = new ObjectFieldBag(false, objectFields);
+
+		ObjectDefinition objectDefinition = Mockito.mock(
+			ObjectDefinition.class);
+
+		Mockito.when(
+			objectDefinition.getObjectFieldBag()
+		).thenReturn(
+			objectFieldBag
+		);
+
+		Mockito.when(
+			objectDefinition.getTitleObjectFieldId()
+		).thenReturn(
+			_OBJECT_FIELD_ID_TITLE
+		);
+
+		ObjectEntry objectEntry = Mockito.mock(ObjectEntry.class);
+
+		Mockito.when(
+			objectEntry.getDefaultLanguageId()
+		).thenReturn(
+			"en_US"
+		);
+
+		Mockito.when(
+			objectEntry.getIndexedValues()
+		).thenReturn(
+			indexedValues
+		);
+
+		Mockito.when(
+			objectEntry.getObjectDefinition()
+		).thenReturn(
+			objectDefinition
+		);
+
+		return objectEntry;
+	}
+
+	private ObjectField _mockObjectField(
+		String businessType, String i18nObjectFieldName, boolean localized,
+		long objectFieldId, String name) {
+
+		ObjectField objectField = Mockito.mock(ObjectField.class);
+
+		Mockito.when(
+			objectField.getBusinessType()
+		).thenReturn(
+			businessType
+		);
+
+		Mockito.when(
+			objectField.getI18nObjectFieldName()
+		).thenReturn(
+			i18nObjectFieldName
+		);
+
+		Mockito.when(
+			objectField.getName()
+		).thenReturn(
+			name
+		);
+
+		Mockito.when(
+			objectField.getObjectFieldId()
+		).thenReturn(
+			objectFieldId
+		);
+
+		Mockito.when(
+			objectField.isIndexed()
+		).thenReturn(
+			true
+		);
+
+		Mockito.when(
+			objectField.isLocalized()
+		).thenReturn(
+			localized
+		);
+
+		return objectField;
+	}
+
+	private static final long _OBJECT_FIELD_ID_CONTENT = 2;
+
+	private static final long _OBJECT_FIELD_ID_REFERENCE = 3;
+
+	private static final long _OBJECT_FIELD_ID_TITLE = 1;
+
+	private CMSContentSimilarAssetTextExtractor
+		_cmsContentSimilarAssetTextExtractor;
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/search/similar/asset/SimilarAssetHashUtilTest.java
+++ b/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/search/similar/asset/SimilarAssetHashUtilTest.java
@@ -20,7 +20,7 @@ import org.junit.Test;
 /**
  * @author Mikel Lorza
  */
-public class SimilarAssetUtilTest {
+public class SimilarAssetHashUtilTest {
 
 	@ClassRule
 	@Rule
@@ -28,33 +28,25 @@ public class SimilarAssetUtilTest {
 		LiferayUnitTestRule.INSTANCE;
 
 	@Test
-	public void testBlankTextYieldsNoSimilarAssets() {
-		Assert.assertEquals(0, SimilarAssetUtil.getSimilarAssets(null).length);
-		Assert.assertEquals(0, SimilarAssetUtil.getSimilarAssets("").length);
-		Assert.assertEquals(0, SimilarAssetUtil.getSimilarAssets("   ").length);
-	}
-
-	@Test
-	public void testDeterministic() {
+	public void testGetHashesIsDeterministic() {
 		Assert.assertArrayEquals(
-			SimilarAssetUtil.getSimilarAssets(_A),
-			SimilarAssetUtil.getSimilarAssets(_A));
+			SimilarAssetHashUtil.getHashes(_A),
+			SimilarAssetHashUtil.getHashes(_A));
 	}
 
 	@Test
-	public void testDeterministicAcrossDefaultLocales() {
+	public void testGetHashesIsDeterministicAcrossDefaultLocales() {
 		Locale defaultLocale = LocaleUtil.getDefault();
 
 		try {
 			LocaleUtil.setDefault("en", "US", null);
 
-			String[] similarAssets = SimilarAssetUtil.getSimilarAssets(
-				_TURKISH);
+			String[] hashes = SimilarAssetHashUtil.getHashes(_TURKISH);
 
 			LocaleUtil.setDefault("tr", "TR", null);
 
 			Assert.assertArrayEquals(
-				similarAssets, SimilarAssetUtil.getSimilarAssets(_TURKISH));
+				hashes, SimilarAssetHashUtil.getHashes(_TURKISH));
 		}
 		finally {
 			LocaleUtil.setDefault(
@@ -64,33 +56,40 @@ public class SimilarAssetUtilTest {
 	}
 
 	@Test
-	public void testDistinctTextSharesNoSimilarAssets() {
-		Assert.assertEquals(0, _getSharedSimilarAssetCount(_A, _DISTINCT));
+	public void testGetHashesIsEmptyForBlankText() {
+		Assert.assertEquals(0, SimilarAssetHashUtil.getHashes(null).length);
+		Assert.assertEquals(0, SimilarAssetHashUtil.getHashes("").length);
+		Assert.assertEquals(0, SimilarAssetHashUtil.getHashes("   ").length);
 	}
 
 	@Test
-	public void testSimilarTextSharesMoreThanDistinct() {
+	public void testGetHashesSharesMoreForSimilarThanForDistinctText() {
 		Assert.assertTrue(
-			_getSharedSimilarAssetCount(_A, _A + " 2") >
-				_getSharedSimilarAssetCount(_A, _DISTINCT));
+			_getSharedHashCount(_A, _A + " 2") > _getSharedHashCount(
+				_A, _DISTINCT));
 	}
 
 	@Test
-	public void testSimilarTextSharesMostSimilarAssets() {
-		Assert.assertTrue(_getSharedSimilarAssetCount(_A, _A + " 2") >= 20);
+	public void testGetHashesSharesMostForNearDuplicateText() {
+		Assert.assertTrue(_getSharedHashCount(_A, _A + " 2") >= 20);
 	}
 
-	private int _getSharedSimilarAssetCount(String text1, String text2) {
-		Set<String> similarAssets = new HashSet<>();
+	@Test
+	public void testGetHashesSharesNothingBetweenDistinctText() {
+		Assert.assertEquals(0, _getSharedHashCount(_A, _DISTINCT));
+	}
 
-		for (String similarAsset : SimilarAssetUtil.getSimilarAssets(text1)) {
-			similarAssets.add(similarAsset);
+	private int _getSharedHashCount(String text1, String text2) {
+		Set<String> hashes = new HashSet<>();
+
+		for (String hash : SimilarAssetHashUtil.getHashes(text1)) {
+			hashes.add(hash);
 		}
 
 		int count = 0;
 
-		for (String similarAsset : SimilarAssetUtil.getSimilarAssets(text2)) {
-			if (similarAssets.contains(similarAsset)) {
+		for (String hash : SimilarAssetHashUtil.getHashes(text2)) {
+			if (hashes.contains(hash)) {
 				count++;
 			}
 		}

--- a/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/search/similar/asset/SimilarAssetUtilTest.java
+++ b/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/search/similar/asset/SimilarAssetUtilTest.java
@@ -1,0 +1,116 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.search.similar.asset;
+
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Mikel Lorza
+ */
+public class SimilarAssetUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testBlankTextYieldsNoSimilarAssets() {
+		Assert.assertEquals(0, SimilarAssetUtil.getSimilarAssets(null).length);
+		Assert.assertEquals(0, SimilarAssetUtil.getSimilarAssets("").length);
+		Assert.assertEquals(0, SimilarAssetUtil.getSimilarAssets("   ").length);
+	}
+
+	@Test
+	public void testDeterministic() {
+		Assert.assertArrayEquals(
+			SimilarAssetUtil.getSimilarAssets(_A),
+			SimilarAssetUtil.getSimilarAssets(_A));
+	}
+
+	@Test
+	public void testDeterministicAcrossDefaultLocales() {
+		Locale defaultLocale = LocaleUtil.getDefault();
+
+		try {
+			LocaleUtil.setDefault("en", "US", null);
+
+			String[] similarAssets = SimilarAssetUtil.getSimilarAssets(
+				_TURKISH);
+
+			LocaleUtil.setDefault("tr", "TR", null);
+
+			Assert.assertArrayEquals(
+				similarAssets, SimilarAssetUtil.getSimilarAssets(_TURKISH));
+		}
+		finally {
+			LocaleUtil.setDefault(
+				defaultLocale.getLanguage(), defaultLocale.getCountry(),
+				defaultLocale.getVariant());
+		}
+	}
+
+	@Test
+	public void testDistinctTextSharesNoSimilarAssets() {
+		Assert.assertEquals(0, _getSharedSimilarAssetCount(_A, _DISTINCT));
+	}
+
+	@Test
+	public void testSimilarTextSharesMoreThanDistinct() {
+		Assert.assertTrue(
+			_getSharedSimilarAssetCount(_A, _A + " 2") >
+				_getSharedSimilarAssetCount(_A, _DISTINCT));
+	}
+
+	@Test
+	public void testSimilarTextSharesMostSimilarAssets() {
+		Assert.assertTrue(_getSharedSimilarAssetCount(_A, _A + " 2") >= 20);
+	}
+
+	private int _getSharedSimilarAssetCount(String text1, String text2) {
+		Set<String> similarAssets = new HashSet<>();
+
+		for (String similarAsset : SimilarAssetUtil.getSimilarAssets(text1)) {
+			similarAssets.add(similarAsset);
+		}
+
+		int count = 0;
+
+		for (String similarAsset : SimilarAssetUtil.getSimilarAssets(text2)) {
+			if (similarAssets.contains(similarAsset)) {
+				count++;
+			}
+		}
+
+		return count;
+	}
+
+	private static final String _A =
+		"If you forgot your password, go to the login page and click the " +
+			"forgot password link. Enter your email address and you will " +
+				"receive an email with instructions to create a new password.";
+
+	private static final String _DISTINCT =
+		"The quarterly sales report shows strong revenue growth across the " +
+			"European market. Product categories in retail and wholesale " +
+				"increased during the last fiscal period.";
+
+	private static final String _TURKISH =
+		"KULLANICI ADINIZI VE \u0130NTERNET \u015E\u0130FREN\u0130Z\u0130 " +
+			"G\u0130R\u0130N VE OTURUM A\u00c7MAK \u0130\u00c7\u0130N " +
+				"\u0130LER\u0130 D\u00dc\u011eMES\u0130NE BASIN";
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/search/spi/index/configuration/contributor/CMSSimilarAssetCompanyIndexConfigurationContributorTest.java
+++ b/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/search/spi/index/configuration/contributor/CMSSimilarAssetCompanyIndexConfigurationContributorTest.java
@@ -1,0 +1,59 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.search.spi.index.configuration.contributor;
+
+import com.liferay.petra.string.CharPool;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.search.spi.index.configuration.contributor.helper.MappingsHelper;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+/**
+ * @author Mikel Lorza
+ */
+public class CMSSimilarAssetCompanyIndexConfigurationContributorTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testContributeMappings() {
+		CMSSimilarAssetCompanyIndexConfigurationContributor
+			cmsSimilarAssetCompanyIndexConfigurationContributor =
+				new CMSSimilarAssetCompanyIndexConfigurationContributor();
+
+		MappingsHelper mappingsHelper = Mockito.mock(MappingsHelper.class);
+
+		cmsSimilarAssetCompanyIndexConfigurationContributor.contributeMappings(
+			RandomTestUtil.randomLong(), mappingsHelper);
+
+		ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(
+			String.class);
+
+		Mockito.verify(
+			mappingsHelper
+		).putMappings(
+			argumentCaptor.capture()
+		);
+
+		Assert.assertEquals(
+			"{\"properties\": {\"similarAssets\": {\"type\": \"keyword\"}}}",
+			StringUtil.removeChars(
+				argumentCaptor.getValue(), CharPool.NEW_LINE, CharPool.RETURN,
+				CharPool.TAB));
+	}
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/search/spi/index/configuration/contributor/CMSSimilarAssetCompanyIndexConfigurationContributorTest.java
+++ b/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/search/spi/index/configuration/contributor/CMSSimilarAssetCompanyIndexConfigurationContributorTest.java
@@ -50,7 +50,8 @@ public class CMSSimilarAssetCompanyIndexConfigurationContributorTest {
 		);
 
 		Assert.assertEquals(
-			"{\"properties\": {\"similarAssets\": {\"type\": \"keyword\"}}}",
+			"{\"properties\": {\"similarAssetHashes\": {\"type\": " +
+				"\"keyword\"}}}",
 			StringUtil.removeChars(
 				argumentCaptor.getValue(), CharPool.NEW_LINE, CharPool.RETURN,
 				CharPool.TAB));

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/dashboard/GovernanceService.test.ts
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/dashboard/GovernanceService.test.ts
@@ -24,7 +24,7 @@ describe('GovernanceService.getAssetStatistics', () => {
 		);
 
 		expect(getSpy).toHaveBeenCalledWith(
-			'/o/headless-cms/v1.0/similarity-clusters?assetLibraryId=123&pageSize=1',
+			'/o/headless-cms/v1.0/similar-asset-sets?assetLibraryId=123&pageSize=1',
 			undefined
 		);
 	});
@@ -42,7 +42,7 @@ describe('GovernanceService.getAssetStatistics', () => {
 		);
 
 		expect(getSpy).toHaveBeenCalledWith(
-			'/o/headless-cms/v1.0/similarity-clusters?pageSize=1',
+			'/o/headless-cms/v1.0/similar-asset-sets?pageSize=1',
 			undefined
 		);
 	});
@@ -62,14 +62,14 @@ describe('GovernanceService.getAssetStatistics', () => {
 		);
 
 		expect(getSpy).toHaveBeenCalledWith(
-			'/o/headless-cms/v1.0/similarity-clusters?pageSize=1',
+			'/o/headless-cms/v1.0/similar-asset-sets?pageSize=1',
 			signal
 		);
 	});
 
 	it('counts the assets in similar asset sets as the duplicated count', async () => {
 		jest.spyOn(ApiHelper, 'get').mockImplementation(((url: string) => {
-			if (url.includes('similarity-clusters')) {
+			if (url.includes('similar-asset-sets')) {
 				return Promise.resolve({data: {totalCount: 5}, error: null});
 			}
 
@@ -83,7 +83,7 @@ describe('GovernanceService.getAssetStatistics', () => {
 
 	it('leaves the duplicated count unset when the clusters are unavailable', async () => {
 		jest.spyOn(ApiHelper, 'get').mockImplementation(((url: string) => {
-			if (url.includes('similarity-clusters')) {
+			if (url.includes('similar-asset-sets')) {
 				return Promise.resolve({data: null, error: 'Not Found'});
 			}
 

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/dashboard/GovernanceService.test.ts
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/dashboard/GovernanceService.test.ts
@@ -67,7 +67,7 @@ describe('GovernanceService.getAssetStatistics', () => {
 		);
 	});
 
-	it('counts the assets in similarity clusters as the duplicated count', async () => {
+	it('counts the assets in similar asset sets as the duplicated count', async () => {
 		jest.spyOn(ApiHelper, 'get').mockImplementation(((url: string) => {
 			if (url.includes('similarity-clusters')) {
 				return Promise.resolve({data: {totalCount: 5}, error: null});


### PR DESCRIPTION
Hi @brianchandotcom ,

In relation of  your question of the last pr: https://github.com/brianchandotcom/liferay-portal/pull/181262#issuecomment-5526002768

They are strings, not DTOs, and that is what the old name got wrong: the field was called `similarAssets`, the same name as the `SimilarAsset` DTO and as its array inside `SimilarAssetSet`.

Each content is reduced to a fingerprint that is split into 32 hashes, and each hash is indexed as a keyword. Two contents that share one hash are candidates for being near duplicates, and how many hashes they share is what decides whether they end up in the same set.

So I [added](https://github.com/brianchandotcom/liferay-portal/pull/181277/commits/2168b803a90ec5fe445c95af6e020c116676dbc5) a commit renaming the multivalued field from `similarAssets` to `similarAssetHashes`, and the aggregation variable you pointed at to `sharedSimilarAssetHashes`.


Regards

https://liferay.atlassian.net/browse/LPD-97867

## What Is Being Fixed

The Content Governance Dashboard's Text Similarity card has no API behind it. Nothing in the portal can answer which CMS contents are near duplicates of one another, and the obvious way to answer it does not fit inside a request: comparing every content against every other one is 1.25 billion pairs at 50,000 contents. `MoreLikeThisQuery` answers a different question, since it needs a seed document and this card has none.

## How It Is Being Fixed

An index only matches equal values, never similar ones, so the text of each content is reduced at index time to a fingerprint that near duplicates literally share. `SimilarAssetHashUtil` cuts the indexed `TEXT`, `LONG_TEXT` and `RICH_TEXT` fields into sets of three consecutive keywords, hashes each with murmur3, and runs hash4j's `superMinHash` pinned to `SuperMinHashVersion.V1` over 32 x 4 samples. The 128 samples are banded four at a time into 32 strings per language, indexed as the multivalued keyword field `similarAssetHashes` with the language inside the token, so a translation is only ever compared against the same translation of other content. The title is excluded on purpose: it is a different dimension.

`GET /o/headless-cms/v1.0/similar-asset-sets` then answers with two searches, both carrying the caller's permissions. A terms aggregation with `minDocCount(2)`, restricted to the requested language, returns the hashes at least two contents share; a terms query fetches those candidates with only `objectEntryId` and `similarAssetHashes`. Java counts how many hashes each pair shares, joins the pairs that reach three with union-find, and returns `Page<SimilarAssetSet>` paginated by asset, so `totalCount` is the number of grouped assets that the card shows. A hash shared by more than 500 assets is treated as boilerplate and grouped by the set of common hashes instead of by pairs, which keeps a shared footer from collapsing a whole space into one set.

Why 32 x 4 with a threshold of three: expected matching hashes are 32*J^4, so two contents link with probability 0.2% at 30% overlap, 32% at 50% and 99% at 70%. A threshold of one hash would link 57% of pairs at 40% overlap, and because grouping is transitive a single false link merges hundreds of contents. Measured over the 1.25 billion pairs of a 50,000 document corpus, zero clusters were contaminated.

Two ceilings are deliberate and documented in the code: the aggregation asks for 10,000 hashes, which is roughly 850 sets per language, and the document search asks for 10,000, exactly the default `index.max_result_window`. Raising the first deserves its own ticket.

## What Changed Since The Previous Round Of Review

Four points from the review, all applied except the naming of the grouping methods, which was left alone on purpose.

**The OpenAPI descriptions no longer call a set a group.** Beyond the two schema descriptions, the operation's own description said `grouping always spans the whole space` and `totalCount counts the grouped assets`; both now speak of sets. The word does not appear anywhere in the file. The Java internals keep it, since the scope of the rename is the public prose.

**The resource test now follows rule 605.** `testGraphQLGetSimilarAssetSetsPage` was a top-level `@Test` matching no method of the generated base, which severs the scenario from the path it covers; it is now `_testGetSimilarAssetSetsPageGraphQL`, called from the `testGetSimilarAssetSetsPage` override beside `_testGetSimilarAssetSetsPagePermissions` and `_testGetSimilarAssetSetsPageTranslation`, both renamed so their prefix matches the override they hang from.

The one part of the rule that cannot be honoured is the `super` call. Both generated tests go through `testGetSimilarAssetSetsPage_addSimilarAssetSet`, which throws `UnsupportedOperationException`, and it cannot be implemented: a similar asset set is computed from indexed content and never created, so there is no way to add one with a random title and size. This is the same reason the generated pagination test had to be overridden in the first place.

**The API needs the version bump after all, by one day.** `com.liferay.headless.cms.api` `3.1.0` was released on 2026-09-01, and its published jar exports `com.liferay.headless.cms.dto.v1_0;version="2.3.0"` and `com.liferay.headless.cms.resource.v1_0;version="3.1.0"` with no `SimilarAsset` type in it. The local baseline was green only because the Gradle cache held `3.0.0` and compared against that; `--refresh-dependencies` resolves `3.1.0` and the bump becomes required. It lands in its own commit: `Bundle-Version` `3.1.0` to `3.2.0`, `dto.v1_0` `2.3.0` to `2.4.0`, `resource.v1_0` `3.1.0` to `3.2.0`. Baseline then passes against `3.1.0` with no findings. `headless-cms-client` exports no package, so its baseline is skipped and it owes nothing.

**The three grouping methods keep their names.** `_getRootObjectEntryId`, `_getObjectEntryIdsMap` and `_getGroupedObjectEntryIdsMap` do mutate — the first compresses the union-find path as it walks — but renaming them was left out of this round by the author's call.

Every fix from that round is folded into the commit that introduced the code. The rename that follows it is a commit of its own, so the branch is those six commits, the baseline one, and the rename.

## What Changed In The Round Before That

The previous round was closed on terminology: "I don't understand the terms asset bucket and asset groups". Nothing else was raised, so this round is a rename and nothing more.

`SimilarAssetGroup` is now `SimilarAssetSet` and the operation is `/similar-asset-sets`. In this codebase `Group` means Site, and the very method returning the page also declares a `Long[] groupIds` meaning exactly that; `Set` has precedent in `FragmentSet`, `PageTemplateSet`, `DocumentMetadataSet` and `ToolSet`. The indexed field `similarAssetBuckets` became `similarAssets`, and is now `similarAssetHashes`: "bucket" is locality-sensitive-hashing jargon and collided with Elasticsearch's own aggregation `Bucket`, which is iterated three lines from the constant in the same method. `_getWordSequences` is now `_getKeywordSequences`, `_getSignatureObjectFields` is now `_getObjectFields`, and the near-duplicate vocabulary is now "similar" throughout the descriptions and the tests. `SimilarAsset` stays, since `BrokenLinkAsset`, `AssetStatistics` and `AssetUsage` are already merged in the same `rest-openapi.yaml`.

One rename is not cosmetic and is worth a reviewer's attention. `GovernanceService.ts` in master calls `/o/headless-cms/v1.0/similarity-clusters`, a name from an earlier round of this same feature that never shipped, since this endpoint has not merged yet. This branch points that caller at `/similar-asset-sets`, so the card and the operation agree for the first time. No reference to the old name is left anywhere in the tree.

That round's renames were folded through all six commits, so neither `Group` nor `bucket` appears anywhere in the branch's history. The branch is also rebased from its previous base onto current master, which is what made this possible without a conflict: LPD-103025's `/broken-link-assets` has since merged and no longer collides.

## PR Check

**pr-check: PASS** — tested on `2168b803a90ec5fe445c95af6e020c116676dbc5`

| Validation | Result |
| --- | --- |
| REST Builder | PASS |
| Source Format | PASS |
| Transaction Usage | PASS |
| HTML Escaping | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | NOT VERIFIED |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |
| JavaScript Unit Tests | PASS |

Cross-Module Compile verified nothing. The consumer set came to 9 modules, over the cap of 8, and the rule forbids a partial expansion, so no consumer was compiled. The set is inflated by a name collision: the changed `Query.java` is `com.liferay.headless.cms.internal.graphql.query.v1_0.Query`, an internal GraphQL class, while eight of the nine hits match `com.liferay.portal.kernel.search.Query`, `com.liferay.portal.search.query.Query` or `org.apache.lucene.search.Query` in unrelated modules. The one genuine consumer is `headless-cms-test`, which Integration Test Compile compiled with `--rerun-tasks`, 374 of 374 tasks executed.

Baseline reports one finding, inherited rather than this branch's: `portal-kernel` needs a minor bump for `RawMetadataProcessorUtil`, added on master by `LPD-97515`. Both repairs were restored rather than committed. This branch's own module compares `3.2.0` against the released `3.1.0` with `--refresh-dependencies` and reports nothing. The bump is required because `3.1.0` was released on 2026-09-01 and master's own release prep then raised `Bundle-Version` to `3.1.1`.

JavaScript Unit Tests passed 183 suites and 1079 tests, but one suite, `ReferencedStructureModal`, needed an isolated rerun: on a loaded machine it failed on the 5 second per test timeout. The module's JavaScript tree is byte identical to the previously verified head and this branch touches neither of the files involved.

Beyond pr-check, and not part of it: `SimilarAssetSetResourceTest` passes 5 of 5 against a live portal running this exact head, the rename included, with the bundle carrying the rebuilt `headless-cms-impl` and `site-cms-site-initializer` jars. That is the run that proves the writer and the reader still agree on the field name, since the contributor indexes it and the aggregation reads it back.

<!-- pr-check {"result": "success", "sha": "2168b803a90ec5fe445c95af6e020c116676dbc5"} -->
