### PR TITLE
LPD-103877 Fold Search Experiences and Search Tuning into Search

### DIFF
--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/build.gradle
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/build.gradle
@@ -34,7 +34,6 @@ dependencies {
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 	compileOnly project(":core:petra:petra-string")
 	compileOnly project(":dxp:apps:portal-search-tuning:portal-search-tuning-rankings-api")
-	compileOnly project(":dxp:apps:portal-search-tuning:portal-search-tuning-web-api")
 	testImplementation group: "com.fasterxml.jackson.core", name: "jackson-core", version: "2.18.9"
 	testImplementation group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.18.9"
 	testImplementation project(":apps:portal-search:portal-search")

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/application/list/ResultRankingsPanelApp.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/application/list/ResultRankingsPanelApp.java
@@ -13,7 +13,7 @@ import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.search.engine.SearchEngineInformation;
 import com.liferay.portal.search.tuning.rankings.web.internal.constants.ResultRankingsPortletKeys;
-import com.liferay.portal.search.tuning.web.application.list.constants.SearchTuningPanelCategoryKeys;
+import com.liferay.portal.search.web.application.list.constants.SearchPanelCategoryKeys;
 
 import java.util.Objects;
 
@@ -25,8 +25,8 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	property = {
-		"panel.app.order:Integer=150",
-		"panel.category.key=" + SearchTuningPanelCategoryKeys.CONTROL_PANEL_SEARCH_TUNING
+		"panel.app.order:Integer=300",
+		"panel.category.key=" + SearchPanelCategoryKeys.CONTROL_PANEL_SEARCH
 	},
 	service = PanelApp.class
 )

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/build.gradle
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/build.gradle
@@ -19,6 +19,7 @@ dependencies {
 	compileOnly project(":apps:portal-search:portal-search-api")
 	compileOnly project(":apps:portal-search:portal-search-engine-adapter-api")
 	compileOnly project(":apps:portal-search:portal-search-spi")
+	compileOnly project(":apps:portal-search:portal-search-web-api")
 	compileOnly project(":apps:portal:portal-instance-lifecycle-api")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":apps:static:portal:portal-upgrade-api")
@@ -28,7 +29,6 @@ dependencies {
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 	compileOnly project(":core:petra:petra-string")
 	compileOnly project(":dxp:apps:portal-search-tuning:portal-search-tuning-synonyms-api")
-	compileOnly project(":dxp:apps:portal-search-tuning:portal-search-tuning-web-api")
 	testImplementation project(":apps:static:portal-configuration:portal-configuration-persistence-api")
 	testImplementation project(":apps:static:portal-file-install:portal-file-install-api")
 }

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/java/com/liferay/portal/search/tuning/synonyms/web/internal/application/list/SynonymsPanelApp.java
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-synonyms-web/src/main/java/com/liferay/portal/search/tuning/synonyms/web/internal/application/list/SynonymsPanelApp.java
@@ -13,7 +13,7 @@ import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.search.engine.SearchEngineInformation;
 import com.liferay.portal.search.tuning.synonyms.web.internal.constants.SynonymsPortletKeys;
-import com.liferay.portal.search.tuning.web.application.list.constants.SearchTuningPanelCategoryKeys;
+import com.liferay.portal.search.web.application.list.constants.SearchPanelCategoryKeys;
 
 import java.util.Objects;
 
@@ -25,8 +25,8 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	property = {
-		"panel.app.order:Integer=100",
-		"panel.category.key=" + SearchTuningPanelCategoryKeys.CONTROL_PANEL_SEARCH_TUNING
+		"panel.app.order:Integer=200",
+		"panel.category.key=" + SearchPanelCategoryKeys.CONTROL_PANEL_SEARCH
 	},
 	service = PanelApp.class
 )

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/blueprint/admin/application/list/SXPBlueprintAdminPanelApp.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/blueprint/admin/application/list/SXPBlueprintAdminPanelApp.java
@@ -12,7 +12,7 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.search.engine.SearchEngineInformation;
-import com.liferay.search.experiences.constants.SXPPanelCategoryKeys;
+import com.liferay.portal.search.web.application.list.constants.SearchPanelCategoryKeys;
 import com.liferay.search.experiences.constants.SXPPortletKeys;
 
 import java.util.Objects;
@@ -27,7 +27,7 @@ import org.osgi.service.component.annotations.Reference;
 	enabled = false,
 	property = {
 		"panel.app.order:Integer=100",
-		"panel.category.key=" + SXPPanelCategoryKeys.CONTROL_PANEL_SEARCH_EXPERIENCES
+		"panel.category.key=" + SearchPanelCategoryKeys.CONTROL_PANEL_SEARCH
 	},
 	service = PanelApp.class
 )

