### PR TITLE
LPD-104734 Finish the definitions listing before searching for a definition

### DIFF
--- a/modules/test/playwright/pages/object-web/ViewObjectDefinitionsPage.ts
+++ b/modules/test/playwright/pages/object-web/ViewObjectDefinitionsPage.ts
@@ -4,13 +4,14 @@
  */
 
 import {ObjectFolder} from '@liferay/object-admin-rest-client-js';
-import {Locator, Page, Response, expect} from '@playwright/test';
+import {Locator, Page, Request, Response, expect} from '@playwright/test';
 import {readFile} from 'fs/promises';
 import path from 'path';
 
 import {gotoWithRetry} from '../../utils/gotoWithRetry';
 import {PORTLET_URLS} from '../../utils/portletUrls';
 import {getTempDir} from '../../utils/temp';
+import {waitForFDS} from '../../utils/waitFor';
 import {waitForSearchToBeReady} from '../../utils/waitForSearchToBeReady';
 
 export class ViewObjectDefinitionsPage {
@@ -138,7 +139,7 @@ export class ViewObjectDefinitionsPage {
 
 		await waitForSearchToBeReady(this.page);
 
-		await this.page.keyboard.press('Enter');
+		await this._submitSearch(objectDefinitionLabel);
 
 		await this.page
 			.getByRole('link', {exact: true, name: objectDefinitionLabel})
@@ -203,7 +204,7 @@ export class ViewObjectDefinitionsPage {
 
 		await waitForSearchToBeReady(this.page);
 
-		await this.page.keyboard.press('Enter');
+		await this._submitSearch(objectDefinitionLabel);
 
 		const downloadPromise = this.page.waitForEvent('download');
 
@@ -303,5 +304,37 @@ export class ViewObjectDefinitionsPage {
 			.getByRole('listitem')
 			.filter({hasText: objectFolderLabel})
 			.click({timeout: options?.timeout});
+	}
+
+	private async _submitSearch(objectDefinitionLabel: string) {
+		await waitForFDS({page: this.page});
+
+		const searchRequestSettled = new Promise<void>((resolve) => {
+			const settle = (request: Request) => {
+				const url = new URL(request.url());
+
+				if (
+					request.method() !== 'GET' ||
+					!url.pathname.endsWith(
+						'/o/object-admin/v1.0/object-definitions'
+					) ||
+					url.searchParams.get('search') !== objectDefinitionLabel
+				) {
+					return;
+				}
+
+				this.page.off('requestfailed', settle);
+				this.page.off('requestfinished', settle);
+
+				resolve();
+			};
+
+			this.page.on('requestfailed', settle);
+			this.page.on('requestfinished', settle);
+		});
+
+		await this.page.keyboard.press('Enter');
+
+		await searchRequestSettled;
 	}
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-104734

## What Is Being Fixed

Both shared helpers in the Playwright page object `ViewObjectDefinitionsPage` fill the management bar search, wait only for the search to be submittable, press Enter and act at once. The data set that lists the object definitions issues its own listing request when it mounts, and pressing Enter makes it start the filtered request and cancel the listing request that is still in flight. On a portal that has not finished writing that listing, the cancel closes the connection under the response, and the portal logs an `ExceptionMapper` broken pipe error thrown from `BaseMessageBodyWriter.writeTo` underneath `AbstractHTTPServlet.doGet`, together with the collateral `TransactionContainerRequestFilter` report that it was unable to roll back the transaction.

The upgrade batches run against a freshly restarted portal, whose first responses are slow enough for the cancel to land mid-write, and the log assertor is armed on those batches, so that single logged error turns the whole axis red although every test on it passes.

The failure appeared on three consecutive bare-master `ci:test:object` runs on 2026-09-03 and 2026-09-04, always on the Playwright upgrade batch, always on the test "Can view and edit object definition after upgrade", the second test of `object-web/upgrade/objectUpgrade.spec.ts`, running against a portal 15 to 36 seconds past its first request. The error was logged 75 to 223 milliseconds after Enter every time, with identical stacks.

Locally, over a throttled connection, the unguarded helper cancelled the in-flight listing in 10 runs out of 10, visible in the browser as the listing request failing with `ERR_ABORTED` a few milliseconds after Enter, while the guarded helper cancelled nothing in 4 runs out of 4. On a cold portal the same cancel produced the logged broken pipe error.

## How It Is Being Fixed

Both helpers now take two waits.

First, they wait for the data set to have rendered its listing before pressing Enter. That means the listing response has been read to its end, so there is nothing left in flight for Enter to cancel. Waiting on the filtered request alone does not help, because the cancel happens at the moment Enter is pressed.

Second, they wait for the filtered request that Enter starts to settle before touching the page, so the click cannot navigate away from a response that is still being written either.

Fixing `clickEditObjectDefinitionLink` covers all of its call sites, `EditObjectDetailsPage.goto` included. This is test-side only; no production code changes.

## PR Check

**pr-check: PASS** — tested on `a62a781e0534e94a49e482a729de7255ca23ce6a`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| HTML Escaping | PASS |
| Per-Module Compile | NOT VERIFIED |
| Baseline | PASS (baseline-all + seven Ant projects + 0 changed exporting modules) |
| JavaScript Unit Tests | NOT VERIFIED |

Per-Module Compile verified nothing. The only changed path, `modules/test/playwright/pages/object-web/ViewObjectDefinitionsPage.ts`, has no ancestor holding a `bnd.bnd`, carries no `.lfrbuild-*` marker, and `modules/test/playwright` has its own `settings.gradle` and no `deploy` task, so it is not an OSGi bundle in the `modules` project graph and the deploy set is empty. The diff touches no `package.json`, so the lockfile check had nothing to compare. Compilation of the changed file was instead covered by the TypeScript project check, which Source Format runs (`Checking 1 TypeScript projects`, `SUCCESS: Everything is correctly formatted`) and which `npx tsc --noEmit -p .` in `modules/test/playwright` confirms independently, exiting 0 with no diagnostics.

JavaScript Unit Tests verified nothing. The module resolves to `modules/test/playwright`, whose `test` script is `playwright test` rather than a Jest suite, and Playwright tests are out of scope for pr-check. No other module declares `@liferay/playwright` in its dependencies, so the cross-module consumer snapshot sweep selected nothing, and the diff adds no third-party dependency, so the stale stub list sweep does not apply.

<!-- pr-check {"result": "success", "sha": "a62a781e0534e94a49e482a729de7255ca23ce6a"} -->
