### PR TITLE
LCD-53280 Let the operator write marketplace add-ons on AWS and GCP

### DIFF
--- a/cloud/helm/aws/tests/marketplace_test.yaml
+++ b/cloud/helm/aws/tests/marketplace_test.yaml
@@ -11,6 +11,9 @@ tests:
                     path: spec.accessModes
                     value:
                         -   ReadWriteMany
+            -   equal:
+                    path: spec.csi.volumeHandle
+                    value: fs-0123456789abcdef0::fsap-0123456789abcdef0
         documentSelector:
             path: kind
             skipEmptyTemplates: true
@@ -18,7 +21,7 @@ tests:
         it: Backs the marketplace volume with the EFS CSI driver
         set:
             liferay-default.licensing.enabled: true
-            liferay-default.marketplace.csi.volumeHandle: fs-0123456789abcdef0
+            liferay-default.marketplace.csi.volumeHandle: fs-0123456789abcdef0::fsap-0123456789abcdef0
             liferay-default.marketplace.enabled: true
     -   asserts:
             -   equal:
@@ -36,7 +39,7 @@ tests:
             namespace: NAMESPACE
         set:
             liferay-default.licensing.enabled: true
-            liferay-default.marketplace.csi.volumeHandle: fs-0123456789abcdef0
+            liferay-default.marketplace.csi.volumeHandle: fs-0123456789abcdef0::fsap-0123456789abcdef0
             liferay-default.marketplace.enabled: true
     -   asserts:
             -   equal:

--- a/cloud/helm/dxp-operator/tests/deployment_test.yaml
+++ b/cloud/helm/dxp-operator/tests/deployment_test.yaml
@@ -203,6 +203,20 @@ tests:
         it: Sets the pod and container security contexts from the values
     -   asserts:
             -   equal:
+                    path: spec.template.spec.securityContext
+                    value:
+                        fsGroup: 1000
+                        fsGroupChangePolicy: OnRootMismatch
+                        runAsNonRoot: true
+                        seccompProfile:
+                            type: RuntimeDefault
+        it: Sets the pod file system group for volumes that honor it
+        set:
+            podSecurityContext:
+                fsGroup: 1000
+                fsGroupChangePolicy: OnRootMismatch
+    -   asserts:
+            -   equal:
                     path: spec.template.spec.containers[0].resources
                     value:
                         limits:

--- a/cloud/helm/dxp-operator/tests/marketplace-pv_test.yaml
+++ b/cloud/helm/dxp-operator/tests/marketplace-pv_test.yaml
@@ -1,0 +1,29 @@
+suite: Marketplace Volume
+templates:
+    -   templates/marketplace-pv.yaml
+tests:
+    -   asserts:
+            -   hasDocuments:
+                    count: 0
+        it: Emits no marketplace volume until the volume handle is known
+        set:
+            marketplace.claimName: dxp-operator-marketplace
+            marketplace.csi.driver: efs.csi.aws.com
+            marketplace.enabled: true
+    -   asserts:
+            -   equal:
+                    path: spec.csi.driver
+                    value: efs.csi.aws.com
+            -   equal:
+                    path: spec.csi.volumeHandle
+                    value: fs-0123456789abcdef0::fsap-0123456789abcdef0
+        documentSelector:
+            path: kind
+            skipEmptyTemplates: true
+            value: PersistentVolume
+        it: Mounts the marketplace volume through its access point
+        set:
+            marketplace.claimName: dxp-operator-marketplace
+            marketplace.csi.driver: efs.csi.aws.com
+            marketplace.csi.volumeHandle: fs-0123456789abcdef0::fsap-0123456789abcdef0
+            marketplace.enabled: true

--- a/cloud/helm/gcp-infrastructure-provider/values.yaml
+++ b/cloud/helm/gcp-infrastructure-provider/values.yaml
@@ -37,6 +37,9 @@ liferay-dxp-operator:
         enabled: true
         mountPath: /marketplace
     namespaceOverride: dxp-operator-system
+    podSecurityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
 liferay-subchart-backup-controller:
     enabled: true
     serviceAccountName: backup-controller

