### PR TITLE
LPD-103877 Revert the panel category fold that collides at order 500

### DIFF
--- a/modules/apps/portal-search/portal-search-admin-web/src/main/java/com/liferay/portal/search/admin/web/internal/application/list/SearchPanelCategory.java
+++ b/modules/apps/portal-search/portal-search-admin-web/src/main/java/com/liferay/portal/search/admin/web/internal/application/list/SearchPanelCategory.java
@@ -22,7 +22,7 @@ import org.osgi.service.component.annotations.Reference;
 @Component(
 	property = {
 		"panel.category.key=" + PanelCategoryKeys.APPLICATIONS_MENU_APPLICATIONS,
-		"panel.category.order:Integer=500"
+		"panel.category.order:Integer=550"
 	},
 	service = PanelCategory.class
 )

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/build.gradle
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/build.gradle
@@ -34,6 +34,7 @@ dependencies {
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 	compileOnly project(":core:petra:petra-string")
 	compileOnly project(":dxp:apps:portal-search-tuning:portal-search-tuning-rankings-api")
+	compileOnly project(":dxp:apps:portal-search-tuning:portal-search-tuning-web-api")
 	testImplementation group: "com.fasterxml.jackson.core", name: "jackson-core", version: "2.18.9"
 	testImplementation group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.18.9"
 	testImplementation project(":apps:portal-search:portal-search")

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/application/list/ResultRankingsPanelApp.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/application/list/ResultRankingsPanelApp.java
@@ -13,7 +13,7 @@ import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.search.engine.SearchEngineInformation;
 import com.liferay.portal.search.tuning.rankings.web.internal.constants.ResultRankingsPortletKeys;
-import com.liferay.portal.search.web.application.list.constants.SearchPanelCategoryKeys;
+import com.liferay.portal.search.tuning.web.application.list.constants.SearchTuningPanelCategoryKeys;
 
 import java.util.Objects;
 
@@ -25,8 +25,8 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	property = {
-		"panel.app.order:Integer=300",
-		"panel.category.key=" + SearchPanelCategoryKeys.CONTROL_PANEL_SEARCH
+		"panel.app.order:Integer=150",
+		"panel.category.key=" + SearchTuningPanelCategoryKeys.CONTROL_PANEL_SEARCH_TUNING
 	},
 	service = PanelApp.class
 )

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/build.gradle
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/build.gradle
@@ -19,7 +19,6 @@ dependencies {
 	compileOnly project(":apps:portal-search:portal-search-api")
 	compileOnly project(":apps:portal-search:portal-search-engine-adapter-api")
 	compileOnly project(":apps:portal-search:portal-search-spi")
-	compileOnly project(":apps:portal-search:portal-search-web-api")
 	compileOnly project(":apps:portal:portal-instance-lifecycle-api")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":apps:static:portal:portal-upgrade-api")
@@ -29,6 +28,7 @@ dependencies {
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 	compileOnly project(":core:petra:petra-string")
 	compileOnly project(":dxp:apps:portal-search-tuning:portal-search-tuning-synonyms-api")
+	compileOnly project(":dxp:apps:portal-search-tuning:portal-search-tuning-web-api")
 	testImplementation project(":apps:static:portal-configuration:portal-configuration-persistence-api")
 	testImplementation project(":apps:static:portal-file-install:portal-file-install-api")
 }

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/java/com/liferay/portal/search/tuning/synonyms/web/internal/application/list/SynonymsPanelApp.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/java/com/liferay/portal/search/tuning/synonyms/web/internal/application/list/SynonymsPanelApp.java
@@ -13,7 +13,7 @@ import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.search.engine.SearchEngineInformation;
 import com.liferay.portal.search.tuning.synonyms.web.internal.constants.SynonymsPortletKeys;
-import com.liferay.portal.search.web.application.list.constants.SearchPanelCategoryKeys;
+import com.liferay.portal.search.tuning.web.application.list.constants.SearchTuningPanelCategoryKeys;
 
 import java.util.Objects;
 
