### PR TITLE
LPD-104725 Fix stale upgrade process class name in changeset test

### DIFF
--- a/modules/apps/changeset/changeset-test/src/testIntegration/java/com/liferay/changeset/internal/upgrade/v3_0_0/test/ChangesetEntryIndexedColumnSizeUpgradeProcessTest.java
+++ b/modules/apps/changeset/changeset-test/src/testIntegration/java/com/liferay/changeset/internal/upgrade/v3_0_0/test/ChangesetEntryIndexedColumnSizeUpgradeProcessTest.java
@@ -61,7 +61,7 @@ public class ChangesetEntryIndexedColumnSizeUpgradeProcessTest
 
 	@Override
 	protected String getUpgradeProcessClassName() {
-		return "com.liferay.changeset.internal.upgrade.v2_2_0." +
+		return "com.liferay.changeset.internal.upgrade.v3_0_0." +
 			"ChangesetEntryIndexedColumnSizeUpgradeProcess";
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-104725

## What Is Being Fixed

`ChangesetEntryIndexedColumnSizeUpgradeProcessTest` was failing both `testUpgrade` and `testUpgradeWithDuplicateUniqueIndexEntries` in CI (Testray case result 519511455) with `ArrayIndexOutOfBoundsException: Index 0 out of bounds for length 0` in `UpgradeTestUtil.getUpgradeStep`. Commit 03ac804 ("LPD-89588 Document major bump") renamed the ChangesetEntryIndexedColumnSizeUpgradeProcess package from v2_2_0 to v3_0_0 across the registrator, the production class, and this test's own package declaration, but left getUpgradeProcessClassName() still returning the old v2_2_0 package name. UpgradeTestUtil.getUpgradeStep() looks up the registered upgrade step by matching that string against every step the registrator returns, found no match, and threw the exception before either test could exercise anything.

## How It Is Being Fixed

getUpgradeProcessClassName() now returns the current v3_0_0 package, matching the sibling tests touched by the same commit (ObjectEntryIndexedColumnSizeUpgradeProcessTest, OAuth2ApplicationIndexedColumnSizeUpgradeProcessTest), which already reference their post-rename package correctly. Both tests pass locally after the change.

## Why Are There No Tests?

This is a test-fix PR: the failing test itself was the bug (a stale class-name string left over from an incomplete rename), and correcting the reference is the entire fix. No new test coverage is needed since the existing test now correctly exercises the upgrade process it was always meant to cover.

## PR Check

**pr-check: PASS** — tested on `4a23260aa0e76d9d1adbac4bec7787185ca11983`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Service Registration | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | NOT VERIFIED |
| Integration Test Compile | PASS |
| Baseline | NOT VERIFIED |
| Java Unit Tests | NOT VERIFIED |

Per-Module Compile verified nothing — the diff's only change is under `src/testIntegration` in a `-test` module, which the deploy set excludes by design (`deploy` never compiles `testIntegration` sources); Integration Test Compile covers it instead. Baseline verified nothing — `changeset-test`'s `bnd.bnd` carries no `Export-Package`, so the diff touches no exported API for this branch to baseline. Java Unit Tests verified nothing — the changed file is exclusively under `src/testIntegration`, out of scope per its own Trigger (unit tests don't cover IT sources; Integration Test Compile catches signature breaks there).

<!-- pr-check {"result": "success", "sha": "4a23260aa0e76d9d1adbac4bec7787185ca11983"} -->
