### PR TITLE
LPD-103690 Reuse OpenNLP name finders across auto tag invocations

### DIFF
--- a/modules/apps/asset/asset-auto-tagger-opennlp-impl/src/main/java/com/liferay/asset/auto/tagger/opennlp/internal/OpenNLPDocumentAssetAutoTagProvider.java
+++ b/modules/apps/asset/asset-auto-tagger-opennlp-impl/src/main/java/com/liferay/asset/auto/tagger/opennlp/internal/OpenNLPDocumentAssetAutoTagProvider.java
@@ -35,7 +35,8 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Supplier;
 
-import opennlp.tools.namefind.NameFinderME;
+import opennlp.tools.namefind.ThreadSafeNameFinderME;
+import opennlp.tools.namefind.TokenNameFinder;
 import opennlp.tools.namefind.TokenNameFinderModel;
 import opennlp.tools.sentdetect.SentenceDetectorME;
 import opennlp.tools.sentdetect.SentenceModel;
@@ -97,27 +98,35 @@ public class OpenNLPDocumentAssetAutoTagProvider
 		_bundle = bundleContext.getBundle();
 	}
 
+	private TokenNameFinder _createTokenNameFinder(String resourceName)
+		throws IOException {
+
+		return new ThreadSafeNameFinderME(
+			new TokenNameFinderModel(_bundle.getResource(resourceName)));
+	}
+
 	private String[] _getTagNames(
-		List<TokenNameFinderModel> tokenNameFinderModels, String[] tokens,
+		List<TokenNameFinder> tokenNameFinders, String[] tokens,
 		double confidenceThreshold) {
 
 		List<Span> spans = new ArrayList<>();
 
-		for (TokenNameFinderModel tokenNameFinderModel :
-				tokenNameFinderModels) {
+		for (TokenNameFinder tokenNameFinder : tokenNameFinders) {
+			try {
+				spans.addAll(
+					TransformUtil.transformToList(
+						tokenNameFinder.find(tokens),
+						nameSpan -> {
+							if (nameSpan.getProb() > confidenceThreshold) {
+								return nameSpan;
+							}
 
-			NameFinderME nameFinderME = new NameFinderME(tokenNameFinderModel);
-
-			spans.addAll(
-				TransformUtil.transformToList(
-					nameFinderME.find(tokens),
-					nameSpan -> {
-						if (nameSpan.getProb() > confidenceThreshold) {
-							return nameSpan;
-						}
-
-						return null;
-					}));
+							return null;
+						}));
+			}
+			finally {
+				tokenNameFinder.clearAdaptiveData();
+			}
 		}
 
 		return Span.spansToStrings(spans.toArray(new Span[0]), tokens);
@@ -162,23 +171,18 @@ public class OpenNLPDocumentAssetAutoTagProvider
 					}
 				}));
 
-		List<TokenNameFinderModel> tokenNameFinderModels =
-			_tokenNameFinderModelsDCLSingleton.getSingleton(
+		List<TokenNameFinder> tokenNameFinders =
+			_tokenNameFindersDCLSingleton.getSingleton(
 				() -> {
 					try {
 						return Arrays.asList(
-							new TokenNameFinderModel(
-								_bundle.getResource(
-									"org.apache.opennlp.model.en.ner." +
-										"location.bin")),
-							new TokenNameFinderModel(
-								_bundle.getResource(
-									"org.apache.opennlp.model.en.ner." +
-										"organization.bin")),
-							new TokenNameFinderModel(
-								_bundle.getResource(
-									"org.apache.opennlp.model.en.ner.person." +
-										"bin")));
+							_createTokenNameFinder(
+								"org.apache.opennlp.model.en.ner.location.bin"),
+							_createTokenNameFinder(
+								"org.apache.opennlp.model.en.ner." +
+									"organization.bin"),
+							_createTokenNameFinder(
+								"org.apache.opennlp.model.en.ner.person.bin"));
 					}
 					catch (IOException ioException) {
 						return ReflectionUtil.throwException(ioException);
@@ -199,7 +203,7 @@ public class OpenNLPDocumentAssetAutoTagProvider
 			Collections.addAll(
 				tagNames,
 				_getTagNames(
-					tokenNameFinderModels, tokenizerME.tokenize(sentence),
+					tokenNameFinders, tokenizerME.tokenize(sentence),
 					openNLPDocumentAssetAutoTaggerCompanyConfiguration.
 						confidenceThreshold()));
 		}
@@ -250,7 +254,7 @@ public class OpenNLPDocumentAssetAutoTagProvider
 
 	private final DCLSingleton<TokenizerModel> _tokenizerModelDCLSingleton =
 		new DCLSingleton<>();
-	private final DCLSingleton<List<TokenNameFinderModel>>
-		_tokenNameFinderModelsDCLSingleton = new DCLSingleton<>();
+	private final DCLSingleton<List<TokenNameFinder>>
+		_tokenNameFindersDCLSingleton = new DCLSingleton<>();
 
 }

--- a/modules/apps/asset/asset-auto-tagger-opennlp-test/src/testIntegration/java/com/liferay/asset/auto/tagger/opennlp/test/BaseOpenNLPDocumentAssetAutoTaggerTestCase.java
+++ b/modules/apps/asset/asset-auto-tagger-opennlp-test/src/testIntegration/java/com/liferay/asset/auto/tagger/opennlp/test/BaseOpenNLPDocumentAssetAutoTaggerTestCase.java
@@ -13,13 +13,18 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
+import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -96,6 +101,31 @@ public abstract class BaseOpenNLPDocumentAssetAutoTaggerTestCase {
 					assetEntry.getTagNames());
 
 				Assert.assertEquals(tagNames.toString(), 0, tagNames.size());
+			});
+	}
+
+	@Test
+	public void testAutoTagsAnAssetReusingNameFinders() throws Exception {
+		testWithOpenNLPDocumentAssetAutoTagProviderEnabled(
+			getClassName(),
+			() -> {
+				getAssetEntry(getTaggableText());
+
+				try (LogCapture logCapture =
+						LoggerTestUtil.configureLog4JLogger(
+							"opennlp.tools.util.XmlUtil",
+							LoggerTestUtil.WARN)) {
+
+					AssetEntry assetEntry = getAssetEntry(getTaggableText());
+
+					Assert.assertTrue(
+						ArrayUtil.isNotEmpty(assetEntry.getTagNames()));
+
+					List<LogEntry> logEntries = logCapture.getLogEntries();
+
+					Assert.assertEquals(
+						logEntries.toString(), 0, logEntries.size());
+				}
 			});
 	}
 