@@ -25,8 +25,8 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	property = {
-		"panel.app.order:Integer=200",
-		"panel.category.key=" + SearchPanelCategoryKeys.CONTROL_PANEL_SEARCH
+		"panel.app.order:Integer=100",
+		"panel.category.key=" + SearchTuningPanelCategoryKeys.CONTROL_PANEL_SEARCH_TUNING
 	},
 	service = PanelApp.class
 )

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/blueprint/admin/application/list/SXPBlueprintAdminPanelApp.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/blueprint/admin/application/list/SXPBlueprintAdminPanelApp.java
@@ -12,7 +12,7 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.search.engine.SearchEngineInformation;
-import com.liferay.portal.search.web.application.list.constants.SearchPanelCategoryKeys;
+import com.liferay.search.experiences.constants.SXPPanelCategoryKeys;
 import com.liferay.search.experiences.constants.SXPPortletKeys;
 
 import java.util.Objects;
@@ -27,7 +27,7 @@ import org.osgi.service.component.annotations.Reference;
 	enabled = false,
 	property = {
 		"panel.app.order:Integer=100",
-		"panel.category.key=" + SearchPanelCategoryKeys.CONTROL_PANEL_SEARCH
+		"panel.category.key=" + SXPPanelCategoryKeys.CONTROL_PANEL_SEARCH_EXPERIENCES
 	},
 	service = PanelApp.class
 )

