### PR TITLE
LPD-104920 Skip the title lookup of an unset object entry relationship

### DIFF
--- a/modules/apps/object/object-info-api/src/main/java/com/liferay/object/info/item/provider/util/ObjectEntryInfoItemValuesProviderUtil.java
+++ b/modules/apps/object/object-info-api/src/main/java/com/liferay/object/info/item/provider/util/ObjectEntryInfoItemValuesProviderUtil.java
@@ -807,6 +807,12 @@ public class ObjectEntryInfoItemValuesProviderUtil {
 		else if (objectField.compareBusinessType(
 					ObjectFieldConstants.BUSINESS_TYPE_RELATIONSHIP)) {
 
+			long primaryKey = GetterUtil.getLong(value);
+
+			if (primaryKey == 0) {
+				return null;
+			}
+
 			ObjectRelationship objectRelationship =
 				objectRelationshipLocalService.
 					fetchObjectRelationshipByObjectFieldId2(
@@ -817,7 +823,7 @@ public class ObjectEntryInfoItemValuesProviderUtil {
 					String.valueOf(value),
 					objectEntryLocalService.getTitleValue(
 						objectRelationship.getObjectDefinitionId1(),
-						GetterUtil.getLong(value)));
+						primaryKey));
 			}
 			catch (Exception exception) {
 				if (_log.isDebugEnabled()) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-104920

Part of the object entry listing optimization tracked under LPD-65366 (LPD-98910 scenario: a site page whose collection display lists a custom object's entries).

## What Is Being Fixed

`ObjectEntryInfoItemValuesProviderUtil` resolves a relationship field to the title of the related entry by asking the object entry service for it, and did so for an unset relationship too, whose stored value is zero. That lookup goes through the service proxy, fails with a `NoSuchObjectEntryException` the provider swallows and, unless debug logging is on, falls through to the raw value, so an unset relationship rendered as `0`. On the collection page of the scenario every row without a related ticket paid that exception on every conversion, and every entry added or edited without a related ticket paid it again.

## How It Is Being Fixed

The provider returns no value for an unset relationship without calling the service.

Visible change: an unset relationship renders empty instead of the raw `0` the debug-off fall-through produced.

## Verification

- JFR `JavaExceptionThrow` events over one iteration of the load on master: three `NoSuchObjectEntryException` for primary key 0 and five `InvocationTargetException` with `getTitleValue` in the stack, all from this lookup; zero with the change.
- Self-CI on shuyangzhou/liferay-portal PR 12742 (same change, earlier head): `ci:test:object` 49/51 where the single failure is the master `ObjectViewExternalReferenceCodeUpgradeProcessTest` regression fixed in #181393, and `ci:test:stable` 14/16 where the two failures are the master compile break of that day (LPD-103842), since fixed on master.

## PR Check

**pr-check: PASS** — tested on `76b596a60899b5ca9b30fcd6d88c88c2fbd72d51`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Service Registration | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS (baseline-all + seven Ant projects + 1 changed exporting module) |
| Java Unit Tests | NOT VERIFIED |

Java Unit Tests verified nothing: `ObjectEntryInfoItemValuesProviderUtil` has no unit test; its coverage is the integration test `ObjectEntryInfoItemFieldValuesProviderTest`, which runs in the object suite. The exported API of the util package is unchanged, so no version bump is required.

<!-- pr-check {"result": "success", "sha": "76b596a60899b5ca9b30fcd6d88c88c2fbd72d51"} -->