### PR DESCRIPTION
> [!NOTE]
> @brianchandotcom Instead of a rename, I've moved the test into the base class. All tests there follow the convention: testAutoTags* or testDoesNotAutoTag*. This test now is applicable to all entities supporting auto tagging.

https://liferay.atlassian.net/browse/LPD-103690

## What Is Being Fixed

Every OpenNLP auto tag call logged a full Xerces stack trace at warning level. In learn.liferay.com, when importing/exporting web content: 455k warning records taking ~1.5 GB of space.

## How It Is Being Fixed

Cache the finder (per worker thread) so that the warnings are logged once per thread. These finders are stateful, so now they need to be cleared after processing each entry.

Verified against the running bundle with `JournalArticleOpenNLPDocumentAssetAutoTaggerTest` using the Learn database: 8k records and 4k finder instances before the fix; 6 records and 3 instances after.

Addressing the review feedback on the previous pull request, `testAutoTagsAnAssetReusingNameFinders` moved from `JournalArticleOpenNLPDocumentAssetAutoTaggerTest` into `BaseOpenNLPDocumentAssetAutoTaggerTestCase`, so it sits with the other `testAutoTagsAnAsset*` cases that cover the same provider entry point and now runs for every asset type rather than only for journal articles.

## PR Check

**pr-check: PASS** — tested on `e36badb6a3f3f8059f75298c3709ca4c2b432ecc`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Service Registration | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS (baseline-all + seven Ant projects + 0 changed exporting modules) |
| Java Unit Tests | NOT VERIFIED |

Source Format: the yarn half never ran rather than running clean. The diff is two `.java` files and neither matches `source.formatter.frontend.file.regex`, so `portal-impl/build.xml` set `skip.node.task` and skipped `downloadNode`, `yarnInstall` and the yarn formatter. The Java half ran clean and the formatter applied no repairs, so there is no `SF` commit. A verbose rerun confirmed `validate.commit.messages=true` reached the `SourceFormatter` argv rather than silently skipping.

Service Registration: the Unsatisfied Reference scan ended at the collection step. The one `@Component` in the diff registers under `service = AssetAutoTagProvider.class`, not `service = {}`, and the only field the diff adds is a `DCLSingleton`, whose type carries no `@Component`, so there was no risky class to sweep the repository for. The Redeclared Interface scan was not selected, as the diff holds no `*ResourceImpl.java`.

Per-Module Compile: deploy set of one, `apps:asset:asset-auto-tagger-opennlp-impl`. The `-test` module is excluded because its only change is under `src/testIntegration`. Consumer expansion is empty: the diff removes no `public` or `protected` member, and every changed member is private and inside an `internal` package. `compileJava` executed rather than being served from cache, and the deployed jar's constant pool was checked to confirm `ThreadSafeNameFinderME` replaced `NameFinderME`. `ThreadSafeNameFinderME` and `TokenNameFinder` were also confirmed present inside the bundle's embedded `opennlp-tools.jar`, since `opennlp-tools` is `compileOnly` and a compileOnly/runtime skew would surface as a `NoClassDefFoundError` rather than a compile error.

Integration Test Compile: 8 of 15 affected modules compiled, so the cap of 8 bound. The control, `apps:blogs:blogs-test`, compiled clean first. Every `compileTestIntegrationJava` task line was bare, so each compile executed under `--rerun` rather than being served from cache.

Baseline: the zero is correct rather than a shortfall. Neither changed module's `bnd.bnd` carries `Export-Package:` — the impl change is confined to an `internal` package — so neither is in baseline's universe and no package version or `Bundle-Version` is owed. Baselining the impl module directly reports the task as `SKIPPED`, which is the positive evidence that there is no exported package to compare. No `packageinfo` or `bnd.bnd` was modified by the run, so there is no `Semantic versioning` commit, and the Local Version Check passed.

Java Unit Tests: `OpenNLPDocumentAssetAutoTagProvider` has no unit test, and the module declares no `src/test` source set at all, so no suite could exercise the change. The provider resolves its models through `_bundle.getResource(...)` and so needs the OSGi runtime. It is covered instead by the integration tests in the sibling `asset-auto-tagger-opennlp-test` module, including the `testAutoTagsAnAssetReusingNameFinders` case this branch adds. No unit test needs to be written here.

<!-- pr-check {"result": "success", "sha": "e36badb6a3f3f8059f75298c3709ca4c2b432ecc"} -->
