### PR TITLE
LPD-104665 Add the campaign detail accounts BFF endpoint

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/ContactsEngineClient.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/ContactsEngineClient.java
@@ -356,7 +356,7 @@ public interface ContactsEngineClient {
 
 	public Results<Campaign> getCampaigns(
 		FaroProject faroProject, long channelId, String filterString,
-		String keywords, String sortString, int cur, int delta);
+		String query, String sortString, int cur, int delta);
 
 	public Results<CatalogField> getCatalogFields(
 			FaroProject faroProject, String capability, String query,

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/ContactsEngineClient.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/ContactsEngineClient.java
@@ -345,6 +345,11 @@ public interface ContactsEngineClient {
 			FaroProject faroProject, long channelId, String id)
 		throws FaroEngineClientException;
 
+	public Results<Account> getCampaignAccounts(
+			FaroProject faroProject, long channelId, String filterString,
+			String id, String query, String sortString, int cur, int delta)
+		throws FaroEngineClientException;
+
 	public List<CampaignMetric> getCampaignMetrics(
 			FaroProject faroProject, long channelId)
 		throws FaroEngineClientException;

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/internal/ContactsEngineClientImpl.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/internal/ContactsEngineClientImpl.java
@@ -1692,6 +1692,44 @@ public class ContactsEngineClientImpl
 	}
 
 	@Override
