### PR TITLE
LPD-104744 Skip the object definition reindex when a folder PUT does not move it

### DIFF
--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectFolderResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectFolderResourceImpl.java
@@ -292,9 +292,13 @@ public class ObjectFolderResourceImpl extends BaseObjectFolderResourceImpl {
 				continue;
 			}
 
-			_objectDefinitionLocalService.updateObjectFolderId(
-				serviceBuilderObjectDefinition.getObjectDefinitionId(),
-				objectFolderId);
+			if (serviceBuilderObjectDefinition.isLinkedToObjectFolder(
+					objectFolderId)) {
+
+				_objectDefinitionLocalService.updateObjectFolderId(
+					serviceBuilderObjectDefinition.getObjectDefinitionId(),
+					objectFolderId);
+			}
 
 			_objectFolderItemLocalService.updateObjectFolderItem(
 				serviceBuilderObjectDefinition.getObjectDefinitionId(),

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectFolderResourceTest.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectFolderResourceTest.java
@@ -9,12 +9,27 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.object.admin.rest.client.dto.v1_0.ObjectFolder;
 import com.liferay.object.admin.rest.client.dto.v1_0.ObjectFolderItem;
 import com.liferay.object.admin.rest.resource.v1_0.test.util.ObjectDefinitionTestUtil;
+import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectFolderLocalService;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.Hits;
+import com.liferay.portal.kernel.search.IndexWriterHelper;
+import com.liferay.portal.kernel.search.Indexer;
+import com.liferay.portal.kernel.search.IndexerRegistryUtil;
+import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.Inject;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Ignore;
@@ -163,6 +178,15 @@ public class ObjectFolderResourceTest extends BaseObjectFolderResourceTestCase {
 	}
 
 	@Override
+	@Test
+	public void testPutObjectFolderByExternalReferenceCode() throws Exception {
+		super.testPutObjectFolderByExternalReferenceCode();
+
+		_testPutObjectFolderByExternalReferenceCodeMovedObjectDefinition();
+		_testPutObjectFolderByExternalReferenceCodeUnmovedObjectDefinition();
+	}
+
+	@Override
 	protected String[] getAdditionalAssertFieldNames() {
 		return new String[] {"label"};
 	}
@@ -251,5 +275,179 @@ public class ObjectFolderResourceTest extends BaseObjectFolderResourceTestCase {
 
 		return testPostObjectFolder_addObjectFolder(randomObjectFolder());
 	}
+
+	private void _assertIndexed(
+			boolean expected, ObjectDefinition objectDefinition)
+		throws Exception {
+
+		List<Long> objectDefinitionIds = _getIndexedObjectDefinitionIds(
+			objectDefinition);
+
+		Assert.assertEquals(
+			StringBundler.concat(
+				"Object definition ", objectDefinition.getObjectDefinitionId(),
+				" named ", objectDefinition.getShortName(),
+				" against the indexed object definition IDs ",
+				objectDefinitionIds),
+			expected,
+			objectDefinitionIds.contains(
+				objectDefinition.getObjectDefinitionId()));
+	}
+
+	private void _deleteObjectDefinitionDocument(
+			ObjectDefinition objectDefinition)
+		throws Exception {
+
+		_assertIndexed(true, objectDefinition);
+
+		Indexer<ObjectDefinition> indexer =
+			IndexerRegistryUtil.nullSafeGetIndexer(ObjectDefinition.class);
+
+		indexer.delete(objectDefinition);
+
+		_indexWriterHelper.commit(objectDefinition.getCompanyId());
+
+		_assertIndexed(false, objectDefinition);
+	}
+
+	private List<Long> _getIndexedObjectDefinitionIds(
+			ObjectDefinition objectDefinition)
+		throws Exception {
+
+		SearchContext searchContext = new SearchContext();
+
+		searchContext.setAttribute(Field.NAME, objectDefinition.getShortName());
+		searchContext.setCompanyId(objectDefinition.getCompanyId());
+		searchContext.setEntryClassNames(
+			new String[] {ObjectDefinition.class.getName()});
+		searchContext.setKeywords(objectDefinition.getShortName());
+
+		Indexer<ObjectDefinition> indexer =
+			IndexerRegistryUtil.nullSafeGetIndexer(ObjectDefinition.class);
+
+		Hits hits = indexer.search(searchContext);
+
+		List<Long> objectDefinitionIds = new ArrayList<>();
+
+		for (Document document : hits.getDocs()) {
+			objectDefinitionIds.add(
+				GetterUtil.getLong(document.get(Field.ENTRY_CLASS_PK)));
+		}
+
+		return objectDefinitionIds;
+	}
+
+	private void _testPutObjectFolderByExternalReferenceCodeMovedObjectDefinition()
+		throws Exception {
+
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.addCustomObjectDefinition();
+
+		_indexWriterHelper.commit(objectDefinition.getCompanyId());
+
+		ObjectFolder objectFolder = null;
+
+		try {
+			_deleteObjectDefinitionDocument(objectDefinition);
+
+			objectFolder = testPostObjectFolder_addObjectFolder(
+				randomObjectFolder());
+
+			objectFolder.setObjectFolderItems(
+				new ObjectFolderItem[] {
+					_toObjectFolderItem(
+						false, objectDefinition.getExternalReferenceCode(), 0,
+						0)
+				});
+
+			objectFolderResource.putObjectFolderByExternalReferenceCode(
+				objectFolder.getExternalReferenceCode(), objectFolder);
+
+			_indexWriterHelper.commit(objectDefinition.getCompanyId());
+
+			_assertIndexed(true, objectDefinition);
+		}
+		finally {
+			_objectDefinitionLocalService.deleteObjectDefinition(
+				objectDefinition.getObjectDefinitionId());
+
+			if (objectFolder != null) {
+				_objectFolderLocalService.deleteObjectFolder(
+					objectFolder.getId());
+			}
+		}
+	}
+
+	private void _testPutObjectFolderByExternalReferenceCodeUnmovedObjectDefinition()
+		throws Exception {
+
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.addCustomObjectDefinition();
+
+		_indexWriterHelper.commit(objectDefinition.getCompanyId());
+
+		try {
+			_deleteObjectDefinitionDocument(objectDefinition);
+
+			ObjectFolder objectFolder =
+				objectFolderResource.getObjectFolderByExternalReferenceCode(
+					ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_DEFAULT);
+
+			ObjectFolderItem[] objectFolderItems =
+				objectFolder.getObjectFolderItems();
+
+			ObjectFolderItem[] newObjectFolderItems =
+				new ObjectFolderItem[objectFolderItems.length];
+
+			for (int i = 0; i < objectFolderItems.length; i++) {
+				ObjectFolderItem objectFolderItem = objectFolderItems[i];
+
+				newObjectFolderItems[i] = _toObjectFolderItem(
+					objectFolderItem.getLinkedObjectDefinition(),
+					objectFolderItem.getObjectDefinitionExternalReferenceCode(),
+					objectFolderItem.getPositionX(),
+					objectFolderItem.getPositionY());
+			}
+
+			objectFolder.setObjectFolderItems(newObjectFolderItems);
+
+			objectFolderResource.putObjectFolderByExternalReferenceCode(
+				ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_DEFAULT,
+				objectFolder);
+
+			_indexWriterHelper.commit(objectDefinition.getCompanyId());
+
+			_assertIndexed(false, objectDefinition);
+		}
+		finally {
+			_objectDefinitionLocalService.deleteObjectDefinition(
+				objectDefinition.getObjectDefinitionId());
+		}
+	}
+
+	private ObjectFolderItem _toObjectFolderItem(
+		Boolean linkedObjectDefinition,
+		String objectDefinitionExternalReferenceCode, Integer positionX,
+		Integer positionY) {
+
+		ObjectFolderItem objectFolderItem = new ObjectFolderItem();
+
+		objectFolderItem.setLinkedObjectDefinition(linkedObjectDefinition);
+		objectFolderItem.setObjectDefinitionExternalReferenceCode(
+			objectDefinitionExternalReferenceCode);
+		objectFolderItem.setPositionX(positionX);
+		objectFolderItem.setPositionY(positionY);
+
+		return objectFolderItem;
+	}
+
+	@Inject
+	private IndexWriterHelper _indexWriterHelper;
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Inject
+	private ObjectFolderLocalService _objectFolderLocalService;
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-104744

Resend of https://github.com/brianchandotcom/liferay-portal/pull/181363 with the tests moved into `ObjectFolderResourceTest` as private methods behind the endpoint's `@Override`, as requested there. The implementation commit is unchanged.

## What Is Being Fixed

`ObjectFolderResourceImpl` called `ObjectDefinitionLocalService.updateObjectFolderId` for every unlinked item of an object folder PUT, including the items whose object definition already sat in that folder. The Model Builder page writes its folder back on every load: an effect keyed on the folder's item count sends the whole folder, every item included, so that the positions the structure load computes for nodes that have none yet are persisted, and it does so whether or not any position changed. One page load therefore fanned the call out over every object definition of the folder while moving none of them.

`updateObjectFolderId` is annotated `@Indexable(type = IndexableType.REINDEX)`, and the annotation reindexes the returned model even when the method returns early without writing to the database. The reindex runs at the request commit as a fetch by id followed by an unversioned, last writer wins document write, so the fan-out is worse than wasted work. When one of those reindexes overlaps a concurrent delete of the same object definition, its fetch can still see the row while its document write lands after the delete has already removed the document, and the index is left holding a document for a row that is gone. Indexing commits immediately, so this write ordering is the only source of such a document, and the index backed object definitions page answers 404 for that object definition for as long as the document survives.

The companion fix LPD-104737 (https://github.com/brianchandotcom/liferay-portal/pull/181362) removes the PUT itself on loads whose nodes are all placed. This change removes the reindex fan-out on the PUTs that remain: a drag, an add, a folder move, and the first load of a never placed node.

Root cause: b5523880e2270 (LPS-201520, 2023-11-21) introduced the loop that calls `updateObjectFolderId` for every object folder item of a PUT, a403f18cfc21d (LPS-191513, 2023-07-24) created `updateObjectFolderId` as `@Indexable`, and b7a093679964b (LPD-89355, 2026-05-08) made the unchanged folder case a database no-op while the reindex kept firing.

## How It Is Being Fixed

`updateObjectFolderId` is now called only for an object definition that sits in a different folder, guarded by `isLinkedToObjectFolder(objectFolderId)`. The object folder item positions are still updated for every item, so a PUT that only reorders keeps working exactly as before.

`ObjectFolderResourceTest.testPutObjectFolderByExternalReferenceCode` overrides the generated test, runs it, and then runs two private cases. `_testPutObjectFolderByExternalReferenceCodeUnmovedObjectDefinition` deletes only the search document of a freshly added object definition, leaving the row in place, replays the object folder PUT that the Model Builder page sends on every structure load, and requires the document to stay gone: a PUT that moves nothing must write nothing to the index. Deleting the document by hand is what makes the fan-out observable, since the reindex of an unmoved object definition writes the same document it would have written anyway. `_testPutObjectFolderByExternalReferenceCodeMovedObjectDefinition` moves a freshly added object definition into a new object folder with the same kind of PUT and requires the document to come back, so the reindex that a real move needs is still covered.

`ObjectFolderResourceTest` runs 22/22 with the change deployed (5 pre-existing `@Ignore`), and the unmoved case fails on the master implementation with `Object definition ... against the indexed object definition IDs [...] expected:<false> but was:<true>`. The previous head of this change ran `ci:test:object` 55/55.

## PR Check

**pr-check: PASS** — tested on `4b459aa4aabba84442e00f57b9755644e80f50dc`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS (0 changed exporting modules) |
| Java Unit Tests | NOT VERIFIED |

Source Format ran `format-source-current-branch` clean on both changed files after the rebase onto `02c10e1131b33`. Per-Module Compile built `apps:object:object-admin-rest-impl` (`jar`, `BUILD SUCCESSFUL`); `apps:object:object-admin-rest-test` only changes under `src/testIntegration`. Integration Test Compile ran `compileTestIntegrationJava --rerun` on `apps:object:object-admin-rest-test` to `BUILD SUCCESSFUL`. Baseline ran on `apps:object:object-admin-rest-impl` with no version repair; neither changed module exports packages, and no `bnd.bnd` or `packageinfo` changed. Java Unit Tests verified nothing: `object-admin-rest-impl` carries no `src/test` tree. Cross-Module Compile, REST Builder, Service Builder and the JavaScript validations did not fire on this diff.

<!-- pr-check {"result": "success", "sha": "4b459aa4aabba84442e00f57b9755644e80f50dc"} -->
