### PR TITLE
LPD-104371 Reindex only the article versions that need to change

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/spi/model/index/contributor/JournalArticleModelIndexerWriterContributor.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/spi/model/index/contributor/JournalArticleModelIndexerWriterContributor.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistryUtil;
 import com.liferay.portal.kernel.search.SearchException;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.search.batch.BatchIndexingHelper;
@@ -34,8 +35,10 @@ import com.liferay.portal.search.indexer.IndexerDocumentBuilder;
 import com.liferay.portal.search.spi.model.index.contributor.ModelIndexerWriterContributor;
 import com.liferay.portal.search.spi.model.index.contributor.helper.IndexerWriterMode;
 
+import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Objects;
+import java.util.Map;
 
 /**
  * @author Lourdes Fernández Besada
@@ -152,7 +155,9 @@ public class JournalArticleModelIndexerWriterContributor
 			_fetchLatestIndexableArticleVersion(
 				journalArticle.getResourcePrimKey());
 
-		if (journalArticle.getId() == latestIndexableArticle.getId()) {
+		if ((latestIndexableArticle != null) &&
+			(journalArticle.getId() == latestIndexableArticle.getId())) {
+
 			return IndexerWriterMode.UPDATE;
 		}
 
@@ -242,6 +247,49 @@ public class JournalArticleModelIndexerWriterContributor
 		return latestIndexableArticle;
 	}
 
+	private Collection<JournalArticle> _getReindexableArticleVersions(
+		JournalArticle article) {
+
+		Map<Long, JournalArticle> reindexableArticleVersions =
+			new LinkedHashMap<>();
+
+		List<JournalArticle> articleVersions =
+			_journalArticleLocalService.getArticles(
+				article.getGroupId(), article.getArticleId(), QueryUtil.ALL_POS,
+				QueryUtil.ALL_POS, ArticleVersionComparator.getInstance(false));
+
+		for (int[] statuses : _REINDEXABLE_STATUSES) {
+			boolean latest = true;
+
+			for (JournalArticle articleVersion : articleVersions) {
+				if (!_hasStatus(articleVersion, statuses)) {
+					continue;
+				}
+
+				reindexableArticleVersions.put(
+					articleVersion.getId(), articleVersion);
+
+				if (!latest || (article.getId() != articleVersion.getId())) {
+					break;
+				}
+
+				latest = false;
+			}
+		}
+
+		reindexableArticleVersions.remove(article.getId());
+
+		return reindexableArticleVersions.values();
+	}
+
+	private boolean _hasStatus(JournalArticle article, int[] statuses) {
+		if (ArrayUtil.contains(statuses, WorkflowConstants.STATUS_ANY)) {
+			return true;
+		}
+
+		return ArrayUtil.contains(statuses, article.getStatus());
+	}
+
 	private void _reindexOtherArticleVersions(JournalArticle journalArticle) {
 		if (PortalUtil.getClassNameId(DDMStructure.class) ==
 				journalArticle.getClassNameId()) {
@@ -249,30 +297,40 @@ public class JournalArticleModelIndexerWriterContributor
 			return;
 		}
 
-		List<JournalArticle> journalArticles =
-			_journalArticleLocalService.getArticles(
-				journalArticle.getGroupId(), journalArticle.getArticleId(),
-				QueryUtil.ALL_POS, QueryUtil.ALL_POS,
-				ArticleVersionComparator.getInstance(false));
-
 		Indexer<JournalArticle> indexer =
 			IndexerRegistryUtil.nullSafeGetIndexer(JournalArticle.class);
 
-		for (JournalArticle versionJournalArticle : journalArticles) {
-			if (Objects.equals(
-					versionJournalArticle.getId(), journalArticle.getId())) {
-
-				continue;
-			}
+		for (JournalArticle reindexableArticleVersion :
+				_getReindexableArticleVersions(journalArticle)) {
 
 			try {
-				indexer.reindex(versionJournalArticle, false);
+				indexer.reindex(reindexableArticleVersion, false);
 			}
 			catch (SearchException searchException) {
 				throw new SystemException(searchException);
 			}
 		}
 	}
+
+	private static final int[][] _REINDEXABLE_STATUSES = {
+
+		// JournalUtil#isHead
+
+		{WorkflowConstants.STATUS_APPROVED, WorkflowConstants.STATUS_IN_TRASH},
+
+		// JournalUtil#isHeadListable
+
+		{
+			WorkflowConstants.STATUS_APPROVED,
+			WorkflowConstants.STATUS_IN_TRASH,
+			WorkflowConstants.STATUS_SCHEDULED
+		},
+
+		// JournalUtil#isLatestArticle
+
+		{WorkflowConstants.STATUS_ANY}
+
+	};
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		JournalArticleModelIndexerWriterContributor.class);

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/spi/model/index/contributor/JournalArticleModelIndexerWriterContributor.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/spi/model/index/contributor/JournalArticleModelIndexerWriterContributor.java
@@ -247,29 +247,26 @@ public class JournalArticleModelIndexerWriterContributor
 		return latestIndexableArticle;
 	}
 
-	private Collection<JournalArticle> _getReindexableArticleVersions(
+	private Collection<JournalArticle> _getReindexableArticles(
 		JournalArticle article) {
 
-		Map<Long, JournalArticle> reindexableArticleVersions =
-			new LinkedHashMap<>();
+		Map<Long, JournalArticle> reindexableArticles = new LinkedHashMap<>();
 
-		List<JournalArticle> articleVersions =
-			_journalArticleLocalService.getArticles(
-				article.getGroupId(), article.getArticleId(), QueryUtil.ALL_POS,
-				QueryUtil.ALL_POS, ArticleVersionComparator.getInstance(false));
+		List<JournalArticle> articles = _journalArticleLocalService.getArticles(
+			article.getGroupId(), article.getArticleId(), QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS, ArticleVersionComparator.getInstance(false));
 
 		for (int[] statuses : _REINDEXABLE_STATUSES) {
 			boolean latest = true;
 
-			for (JournalArticle articleVersion : articleVersions) {
-				if (!_hasStatus(articleVersion, statuses)) {
+			for (JournalArticle versionArticle : articles) {
+				if (!_hasStatus(versionArticle, statuses)) {
 					continue;
 				}
 
-				reindexableArticleVersions.put(
-					articleVersion.getId(), articleVersion);
+				reindexableArticles.put(versionArticle.getId(), versionArticle);
 
-				if (!latest || (article.getId() != articleVersion.getId())) {
+				if (!latest || (article.getId() != versionArticle.getId())) {
 					break;
 				}
 
@@ -277,9 +274,9 @@ public class JournalArticleModelIndexerWriterContributor
 			}
 		}
 
-		reindexableArticleVersions.remove(article.getId());
+		reindexableArticles.remove(article.getId());
 
-		return reindexableArticleVersions.values();
+		return reindexableArticles.values();
 	}
 
 	private boolean _hasStatus(JournalArticle article, int[] statuses) {
@@ -300,11 +297,11 @@ public class JournalArticleModelIndexerWriterContributor
 		Indexer<JournalArticle> indexer =
 			IndexerRegistryUtil.nullSafeGetIndexer(JournalArticle.class);
 
-		for (JournalArticle reindexableArticleVersion :
-				_getReindexableArticleVersions(journalArticle)) {
+		for (JournalArticle reindexableArticle :
+				_getReindexableArticles(journalArticle)) {
 
 			try {
-				indexer.reindex(reindexableArticleVersion, false);
+				indexer.reindex(reindexableArticle, false);
 			}
 			catch (SearchException searchException) {
 				throw new SystemException(searchException);

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -1584,9 +1584,14 @@ public class JournalArticleLocalServiceImpl
 					IndexerRegistryUtil.nullSafeGetIndexer(
 						JournalArticle.class);
 
-				indexer.reindex(
-					getLatestArticle(
-						groupId, articleId, WorkflowConstants.STATUS_ANY));
+				for (JournalArticle article :
+						journalArticlePersistence.findByG_A(
+							groupId, articleId, QueryUtil.ALL_POS,
+							QueryUtil.ALL_POS,
+							ArticleVersionComparator.getInstance(true))) {
+
+					indexer.reindex(article, false);
+				}
 			}
 		}
 		else {
@@ -6120,6 +6125,10 @@ public class JournalArticleLocalServiceImpl
 
 							currentArticle = journalArticlePersistence.update(
 								currentArticle);
+
+							if (indexer != null) {
+								indexer.reindex(currentArticle, false);
+							}
 
 							notifySubscribers(
 								0, currentArticle, "expired",

--- a/modules/apps/journal/journal-service/src/test/java/com/liferay/journal/internal/search/spi/model/index/contributor/JournalArticleModelIndexerWriterContributorTest.java
+++ b/modules/apps/journal/journal-service/src/test/java/com/liferay/journal/internal/search/spi/model/index/contributor/JournalArticleModelIndexerWriterContributorTest.java
@@ -13,12 +13,15 @@ import com.liferay.journal.util.comparator.ArticleVersionComparator;
 import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistryUtil;
-import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.search.batch.BatchIndexingHelper;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.After;
@@ -46,7 +49,10 @@ public class JournalArticleModelIndexerWriterContributorTest {
 		_setUpIndexer();
 		_setUpIndexerRegistryUtil();
 		_setUpJournalArticleLocalService();
-		_setUpJournalArticles();
+		_setUpJournalArticles(
+			WorkflowConstants.STATUS_APPROVED,
+			WorkflowConstants.STATUS_APPROVED,
+			WorkflowConstants.STATUS_APPROVED);
 		_setUpPortal();
 	}
 
@@ -75,6 +81,110 @@ public class JournalArticleModelIndexerWriterContributorTest {
 		_testModelDeleted(_journalArticles.get(0), _journalArticles.get(2), 1);
 		_testModelDeleted(_journalArticles.get(1), _journalArticles.get(2), 1);
 		_testModelDeleted(_journalArticles.get(2), _journalArticles.get(1), 1);
+	}
+
+	@Test
+	public void testModelDeletedWithAllVersionsApproved() throws Exception {
+		_setUpJournalServiceConfiguration(true);
+
+		_setUpJournalArticles(_getStatuses());
+
+		Mockito.when(
+			_journalArticleLocalService.fetchLatestArticle(
+				Mockito.anyLong(), Mockito.any(int[].class))
+		).thenReturn(
+			_journalArticles.get(_JOURNAL_ARTICLE_VERSION_COUNT - 2)
+		);
+
+		JournalArticleModelIndexerWriterContributor
+			journalArticleModelIndexerWriterContributor =
+				_createJournalArticleModelIndexerWriterContributor();
+
+		journalArticleModelIndexerWriterContributor.modelDeleted(
+			_journalArticles.get(_JOURNAL_ARTICLE_VERSION_COUNT - 1));
+
+		Mockito.verify(
+			_indexer
+		).reindex(
+			_journalArticles.get(_JOURNAL_ARTICLE_VERSION_COUNT - 2), false
+		);
+
+		Mockito.verifyNoMoreInteractions(_indexer);
+	}
+
+	@Test
+	public void testModelIndexedWithAllVersionsApproved() throws Exception {
+		_setUpJournalServiceConfiguration(true);
+
+		_setUpJournalArticles(_getStatuses());
+
+		JournalArticleModelIndexerWriterContributor
+			journalArticleModelIndexerWriterContributor =
+				_createJournalArticleModelIndexerWriterContributor();
+
+		journalArticleModelIndexerWriterContributor.modelIndexed(
+			_journalArticles.get(_JOURNAL_ARTICLE_VERSION_COUNT - 1));
+
+		Mockito.verify(
+			_indexer
+		).reindex(
+			_journalArticles.get(_JOURNAL_ARTICLE_VERSION_COUNT - 2), false
+		);
+
+		Mockito.verifyNoMoreInteractions(_indexer);
+	}
+
+	@Test
+	public void testModelIndexedWithOnlyFirstAndLastVersionsApproved()
+		throws Exception {
+
+		_setUpJournalServiceConfiguration(true);
+
+		int[] statuses = _getStatuses();
+
+		for (int i = 1; i < (_JOURNAL_ARTICLE_VERSION_COUNT - 1); i++) {
+			statuses[i] = WorkflowConstants.STATUS_DRAFT;
+		}
+
+		_setUpJournalArticles(statuses);
+
+		JournalArticleModelIndexerWriterContributor
+			journalArticleModelIndexerWriterContributor =
+				_createJournalArticleModelIndexerWriterContributor();
+
+		journalArticleModelIndexerWriterContributor.modelIndexed(
+			_journalArticles.get(_JOURNAL_ARTICLE_VERSION_COUNT - 1));
+
+		Mockito.verify(
+			_indexer
+		).reindex(
+			_journalArticles.get(0), false
+		);
+
+		Mockito.verify(
+			_indexer
+		).reindex(
+			_journalArticles.get(_JOURNAL_ARTICLE_VERSION_COUNT - 2), false
+		);
+
+		Mockito.verifyNoMoreInteractions(_indexer);
+	}
+
+	private JournalArticleModelIndexerWriterContributor
+		_createJournalArticleModelIndexerWriterContributor() {
+
+		return new JournalArticleModelIndexerWriterContributor(
+			Mockito.mock(BatchIndexingHelper.class), _configurationProvider,
+			_journalArticleLocalService,
+			Mockito.mock(JournalArticleResourceLocalService.class));
+	}
+
+	private int[] _getStatuses() {
+		int[] statuses = new int[_JOURNAL_ARTICLE_VERSION_COUNT];
+
+		Arrays.fill(statuses, WorkflowConstants.STATUS_APPROVED);
+
+		return statuses;
 	}
 
 	private void _setUpConfigurationProvider() throws Exception {
@@ -111,16 +221,26 @@ public class JournalArticleModelIndexerWriterContributorTest {
 			_journalArticleLocalService.getArticles(
 				Mockito.anyLong(), Mockito.anyString(), Mockito.anyInt(),
 				Mockito.anyInt(), Mockito.any(ArticleVersionComparator.class))
-		).thenReturn(
-			_journalArticles
+		).thenAnswer(
+			invocationOnMock -> {
+				List<JournalArticle> journalArticles = new ArrayList<>(
+					_journalArticles);
+
+				Collections.reverse(journalArticles);
+
+				return journalArticles;
+			}
 		);
 	}
 
-	private void _setUpJournalArticles() {
-		double version = 1.0;
-		long id = 0;
+	private void _setUpJournalArticles(int... statuses) {
+		_journalArticles = new ArrayList<>(statuses.length);
 
-		for (JournalArticle journalArticle : _journalArticles) {
+		double version = 1.0;
+
+		for (int i = 0; i < statuses.length; i++) {
+			JournalArticle journalArticle = Mockito.mock(JournalArticle.class);
+
 			Mockito.when(
 				journalArticle.getArticleId()
 			).thenReturn(
@@ -130,7 +250,13 @@ public class JournalArticleModelIndexerWriterContributorTest {
 			Mockito.when(
 				journalArticle.getId()
 			).thenReturn(
-				id++
+				(long)i
+			);
+
+			Mockito.when(
+				journalArticle.getStatus()
+			).thenReturn(
+				statuses[i]
 			);
 
 			Mockito.when(
@@ -138,7 +264,10 @@ public class JournalArticleModelIndexerWriterContributorTest {
 			).thenReturn(
 				version
 			);
+
 			version += 0.1;
+
+			_journalArticles.add(journalArticle);
 		}
 	}
 
@@ -182,10 +311,7 @@ public class JournalArticleModelIndexerWriterContributorTest {
 
 		JournalArticleModelIndexerWriterContributor
 			journalArticleModelIndexerWriterContributor =
-				new JournalArticleModelIndexerWriterContributor(
-					Mockito.mock(BatchIndexingHelper.class),
-					_configurationProvider, _journalArticleLocalService,
-					Mockito.mock(JournalArticleResourceLocalService.class));
+				_createJournalArticleModelIndexerWriterContributor();
 
 		journalArticleModelIndexerWriterContributor.modelDeleted(
 			deletedVersionJournalArticle);
@@ -197,13 +323,13 @@ public class JournalArticleModelIndexerWriterContributorTest {
 		);
 	}
 
+	private static final int _JOURNAL_ARTICLE_VERSION_COUNT = 50;
+
 	private ConfigurationProvider _configurationProvider;
 	private Indexer<JournalArticle> _indexer;
 	private MockedStatic<IndexerRegistryUtil> _indexerRegistryUtilMockedStatic;
 	private JournalArticleLocalService _journalArticleLocalService;
-	private final List<JournalArticle> _journalArticles = ListUtil.fromArray(
-		Mockito.mock(JournalArticle.class), Mockito.mock(JournalArticle.class),
-		Mockito.mock(JournalArticle.class));
+	private List<JournalArticle> _journalArticles;
 	private final JournalServiceConfiguration _journalServiceConfiguration =
 		Mockito.mock(JournalServiceConfiguration.class);
 

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleIndexVersionsTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleIndexVersionsTest.java
@@ -12,6 +12,7 @@ import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.service.JournalArticleLocalService;
 import com.liferay.journal.test.util.JournalTestUtil;
 import com.liferay.journal.util.JournalHelper;
+import com.liferay.petra.function.UnsafeRunnable;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.search.BaseIndexerPostProcessor;
 import com.liferay.portal.kernel.search.Document;
@@ -29,6 +30,7 @@ import com.liferay.portal.kernel.settings.Settings;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.SearchContextTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -183,49 +185,20 @@ public class JournalArticleIndexVersionsTest {
 			_group.getGroupId(),
 			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID);
 
-		JournalArticle updatedArticle = JournalTestUtil.updateArticle(
+		JournalArticle updatedArticle1 = JournalTestUtil.updateArticle(
 			article, article.getTitleMap(), article.getContent(), true, true,
 			ServiceContextTestUtil.getServiceContext());
 
-		updatedArticle = JournalTestUtil.updateArticle(
-			updatedArticle, updatedArticle.getTitleMap(),
-			updatedArticle.getContent(), true, true,
+		JournalArticle updatedArticle2 = JournalTestUtil.updateArticle(
+			updatedArticle1, updatedArticle1.getTitleMap(),
+			updatedArticle1.getContent(), true, true,
 			ServiceContextTestUtil.getServiceContext());
 
-		AtomicInteger postProcessDocumentCount = new AtomicInteger();
-
-		Bundle bundle = FrameworkUtil.getBundle(
-			JournalArticleIndexVersionsTest.class);
-
-		BundleContext bundleContext = bundle.getBundleContext();
-
-		Indexer<JournalArticle> indexer = _indexerRegistry.getIndexer(
-			JournalArticle.class);
-
-		ServiceRegistration<IndexerPostProcessor> serviceRegistration =
-			bundleContext.registerService(
-				IndexerPostProcessor.class,
-				new BaseIndexerPostProcessor() {
-
-					@Override
-					public void postProcessDocument(
-						Document document, Object object) {
-
-						postProcessDocumentCount.incrementAndGet();
-					}
-
-				},
-				MapUtil.singletonDictionary(
-					"indexer.class.name", indexer.getClassName()));
-
-		try {
-			JournalTestUtil.expireArticle(_group.getGroupId(), updatedArticle);
-		}
-		finally {
-			serviceRegistration.unregister();
-		}
-
-		Assert.assertEquals(3, postProcessDocumentCount.get());
+		Assert.assertEquals(
+			3,
+			_getPostProcessedDocumentCount(
+				() -> JournalTestUtil.expireArticle(
+					_group.getGroupId(), updatedArticle2)));
 	}
 
 	@Test
@@ -308,6 +281,37 @@ public class JournalArticleIndexVersionsTest {
 		assertSearchCount(1, true);
 	}
 
+	@Test
+	public void testUpdateArticleKeepsSingleHeadArticleVersion()
+		throws Exception {
+
+		_enableIndexAllArticleVersions();
+
+		JournalArticle article = _updateArticle(_VERSION_COUNT);
+
+		assertSearchArticle(
+			1,
+			_journalArticleLocalService.fetchLatestArticle(
+				article.getResourcePrimKey()));
+
+		assertSearchCount(_VERSION_COUNT, false);
+	}
+
+	@Test
+	public void testUpdateArticleReindexesConstantNumberOfArticleVersions()
+		throws Exception {
+
+		_enableIndexAllArticleVersions();
+
+		JournalArticle article1 = _updateArticle(
+			RandomTestUtil.randomInt(3, _VERSION_COUNT));
+		JournalArticle article2 = _updateArticle(2);
+
+		Assert.assertEquals(
+			_getPostProcessedDocumentCount(() -> _updateArticle(article2)),
+			_getPostProcessedDocumentCount(() -> _updateArticle(article1)));
+	}
+
 	@Rule
 	public SearchTestRule searchTestRule = new SearchTestRule();
 
@@ -369,6 +373,66 @@ public class JournalArticleIndexVersionsTest {
 		_updateJournalServiceConfiguration(true, true);
 	}
 
+	private int _getPostProcessedDocumentCount(
+			UnsafeRunnable<Exception> unsafeRunnable)
+		throws Exception {
+
+		AtomicInteger postProcessedDocumentCount = new AtomicInteger();
+
+		Bundle bundle = FrameworkUtil.getBundle(
+			JournalArticleIndexVersionsTest.class);
+
+		BundleContext bundleContext = bundle.getBundleContext();
+
+		Indexer<JournalArticle> indexer = _indexerRegistry.getIndexer(
+			JournalArticle.class);
+
+		ServiceRegistration<IndexerPostProcessor> serviceRegistration =
+			bundleContext.registerService(
+				IndexerPostProcessor.class,
+				new BaseIndexerPostProcessor() {
+
+					@Override
+					public void postProcessDocument(
+						Document document, Object object) {
+
+						postProcessedDocumentCount.incrementAndGet();
+					}
+
+				},
+				MapUtil.singletonDictionary(
+					"indexer.class.name", indexer.getClassName()));
+
+		try {
+			unsafeRunnable.run();
+		}
+		finally {
+			serviceRegistration.unregister();
+		}
+
+		return postProcessedDocumentCount.get();
+	}
+
+	private JournalArticle _updateArticle(int versionCount) throws Exception {
+		JournalArticle article = JournalTestUtil.addArticle(
+			_group.getGroupId(),
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID);
+
+		for (int i = 1; i < versionCount; i++) {
+			article = _updateArticle(article);
+		}
+
+		return article;
+	}
+
+	private JournalArticle _updateArticle(JournalArticle article)
+		throws Exception {
+
+		return JournalTestUtil.updateArticle(
+			article, article.getTitleMap(), article.getContent(), true, true,
+			ServiceContextTestUtil.getServiceContext());
+	}
+
 	private void _updateJournalServiceConfiguration(
 			boolean expireAllArticleVersionsEnabled,
 			boolean indexAllArticleVersionsEnabled)
@@ -391,6 +455,8 @@ public class JournalArticleIndexVersionsTest {
 
 		modifiableSettings.store();
 	}
+
+	private static final int _VERSION_COUNT = 10;
 
 	@DeleteAfterTestRun
 	private Group _group;


### PR DESCRIPTION
> [!NOTE]
> This is a followup to https://github.com/brianchandotcom/liferay-portal/pull/181337
> This just adds an SF commit with a simple rename. Sent directly.

https://liferay.atlassian.net/browse/LPD-104371

## What Is Being Fixed

Indexing a journal article reindexed all its versions with a cost quadratic cost in its version count.

This was discovered while testing export/import in the learn.liferay.com site. There, each article carries on average 168 versions (most of them expired), so for each approved article there were ~167 index operations. This made imports unrealistic.

## How It Is Being Fixed

By reindexing only those articles that need its document updated. Only the "head", "headListable", "latest" and "visible" fields are affected when a new version is published, and it is possible to know if an version needs to update any of these fields based on its status (i.e. if it is the "latest" article in each category of statuses). Note that "visible" doesn't have its own category because it uses the same as "headListable".

## PR Check

**pr-check: PASS** — tested on `a1917142174560d63e4d12952dd534e363ceb741`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

Baseline reported one inherited finding, in a module this branch does not touch: `portal-db-partition-test-util` needs a MAJOR bump, because `BaseDBPartitionTestCase.getExportedPartitionName(long)` (protected static) was removed at 6.0.0 without one. `ant baseline-all` therefore exits nonzero on any branch. Both files the task repaired were restored, so the tree is unmodified, and the branch itself carries no baseline obligation: neither changed module exports packages and no changed file sits under a baselined API root.

<!-- pr-check {"result": "success", "sha": "a1917142174560d63e4d12952dd534e363ceb741"} -->