--- a/modules/test/playwright/tests/roles-admin-web/main/roles.spec.ts
+++ b/modules/test/playwright/tests/roles-admin-web/main/roles.spec.ts
@@ -1262,8 +1262,7 @@ test(
 		const menuItems = {
 			'Applications Menu': [
 				'Content',
-				'Developer and Integration',
-				'Search',
+				'Developer & Integration',
 				'Workflow',
 			],
 			'Control Panel': [

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/search/elasticsearch/SearchTuningES8.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/search/elasticsearch/SearchTuningES8.testcase
@@ -710,7 +710,7 @@ definition {
 	@priority = 3
 	test NavigateToResultRankingsViaUI {
 		ApplicationsMenu.gotoPortlet(
-			category = "Search",
+			category = "Search Tuning",
 			panel = "Applications",
 			portlet = "Result Rankings");
 
@@ -720,7 +720,7 @@ definition {
 	@priority = 3
 	test NavigateToSynonymsViaUI {
 		ApplicationsMenu.gotoPortlet(
-			category = "Search",
+			category = "Search Tuning",
 			panel = "Applications",
 			portlet = "Synonyms");
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/search/searchexperiences/Blueprints.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/search/searchexperiences/Blueprints.testcase
@@ -1388,7 +1388,7 @@ definition {
 			userLoginFullName = "userfn userln");
 
 		ApplicationsMenu.gotoPortlet(
-			category = "Search",
+			category = "Search Experiences",
 			panel = "Applications",
 			portlet = "Blueprints");
 
@@ -1458,7 +1458,7 @@ definition {
 			userLoginFullName = "userfn userln");
 
 		ApplicationsMenu.gotoPortlet(
-			category = "Search",
+			category = "Search Experiences",
 			panel = "Applications",
 			portlet = "Blueprints");
 
@@ -4744,7 +4744,7 @@ definition {
 		ApplicationsMenu.openApplicationsMenu();
 
 		ApplicationsMenu.gotoPortlet(
-			category = "Search",
+			category = "Search Experiences",
 			panel = "Applications",
 			portlet = "Blueprints");
 
@@ -4757,7 +4757,7 @@ definition {
 		ApplicationsMenu.openApplicationsMenu();
 
 		ApplicationsMenu.gotoPortlet(
-			category = "Search",
+			category = "Search Experiences",
 			panel = "Applications",
 			portlet = "Blueprints");
 
@@ -4825,7 +4825,7 @@ definition {
 		ApplicationsMenu.openApplicationsMenu();
 
 		ApplicationsMenu.gotoPortlet(
-			category = "Search",
+			category = "Search Experiences",
 			panel = "Applications",
 			portlet = "Blueprints");
 
@@ -4838,7 +4838,7 @@ definition {
 		ApplicationsMenu.openApplicationsMenu();
 
 		ApplicationsMenu.gotoPortlet(
-			category = "Search",
+			category = "Search Experiences",
 			panel = "Applications",
 			portlet = "Blueprints");
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103877

## What Is Being Fixed

Brian's upstream syncing job test-portal-testsuite-upstream(master) build 1377 on test-1-45 (a3a454f, ci:test:stable) fails PortalLogAssertorTest on three axes, because every clean startup now prints this WARN:

```
2026-09-03 18:25:14.849 WARN  [main][PanelCategoryRegistryUtil:68] The panel categories "control_panel.search" and "control_panel.search_tuning" have the same order 500 and category key "applications_menu.applications"
```

Commit 36778cf643907 (LPD-103877) changed SearchPanelCategory's order from 550 to 500, which collides with the untouched DXP SearchTuningPanelCategory (order 500, same parent). PortalLogAssertorTest fails the stable suite on any WARN.

The change reached master through a forwarded PR on which only ci:test:sf ran, so no portal booted before it landed.

## How It Is Being Fixed

Plain `git revert` of the whole LPD-103877 series, newest first:

- 90654b95a763c LPD-103877 Expect Search in the Roles permissions navigation
- a4bf7f73a32c0 LPD-103877 Navigate to the moved applications through Search
- 36778cf643907 LPD-103877 Fold Search Experiences and Search Tuning into Search

The two test commits assert the folded menu, so they cannot stay without the production change. All nine files are byte-identical to their state before 36778cf.

Local proof: two clean boots (fresh database, wiped OSGi state and Elasticsearch data, `ant all`), one on master tip 29547bc64a82a which prints the WARN once at startup, one on this branch which prints no PanelCategoryRegistryUtil line at all and no other new WARN or ERROR.

@gabsprates The review on liferay-platform-experience/liferay-portal#2281 flagged this collision and it was deferred to LPD-100257, which is still open. When re-landing the fold, please give Search an order that does not collide with control_panel.search_tuning (or land it together with LPD-100257), and boot a portal before forwarding so PortalLogAssertorTest stays green.

## PR Check

**pr-check: PASS** — tested on `af370125149fb02816d5ba70a2ee282732adc220`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Service Registration | PASS |
| Transaction Usage | PASS |
| HTML Escaping | PASS |
| Full Portal Build | NOT VERIFIED |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS (baseline-all + seven Ant projects + 0 changed exporting modules) |
| Poshi Syntax | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | NOT VERIFIED |
| JavaScript Unit Tests | NOT VERIFIED |

Full Portal Build verified nothing. Its regex fired only on the two Poshi `.testcase` files under `portal-web/test/functional`, which `ant all` compiles nothing from — Poshi Syntax covers those instead. `ant all` was not run because the bundle attached to this checkout is a live server and the build's deploy target would write into it. Per-Module Compile and Integration Test Compile therefore both ran, exactly as they do when Full Portal Build does not fire, so no compile signal was lost.

Per-Module Compile ran `compileJava --rerun` plus `jar` for each of the four changed modules in place of `deploy`, for the same reason. Every module's compile task executed (no `UP-TO-DATE`, `FROM-CACHE` or `NO-SOURCE`) and both tasks reported `BUILD SUCCESSFUL`. This is the load-bearing check for the revert: it confirms the restored `compileOnly project(":dxp:apps:portal-search-tuning:portal-search-tuning-web-api")` edge and the restored `SearchTuningPanelCategoryKeys` and `SXPPanelCategoryKeys` imports still resolve on today's master, and that the reverted category keys reach the compiled output.

Java Unit Tests verified nothing for two of the four changed classes. `SearchPanelCategory` and `SXPBlueprintAdminPanelApp` have no unit test, and no same-named integration test exists in their sibling `-test` modules either. The two counterparts that do exist both ran clean: `ResultRankingsPanelAppTest` (`tests="2" failures="0" errors="0"`) and `SynonymsPanelAppTest` (`tests="1" failures="0" errors="0"`). No Java test at any layer asserts on `panel.category.key`, `panel.category.order` or `panel.app.order`, since those are `@Component` annotation properties, so the reverted placement is pinned by this branch's Poshi and Playwright changes rather than here.

JavaScript Unit Tests verified nothing. The only JS/TS file in the diff is `modules/test/playwright/tests/roles-admin-web/main/roles.spec.ts`, and its module's `test` script is `playwright test` rather than a Jest suite. Playwright execution is out of scope for pr-check, so no Jest verdict was obtainable for this diff.

<!-- pr-check {"result": "success", "sha": "af370125149fb02816d5ba70a2ee282732adc220"} -->
