### PR TITLE
LPD-104922 Skip the file entry lookup of an unset object entry attachment in the audit value

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/model/listener/ObjectEntryModelListener.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/model/listener/ObjectEntryModelListener.java
@@ -383,19 +383,21 @@ public class ObjectEntryModelListener extends BaseModelListener<ObjectEntry> {
 
 			long dlFileEntryId = GetterUtil.getLong(value);
 
-			try {
-				DLFileEntry dlFileEntry =
-					_dlFileEntryLocalService.getDLFileEntry(dlFileEntryId);
+			if (dlFileEntryId != 0) {
+				try {
+					DLFileEntry dlFileEntry =
+						_dlFileEntryLocalService.getDLFileEntry(dlFileEntryId);
 
-				return JSONUtil.put(
-					"dlFileEntryId", dlFileEntryId
-				).put(
-					"title", dlFileEntry.getTitle()
-				);
-			}
-			catch (PortalException portalException) {
-				if (_log.isDebugEnabled()) {
-					_log.debug(portalException);
+					return JSONUtil.put(
+						"dlFileEntryId", dlFileEntryId
+					).put(
+						"title", dlFileEntry.getTitle()
+					);
+				}
+				catch (PortalException portalException) {
+					if (_log.isDebugEnabled()) {
+						_log.debug(portalException);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-104922

Part of the object entry listing optimization tracked under LPD-65366 (LPD-98910 scenario: a site page whose collection display lists a custom object's entries). The audit twin of #181424.

## What Is Being Fixed

The audit value of an attachment field is the file entry's id and title, which `ObjectEntryModelListener` resolves by asking the document library service for the file entry, and did so for an unset attachment too, whose stored value is zero. That lookup fails with a `NoSuchFileEntryException` the listener swallows and falls through to the stored value. On a definition with entry history enabled, every add or update of an entry without an attachment pays that exception; in the scenario that is every ticket the load adds and every ticket it edits.

## How It Is Being Fixed

The listener falls through to the stored value without asking the service when the attachment is unset. The audit value is unchanged; only the lookup and its exception go.

## Verification

- JFR `JavaExceptionThrow` attribution of the add and edit steps of the load: `NoSuchFileEntryException` for primary key 0 from the file entry lookup in the audit value, once per audited add or update; none with the change.
- Self-CI on shuyangzhou/liferay-portal PR 12747: `ci:test:stable` 16/16 and `ci:test:object` 50/50 on this exact head (`6123efe`), 2026-09-07.
- The change is a guard in front of an existing lookup; the existing audit coverage in `object-test` exercises both branches.

## PR Check

**pr-check: PASS** — tested on `6123efe8ed295622582efe4b8b1ba056dc8015a4`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Service Registration | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS (baseline-all + seven Ant projects + 0 changed exporting modules) |
| Java Unit Tests | NOT VERIFIED |

Java Unit Tests verified nothing: `ObjectEntryModelListener` has no unit test; its coverage is the integration test `ObjectEntryModelListenerTest` in `object-test`, which runs in the object suite.

<!-- pr-check {"result": "success", "sha": "6123efe8ed295622582efe4b8b1ba056dc8015a4"} -->
