### PR TITLE
LPD-104797 Ask whether a listing is plain instead of which group serves it

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -824,17 +824,28 @@ public class DefaultObjectEntryManagerImpl
 		boolean preferApproved = GetterUtil.getBoolean(
 			dtoConverterContext.getAttribute("preferApproved"));
 
-		Long objectEntriesGroupId = _getObjectEntriesGroupId(
-			groupIds, objectDefinition, predicate, preferApproved, search,
-			sorts);
-
 		int start = _getStartPosition(pagination);
 		int end = _getEndPosition(pagination);
 
 		List<ObjectEntry> objectEntries = null;
 		int objectEntriesCount = 0;
 
-		if (objectEntriesGroupId == null) {
+		if (_isPlainListing(
+				groupIds, objectDefinition, predicate, preferApproved, search,
+				sorts)) {
+
+			objectEntries = TransformUtil.transform(
+				_objectEntryService.getObjectEntries(
+					groupIds[0], objectDefinition.getObjectDefinitionId(),
+					WorkflowConstants.STATUS_ANY, start, end),
+				serviceBuilderObjectEntry -> _getObjectEntry(
+					dtoConverterContext, objectDefinition,
+					serviceBuilderObjectEntry));
+			objectEntriesCount = _objectEntryService.getObjectEntriesCount(
+				groupIds[0], objectDefinition.getObjectDefinitionId(),
+				WorkflowConstants.STATUS_ANY);
+		}
+		else {
 			objectEntries = TransformUtil.transform(
 				objectEntryLocalService.getPrimaryKeys(
 					groupIds, companyId, dtoConverterContext.getUserId(),
@@ -846,19 +857,6 @@ public class DefaultObjectEntryManagerImpl
 				groupIds, companyId, dtoConverterContext.getUserId(),
 				objectDefinition.getObjectDefinitionId(), predicate,
 				preferApproved, search);
-		}
-		else {
-			objectEntries = TransformUtil.transform(
-				_objectEntryService.getObjectEntries(
-					objectEntriesGroupId,
-					objectDefinition.getObjectDefinitionId(),
-					WorkflowConstants.STATUS_ANY, start, end),
-				serviceBuilderObjectEntry -> _getObjectEntry(
-					dtoConverterContext, objectDefinition,
-					serviceBuilderObjectEntry));
-			objectEntriesCount = _objectEntryService.getObjectEntriesCount(
-				objectEntriesGroupId, objectDefinition.getObjectDefinitionId(),
-				WorkflowConstants.STATUS_ANY);
 		}
 
 		return Page.of(
@@ -2418,41 +2416,6 @@ public class DefaultObjectEntryManagerImpl
 		return getGroupId(objectDefinition, scopeKey, true);
 	}
 
-	private Long _getObjectEntriesGroupId(
-		Long[] groupIds, ObjectDefinition objectDefinition, Predicate predicate,
-		boolean preferApproved, String search, Sort[] sorts) {
-
-		if ((predicate != null) || preferApproved ||
-			Validator.isNotNull(search) || !_isDefaultSort(sorts) ||
-			ArrayUtil.isNotEmpty(
-				objectDefinition.getRootObjectDefinitionIds())) {
-
-			return null;
-		}
-
-		long groupId = 0;
-
-		if (!StringUtil.equals(
-				objectDefinition.getScope(),
-				ObjectDefinitionConstants.SCOPE_COMPANY)) {
-
-			if (groupIds.length != 1) {
-				return null;
-			}
-
-			groupId = groupIds[0];
-		}
-
-		if ((PermissionThreadLocal.getPermissionChecker() != null) &&
-			_inlineSQLHelper.isEnabled(
-				objectDefinition.getCompanyId(), groupId)) {
-
-			return null;
-		}
-
-		return groupId;
-	}
-
 	private String _getGroupExternalReferenceCode(FileEntry fileEntry) {
 		Scope scope = fileEntry.getScope();
 
@@ -3228,6 +3191,29 @@ public class DefaultObjectEntryManagerImpl
 		}
 
 		return false;
+	}
+
+	private boolean _isPlainListing(
+		Long[] groupIds, ObjectDefinition objectDefinition, Predicate predicate,
+		boolean preferApproved, String search, Sort[] sorts) {
+
+		if ((predicate != null) || preferApproved ||
+			Validator.isNotNull(search) || !_isDefaultSort(sorts) ||
+			ArrayUtil.isNotEmpty(
+				objectDefinition.getRootObjectDefinitionIds()) ||
+			(groupIds.length != 1)) {
+
+			return false;
+		}
+
+		if ((PermissionThreadLocal.getPermissionChecker() != null) &&
+			_inlineSQLHelper.isEnabled(
+				objectDefinition.getCompanyId(), groupIds[0])) {
+
+			return false;
+		}
+
+		return true;
 	}
 
 	private boolean _isUniqueName(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-104797

Follow-up to #181419, as asked there: the helper that returned the group id of a listing the finder could serve, and null for the DSL path, is gone. Its name had to carry both the decision and the group, which is why neither `getFinderGroupId` nor `getObjectEntriesGroupId` read well.

## What Is Being Fixed

The decision is a predicate now, `_isPlainListing`: no filter, no search, no custom sort, no preference for approved versions, no root definitions, exactly one resolved group and no inline permission checks for the user. The group the finder lists is that one resolved group, `groupIds[0]`, which the scope resolution already produced. The company scope needs no special case anymore, because it resolves to the single group 0. The finder branch comes first in the listing so the condition reads positively; the DSL path is unchanged.

## Verification

- Self-CI on shuyangzhou/liferay-portal PR 12745: `ci:test:stable` 16/16 and `ci:test:object` 50/50 on this exact head (`fd0e390`), 2026-09-07.
- Locally on a fresh database: `DefaultObjectEntryManagerImplTest` 90/90 and `ObjectEntryResourceTest` 137/138, the single failure being the known environmental `testPostCustomObjectEntryWithLargeAttachmentObjectField` heap exhaustion while base64-encoding a 60 MB array in the portal JVM.

## PR Check

**pr-check: PASS** — tested on `fd0e390afa61a1bd19ef476b5ba0b39df9d9e5fd`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Service Registration | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS (baseline-all + seven Ant projects + 0 changed exporting modules) |
| Java Unit Tests | NOT VERIFIED |

Java Unit Tests verified nothing: `DefaultObjectEntryManagerImpl` has no unit test; its coverage is the integration test `DefaultObjectEntryManagerImplTest`, run locally and in the self-CI object suite.

<!-- pr-check {"result": "success", "sha": "fd0e390afa61a1bd19ef476b5ba0b39df9d9e5fd"} -->