+	public Results<Account> getCampaignAccounts(
+			FaroProject faroProject, long channelId, String filterString,
+			String id, String query, String sortString, int cur, int delta)
+		throws FaroEngineClientException {
+
+		Map<String, Object> uriVariables = getUriVariables(
+			faroProject, cur, delta, null);
+
+		uriVariables.put("channelId", channelId);
+
+		if (Validator.isNotNull(filterString)) {
+			uriVariables.put("filter", filterString);
+		}
+
+		uriVariables.put("id", id);
+
+		if (Validator.isNotNull(query)) {
+			uriVariables.put("query", query);
+		}
+
+		if (Validator.isNotNull(sortString)) {
+			uriVariables.put(
+				"sort",
+				Arrays.asList(
+					StringUtil.replace(
+						sortString, CharPool.COLON, CharPool.COMMA)));
+		}
+
+		PagedModel<?, Account> pagedModel = get(
+			faroProject, Rels.CAMPAIGN_ACCOUNTS,
+			new ParameterizedTypeReference<EntityModelPagedModel<Account>>() {
+			},
+			uriVariables);
+
+		return pagedModel.getResults();
+	}
+
+	@Override
 	public List<CampaignMetric> getCampaignMetrics(
 			FaroProject faroProject, long channelId)
 		throws FaroEngineClientException {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/internal/ContactsEngineClientImpl.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/internal/ContactsEngineClientImpl.java
@@ -1748,7 +1748,7 @@ public class ContactsEngineClientImpl
 	@Override
 	public Results<Campaign> getCampaigns(
 		FaroProject faroProject, long channelId, String filterString,
-		String keywords, String sortString, int cur, int delta) {
+		String query, String sortString, int cur, int delta) {
 
 		Map<String, Object> uriVariables = getUriVariables(
 			faroProject, cur, delta, null);
@@ -1759,8 +1759,8 @@ public class ContactsEngineClientImpl
 			uriVariables.put("filter", filterString);
 		}
 
-		if (Validator.isNotNull(keywords)) {
-			uriVariables.put("keywords", keywords);
+		if (Validator.isNotNull(query)) {
+			uriVariables.put("query", query);
 		}
 
 		if (Validator.isNotNull(sortString)) {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/model/Rels.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/model/Rels.java
@@ -96,6 +96,8 @@ public interface Rels {
 
 	public static final String CAMPAIGN = "campaign";
 
+	public static final String CAMPAIGN_ACCOUNTS = "campaign-accounts";
+
 	public static final String CAMPAIGNS = "campaigns";
 
 	public static final String CAMPAIGNS_METRICS = "campaigns-metrics";

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/resources/com/liferay/osb/faro/engine/client/model/packageinfo
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/resources/com/liferay/osb/faro/engine/client/model/packageinfo
@@ -1,1 +1,1 @@
-version 3.2.0
+version 3.3.0

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/resources/com/liferay/osb/faro/engine/client/packageinfo
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/resources/com/liferay/osb/faro/engine/client/packageinfo
@@ -1,1 +1,1 @@
-version 3.2.0
+version 3.3.0

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-mock-engine-client/src/main/java/com/liferay/osb/faro/mock/engine/client/internal/BaseMockContactsEngineClientImpl.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-mock-engine-client/src/main/java/com/liferay/osb/faro/mock/engine/client/internal/BaseMockContactsEngineClientImpl.java
@@ -660,6 +660,17 @@ public abstract class BaseMockContactsEngineClientImpl
 	}
 
 	@Override
+	public Results<Account> getCampaignAccounts(
+			FaroProject faroProject, long channelId, String filterString,
+			String id, String query, String sortString, int cur, int delta)
+		throws FaroEngineClientException {
+
+		return contactsEngineClient.getCampaignAccounts(
+			faroProject, channelId, filterString, id, query, sortString, cur,
+			delta);
+	}
+
+	@Override
 	public List<CampaignMetric> getCampaignMetrics(
 			FaroProject faroProject, long channelId)
 		throws FaroEngineClientException {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-mock-engine-client/src/main/java/com/liferay/osb/faro/mock/engine/client/internal/BaseMockContactsEngineClientImpl.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-mock-engine-client/src/main/java/com/liferay/osb/faro/mock/engine/client/internal/BaseMockContactsEngineClientImpl.java
@@ -681,10 +681,10 @@ public abstract class BaseMockContactsEngineClientImpl
 	@Override
 	public Results<Campaign> getCampaigns(
 		FaroProject faroProject, long channelId, String filterString,
-		String keywords, String sortString, int cur, int delta) {
+		String query, String sortString, int cur, int delta) {
 
 		return contactsEngineClient.getCampaigns(
-			faroProject, channelId, filterString, keywords, sortString, cur,
+			faroProject, channelId, filterString, query, sortString, cur,
 			delta);
 	}
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/CampaignFaroController.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/CampaignFaroController.java
@@ -5,10 +5,12 @@
 
 package com.liferay.osb.faro.web.internal.controller.contacts;
 
+import com.liferay.osb.faro.engine.client.model.Account;
 import com.liferay.osb.faro.engine.client.model.Campaign;
 import com.liferay.osb.faro.engine.client.model.CampaignMetric;
 import com.liferay.osb.faro.web.internal.controller.BaseFaroController;
 import com.liferay.osb.faro.web.internal.model.display.FaroFDSResultsDisplay;
+import com.liferay.osb.faro.web.internal.model.display.contacts.AccountDisplay;
 import com.liferay.osb.faro.web.internal.model.display.contacts.CampaignDisplay;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.RoleConstants;
@@ -34,6 +36,28 @@ import org.osgi.service.component.annotations.Component;
 @Path("/{groupId}/campaigns")
 @Produces(MediaType.APPLICATION_JSON)
 public class CampaignFaroController extends BaseFaroController {
+
+	@GET
+	@Path("/{id}/accounts")
+	@RolesAllowed(RoleConstants.SITE_MEMBER)
+	public FaroFDSResultsDisplay<Account> getAccountsFaroFDSResultsDisplay(
+			@PathParam("groupId") long groupId, @PathParam("id") String id,
+			@QueryParam("channelId") long channelId,
+			@QueryParam("filter") String filterString,
+			@QueryParam("page") int page,
+			@DefaultValue("20") @QueryParam("pageSize") int pageSize,
+			@QueryParam("search") String search,
+			@DefaultValue(StringPool.BLANK) @QueryParam("sort") String
+				sortString)
+		throws Exception {
+
+		return new FaroFDSResultsDisplay<>(
+			contactsEngineClient.getCampaignAccounts(
+				faroProjectLocalService.getFaroProjectByGroupId(groupId),
+				channelId, filterString, id, search, sortString, page,
+				pageSize),
+			AccountDisplay::new, page, pageSize);
+	}
 
 	@GET
 	@Path("/{id}")

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/CampaignFaroController.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/CampaignFaroController.java
@@ -92,9 +92,9 @@ public class CampaignFaroController extends BaseFaroController {
 			@PathParam("groupId") long groupId,
 			@QueryParam("channelId") long channelId,
 			@QueryParam("filter") String filterString,
-			@QueryParam("keywords") String keywords,
 			@QueryParam("page") int page,
 			@DefaultValue("20") @QueryParam("pageSize") int pageSize,
+			@QueryParam("search") String search,
 			@DefaultValue(StringPool.BLANK) @QueryParam("sort") String
 				sortString)
 		throws Exception {
@@ -102,7 +102,7 @@ public class CampaignFaroController extends BaseFaroController {
 		return new FaroFDSResultsDisplay<>(
 			contactsEngineClient.getCampaigns(
 				faroProjectLocalService.getFaroProjectByGroupId(groupId),
-				channelId, filterString, keywords, sortString, page, pageSize),
+				channelId, filterString, search, sortString, page, pageSize),
 			CampaignDisplay::new, page, pageSize);
 	}
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/test/java/com/liferay/osb/faro/web/internal/controller/contacts/CampaignFaroControllerTest.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/test/java/com/liferay/osb/faro/web/internal/controller/contacts/CampaignFaroControllerTest.java
@@ -168,9 +168,9 @@ public class CampaignFaroControllerTest {
 	public void testGetCampaignsFaroFDSResultsDisplay() throws Exception {
 		long channelId = RandomTestUtil.randomLong();
 		String filterString = RandomTestUtil.randomString();
-		String keywords = RandomTestUtil.randomString();
 		int page = RandomTestUtil.randomInt();
 		int pageSize = RandomTestUtil.randomInt();
+		String search = RandomTestUtil.randomString();
 		String sortString = RandomTestUtil.randomString();
 		int total = RandomTestUtil.randomInt();
 
@@ -180,8 +180,8 @@ public class CampaignFaroControllerTest {
 
 		Mockito.when(
 			_contactsEngineClient.getCampaigns(
-				_faroProject, channelId, filterString, keywords, sortString,
-				page, pageSize)
+				_faroProject, channelId, filterString, search, sortString, page,
+				pageSize)
 		).thenReturn(
 			new Results<>(Collections.singletonList(campaign), total)
 		);
@@ -190,7 +190,7 @@ public class CampaignFaroControllerTest {
 
 		FaroFDSResultsDisplay<Campaign> faroFDSResultsDisplay =
 			_campaignFaroController.getCampaignsFaroFDSResultsDisplay(
-				groupId, channelId, filterString, keywords, page, pageSize,
+				groupId, channelId, filterString, page, pageSize, search,
 				sortString);
 
 		List<?> items = faroFDSResultsDisplay.getItems();
@@ -208,7 +208,7 @@ public class CampaignFaroControllerTest {
 		Mockito.verify(
 			_contactsEngineClient
 		).getCampaigns(
-			_faroProject, channelId, filterString, keywords, sortString, page,
+			_faroProject, channelId, filterString, search, sortString, page,
 			pageSize
 		);
 	}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/test/java/com/liferay/osb/faro/web/internal/controller/contacts/CampaignFaroControllerTest.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/test/java/com/liferay/osb/faro/web/internal/controller/contacts/CampaignFaroControllerTest.java
@@ -6,12 +6,14 @@
 package com.liferay.osb.faro.web.internal.controller.contacts;
 
 import com.liferay.osb.faro.engine.client.ContactsEngineClient;
+import com.liferay.osb.faro.engine.client.model.Account;
 import com.liferay.osb.faro.engine.client.model.Campaign;
 import com.liferay.osb.faro.engine.client.model.CampaignMetric;
 import com.liferay.osb.faro.engine.client.model.Results;
 import com.liferay.osb.faro.model.FaroProject;
 import com.liferay.osb.faro.service.FaroProjectLocalService;
 import com.liferay.osb.faro.web.internal.model.display.FaroFDSResultsDisplay;
+import com.liferay.osb.faro.web.internal.model.display.contacts.AccountDisplay;
 import com.liferay.osb.faro.web.internal.model.display.contacts.CampaignDisplay;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -46,6 +48,56 @@ public class CampaignFaroControllerTest {
 		ReflectionTestUtils.setField(
 			_campaignFaroController, "faroProjectLocalService",
 			_faroProjectLocalService);
+	}
+
+	@Test
+	public void testGetAccountsFaroFDSResultsDisplay() throws Exception {
+		long channelId = RandomTestUtil.randomLong();
+		String filterString = RandomTestUtil.randomString();
+		String id = RandomTestUtil.randomString();
+		int page = RandomTestUtil.randomInt();
+		int pageSize = RandomTestUtil.randomInt();
+		String search = RandomTestUtil.randomString();
+		String sortString = RandomTestUtil.randomString();
+		int total = RandomTestUtil.randomInt();
+
+		Account account = new Account();
+
+		account.setId(RandomTestUtil.randomString());
+
+		Mockito.when(
+			_contactsEngineClient.getCampaignAccounts(
+				_faroProject, channelId, filterString, id, search, sortString,
+				page, pageSize)
+		).thenReturn(
+			new Results<>(Collections.singletonList(account), total)
+		);
+
+		long groupId = RandomTestUtil.randomLong();
+
+		FaroFDSResultsDisplay<Account> faroFDSResultsDisplay =
+			_campaignFaroController.getAccountsFaroFDSResultsDisplay(
+				groupId, id, channelId, filterString, page, pageSize, search,
+				sortString);
+
+		List<?> items = faroFDSResultsDisplay.getItems();
+
+		AccountDisplay accountDisplay = (AccountDisplay)items.get(0);
+
+		Assert.assertEquals(
+			account.getId(),
+			ReflectionTestUtil.getFieldValue(accountDisplay, "_id"));
+
+		Assert.assertEquals(page, faroFDSResultsDisplay.getPage());
+		Assert.assertEquals(pageSize, faroFDSResultsDisplay.getPageSize());
+		Assert.assertEquals(total, faroFDSResultsDisplay.getTotalCount());
+
+		Mockito.verify(
+			_contactsEngineClient
+		).getCampaignAccounts(
+			_faroProject, channelId, filterString, id, search, sortString, page,
+			pageSize
+		);
 	}
 
 	@Test


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-104665
https://liferay.atlassian.net/browse/LPD-104659

## What Is Being Fixed

The Campaigns detail page renders its accounts table from mocked data, added as a placeholder while the backend was outstanding. Nothing served the accounts belonging to a campaign: the engine client had no call for them, so the frontend had no endpoint to move onto.

The campaign list endpoint also took its free text parameter as `keywords`, which matches neither the `search` parameter the frontend data set sends nor the `query` the engine expects, so the frontend had to rename it in transit.

## How It Is Being Fixed

`CampaignFaroController` gains a `GET /{groupId}/campaigns/{id}/accounts` resource that takes the channel through a query parameter and delegates to the engine client, resolving the project from the group the way the section's other endpoints do. It returns a `FaroFDSResultsDisplay<Account>` mapped through `AccountDisplay`, so filtering, searching, sorting and pagination arrive in the shape the frontend data set already consumes.

The engine client side adds `getCampaignAccounts(FaroProject, long, String, String, String, String, int, int)` to `ContactsEngineClient` and implements it against the new `campaign-accounts` rel, deserializing into a paged model of the existing `Account`. `BaseMockContactsEngineClientImpl` gets the matching stub so the mock engine keeps satisfying the interface.

The last commit renames the campaign search parameter to align with the frontend data set: the controller now exposes `search` and the engine client takes `query`, dropping `keywords` from both. It is a follow-up too small to carry its own ticket, so it stays on LPD-104659.

The two exported packages of `osb-faro-engine-client` move from 3.2.0 to 3.3.0. Both changes are additive.

## PR Check

**pr-check: PASS** — tested on `f81b7ca57cb41653151558016b59acfbb7e34a32`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Service Registration | PASS |
| Transaction Usage | PASS |
| Baseline | PASS (baseline-all + seven Ant projects + 1 changed exporting module, verified by hand) |
| Workspace Build | PASS |
| Java Unit Tests | NOT VERIFIED |

Baseline could not baseline the branch's one exporting module: the osbfaro workspace disables the `baseline` task for every subproject, and `baseline-all` roots its fileset at `${project.dir}/modules`, which never scans `workspaces/`. Coverage there rests on the Local Version Check, which passes — both exported packages carry the 3.2.0 to 3.3.0 bump, the rebuilt jar manifest confirms `version="3.3.0"` on each, and no `public` or `protected` line is removed anywhere in the diff. The four `portal-kernel` MINOR findings `baseline-all` reported are inherited from master, were restored, and do not fail the branch.

Workspace Build passes, but `./gradlew build` does not exercise the branch's tests: `osb-faro-web/build.gradle` sets `build { setDependsOn([assemble]) }`, dropping `check` and `test`. `CampaignFaroControllerTest` was therefore run explicitly — 4 tests, 0 failures, 0 errors, including `testGetAccountsFaroFDSResultsDisplay`.

Java Unit Tests verified only part of the diff. `ContactsEngineClientImpl` carries the branch's largest change yet has no unit test counterpart and no integration test at any layer, as do `Rels` and `BaseMockContactsEngineClientImpl`, so the wire call, the filter and sort handling, and the response parsing are exercised only through the controller's mock.

Source Format was re-run after the commits were reordered, against the same tree the rest of the run tested.

<!-- pr-check {"result": "success", "sha": "f81b7ca57cb41653151558016b59acfbb7e34a32"} -->
