### PR TITLE
LPD-100579 LPD-104380 Register the two object service upgrade steps of 13.6.0 as one step

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/registry/ObjectServiceUpgradeStepRegistrator.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/registry/ObjectServiceUpgradeStepRegistrator.java
@@ -758,10 +758,7 @@ public class ObjectServiceUpgradeStepRegistrator
 		registry.register(
 			"13.5.0", "13.6.0",
 			UpgradeProcessFactory.runSQL(
-				"delete from PLOEntry where key_ = 'model.resource.'"));
-
-		registry.register(
-			"13.5.0", "13.6.0",
+				"delete from PLOEntry where key_ = 'model.resource.'"),
 			UpgradeProcessFactory.runSQL(
 				StringBundler.concat(
 					"update ObjectField set readOnly = '",

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/upgrade/v13_5_0/test/ObjectViewExternalReferenceCodeUpgradeProcessTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/upgrade/v13_5_0/test/ObjectViewExternalReferenceCodeUpgradeProcessTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-package com.liferay.object.internal.upgrade.v13_4_0.test;
+package com.liferay.object.internal.upgrade.v13_5_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.object.model.ObjectDefinition;
@@ -79,7 +79,7 @@ public class ObjectViewExternalReferenceCodeUpgradeProcessTest
 
 	@Override
 	protected Version getVersion() {
-		return new Version(13, 4, 0);
+		return new Version(13, 5, 0);
 	}
 
 	@DeleteAfterTestRun


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100579
https://liferay.atlassian.net/browse/LPD-104380

@mariuo @adolfopa, tagging you both because this fixes the fallout of #181349 and #181348 landing on the same upgrade step range. To be clear about who did what, because the git history is misleading here:

- #181349 (LPD-100579) is the change that caused both problems. It inserted a `DummyUpgradeStep` at `13.1.0` to `13.2.0` and shifted every later object service step up by one version, so the `PLOEntry` cleanup moved from `13.4.0` to `13.5.0` onto `13.5.0` to `13.6.0`, and the object view ERC step moved from `13.4.0` to `13.5.0`. That shift is what makes `ObjectViewExternalReferenceCodeUpgradeProcessTest` fail on every `ci:test:object` run since the merge, and it is what turned the range below into a collision.
- #181348 (LPD-104380) is a rebase victim, not a mistake. It was sent first (liferay-bpm#6694 at 10:41 UTC, forwarded at 12:31 UTC on 2026-09-04, #181349 followed at 13:05 UTC) and registered the readOnly repair as `13.5.0` to `13.6.0`, which was the correct next range on the master it was written against. Brian merged #181349 first and #181348 three minutes later with a rebase that did not conflict, because #181349 edited existing register calls while #181348 appended a new one. The merged history therefore shows #181348 registering a range that was already taken, although its original PR had it right. Nobody renumbered it, and nothing could have flagged it: the release graph keeps a single edge per version pair, so the second registration was silently dropped and the readOnly repair never ran on an upgrade, while the repair's integration test kept passing because it collects every step registered for `13.6.0`.

## What Is Being Fixed

1. `ObjectServiceUpgradeStepRegistrator` holds two separate registrations for `13.5.0` to `13.6.0`, the `PLOEntry` cleanup and the `ObjectField.readOnly` repair; only the first one runs on an upgrade.
2. `ObjectViewExternalReferenceCodeUpgradeProcessTest` still resolves the object view ERC step at `13.4.0` after the step moved to `13.5.0`, so it fails on every `ci:test:object` run and on the bare-master baselines.

## How It Is Being Fixed

The two `13.6.0` steps become one `registry.register("13.5.0", "13.6.0", ...)` call carrying both `runSQL` steps, which the registry runs as a single step in order, so the readOnly repair runs again without renumbering any shipped version. The test moves to the `v13_5_0` package and pins `new Version(13, 5, 0)`.

## Verification

- `ci:test:object` 51 of 51 (Testray 520182319): the upgrade test passes again.
- `ci:test:upgrade` 338 of 363 (Testray 520235825) with no regression: every failure unique to the pull is a chronic master failure that predates the branch (the `ObjectDefinition#Z7P5` class-name cleanup warning on the 7.4.13 partitioned archive, failing on every nightly master upgrade run since 2026-09-01; the smoke-upgrade 403 on `my-user-account`, failing on EE Development Acceptance master 59 through 64; one WorkflowMetrics scheduler error). The merged `13.6.0` step completed on both partitions in the failing axes' logs with zero ERROR lines.

## PR Check

**pr-check: PASS** — tested on `151ae7f6a34bf50a5edc1896717e942fcbd7eb37`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Service Registration | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS (baseline-all + seven Ant projects + 0 changed exporting modules) |
| Java Unit Tests | NOT VERIFIED |

<!-- pr-check {"result": "success", "sha": "151ae7f6a34bf50a5edc1896717e942fcbd7eb37"} -->
