### PR TITLE
LPD-104797 Ask whether the object entries page needs the complex query

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -829,22 +829,10 @@ public class DefaultObjectEntryManagerImpl
 		List<ObjectEntry> objectEntries = null;
 		int objectEntriesCount = 0;
 
-		if (_isPlainListing(
+		if (_isUseComplexQuery(
 				groupIds, objectDefinition, predicate, preferApproved, search,
 				sorts)) {
 
-			objectEntries = TransformUtil.transform(
-				_objectEntryService.getObjectEntries(
-					groupIds[0], objectDefinition.getObjectDefinitionId(),
-					WorkflowConstants.STATUS_ANY, start, end),
-				serviceBuilderObjectEntry -> _getObjectEntry(
-					dtoConverterContext, objectDefinition,
-					serviceBuilderObjectEntry));
-			objectEntriesCount = _objectEntryService.getObjectEntriesCount(
-				groupIds[0], objectDefinition.getObjectDefinitionId(),
-				WorkflowConstants.STATUS_ANY);
-		}
-		else {
 			objectEntries = TransformUtil.transform(
 				objectEntryLocalService.getPrimaryKeys(
 					groupIds, companyId, dtoConverterContext.getUserId(),
@@ -856,6 +844,18 @@ public class DefaultObjectEntryManagerImpl
 				groupIds, companyId, dtoConverterContext.getUserId(),
 				objectDefinition.getObjectDefinitionId(), predicate,
 				preferApproved, search);
+		}
+		else {
+			objectEntries = TransformUtil.transform(
+				_objectEntryService.getObjectEntries(
+					groupIds[0], objectDefinition.getObjectDefinitionId(),
+					WorkflowConstants.STATUS_ANY, start, end),
+				serviceBuilderObjectEntry -> _getObjectEntry(
+					dtoConverterContext, objectDefinition,
+					serviceBuilderObjectEntry));
+			objectEntriesCount = _objectEntryService.getObjectEntriesCount(
+				groupIds[0], objectDefinition.getObjectDefinitionId(),
+				WorkflowConstants.STATUS_ANY);
 		}
 
 		return Page.of(
@@ -3192,29 +3192,6 @@ public class DefaultObjectEntryManagerImpl
 		return false;
 	}
 
-	private boolean _isPlainListing(
-		Long[] groupIds, ObjectDefinition objectDefinition, Predicate predicate,
-		boolean preferApproved, String search, Sort[] sorts) {
-
-		if ((predicate != null) || preferApproved ||
-			Validator.isNotNull(search) || !_isDefaultSort(sorts) ||
-			ArrayUtil.isNotEmpty(
-				objectDefinition.getRootObjectDefinitionIds()) ||
-			(groupIds.length != 1)) {
-
-			return false;
-		}
-
-		if ((PermissionThreadLocal.getPermissionChecker() != null) &&
-			_inlineSQLHelper.isEnabled(
-				objectDefinition.getCompanyId(), groupIds[0])) {
-
-			return false;
-		}
-
-		return true;
-	}
-
 	private boolean _isUniqueName(
 			ObjectDefinition objectDefinition,
 			ObjectEntryFolder objectEntryFolder,
@@ -3234,6 +3211,29 @@ public class DefaultObjectEntryManagerImpl
 			false, null);
 
 		if (count == 0) {
+			return true;
+		}
+
+		return false;
+	}
+
+	private boolean _isUseComplexQuery(
+		Long[] groupIds, ObjectDefinition objectDefinition, Predicate predicate,
+		boolean preferApproved, String search, Sort[] sorts) {
+
+		if ((predicate != null) || preferApproved ||
+			Validator.isNotNull(search) || !_isDefaultSort(sorts) ||
+			ArrayUtil.isNotEmpty(
+				objectDefinition.getRootObjectDefinitionIds()) ||
+			(groupIds.length != 1)) {
+
+			return true;
+		}
+
+		if ((PermissionThreadLocal.getPermissionChecker() != null) &&
+			_inlineSQLHelper.isEnabled(
+				objectDefinition.getCompanyId(), groupIds[0])) {
+
 			return true;
 		}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-104797

Follow-up to #181421, per the review comment there that `isPlainListing` is still a strange name.

## What Is Being Fixed

The predicate that chooses between the finder and the DSL query when paging a custom object's entries was named `_isPlainListing`, describing the page it let through with an adjective and a noun the codebase uses nowhere else.

## How It Is Being Fixed

The predicate is now `_isUseComplexQuery`, the shape `GroupLocalServiceImpl.isUseComplexSQL` and `UserLocalServiceImpl.isUseCustomSQL` give the same decision: a predicate over the request that is true when the heavy query has to be built, tested first, with the direct finder as the fallthrough. Each condition is a reason the page cannot come from a lookup on the ObjectEntry table alone: a filter, a search, a custom sort, a preference for approved versions, root definitions, more than one group, or inline permission SQL. "Complex" is already the object module's word for a value that cannot be answered from the entry's own columns (`ObjectEntryFieldSortDSLQueryVisitor._isParentComplexField`, `PredicateExpressionVisitorImpl._isComplexProperExpression`). Flipping the polarity puts the DSL branch under the positive condition and the finder in the else; the body is otherwise unchanged.

## Verification

- Self-CI on shuyangzhou/liferay-portal PR 12749 on this exact head (`2ca31fd`), based on brianchandotcom/master `0a79b7a`: `ci:test:stable` 16/16, `ci:test:object` 50/50, `ci:test:relevant` 59/68. The relevant failures in common with upstream are upstream's; the two axes unique to the pull are export-import-web Playwright tests (the Tags import report, the Clarity site initializer export/import and three staging use cases), each a 90 s timeout waiting on a background import or publish task, with a chronic failure history on master in Testray (29 of 81, 128 of 3657 and 166 of 4127 recorded runs) and no path into objects.

## PR Check

**pr-check: PASS** — tested on `2ca31fd134306def9a9203ca32f58c7c97acb652`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Service Registration | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS (baseline-all + seven Ant projects + 0 changed exporting modules) |
| Java Unit Tests | NOT VERIFIED |

Java Unit Tests verified nothing: `DefaultObjectEntryManagerImpl` has no unit test; its coverage is the integration test `DefaultObjectEntryManagerImplTest` in `object-rest-test`, which runs in the object suite. The rename is of a private method, so no exported API changed and no version bump is required.

<!-- pr-check {"result": "success", "sha": "2ca31fd134306def9a9203ca32f58c7c97acb652"} -->
