### PR TITLE
LPD-102355 Retract breaking change declaration for get_file commit

### DIFF
--- a/readme/BREAKING_CHANGES_AMENDMENTS.md
+++ b/readme/BREAKING_CHANGES_AMENDMENTS.md
@@ -797,3 +797,13 @@ The name field was populated with the fieldReference rather than the field's nam
 
 Consumers that relied on the name field to obtain the fieldReference should read the fieldReference field of ContentField instead.
 ```
+
+----
+
+# 7cd5fb381b90d943eb24da5c9d5683791394cc20
+
+This commit should not be reported as a breaking change. The correct message is:
+
+```
+LPD-102355 Enforce DOWNLOAD permission on /c/document_library/get_file
+```


### PR DESCRIPTION
The declaration describes how a user with only VIEW permission could retrieve the original file through /c/document_library/get_file. Publishing it in the breaking changes report would hand attackers reproduction steps against unpatched installations, so the commit is reported by its title alone.