### PR TITLE
LPD-104797 Serve a plain object entry listing from a finder instead of the DSL join query

### DIFF
--- a/modules/apps/object/object-api/bnd.bnd
+++ b/modules/apps/object/object-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Object API
 Bundle-SymbolicName: com.liferay.object.api
-Bundle-Version: 128.0.2
+Bundle-Version: 128.1.0
 Export-Package:\
 	com.liferay.object.action.engine,\
 	com.liferay.object.action.executor,\

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalService.java
@@ -391,6 +391,10 @@ public interface ObjectEntryLocalService
 	public int getObjectEntriesCount(long groupId, long objectDefinitionId);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public int getObjectEntriesCount(
+		long groupId, long objectDefinitionId, int status);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public long getObjectEntriesCount(
 			long groupId, String languageId, ObjectDefinition objectDefinition,
 			Predicate predicate)
@@ -621,4 +625,4 @@ public interface ObjectEntryLocalService
 		throws PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1438134472
+// LIFERAY-SERVICE-BUILDER-HASH:872444325

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalServiceUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalServiceUtil.java
@@ -512,6 +512,13 @@ public class ObjectEntryLocalServiceUtil {
 		return getService().getObjectEntriesCount(groupId, objectDefinitionId);
 	}
 
+	public static int getObjectEntriesCount(
+		long groupId, long objectDefinitionId, int status) {
+
+		return getService().getObjectEntriesCount(
+			groupId, objectDefinitionId, status);
+	}
+
 	public static long getObjectEntriesCount(
 			long groupId, String languageId,
 			com.liferay.object.model.ObjectDefinition objectDefinition,
@@ -903,4 +910,4 @@ public class ObjectEntryLocalServiceUtil {
 			ObjectEntryLocalServiceUtil.class, ObjectEntryLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:846990680
+// LIFERAY-SERVICE-BUILDER-HASH:481668498

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalServiceWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalServiceWrapper.java
@@ -585,6 +585,14 @@ public class ObjectEntryLocalServiceWrapper
 	}
 
 	@Override
+	public int getObjectEntriesCount(
+		long groupId, long objectDefinitionId, int status) {
+
+		return _objectEntryLocalService.getObjectEntriesCount(
+			groupId, objectDefinitionId, status);
+	}
+
+	@Override
 	public long getObjectEntriesCount(
 			long groupId, String languageId,
 			com.liferay.object.model.ObjectDefinition objectDefinition,
@@ -1042,4 +1050,4 @@ public class ObjectEntryLocalServiceWrapper
 	private ObjectEntryLocalService _objectEntryLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1063774189
+// LIFERAY-SERVICE-BUILDER-HASH:660663488

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryService.java
@@ -117,6 +117,10 @@ public interface ObjectEntryService extends BaseService {
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public int getObjectEntriesCount(
+		long groupId, long objectDefinitionId, int status);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public ObjectEntry getObjectEntry(long objectEntryId)
 		throws PortalException;
 
@@ -206,4 +210,4 @@ public interface ObjectEntryService extends BaseService {
 		throws PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1867059792
+// LIFERAY-SERVICE-BUILDER-HASH:222530909

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryServiceUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryServiceUtil.java
@@ -146,6 +146,13 @@ public class ObjectEntryServiceUtil {
 			groupId, objectDefinitionId, status, start, end);
 	}
 
+	public static int getObjectEntriesCount(
+		long groupId, long objectDefinitionId, int status) {
+
+		return getService().getObjectEntriesCount(
+			groupId, objectDefinitionId, status);
+	}
+
 	public static ObjectEntry getObjectEntry(long objectEntryId)
 		throws PortalException {
 
@@ -311,4 +318,4 @@ public class ObjectEntryServiceUtil {
 		new Snapshot<>(ObjectEntryServiceUtil.class, ObjectEntryService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1323039996
+// LIFERAY-SERVICE-BUILDER-HASH:1024998454

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryServiceWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryServiceWrapper.java
@@ -161,6 +161,14 @@ public class ObjectEntryServiceWrapper
 	}
 
 	@Override
+	public int getObjectEntriesCount(
+		long groupId, long objectDefinitionId, int status) {
+
+		return _objectEntryService.getObjectEntriesCount(
+			groupId, objectDefinitionId, status);
+	}
+
+	@Override
 	public com.liferay.object.model.ObjectEntry getObjectEntry(
 			long objectEntryId)
 		throws com.liferay.portal.kernel.exception.PortalException {
@@ -352,4 +360,4 @@ public class ObjectEntryServiceWrapper
 	private ObjectEntryService _objectEntryService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-29569206
+// LIFERAY-SERVICE-BUILDER-HASH:-786646980

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/persistence/ObjectEntryPersistence.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/persistence/ObjectEntryPersistence.java
@@ -867,6 +867,127 @@ public interface ObjectEntryPersistence extends BasePersistence<ObjectEntry> {
 		long groupId, long objectDefinitionId, int status);
 
 	/**
+	 * Returns all the object entries where groupId = &#63; and objectDefinitionId = &#63; and status &ne; &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param objectDefinitionId the object definition ID
+	 * @param status the status
+	 * @return the matching object entries
+	 */
+	public java.util.List<ObjectEntry> findByG_ODI_NotS(
+		long groupId, long objectDefinitionId, int status);
+
+	/**
+	 * Returns a range of all the object entries where groupId = &#63; and objectDefinitionId = &#63; and status &ne; &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.object.model.impl.ObjectEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param objectDefinitionId the object definition ID
+	 * @param status the status
+	 * @param start the lower bound of the range of object entries
+	 * @param end the upper bound of the range of object entries (not inclusive)
+	 * @return the range of matching object entries
+	 */
+	public java.util.List<ObjectEntry> findByG_ODI_NotS(
+		long groupId, long objectDefinitionId, int status, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the object entries where groupId = &#63; and objectDefinitionId = &#63; and status &ne; &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.object.model.impl.ObjectEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param objectDefinitionId the object definition ID
+	 * @param status the status
+	 * @param start the lower bound of the range of object entries
+	 * @param end the upper bound of the range of object entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching object entries
+	 */
+	public java.util.List<ObjectEntry> findByG_ODI_NotS(
+		long groupId, long objectDefinitionId, int status, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<ObjectEntry>
+			orderByComparator);
+
+	/**
+	 * Returns an ordered range of all the object entries where groupId = &#63; and objectDefinitionId = &#63; and status &ne; &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.object.model.impl.ObjectEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param objectDefinitionId the object definition ID
+	 * @param status the status
+	 * @param start the lower bound of the range of object entries
+	 * @param end the upper bound of the range of object entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching object entries
+	 */
+	public java.util.List<ObjectEntry> findByG_ODI_NotS(
+		long groupId, long objectDefinitionId, int status, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<ObjectEntry>
+			orderByComparator,
+		boolean useFinderCache);
+
+	/**
+	 * Returns the first object entry in the ordered set where groupId = &#63; and objectDefinitionId = &#63; and status &ne; &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param objectDefinitionId the object definition ID
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching object entry
+	 * @throws NoSuchObjectEntryException if a matching object entry could not be found
+	 */
+	public ObjectEntry findByG_ODI_NotS_First(
+			long groupId, long objectDefinitionId, int status,
+			com.liferay.portal.kernel.util.OrderByComparator<ObjectEntry>
+				orderByComparator)
+		throws NoSuchObjectEntryException;
+
+	/**
+	 * Returns the first object entry in the ordered set where groupId = &#63; and objectDefinitionId = &#63; and status &ne; &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param objectDefinitionId the object definition ID
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching object entry, or <code>null</code> if a matching object entry could not be found
+	 */
+	public ObjectEntry fetchByG_ODI_NotS_First(
+		long groupId, long objectDefinitionId, int status,
+		com.liferay.portal.kernel.util.OrderByComparator<ObjectEntry>
+			orderByComparator);
+
+	/**
+	 * Removes all the object entries where groupId = &#63; and objectDefinitionId = &#63; and status &ne; &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param objectDefinitionId the object definition ID
+	 * @param status the status
+	 */
+	public void removeByG_ODI_NotS(
+		long groupId, long objectDefinitionId, int status);
+
+	/**
+	 * Returns the number of object entries where groupId = &#63; and objectDefinitionId = &#63; and status &ne; &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param objectDefinitionId the object definition ID
+	 * @param status the status
+	 * @return the number of matching object entries
+	 */
+	public int countByG_ODI_NotS(
+		long groupId, long objectDefinitionId, int status);
+
+	/**
 	 * Returns all the object entries where userId = &#63; and createDate &gt; &#63; and objectDefinitionId = &#63;.
 	 *
 	 * @param userId the user ID
@@ -1594,4 +1715,4 @@ public interface ObjectEntryPersistence extends BasePersistence<ObjectEntry> {
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1585792985
+// LIFERAY-SERVICE-BUILDER-HASH:-1253816660

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/persistence/ObjectEntryUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/persistence/ObjectEntryUtil.java
@@ -1141,6 +1141,156 @@ public class ObjectEntryUtil {
 	}
 
 	/**
+	 * Returns all the object entries where groupId = &#63; and objectDefinitionId = &#63; and status &ne; &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param objectDefinitionId the object definition ID
+	 * @param status the status
+	 * @return the matching object entries
+	 */
+	public static List<ObjectEntry> findByG_ODI_NotS(
+		long groupId, long objectDefinitionId, int status) {
+
+		return getPersistence().findByG_ODI_NotS(
+			groupId, objectDefinitionId, status);
+	}
+
+	/**
+	 * Returns a range of all the object entries where groupId = &#63; and objectDefinitionId = &#63; and status &ne; &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.object.model.impl.ObjectEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param objectDefinitionId the object definition ID
+	 * @param status the status
+	 * @param start the lower bound of the range of object entries
+	 * @param end the upper bound of the range of object entries (not inclusive)
+	 * @return the range of matching object entries
+	 */
+	public static List<ObjectEntry> findByG_ODI_NotS(
+		long groupId, long objectDefinitionId, int status, int start, int end) {
+
+		return getPersistence().findByG_ODI_NotS(
+			groupId, objectDefinitionId, status, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the object entries where groupId = &#63; and objectDefinitionId = &#63; and status &ne; &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.object.model.impl.ObjectEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param objectDefinitionId the object definition ID
+	 * @param status the status
+	 * @param start the lower bound of the range of object entries
+	 * @param end the upper bound of the range of object entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching object entries
+	 */
+	public static List<ObjectEntry> findByG_ODI_NotS(
+		long groupId, long objectDefinitionId, int status, int start, int end,
+		OrderByComparator<ObjectEntry> orderByComparator) {
+
+		return getPersistence().findByG_ODI_NotS(
+			groupId, objectDefinitionId, status, start, end, orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the object entries where groupId = &#63; and objectDefinitionId = &#63; and status &ne; &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.object.model.impl.ObjectEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param objectDefinitionId the object definition ID
+	 * @param status the status
+	 * @param start the lower bound of the range of object entries
+	 * @param end the upper bound of the range of object entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching object entries
+	 */
+	public static List<ObjectEntry> findByG_ODI_NotS(
+		long groupId, long objectDefinitionId, int status, int start, int end,
+		OrderByComparator<ObjectEntry> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByG_ODI_NotS(
+			groupId, objectDefinitionId, status, start, end, orderByComparator,
+			useFinderCache);
+	}
+
+	/**
+	 * Returns the first object entry in the ordered set where groupId = &#63; and objectDefinitionId = &#63; and status &ne; &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param objectDefinitionId the object definition ID
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching object entry
+	 * @throws NoSuchObjectEntryException if a matching object entry could not be found
+	 */
+	public static ObjectEntry findByG_ODI_NotS_First(
+			long groupId, long objectDefinitionId, int status,
+			OrderByComparator<ObjectEntry> orderByComparator)
+		throws com.liferay.object.exception.NoSuchObjectEntryException {
+
+		return getPersistence().findByG_ODI_NotS_First(
+			groupId, objectDefinitionId, status, orderByComparator);
+	}
+
+	/**
+	 * Returns the first object entry in the ordered set where groupId = &#63; and objectDefinitionId = &#63; and status &ne; &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param objectDefinitionId the object definition ID
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching object entry, or <code>null</code> if a matching object entry could not be found
+	 */
+	public static ObjectEntry fetchByG_ODI_NotS_First(
+		long groupId, long objectDefinitionId, int status,
+		OrderByComparator<ObjectEntry> orderByComparator) {
+
+		return getPersistence().fetchByG_ODI_NotS_First(
+			groupId, objectDefinitionId, status, orderByComparator);
+	}
+
+	/**
+	 * Removes all the object entries where groupId = &#63; and objectDefinitionId = &#63; and status &ne; &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param objectDefinitionId the object definition ID
+	 * @param status the status
+	 */
+	public static void removeByG_ODI_NotS(
+		long groupId, long objectDefinitionId, int status) {
+
+		getPersistence().removeByG_ODI_NotS(
+			groupId, objectDefinitionId, status);
+	}
+
+	/**
+	 * Returns the number of object entries where groupId = &#63; and objectDefinitionId = &#63; and status &ne; &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param objectDefinitionId the object definition ID
+	 * @param status the status
+	 * @return the number of matching object entries
+	 */
+	public static int countByG_ODI_NotS(
+		long groupId, long objectDefinitionId, int status) {
+
+		return getPersistence().countByG_ODI_NotS(
+			groupId, objectDefinitionId, status);
+	}
+
+	/**
 	 * Returns all the object entries where userId = &#63; and createDate &gt; &#63; and objectDefinitionId = &#63;.
 	 *
 	 * @param userId the user ID
@@ -1901,4 +2051,4 @@ public class ObjectEntryUtil {
 	private static volatile ObjectEntryPersistence _persistence;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1589412355
+// LIFERAY-SERVICE-BUILDER-HASH:425117630

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/service/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/service/packageinfo
@@ -1,1 +1,1 @@
-version 88.0.0
+version 88.1.0

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/service/persistence/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 14.1.0
+version 14.2.0

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -112,6 +112,7 @@ import com.liferay.portal.kernel.search.filter.BooleanFilter;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.search.filter.TermFilter;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.InlineSQLHelper;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
@@ -823,6 +824,42 @@ public class DefaultObjectEntryManagerImpl
 		int start = _getStartPosition(pagination);
 		int end = _getEndPosition(pagination);
 
+		boolean preferApproved = GetterUtil.getBoolean(
+			dtoConverterContext.getAttribute("preferApproved"));
+
+		List<ObjectEntry> objectEntries = null;
+		int objectEntriesCount = 0;
+
+		Long finderGroupId = _getFinderGroupId(
+			objectDefinition, groupIds, predicate, preferApproved, search,
+			sorts);
+
+		if (finderGroupId == null) {
+			objectEntries = TransformUtil.transform(
+				objectEntryLocalService.getPrimaryKeys(
+					groupIds, companyId, dtoConverterContext.getUserId(),
+					objectDefinition.getObjectDefinitionId(), predicate,
+					preferApproved, search, start, end, sorts),
+				primaryKey -> _getObjectEntry(
+					dtoConverterContext, objectDefinition, primaryKey));
+			objectEntriesCount = objectEntryLocalService.getValuesListCount(
+				groupIds, companyId, dtoConverterContext.getUserId(),
+				objectDefinition.getObjectDefinitionId(), predicate,
+				preferApproved, search);
+		}
+		else {
+			objectEntries = TransformUtil.transform(
+				_objectEntryService.getObjectEntries(
+					finderGroupId, objectDefinition.getObjectDefinitionId(),
+					WorkflowConstants.STATUS_ANY, start, end),
+				serviceBuilderObjectEntry -> _getObjectEntry(
+					dtoConverterContext, objectDefinition,
+					serviceBuilderObjectEntry));
+			objectEntriesCount = _objectEntryService.getObjectEntriesCount(
+				finderGroupId, objectDefinition.getObjectDefinitionId(),
+				WorkflowConstants.STATUS_ANY);
+		}
+
 		return Page.of(
 			HashMapBuilder.put(
 				"create",
@@ -868,22 +905,7 @@ public class DefaultObjectEntryManagerImpl
 					aggregationTerm, predicate,
 					GetterUtil.getBoolean(
 						dtoConverterContext.getAttribute("preferApproved")))),
-			TransformUtil.transform(
-				objectEntryLocalService.getPrimaryKeys(
-					groupIds, companyId, dtoConverterContext.getUserId(),
-					objectDefinition.getObjectDefinitionId(), predicate,
-					GetterUtil.getBoolean(
-						dtoConverterContext.getAttribute("preferApproved")),
-					search, start, end, sorts),
-				primaryKey -> _getObjectEntry(
-					dtoConverterContext, objectDefinition, primaryKey)),
-			pagination,
-			objectEntryLocalService.getValuesListCount(
-				groupIds, companyId, dtoConverterContext.getUserId(),
-				objectDefinition.getObjectDefinitionId(), predicate,
-				GetterUtil.getBoolean(
-					dtoConverterContext.getAttribute("preferApproved")),
-				search));
+			objectEntries, pagination, objectEntriesCount);
 	}
 
 	@Override
@@ -2395,6 +2417,41 @@ public class DefaultObjectEntryManagerImpl
 		return getGroupId(objectDefinition, scopeKey, true);
 	}
 
+	private Long _getFinderGroupId(
+		ObjectDefinition objectDefinition, Long[] groupIds, Predicate predicate,
+		boolean preferApproved, String search, Sort[] sorts) {
+
+		if ((predicate != null) || preferApproved ||
+			Validator.isNotNull(search) || !_isDefaultSort(sorts) ||
+			ArrayUtil.isNotEmpty(
+				objectDefinition.getRootObjectDefinitionIds())) {
+
+			return null;
+		}
+
+		long groupId = 0;
+
+		if (!StringUtil.equals(
+				objectDefinition.getScope(),
+				ObjectDefinitionConstants.SCOPE_COMPANY)) {
+
+			if (groupIds.length != 1) {
+				return null;
+			}
+
+			groupId = groupIds[0];
+		}
+
+		if ((PermissionThreadLocal.getPermissionChecker() != null) &&
+			_inlineSQLHelper.isEnabled(
+				objectDefinition.getCompanyId(), groupId)) {
+
+			return null;
+		}
+
+		return groupId;
+	}
+
 	private String _getGroupExternalReferenceCode(FileEntry fileEntry) {
 		Scope scope = fileEntry.getScope();
 
@@ -3123,6 +3180,24 @@ public class DefaultObjectEntryManagerImpl
 		}
 
 		return (Serializable)value;
+	}
+
+	private boolean _isDefaultSort(Sort[] sorts) {
+		if (sorts == null) {
+			return true;
+		}
+
+		if (sorts.length != 1) {
+			return false;
+		}
+
+		Sort sort = sorts[0];
+
+		if (Objects.equals(sort.getFieldName(), "id") && !sort.isReverse()) {
+			return true;
+		}
+
+		return false;
 	}
 
 	private boolean _isObjectEntryDraft(Status status) {
@@ -4216,6 +4291,9 @@ public class DefaultObjectEntryManagerImpl
 
 	@Reference
 	private Http _http;
+
+	@Reference
+	private InlineSQLHelper _inlineSQLHelper;
 
 	@Reference
 	private JSONFactory _jsonFactory;

--- a/modules/apps/object/object-service/service.xml
+++ b/modules/apps/object/object-service/service.xml
@@ -313,6 +313,11 @@
 			<finder-column name="objectDefinitionId" />
 			<finder-column name="status" />
 		</finder>
+		<finder name="G_ODI_NotS" return-type="Collection" where="objectEntryId = headObjectEntryId">
+			<finder-column name="groupId" />
+			<finder-column name="objectDefinitionId" />
+			<finder-column comparator="!=" name="status" />
+		</finder>
 		<finder name="U_GtCD_ODI" return-type="Collection" where="objectEntryId = headObjectEntryId">
 			<finder-column name="userId" />
 			<finder-column comparator="&gt;" name="createDate" />

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/http/ObjectEntryServiceHttp.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/http/ObjectEntryServiceHttp.java
@@ -589,6 +589,39 @@ public class ObjectEntryServiceHttp {
 		}
 	}
 
+	public static int getObjectEntriesCount(
+		HttpPrincipal httpPrincipal, long groupId, long objectDefinitionId,
+		int status) {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				ObjectEntryServiceUtil.class, "getObjectEntriesCount",
+				_getObjectEntriesCountParameterTypes13);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, groupId, objectDefinitionId, status);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return ((Integer)returnObj).intValue();
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
 	public static com.liferay.object.model.ObjectEntry getObjectEntry(
 			HttpPrincipal httpPrincipal, long objectEntryId)
 		throws com.liferay.portal.kernel.exception.PortalException {
@@ -596,7 +629,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "getObjectEntry",
-				_getObjectEntryParameterTypes13);
+				_getObjectEntryParameterTypes14);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, objectEntryId);
@@ -637,7 +670,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "getObjectEntry",
-				_getObjectEntryParameterTypes14);
+				_getObjectEntryParameterTypes15);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, externalReferenceCode, groupId, objectDefinitionId);
@@ -683,7 +716,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "getOneToManyObjectEntries",
-				_getOneToManyObjectEntriesParameterTypes15);
+				_getOneToManyObjectEntriesParameterTypes16);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, objectRelationshipId, predicate,
@@ -728,7 +761,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "getOneToManyObjectEntriesCount",
-				_getOneToManyObjectEntriesCountParameterTypes16);
+				_getOneToManyObjectEntriesCountParameterTypes17);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, objectRelationshipId, predicate, primaryKey,
@@ -770,7 +803,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "getOrAddEmptyObjectEntry",
-				_getOrAddEmptyObjectEntryParameterTypes17);
+				_getOrAddEmptyObjectEntryParameterTypes18);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, externalReferenceCode, groupId, objectDefinitionId);
@@ -811,7 +844,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "hasModelResourcePermission",
-				_hasModelResourcePermissionParameterTypes18);
+				_hasModelResourcePermissionParameterTypes19);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, objectDefinitionId, objectEntryId, actionId);
@@ -852,7 +885,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "hasModelResourcePermission",
-				_hasModelResourcePermissionParameterTypes19);
+				_hasModelResourcePermissionParameterTypes20);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, objectEntry, actionId);
@@ -894,7 +927,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "hasModelResourcePermission",
-				_hasModelResourcePermissionParameterTypes20);
+				_hasModelResourcePermissionParameterTypes21);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, user, objectEntryId, actionId);
@@ -935,7 +968,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "hasPortletResourcePermission",
-				_hasPortletResourcePermissionParameterTypes21);
+				_hasPortletResourcePermissionParameterTypes22);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, objectDefinitionId, actionId);
@@ -978,7 +1011,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "moveObjectEntry",
-				_moveObjectEntryParameterTypes22);
+				_moveObjectEntryParameterTypes23);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, objectEntryId, objectEntryFolderId, values,
@@ -1021,7 +1054,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "moveObjectEntryToTrash",
-				_moveObjectEntryToTrashParameterTypes23);
+				_moveObjectEntryToTrashParameterTypes24);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, objectEntry, serviceContext);
@@ -1064,7 +1097,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "partialUpdateObjectEntry",
-				_partialUpdateObjectEntryParameterTypes24);
+				_partialUpdateObjectEntryParameterTypes25);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, objectEntryId, objectEntryFolderId, values,
@@ -1108,7 +1141,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "restoreObjectEntryFromTrash",
-				_restoreObjectEntryFromTrashParameterTypes25);
+				_restoreObjectEntryFromTrashParameterTypes26);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, objectEntry, serviceContext);
@@ -1148,7 +1181,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "subscribeObjectEntry",
-				_subscribeObjectEntryParameterTypes26);
+				_subscribeObjectEntryParameterTypes27);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, objectEntryId);
@@ -1184,7 +1217,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "unsubscribeObjectEntry",
-				_unsubscribeObjectEntryParameterTypes27);
+				_unsubscribeObjectEntryParameterTypes28);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, objectEntryId);
@@ -1223,7 +1256,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "updateObjectEntry",
-				_updateObjectEntryParameterTypes28);
+				_updateObjectEntryParameterTypes29);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, objectEntryId, objectEntryFolderId, values,
@@ -1267,7 +1300,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "validate",
-				_validateParameterTypes29);
+				_validateParameterTypes30);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, objectEntry,
@@ -1347,11 +1380,13 @@ public class ObjectEntryServiceHttp {
 		_getModelResourcePermissionParameterTypes11 = new Class[] {long.class};
 	private static final Class<?>[] _getObjectEntriesParameterTypes12 =
 		new Class[] {long.class, long.class, int.class, int.class, int.class};
-	private static final Class<?>[] _getObjectEntryParameterTypes13 =
-		new Class[] {long.class};
+	private static final Class<?>[] _getObjectEntriesCountParameterTypes13 =
+		new Class[] {long.class, long.class, int.class};
 	private static final Class<?>[] _getObjectEntryParameterTypes14 =
+		new Class[] {long.class};
+	private static final Class<?>[] _getObjectEntryParameterTypes15 =
 		new Class[] {String.class, long.class, long.class};
-	private static final Class<?>[] _getOneToManyObjectEntriesParameterTypes15 =
+	private static final Class<?>[] _getOneToManyObjectEntriesParameterTypes16 =
 		new Class[] {
 			long.class, long.class,
 			com.liferay.petra.sql.dsl.expression.Predicate.class, boolean.class,
@@ -1359,63 +1394,63 @@ public class ObjectEntryServiceHttp {
 			com.liferay.portal.kernel.search.Sort[].class
 		};
 	private static final Class<?>[]
-		_getOneToManyObjectEntriesCountParameterTypes16 = new Class[] {
+		_getOneToManyObjectEntriesCountParameterTypes17 = new Class[] {
 			long.class, long.class,
 			com.liferay.petra.sql.dsl.expression.Predicate.class, long.class,
 			boolean.class, String.class
 		};
-	private static final Class<?>[] _getOrAddEmptyObjectEntryParameterTypes17 =
+	private static final Class<?>[] _getOrAddEmptyObjectEntryParameterTypes18 =
 		new Class[] {String.class, long.class, long.class};
 	private static final Class<?>[]
-		_hasModelResourcePermissionParameterTypes18 = new Class[] {
-			long.class, long.class, String.class
-		};
-	private static final Class<?>[]
 		_hasModelResourcePermissionParameterTypes19 = new Class[] {
-			com.liferay.object.model.ObjectEntry.class, String.class
+			long.class, long.class, String.class
 		};
 	private static final Class<?>[]
 		_hasModelResourcePermissionParameterTypes20 = new Class[] {
+			com.liferay.object.model.ObjectEntry.class, String.class
+		};
+	private static final Class<?>[]
+		_hasModelResourcePermissionParameterTypes21 = new Class[] {
 			com.liferay.portal.kernel.model.User.class, long.class, String.class
 		};
 	private static final Class<?>[]
-		_hasPortletResourcePermissionParameterTypes21 = new Class[] {
+		_hasPortletResourcePermissionParameterTypes22 = new Class[] {
 			long.class, long.class, String.class
 		};
-	private static final Class<?>[] _moveObjectEntryParameterTypes22 =
+	private static final Class<?>[] _moveObjectEntryParameterTypes23 =
 		new Class[] {
 			long.class, long.class, java.util.Map.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _moveObjectEntryToTrashParameterTypes23 =
+	private static final Class<?>[] _moveObjectEntryToTrashParameterTypes24 =
 		new Class[] {
 			com.liferay.object.model.ObjectEntry.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _partialUpdateObjectEntryParameterTypes24 =
+	private static final Class<?>[] _partialUpdateObjectEntryParameterTypes25 =
 		new Class[] {
 			long.class, long.class, java.util.Map.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
 	private static final Class<?>[]
-		_restoreObjectEntryFromTrashParameterTypes25 = new Class[] {
+		_restoreObjectEntryFromTrashParameterTypes26 = new Class[] {
 			com.liferay.object.model.ObjectEntry.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _subscribeObjectEntryParameterTypes26 =
+	private static final Class<?>[] _subscribeObjectEntryParameterTypes27 =
 		new Class[] {long.class, long.class};
-	private static final Class<?>[] _unsubscribeObjectEntryParameterTypes27 =
+	private static final Class<?>[] _unsubscribeObjectEntryParameterTypes28 =
 		new Class[] {long.class};
-	private static final Class<?>[] _updateObjectEntryParameterTypes28 =
+	private static final Class<?>[] _updateObjectEntryParameterTypes29 =
 		new Class[] {
 			long.class, long.class, java.util.Map.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _validateParameterTypes29 = new Class[] {
+	private static final Class<?>[] _validateParameterTypes30 = new Class[] {
 		long.class, com.liferay.object.model.ObjectEntry.class,
 		java.util.List.class,
 		com.liferay.portal.kernel.service.ServiceContext.class
 	};
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:575751263
+// LIFERAY-SERVICE-BUILDER-HASH:-2008799208

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -1369,6 +1369,12 @@ public class ObjectEntryLocalServiceImpl
 	public List<ObjectEntry> getObjectEntries(
 		long groupId, long objectDefinitionId, int status, int start, int end) {
 
+		if (status == WorkflowConstants.STATUS_ANY) {
+			return objectEntryPersistence.findByG_ODI_NotS(
+				groupId, objectDefinitionId, WorkflowConstants.STATUS_IN_TRASH,
+				start, end);
+		}
+
 		return objectEntryPersistence.findByG_ODI_S(
 			groupId, objectDefinitionId, status, start, end);
 	}
@@ -1391,6 +1397,19 @@ public class ObjectEntryLocalServiceImpl
 	@Override
 	public int getObjectEntriesCount(long groupId, long objectDefinitionId) {
 		return objectEntryPersistence.countByG_ODI(groupId, objectDefinitionId);
+	}
+
+	@Override
+	public int getObjectEntriesCount(
+		long groupId, long objectDefinitionId, int status) {
+
+		if (status == WorkflowConstants.STATUS_ANY) {
+			return objectEntryPersistence.countByG_ODI_NotS(
+				groupId, objectDefinitionId, WorkflowConstants.STATUS_IN_TRASH);
+		}
+
+		return objectEntryPersistence.countByG_ODI_S(
+			groupId, objectDefinitionId, status);
 	}
 
 	@Override

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryServiceImpl.java
@@ -326,20 +326,36 @@ public class ObjectEntryServiceImpl extends ObjectEntryServiceBaseImpl {
 			int end)
 		throws PortalException {
 
-		List<ObjectEntry> objectEntries = objectEntryPersistence.findByG_ODI_S(
-			groupId, objectDefinitionId, status, start, end);
+		List<ObjectEntry> objectEntries = null;
+
+		if (status == WorkflowConstants.STATUS_ANY) {
+			objectEntries = objectEntryPersistence.findByG_ODI_NotS(
+				groupId, objectDefinitionId, WorkflowConstants.STATUS_IN_TRASH,
+				start, end);
+		}
+		else {
+			objectEntries = objectEntryPersistence.findByG_ODI_S(
+				groupId, objectDefinitionId, status, start, end);
+		}
 
 		if (ObjectEntryThreadLocal.isSkipObjectEntryResourcePermission()) {
 			return objectEntries;
 		}
 
+		ObjectDefinition objectDefinition =
+			_objectDefinitionPersistence.findByPrimaryKey(objectDefinitionId);
+
 		ModelResourcePermission<ObjectEntry> modelResourcePermission =
-			getModelResourcePermission(objectDefinitionId);
+			ModelResourcePermissionRegistryUtil.getModelResourcePermission(
+				objectDefinition.getClassName());
+
 		PermissionChecker permissionChecker = getPermissionChecker();
 
 		return TransformUtil.transform(
 			objectEntries,
 			objectEntry -> {
+				objectEntry.setObjectDefinition(objectDefinition);
+
 				if (modelResourcePermission.contains(
 						permissionChecker, objectEntry, ActionKeys.VIEW)) {
 
@@ -348,6 +364,19 @@ public class ObjectEntryServiceImpl extends ObjectEntryServiceBaseImpl {
 
 				return null;
 			});
+	}
+
+	@Override
+	public int getObjectEntriesCount(
+		long groupId, long objectDefinitionId, int status) {
+
+		if (status == WorkflowConstants.STATUS_ANY) {
+			return objectEntryPersistence.countByG_ODI_NotS(
+				groupId, objectDefinitionId, WorkflowConstants.STATUS_IN_TRASH);
+		}
+
+		return objectEntryPersistence.countByG_ODI_S(
+			groupId, objectDefinitionId, status);
 	}
 
 	@Override

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/persistence/impl/ObjectEntryPersistenceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/persistence/impl/ObjectEntryPersistenceImpl.java
@@ -1252,6 +1252,171 @@ public class ObjectEntryPersistenceImpl
 	}
 
 	private CollectionPersistenceFinder<ObjectEntry, NoSuchObjectEntryException>
+		_collectionPersistenceFinderByG_ODI_NotS;
+
+	/**
+	 * Returns all the object entries where groupId = &#63; and objectDefinitionId = &#63; and status &ne; &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param objectDefinitionId the object definition ID
+	 * @param status the status
+	 * @return the matching object entries
+	 */
+	@Override
+	public List<ObjectEntry> findByG_ODI_NotS(
+		long groupId, long objectDefinitionId, int status) {
+
+		return findByG_ODI_NotS(
+			groupId, objectDefinitionId, status, QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the object entries where groupId = &#63; and objectDefinitionId = &#63; and status &ne; &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ObjectEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param objectDefinitionId the object definition ID
+	 * @param status the status
+	 * @param start the lower bound of the range of object entries
+	 * @param end the upper bound of the range of object entries (not inclusive)
+	 * @return the range of matching object entries
+	 */
+	@Override
+	public List<ObjectEntry> findByG_ODI_NotS(
+		long groupId, long objectDefinitionId, int status, int start, int end) {
+
+		return findByG_ODI_NotS(
+			groupId, objectDefinitionId, status, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the object entries where groupId = &#63; and objectDefinitionId = &#63; and status &ne; &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ObjectEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param objectDefinitionId the object definition ID
+	 * @param status the status
+	 * @param start the lower bound of the range of object entries
+	 * @param end the upper bound of the range of object entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching object entries
+	 */
+	@Override
+	public List<ObjectEntry> findByG_ODI_NotS(
+		long groupId, long objectDefinitionId, int status, int start, int end,
+		OrderByComparator<ObjectEntry> orderByComparator) {
+
+		return findByG_ODI_NotS(
+			groupId, objectDefinitionId, status, start, end, orderByComparator,
+			true);
+	}
+
+	/**
+	 * Returns an ordered range of all the object entries where groupId = &#63; and objectDefinitionId = &#63; and status &ne; &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ObjectEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param objectDefinitionId the object definition ID
+	 * @param status the status
+	 * @param start the lower bound of the range of object entries
+	 * @param end the upper bound of the range of object entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching object entries
+	 */
+	@Override
+	public List<ObjectEntry> findByG_ODI_NotS(
+		long groupId, long objectDefinitionId, int status, int start, int end,
+		OrderByComparator<ObjectEntry> orderByComparator,
+		boolean useFinderCache) {
+
+		return _collectionPersistenceFinderByG_ODI_NotS.find(
+			finderCache, new Object[] {groupId, objectDefinitionId, status},
+			start, end, orderByComparator, useFinderCache);
+	}
+
+	/**
+	 * Returns the first object entry in the ordered set where groupId = &#63; and objectDefinitionId = &#63; and status &ne; &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param objectDefinitionId the object definition ID
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching object entry
+	 * @throws NoSuchObjectEntryException if a matching object entry could not be found
+	 */
+	@Override
+	public ObjectEntry findByG_ODI_NotS_First(
+			long groupId, long objectDefinitionId, int status,
+			OrderByComparator<ObjectEntry> orderByComparator)
+		throws NoSuchObjectEntryException {
+
+		return _collectionPersistenceFinderByG_ODI_NotS.findFirst(
+			finderCache, new Object[] {groupId, objectDefinitionId, status},
+			orderByComparator);
+	}
+
+	/**
+	 * Returns the first object entry in the ordered set where groupId = &#63; and objectDefinitionId = &#63; and status &ne; &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param objectDefinitionId the object definition ID
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching object entry, or <code>null</code> if a matching object entry could not be found
+	 */
+	@Override
+	public ObjectEntry fetchByG_ODI_NotS_First(
+		long groupId, long objectDefinitionId, int status,
+		OrderByComparator<ObjectEntry> orderByComparator) {
+
+		return _collectionPersistenceFinderByG_ODI_NotS.fetchFirst(
+			finderCache, new Object[] {groupId, objectDefinitionId, status},
+			orderByComparator);
+	}
+
+	/**
+	 * Removes all the object entries where groupId = &#63; and objectDefinitionId = &#63; and status &ne; &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param objectDefinitionId the object definition ID
+	 * @param status the status
+	 */
+	@Override
+	public void removeByG_ODI_NotS(
+		long groupId, long objectDefinitionId, int status) {
+
+		_collectionPersistenceFinderByG_ODI_NotS.remove(
+			finderCache, new Object[] {groupId, objectDefinitionId, status});
+	}
+
+	/**
+	 * Returns the number of object entries where groupId = &#63; and objectDefinitionId = &#63; and status &ne; &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param objectDefinitionId the object definition ID
+	 * @param status the status
+	 * @return the number of matching object entries
+	 */
+	@Override
+	public int countByG_ODI_NotS(
+		long groupId, long objectDefinitionId, int status) {
+
+		return _collectionPersistenceFinderByG_ODI_NotS.count(
+			finderCache, new Object[] {groupId, objectDefinitionId, status});
+	}
+
+	private CollectionPersistenceFinder<ObjectEntry, NoSuchObjectEntryException>
 		_collectionPersistenceFinderByU_GtCD_ODI;
 
 	/**
@@ -2128,6 +2293,44 @@ public class ObjectEntryPersistenceImpl
 					"objectEntry.", "status", FinderColumn.Type.INTEGER, "=",
 					true, true, ObjectEntry::getStatus));
 
+		_collectionPersistenceFinderByG_ODI_NotS =
+			new CollectionPersistenceFinder<>(
+				this,
+				new FinderPath(
+					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_ODI_NotS",
+					new String[] {
+						Long.class.getName(), Long.class.getName(),
+						Integer.class.getName(), Integer.class.getName(),
+						Integer.class.getName(),
+						OrderByComparator.class.getName()
+					},
+					new String[] {"groupId", "objectDefinitionId", "status"},
+					true),
+				null,
+				new FinderPath(
+					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByG_ODI_NotS",
+					new String[] {
+						Long.class.getName(), Long.class.getName(),
+						Integer.class.getName()
+					},
+					new String[] {"groupId", "objectDefinitionId", "status"},
+					false),
+				_SQL_SELECT_OBJECTENTRY_WHERE, _SQL_COUNT_OBJECTENTRY_WHERE,
+				ObjectEntryModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
+				"objectEntry.objectEntryId = objectEntry.headObjectEntryId",
+				"objectEntry.objectEntryId = objectEntry.headObjectEntryId",
+				null,
+				new FinderColumn<>(
+					"objectEntry.", "groupId", FinderColumn.Type.LONG, "=",
+					true, true, ObjectEntry::getGroupId),
+				new FinderColumn<>(
+					"objectEntry.", "objectDefinitionId",
+					FinderColumn.Type.LONG, "=", true, true,
+					ObjectEntry::getObjectDefinitionId),
+				new FinderColumn<>(
+					"objectEntry.", "status", FinderColumn.Type.INTEGER, "!=",
+					true, true, ObjectEntry::getStatus));
+
 		_collectionPersistenceFinderByU_GtCD_ODI =
 			new CollectionPersistenceFinder<>(
 				this,
@@ -2260,4 +2463,4 @@ public class ObjectEntryPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1937264170
+// LIFERAY-SERVICE-BUILDER-HASH:-1342389250

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectEntryPersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectEntryPersistenceTest.java
@@ -335,6 +335,15 @@ public class ObjectEntryPersistenceTest {
 	}
 
 	@Test
+	public void testCountByG_ODI_NotS() throws Exception {
+		_persistence.countByG_ODI_NotS(
+			RandomTestUtil.nextLong(), RandomTestUtil.nextLong(),
+			RandomTestUtil.nextInt());
+
+		_persistence.countByG_ODI_NotS(0L, 0L, 0);
+	}
+
+	@Test
 	public void testCountByU_GtCD_ODI() throws Exception {
 		_persistence.countByU_GtCD_ODI(
 			RandomTestUtil.nextLong(), RandomTestUtil.nextDate(),
@@ -753,4 +762,4 @@ public class ObjectEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1440861900
+// LIFERAY-SERVICE-BUILDER-HASH:-581398502

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -5524,6 +5524,56 @@ public class ObjectEntryLocalServiceTest {
 	}
 
 	@Test
+	public void testGetObjectEntriesByStatus() throws Exception {
+		ObjectEntry objectEntry1 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"emailAddressRequired", "peter@liferay.com"
+			).put(
+				"firstName", "Peter"
+			).put(
+				"listTypeEntryKeyRequired", "listTypeEntryKey1"
+			).build());
+		ObjectEntry objectEntry2 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"emailAddressRequired", "james@liferay.com"
+			).put(
+				"firstName", "James"
+			).put(
+				"listTypeEntryKeyRequired", "listTypeEntryKey2"
+			).build());
+		ObjectEntry objectEntry3 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"emailAddressRequired", "john@liferay.com"
+			).put(
+				"firstName", "John"
+			).put(
+				"listTypeEntryKeyRequired", "listTypeEntryKey3"
+			).build());
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext();
+
+		_objectEntryLocalService.updateStatus(
+			TestPropsValues.getUserId(), objectEntry2.getObjectEntryId(),
+			WorkflowConstants.STATUS_DRAFT, serviceContext);
+		_objectEntryLocalService.moveObjectEntryToTrash(
+			TestPropsValues.getUserId(), objectEntry3, serviceContext);
+
+		_assertObjectEntries(
+			Arrays.asList(objectEntry1, objectEntry2),
+			WorkflowConstants.STATUS_ANY);
+		_assertObjectEntries(
+			Collections.singletonList(objectEntry1),
+			WorkflowConstants.STATUS_APPROVED);
+		_assertObjectEntries(
+			Collections.singletonList(objectEntry2),
+			WorkflowConstants.STATUS_DRAFT);
+		_assertObjectEntries(
+			Collections.singletonList(objectEntry3),
+			WorkflowConstants.STATUS_IN_TRASH);
+	}
+
+	@Test
 	public void testGetObjectEntry() throws Exception {
 		ObjectEntry objectEntry = _addObjectEntry(
 			HashMapBuilder.<String, Serializable>put(
@@ -9577,6 +9627,27 @@ public class ObjectEntryLocalServiceTest {
 			objectAction.getObjectActionId());
 
 		Assert.assertEquals(expectedStatus, objectAction.getStatus());
+	}
+
+	private void _assertObjectEntries(
+		List<ObjectEntry> expectedObjectEntries, int status) {
+
+		List<Long> expectedObjectEntryIds = ListUtil.sort(
+			TransformUtil.transform(
+				expectedObjectEntries, ObjectEntry::getObjectEntryId));
+
+		Assert.assertEquals(
+			expectedObjectEntryIds,
+			ListUtil.sort(
+				TransformUtil.transform(
+					_objectEntryLocalService.getObjectEntries(
+						0, _objectDefinition.getObjectDefinitionId(), status,
+						QueryUtil.ALL_POS, QueryUtil.ALL_POS),
+					ObjectEntry::getObjectEntryId)));
+		Assert.assertEquals(
+			expectedObjectEntryIds.size(),
+			_objectEntryLocalService.getObjectEntriesCount(
+				0, _objectDefinition.getObjectDefinitionId(), status));
 	}
 
 	private void _assertObjectEntryLocalizedValues(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-104797

Resend of #181396 with the rename requested there: no new method names. `WorkflowConstants.STATUS_ANY` on the existing status listing carries the "not in the trash" meaning, the way `QueryDefinition` and the knowledge base articles already read it.

First change of the object entry listing optimization tracked under LPD-65366 (LPD-98910 scenario: a site page whose collection display lists a custom object's entries).

## What Is Being Fixed

`DefaultObjectEntryManagerImpl` builds every listing through the DSL query, which joins the definition's dynamic table, its extension table and, when present, its localization table to `ObjectEntry`, pages that join and counts it with `DISTINCT`. On a plain listing nothing reads the joined tables: the predicates on group, definition, root, head and status are `ObjectEntry` columns and the default sort is the primary key. On a definition with one hundred thousand entries the count examines three hundred thousand rows for an answer `ObjectEntry` alone gives from one hundred thousand, and the page then loads and permission checks every entry again by primary key, because the query returned primary keys.

## How It Is Being Fixed

A generated finder, `G_ODI_NotS` (group, definition, status not equal, `objectEntryId = headObjectEntryId`), answers the plain listing from `ObjectEntry` alone with the finder and entity caches.

`ObjectEntryService.getObjectEntries(groupId, objectDefinitionId, status, start, end)` already lists by one status. It now reads `WorkflowConstants.STATUS_ANY` as every status but the trash and lists through that finder, the convention `QueryDefinition` applies when it turns `STATUS_ANY` into `STATUS_IN_TRASH` with `excludeStatus`, and `KBArticleLocalServiceImpl.getGroupKBArticles` applies when it switches to its `NotS` finder. `getObjectEntriesCount(groupId, objectDefinitionId, status)` counts the same way, without a permission check, as the other remote counts do. The local service's overload reads the status the same way. The remote listing keeps filtering the entries by the view permission, and resolves the definition once per list so each entry carries it into the check instead of asking the definition service again for every row.

The manager takes the finder path only when the request carries no filter, no search term, no custom sort and no preference for approved versions, the definition has no root definitions, the scope resolves to a single group and inline permission checks do not apply to the user. Every other request keeps the DSL path unchanged.

## Verification

- `ObjectEntryLocalServiceTest.testGetObjectEntriesByStatus` covers the list and the count for `STATUS_ANY` (every entry but the trash), approved, draft and trash.
- Self-CI on shuyangzhou/liferay-portal PR 12744: `ci:test:stable` 16/16 and `ci:test:object` 50/50 on this exact head (`ec0da54`), 2026-09-07. Locally on a fresh database: `ObjectEntryLocalServiceTest` 86/86, `ObjectEntryServiceTest` 16/16, `DefaultObjectEntryManagerImplTest` 90/90.
- The previous shape of this change (#181396) ran `ci:test:stable` 16/16 and `ci:test:object` 49/51 on shuyangzhou/liferay-portal PR 12736, the single failure being the master `ObjectViewExternalReferenceCodeUpgradeProcessTest` regression fixed in #181393. The rework changes the method names and the status switch only; the finder and the manager branch are the same.
- Local load driver on the 100k sample entries, measured on the previous shape: the collection page view no longer runs the DSL join page and the `DISTINCT` count (rows examined per view from about 306k to about 102k, the finder result cached between writes); 10 threads x 100 iterations, p50 301 ms vs 436 ms, p95 373 ms vs 643 ms.

## PR Check

**pr-check: PASS** — tested on `ec0da541fd81c3abb5ed9f48beb24e13b0a74d9c`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Service Registration | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | NOT VERIFIED |
| Baseline | PASS (baseline-all + seven Ant projects + 1 changed exporting module) |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

Cross-Module Compile found 45 test modules referencing `ObjectEntryLocalService`, above the validation's cap of 8, so it verified nothing; Integration Test Compile covered 8 of them, including `object-test`, and the diff only adds members.

<!-- pr-check {"result": "success", "sha": "ec0da541fd81c3abb5ed9f48beb24e13b0a74d9c"} -->
