### PR TITLE
LPD-104744 Skip the object definition reindex when a folder PUT does not move it

### DIFF
--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectFolderResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectFolderResourceImpl.java
@@ -292,9 +292,13 @@ public class ObjectFolderResourceImpl extends BaseObjectFolderResourceImpl {
 				continue;
 			}
 
-			_objectDefinitionLocalService.updateObjectFolderId(
-				serviceBuilderObjectDefinition.getObjectDefinitionId(),
-				objectFolderId);
+			if (serviceBuilderObjectDefinition.isLinkedToObjectFolder(
+					objectFolderId)) {
+
+				_objectDefinitionLocalService.updateObjectFolderId(
+					serviceBuilderObjectDefinition.getObjectDefinitionId(),
+					objectFolderId);
+			}
 
 			_objectFolderItemLocalService.updateObjectFolderItem(
 				serviceBuilderObjectDefinition.getObjectDefinitionId(),

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectFolderPutReindexTest.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectFolderPutReindexTest.java
@@ -1,0 +1,260 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.admin.rest.resource.v1_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.object.admin.rest.dto.v1_0.ObjectFolder;
+import com.liferay.object.admin.rest.dto.v1_0.ObjectFolderItem;
+import com.liferay.object.admin.rest.resource.v1_0.ObjectFolderResource;
+import com.liferay.object.admin.rest.resource.v1_0.test.util.ObjectDefinitionTestUtil;
+import com.liferay.object.constants.ObjectFolderConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectFolderLocalService;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.Hits;
+import com.liferay.portal.kernel.search.IndexWriterHelper;
+import com.liferay.portal.kernel.search.Indexer;
+import com.liferay.portal.kernel.search.IndexerRegistryUtil;
+import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Shuyang Zhou
+ */
+@RunWith(Arquillian.class)
+public class ObjectFolderPutReindexTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_indexer = IndexerRegistryUtil.nullSafeGetIndexer(
+			ObjectDefinition.class);
+
+		ObjectFolderResource.Builder builder =
+			_objectFolderResourceFactory.create();
+
+		_objectFolderResource = builder.user(
+			TestPropsValues.getUser()
+		).build();
+
+		_objectDefinition =
+			ObjectDefinitionTestUtil.addCustomObjectDefinition();
+
+		_indexWriterHelper.commit(_objectDefinition.getCompanyId());
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.fetchObjectDefinition(
+				_objectDefinition.getObjectDefinitionId());
+
+		if (objectDefinition != null) {
+			_objectDefinitionLocalService.deleteObjectDefinition(
+				objectDefinition);
+		}
+
+		if (_objectFolderId != 0) {
+			_objectFolderLocalService.deleteObjectFolder(_objectFolderId);
+		}
+	}
+
+	@Test
+	public void testPutObjectFolderReindexesMovedObjectDefinition()
+		throws Exception {
+
+		_deleteObjectDefinitionDocument();
+
+		ObjectFolder objectFolder = _objectFolderResource.postObjectFolder(
+			new ObjectFolder() {
+				{
+					setExternalReferenceCode(RandomTestUtil.randomString());
+					setLabel(
+						Collections.singletonMap(
+							"en_US", RandomTestUtil.randomString()));
+					setName(
+						StringUtil.toLowerCase(RandomTestUtil.randomString()));
+					setObjectFolderItems(new ObjectFolderItem[0]);
+				}
+			});
+
+		_objectFolderId = objectFolder.getId();
+
+		objectFolder.setObjectFolderItems(
+			new ObjectFolderItem[] {
+				_toObjectFolderItem(
+					false, _objectDefinition.getExternalReferenceCode(), 0, 0)
+			});
+
+		_objectFolderResource.putObjectFolderByExternalReferenceCode(
+			objectFolder.getExternalReferenceCode(), objectFolder);
+
+		_indexWriterHelper.commit(_objectDefinition.getCompanyId());
+
+		List<Long> objectDefinitionIds = _getIndexedObjectDefinitionIds();
+
+		Assert.assertTrue(
+			_getMessage(objectDefinitionIds),
+			objectDefinitionIds.contains(
+				_objectDefinition.getObjectDefinitionId()));
+	}
+
+	@Test
+	public void testPutObjectFolderSkipsUnmovedObjectDefinition()
+		throws Exception {
+
+		_deleteObjectDefinitionDocument();
+
+		ObjectFolder objectFolder =
+			_objectFolderResource.getObjectFolderByExternalReferenceCode(
+				ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_DEFAULT);
+
+		ObjectFolderItem[] objectFolderItems =
+			objectFolder.getObjectFolderItems();
+
+		ObjectFolderItem[] newObjectFolderItems =
+			new ObjectFolderItem[objectFolderItems.length];
+
+		for (int i = 0; i < objectFolderItems.length; i++) {
+			ObjectFolderItem objectFolderItem = objectFolderItems[i];
+
+			newObjectFolderItems[i] = _toObjectFolderItem(
+				objectFolderItem.getLinkedObjectDefinition(),
+				objectFolderItem.getObjectDefinitionExternalReferenceCode(),
+				objectFolderItem.getPositionX(),
+				objectFolderItem.getPositionY());
+		}
+
+		objectFolder.setObjectFolderItems(newObjectFolderItems);
+
+		_objectFolderResource.putObjectFolderByExternalReferenceCode(
+			ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_DEFAULT,
+			objectFolder);
+
+		_indexWriterHelper.commit(_objectDefinition.getCompanyId());
+
+		List<Long> objectDefinitionIds = _getIndexedObjectDefinitionIds();
+
+		Assert.assertFalse(
+			_getMessage(objectDefinitionIds),
+			objectDefinitionIds.contains(
+				_objectDefinition.getObjectDefinitionId()));
+	}
+
+	private void _deleteObjectDefinitionDocument() throws Exception {
+		List<Long> objectDefinitionIds = _getIndexedObjectDefinitionIds();
+
+		Assert.assertTrue(
+			_getMessage(objectDefinitionIds),
+			objectDefinitionIds.contains(
+				_objectDefinition.getObjectDefinitionId()));
+
+		_indexer.delete(_objectDefinition);
+
+		_indexWriterHelper.commit(_objectDefinition.getCompanyId());
+
+		objectDefinitionIds = _getIndexedObjectDefinitionIds();
+
+		Assert.assertFalse(
+			_getMessage(objectDefinitionIds),
+			objectDefinitionIds.contains(
+				_objectDefinition.getObjectDefinitionId()));
+	}
+
+	private List<Long> _getIndexedObjectDefinitionIds() throws Exception {
+		SearchContext searchContext = new SearchContext();
+
+		searchContext.setAttribute(
+			Field.NAME, _objectDefinition.getShortName());
+		searchContext.setCompanyId(_objectDefinition.getCompanyId());
+		searchContext.setEntryClassNames(
+			new String[] {ObjectDefinition.class.getName()});
+		searchContext.setKeywords(_objectDefinition.getShortName());
+
+		Hits hits = _indexer.search(searchContext);
+
+		List<Long> objectDefinitionIds = new ArrayList<>();
+
+		for (Document document : hits.getDocs()) {
+			objectDefinitionIds.add(
+				GetterUtil.getLong(document.get(Field.ENTRY_CLASS_PK)));
+		}
+
+		return objectDefinitionIds;
+	}
+
+	private String _getMessage(List<Long> objectDefinitionIds) {
+		return StringBundler.concat(
+			"Object definition ", _objectDefinition.getObjectDefinitionId(),
+			" named ", _objectDefinition.getShortName(),
+			" against the indexed object definition IDs ", objectDefinitionIds);
+	}
+
+	private ObjectFolderItem _toObjectFolderItem(
+		Boolean linkedObjectDefinition,
+		String objectDefinitionExternalReferenceCode, Integer positionX,
+		Integer positionY) {
+
+		ObjectFolderItem objectFolderItem = new ObjectFolderItem();
+
+		objectFolderItem.setLinkedObjectDefinition(linkedObjectDefinition);
+		objectFolderItem.setObjectDefinitionExternalReferenceCode(
+			objectDefinitionExternalReferenceCode);
+		objectFolderItem.setPositionX(positionX);
+		objectFolderItem.setPositionY(positionY);
+
+		return objectFolderItem;
+	}
+
+	private Indexer<ObjectDefinition> _indexer;
+
+	@Inject
+	private IndexWriterHelper _indexWriterHelper;
+
+	private ObjectDefinition _objectDefinition;
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	private long _objectFolderId;
+
+	@Inject
+	private ObjectFolderLocalService _objectFolderLocalService;
+
+	private ObjectFolderResource _objectFolderResource;
+
+	@Inject
+	private ObjectFolderResource.Factory _objectFolderResourceFactory;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-104744

