### PR TITLE
LPD-101811 Use the conventional tokens in the test scenario names

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/servlet/test/CompareObjectEntryVersionsCMSServletTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/servlet/test/CompareObjectEntryVersionsCMSServletTest.java
@@ -101,12 +101,12 @@ public class CompareObjectEntryVersionsCMSServletTest
 
 	@Test
 	public void testCompareObjectEntryVersions() throws Exception {
-		_testCompareObjectEntryVersionsWithChangedDateField();
-		_testCompareObjectEntryVersionsWithChangedRichTextField();
-		_testCompareObjectEntryVersionsWithChangedTextField();
-		_testCompareObjectEntryVersionsWithEqualVersions();
-		_testCompareObjectEntryVersionsWithMalformedContent();
+		_testCompareObjectEntryVersionsWithDateObjectField();
+		_testCompareObjectEntryVersionsWithInvalidContent();
 		_testCompareObjectEntryVersionsWithoutUpdatePermission();
+		_testCompareObjectEntryVersionsWithRichTextObjectField();
+		_testCompareObjectEntryVersionsWithSameVersions();
+		_testCompareObjectEntryVersionsWithTextObjectField();
 	}
 
 	private void _addModelResourcePermissions(
@@ -225,7 +225,7 @@ public class CompareObjectEntryVersionsCMSServletTest
 		return _service(content.getBytes(), user);
 	}
 
-	private void _testCompareObjectEntryVersionsWithChangedDateField()
+	private void _testCompareObjectEntryVersionsWithDateObjectField()
 		throws Exception {
 
 		ObjectDefinition objectDefinition =
@@ -280,118 +280,7 @@ public class CompareObjectEntryVersionsCMSServletTest
 			objectDefinition.getObjectDefinitionId());
 	}
 
