### PR TITLE
LPD-104639 Release a deleted object definition's portlet id and tables

### DIFF
--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionLocalService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionLocalService.java
@@ -532,4 +532,4 @@ public interface ObjectDefinitionLocalService
 		throws PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1621170873
+// LIFERAY-SERVICE-BUILDER-HASH:-981507540

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -2449,16 +2449,11 @@ public class ObjectDefinitionLocalServiceImpl
 	private String _getUniqueClassName(
 		String className, boolean modifiable, boolean system) {
 
-		if (_isUnmodifiableSystemObject(modifiable, system)) {
+		if (_isUnmodifiableSystemObject(modifiable, system) ||
+			(Validator.isNotNull(className) &&
+			 _isClassNameAvailable(className))) {
+
 			return className;
-		}
-
-		if (Validator.isNotNull(className)) {
-			int count = _getObjectDefinitionsCountByClassName(className);
-
-			if (count == 0) {
-				return className;
-			}
 		}
 
 		while (true) {
@@ -2470,7 +2465,7 @@ public class ObjectDefinitionLocalServiceImpl
 				StringUtil.toUpperCase(StringUtil.randomId(1)),
 				RandomUtil.nextInt(10));
 
-			if (_getObjectDefinitionsCountByClassName(randomClassName) == 0) {
+			if (_isClassNameAvailable(randomClassName)) {
 				return randomClassName;
 			}
 		}
@@ -2530,6 +2525,21 @@ public class ObjectDefinitionLocalServiceImpl
 			_fragmentEntryLinkCache.removeFragmentEntryLinkCache(
 				GetterUtil.getLong(layoutClassedModelUsage.getContainerKey()));
 		}
+	}
+
+	private boolean _isClassNameAvailable(String className) {
+		if (_getObjectDefinitionsCountByClassName(className) != 0) {
+			return false;
+		}
+
+		Portlet portlet = _portletLocalService.getPortletById(
+			ObjectDefinitionUtil.getPortletId(className));
+
+		if (portlet == null) {
+			return true;
+		}
+
+		return false;
 	}
 
 	private boolean _isUnmodifiableSystemObject(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -731,10 +731,6 @@ public class ObjectDefinitionLocalServiceImpl
 				catch (Exception exception) {
 					throw new PortalException(exception);
 				}
-
-				_dropTable(objectDefinition.getDBTableName());
-				_dropTable(objectDefinition.getExtensionDBTableName());
-				_dropTable(objectDefinition.getLocalizationDBTableName());
 			}
 
 			_undeployObjectDefinition(objectDefinition, approved);