## What Is Being Fixed

`ObjectFolderResourceImpl` called `ObjectDefinitionLocalService.updateObjectFolderId` for every unlinked item of an object folder PUT, including the items whose object definition already sat in that folder. The Model Builder page writes its folder back on every load: an effect keyed on the folder's item count sends the whole folder, every item included, so that the positions the structure load computes for nodes that have none yet are persisted, and it does so whether or not any position changed. One page load therefore fanned the call out over every object definition of the folder while moving none of them.

`updateObjectFolderId` is annotated `@Indexable(type = IndexableType.REINDEX)`, and the annotation buffers a reindex of the returned model even when the method returns early without writing to the database. The buffered reindex runs at the request commit as a fetch by id followed by an unversioned, last writer wins document write, so the fan-out is worse than wasted work. When one of those reindexes overlaps a concurrent delete of the same object definition, its fetch can still see the row while its document write lands after the delete has already removed the document, and the index is left holding a document for a row that is gone. Indexing commits immediately, so this write ordering is the only source of such a document, and the index backed object definitions page answers 404 for that object definition for as long as the document survives.

The companion fix LPD-104737 (https://github.com/brianchandotcom/liferay-portal/pull/181362) removes the PUT itself on loads whose nodes are all placed. This change removes the reindex fan-out on the PUTs that remain: a drag, an add, a folder move, and the first load of a never placed node.

Root cause: b5523880e2270 (LPS-201520, 2023-11-21) introduced the loop that calls `updateObjectFolderId` for every object folder item of a PUT, a403f18cfc21d (LPS-191513, 2023-07-24) created `updateObjectFolderId` as `@Indexable`, and b7a093679964b (LPD-89355, 2026-05-08) made the unchanged folder case a database no-op while the buffered reindex kept firing.

## How It Is Being Fixed

`updateObjectFolderId` is now called only for an object definition that sits in a different folder, guarded by `isLinkedToObjectFolder(objectFolderId)`. The object folder item positions are still updated for every item, so a PUT that only reorders keeps working exactly as before.

`ObjectFolderPutReindexTest` covers both directions with two methods. The first deletes only the search document of a freshly added object definition, leaving the row in place, then replays the object folder PUT that the Model Builder page sends on every structure load, and requires the document to stay gone: a PUT that moves nothing must write nothing to the index. Deleting the document by hand is what makes the fan-out observable, since the buffered reindex of an unmoved object definition writes the same document it would have written anyway. The second moves the same object definition into a new object folder with the same kind of PUT and requires the document to come back, so the reindex that a real move needs is still covered.

The test is red on master (`Object definition ... against the indexed object definition IDs [...]`) and 2/2 green with the change. `ObjectFolderResourceTest` stays 22/22, and `ci:test:object` ran 55/55 on this tree.

## PR Check

**pr-check: PASS** — tested on `66e5532486d99b44225004f1640924aa235ac6fe`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Service Registration | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS (baseline-all + seven Ant projects + 0 changed exporting modules) |
| Java Unit Tests | NOT VERIFIED |

Source Format ran clean on both changed files, with no `SourceCheck:` violation and no `ERROR: Dependency`. The yarn half never ran, since the diff holds no frontend file, so its empty search is a skip rather than a pass.

Per-Module Compile built `apps:object:object-admin-rest-impl` (`compileJava` and `jar` both executed, `BUILD SUCCESSFUL`). `apps:object:object-admin-rest-test` is out of the deploy set because its only change is under `src/testIntegration`. Nothing expanded by consumers: the diff removes and changes no `public` or `protected` member.

Integration Test Compile ran `compileTestIntegrationJava --rerun` on the five `-test` modules under `modules/apps/object` that hold `src/testIntegration` sources — `object-admin-rest-test`, `object-rest-test`, `object-storage-salesforce-test`, `object-storage-sugarcrm-test`, `object-test` — and all five tasks executed to `BUILD SUCCESSFUL`.

Baseline reported no warning row from `ant baseline-all`, and each of the seven Ant projects printed `1 executed` on a standalone `baseline --rerun`. Neither changed module's `bnd.bnd` carries `Export-Package:`, so there was no changed exporting module to confirm, and `git status --porcelain --untracked-files=all -- '*bnd.bnd' '*packageinfo'` came back empty, so the run left no repair and needed no version commit. The Local Version Check found no changed `.java` under an `*-api` `src/main/java`, `portal-impl/src`, or `portal-kernel/src`, and no lowered version in the diff.

Java Unit Tests verified nothing. `ObjectFolderResourceImpl` has no unit test: `object-admin-rest-impl` carries no `src/test` tree, and no `ObjectFolderResourceImplTest.java` exists anywhere in the repository, so there was no suite to run. The class is covered by the integration tests in the sibling `object-admin-rest-test` module, `ObjectFolderPutReindexTest.java` and `ObjectFolderResourceTest.java`, which this validation does not run.

Cross-Module Compile, Full Portal Build, REST Builder, Service Builder, Module Registration, Structural Smoke, JSP Compile, and the JavaScript validations did not fire on this diff.

<!-- pr-check {"result": "success", "sha": "66e5532486d99b44225004f1640924aa235ac6fe"} -->
