### PR TITLE
LPD-104423 Run the layout structure rules test with the page rules flag

### DIFF
--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/taglib/test/RenderLayoutStructureTagTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/taglib/test/RenderLayoutStructureTagTest.java
@@ -188,6 +188,7 @@ import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -876,6 +877,7 @@ public class RenderLayoutStructureTagTest {
 		Assert.assertFalse(content.contains(xssScript));
 	}
 
+	@FeatureFlag("LPS-169837")
 	@Test
 	@TestInfo("LPD-103459")
 	public void testLayoutStructureRules() throws Exception {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-104423

## What Is Being Fixed

`RenderLayoutStructureTagTest.testLayoutStructureRules` fails on the LPD-104423 backport pull requests. That change stopped evaluating a page's rules when the `LPS-169837` feature flag is disabled, and the flag is disabled by default, so the rules the test sets up are never applied. The submit button is not disabled and the text input the rule hides is still rendered, which is exactly what the test asserts against.

## How It Is Being Fixed

The test now declares the feature flag it depends on. Before LPD-104423 the rules were evaluated whatever the flag said, so the test happened to pass without it, but the flag was always the real precondition for the behavior under test. Annotating the method rather than the class leaves the rest of the class on the default configuration.

## PR Check

**pr-check: PASS** — tested on `702af8871e880c0529058dfb60ce3c54c1ea5ad9`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Service Registration | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | NOT VERIFIED |
| Integration Test Compile | PASS |
| Baseline | PASS (baseline-all + seven Ant projects + 0 changed exporting modules) |
| Java Unit Tests | NOT VERIFIED |

Per-Module Compile verified nothing. The only change is under `modules/apps/layout/layout-test/src/testIntegration`, which the validation's own `src/testIntegration` exclusion removes from the deploy set; Integration Test Compile covers that module via `compileTestIntegrationJava`.

Java Unit Tests verified nothing. The only Java change is an annotation on `RenderLayoutStructureTagTest`, an integration test in `modules/apps/layout/layout-test` that has no unit-test counterpart and no unit source set; the changed file is itself the test that covers the class.

<!-- pr-check {"result": "success", "sha": "702af8871e880c0529058dfb60ce3c54c1ea5ad9"} -->