@@ -2716,6 +2712,14 @@ public class ObjectDefinitionLocalServiceImpl
 
 	private void _undeployObjectDefinition(
 		ObjectDefinition objectDefinition, boolean approved) {
+
+		String dbTableName = objectDefinition.getDBTableName();
+
+		if (Validator.isNotNull(dbTableName)) {
+			_dropTable(dbTableName);
+			_dropTable(objectDefinition.getExtensionDBTableName());
+			_dropTable(objectDefinition.getLocalizationDBTableName());
+		}
 
 		if (!approved) {
 			Portlet portlet = _portletLocalService.getPortletById(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -145,6 +145,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.mass.delete.MassDeleteCacheThreadLocal;
 import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
@@ -706,35 +707,37 @@ public class ObjectDefinitionLocalServiceImpl
 		if (objectDefinition.isUnmodifiableSystemObject()) {
 			_dropTable(objectDefinition.getExtensionDBTableName());
 		}
-		else if (objectDefinition.isApproved()) {
-			_assetListEntryLocalService.updateAssetListEntryTypeSettings(
-				objectDefinition.getCompanyId(),
-				_classNameLocalService.getClassNameId(
-					objectDefinition.getClassName()));
+		else {
+			boolean approved = objectDefinition.isApproved();
 
-			_portletLocalService.removePortletModelResources(
-				objectDefinition.getCompanyId(),
-				objectDefinition.getPortletId());
+			if (approved) {
+				_assetListEntryLocalService.updateAssetListEntryTypeSettings(
+					objectDefinition.getCompanyId(),
+					_classNameLocalService.getClassNameId(
+						objectDefinition.getClassName()));
 
-			try (SafeCloseable safeCloseable = CompanyThreadLocal.lock(
-					objectDefinition.getCompanyId())) {
+				_portletLocalService.removePortletModelResources(
+					objectDefinition.getCompanyId(),
+					objectDefinition.getPortletId());
 
-				ObjectDefinitionResourcePermissionUtil.removeResourceActions(
-					_objectActionLocalService, objectDefinition,
-					_objectFieldLocalService, _resourceActions);
+				try (SafeCloseable safeCloseable = CompanyThreadLocal.lock(
+						objectDefinition.getCompanyId())) {
+
+					ObjectDefinitionResourcePermissionUtil.
+						removeResourceActions(
+							_objectActionLocalService, objectDefinition,
+							_objectFieldLocalService, _resourceActions);
+				}
+				catch (Exception exception) {
+					throw new PortalException(exception);
+				}
+
+				_dropTable(objectDefinition.getDBTableName());
+				_dropTable(objectDefinition.getExtensionDBTableName());
+				_dropTable(objectDefinition.getLocalizationDBTableName());
 			}
-			catch (Exception exception) {
-				throw new PortalException(exception);
-			}
 
-			_dropTable(objectDefinition.getDBTableName());
-			_dropTable(objectDefinition.getExtensionDBTableName());
-			_dropTable(objectDefinition.getLocalizationDBTableName());
-
-			undeployObjectDefinition(objectDefinition);
-
-			_registerTransactionCallbackForCluster(
-				_undeployObjectDefinitionMethodKey, objectDefinition);
+			_undeployObjectDefinition(objectDefinition, approved);
 		}
 
 		objectDefinitionPersistence.remove(objectDefinition);
@@ -2709,6 +2712,24 @@ public class ObjectDefinitionLocalServiceImpl
 		objectDefinitionDeployer.undeploy(objectDefinition);
 
 		_unregister(objectDefinition, serviceRegistrationsMap);
+	}
+
+	private void _undeployObjectDefinition(
+		ObjectDefinition objectDefinition, boolean approved) {
+
+		if (!approved) {
+			Portlet portlet = _portletLocalService.getPortletById(
+				objectDefinition.getPortletId());
+
+			if (portlet == null) {
+				return;
+			}
+		}
+
+		undeployObjectDefinition(objectDefinition);
+
+		_registerTransactionCallbackForCluster(
+			_undeployObjectDefinitionMethodKey, objectDefinition);
 	}
 
 	private void _unregister(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
@@ -822,6 +822,66 @@ public class ObjectDefinitionLocalServiceTest {
 	}
 
 	@Test
+	public void testAddCustomObjectDefinitionWithRegisteredPortletId()
+		throws Exception {
+
+		ObjectDefinition objectDefinition1 =
+			ObjectDefinitionTestUtil.publishObjectDefinition();
+
+		String className = objectDefinition1.getClassName();
+
+		String portletId = objectDefinition1.getPortletId();
+
+		com.liferay.portal.kernel.model.Portlet portlet =
+			_portletLocalService.getPortletById(portletId);
+
+		Assert.assertNotNull(portletId, portlet);
+
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			objectDefinition1.getObjectDefinitionId());
+
+		Assert.assertNull(
+			portletId, _portletLocalService.getPortletById(portletId));
+
+		ObjectDefinition objectDefinition2 = null;
+
+		_portletLocalService.deployRemotePortlet(
+			new long[0], portlet, new String[0], false, false);
+
+		try {
+			Assert.assertNotNull(
+				portletId, _portletLocalService.getPortletById(portletId));
+
+			objectDefinition2 = _addCustomObjectDefinition(
+				className, ObjectDefinitionTestUtil.getRandomName());
+
+			Assert.assertNotEquals(className, objectDefinition2.getClassName());
+
+			objectDefinition2 =
+				_objectDefinitionLocalService.publishCustomObjectDefinition(
+					TestPropsValues.getUserId(),
+					objectDefinition2.getObjectDefinitionId());
+
+			String publishedPortletId = objectDefinition2.getPortletId();
+
+			Assert.assertNotNull(
+				publishedPortletId,
+				_portletLocalService.getPortletById(publishedPortletId));
+		}
+		finally {
+			if (objectDefinition2 != null) {
+				_objectDefinitionLocalService.deleteObjectDefinition(
+					objectDefinition2.getObjectDefinitionId());
+			}
+
+			_portletLocalService.destroyPortlet(portlet);
+		}
+
+		Assert.assertNull(
+			portletId, _portletLocalService.getPortletById(portletId));
+	}
+
+	@Test
 	public void testAddObjectDefinition() throws Exception {
 		try (SafeCloseable safeCloseable =
 				LazyReferencingThreadLocal.setEnabledWithSafeCloseable(true)) {

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
@@ -156,6 +156,7 @@ import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.security.permission.ResourceActions;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
@@ -2968,6 +2969,50 @@ public class ObjectDefinitionLocalServiceTest {
 		Assert.assertNull(
 			_objectRelationshipLocalService.fetchObjectRelationship(
 				objectRelationship.getObjectRelationshipId()));
+	}
+
+	@Test
+	public void testDeleteObjectDefinitionWithRolledBackPublish()
+		throws Exception {
+
+		ObjectDefinition objectDefinition = _addCustomObjectDefinition(
+			ObjectDefinitionTestUtil.getRandomName());
+
+		objectDefinition =
+			_objectDefinitionLocalService.publishCustomObjectDefinition(
+				TestPropsValues.getUserId(),
+				objectDefinition.getObjectDefinitionId());
+
+		String portletId = objectDefinition.getPortletId();
+
+		Assert.assertNotNull(
+			portletId, _portletLocalService.getPortletById(portletId));
+
+		objectDefinition.setStatus(WorkflowConstants.STATUS_DRAFT);
+
+		objectDefinition = _objectDefinitionLocalService.updateObjectDefinition(
+			objectDefinition);
+
+		Assert.assertFalse(objectDefinition.isApproved());
+
+		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
+
+		Assert.assertNull(
+			_objectDefinitionLocalService.fetchObjectDefinition(
+				objectDefinition.getObjectDefinitionId()));
+
+		Assert.assertNull(
+			portletId, _portletLocalService.getPortletById(portletId));
+
+		String dbTableName = objectDefinition.getDBTableName();
+
+		Assert.assertFalse(dbTableName, _hasTable(dbTableName));
+
+		String extensionDBTableName =
+			objectDefinition.getExtensionDBTableName();
+
+		Assert.assertFalse(
+			extensionDBTableName, _hasTable(extensionDBTableName));
 	}
 
 	@Test
@@ -5982,6 +6027,9 @@ public class ObjectDefinitionLocalServiceTest {
 
 	@Inject
 	private PLOEntryLocalService _ploEntryLocalService;
+
+	@Inject
+	private PortletLocalService _portletLocalService;
 
 	@Inject
 	private ResourceActionLocalService _resourceActionLocalService;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-104639

## What Is Being Fixed

Integration axes of several `ci:test:object` runs failed `PortalLogAssertorTest` on an ERROR logged by `PortletTracker` while a custom object definition was being published:

```
PortletTracker:160 Portlet id com_liferay_object_web_internal_object_definitions_portlet_ObjectDefinitionsPortlet_<token> is already in use
```

The tracker refuses the portlet, so the definition being published quietly ends up with no portlet, and the ERROR turns the whole axis red. Nine occurrences were collected across `ci:test:object` in fourteen days, and every one of them carried an orphaned portlet map entry whose object definition row no longer existed.

A custom object definition's portlet id is derived from its class name, and the portlet registered for it lives in `PortletLocalServiceImpl`'s JVM-global `_portletsMap`, outside any transaction, as does the OSGi registration behind it. Publishing marks the row approved, creates the dynamic, extension and localization tables and deploys the definition inside one transaction, so a failure after the deploy, for example the deploy of a related definition, reverts the row to draft while the deploy that already happened stays in place. On MySQL, MariaDB, Oracle and Hypersonic every DDL statement commits implicitly, so those three tables survive the rollback as well; on PostgreSQL, SQL Server and DB2 the rollback removes them.

`deleteObjectDefinition` undeployed the portlet and dropped the tables only for an approved row, so deleting the draft that a failed publish left behind removed the row and left both the registration and the tables in place. An orphaned map entry has no row behind it, so nothing ever removes it.

The class name generator then closed the loop. `_getUniqueClassName` probed only the database for its four character token, `[A-Z][0-9][A-Z][0-9]` behind the `com.liferay.object.model.ObjectDefinition#` prefix, which is only 67,600 values. A token whose object definition row is gone but whose portlet is still registered looked free, so a later definition drew it, found the class name available and the portlet id already taken.

Root causes: `14f9cd859313b` (LPS-135650, 2021-07-25) wrapped the undeploy, until then guarded only by `isSystem`, in a status check; `59c611943b482` (LPS-135404, 2021-08-03) added the table drops inside that same approved branch; `099801228f457` (LPD-39729, 2024-10-23) replaced the counter-based class name with the four character random draw probed against the database alone, and `e4e180f5e3a68` (LPD-41065, 2024-11-06) then derived the portlet id from that same token, leaving a second, non-transactional namespace behind a database-only uniqueness check.

## How It Is Being Fixed

Three production commits, one regeneration, then two tests.

`LPD-104639 Undeploy a deleted object definition whenever its portlet is still registered` — deleting a definition that is not approved now looks its portlet up and undeploys whenever it is still registered, which closes the producer. The undeploy is a safe no-op for a definition with no registrations: `deployObjectDefinition` and `deployInactiveObjectDefinition` already call it unconditionally on every deploy, `ObjectDefinitionDeployer.undeploy` defaults to doing nothing, and every teardown step either removes from a map or walks a null-checked registration list. The resource actions, the table drops, and the asset list entry type settings stay under the approved condition because they undo work that only publishing does.

`LPD-104639 buildService` — the undeploy commit adds `import com.liferay.portal.kernel.model.Portlet;` to `ObjectDefinitionLocalServiceImpl`, and Service Builder hashes the implementation's import set along with the interface content, so the trailing `LIFERAY-SERVICE-BUILDER-HASH` marker on the generated `ObjectDefinitionLocalService` moves while the generated interface body itself is unchanged. This commit carries that one regenerated line, so `ant build-services` on the branch tip leaves the tree clean.

`LPD-104639 Drop the tables left behind when a publish rolled back` — the delete now drops the tables whether or not the row is approved. `_dropTable` runs `DROP_TABLE_IF_EXISTS`, so a draft that was never published, which has a table name but no tables, is unaffected, and the drops are skipped for a definition that has no table name at all, the placeholder `getOrAddEmptyObjectDefinition` creates with an empty status, whose extension and localization table names would otherwise degrade to bare suffixes. This also fixes the existing bug on the implicit-DDL-commit databases, where the leftover tables made publishing the same definition again fail on the table that already existed.

`LPD-104639 Skip class names whose portlet id is still registered when generating one` — `_isClassNameAvailable` now requires both that no row holds the class name and that no portlet holds the id derived from it, and both the supplied class name check and the random loop go through it.

`LPD-104639 Cover the delete of an object definition whose publish rolled back` — the test reproduces the rolled-back state directly: it publishes a definition, moves the row back to draft through the service with the registration and the tables left in place, and deletes it through the service with that draft model. It then asserts that the row, the portlet registration and both tables are gone.

`LPD-104639 Cover the class name draw against an orphaned portlet registration` — the fixture needs a class name that no object definition row holds and whose portlet id is nevertheless registered, so the test publishes a definition, keeps its class name and portlet, deletes it through the service, and then puts the portlet back with `deployRemotePortlet`. Passing an empty company id array makes that call a plain write into `PortletLocalServiceImpl`'s map, with no portlet row, no category, and no cache flush, and `destroyPortlet` in the finally block takes the entry out again, which is the same teardown `PortletLocalServiceImpl` and the data guard rule use. Asking for that class name explicitly then proves the draw refuses it, and publishing the definition it did get proves the portlet the definition ends up with is really registered.

Both tests were run as red controls against the master implementation and fail there. The full `ObjectDefinitionLocalServiceTest` is 34/34 green locally, and a self-hosted `ci:test:object` run on the branch tip was 55/55 green.

## PR Check

**pr-check: PASS** — tested on `24fa1a4be6b55cba1ba84682e45fe47be2d17e11`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Service Registration | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | NOT VERIFIED |
| Baseline | PASS (baseline-all + seven Ant projects + 1 changed exporting module) |
| Java Unit Tests | NOT VERIFIED |

Cross-Module Compile verified nothing. The `testIntegration` surface referencing `ObjectDefinitionLocalService` is 59 modules, far past the validation's cap of 8, so per its own rule the expansion is skipped for every symbol rather than run on an arbitrary subset. The `.lfrbuild-portal-deprecated` surface is independently clean (0 modules for all three type names, with a positive control proving the scan could see). The residual risk is bounded by the diff: the only `-api` change is the generated interface's trailing `LIFERAY-SERVICE-BUILDER-HASH` comment, and the branch adds and removes no `public` or `protected` line in `object-api`, so no consumer's compile surface changed.

Java Unit Tests verified nothing. Neither `ObjectDefinitionLocalService` nor `ObjectDefinitionLocalServiceImpl` has a `src/test/java` unit counterpart. The coverage for the change is the integration test this branch extends, `modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java`, which this validation does not run. Both modules' full unit suites were run anyway as an unrelated-break check: 29 tests, 0 failures, 0 errors.

<!-- pr-check {"result": "success", "sha": "24fa1a4be6b55cba1ba84682e45fe47be2d17e11"} -->