-	private void _testCompareObjectEntryVersionsWithChangedRichTextField()
-		throws Exception {
-
-		String sourceContent = RandomTestUtil.randomString();
-		String title = RandomTestUtil.randomString();
-
-		ObjectEntry objectEntry = _addObjectEntry(
-			"<p>" + sourceContent + "</p>", title);
-
-		String targetContent = RandomTestUtil.randomString();
-
-		objectEntry = _updateObjectEntry(
-			objectEntry, "<p>" + targetContent + "</p>", title);
-
-		Assert.assertEquals(2, objectEntry.getVersion());
-
-		JSONObject diffsJSONObject = _toDiffsJSONObject(
-			_service(
-				objectEntry.getObjectEntryId(), 1, 2,
-				TestPropsValues.getUser()));
-
-		JSONObject sourceJSONObject = diffsJSONObject.getJSONObject("source");
-		JSONObject targetJSONObject = diffsJSONObject.getJSONObject("target");
-
-		Assert.assertFalse(
-			sourceJSONObject.toString(), sourceJSONObject.has("title"));
-		Assert.assertFalse(
-			targetJSONObject.toString(), targetJSONObject.has("title"));
-
-		Assert.assertFalse(
-			sourceJSONObject.toString(),
-			sourceJSONObject.has("contentRawText"));
-		Assert.assertFalse(
-			targetJSONObject.toString(),
-			targetJSONObject.has("contentRawText"));
-
-		String sourceDiff = sourceJSONObject.getString("content");
-		String targetDiff = targetJSONObject.getString("content");
-
-		Assert.assertTrue(sourceDiff, sourceDiff.contains(sourceContent));
-		Assert.assertTrue(targetDiff, targetDiff.contains(targetContent));
-	}
-
-	private void _testCompareObjectEntryVersionsWithChangedTextField()
-		throws Exception {
-
-		String content = RandomTestUtil.randomString();
-		String sourceTitle = RandomTestUtil.randomString();
-
-		ObjectEntry objectEntry = _addObjectEntry(content, sourceTitle);
-
-		String targetTitle = RandomTestUtil.randomString();
-
-		objectEntry = _updateObjectEntry(objectEntry, content, targetTitle);
-
-		Assert.assertEquals(2, objectEntry.getVersion());
-
-		MockHttpServletResponse mockHttpServletResponse = _service(
-			objectEntry.getObjectEntryId(), 1, 2, TestPropsValues.getUser());
-
-		Assert.assertEquals(
-			ContentTypes.APPLICATION_JSON,
-			mockHttpServletResponse.getContentType());
-		Assert.assertEquals(
-			HttpServletResponse.SC_OK, mockHttpServletResponse.getStatus());
-
-		JSONObject diffsJSONObject = _toDiffsJSONObject(
-			mockHttpServletResponse);
-
-		JSONObject sourceJSONObject = diffsJSONObject.getJSONObject("source");
-		JSONObject targetJSONObject = diffsJSONObject.getJSONObject("target");
-
-		Assert.assertFalse(
-			sourceJSONObject.toString(), sourceJSONObject.has("content"));
-		Assert.assertFalse(
-			targetJSONObject.toString(), targetJSONObject.has("content"));
-
-		String sourceDiff = sourceJSONObject.getString("title");
-		String targetDiff = targetJSONObject.getString("title");
-
-		_assertDiffHtml(sourceTitle, sourceDiff, targetTitle);
-		_assertDiffHtml(targetTitle, targetDiff, sourceTitle);
-	}
-
-	private void _testCompareObjectEntryVersionsWithEqualVersions()
-		throws Exception {
-
-		ObjectEntry objectEntry = _addObjectEntry(
-			RandomTestUtil.randomString(), RandomTestUtil.randomString());
-
-		MockHttpServletResponse mockHttpServletResponse = _service(
-			objectEntry.getObjectEntryId(), 1, 1, TestPropsValues.getUser());
-
-		Assert.assertEquals(
-			ContentTypes.APPLICATION_JSON,
-			mockHttpServletResponse.getContentType());
-		Assert.assertEquals(
-			HttpServletResponse.SC_OK, mockHttpServletResponse.getStatus());
-
-		JSONObject diffsJSONObject = _toDiffsJSONObject(
-			mockHttpServletResponse);
-
-		JSONObject sourceJSONObject = diffsJSONObject.getJSONObject("source");
-		JSONObject targetJSONObject = diffsJSONObject.getJSONObject("target");
-
-		Assert.assertEquals(
-			sourceJSONObject.toString(), 0, sourceJSONObject.length());
-		Assert.assertEquals(
-			targetJSONObject.toString(), 0, targetJSONObject.length());
-	}
-
-	private void _testCompareObjectEntryVersionsWithMalformedContent()
+	private void _testCompareObjectEntryVersionsWithInvalidContent()
 		throws Exception {
 
 		String content = RandomTestUtil.randomString();
@@ -469,6 +358,117 @@ public class CompareObjectEntryVersionsCMSServletTest
 		PrincipalThreadLocal.setName(name);
 
 		_userLocalService.deleteUser(user);
+	}
+
+	private void _testCompareObjectEntryVersionsWithRichTextObjectField()
+		throws Exception {
+
+		String sourceContent = RandomTestUtil.randomString();
+		String title = RandomTestUtil.randomString();
+
+		ObjectEntry objectEntry = _addObjectEntry(
+			"<p>" + sourceContent + "</p>", title);
+
+		String targetContent = RandomTestUtil.randomString();
+
+		objectEntry = _updateObjectEntry(
+			objectEntry, "<p>" + targetContent + "</p>", title);
+
+		Assert.assertEquals(2, objectEntry.getVersion());
+
+		JSONObject diffsJSONObject = _toDiffsJSONObject(
+			_service(
+				objectEntry.getObjectEntryId(), 1, 2,
+				TestPropsValues.getUser()));
+
+		JSONObject sourceJSONObject = diffsJSONObject.getJSONObject("source");
+		JSONObject targetJSONObject = diffsJSONObject.getJSONObject("target");
+
+		Assert.assertFalse(
+			sourceJSONObject.toString(), sourceJSONObject.has("title"));
+		Assert.assertFalse(
+			targetJSONObject.toString(), targetJSONObject.has("title"));
+
+		Assert.assertFalse(
+			sourceJSONObject.toString(),
+			sourceJSONObject.has("contentRawText"));
+		Assert.assertFalse(
+			targetJSONObject.toString(),
+			targetJSONObject.has("contentRawText"));
+
+		String sourceDiff = sourceJSONObject.getString("content");
+		String targetDiff = targetJSONObject.getString("content");
+
+		Assert.assertTrue(sourceDiff, sourceDiff.contains(sourceContent));
+		Assert.assertTrue(targetDiff, targetDiff.contains(targetContent));
+	}
+
+	private void _testCompareObjectEntryVersionsWithSameVersions()
+		throws Exception {
+
+		ObjectEntry objectEntry = _addObjectEntry(
+			RandomTestUtil.randomString(), RandomTestUtil.randomString());
+
+		MockHttpServletResponse mockHttpServletResponse = _service(
+			objectEntry.getObjectEntryId(), 1, 1, TestPropsValues.getUser());
+
+		Assert.assertEquals(
+			ContentTypes.APPLICATION_JSON,
+			mockHttpServletResponse.getContentType());
+		Assert.assertEquals(
+			HttpServletResponse.SC_OK, mockHttpServletResponse.getStatus());
+
+		JSONObject diffsJSONObject = _toDiffsJSONObject(
+			mockHttpServletResponse);
+
+		JSONObject sourceJSONObject = diffsJSONObject.getJSONObject("source");
+		JSONObject targetJSONObject = diffsJSONObject.getJSONObject("target");
+
+		Assert.assertEquals(
+			sourceJSONObject.toString(), 0, sourceJSONObject.length());
+		Assert.assertEquals(
+			targetJSONObject.toString(), 0, targetJSONObject.length());
+	}
+
+	private void _testCompareObjectEntryVersionsWithTextObjectField()
+		throws Exception {
+
+		String content = RandomTestUtil.randomString();
+		String sourceTitle = RandomTestUtil.randomString();
+
+		ObjectEntry objectEntry = _addObjectEntry(content, sourceTitle);
+
+		String targetTitle = RandomTestUtil.randomString();
+
+		objectEntry = _updateObjectEntry(objectEntry, content, targetTitle);
+
+		Assert.assertEquals(2, objectEntry.getVersion());
+
+		MockHttpServletResponse mockHttpServletResponse = _service(
+			objectEntry.getObjectEntryId(), 1, 2, TestPropsValues.getUser());
+
+		Assert.assertEquals(
+			ContentTypes.APPLICATION_JSON,
+			mockHttpServletResponse.getContentType());
+		Assert.assertEquals(
+			HttpServletResponse.SC_OK, mockHttpServletResponse.getStatus());
+
+		JSONObject diffsJSONObject = _toDiffsJSONObject(
+			mockHttpServletResponse);
+
+		JSONObject sourceJSONObject = diffsJSONObject.getJSONObject("source");
+		JSONObject targetJSONObject = diffsJSONObject.getJSONObject("target");
+
+		Assert.assertFalse(
+			sourceJSONObject.toString(), sourceJSONObject.has("content"));
+		Assert.assertFalse(
+			targetJSONObject.toString(), targetJSONObject.has("content"));
+
+		String sourceDiff = sourceJSONObject.getString("title");
+		String targetDiff = targetJSONObject.getString("title");
+
+		_assertDiffHtml(sourceTitle, sourceDiff, targetTitle);
+		_assertDiffHtml(targetTitle, targetDiff, sourceTitle);
 	}
 
 	private JSONObject _toDiffsJSONObject(

--- a/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/comparison/ObjectEntryVersionFieldValueResolverTest.java
+++ b/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/comparison/ObjectEntryVersionFieldValueResolverTest.java
@@ -104,18 +104,18 @@ public class ObjectEntryVersionFieldValueResolverTest {
 
 	@Test
 	public void testToDisplayValue() throws Exception {
-		_testToDisplayValueWithAttachmentBusinessType();
-		_testToDisplayValueWithBooleanBusinessType();
-		_testToDisplayValueWithDateBusinessType();
-		_testToDisplayValueWithDateTimeBusinessType();
-		_testToDisplayValueWithMultiselectPicklistBusinessType();
+		_testToDisplayValueWithAttachmentObjectField();
+		_testToDisplayValueWithBooleanObjectField();
+		_testToDisplayValueWithDateObjectField();
+		_testToDisplayValueWithDateTimeObjectField();
+		_testToDisplayValueWithHTMLFileName();
+		_testToDisplayValueWithHTMLListTypeEntryName();
+		_testToDisplayValueWithHTMLTextValue();
+		_testToDisplayValueWithMultiselectPicklistObjectField();
+		_testToDisplayValueWithNonexistentFileEntry();
 		_testToDisplayValueWithNullValue();
-		_testToDisplayValueWithPicklistBusinessType();
-		_testToDisplayValueWithRichTextBusinessType();
-		_testToDisplayValueWithUnresolvableAttachment();
-		_testToDisplayValueWithUnsafeAttachmentFileName();
-		_testToDisplayValueWithUnsafePicklistName();
-		_testToDisplayValueWithUnsafeTextValue();
+		_testToDisplayValueWithPicklistObjectField();
+		_testToDisplayValueWithRichTextObjectField();
 	}
 
 	private void _assertNullDisplayValue(String businessType) {
@@ -343,7 +343,7 @@ public class ObjectEntryVersionFieldValueResolverTest {
 		Assert.assertEquals("Hola", fieldValues.get("title"));
 	}
 
-	private void _testToDisplayValueWithAttachmentBusinessType()
+	private void _testToDisplayValueWithAttachmentObjectField()
 		throws Exception {
 
 		long fileEntryId = RandomTestUtil.randomLong();
@@ -373,7 +373,7 @@ public class ObjectEntryVersionFieldValueResolverTest {
 				_LANGUAGE_ID, objectField, null, fileEntryId));
 	}
 
-	private void _testToDisplayValueWithBooleanBusinessType() {
+	private void _testToDisplayValueWithBooleanObjectField() {
 		_setUpBooleanLabels();
 
 		ObjectField objectField = _mockObjectField(
@@ -393,7 +393,7 @@ public class ObjectEntryVersionFieldValueResolverTest {
 				_LANGUAGE_ID, objectField, null, true));
 	}
 
-	private void _testToDisplayValueWithDateBusinessType() {
+	private void _testToDisplayValueWithDateObjectField() {
 		Assert.assertEquals(
 			"09/15/2026",
 			_objectEntryVersionFieldValueResolver.toDisplayValue(
@@ -408,7 +408,7 @@ public class ObjectEntryVersionFieldValueResolverTest {
 				_DATE_VALUE));
 	}
 
-	private void _testToDisplayValueWithDateTimeBusinessType() {
+	private void _testToDisplayValueWithDateTimeObjectField() {
 		ObjectField convertToUTCObjectField = _mockObjectField(
 			ObjectFieldConstants.BUSINESS_TYPE_DATE_TIME,
 			ObjectFieldSettingConstants.VALUE_CONVERT_TO_UTC);
@@ -441,7 +441,58 @@ public class ObjectEntryVersionFieldValueResolverTest {
 			useInputAsEnteredDisplayValue.startsWith("09/15/2026, 12:00"));
 	}
 
-	private void _testToDisplayValueWithMultiselectPicklistBusinessType() {
+	private void _testToDisplayValueWithHTMLFileName() throws Exception {
+		long fileEntryId = RandomTestUtil.randomLong();
+		String previewURL = RandomTestUtil.randomString();
+
+		_setUpAttachment(
+			fileEntryId, "\"><img src=x onerror=alert(1)>", previewURL);
+
+		String escapedFileName = "&#34;&gt;&lt;img src=x onerror=alert(1)&gt;";
+
+		Assert.assertEquals(
+			StringBundler.concat(
+				"<img alt=\"", escapedFileName,
+				"\" class=\"cms-compare-versions-attachment\" src=\"",
+				previewURL, "\" /> ", escapedFileName),
+			_objectEntryVersionFieldValueResolver.toDisplayValue(
+				_LANGUAGE_ID,
+				_mockObjectField(ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT),
+				null, fileEntryId));
+	}
+
+	private void _testToDisplayValueWithHTMLListTypeEntryName() {
+		long listTypeDefinitionId = RandomTestUtil.randomLong();
+		String key = RandomTestUtil.randomString();
+
+		ObjectField objectField = _mockObjectField(
+			ObjectFieldConstants.BUSINESS_TYPE_PICKLIST);
+
+		Mockito.when(
+			objectField.getListTypeDefinitionId()
+		).thenReturn(
+			listTypeDefinitionId
+		);
+
+		_setUpListTypeEntry(
+			listTypeDefinitionId, key, "<img src=x onerror=alert(1)>");
+
+		Assert.assertEquals(
+			"&lt;img src=x onerror=alert(1)&gt;",
+			_objectEntryVersionFieldValueResolver.toDisplayValue(
+				_LANGUAGE_ID, objectField, null, key));
+	}
+
+	private void _testToDisplayValueWithHTMLTextValue() {
+		Assert.assertEquals(
+			"&lt;img src=x onerror=alert(1)&gt;",
+			_objectEntryVersionFieldValueResolver.toDisplayValue(
+				_LANGUAGE_ID,
+				_mockObjectField(ObjectFieldConstants.BUSINESS_TYPE_TEXT), null,
+				"<img src=x onerror=alert(1)>"));
+	}
+
+	private void _testToDisplayValueWithMultiselectPicklistObjectField() {
 		long listTypeDefinitionId = RandomTestUtil.randomLong();
 
 		ObjectField objectField = _mockObjectField(
@@ -481,6 +532,28 @@ public class ObjectEntryVersionFieldValueResolverTest {
 				_LANGUAGE_ID, objectField, null, new Object[0]));
 	}
 
+	private void _testToDisplayValueWithNonexistentFileEntry() {
+		long fileEntryId = RandomTestUtil.randomLong();
+
+		Mockito.when(
+			_dlFileEntryLocalService.fetchDLFileEntry(fileEntryId)
+		).thenReturn(
+			null
+		);
+
+		ObjectField objectField = _mockObjectField(
+			ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT);
+
+		Assert.assertEquals(
+			StringPool.BLANK,
+			_objectEntryVersionFieldValueResolver.toDisplayValue(
+				_LANGUAGE_ID, objectField, null, Collections.emptyMap()));
+		Assert.assertEquals(
+			StringPool.BLANK,
+			_objectEntryVersionFieldValueResolver.toDisplayValue(
+				_LANGUAGE_ID, objectField, null, fileEntryId));
+	}
+
 	private void _testToDisplayValueWithNullValue() {
 		_setUpBooleanLabels();
 
@@ -498,7 +571,7 @@ public class ObjectEntryVersionFieldValueResolverTest {
 				_LANGUAGE_ID, null, null, null));
 	}
 
-	private void _testToDisplayValueWithPicklistBusinessType() {
+	private void _testToDisplayValueWithPicklistObjectField() {
 		long listTypeDefinitionId = RandomTestUtil.randomLong();
 		String key = RandomTestUtil.randomString();
 
@@ -533,7 +606,7 @@ public class ObjectEntryVersionFieldValueResolverTest {
 				_LANGUAGE_ID, objectField, null, unknownKey));
 	}
 
-	private void _testToDisplayValueWithRichTextBusinessType() {
+	private void _testToDisplayValueWithRichTextObjectField() {
 		String richText = "<p>Hello <b>World</b></p>";
 
 		Assert.assertEquals(
@@ -542,81 +615,6 @@ public class ObjectEntryVersionFieldValueResolverTest {
 				_LANGUAGE_ID,
 				_mockObjectField(ObjectFieldConstants.BUSINESS_TYPE_RICH_TEXT),
 				null, richText));
-	}
-
-	private void _testToDisplayValueWithUnresolvableAttachment() {
-		long fileEntryId = RandomTestUtil.randomLong();
-
-		Mockito.when(
-			_dlFileEntryLocalService.fetchDLFileEntry(fileEntryId)
-		).thenReturn(
-			null
-		);
-
-		ObjectField objectField = _mockObjectField(
-			ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT);
-
-		Assert.assertEquals(
-			StringPool.BLANK,
-			_objectEntryVersionFieldValueResolver.toDisplayValue(
-				_LANGUAGE_ID, objectField, null, Collections.emptyMap()));
-		Assert.assertEquals(
-			StringPool.BLANK,
-			_objectEntryVersionFieldValueResolver.toDisplayValue(
-				_LANGUAGE_ID, objectField, null, fileEntryId));
-	}
-
-	private void _testToDisplayValueWithUnsafeAttachmentFileName()
-		throws Exception {
-
-		long fileEntryId = RandomTestUtil.randomLong();
-		String previewURL = RandomTestUtil.randomString();
-
-		_setUpAttachment(
-			fileEntryId, "\"><img src=x onerror=alert(1)>", previewURL);
-
-		String escapedFileName = "&#34;&gt;&lt;img src=x onerror=alert(1)&gt;";
-
-		Assert.assertEquals(
-			StringBundler.concat(
-				"<img alt=\"", escapedFileName,
-				"\" class=\"cms-compare-versions-attachment\" src=\"",
-				previewURL, "\" /> ", escapedFileName),
-			_objectEntryVersionFieldValueResolver.toDisplayValue(
-				_LANGUAGE_ID,
-				_mockObjectField(ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT),
-				null, fileEntryId));
-	}
-
-	private void _testToDisplayValueWithUnsafePicklistName() {
-		long listTypeDefinitionId = RandomTestUtil.randomLong();
-		String key = RandomTestUtil.randomString();
-
-		ObjectField objectField = _mockObjectField(
-			ObjectFieldConstants.BUSINESS_TYPE_PICKLIST);
-
-		Mockito.when(
-			objectField.getListTypeDefinitionId()
-		).thenReturn(
-			listTypeDefinitionId
-		);
-
-		_setUpListTypeEntry(
-			listTypeDefinitionId, key, "<img src=x onerror=alert(1)>");
-
-		Assert.assertEquals(
-			"&lt;img src=x onerror=alert(1)&gt;",
-			_objectEntryVersionFieldValueResolver.toDisplayValue(
-				_LANGUAGE_ID, objectField, null, key));
-	}
-
-	private void _testToDisplayValueWithUnsafeTextValue() {
-		Assert.assertEquals(
-			"&lt;img src=x onerror=alert(1)&gt;",
-			_objectEntryVersionFieldValueResolver.toDisplayValue(
-				_LANGUAGE_ID,
-				_mockObjectField(ObjectFieldConstants.BUSINESS_TYPE_TEXT), null,
-				"<img src=x onerror=alert(1)>"));
 	}
 
 	private static final String _DATE_VALUE = "2026-09-15T00:00:00.000Z";


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101811

Follow up to your review on #181276: making the test method names more robotic.

## What Changed

`ChangedDateField` named what the test did rather than what the input is. Every token I had invented turns out to be a hapax, and the repo already has an established word for each case. Counts are distinct helper names matching `_test…With(out)?<token>` across `modules/`.

| Was | Now | Was count | Now count |
| --- | --- | --- | --- |
| `WithChangedDateField` | `WithDateObjectField` | 3, all mine | 30 |
| `WithChangedRichTextField` | `WithRichTextObjectField` | 3, all mine | 30 |
| `WithChangedTextField` | `WithTextObjectField` | 3, all mine | 30 |
| `WithEqualVersions` | `WithSameVersions` | 1, mine | 13 |
| `WithMalformedContent` | `WithInvalidContent` | 3 | 51 |
| `WithoutUpdatePermission` | unchanged | 86 | 86 |

`ObjectEntryVersionFieldValueResolverTest` had the same problem, so it gets the same treatment: the seven `With<X>BusinessType` become `With<X>ObjectField`, `WithUnresolvableAttachment` becomes `WithNonexistentFileEntry`, and the three `WithUnsafe…` become `WithHTMLFileName`, `WithHTMLListTypeEntryName` and `WithHTMLTextValue`. `WithNullValue` stays.

`With<BusinessType>ObjectField` follows `_testCopyObjectEntryWithAttachmentObjectField`, `_testAddObjectEntryWithRichTextObjectField` and `_testContributeWithMultiselectPicklistObjectField`.

The commit is a rename and a reorder, nothing else. Sorting both files and diffing them against the renamed base gives no difference, so no assertion or setup changed.

## Test execution

    cd modules/apps/site/site-cms-site-initializer
    gradlew test --tests ObjectEntryVersionFieldValueResolverTest

    cd modules/apps/site/site-cms-site-initializer-test
    gradlew testIntegration --tests CompareObjectEntryVersionsCMSServletTest

Unit `tests="3" failures="0" errors="0"`, integration `tests="1" failures="0" errors="0"`.

## PR Check

**pr-check: PASS** — tested on `75c682eac262925bbee977e4489974492597bbe2`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Service Registration | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | NOT VERIFIED |
| Integration Test Compile | PASS |
| Baseline | PASS (baseline-all + seven Ant projects + 0 changed exporting modules) |
| Java Unit Tests | PASS |

Per-Module Compile verified nothing. The diff is two test sources, and `deploy` compiles only `src/main/java` while `-test` modules deploy no bundle, so neither changed file was examined by it. Both are covered elsewhere, by Java Unit Tests and Integration Test Compile.

<!-- pr-check {"result": "success", "sha": "75c682eac262925bbee977e4489974492597bbe2"} -->