--- a/cloud/terraform/aws/gitops/resources/argocd.tf
+++ b/cloud/terraform/aws/gitops/resources/argocd.tf
@@ -272,7 +272,7 @@ resource "kubernetes_manifest" "infrastructure_provider_application" {
 								},
 								{
 									name="liferay-dxp-operator.marketplace.csi.volumeHandle"
-									value=data.aws_efs_file_system.marketplace.file_system_id
+									value=local.marketplace_volume_handle
 								},
 								{
 									name="liferayServiceAccountRoleName"
@@ -384,7 +384,7 @@ resource "kubernetes_manifest" "liferay_applicationset" {
 									parameters=[
 										{
 											name="${local.liferay_helm_chart_config.values_scope_prefix}marketplace.csi.volumeHandle"
-											value=data.aws_efs_file_system.marketplace.file_system_id
+											value=local.marketplace_volume_handle
 										},
 										{
 											name="${local.liferay_helm_chart_config.values_scope_prefix}network.gatewayName"

--- a/cloud/terraform/aws/gitops/resources/efs.tf
+++ b/cloud/terraform/aws/gitops/resources/efs.tf
@@ -1,0 +1,18 @@
+resource "aws_efs_access_point" "marketplace" {
+	file_system_id=data.aws_efs_file_system.marketplace.id
+	posix_user {
+		gid=local.marketplace_posix_id
+		uid=local.marketplace_posix_id
+	}
+	root_directory {
+		creation_info {
+			owner_gid=local.marketplace_posix_id
+			owner_uid=local.marketplace_posix_id
+			permissions="0755"
+		}
+		path="/marketplace"
+	}
+	tags={
+		Name="${var.deployment_name}-marketplace"
+	}
+}

--- a/cloud/terraform/aws/gitops/resources/locals.tf
+++ b/cloud/terraform/aws/gitops/resources/locals.tf
@@ -155,6 +155,8 @@ locals {
 	liferay_namespace_pattern="liferay-*"
 	liferay_service_account_role_arn="arn:aws:iam::${local.account_id}:role/${local.liferay_service_account_role_name}"
 	liferay_service_account_role_name="${var.deployment_name}-irsa"
+	marketplace_posix_id=1000
+	marketplace_volume_handle="${data.aws_efs_file_system.marketplace.id}::${aws_efs_access_point.marketplace.id}"
 	oidc_provider=replace(data.aws_eks_cluster.cluster.identity[0].oidc[0].issuer, "https://", "")
 	rds_exporter_role_arn=var.observability_config.enabled ? "arn:aws:iam::${local.account_id}:role/${var.deployment_name}-rds-exporter" : ""
 	secret_prefixes={

--- a/cloud/terraform/aws/gitops/resources/tests/marketplace.tftest.hcl
+++ b/cloud/terraform/aws/gitops/resources/tests/marketplace.tftest.hcl
@@ -1,0 +1,110 @@
+mock_provider "aws" {
+	mock_data "aws_iam_policy_document" {
+		defaults={
+			json="{\"Statement\": [], \"Version\": \"2012-10-17\"}"
+		}
+	}
+	mock_resource "aws_iam_policy" {
+		defaults={
+			arn="arn:aws:iam::123456789012:policy/mock"
+		}
+	}
+}
+mock_provider "helm" {}
+mock_provider "kubernetes" {}
+override_data {
+	target=data.aws_caller_identity.current
+	values={
+		account_id="123456789012"
+	}
+}
+override_data {
+	target=data.aws_efs_file_system.marketplace
+	values={
+		id="fs-0123456789abcdef0"
+	}
+}
+override_data {
+	target=data.aws_eks_cluster.cluster
+	values={
+		identity=[{
+			oidc=[{
+				issuer="https://oidc.eks.us-east-1.amazonaws.com/id/EXAMPLE"
+			}]
+		}]
+		vpc_config=[{
+			cluster_security_group_id="sg-0123456789abcdef0"
+			endpoint_private_access=true
+			endpoint_public_access=true
+			public_access_cidrs=["0.0.0.0/0"]
+			security_group_ids=[]
+			subnet_ids=["subnet-aaa", "subnet-bbb"]
+			vpc_id="vpc-0123456789abcdef0"
+		}]
+	}
+}
+override_data {
+	target=data.aws_subnets.private
+	values={
+		ids=["subnet-aaa", "subnet-bbb"]
+	}
+}
+override_data {
+	target=data.aws_vpc.current
+	values={
+		cidr_block="10.0.0.0/16"
+	}
+}
+override_resource {
+	override_during=plan
+	target=aws_efs_access_point.marketplace
+	values={
+		id="fsap-0123456789abcdef0"
+	}
+}
+run "should_own_the_marketplace_directory_as_the_liferay_user" {
+	assert {
+		condition=aws_efs_access_point.marketplace.posix_user[0].gid == 1000 && aws_efs_access_point.marketplace.posix_user[0].uid == 1000
+		error_message="The marketplace access point must enforce the Liferay POSIX identity so the operator writes as a known user"
+	}
+	assert {
+		condition=aws_efs_access_point.marketplace.root_directory[0].creation_info[0].owner_gid == 1000 && aws_efs_access_point.marketplace.root_directory[0].creation_info[0].owner_uid == 1000
+		error_message="The marketplace access point must create its root directory owned by the Liferay POSIX identity"
+	}
+	assert {
+		condition=aws_efs_access_point.marketplace.root_directory[0].creation_info[0].permissions == "0755"
+		error_message="The marketplace access point root directory must be writable by its owner and readable by the Liferay pods"
+	}
+	assert {
+		condition=aws_efs_access_point.marketplace.root_directory[0].path == "/marketplace"
+		error_message="The marketplace access point must be rooted at the marketplace directory"
+	}
+	command=plan
+}
+run "should_qualify_the_marketplace_volume_handles_with_the_access_point" {
+	assert {
+		condition=one([
+			for parameter in kubernetes_manifest.infrastructure_provider_application.manifest.spec.sources[0].helm.parameters :
+			parameter.value
+			if parameter.name == "liferay-dxp-operator.marketplace.csi.volumeHandle"
+		]) == "fs-0123456789abcdef0::fsap-0123456789abcdef0"
+		error_message="The operator marketplace volume must be mounted through the access point"
+	}
+	assert {
+		condition=one([
+			for parameter in kubernetes_manifest.liferay_applicationset.manifest.spec.template.spec.sources[0].helm.parameters :
+			parameter.value
+			if parameter.name == "liferay-default.marketplace.csi.volumeHandle"
+		]) == "fs-0123456789abcdef0::fsap-0123456789abcdef0"
+		error_message="The Liferay marketplace volume must be mounted through the same access point as the operator"
+	}
+	command=plan
+}
+variables {
+	deployment_name="liferay-test"
+	infrastructure_helm_chart_version="0.4.9"
+	infrastructure_provider_helm_chart_version="0.3.12"
+	liferay_git_repo_url="https://github.com/example/liferay-gitops.git"
+	liferay_helm_chart_version="0.4.20"
+	region="us-east-1"
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LCD-53280

## What Is Being Fixed

The DXP operator cannot download marketplace add-ons on either cloud. It creates its cache directory with `os.MkdirAll("/marketplace/<namespace>")`, but that path is the root of the shared volume, which is owned by `root` with mode 0755, and the operator runs under `runAsNonRoot: true` with no `runAsUser`. The first statement of the download routine returns `EACCES` and aborts, so no add-on ever reaches the filesystem. Everything downstream of that mkdir is wired correctly and simply never receives a file.

The obvious remedy, adding an `fsGroup` to the operator pod, works on only one of the two clouds, which is why the fix differs per provider.

## How It Is Being Fixed

On AWS the EFS CSI driver declares `fsGroupPolicy: ReadWriteOnceWithFSType`, so it never changes ownership on a ReadWriteMany volume and `fsGroup` is inert there. The Liferay pod already sets `fsGroup: 1000` and its sidecar still sees the root as `0:0`. Instead this adds a single EFS access point rooted at `/marketplace` with `posix_user` and `creation_info` both `1000:1000` and mode 0755, and both consumers now mount through it via `volumeHandle: <fs-id>::<fsap-id>`. Access point identity enforcement squashes every NFS operation to uid 1000, so the operator's container uid stops mattering and no `runAsUser` pinning is needed. One access point is used rather than one per consumer on purpose: two rooted at the same directory with different POSIX identities would deadlock, because whichever side creates the namespace directory first owns it 0755 and the other can no longer write into it. The access point lives in the `gitops/resources` stage because there is no clean terraform expression for discovering an access point id across stages.

On GCP the Filestore driver declares `fsGroupPolicy: File`, which applies `fsGroup` regardless of access mode, so there `fsGroup` is the supported mechanism and no access point equivalent exists. Since the GCP Liferay pod already carries `fsGroup: 1000`, the share's group bits are already correct and the operator merely lacked membership, so this adds `fsGroup: 1000` with `fsGroupChangePolicy: OnRootMismatch` to the operator pod. The change policy is for cost, not correctness: the default `Always` re-walks the 1 TiB share on every operator restart.

Both halves were validated on live clusters. The GCP behaviour was confirmed on a throwaway GKE 1.35 cluster, where the managed driver reports `fsGroupPolicy: File` and, on a root-owned 0755 volume root, a uid-65532 pod without `fsGroup` gets `mkdir: Permission denied` while the same pod with `fsGroup: 1000` sees the root become `drwxrwsr-x 0 1000` and both mkdir and write succeed. Files land 0644 owned `65532:1000` through setgid, and a uid-1000 pod reading them back through a `subPath` read-only mount succeeds, which is the sidecar's path.

## Supersedes

This replaces cloudnative-team/liferay-portal#401, which targeted the `cloudnative-team` fork. That fork's `master` is currently 81 commits behind this one, so a branch rebased onto `brianchandotcom:master` could not produce a reviewable diff there, and the automatic forward out of that fork failed with a merge conflict against LCD-53176. This branch is rebased directly onto `brianchandotcom:master` at `4c1bcf798554`, which resolves that conflict: LCD-53176 removes the `marketplace.enabled` default from `cloud/helm/aws/values.yaml`, so the `marketplace.enabled: true` lines it added to `cloud/helm/aws/tests/marketplace_test.yaml` are retained here and the access point volume handle is layered on top of them.

`ci:test:sf` passed on #401 for the equivalent content (source formatter 1.0.1625).

## PR Check

**pr-check: PASS** — tested on `8270c2c7b560c7ecd5f28657f7cb9365b01bf712`

| Validation | Result |
| --- | --- |
| Source Format | NOT VERIFIED |
| Baseline | NOT VERIFIED |

Source Format verified nothing. `ant setup-sdk` exited nonzero with `build-common.xml:94: lib/development does not exist` — this working copy is a sparse checkout limited to `.claude`, `.github`, and `cloud`, so `lib`, `modules`, `portal-impl`, and `portal-kernel` are not on disk. Per the validation, a failing `setup-sdk` is an environment failure, so the formatter was not run against an unprepared tree. CI's `ci:test:sf` covered this content on #401 instead.

Baseline verified nothing. Its setup, `ant compile install-portal-snapshots`, exited 1 with `BUILD FAILED` at the same missing `lib/development`, so `baseline-all` never ran and the comparison universe is empty. The branch changes no `.java`, no `bnd.bnd`, and no `packageinfo`, and no changed path has a `bnd.bnd`-bearing ancestor, so it exports no API that Baseline could fail on.

No autocommit was made by either validation and the tree is clean, so the tested SHA is the branch head. Chart suites pass locally (aws 4/4, dxp-operator 8/8, gcp-infrastructure-provider 2/2, default 11/11, gcp 2/2) and `terraform test` passes 38/38 in `cloud/terraform/aws/gitops/resources`.

<!-- pr-check {"result": "success", "sha": "8270c2c7b560c7ecd5f28657f7cb9365b01bf712"} -->
