### PR TITLE
LPD-104797 Serve a plain object entry listing from a finder instead of the DSL join query

### DIFF
--- a/modules/apps/object/object-api/bnd.bnd
+++ b/modules/apps/object/object-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Object API
 Bundle-SymbolicName: com.liferay.object.api
-Bundle-Version: 128.0.2
+Bundle-Version: 128.1.0
 Export-Package:\
 	com.liferay.object.action.engine,\
 	com.liferay.object.action.executor,\

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryService.java
@@ -117,6 +117,16 @@ public interface ObjectEntryService extends BaseService {
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<ObjectEntry> getObjectEntriesNotInStatus(
+			long groupId, long objectDefinitionId, int status, int start,
+			int end)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public int getObjectEntriesNotInStatusCount(
+		long groupId, long objectDefinitionId, int status);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public ObjectEntry getObjectEntry(long objectEntryId)
 		throws PortalException;
 
@@ -206,4 +216,4 @@ public interface ObjectEntryService extends BaseService {
 		throws PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1867059792
+// LIFERAY-SERVICE-BUILDER-HASH:1434687165

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryServiceUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryServiceUtil.java
@@ -146,6 +146,22 @@ public class ObjectEntryServiceUtil {
 			groupId, objectDefinitionId, status, start, end);
 	}
 
+	public static List<ObjectEntry> getObjectEntriesNotInStatus(
+			long groupId, long objectDefinitionId, int status, int start,
+			int end)
+		throws PortalException {
+
+		return getService().getObjectEntriesNotInStatus(
+			groupId, objectDefinitionId, status, start, end);
+	}
+
+	public static int getObjectEntriesNotInStatusCount(
+		long groupId, long objectDefinitionId, int status) {
+
+		return getService().getObjectEntriesNotInStatusCount(
+			groupId, objectDefinitionId, status);
+	}
+
 	public static ObjectEntry getObjectEntry(long objectEntryId)
 		throws PortalException {
 
@@ -311,4 +327,4 @@ public class ObjectEntryServiceUtil {
 		new Snapshot<>(ObjectEntryServiceUtil.class, ObjectEntryService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1323039996
+// LIFERAY-SERVICE-BUILDER-HASH:-99622791

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryServiceWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryServiceWrapper.java
@@ -161,6 +161,25 @@ public class ObjectEntryServiceWrapper
 	}
 
 	@Override
+	public java.util.List<com.liferay.object.model.ObjectEntry>
+			getObjectEntriesNotInStatus(
+				long groupId, long objectDefinitionId, int status, int start,
+				int end)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _objectEntryService.getObjectEntriesNotInStatus(
+			groupId, objectDefinitionId, status, start, end);
+	}
+
+	@Override
+	public int getObjectEntriesNotInStatusCount(
+		long groupId, long objectDefinitionId, int status) {
+
+		return _objectEntryService.getObjectEntriesNotInStatusCount(
+			groupId, objectDefinitionId, status);
+	}
+
+	@Override
 	public com.liferay.object.model.ObjectEntry getObjectEntry(
 			long objectEntryId)
 		throws com.liferay.portal.kernel.exception.PortalException {
@@ -352,4 +371,4 @@ public class ObjectEntryServiceWrapper
 	private ObjectEntryService _objectEntryService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-29569206
+// LIFERAY-SERVICE-BUILDER-HASH:1648447153

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/persistence/ObjectEntryPersistence.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/persistence/ObjectEntryPersistence.java
@@ -867,6 +867,127 @@ public interface ObjectEntryPersistence extends BasePersistence<ObjectEntry> {
 		long groupId, long objectDefinitionId, int status);
 
 	/**
+	 * Returns all the object entries where groupId = &#63; and objectDefinitionId = &#63; and status &ne; &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param objectDefinitionId the object definition ID
+	 * @param status the status
+	 * @return the matching object entries
+	 */
+	public java.util.List<ObjectEntry> findByG_ODI_NotS(
+		long groupId, long objectDefinitionId, int status);
+
+	/**
+	 * Returns a range of all the object entries where groupId = &#63; and objectDefinitionId = &#63; and status &ne; &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.object.model.impl.ObjectEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param objectDefinitionId the object definition ID
+	 * @param status the status
+	 * @param start the lower bound of the range of object entries
+	 * @param end the upper bound of the range of object entries (not inclusive)
+	 * @return the range of matching object entries
+	 */
+	public java.util.List<ObjectEntry> findByG_ODI_NotS(
+		long groupId, long objectDefinitionId, int status, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the object entries where groupId = &#63; and objectDefinitionId = &#63; and status &ne; &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.object.model.impl.ObjectEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param objectDefinitionId the object definition ID
+	 * @param status the status
+	 * @param start the lower bound of the range of object entries
+	 * @param end the upper bound of the range of object entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching object entries
+	 */
+	public java.util.List<ObjectEntry> findByG_ODI_NotS(
+		long groupId, long objectDefinitionId, int status, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<ObjectEntry>
+			orderByComparator);
+
+	/**
+	 * Returns an ordered range of all the object entries where groupId = &#63; and objectDefinitionId = &#63; and status &ne; &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.object.model.impl.ObjectEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param objectDefinitionId the object definition ID
+	 * @param status the status
+	 * @param start the lower bound of the range of object entries
+	 * @param end the upper bound of the range of object entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching object entries
+	 */
+	public java.util.List<ObjectEntry> findByG_ODI_NotS(
+		long groupId, long objectDefinitionId, int status, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<ObjectEntry>
+			orderByComparator,
+		boolean useFinderCache);
+
+	/**
+	 * Returns the first object entry in the ordered set where groupId = &#63; and objectDefinitionId = &#63; and status &ne; &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param objectDefinitionId the object definition ID
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching object entry
+	 * @throws NoSuchObjectEntryException if a matching object entry could not be found
+	 */
+	public ObjectEntry findByG_ODI_NotS_First(
+			long groupId, long objectDefinitionId, int status,
+			com.liferay.portal.kernel.util.OrderByComparator<ObjectEntry>
+				orderByComparator)
+		throws NoSuchObjectEntryException;
+
+	/**
+	 * Returns the first object entry in the ordered set where groupId = &#63; and objectDefinitionId = &#63; and status &ne; &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param objectDefinitionId the object definition ID
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching object entry, or <code>null</code> if a matching object entry could not be found
+	 */
+	public ObjectEntry fetchByG_ODI_NotS_First(
+		long groupId, long objectDefinitionId, int status,
+		com.liferay.portal.kernel.util.OrderByComparator<ObjectEntry>
+			orderByComparator);
+
+	/**
+	 * Removes all the object entries where groupId = &#63; and objectDefinitionId = &#63; and status &ne; &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param objectDefinitionId the object definition ID
+	 * @param status the status
+	 */
+	public void removeByG_ODI_NotS(
+		long groupId, long objectDefinitionId, int status);
+
+	/**
+	 * Returns the number of object entries where groupId = &#63; and objectDefinitionId = &#63; and status &ne; &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param objectDefinitionId the object definition ID
+	 * @param status the status
+	 * @return the number of matching object entries
+	 */
+	public int countByG_ODI_NotS(
+		long groupId, long objectDefinitionId, int status);
+
+	/**
 	 * Returns all the object entries where userId = &#63; and createDate &gt; &#63; and objectDefinitionId = &#63;.
 	 *
 	 * @param userId the user ID
@@ -1594,4 +1715,4 @@ public interface ObjectEntryPersistence extends BasePersistence<ObjectEntry> {
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1585792985
+// LIFERAY-SERVICE-BUILDER-HASH:-1253816660

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/persistence/ObjectEntryUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/persistence/ObjectEntryUtil.java
@@ -1141,6 +1141,156 @@ public class ObjectEntryUtil {
 	}
 
 	/**
+	 * Returns all the object entries where groupId = &#63; and objectDefinitionId = &#63; and status &ne; &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param objectDefinitionId the object definition ID
+	 * @param status the status
+	 * @return the matching object entries
+	 */
+	public static List<ObjectEntry> findByG_ODI_NotS(
+		long groupId, long objectDefinitionId, int status) {
+
+		return getPersistence().findByG_ODI_NotS(
+			groupId, objectDefinitionId, status);
+	}
+
+	/**
+	 * Returns a range of all the object entries where groupId = &#63; and objectDefinitionId = &#63; and status &ne; &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.object.model.impl.ObjectEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param objectDefinitionId the object definition ID
+	 * @param status the status
+	 * @param start the lower bound of the range of object entries
+	 * @param end the upper bound of the range of object entries (not inclusive)
+	 * @return the range of matching object entries
+	 */
+	public static List<ObjectEntry> findByG_ODI_NotS(
+		long groupId, long objectDefinitionId, int status, int start, int end) {
+
+		return getPersistence().findByG_ODI_NotS(
+			groupId, objectDefinitionId, status, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the object entries where groupId = &#63; and objectDefinitionId = &#63; and status &ne; &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.object.model.impl.ObjectEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param objectDefinitionId the object definition ID
+	 * @param status the status
+	 * @param start the lower bound of the range of object entries
+	 * @param end the upper bound of the range of object entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching object entries
+	 */
+	public static List<ObjectEntry> findByG_ODI_NotS(
+		long groupId, long objectDefinitionId, int status, int start, int end,
+		OrderByComparator<ObjectEntry> orderByComparator) {
+
+		return getPersistence().findByG_ODI_NotS(
+			groupId, objectDefinitionId, status, start, end, orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the object entries where groupId = &#63; and objectDefinitionId = &#63; and status &ne; &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.object.model.impl.ObjectEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param objectDefinitionId the object definition ID
+	 * @param status the status
+	 * @param start the lower bound of the range of object entries
+	 * @param end the upper bound of the range of object entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching object entries
+	 */
+	public static List<ObjectEntry> findByG_ODI_NotS(
+		long groupId, long objectDefinitionId, int status, int start, int end,
+		OrderByComparator<ObjectEntry> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByG_ODI_NotS(
+			groupId, objectDefinitionId, status, start, end, orderByComparator,
+			useFinderCache);
+	}
+
+	/**
+	 * Returns the first object entry in the ordered set where groupId = &#63; and objectDefinitionId = &#63; and status &ne; &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param objectDefinitionId the object definition ID
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching object entry
+	 * @throws NoSuchObjectEntryException if a matching object entry could not be found
+	 */
+	public static ObjectEntry findByG_ODI_NotS_First(
+			long groupId, long objectDefinitionId, int status,
+			OrderByComparator<ObjectEntry> orderByComparator)
+		throws com.liferay.object.exception.NoSuchObjectEntryException {
+
+		return getPersistence().findByG_ODI_NotS_First(
+			groupId, objectDefinitionId, status, orderByComparator);
+	}
+
+	/**
+	 * Returns the first object entry in the ordered set where groupId = &#63; and objectDefinitionId = &#63; and status &ne; &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param objectDefinitionId the object definition ID
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching object entry, or <code>null</code> if a matching object entry could not be found
+	 */
+	public static ObjectEntry fetchByG_ODI_NotS_First(
+		long groupId, long objectDefinitionId, int status,
+		OrderByComparator<ObjectEntry> orderByComparator) {
+
+		return getPersistence().fetchByG_ODI_NotS_First(
+			groupId, objectDefinitionId, status, orderByComparator);
+	}
+
+	/**
+	 * Removes all the object entries where groupId = &#63; and objectDefinitionId = &#63; and status &ne; &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param objectDefinitionId the object definition ID
+	 * @param status the status
+	 */
+	public static void removeByG_ODI_NotS(
+		long groupId, long objectDefinitionId, int status) {
+
+		getPersistence().removeByG_ODI_NotS(
+			groupId, objectDefinitionId, status);
+	}
+
+	/**
+	 * Returns the number of object entries where groupId = &#63; and objectDefinitionId = &#63; and status &ne; &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param objectDefinitionId the object definition ID
+	 * @param status the status
+	 * @return the number of matching object entries
+	 */
+	public static int countByG_ODI_NotS(
+		long groupId, long objectDefinitionId, int status) {
+
+		return getPersistence().countByG_ODI_NotS(
+			groupId, objectDefinitionId, status);
+	}
+
+	/**
 	 * Returns all the object entries where userId = &#63; and createDate &gt; &#63; and objectDefinitionId = &#63;.
 	 *
 	 * @param userId the user ID
@@ -1901,4 +2051,4 @@ public class ObjectEntryUtil {
 	private static volatile ObjectEntryPersistence _persistence;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1589412355
+// LIFERAY-SERVICE-BUILDER-HASH:425117630

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/service/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/service/packageinfo
@@ -1,1 +1,1 @@
-version 88.0.0
+version 88.1.0

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/service/persistence/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 14.1.0
+version 14.2.0

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -111,6 +111,7 @@ import com.liferay.portal.kernel.search.filter.BooleanFilter;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.search.filter.TermFilter;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.InlineSQLHelper;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
@@ -822,6 +823,43 @@ public class DefaultObjectEntryManagerImpl
 		int start = _getStartPosition(pagination);
 		int end = _getEndPosition(pagination);
 
+		boolean preferApproved = GetterUtil.getBoolean(
+			dtoConverterContext.getAttribute("preferApproved"));
+
+		List<ObjectEntry> objectEntries = null;
+		int objectEntriesCount = 0;
+
+		Long finderGroupId = _getFinderGroupId(
+			objectDefinition, groupIds, predicate, preferApproved, search,
+			sorts);
+
+		if (finderGroupId == null) {
+			objectEntries = TransformUtil.transform(
+				objectEntryLocalService.getPrimaryKeys(
+					groupIds, companyId, dtoConverterContext.getUserId(),
+					objectDefinition.getObjectDefinitionId(), predicate,
+					preferApproved, search, start, end, sorts),
+				primaryKey -> _getObjectEntry(
+					dtoConverterContext, objectDefinition, primaryKey));
+			objectEntriesCount = objectEntryLocalService.getValuesListCount(
+				groupIds, companyId, dtoConverterContext.getUserId(),
+				objectDefinition.getObjectDefinitionId(), predicate,
+				preferApproved, search);
+		}
+		else {
+			objectEntries = TransformUtil.transform(
+				_objectEntryService.getObjectEntriesNotInStatus(
+					finderGroupId, objectDefinition.getObjectDefinitionId(),
+					WorkflowConstants.STATUS_IN_TRASH, start, end),
+				serviceBuilderObjectEntry -> _getObjectEntry(
+					dtoConverterContext, objectDefinition,
+					serviceBuilderObjectEntry));
+			objectEntriesCount =
+				_objectEntryService.getObjectEntriesNotInStatusCount(
+					finderGroupId, objectDefinition.getObjectDefinitionId(),
+					WorkflowConstants.STATUS_IN_TRASH);
+		}
+
 		return Page.of(
 			HashMapBuilder.put(
 				"create",
@@ -867,22 +905,7 @@ public class DefaultObjectEntryManagerImpl
 					aggregationTerm, predicate,
 					GetterUtil.getBoolean(
 						dtoConverterContext.getAttribute("preferApproved")))),
-			TransformUtil.transform(
-				objectEntryLocalService.getPrimaryKeys(
-					groupIds, companyId, dtoConverterContext.getUserId(),
-					objectDefinition.getObjectDefinitionId(), predicate,
-					GetterUtil.getBoolean(
-						dtoConverterContext.getAttribute("preferApproved")),
-					search, start, end, sorts),
-				primaryKey -> _getObjectEntry(
-					dtoConverterContext, objectDefinition, primaryKey)),
-			pagination,
-			objectEntryLocalService.getValuesListCount(
-				groupIds, companyId, dtoConverterContext.getUserId(),
-				objectDefinition.getObjectDefinitionId(), predicate,
-				GetterUtil.getBoolean(
-					dtoConverterContext.getAttribute("preferApproved")),
-				search));
+			objectEntries, pagination, objectEntriesCount);
 	}
 
 	@Override
@@ -2394,6 +2417,41 @@ public class DefaultObjectEntryManagerImpl
 		return getGroupId(objectDefinition, scopeKey, true);
 	}
 
+	private Long _getFinderGroupId(
+		ObjectDefinition objectDefinition, Long[] groupIds, Predicate predicate,
+		boolean preferApproved, String search, Sort[] sorts) {
+
+		if ((predicate != null) || preferApproved ||
+			Validator.isNotNull(search) || !_isDefaultSort(sorts) ||
+			ArrayUtil.isNotEmpty(
+				objectDefinition.getRootObjectDefinitionIds())) {
+
+			return null;
+		}
+
+		long groupId = 0;
+
+		if (!StringUtil.equals(
+				objectDefinition.getScope(),
+				ObjectDefinitionConstants.SCOPE_COMPANY)) {
+
+			if (groupIds.length != 1) {
+				return null;
+			}
+
+			groupId = groupIds[0];
+		}
+
+		if ((PermissionThreadLocal.getPermissionChecker() != null) &&
+			_inlineSQLHelper.isEnabled(
+				objectDefinition.getCompanyId(), groupId)) {
+
+			return null;
+		}
+
+		return groupId;
+	}
+
 	private String _getGroupExternalReferenceCode(FileEntry fileEntry) {
 		Scope scope = fileEntry.getScope();
 
@@ -3113,6 +3171,24 @@ public class DefaultObjectEntryManagerImpl
 		}
 
 		return (Serializable)value;
+	}
+
+	private boolean _isDefaultSort(Sort[] sorts) {
+		if (sorts == null) {
+			return true;
+		}
+
+		if (sorts.length != 1) {
+			return false;
+		}
+
+		Sort sort = sorts[0];
+
+		if (Objects.equals(sort.getFieldName(), "id") && !sort.isReverse()) {
+			return true;
+		}
+
+		return false;
 	}
 
 	private boolean _isObjectEntryDraft(Status status) {
@@ -4184,6 +4260,9 @@ public class DefaultObjectEntryManagerImpl
 
 	@Reference
 	private Http _http;
+
+	@Reference
+	private InlineSQLHelper _inlineSQLHelper;
 
 	@Reference
 	private JSONFactory _jsonFactory;

--- a/modules/apps/object/object-service/service.xml
+++ b/modules/apps/object/object-service/service.xml
@@ -313,6 +313,11 @@
 			<finder-column name="objectDefinitionId" />
 			<finder-column name="status" />
 		</finder>
+		<finder name="G_ODI_NotS" return-type="Collection" where="objectEntryId = headObjectEntryId">
+			<finder-column name="groupId" />
+			<finder-column name="objectDefinitionId" />
+			<finder-column comparator="!=" name="status" />
+		</finder>
 		<finder name="U_GtCD_ODI" return-type="Collection" where="objectEntryId = headObjectEntryId">
 			<finder-column name="userId" />
 			<finder-column comparator="&gt;" name="createDate" />

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/security/permission/resource/ObjectEntryModelResourcePermission.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/security/permission/resource/ObjectEntryModelResourcePermission.java
@@ -155,9 +155,7 @@ public class ObjectEntryModelResourcePermission
 			objectEntry = rootObjectEntry;
 		}
 
-		ObjectDefinition objectDefinition =
-			_objectDefinitionLocalService.getObjectDefinition(
-				objectEntry.getObjectDefinitionId());
+		ObjectDefinition objectDefinition = objectEntry.getObjectDefinition();
 
 		if (Objects.equals(actionId, ActionKeys.DOWNLOAD) &&
 			Objects.equals(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/http/ObjectEntryServiceHttp.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/http/ObjectEntryServiceHttp.java
@@ -589,6 +589,83 @@ public class ObjectEntryServiceHttp {
 		}
 	}
 
+	public static java.util.List<com.liferay.object.model.ObjectEntry>
+			getObjectEntriesNotInStatus(
+				HttpPrincipal httpPrincipal, long groupId,
+				long objectDefinitionId, int status, int start, int end)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				ObjectEntryServiceUtil.class, "getObjectEntriesNotInStatus",
+				_getObjectEntriesNotInStatusParameterTypes13);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, groupId, objectDefinitionId, status, start, end);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (java.util.List<com.liferay.object.model.ObjectEntry>)
+				returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static int getObjectEntriesNotInStatusCount(
+		HttpPrincipal httpPrincipal, long groupId, long objectDefinitionId,
+		int status) {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				ObjectEntryServiceUtil.class,
+				"getObjectEntriesNotInStatusCount",
+				_getObjectEntriesNotInStatusCountParameterTypes14);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, groupId, objectDefinitionId, status);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return ((Integer)returnObj).intValue();
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
 	public static com.liferay.object.model.ObjectEntry getObjectEntry(
 			HttpPrincipal httpPrincipal, long objectEntryId)
 		throws com.liferay.portal.kernel.exception.PortalException {
@@ -596,7 +673,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "getObjectEntry",
-				_getObjectEntryParameterTypes13);
+				_getObjectEntryParameterTypes15);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, objectEntryId);
@@ -637,7 +714,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "getObjectEntry",
-				_getObjectEntryParameterTypes14);
+				_getObjectEntryParameterTypes16);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, externalReferenceCode, groupId, objectDefinitionId);
@@ -683,7 +760,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "getOneToManyObjectEntries",
-				_getOneToManyObjectEntriesParameterTypes15);
+				_getOneToManyObjectEntriesParameterTypes17);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, objectRelationshipId, predicate,
@@ -728,7 +805,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "getOneToManyObjectEntriesCount",
-				_getOneToManyObjectEntriesCountParameterTypes16);
+				_getOneToManyObjectEntriesCountParameterTypes18);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, objectRelationshipId, predicate, primaryKey,
@@ -770,7 +847,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "getOrAddEmptyObjectEntry",
-				_getOrAddEmptyObjectEntryParameterTypes17);
+				_getOrAddEmptyObjectEntryParameterTypes19);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, externalReferenceCode, groupId, objectDefinitionId);
@@ -811,7 +888,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "hasModelResourcePermission",
-				_hasModelResourcePermissionParameterTypes18);
+				_hasModelResourcePermissionParameterTypes20);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, objectDefinitionId, objectEntryId, actionId);
@@ -852,7 +929,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "hasModelResourcePermission",
-				_hasModelResourcePermissionParameterTypes19);
+				_hasModelResourcePermissionParameterTypes21);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, objectEntry, actionId);
@@ -894,7 +971,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "hasModelResourcePermission",
-				_hasModelResourcePermissionParameterTypes20);
+				_hasModelResourcePermissionParameterTypes22);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, user, objectEntryId, actionId);
@@ -935,7 +1012,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "hasPortletResourcePermission",
-				_hasPortletResourcePermissionParameterTypes21);
+				_hasPortletResourcePermissionParameterTypes23);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, objectDefinitionId, actionId);
@@ -978,7 +1055,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "moveObjectEntry",
-				_moveObjectEntryParameterTypes22);
+				_moveObjectEntryParameterTypes24);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, objectEntryId, objectEntryFolderId, values,
@@ -1021,7 +1098,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "moveObjectEntryToTrash",
-				_moveObjectEntryToTrashParameterTypes23);
+				_moveObjectEntryToTrashParameterTypes25);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, objectEntry, serviceContext);
@@ -1064,7 +1141,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "partialUpdateObjectEntry",
-				_partialUpdateObjectEntryParameterTypes24);
+				_partialUpdateObjectEntryParameterTypes26);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, objectEntryId, objectEntryFolderId, values,
@@ -1108,7 +1185,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "restoreObjectEntryFromTrash",
-				_restoreObjectEntryFromTrashParameterTypes25);
+				_restoreObjectEntryFromTrashParameterTypes27);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, objectEntry, serviceContext);
@@ -1148,7 +1225,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "subscribeObjectEntry",
-				_subscribeObjectEntryParameterTypes26);
+				_subscribeObjectEntryParameterTypes28);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, objectEntryId);
@@ -1184,7 +1261,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "unsubscribeObjectEntry",
-				_unsubscribeObjectEntryParameterTypes27);
+				_unsubscribeObjectEntryParameterTypes29);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, objectEntryId);
@@ -1223,7 +1300,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "updateObjectEntry",
-				_updateObjectEntryParameterTypes28);
+				_updateObjectEntryParameterTypes30);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, objectEntryId, objectEntryFolderId, values,
@@ -1267,7 +1344,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "validate",
-				_validateParameterTypes29);
+				_validateParameterTypes31);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, objectEntry,
@@ -1347,11 +1424,19 @@ public class ObjectEntryServiceHttp {
 		_getModelResourcePermissionParameterTypes11 = new Class[] {long.class};
 	private static final Class<?>[] _getObjectEntriesParameterTypes12 =
 		new Class[] {long.class, long.class, int.class, int.class, int.class};
-	private static final Class<?>[] _getObjectEntryParameterTypes13 =
+	private static final Class<?>[]
+		_getObjectEntriesNotInStatusParameterTypes13 = new Class[] {
+			long.class, long.class, int.class, int.class, int.class
+		};
+	private static final Class<?>[]
+		_getObjectEntriesNotInStatusCountParameterTypes14 = new Class[] {
+			long.class, long.class, int.class
+		};
+	private static final Class<?>[] _getObjectEntryParameterTypes15 =
 		new Class[] {long.class};
-	private static final Class<?>[] _getObjectEntryParameterTypes14 =
+	private static final Class<?>[] _getObjectEntryParameterTypes16 =
 		new Class[] {String.class, long.class, long.class};
-	private static final Class<?>[] _getOneToManyObjectEntriesParameterTypes15 =
+	private static final Class<?>[] _getOneToManyObjectEntriesParameterTypes17 =
 		new Class[] {
 			long.class, long.class,
 			com.liferay.petra.sql.dsl.expression.Predicate.class, boolean.class,
@@ -1359,63 +1444,63 @@ public class ObjectEntryServiceHttp {
 			com.liferay.portal.kernel.search.Sort[].class
 		};
 	private static final Class<?>[]
-		_getOneToManyObjectEntriesCountParameterTypes16 = new Class[] {
+		_getOneToManyObjectEntriesCountParameterTypes18 = new Class[] {
 			long.class, long.class,
 			com.liferay.petra.sql.dsl.expression.Predicate.class, long.class,
 			boolean.class, String.class
 		};
-	private static final Class<?>[] _getOrAddEmptyObjectEntryParameterTypes17 =
+	private static final Class<?>[] _getOrAddEmptyObjectEntryParameterTypes19 =
 		new Class[] {String.class, long.class, long.class};
 	private static final Class<?>[]
-		_hasModelResourcePermissionParameterTypes18 = new Class[] {
+		_hasModelResourcePermissionParameterTypes20 = new Class[] {
 			long.class, long.class, String.class
 		};
 	private static final Class<?>[]
-		_hasModelResourcePermissionParameterTypes19 = new Class[] {
+		_hasModelResourcePermissionParameterTypes21 = new Class[] {
 			com.liferay.object.model.ObjectEntry.class, String.class
 		};
 	private static final Class<?>[]
-		_hasModelResourcePermissionParameterTypes20 = new Class[] {
+		_hasModelResourcePermissionParameterTypes22 = new Class[] {
 			com.liferay.portal.kernel.model.User.class, long.class, String.class
 		};
 	private static final Class<?>[]
-		_hasPortletResourcePermissionParameterTypes21 = new Class[] {
+		_hasPortletResourcePermissionParameterTypes23 = new Class[] {
 			long.class, long.class, String.class
 		};
-	private static final Class<?>[] _moveObjectEntryParameterTypes22 =
+	private static final Class<?>[] _moveObjectEntryParameterTypes24 =
 		new Class[] {
 			long.class, long.class, java.util.Map.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _moveObjectEntryToTrashParameterTypes23 =
+	private static final Class<?>[] _moveObjectEntryToTrashParameterTypes25 =
 		new Class[] {
 			com.liferay.object.model.ObjectEntry.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _partialUpdateObjectEntryParameterTypes24 =
+	private static final Class<?>[] _partialUpdateObjectEntryParameterTypes26 =
 		new Class[] {
 			long.class, long.class, java.util.Map.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
 	private static final Class<?>[]
-		_restoreObjectEntryFromTrashParameterTypes25 = new Class[] {
+		_restoreObjectEntryFromTrashParameterTypes27 = new Class[] {
 			com.liferay.object.model.ObjectEntry.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _subscribeObjectEntryParameterTypes26 =
+	private static final Class<?>[] _subscribeObjectEntryParameterTypes28 =
 		new Class[] {long.class, long.class};
-	private static final Class<?>[] _unsubscribeObjectEntryParameterTypes27 =
+	private static final Class<?>[] _unsubscribeObjectEntryParameterTypes29 =
 		new Class[] {long.class};
-	private static final Class<?>[] _updateObjectEntryParameterTypes28 =
+	private static final Class<?>[] _updateObjectEntryParameterTypes30 =
 		new Class[] {
 			long.class, long.class, java.util.Map.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _validateParameterTypes29 = new Class[] {
+	private static final Class<?>[] _validateParameterTypes31 = new Class[] {
 		long.class, com.liferay.object.model.ObjectEntry.class,
 		java.util.List.class,
 		com.liferay.portal.kernel.service.ServiceContext.class
 	};
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:575751263
+// LIFERAY-SERVICE-BUILDER-HASH:108309628

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryServiceImpl.java
@@ -313,11 +313,8 @@ public class ObjectEntryServiceImpl extends ObjectEntryServiceBaseImpl {
 			long objectDefinitionId)
 		throws PortalException {
 
-		ObjectDefinition objectDefinition =
-			_objectDefinitionPersistence.findByPrimaryKey(objectDefinitionId);
-
-		return ModelResourcePermissionRegistryUtil.getModelResourcePermission(
-			objectDefinition.getClassName());
+		return _getModelResourcePermission(
+			_objectDefinitionPersistence.findByPrimaryKey(objectDefinitionId));
 	}
 
 	@Override
@@ -348,6 +345,43 @@ public class ObjectEntryServiceImpl extends ObjectEntryServiceBaseImpl {
 
 				return null;
 			});
+	}
+
+	@Override
+	public List<ObjectEntry> getObjectEntriesNotInStatus(
+			long groupId, long objectDefinitionId, int status, int start,
+			int end)
+		throws PortalException {
+
+		List<ObjectEntry> objectEntries =
+			objectEntryPersistence.findByG_ODI_NotS(
+				groupId, objectDefinitionId, status, start, end);
+
+		if (!ObjectEntryThreadLocal.isSkipObjectEntryResourcePermission()) {
+			ObjectDefinition objectDefinition =
+				_objectDefinitionPersistence.findByPrimaryKey(
+					objectDefinitionId);
+
+			ModelResourcePermission<ObjectEntry> modelResourcePermission =
+				_getModelResourcePermission(objectDefinition);
+
+			for (ObjectEntry objectEntry : objectEntries) {
+				objectEntry.setObjectDefinition(objectDefinition);
+
+				_checkPermission(
+					ActionKeys.VIEW, modelResourcePermission, objectEntry);
+			}
+		}
+
+		return objectEntries;
+	}
+
+	@Override
+	public int getObjectEntriesNotInStatusCount(
+		long groupId, long objectDefinitionId, int status) {
+
+		return objectEntryPersistence.countByG_ODI_NotS(
+			groupId, objectDefinitionId, status);
 	}
 
 	@Override
@@ -745,8 +779,16 @@ public class ObjectEntryServiceImpl extends ObjectEntryServiceBaseImpl {
 			String actionId, long objectDefinitionId, ObjectEntry objectEntry)
 		throws PortalException {
 
-		ModelResourcePermission<ObjectEntry> modelResourcePermission =
-			getModelResourcePermission(objectDefinitionId);
+		_checkPermission(
+			actionId, getModelResourcePermission(objectDefinitionId),
+			objectEntry);
+	}
+
+	private void _checkPermission(
+			String actionId,
+			ModelResourcePermission<ObjectEntry> modelResourcePermission,
+			ObjectEntry objectEntry)
+		throws PortalException {
 
 		if (objectEntry.isRootDescendantNode() &&
 			(actionId.equals(ActionKeys.DELETE) ||
@@ -759,6 +801,13 @@ public class ObjectEntryServiceImpl extends ObjectEntryServiceBaseImpl {
 
 		modelResourcePermission.check(
 			getPermissionChecker(), objectEntry, actionId);
+	}
+
+	private ModelResourcePermission<ObjectEntry> _getModelResourcePermission(
+		ObjectDefinition objectDefinition) {
+
+		return ModelResourcePermissionRegistryUtil.getModelResourcePermission(
+			objectDefinition.getClassName());
 	}
 
 	private ObjectEntry _getRootObjectEntry(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/persistence/impl/ObjectEntryPersistenceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/persistence/impl/ObjectEntryPersistenceImpl.java
@@ -1252,6 +1252,171 @@ public class ObjectEntryPersistenceImpl
 	}
 
 	private CollectionPersistenceFinder<ObjectEntry, NoSuchObjectEntryException>
+		_collectionPersistenceFinderByG_ODI_NotS;
+
+	/**
+	 * Returns all the object entries where groupId = &#63; and objectDefinitionId = &#63; and status &ne; &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param objectDefinitionId the object definition ID
+	 * @param status the status
+	 * @return the matching object entries
+	 */
+	@Override
+	public List<ObjectEntry> findByG_ODI_NotS(
+		long groupId, long objectDefinitionId, int status) {
+
+		return findByG_ODI_NotS(
+			groupId, objectDefinitionId, status, QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the object entries where groupId = &#63; and objectDefinitionId = &#63; and status &ne; &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ObjectEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param objectDefinitionId the object definition ID
+	 * @param status the status
+	 * @param start the lower bound of the range of object entries
+	 * @param end the upper bound of the range of object entries (not inclusive)
+	 * @return the range of matching object entries
+	 */
+	@Override
+	public List<ObjectEntry> findByG_ODI_NotS(
+		long groupId, long objectDefinitionId, int status, int start, int end) {
+
+		return findByG_ODI_NotS(
+			groupId, objectDefinitionId, status, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the object entries where groupId = &#63; and objectDefinitionId = &#63; and status &ne; &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ObjectEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param objectDefinitionId the object definition ID
+	 * @param status the status
+	 * @param start the lower bound of the range of object entries
+	 * @param end the upper bound of the range of object entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching object entries
+	 */
+	@Override
+	public List<ObjectEntry> findByG_ODI_NotS(
+		long groupId, long objectDefinitionId, int status, int start, int end,
+		OrderByComparator<ObjectEntry> orderByComparator) {
+
+		return findByG_ODI_NotS(
+			groupId, objectDefinitionId, status, start, end, orderByComparator,
+			true);
+	}
+
+	/**
+	 * Returns an ordered range of all the object entries where groupId = &#63; and objectDefinitionId = &#63; and status &ne; &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ObjectEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param objectDefinitionId the object definition ID
+	 * @param status the status
+	 * @param start the lower bound of the range of object entries
+	 * @param end the upper bound of the range of object entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching object entries
+	 */
+	@Override
+	public List<ObjectEntry> findByG_ODI_NotS(
+		long groupId, long objectDefinitionId, int status, int start, int end,
+		OrderByComparator<ObjectEntry> orderByComparator,
+		boolean useFinderCache) {
+
+		return _collectionPersistenceFinderByG_ODI_NotS.find(
+			finderCache, new Object[] {groupId, objectDefinitionId, status},
+			start, end, orderByComparator, useFinderCache);
+	}
+
+	/**
+	 * Returns the first object entry in the ordered set where groupId = &#63; and objectDefinitionId = &#63; and status &ne; &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param objectDefinitionId the object definition ID
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching object entry
+	 * @throws NoSuchObjectEntryException if a matching object entry could not be found
+	 */
+	@Override
+	public ObjectEntry findByG_ODI_NotS_First(
+			long groupId, long objectDefinitionId, int status,
+			OrderByComparator<ObjectEntry> orderByComparator)
+		throws NoSuchObjectEntryException {
+
+		return _collectionPersistenceFinderByG_ODI_NotS.findFirst(
+			finderCache, new Object[] {groupId, objectDefinitionId, status},
+			orderByComparator);
+	}
+
+	/**
+	 * Returns the first object entry in the ordered set where groupId = &#63; and objectDefinitionId = &#63; and status &ne; &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param objectDefinitionId the object definition ID
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching object entry, or <code>null</code> if a matching object entry could not be found
+	 */
+	@Override
+	public ObjectEntry fetchByG_ODI_NotS_First(
+		long groupId, long objectDefinitionId, int status,
+		OrderByComparator<ObjectEntry> orderByComparator) {
+
+		return _collectionPersistenceFinderByG_ODI_NotS.fetchFirst(
+			finderCache, new Object[] {groupId, objectDefinitionId, status},
+			orderByComparator);
+	}
+
+	/**
+	 * Removes all the object entries where groupId = &#63; and objectDefinitionId = &#63; and status &ne; &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param objectDefinitionId the object definition ID
+	 * @param status the status
+	 */
+	@Override
+	public void removeByG_ODI_NotS(
+		long groupId, long objectDefinitionId, int status) {
+
+		_collectionPersistenceFinderByG_ODI_NotS.remove(
+			finderCache, new Object[] {groupId, objectDefinitionId, status});
+	}
+
+	/**
+	 * Returns the number of object entries where groupId = &#63; and objectDefinitionId = &#63; and status &ne; &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param objectDefinitionId the object definition ID
+	 * @param status the status
+	 * @return the number of matching object entries
+	 */
+	@Override
+	public int countByG_ODI_NotS(
+		long groupId, long objectDefinitionId, int status) {
+
+		return _collectionPersistenceFinderByG_ODI_NotS.count(
+			finderCache, new Object[] {groupId, objectDefinitionId, status});
+	}
+
+	private CollectionPersistenceFinder<ObjectEntry, NoSuchObjectEntryException>
 		_collectionPersistenceFinderByU_GtCD_ODI;
 
 	/**
@@ -2128,6 +2293,44 @@ public class ObjectEntryPersistenceImpl
 					"objectEntry.", "status", FinderColumn.Type.INTEGER, "=",
 					true, true, ObjectEntry::getStatus));
 
+		_collectionPersistenceFinderByG_ODI_NotS =
+			new CollectionPersistenceFinder<>(
+				this,
+				new FinderPath(
+					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_ODI_NotS",
+					new String[] {
+						Long.class.getName(), Long.class.getName(),
+						Integer.class.getName(), Integer.class.getName(),
+						Integer.class.getName(),
+						OrderByComparator.class.getName()
+					},
+					new String[] {"groupId", "objectDefinitionId", "status"},
+					true),
+				null,
+				new FinderPath(
+					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByG_ODI_NotS",
+					new String[] {
+						Long.class.getName(), Long.class.getName(),
+						Integer.class.getName()
+					},
+					new String[] {"groupId", "objectDefinitionId", "status"},
+					false),
+				_SQL_SELECT_OBJECTENTRY_WHERE, _SQL_COUNT_OBJECTENTRY_WHERE,
+				ObjectEntryModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
+				"objectEntry.objectEntryId = objectEntry.headObjectEntryId",
+				"objectEntry.objectEntryId = objectEntry.headObjectEntryId",
+				null,
+				new FinderColumn<>(
+					"objectEntry.", "groupId", FinderColumn.Type.LONG, "=",
+					true, true, ObjectEntry::getGroupId),
+				new FinderColumn<>(
+					"objectEntry.", "objectDefinitionId",
+					FinderColumn.Type.LONG, "=", true, true,
+					ObjectEntry::getObjectDefinitionId),
+				new FinderColumn<>(
+					"objectEntry.", "status", FinderColumn.Type.INTEGER, "!=",
+					true, true, ObjectEntry::getStatus));
+
 		_collectionPersistenceFinderByU_GtCD_ODI =
 			new CollectionPersistenceFinder<>(
 				this,
@@ -2260,4 +2463,4 @@ public class ObjectEntryPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1937264170
+// LIFERAY-SERVICE-BUILDER-HASH:-1342389250

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectEntryPersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectEntryPersistenceTest.java
@@ -335,6 +335,15 @@ public class ObjectEntryPersistenceTest {
 	}
 
 	@Test
+	public void testCountByG_ODI_NotS() throws Exception {
+		_persistence.countByG_ODI_NotS(
+			RandomTestUtil.nextLong(), RandomTestUtil.nextLong(),
+			RandomTestUtil.nextInt());
+
+		_persistence.countByG_ODI_NotS(0L, 0L, 0);
+	}
+
+	@Test
 	public void testCountByU_GtCD_ODI() throws Exception {
 		_persistence.countByU_GtCD_ODI(
 			RandomTestUtil.nextLong(), RandomTestUtil.nextDate(),
@@ -753,4 +762,4 @@ public class ObjectEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1440861900
+// LIFERAY-SERVICE-BUILDER-HASH:-581398502


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-104797

First change of the object entry listing optimization tracked under LPD-65366 (LPD-98910 scenario: a site page whose collection display lists a custom object's entries).

## What Is Being Fixed

`DefaultObjectEntryManagerImpl` builds every listing through the DSL query, which joins the definition's dynamic table, its extension table and, when present, its localization table to `ObjectEntry`, pages that join and counts it with `DISTINCT`. On a plain listing nothing reads the joined tables: the predicates on group, definition, root, head and status are `ObjectEntry` columns and the default sort is the primary key. On the 100k-entry sample data each page view examines about 306k rows for those two statements, and both sit behind the volatile query cache that any object entry write evicts.

## How It Is Being Fixed

A generated finder, `G_ODI_NotS` (group, definition, status not equal, `objectEntryId = headObjectEntryId`), answers the plain listing from `ObjectEntry` alone with the finder and entity caches. `ObjectEntryService.getObjectEntriesNotInStatus` and `getObjectEntriesNotInStatusCount` expose it on the remote service with the same view check `getObjectEntry` applies, resolving the definition and its model resource permission once per list and handing the definition to every entry before the check so the permission logic does not ask the definition service per row. The manager lists and counts through them when the request carries no filter, no search term, no custom sort and no preference for approved versions, the definition has no root definitions, the scope resolves to a single group and inline permission checks do not apply to the user. Every other request keeps the DSL path unchanged.

## Verification

- Integration tests cover the finder, the two remote service methods (per-entry view check, count) and the manager's finder branch against the DSL branch.
- Self-CI on shuyangzhou/liferay-portal PR 12736: `ci:test:stable` 16/16; `ci:test:object` 49/51 where the single failure is the known master `ObjectViewExternalReferenceCodeUpgradeProcessTest` regression fixed in #181393; `ci:test:relevant` with only the chronic export-import-web Playwright specs failing.
- Local load driver on the 100k sample entries: the collection page view no longer runs the DSL join page and the `DISTINCT` count (rows examined per view from about 306k to about 102k, the finder result cached between writes); 10 threads x 100 iterations, p50 301 ms vs 436 ms, p95 373 ms vs 643 ms.

## PR Check

**pr-check: PASS** — tested on `71d6999e71e27a387d21d8be213dc95e9ca4d5ca`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Service Registration | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS (baseline-all + seven Ant projects + 1 changed exporting module) |
| Structural Smoke | PASS |
| Java Unit Tests | NOT VERIFIED |

<!-- pr-check {"result": "success", "sha": "71d6999e71e27a387d21d8be213dc95e9ca4d5ca"} -->
