### PR TITLE
LPD-105041 Do not cache string template resources by template id

### DIFF
--- a/modules/apps/portal-template/portal-template-engine-api/src/main/java/com/liferay/portal/template/engine/BaseTemplate.java
+++ b/modules/apps/portal-template/portal-template-engine-api/src/main/java/com/liferay/portal/template/engine/BaseTemplate.java
@@ -8,6 +8,7 @@ package com.liferay.portal.template.engine;
 import com.liferay.petra.io.unsync.UnsyncStringWriter;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.template.StringTemplateResource;
 import com.liferay.portal.kernel.template.Template;
 import com.liferay.portal.kernel.template.TemplateConstants;
 import com.liferay.portal.kernel.template.TemplateException;
@@ -215,6 +216,10 @@ public abstract class BaseTemplate implements Template {
 	protected void cacheTemplateResource(
 		TemplateResourceCache templateResourceCache,
 		TemplateResource templateResource) {
+
+		if (templateResource instanceof StringTemplateResource) {
+			return;
+		}
 
 		TemplateResource cachedTemplateResource =
 			templateResourceCache.getTemplateResource(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-105041

Part of the object entry listing optimization tracked under LPD-65366 (LPD-98910 scenario: a site page whose collection display lists a custom object's entries). This one is in the template engine rather than in Objects.

## What Is Being Fixed

The first-level template resource cache is keyed by template id so that a resource processed once can be resolved again by that id, for example by an include or an error template. That is only sound while the id determines the content. A `StringTemplateResource` carries its content, its equality includes that content, and its id is picked by the caller, so registering it by id lets unrelated string templates that happen to share an id replace each other. Each replacement reaches `BaseTemplateResourceCache` as an update of that id, whose listener drops the parsed template stored under the previous resource in the second-level cache.

`FreeMarkerFragmentEntryProcessor` renders every fragment as a `StringTemplateResource` under the constant id `template_id`. On a page with several distinct fragments each render replaces the previous fragment's registration, so `LiferayTemplateCache` misses on every render and FreeMarker parses the fragment again, throwing two `IOException`s from `SimpleCharStream.FillBuff` per parse. On the scenario's collection page that is roughly 38 re-parses per page view.

## How It Is Being Fixed

`BaseTemplate.cacheTemplateResource` leaves string template resources out of the id-keyed first-level cache. The second-level cache, keyed by the resource itself, identifies them by content, so only the first render of each distinct fragment parses. A lookup by the id of a string template resource no longer finds it in the first-level cache and goes to the template resource loaders like any id the engines never processed.

Root cause: LPS-28491 (d112da99947ed) made the engines register every directly processed template resource in the id-keyed first-level cache, which assumed the id determines the content. LPS-95199 (3cfa890e0df27) then processed every fragment under one constant id, so different fragments started evicting each other's parsed templates.

## Verification

- JFR `JavaExceptionThrow` attribution of the collection page view: the `SimpleCharStream.FillBuff` `IOException` pairs, about 38 per view on master, are gone with the change; the fragments parse once and are served from `LiferayTemplateCache` afterwards.
- Self-CI on shuyangzhou/liferay-portal PR 12746 (same change, earlier head `4fb1d81` on `b9af7a2`): `ci:test:stable` and `ci:test:relevant` all jobs passed; `ci:test:object` 48/50 where the single failure is the FDS draft-delete Playwright race fixed in #181445, unrelated to templates.

## PR Check

**pr-check: PASS** — tested on `0256ec84858f27444be73b124eaa931bec6c4b3d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Service Registration | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS (baseline-all + seven Ant projects + 1 changed exporting module) |
| Java Unit Tests | NOT VERIFIED |

Source Format changed nothing, so no `LPD-105041 SF` commit was needed. Its yarn half never ran rather than running clean: the diff's single file is `.java` and matches none of `js|json|jsp|jspf|scss|ts|tsx`, so `skip.node.task` skipped `downloadNode`, `yarnInstall` and `portalYarnFormatCurrentBranch`.

Per-Module Compile deployed one module, `apps:portal-template:portal-template-engine-api`, with no consumer expansion and no handoff: the diff adds one import and a three-line early return inside an existing method body, and removes or changes no `public` or `protected` member. The lockfile check had nothing to check.

Integration Test Compile compiled `apps:portal-template:portal-template-test` (full affected count 1, cap did not bind) after a passing control, `apps:click-to-chat:click-to-chat-test`.

Cross-Module Compile found an empty consumer set, so it ran no compile: `BaseTemplate` appears in no `.lfrbuild-portal-deprecated` module and in no `-test` module's `src/testIntegration` tree. Both scans were shown non-vacuous with the same commands.

Baseline produced no warning row and no `[Baseline Warning]` line, so no version bump was required and no `LPD-105041 Semantic versioning` commit was warranted. The branch changes an exported package's source without changing an exported signature, so `Bundle-Version: 2.0.5` and `packageinfo` `version 2.0.0` are right as they stand.

Java Unit Tests verified nothing. `BaseTemplate.java` has no unit test — no `BaseTemplateTest.java` exists anywhere and the module has no test source set — and the changed early return is unreachable from any unit suite, because its only two callers gate it on `templateResourceCache.isEnabled()` and both subclass suites stub that to `false`. The class is covered by an integration test this validation does not run, `portal-template-test`'s `TemplateRestrictedVariablesTest`. The two subclass suites were run anyway and are green (`FreeMarkerTemplateTest` 11 tests, `VelocityTemplateTest` 10 tests, 0 failures, 0 errors).

<!-- pr-check {"result": "success", "sha": "0256ec84858f27444be73b124eaa931bec6c4b3d"} -->
