### PR TITLE
LPD-101861 Guard the callers that reach an arrayable finder with an empty array

### DIFF
--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetVocabularyLocalServiceTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetVocabularyLocalServiceTest.java
@@ -38,6 +38,7 @@ import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.portlet.asset.util.AssetVocabularySettingsHelper;
 
 import java.util.HashMap;
+import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -75,6 +76,45 @@ public class AssetVocabularyLocalServiceTest {
 	public void testDeleteVocabulary() throws Exception {
 		_testDeleteVocabularySystem();
 		_testDeleteVocabularySystemWhenImporting();
+	}
+
+	@Test
+	public void testGetGroupsVocabularies() throws Exception {
+		AssetTestUtil.addVocabulary(_group.getGroupId());
+
+		List<AssetVocabulary> assetVocabularies =
+			_assetVocabularyLocalService.getGroupsVocabularies(new long[0]);
+
+		Assert.assertTrue(
+			assetVocabularies.toString(), assetVocabularies.isEmpty());
+	}
+
+	@Test
+	public void testGetGroupVocabularies() throws Exception {
+		AssetVocabulary assetVocabulary = AssetTestUtil.addVocabulary(
+			_group.getGroupId());
+
+		List<AssetVocabulary> assetVocabularies =
+			_assetVocabularyLocalService.getGroupVocabularies(new long[0]);
+
+		Assert.assertTrue(
+			assetVocabularies.toString(), assetVocabularies.isEmpty());
+
+		assetVocabularies = _assetVocabularyLocalService.getGroupVocabularies(
+			new long[0], new int[] {assetVocabulary.getVisibilityType()});
+
+		Assert.assertTrue(
+			assetVocabularies.toString(), assetVocabularies.isEmpty());
+	}
+
+	@Test
+	public void testGetGroupVocabulariesCount() throws Exception {
+		AssetTestUtil.addVocabulary(_group.getGroupId());
+
+		Assert.assertEquals(
+			0,
+			_assetVocabularyLocalService.getGroupVocabulariesCount(
+				new long[0]));
 	}
 
 	@Test

--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetVocabularyServiceTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetVocabularyServiceTest.java
@@ -357,6 +357,25 @@ public class AssetVocabularyServiceTest {
 	}
 
 	@Test
+	public void testGetGroupsVocabulariesWithNoGroupIds() throws Exception {
+		AssetTestUtil.addVocabulary(_group.getGroupId());
+
+		List<AssetVocabulary> assetVocabularies =
+			_assetVocabularyService.getGroupsVocabularies(new long[0]);
+
+		Assert.assertTrue(
+			assetVocabularies.toString(), assetVocabularies.isEmpty());
+	}
+
+	@Test
+	public void testGetGroupVocabulariesCountWithNoGroupIds() throws Exception {
+		AssetTestUtil.addVocabulary(_group.getGroupId());
+
+		Assert.assertEquals(
+			0, _assetVocabularyService.getGroupVocabulariesCount(new long[0]));
+	}
+
+	@Test
 	public void testGetGroupVocabulariesPaginatedWithNoViewableVocabularies()
 		throws Exception {
 
@@ -449,6 +468,24 @@ public class AssetVocabularyServiceTest {
 
 		Assert.assertEquals(
 			assetVocabularies.toString(), 1, assetVocabularies.size());
+	}
+
+	@Test
+	public void testGetGroupVocabulariesWithNoGroupIds() throws Exception {
+		AssetVocabulary assetVocabulary = AssetTestUtil.addVocabulary(
+			_group.getGroupId());
+
+		List<AssetVocabulary> assetVocabularies =
+			_assetVocabularyService.getGroupVocabularies(new long[0]);
+
+		Assert.assertTrue(
+			assetVocabularies.toString(), assetVocabularies.isEmpty());
+
+		assetVocabularies = _assetVocabularyService.getGroupVocabularies(
+			new long[0], new int[] {assetVocabulary.getVisibilityType()});
+
+		Assert.assertTrue(
+			assetVocabularies.toString(), assetVocabularies.isEmpty());
 	}
 
 	@Test

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/service/impl/AssetListEntryServiceImpl.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/service/impl/AssetListEntryServiceImpl.java
@@ -16,8 +16,10 @@ import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.security.permission.resource.PortletResourcePermission;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 
+import java.util.Collections;
 import java.util.List;
 
 import org.osgi.service.component.annotations.Component;
@@ -267,6 +269,10 @@ public class AssetListEntryServiceImpl extends AssetListEntryServiceBaseImpl {
 		long[] groupIds, String title, String[] assetEntryTypes, int start,
 		int end, OrderByComparator<AssetListEntry> orderByComparator) {
 
+		if (ArrayUtil.isEmpty(assetEntryTypes)) {
+			return Collections.emptyList();
+		}
+
 		return assetListEntryPersistence.filterFindByG_LikeT_AET(
 			groupIds,
 			_customSQL.keywords(title, false, WildcardMode.SURROUND)[0],
@@ -277,6 +283,10 @@ public class AssetListEntryServiceImpl extends AssetListEntryServiceBaseImpl {
 	public List<AssetListEntry> getAssetListEntries(
 		long[] groupIds, String[] assetEntryTypes, int start, int end,
 		OrderByComparator<AssetListEntry> orderByComparator) {
+
+		if (ArrayUtil.isEmpty(assetEntryTypes)) {
+			return Collections.emptyList();
+		}
 
 		return assetListEntryPersistence.filterFindByG_AET(
 			groupIds, assetEntryTypes, start, end, orderByComparator);
@@ -329,6 +339,10 @@ public class AssetListEntryServiceImpl extends AssetListEntryServiceBaseImpl {
 	public int getAssetListEntriesCount(
 		long[] groupIds, String title, String[] assetEntryTypes) {
 
+		if (ArrayUtil.isEmpty(assetEntryTypes)) {
+			return 0;
+		}
+
 		return assetListEntryPersistence.filterCountByG_LikeT_AET(
 			groupIds,
 			_customSQL.keywords(title, false, WildcardMode.SURROUND)[0],
@@ -338,6 +352,10 @@ public class AssetListEntryServiceImpl extends AssetListEntryServiceBaseImpl {
 	@Override
 	public int getAssetListEntriesCount(
 		long[] groupIds, String[] assetEntryTypes) {
+
+		if (ArrayUtil.isEmpty(assetEntryTypes)) {
+			return 0;
+		}
 
 		return assetListEntryPersistence.filterCountByG_AET(
 			groupIds, assetEntryTypes);

--- a/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/service/test/AssetListEntryServiceTest.java
+++ b/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/service/test/AssetListEntryServiceTest.java
@@ -519,6 +519,47 @@ public class AssetListEntryServiceTest {
 	}
 
 	@Test
+	public void testGetAssetListEntriesWithNoAssetEntryTypes()
+		throws PortalException {
+
+		AssetListEntry assetListEntry = _addAssetListEntry("Asset List Title");
+
+		long[] groupIds = {_group.getGroupId()};
+
+		List<AssetListEntry> assetListEntries =
+			_assetListEntryService.getAssetListEntries(
+				groupIds, new String[] {assetListEntry.getAssetEntryType()},
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+
+		Assert.assertEquals(
+			assetListEntries.toString(), 1, assetListEntries.size());
+
+		assetListEntries = _assetListEntryService.getAssetListEntries(
+			groupIds, new String[0], QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+			null);
+
+		Assert.assertTrue(
+			assetListEntries.toString(), assetListEntries.isEmpty());
+
+		Assert.assertEquals(
+			0,
+			_assetListEntryService.getAssetListEntriesCount(
+				groupIds, new String[0]));
+
+		assetListEntries = _assetListEntryService.getAssetListEntries(
+			groupIds, "Asset List", new String[0], QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS, null);
+
+		Assert.assertTrue(
+			assetListEntries.toString(), assetListEntries.isEmpty());
+
+		Assert.assertEquals(
+			0,
+			_assetListEntryService.getAssetListEntriesCount(
+				groupIds, "Asset List", new String[0]));
+	}
+
+	@Test
 	public void testManualAssetEntryTypeAssetListEntry()
 		throws PortalException {
 

--- a/modules/apps/asset/asset-taglib-test/src/testIntegration/java/com/liferay/asset/taglib/servlet/taglib/test/AssetCategoriesSelectorTagTest.java
+++ b/modules/apps/asset/asset-taglib-test/src/testIntegration/java/com/liferay/asset/taglib/servlet/taglib/test/AssetCategoriesSelectorTagTest.java
@@ -123,6 +123,7 @@ public class AssetCategoriesSelectorTagTest {
 		ThemeDisplay themeDisplay = new ThemeDisplay();
 
 		themeDisplay.setLocale(LocaleUtil.getDefault());
+		themeDisplay.setScopeGroupId(_group.getGroupId());
 
 		ReflectionTestUtil.setFieldValue(
 			assetCategoriesSelectorTag, "_httpServletRequest",
@@ -139,11 +140,6 @@ public class AssetCategoriesSelectorTagTest {
 
 		String[] categoryIdsTitle = categoryIdsTitles.get(0);
 
-		Assert.assertEquals(StringPool.BLANK, categoryIdsTitle[0]);
-		Assert.assertEquals(StringPool.BLANK, categoryIdsTitle[1]);
-
-		categoryIdsTitle = categoryIdsTitles.get(1);
-
 		Assert.assertEquals(
 			StringBundler.concat(
 				assetCategory1.getCategoryId(), StringPool.COMMA,
@@ -156,6 +152,11 @@ public class AssetCategoriesSelectorTagTest {
 				assetCategory2.getName(), AssetCategoryUtil.CATEGORY_SEPARATOR,
 				assetCategory3.getName()),
 			categoryIdsTitle[1]);
+
+		categoryIdsTitle = categoryIdsTitles.get(1);
+
+		Assert.assertEquals(StringPool.BLANK, categoryIdsTitle[0]);
+		Assert.assertEquals(StringPool.BLANK, categoryIdsTitle[1]);
 	}
 
 	@Test

--- a/modules/apps/asset/asset-tags-test/src/testIntegration/java/com/liferay/asset/tags/service/test/AssetTagServiceTest.java
+++ b/modules/apps/asset/asset-tags-test/src/testIntegration/java/com/liferay/asset/tags/service/test/AssetTagServiceTest.java
@@ -6,7 +6,10 @@
 package com.liferay.asset.tags.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.kernel.model.AssetTag;
 import com.liferay.asset.kernel.service.AssetTagLocalServiceUtil;
+import com.liferay.asset.kernel.service.AssetTagServiceUtil;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -16,6 +19,9 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -33,7 +39,9 @@ public class AssetTagServiceTest {
 	@ClassRule
 	@Rule
 	public static final AggregateTestRule aggregateTestRule =
-		new LiferayIntegrationTestRule();
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
 
 	@Before
 	public void setUp() throws Exception {
@@ -64,6 +72,50 @@ public class AssetTagServiceTest {
 		Assert.assertEquals(
 			initialTagsCount,
 			AssetTagLocalServiceUtil.getGroupTagsCount(_group.getGroupId()));
+	}
+
+	@Test
+	public void testGetGroupsTagsWithNoGroupIds() throws Exception {
+		_addTag();
+
+		List<AssetTag> assetTags = AssetTagServiceUtil.getGroupsTags(
+			new long[0]);
+
+		Assert.assertTrue(assetTags.toString(), assetTags.isEmpty());
+	}
+
+	@Test
+	public void testGetTagsCountWithNoGroupIds() throws Exception {
+		AssetTag assetTag = _addTag();
+
+		Assert.assertEquals(
+			0, AssetTagServiceUtil.getTagsCount(new long[0], null));
+		Assert.assertEquals(
+			0,
+			AssetTagServiceUtil.getTagsCount(new long[0], assetTag.getName()));
+	}
+
+	@Test
+	public void testGetTagsWithNoGroupIds() throws Exception {
+		AssetTag assetTag = _addTag();
+
+		List<AssetTag> assetTags = AssetTagServiceUtil.getTags(
+			new long[0], null, QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+
+		Assert.assertTrue(assetTags.toString(), assetTags.isEmpty());
+
+		assetTags = AssetTagServiceUtil.getTags(
+			new long[0], assetTag.getName(), QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS);
+
+		Assert.assertTrue(assetTags.toString(), assetTags.isEmpty());
+	}
+
+	private AssetTag _addTag() throws Exception {
+		return AssetTagLocalServiceUtil.addTag(
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
+			RandomTestUtil.randomString(),
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 	}
 
 	@DeleteAfterTestRun

--- a/modules/apps/bookmarks/bookmarks-service/src/main/java/com/liferay/bookmarks/service/impl/BookmarksEntryLocalServiceImpl.java
+++ b/modules/apps/bookmarks/bookmarks-service/src/main/java/com/liferay/bookmarks/service/impl/BookmarksEntryLocalServiceImpl.java
@@ -59,6 +59,7 @@ import com.liferay.portal.kernel.transaction.Transactional;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.GroupSubscriptionCheckSubscriptionSender;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.Localization;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.Portal;
@@ -311,6 +312,10 @@ public class BookmarksEntryLocalServiceImpl
 
 	@Override
 	public int getFoldersEntriesCount(long groupId, List<Long> folderIds) {
+		if (ListUtil.isEmpty(folderIds)) {
+			return 0;
+		}
+
 		return bookmarksEntryPersistence.countByG_F_S(
 			groupId, ArrayUtil.toArray(folderIds.toArray(new Long[0])),
 			WorkflowConstants.STATUS_APPROVED);

--- a/modules/apps/bookmarks/bookmarks-service/src/main/java/com/liferay/bookmarks/service/impl/BookmarksEntryServiceImpl.java
+++ b/modules/apps/bookmarks/bookmarks-service/src/main/java/com/liferay/bookmarks/service/impl/BookmarksEntryServiceImpl.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermi
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermissionUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
@@ -111,6 +112,10 @@ public class BookmarksEntryServiceImpl extends BookmarksEntryServiceBaseImpl {
 
 	@Override
 	public int getFoldersEntriesCount(long groupId, List<Long> folderIds) {
+		if (ListUtil.isEmpty(folderIds)) {
+			return 0;
+		}
+
 		return bookmarksEntryPersistence.filterCountByG_F_S(
 			groupId, ArrayUtil.toArray(folderIds.toArray(new Long[0])),
 			WorkflowConstants.STATUS_APPROVED);

--- a/modules/apps/bookmarks/bookmarks-test/src/testIntegration/java/com/liferay/bookmarks/service/test/BookmarksEntryServiceTest.java
+++ b/modules/apps/bookmarks/bookmarks-test/src/testIntegration/java/com/liferay/bookmarks/service/test/BookmarksEntryServiceTest.java
@@ -7,6 +7,7 @@ package com.liferay.bookmarks.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.bookmarks.model.BookmarksEntry;
+import com.liferay.bookmarks.service.BookmarksEntryLocalServiceUtil;
 import com.liferay.bookmarks.service.BookmarksEntryServiceUtil;
 import com.liferay.bookmarks.test.util.BookmarksTestUtil;
 import com.liferay.portal.kernel.model.Group;
@@ -17,6 +18,9 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
+import java.util.Collections;
+
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -60,6 +64,22 @@ public class BookmarksEntryServiceTest {
 			_group.getGroupId(), true);
 
 		BookmarksEntryServiceUtil.getEntry(entry.getEntryId());
+	}
+
+	@Test
+	public void testGetFoldersEntriesCountWithEmptyFolderIds()
+		throws Exception {
+
+		BookmarksTestUtil.addEntry(_group.getGroupId(), true);
+
+		Assert.assertEquals(
+			0,
+			BookmarksEntryServiceUtil.getFoldersEntriesCount(
+				_group.getGroupId(), Collections.emptyList()));
+		Assert.assertEquals(
+			0,
+			BookmarksEntryLocalServiceUtil.getFoldersEntriesCount(
+				_group.getGroupId(), Collections.emptyList()));
 	}
 
 	@DeleteAfterTestRun

--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarBookingLocalServiceImpl.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarBookingLocalServiceImpl.java
@@ -105,6 +105,7 @@ import com.liferay.trash.model.TrashEntry;
 import com.liferay.trash.service.TrashEntryLocalService;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -688,6 +689,10 @@ public class CalendarBookingLocalServiceImpl
 	@Override
 	public List<CalendarBooking> getCalendarBookings(
 		long calendarId, int[] statuses) {
+
+		if (ArrayUtil.isEmpty(statuses)) {
+			return Collections.emptyList();
+		}
 
 		return calendarBookingPersistence.findByC_S(calendarId, statuses);
 	}

--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarBookingServiceImpl.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarBookingServiceImpl.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
@@ -46,6 +47,7 @@ import java.io.IOException;
 import java.text.Format;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
@@ -263,6 +265,10 @@ public class CalendarBookingServiceImpl extends CalendarBookingServiceBaseImpl {
 	public List<CalendarBooking> getCalendarBookings(
 			long calendarId, int[] statuses)
 		throws PortalException {
+
+		if (ArrayUtil.isEmpty(statuses)) {
+			return Collections.emptyList();
+		}
 
 		return _filterCalendarBookings(
 			calendarBookingLocalService.getCalendarBookings(

--- a/modules/apps/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/service/test/CalendarBookingServiceTest.java
+++ b/modules/apps/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/service/test/CalendarBookingServiceTest.java
@@ -75,6 +75,30 @@ public class CalendarBookingServiceTest {
 	}
 
 	@Test
+	public void testGetCalendarBookingsWithEmptyStatuses() throws Exception {
+		ServiceContext serviceContext = createServiceContext();
+
+		Calendar calendar = CalendarTestUtil.addCalendar(
+			_user1, serviceContext);
+
+		CalendarBookingTestUtil.addRegularCalendarBooking(
+			_user1, calendar, serviceContext);
+
+		List<CalendarBooking> calendarBookings =
+			_calendarBookingService.getCalendarBookings(
+				calendar.getCalendarId(), new int[0]);
+
+		Assert.assertTrue(
+			calendarBookings.toString(), calendarBookings.isEmpty());
+
+		calendarBookings = _calendarBookingLocalService.getCalendarBookings(
+			calendar.getCalendarId(), new int[0]);
+
+		Assert.assertTrue(
+			calendarBookings.toString(), calendarBookings.isEmpty());
+	}
+
+	@Test
 	public void testGetUnapprovedCalendarBookingsForOmniadmin()
 		throws Exception {
 

--- a/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/impl/CommercePriceListServiceImpl.java
+++ b/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/impl/CommercePriceListServiceImpl.java
@@ -24,10 +24,12 @@ import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.security.permission.resource.PortletResourcePermission;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
+import java.util.Collections;
 import java.util.List;
 
 import org.osgi.service.component.annotations.Component;
@@ -217,6 +219,10 @@ public class CommercePriceListServiceImpl
 
 		long[] groupIds = _getGroupIds(companyId);
 
+		if (ArrayUtil.isEmpty(groupIds)) {
+			return Collections.emptyList();
+		}
+
 		if (status == WorkflowConstants.STATUS_ANY) {
 			return commercePriceListPersistence.filterFindByG_C_NotS(
 				groupIds, companyId, WorkflowConstants.STATUS_IN_TRASH, start,
@@ -235,6 +241,10 @@ public class CommercePriceListServiceImpl
 
 		long[] groupIds = _getGroupIds(companyId);
 
+		if (ArrayUtil.isEmpty(groupIds)) {
+			return Collections.emptyList();
+		}
+
 		if (status == WorkflowConstants.STATUS_ANY) {
 			return commercePriceListPersistence.filterFindByG_C_T_NotS(
 				groupIds, companyId, type, WorkflowConstants.STATUS_IN_TRASH,
@@ -250,6 +260,10 @@ public class CommercePriceListServiceImpl
 		throws PortalException {
 
 		long[] groupIds = _getGroupIds(companyId);
+
+		if (ArrayUtil.isEmpty(groupIds)) {
+			return 0;
+		}
 
 		if (status == WorkflowConstants.STATUS_ANY) {
 			return commercePriceListPersistence.filterCountByG_C_NotS(

--- a/modules/apps/commerce/commerce-price-list-test/src/testIntegration/java/com/liferay/commerce/price/list/service/test/CommercePriceListLocalServiceTest.java
+++ b/modules/apps/commerce/commerce-price-list-test/src/testIntegration/java/com/liferay/commerce/price/list/service/test/CommercePriceListLocalServiceTest.java
@@ -12,19 +12,30 @@ import com.liferay.commerce.price.list.exception.CommercePriceListCurrencyExcept
 import com.liferay.commerce.price.list.exception.NoSuchPriceListException;
 import com.liferay.commerce.price.list.model.CommercePriceList;
 import com.liferay.commerce.price.list.service.CommercePriceListLocalService;
+import com.liferay.commerce.price.list.service.CommercePriceListService;
 import com.liferay.commerce.product.model.CommerceCatalog;
 import com.liferay.commerce.product.service.CommerceCatalogLocalServiceUtil;
 import com.liferay.commerce.test.util.price.list.CommercePriceListTestUtil;
 import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.lazy.referencing.LazyReferencingThreadLocal;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.context.ContextUserReplace;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.RoleTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.CalendarFactoryUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
@@ -584,6 +595,52 @@ public class CommercePriceListLocalServiceTest {
 	}
 
 	@Test
+	public void testGetCommercePriceListsWithoutVisibleCatalogs()
+		throws Exception {
+
+		List<CommerceCatalog> commerceCatalogs =
+			CommerceCatalogLocalServiceUtil.getCommerceCatalogs(
+				_company.getCompanyId(), true);
+
+		CommerceCatalog commerceCatalog = commerceCatalogs.get(0);
+
+		CommercePriceListTestUtil.addCommercePriceList(
+			null, commerceCatalog.getGroupId(),
+			Currency.getInstance(
+				LocaleUtil.US
+			).getCurrencyCode(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomDouble(), true,
+			null, null);
+
+		User user = UserTestUtil.addUser(_company);
+
+		Role role = RoleTestUtil.addRole(
+			RandomTestUtil.randomString(), RoleConstants.TYPE_REGULAR,
+			CommercePriceList.class.getName(), ResourceConstants.SCOPE_COMPANY,
+			String.valueOf(_company.getCompanyId()), ActionKeys.VIEW);
+
+		_userLocalService.addRoleUser(role.getRoleId(), user);
+
+		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
+				user, PermissionCheckerFactoryUtil.create(user))) {
+
+			List<CommercePriceList> commercePriceLists =
+				_commercePriceListService.getCommercePriceLists(
+					_company.getCompanyId(), WorkflowConstants.STATUS_APPROVED,
+					QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+
+			Assert.assertTrue(
+				commercePriceLists.toString(), commercePriceLists.isEmpty());
+
+			Assert.assertEquals(
+				0,
+				_commercePriceListService.getCommercePriceListsCount(
+					_company.getCompanyId(),
+					WorkflowConstants.STATUS_APPROVED));
+		}
+	}
+
+	@Test
 	public void testGetOrAddEmptyCommercePriceList() throws Exception {
 		frutillaRule.scenario(
 			"Get or add an empty commerce price list"
@@ -851,6 +908,12 @@ public class CommercePriceListLocalServiceTest {
 	@Inject
 	private CommercePriceListLocalService _commercePriceListLocalService;
 
+	@Inject
+	private CommercePriceListService _commercePriceListService;
+
 	private Group _group;
+
+	@Inject
+	private UserLocalService _userLocalService;
 
 }

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
@@ -55,6 +55,7 @@ import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
@@ -68,6 +69,7 @@ import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
@@ -486,6 +488,10 @@ public class FragmentEntryLinkLocalServiceImpl
 	public List<FragmentEntryLink> getFragmentEntryLinksBySegmentsExperienceId(
 		long groupId, long[] segmentsExperienceIds, long plid) {
 
+		if (ArrayUtil.isEmpty(segmentsExperienceIds)) {
+			return Collections.emptyList();
+		}
+
 		return fragmentEntryLinkPersistence.findByG_S_P(
 			groupId, segmentsExperienceIds, plid);
 	}
@@ -494,6 +500,10 @@ public class FragmentEntryLinkLocalServiceImpl
 	public List<FragmentEntryLink> getFragmentEntryLinksBySegmentsExperienceId(
 		long groupId, long[] segmentsExperienceIds, long plid,
 		boolean deleted) {
+
+		if (ArrayUtil.isEmpty(segmentsExperienceIds)) {
+			return Collections.emptyList();
+		}
 
 		return fragmentEntryLinkPersistence.findByG_S_P_D(
 			groupId, segmentsExperienceIds, plid, deleted);

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/test/FragmentEntryLinkLocalServiceTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/test/FragmentEntryLinkLocalServiceTest.java
@@ -470,6 +470,32 @@ public class FragmentEntryLinkLocalServiceTest {
 	}
 
 	@Test
+	public void testGetFragmentEntryLinksBySegmentsExperienceIdWithEmptyArray()
+		throws Exception {
+
+		_addFragmentEntryLink(
+			_fragmentEntry, null, _defaultSegmentsExperienceId,
+			_layout.getPlid(), StringPool.BLANK, 0, null);
+
+		List<FragmentEntryLink> fragmentEntryLinks =
+			_fragmentEntryLinkLocalService.
+				getFragmentEntryLinksBySegmentsExperienceId(
+					_group.getGroupId(), new long[0], _layout.getPlid());
+
+		Assert.assertTrue(
+			fragmentEntryLinks.toString(), fragmentEntryLinks.isEmpty());
+
+		List<FragmentEntryLink> notDeletedFragmentEntryLinks =
+			_fragmentEntryLinkLocalService.
+				getFragmentEntryLinksBySegmentsExperienceId(
+					_group.getGroupId(), new long[0], _layout.getPlid(), false);
+
+		Assert.assertTrue(
+			notDeletedFragmentEntryLinks.toString(),
+			notDeletedFragmentEntryLinks.isEmpty());
+	}
+
+	@Test
 	public void testGetLayoutFragmentEntryLinksByFragmentEntry()
 		throws Exception {
 

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleServiceImpl.java
@@ -1203,6 +1203,10 @@ public class JournalArticleServiceImpl extends JournalArticleServiceBaseImpl {
 	 */
 	@Override
 	public int getFoldersAndArticlesCount(long groupId, List<Long> folderIds) {
+		if (ListUtil.isEmpty(folderIds)) {
+			return 0;
+		}
+
 		return journalArticlePersistence.filterCountByG_F(
 			groupId, ArrayUtil.toArray(folderIds.toArray(new Long[0])));
 	}

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleServiceTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleServiceTest.java
@@ -74,6 +74,7 @@ import java.io.InputStream;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -933,6 +934,14 @@ public class JournalArticleServiceTest {
 			PermissionThreadLocal.setPermissionChecker(
 				originalPermissionChecker);
 		}
+	}
+
+	@Test
+	public void testGetFoldersAndArticlesCountWithEmptyFolderIds() {
+		Assert.assertEquals(
+			0,
+			_journalArticleService.getFoldersAndArticlesCount(
+				_group.getGroupId(), Collections.emptyList()));
 	}
 
 	@Test

--- a/modules/apps/portal-security/portal-security-permission-test/src/testIntegration/java/com/liferay/portal/security/permission/test/ResourcePermissionLocalServiceTest.java
+++ b/modules/apps/portal-security/portal-security-permission-test/src/testIntegration/java/com/liferay/portal/security/permission/test/ResourcePermissionLocalServiceTest.java
@@ -12,6 +12,7 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.model.Resource;
 import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
@@ -30,7 +31,9 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -84,6 +87,36 @@ public class ResourcePermissionLocalServiceTest {
 			Collections.emptyList(), Collections.emptyList(),
 			Collections.emptyList(), portletName, portletName,
 			_resourceActions.getPortletResourceActions(portletName));
+	}
+
+	@Test
+	public void testSetResourcePermissionsWithEmptyRoleIdsToActionIds()
+		throws Exception {
+
+		_group = GroupTestUtil.addGroup();
+
+		Role role = _roleLocalService.getRole(
+			_group.getCompanyId(), RoleConstants.SITE_MEMBER);
+
+		String primKey = String.valueOf(_group.getGroupId());
+
+		_resourcePermissionLocalService.setResourcePermissions(
+			_group.getCompanyId(), Group.class.getName(),
+			ResourceConstants.SCOPE_INDIVIDUAL, primKey, role.getRoleId(),
+			new String[] {ActionKeys.VIEW});
+
+		Map<Long, Long> roleIdsToActionIds = _getRoleIdsToActionIds(primKey);
+
+		Assert.assertFalse(
+			roleIdsToActionIds.toString(), roleIdsToActionIds.isEmpty());
+
+		_resourcePermissionLocalService.setResourcePermissions(
+			_group.getCompanyId(), Group.class.getName(),
+			ResourceConstants.SCOPE_INDIVIDUAL, primKey,
+			Collections.emptyMap());
+
+		Assert.assertEquals(
+			roleIdsToActionIds, _getRoleIdsToActionIds(primKey));
 	}
 
 	@Test
@@ -170,6 +203,22 @@ public class ResourcePermissionLocalServiceTest {
 		resource.setScope(scope);
 
 		return resource;
+	}
+
+	private Map<Long, Long> _getRoleIdsToActionIds(String primKey) {
+		Map<Long, Long> roleIdsToActionIds = new HashMap<>();
+
+		for (ResourcePermission resourcePermission :
+				_resourcePermissionLocalService.getResourcePermissions(
+					_group.getCompanyId(), Group.class.getName(),
+					ResourceConstants.SCOPE_INDIVIDUAL, primKey)) {
+
+			roleIdsToActionIds.put(
+				resourcePermission.getRoleId(),
+				resourcePermission.getActionIds());
+		}
+
+		return roleIdsToActionIds;
 	}
 
 	private void _testResources(

--- a/modules/apps/ratings/ratings-test/src/testIntegration/java/com/liferay/ratings/service/test/RatingsEntryLocalServiceTest.java
+++ b/modules/apps/ratings/ratings-test/src/testIntegration/java/com/liferay/ratings/service/test/RatingsEntryLocalServiceTest.java
@@ -18,6 +18,8 @@ import com.liferay.ratings.kernel.exception.EntryScoreException;
 import com.liferay.ratings.kernel.model.RatingsEntry;
 import com.liferay.ratings.kernel.service.RatingsEntryLocalServiceUtil;
 
+import java.util.Map;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -39,6 +41,21 @@ public class RatingsEntryLocalServiceTest {
 	@Before
 	public void setUp() throws Exception {
 		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	public void testGetEntriesWithEmptyClassPKs() throws Exception {
+		String className = RandomTestUtil.randomString();
+
+		RatingsEntryLocalServiceUtil.updateEntry(
+			TestPropsValues.getUserId(), className, RandomTestUtil.randomLong(),
+			1, ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		Map<Long, RatingsEntry> ratingsEntries =
+			RatingsEntryLocalServiceUtil.getEntries(
+				TestPropsValues.getUserId(), className, new long[0]);
+
+		Assert.assertTrue(ratingsEntries.toString(), ratingsEntries.isEmpty());
 	}
 
 	@Test

--- a/modules/apps/roles/roles-test/src/testIntegration/java/com/liferay/roles/service/test/RoleLocalServiceTest.java
+++ b/modules/apps/roles/roles-test/src/testIntegration/java/com/liferay/roles/service/test/RoleLocalServiceTest.java
@@ -605,6 +605,20 @@ public class RoleLocalServiceTest {
 	}
 
 	@Test
+	public void testGetRolesWithEmptyTypes() throws Exception {
+		long companyId = TestPropsValues.getCompanyId();
+
+		List<Role> roles = _roleLocalService.getRoles(
+			companyId, RoleConstants.TYPES_REGULAR_AND_SITE);
+
+		Assert.assertFalse(roles.toString(), roles.isEmpty());
+
+		roles = _roleLocalService.getRoles(companyId, new int[0]);
+
+		Assert.assertTrue(roles.toString(), roles.isEmpty());
+	}
+
+	@Test
 	public void testGetTeamRoleMapWithExclusion() throws Exception {
 		createOrganizationAndTeam();
 

--- a/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
@@ -1260,8 +1260,14 @@ public class DataFactory {
 	public AssetEntryModel newAssetEntryModel(
 		ObjectEntryModel objectEntryModel) {
 
+		long groupId = objectEntryModel.getGroupId();
+
+		if (groupId == 0) {
+			groupId = _globalGroupId;
+		}
+
 		return newAssetEntryModel(
-			objectEntryModel.getGroupId(), objectEntryModel.getCreateDate(),
+			groupId, objectEntryModel.getCreateDate(),
 			objectEntryModel.getModifiedDate(),
 			getClassNameId(
 				ObjectDefinitionConstants.

--- a/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
@@ -64,6 +64,7 @@ import com.liferay.portal.kernel.spring.aop.Retry;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -1808,6 +1809,10 @@ public class ResourcePermissionLocalServiceImpl
 			long companyId, String name, int scope, String primKey,
 			long ownerId, Map<Long, String[]> roleIdsToActionIds)
 		throws PortalException {
+
+		if (MapUtil.isEmpty(roleIdsToActionIds)) {
+			return;
+		}
 
 		boolean flushResourcePermissionEnabled =
 			PermissionThreadLocal.isFlushResourcePermissionEnabled(

--- a/portal-impl/src/com/liferay/portal/service/impl/RoleLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/RoleLocalServiceImpl.java
@@ -1025,6 +1025,10 @@ public class RoleLocalServiceImpl extends RoleLocalServiceBaseImpl {
 	 */
 	@Override
 	public List<Role> getRoles(long companyId, int[] types) {
+		if (ArrayUtil.isEmpty(types)) {
+			return Collections.emptyList();
+		}
+
 		return rolePersistence.findByC_T(companyId, types);
 	}
 

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetTagServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetTagServiceImpl.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Autocomplete;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -27,6 +28,7 @@ import com.liferay.portlet.asset.service.permission.AssetTagsPermission;
 import com.liferay.portlet.asset.util.comparator.AssetTagNameComparator;
 import com.liferay.util.dao.orm.CustomSQLUtil;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -97,6 +99,10 @@ public class AssetTagServiceImpl extends AssetTagServiceBaseImpl {
 
 	@Override
 	public List<AssetTag> getGroupsTags(long[] groupIds) {
+		if (ArrayUtil.isEmpty(groupIds)) {
+			return Collections.emptyList();
+		}
+
 		return sanitize(
 			assetTagPersistence.findByGroupId(
 				groupIds, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
@@ -201,6 +207,10 @@ public class AssetTagServiceImpl extends AssetTagServiceBaseImpl {
 		long[] groupIds, String name, int start, int end,
 		OrderByComparator<AssetTag> orderByComparator) {
 
+		if (ArrayUtil.isEmpty(groupIds)) {
+			return Collections.emptyList();
+		}
+
 		if (Validator.isNull(name)) {
 			return sanitize(
 				assetTagPersistence.findByGroupId(
@@ -230,6 +240,10 @@ public class AssetTagServiceImpl extends AssetTagServiceBaseImpl {
 
 	@Override
 	public int getTagsCount(long[] groupIds, String name) {
+		if (ArrayUtil.isEmpty(groupIds)) {
+			return 0;
+		}
+
 		if (Validator.isNull(name)) {
 			return assetTagPersistence.countByGroupId(groupIds);
 		}

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyLocalServiceImpl.java
@@ -351,6 +351,10 @@ public class AssetVocabularyLocalServiceImpl
 	public List<AssetVocabulary> getGroupsVocabularies(
 		long[] groupIds, String className, long classTypePK) {
 
+		if (ArrayUtil.isEmpty(groupIds)) {
+			return Collections.emptyList();
+		}
+
 		List<AssetVocabulary> vocabularies =
 			assetVocabularyPersistence.findByGroupId(groupIds);
 
@@ -400,6 +404,10 @@ public class AssetVocabularyLocalServiceImpl
 
 	@Override
 	public List<AssetVocabulary> getGroupVocabularies(long[] groupIds) {
+		if (ArrayUtil.isEmpty(groupIds)) {
+			return Collections.emptyList();
+		}
+
 		return assetVocabularyPersistence.findByGroupId(groupIds);
 	}
 
@@ -407,11 +415,19 @@ public class AssetVocabularyLocalServiceImpl
 	public List<AssetVocabulary> getGroupVocabularies(
 		long[] groupIds, int[] visibilityTypes) {
 
+		if (ArrayUtil.isEmpty(groupIds)) {
+			return Collections.emptyList();
+		}
+
 		return assetVocabularyPersistence.findByG_V(groupIds, visibilityTypes);
 	}
 
 	@Override
 	public int getGroupVocabulariesCount(long[] groupIds) {
+		if (ArrayUtil.isEmpty(groupIds)) {
+			return 0;
+		}
+
 		return assetVocabularyPersistence.countByGroupId(groupIds);
 	}
 

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyServiceImpl.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.Validator;
@@ -29,6 +30,7 @@ import com.liferay.portlet.asset.util.AssetVocabularySettingsHelper;
 import com.liferay.util.dao.orm.CustomSQLUtil;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -255,6 +257,10 @@ public class AssetVocabularyServiceImpl extends AssetVocabularyServiceBaseImpl {
 	public List<AssetVocabulary> getGroupsVocabularies(
 		long[] groupIds, String className, long classTypePK) {
 
+		if (ArrayUtil.isEmpty(groupIds)) {
+			return Collections.emptyList();
+		}
+
 		List<AssetVocabulary> vocabularies =
 			assetVocabularyPersistence.filterFindByGroupId(groupIds);
 
@@ -346,12 +352,20 @@ public class AssetVocabularyServiceImpl extends AssetVocabularyServiceBaseImpl {
 
 	@Override
 	public List<AssetVocabulary> getGroupVocabularies(long[] groupIds) {
+		if (ArrayUtil.isEmpty(groupIds)) {
+			return Collections.emptyList();
+		}
+
 		return assetVocabularyPersistence.filterFindByGroupId(groupIds);
 	}
 
 	@Override
 	public List<AssetVocabulary> getGroupVocabularies(
 		long[] groupIds, int[] visibilityTypes) {
+
+		if (ArrayUtil.isEmpty(groupIds)) {
+			return Collections.emptyList();
+		}
 
 		return assetVocabularyPersistence.filterFindByG_V(
 			groupIds, visibilityTypes);
@@ -369,6 +383,10 @@ public class AssetVocabularyServiceImpl extends AssetVocabularyServiceBaseImpl {
 
 	@Override
 	public int getGroupVocabulariesCount(long[] groupIds) {
+		if (ArrayUtil.isEmpty(groupIds)) {
+			return 0;
+		}
+
 		return assetVocabularyPersistence.filterCountByGroupId(groupIds);
 	}
 

--- a/portal-impl/src/com/liferay/portlet/ratings/service/impl/RatingsEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/ratings/service/impl/RatingsEntryLocalServiceImpl.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.persistence.UserPersistence;
 import com.liferay.portal.kernel.social.SocialActivityManagerUtil;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portlet.ratings.service.base.RatingsEntryLocalServiceBaseImpl;
 import com.liferay.ratings.kernel.exception.EntryScoreException;
 import com.liferay.ratings.kernel.model.RatingsEntry;
@@ -26,6 +27,7 @@ import com.liferay.ratings.kernel.service.RatingsStatsLocalService;
 import com.liferay.ratings.kernel.service.persistence.RatingsStatsPersistence;
 import com.liferay.social.kernel.model.SocialActivityConstants;
 
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -117,6 +119,10 @@ public class RatingsEntryLocalServiceImpl
 	@Override
 	public Map<Long, RatingsEntry> getEntries(
 		long userId, String className, long[] classPKs) {
+
+		if (ArrayUtil.isEmpty(classPKs)) {
+			return Collections.emptyMap();
+		}
 
 		long classNameId = _classNameLocalService.getClassNameId(className);
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101861

## What Is Being Fixed

A Service Builder arrayable finder column contributes no SQL fragment for an empty or null array, so its condition is dropped. When the arrayable column is the finder's only condition the statement degenerates to `SELECT ... WHERE  ORDER BY ...` and Hibernate throws; when the finder has other conditions the query silently returns every row those conditions allow. Both outcomes are wrong for a caller that means "no ids, therefore no rows".

The symptom that surfaced this was a collection page rendering "An unexpected error occurred." for every field of every listed entry, with roughly 1200 error lines per view: `AssetVocabularyLocalServiceImpl.getGroupsVocabularies` received the empty site-and-depot group array of an asset entry whose group ID is zero, and `findByGroupId` produced the invalid statement above.

## How It Is Being Fixed

The finder contract is left as it is. Every service method that can reach an arrayable finder with an empty or null array now answers without querying: `AssetVocabularyLocalServiceImpl` and `AssetVocabularyServiceImpl` group getters, `AssetTagServiceImpl` group getters, `ResourcePermissionLocalServiceImpl.updateResourcePermission` for an empty role map, `RoleLocalServiceImpl.getRoles` for an empty type array, `FragmentEntryLinkLocalServiceImpl` for no segments experiences, `BookmarksEntryServiceImpl` and `JournalArticleServiceImpl` folder counts, `CalendarBookingServiceImpl` for no statuses, `RatingsEntryLocalServiceImpl` for no class primary keys, `AssetListEntryServiceImpl` for no asset entry types, and `CommercePriceListServiceImpl` when the company exposes no catalog. Each guard carries its own integration test, red on the unguarded code, and the sample SQL builder now gives a company-scoped object entry the company group on its asset entry, which is what the portal itself writes and the only reason the generated benchmark data could reach the crash.

## Why The Fix Is On The Caller Side

An arrayable finder has dropped the condition for an empty array since arrayable finders were introduced in a034d9c15463d (LPS-10628, 2010-06-26), so the behaviour is as old as the feature.

All 399 production call sites of the 170 arrayable finder families were audited. 162 can never pass an empty array, 105 already guard it, and 27 can reach the finder empty. Of those 27, three depend on "empty means everything": the two DDM structure edit alerts and the Pages admin toolbar total. The rest mean "no rows" and today either crash or leak rows.

Changing the finder to return nothing for an empty array flips that contract for every caller at once. It breaks the three callers that rely on it, silently changes results for any external client of the remote services that sends an empty array, and stays invisible until a page happens to exercise it. The finder-level attempt showed exactly that: the asset categories selector test regressed and the Pages admin listing returned no pages with no keyword typed. Guarding the reachable callers keeps the contract, keeps every change inside services that can be named and tested, and leaves each guard independently revertible.

The follow-up on the finder side is a separate change and stays with the authors of the original attempt: log a warning with the stack when an arrayable column receives an empty or null array, with a logger entry so it prints, since PortalLogAssertorTest already fails an axis on a warning. Any new caller that passes an empty array then turns its own axis red before merge, while callers outside the codebase keep working and see the message. The three "empty means everything" callers move to the explicit overloads that already exist before that lands.

## PR Check

**pr-check: PASS** — tested on `d2dbb65d6a297691d068b7d28a6ccdf9af56cb43`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Service Registration | PASS |
| Transaction Usage | PASS |
| Full Portal Build | PASS |
| Baseline | PASS (baseline-all, seven Ant projects included, 0 changed exporting modules) |
| Per-Module Compile | PASS (7 modules) |
| Integration Test Compile | PASS (12 test modules) |
| Java Unit Tests | PASS (ResourcePermissionLocalServiceImplTest 1/1) |

Integration tests were also run against a live portal built from this branch: 11 classes, 148 tests, zero failures. `ci:test:stable` passed 13 of 13. On `ci:test:relevant` the failures unique to this pull are all reproduced on foreign builds: CookiesManagerImplTest fails on the master ci:test:security routine on four consecutive days (372 through 375), the collection display pagination and fragment spacing specs fail on EE Development Acceptance 60 and 61 and on ci:test:page-management 374 and 375, ExportImportInstancePerformanceTest and ClusterCacheReplicationTest fail on EE Development Acceptance 60 and 61, and SaveAuditConfigurationMVCActionCommandTest fails on ci:test:security 374 and 375. The one real regression this branch caused, the asset categories selector test, is fixed here by the original author's own commit and no longer appears.

<!-- pr-check {"result": "success", "sha": "d2dbb65d6a297691d068b7d28a6ccdf9af56cb43"} -->
