### PR TITLE
LPD-104919 Give sample object entries a default language

### DIFF
--- a/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
@@ -8522,6 +8522,7 @@ public class DataFactory {
 
 		// Other fields
 
+		objectEntryModel.setDefaultLanguageId("en_US");
 		objectEntryModel.setHeadObjectEntryId(
 			objectEntryModel.getObjectEntryId());
 		objectEntryModel.setObjectDefinitionId(objectDefinitionId);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-104919

Part of the object entry listing optimization tracked under LPD-65366 (LPD-98910 scenario). This one fixes the sample data the scenario runs on rather than the runtime.

## What Is Being Fixed

The sample SQL builder writes every object entry with an empty `defaultLanguageId`. The friendly URL step of an object entry update keys the entry's URL title on that language, and the friendly URL service stores localized titles only for the site's real locales, so a sample entry's title is never stored: every later edit of the same entry finds no stored title, creates another `FriendlyURLEntry` and repoints the entry's mapping. A sample database used for performance runs accumulates one orphaned friendly URL entry per repeated edit (8249 entries and 8164 mappings on the 100k sample tickets after a few runs), and each such edit pays an insert and an update that a real entry, whose default language is set on creation, never pays.

## How It Is Being Fixed

`DataFactory.newObjectEntryModel` sets the default language id to `en_US`, the same default language the other sample models carry.

Root cause: 5226d6d0db903 (LPD-45398, 2025-01-30) added the column and fills it from the site default locale on creation, but the sample SQL builder's object entry factory was never taught the new column.

## Verification

- Sample data regenerated with the fix and the edit step of the load attributed statement by statement: the friendly URL insert and the mapping update no longer appear for sample entries; a control run against an entry created through the product path never showed them.
- Self-CI on shuyangzhou/liferay-portal PR 12740 (same change, earlier head): `ci:test:relevant` and `ci:test:stable` with no failure unique to the change; the failures recorded there were master's of that day.

## PR Check

**pr-check: PASS** — tested on `3e9e171f7b7d27daea7a622b19c8e87c1d782b48`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Service Registration | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS (baseline-all + seven Ant projects + 0 changed exporting modules) |
| Java Unit Tests | NOT VERIFIED |

Java Unit Tests verified nothing: `DataFactory` has no unit test and the sample builder has no test module; the change is proven by the regenerated sample data above.

<!-- pr-check {"result": "success", "sha": "3e9e171f7b7d27daea7a622b19c8e87c1d782b48"} -->