--- a/modules/test/playwright/tests/roles-admin-web/main/roles.spec.ts
+++ b/modules/test/playwright/tests/roles-admin-web/main/roles.spec.ts
@@ -1262,7 +1262,8 @@ test(
 		const menuItems = {
 			'Applications Menu': [
 				'Content',
-				'Developer & Integration',
+				'Developer and Integration',
+				'Search',
 				'Workflow',
 			],
 			'Control Panel': [

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/search/elasticsearch/SearchTuningES8.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/search/elasticsearch/SearchTuningES8.testcase
@@ -710,7 +710,7 @@ definition {
 	@priority = 3
 	test NavigateToResultRankingsViaUI {
 		ApplicationsMenu.gotoPortlet(
-			category = "Search Tuning",
+			category = "Search",
 			panel = "Applications",
 			portlet = "Result Rankings");
 
@@ -720,7 +720,7 @@ definition {
 	@priority = 3
 	test NavigateToSynonymsViaUI {
 		ApplicationsMenu.gotoPortlet(
-			category = "Search Tuning",
+			category = "Search",
 			panel = "Applications",
 			portlet = "Synonyms");
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/search/searchexperiences/Blueprints.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/search/searchexperiences/Blueprints.testcase
@@ -1388,7 +1388,7 @@ definition {
 			userLoginFullName = "userfn userln");
 
 		ApplicationsMenu.gotoPortlet(
-			category = "Search Experiences",
+			category = "Search",
 			panel = "Applications",
 			portlet = "Blueprints");
 
@@ -1458,7 +1458,7 @@ definition {
 			userLoginFullName = "userfn userln");
 
 		ApplicationsMenu.gotoPortlet(
-			category = "Search Experiences",
+			category = "Search",
 			panel = "Applications",
 			portlet = "Blueprints");
 
@@ -4744,7 +4744,7 @@ definition {
 		ApplicationsMenu.openApplicationsMenu();
 
 		ApplicationsMenu.gotoPortlet(
-			category = "Search Experiences",
+			category = "Search",
 			panel = "Applications",
 			portlet = "Blueprints");
 
@@ -4757,7 +4757,7 @@ definition {
 		ApplicationsMenu.openApplicationsMenu();
 
 		ApplicationsMenu.gotoPortlet(
-			category = "Search Experiences",
+			category = "Search",
 			panel = "Applications",
 			portlet = "Blueprints");
 
@@ -4825,7 +4825,7 @@ definition {
 		ApplicationsMenu.openApplicationsMenu();
 
 		ApplicationsMenu.gotoPortlet(
-			category = "Search Experiences",
+			category = "Search",
 			panel = "Applications",
 			portlet = "Blueprints");
 
@@ -4838,7 +4838,7 @@ definition {
 		ApplicationsMenu.openApplicationsMenu();
 
 		ApplicationsMenu.gotoPortlet(
-			category = "Search Experiences",
+			category = "Search",
 			panel = "Applications",
 			portlet = "Blueprints");
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103877

This re-lands #181270, which #181305 reverted.

## What Is Being Fixed

The Applications Panel had accumulated a group per feature area, so most groups held a single application. Search Experiences and Search Tuning were two of them: each wrapped its applications in a group that named nothing Search did not already name, leaving Blueprints, Synonyms and Result Rankings a level deeper than they needed to be. LPD-98002 defines the target structure, and this subtask covers the two groups whose destination is Search.

## How It Is Being Fixed

Blueprints, Synonyms and Result Rankings now register under `control_panel.search` through `SearchPanelCategoryKeys.CONTROL_PANEL_SEARCH`, with `panel.app.order` 100, 200 and 300. The Search group held nothing before this, so it starts rendering only now.

Both tuning modules drop `portal-search-tuning-web-api`, which they used only for the old key, and `portal-search-tuning-synonyms-web` adds `portal-search-web-api`.

Nothing is removed. A group with nothing in it stops rendering on its own, so the superseded categories, their key constants, their language keys and the `portal-search-tuning-web` modules all stay. LPD-100257 handles their removal. No module here exports a package, so there is no breaking change and no semantic versioning bump.

## What Changed Since #181270

`SearchPanelCategory` keeps `panel.category.order` 550 instead of moving to 500. That move is what #181305 reverted for: 500 is where the untouched DXP `SearchTuningPanelCategory` sits under the same parent, and the collision made every startup print a WARN that `PortalLogAssertorTest` fails on.

Keeping 550 costs nothing the move was after. Search Experiences (450) and Search Tuning (500) both stop rendering once empty, so Search renders between Workflow (400) and Communication (600) either way. `SearchPanelCategory.java` is untouched by this branch — the diff is the reverted one minus that single line.

## Why Are There No Tests?

The change re-registers existing applications under a different panel category and introduces no new behavior to test. The second commit updates the eight `ApplicationsMenu.gotoPortlet` call sites that reach these three applications to name `category = "Search"`, so each fails if its application is not where this change puts it. The third updates `roles.spec.ts`, which enumerates the Applications Menu groups a role can be given permissions over and now lists Search.

The regression that caused the revert is covered by `PortalLogAssertorTest`, which is what caught it.

## PR Check

**pr-check: PASS** — tested on `e7686d2066ca499673771d4caacb30ca5eb6bbbb`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Service Registration | PASS |
| Transaction Usage | PASS |
| HTML Escaping | PASS |
| Full Portal Build | NOT VERIFIED |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS (baseline-all + seven Ant projects + 0 changed exporting modules) |
| Poshi Syntax | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |
| JavaScript Unit Tests | NOT VERIFIED |

Full Portal Build was trimmed. It fires only on the two `.testcase` files, which `ant all` compiles nothing from, and Poshi Syntax covers those directly. Per-Module Compile and Integration Test Compile both ran in its place.

JavaScript Unit Tests verified nothing. The only JS/TS file is `roles.spec.ts`, whose module's `test` script is `playwright test` rather than a Jest suite, and Playwright execution is out of scope for pr-check.

Java Unit Tests exercised two of the three changed classes. `SXPBlueprintAdminPanelApp` has no unit or integration test anywhere in the repository.

Poshi Syntax ran with `test.poshi.script.validation=false`, so it covered the two `.testcase` files at the resource level only.

<!-- pr-check {"result": "success", "sha": "e7686d2066ca499673771d4caacb30ca5eb6bbbb"} -->
