### PR TITLE
LPD-104923 Wait for the object definitions list to reload after deleting a draft definition by its row action

### DIFF
--- a/modules/test/playwright/pages/object-web/ViewObjectDefinitionsPage.ts
+++ b/modules/test/playwright/pages/object-web/ViewObjectDefinitionsPage.ts
@@ -190,6 +190,25 @@ export class ViewObjectDefinitionsPage {
 		await response.finished();
 	}
 
+	async deleteDraftObjectDefinition(label: string) {
+		await this.clickObjectDefinitionActionButton(label);
+
+		const reloadResponse = this.page.waitForResponse(
+			(response) =>
+				response
+					.url()
+					.includes('/o/object-admin/v1.0/object-definitions?') &&
+				response.request().method() === 'GET' &&
+				response.status() === 200
+		);
+
+		await this.deleteObjectDefinitionOption.click();
+
+		const response = await reloadResponse;
+
+		await response.finished();
+	}
+
 	async deleteObjectFolder(objectFolderName: string) {
 		await this.objectFolderDeleteFolderOption.click();
 		await this.confirmObjectFolderNameInput.click();

--- a/modules/test/playwright/tests/object-web/main/objectDefinition.spec.ts
+++ b/modules/test/playwright/tests/object-web/main/objectDefinition.spec.ts
@@ -1037,11 +1037,9 @@ test.describe('Manage object definitions through View Object Definitions', () =>
 
 		await viewObjectDefinitionsPage.goto();
 
-		await viewObjectDefinitionsPage.clickObjectDefinitionActionButton(
+		await viewObjectDefinitionsPage.deleteDraftObjectDefinition(
 			objectDefinition2.label['en_US']
 		);
-
-		await viewObjectDefinitionsPage.deleteObjectDefinitionOption.click();
 
 		apiHelpers.data.splice(
 			apiHelpers.data.findIndex(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-104923

`ci:test:object` Playwright failure fix, under the Objects stabilization epic LPD-99314.

## What Is Being Fixed

`object-web/main/objectDefinition.spec.ts`, "can delete an object definition by FDS action", times out waiting for the `Delete` menu item of the second row it acts on:

```
Error: locator.click: Test timeout of 90000ms exceeded.
Call log:
  - waiting for getByRole('menuitem', { name: 'Delete' })
```

The test deletes a draft object definition through its row action, which for a draft fires the DELETE with no confirmation dialog, and then clicks the next row's actions button without waiting for anything. The data set reloads after the delete: `FrontendDataSet.refreshData` sets `dataLoading` and the view swaps the table for a `ClayLoadingIndicator`, so the rows unmount and the dropdown the click was opening unmounts with them. When the list comes back there is no open menu.

Evidence from the CI trace (test-1-46 build 1867, axis playwright 15/0): the second row-action click came 56 ms after the first `Delete` click; the DOM snapshot at that click already held the loading indicator; the DELETE (204) and the reload GET followed; no dropdown existed afterwards. Playwright's own log in the local reproduction names the mechanism: the menu item resolves, then `element was detached from the DOM`.

## How It Is Being Fixed

The page object already owns this wait for the published path: `deleteObjectDefinition` arms the reload response before confirming. `deleteDraftObjectDefinition(label)` does the same for the draft path, clicking the row action, arming `waitForResponse` for the list's reload GET, clicking `Delete`, and awaiting the response. The test uses it for the draft delete. No retry, no sleep.

Root cause: ddf290e4c16ff (LPD-23165, 2024-04-23) created the test with the two row actions back to back and no wait between the draft delete and the next click, so it raced the list reload from the start.

## Verification

Local, on a clean bundle at master with the CI Playwright environment properties (`--retries=0 --timeout=30000 --workers=1`):

- Amplifier: the DELETE request held, armed immediately before the first `Delete` click, until the next row's actions click had landed (released by a flag, 3 s timer as a bound). Control 5/5 failed with the CI signature, hold released after 63 to 82 ms; fixed 5/5 passed, the owned wait blocking until the 3 s timer released the hold.
- Fix alone 3/3; the whole spec file 44 passed, 0 failed.
- Unamplified, the original test failed with the exact signature on the first execution after a cold boot; cold-boot cycles, one test execution as the first against each fresh boot, no amplifier: unmodified 2/2 failed with the signature (`element is not stable` while the list re-renders), fixed 3/3 passed.
- Self-CI on shuyangzhou/liferay-portal PR 12748: `ci:test:stable` 16/16 and `ci:test:object` three times on the same tree (fix head `a72dec7` and two empty marker commits so each run is genuine, not a cached replay): 48/50, 50/50, 50/50, the fixed test passing in all three. The one failure in the first run is unrelated, `objectEntry.spec.ts` "can view all entries related to an object in the relationship field using autocomplete", a strict-mode violation on the autocomplete menu items that has its own unowned wait and is tracked separately.

Sibling sites left alone, no recorded failures: the other `deleteObjectDefinitionOption.click()` uses in the spec go through the confirmation dialog or assert on it.

## PR Check

**pr-check: PASS** — tested on `a72dec7a7e6cba5496d3c8c688a7314e7ec5fb06`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| HTML Escaping | PASS |
| Per-Module Compile | NOT VERIFIED |
| Baseline | PASS (baseline-all + seven Ant projects + 0 changed exporting modules) |
| JavaScript Unit Tests | NOT VERIFIED |

Per-Module Compile verified nothing: the two changed files live under `modules/test/playwright`, which is not an OSGi module and has no bundle to deploy. Source Format's TypeScript check (`Checking 1 TypeScript projects...`) ran clean, so the change type-checks.

JavaScript Unit Tests verified nothing: `modules/test/playwright` has no Jest suite, its `test` script is `playwright test`. The change is covered by the Playwright evidence above and the self-CI object runs.

<!-- pr-check {"result": "success", "sha": "a72dec7a7e6cba5496d3c8c688a7314e7ec5fb06"} -->
