### PR TITLE
LPD-104441 Add the allow guest access language key

### DIFF
--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=If this is checked, common dictionary words are allo
 allow-empty-searches=Allow Empty Searches
 allow-empty-searches-help=When enabled, an empty search query returns all available assets. By default, an empty query returns no search results.
 allow-flattened-navigation=Allow Flattened Navigation
+allow-guest-access=Allow Guest Access
 allow-guest-users-to-send-files=Allow Guest Users to Send Files
 allow-localization-management=Allow Localization Management
 allow-manual-membership-management=Allow Manual Membership Management

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=إذا تم تحديد هذا الخيار، سيس�
 allow-empty-searches=السماح بعمليات البحث الفارغة
 allow-empty-searches-help=عند التمكين، يُرجع استعلام البحث الفارغ جميع الأصول المتوفرة. ولا يقوم الاستعلام الفارغ بإرجاع أية نتائج بحث بشكل افتراضي.
 allow-flattened-navigation=السماح بالتنقل المسطح
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=سماح للمستخدمين الضيوف بإرسال ملفات
 allow-localization-management=سماح بإدارة التوطين
 allow-manual-membership-management=السماح بإدارة العضوية يدويًا

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=Ако това е отметнато, общите 
 allow-empty-searches=Разреши празни търсения (Automatic Translation)
 allow-empty-searches-help=Когато е активирана, празна заявка за търсене връща всички налични активи. По подразбиране празна заявка не връща резултати от търсенето. (Automatic Translation)
 allow-flattened-navigation=Разреши изравнена навигация (Automatic Translation)
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=Позволяване на потребителите да изпращат файлове (Automatic Translation)
 allow-localization-management=Allow Localization Management (Automatic Copy)
 allow-manual-membership-management=Разрешаване на ръчно управление на членство (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=Si se selecciona aquesta opció, es permetran com a 
 allow-empty-searches=Permet les cerques buides
 allow-empty-searches-help=Si aquesta opció està habilitada, una consulta de cerca buida torna tots els continguts disponibles. Per defecte, una consulta buida no torna cap resultat de cerca.
 allow-flattened-navigation=Permet la navegació aplanada
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=Permet que els usuaris convidats enviïn fitxers
 allow-localization-management=Permet la gestió de la localització
 allow-manual-membership-management=Permet la gestió manual de membres

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=If this is checked, common dictionary words are allo
 allow-empty-searches=Allow Empty Searches (Automatic Copy)
 allow-empty-searches-help=When enabled, an empty search query returns all available assets. By default, an empty query returns no search results. (Automatic Copy)
 allow-flattened-navigation=Allow Flattened Navigation (Automatic Copy)
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=Allow Guest Users to Send Files (Automatic Copy)
 allow-localization-management=Allow Localization Management (Automatic Copy)
 allow-manual-membership-management=Povolit ruční nastavení typu členství

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=Hvis dette er markeret, er almindelige ordbogsord ti
 allow-empty-searches=Tillad tomme søgninger (Automatic Translation)
 allow-empty-searches-help=Når indstillingen er aktiveret, returnerer en tom søgeforespørgsel alle tilgængelige aktiver. En tom forespørgsel returnerer som standard ingen søgeresultater. (Automatic Translation)
 allow-flattened-navigation=Tillad samkopieret navigation (Automatic Translation)
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=Tillad gæstebrugere at sende filer (Automatic Translation)
 allow-localization-management=Allow Localization Management (Automatic Copy)
 allow-manual-membership-management=Allow Manual Membership Management (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=Ist diese Option ausgewählt, dürfen Benutzerkennw�
 allow-empty-searches=Leere Suche erlauben
 allow-empty-searches-help=Ist diese Option aktiviert, gibt eine leere Suchanfrage alle verfügbaren Assets aus. Standardmäßig gibt eine leere Suchanfrage keine Suchergebnisse aus.
 allow-flattened-navigation=Flache Navigation erlauben
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=Gastbenutzern das Senden von Dateien erlauben
 allow-localization-management=Lokalisierungsverwaltung erlauben
 allow-manual-membership-management=Manuelle Mitgliedschaftsverwaltung erlauben

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de_AT.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de_AT.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=Ist diese Option ausgewählt, dürfen Benutzerkennw�
 allow-empty-searches=Leere Suche erlauben
 allow-empty-searches-help=Ist diese Option aktiviert, gibt eine leere Suchanfrage alle verfügbaren Assets aus. Standardmäßig gibt eine leere Suchanfrage keine Suchergebnisse aus.
 allow-flattened-navigation=Flache Navigation erlauben
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=Gastbenutzern das Senden von Dateien erlauben
 allow-localization-management=Lokalisierungsverwaltung erlauben
 allow-manual-membership-management=Manuelle Mitgliedschaftsverwaltung erlauben

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de_CH.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de_CH.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=Ist diese Option ausgewählt, dürfen Benutzerkennw�
 allow-empty-searches=Leere Suche erlauben
 allow-empty-searches-help=Ist diese Option aktiviert, gibt eine leere Suchanfrage alle verfügbaren Assets aus. Standardmäßig gibt eine leere Suchanfrage keine Suchergebnisse aus.
 allow-flattened-navigation=Flache Navigation erlauben
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=Gastbenutzern das Senden von Dateien erlauben
 allow-localization-management=Lokalisierungsverwaltung erlauben
 allow-manual-membership-management=Manuelle Mitgliedschaftsverwaltung erlauben

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=Εάν αυτό είναι επιλεγμένο, ε�
 allow-empty-searches=Να επιτρέπονται κενές αναζητήσεις (Automatic Translation)
 allow-empty-searches-help=Όταν ενεργοποιηθεί, ένα κενό ερώτημα αναζήτησης επιστρέφει όλα τα διαθέσιμα στοιχεία. Από προεπιλογή, ένα κενό ερώτημα δεν επιστρέφει αποτελέσματα αναζήτησης. (Automatic Translation)
 allow-flattened-navigation=Να επιτρέπεται η ισοπέδωση της περιήγησης (Automatic Translation)
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=Να επιτρέπεται στους επισκέπτες χρήστες να στέλνουν αρχεία (Automatic Translation)
 allow-localization-management=Allow Localization Management (Automatic Copy)
 allow-manual-membership-management=Να επιτρέπεται η μη αυτόματη διαχείριση μελών (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=If this is checked, common dictionary words are allo
 allow-empty-searches=Allow Empty Searches
 allow-empty-searches-help=When enabled, an empty search query returns all available assets. By default, an empty query returns no search results.
 allow-flattened-navigation=Allow Flattened Navigation
+allow-guest-access=Allow Guest Access
 allow-guest-users-to-send-files=Allow Guest Users to Send Files
 allow-localization-management=Allow Localization Management
 allow-manual-membership-management=Allow Manual Membership Management

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=If this is checked, common dictionary words are allo
 allow-empty-searches=Allow Empty Searches (Automatic Copy)
 allow-empty-searches-help=When enabled, an empty search query returns all available assets. By default, an empty query returns no search results. (Automatic Copy)
 allow-flattened-navigation=Allow Flattened Navigation (Automatic Copy)
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=Allow Guest Users to Send Files (Automatic Copy)
 allow-localization-management=Allow Localization Management (Automatic Copy)
 allow-manual-membership-management=Allow Manual Membership Management (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_CA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_CA.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=If this is checked, common dictionary words are allo
 allow-empty-searches=Allow Empty Searches (Automatic Copy)
 allow-empty-searches-help=When enabled, an empty search query returns all available assets. By default, an empty query returns no search results. (Automatic Copy)
 allow-flattened-navigation=Allow Flattened Navigation (Automatic Copy)
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=Allow Guest Users to Send Files (Automatic Copy)
 allow-localization-management=Allow Localization Management (Automatic Copy)
 allow-manual-membership-management=Allow Manual Membership Management (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=If this is checked, common dictionary words are allo
 allow-empty-searches=Allow Empty Searches (Automatic Copy)
 allow-empty-searches-help=When enabled, an empty search query returns all available assets. By default, an empty query returns no search results. (Automatic Copy)
 allow-flattened-navigation=Allow Flattened Navigation (Automatic Copy)
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=Allow Guest Users to Send Files (Automatic Copy)
 allow-localization-management=Allow Localization Management (Automatic Copy)
 allow-manual-membership-management=Allow Manual Membership Management (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_IE.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_IE.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=If this is checked, common dictionary words are allo
 allow-empty-searches=Allow Empty Searches (Automatic Copy)
 allow-empty-searches-help=When enabled, an empty search query returns all available assets. By default, an empty query returns no search results. (Automatic Copy)
 allow-flattened-navigation=Allow Flattened Navigation (Automatic Copy)
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=Allow Guest Users to Send Files (Automatic Copy)
 allow-localization-management=Allow Localization Management (Automatic Copy)
 allow-manual-membership-management=Allow Manual Membership Management (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=Si se marca, las palabras comunes del diccionario se
 allow-empty-searches=Permitir búsquedas vacías
 allow-empty-searches-help=Al habilitar esta opción, las consultas de búsqueda vacías devolverán todos los activos disponibles. Por defecto, las consultas vacías no devuelven resultados de búsqueda.
 allow-flattened-navigation=Permitir navegación plana
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=Permitir que usuarios invitados envíen archivos
 allow-localization-management=Permitir la administración de la localización
 allow-manual-membership-management=Permitir la gestión manual de membresía

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_AR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_AR.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=Si se marca, las palabras comunes del diccionario se
 allow-empty-searches=Permitir búsquedas vacías
 allow-empty-searches-help=Al habilitar esta opción, las consultas de búsqueda vacías devolverán todos los activos disponibles. Por defecto, las consultas vacías no devuelven resultados de búsqueda.
 allow-flattened-navigation=Permitir navegación plana
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=Permitir que usuarios invitados envíen archivos
 allow-localization-management=Permitir la administración de la localización
 allow-manual-membership-management=Permitir la gestión manual de membresía

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=Si se marca, las palabras comunes del diccionario se
 allow-empty-searches=Permitir búsquedas vacías
 allow-empty-searches-help=Al habilitar esta opción, las consultas de búsqueda vacías devolverán todos los activos disponibles. Por defecto, las consultas vacías no devuelven resultados de búsqueda.
 allow-flattened-navigation=Permitir navegación plana
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=Permitir que usuarios invitados envíen archivos
 allow-localization-management=Permitir la administración de la localización
 allow-manual-membership-management=Permitir la gestión manual de membresía

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_MX.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_MX.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=Si se marca, las palabras comunes del diccionario se
 allow-empty-searches=Permitir búsquedas vacías
 allow-empty-searches-help=Al habilitar esta opción, las consultas de búsqueda vacías devolverán todos los activos disponibles. Por defecto, las consultas vacías no devuelven resultados de búsqueda.
 allow-flattened-navigation=Permitir navegación plana
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=Permitir que usuarios invitados envíen archivos
 allow-localization-management=Permitir la administración de la localización
 allow-manual-membership-management=Permitir la gestión manual de membresía

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=Sisselülitamisel on kasutaja paroolidena lubatud ta
 allow-empty-searches=Luba tühjad otsingud (Automatic Translation)
 allow-empty-searches-help=Kui see on lubatud, tagastab tühi otsingupäring kõik saadaolevad varad. Vaikimisi ei tagasta tühi päring otsingutulemeid. (Automatic Translation)
 allow-flattened-navigation=Luba tasandatud navigeerimine (Automatic Translation)
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=Luba külaliskasutajatel faile saata (Automatic Translation)
 allow-localization-management=Allow Localization Management (Automatic Copy)
 allow-manual-membership-management=Luba käsitsi liikmesuse haldus (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=If this is checked, common dictionary words are allo
 allow-empty-searches=Allow Empty Searches (Automatic Copy)
 allow-empty-searches-help=When enabled, an empty search query returns all available assets. By default, an empty query returns no search results. (Automatic Copy)
 allow-flattened-navigation=Allow Flattened Navigation (Automatic Copy)
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=Erabiltzaile anonimoek fitxategiak bidaltzea onartu
 allow-localization-management=Allow Localization Management (Automatic Copy)
 allow-manual-membership-management=Gaitu kideen eskuzko kudeaketa

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=اگر این چک شده است. کلمات معم�
 allow-empty-searches=اجازه جستجوهای خالی
 allow-empty-searches-help=هنگامی که فعال شد، یک پرس و جو جستجوی خالی تمام دارایی های موجود را برمیگرداند. به طور پیش فرض، یک پرس و جو خالی هیچ نتیجه جستجو را بر نمیگرداند. (Automatic Translation)
 allow-flattened-navigation=اجازه دادن به پیمایش مسطح
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=اجازه دادن به کاربران مهمان برای ارسال پرونده ها (Automatic Translation)
 allow-localization-management=Allow Localization Management (Automatic Copy)
 allow-manual-membership-management=امکان مدیریت کاربران به صورت دستی وجود داشته باشد

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=Olessa valittuna, sanakirjan sanat sallitaan käytt�
 allow-empty-searches=Salli Tyhjät Haut
 allow-empty-searches-help=Kun käytössä, tyhjä haku palauttaa kaikki käytettävissä olevat sisällöt. Oletusarvona tyhjä kysely ei palauta hakutuloksia.
 allow-flattened-navigation=Salli Tasoitettu Navigointi
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=Salli Vieraskäyttäjien Lähettää Tiedostoja
 allow-localization-management=Salli lokalisoinnin hallinta
 allow-manual-membership-management=Salli manuaalinen jäsennyyksien hallinta

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=Si cette case est cochée, les mots du dictionnaire 
 allow-empty-searches=Autoriser les recherches à vide
 allow-empty-searches-help=Quand cette option est activée, les requêtes de recherche vides renvoient tous les actifs disponibles. Par défaut, une requête vide ne renvoie aucun résultat de recherche.
 allow-flattened-navigation=Autoriser la navigation à plat
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=Autoriser les utilisateurs invités à envoyer des fichiers
 allow-localization-management=Autoriser la gestion de la localisation
 allow-manual-membership-management=Autoriser la gestion manuelle des membres

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_BE.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_BE.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=Si cette case est cochée, les mots du dictionnaire 
 allow-empty-searches=Autoriser les recherches à vide
 allow-empty-searches-help=Quand cette option est activée, les requêtes de recherche vides renvoient tous les actifs disponibles. Par défaut, une requête vide ne renvoie aucun résultat de recherche.
 allow-flattened-navigation=Autoriser la navigation à plat
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=Autoriser les utilisateurs invités à envoyer des fichiers
 allow-localization-management=Autoriser la gestion de la localisation
 allow-manual-membership-management=Autoriser la gestion manuelle des membres

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=Si cette case est cochée, les mots du dictionnaire 
 allow-empty-searches=Autoriser les recherches à vide
 allow-empty-searches-help=Quand cette option est activée, les requêtes de recherche vides renvoient tous les actifs disponibles. Par défaut, une requête vide ne renvoie aucun résultat de recherche.
 allow-flattened-navigation=Autoriser la navigation à plat
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=Autoriser les utilisateurs invités à envoyer des fichiers
 allow-localization-management=Allow Localization Management (Automatic Copy)
 allow-manual-membership-management=Autoriser la gestion manuelle des membres

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CH.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CH.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=Si cette case est cochée, les mots du dictionnaire 
 allow-empty-searches=Autoriser les recherches à vide
 allow-empty-searches-help=Quand cette option est activée, les requêtes de recherche vides renvoient tous les actifs disponibles. Par défaut, une requête vide ne renvoie aucun résultat de recherche.
 allow-flattened-navigation=Autoriser la navigation à plat
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=Autoriser les utilisateurs invités à envoyer des fichiers
 allow-localization-management=Autoriser la gestion de la localisation
 allow-manual-membership-management=Autoriser la gestion manuelle des membres

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=Se se comproba, permítense palabras comúns do dici
 allow-empty-searches=Permitir buscas baleiras
 allow-empty-searches-help=Cando está activado, unha consulta de busca baleira devolve todos os activos dispoñibles. Por defecto, unha consulta baleira non devolve resultados de busca.
 allow-flattened-navigation=Permitir navegación plana
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=Permitir aos usuarios convidados enviar ficheiros
 allow-localization-management=Allow Localization Management (Automatic Copy)
 allow-manual-membership-management=Permitir a xestión de adhesión manual

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=यदि यह जांच की जाती �
 allow-empty-searches=खाली खोजों की अनुमति दें (Automatic Translation)
 allow-empty-searches-help=सक्षम होने पर, एक खाली खोज क्वेरी सभी उपलब्ध परिसंपत्तियों को वापस करती है। डिफ़ॉल्ट रूप से, एक खाली क्वेरी कोई खोज परिणाम नहीं देता है। (Automatic Translation)
 allow-flattened-navigation=चपटा नेविगेशन की अनुमति दें
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=अतिथि उपयोगकर्ताओं को फ़ाइलें भेजने की अनुमति दें (Automatic Translation)
 allow-localization-management=Allow Localization Management (Automatic Copy)
 allow-manual-membership-management=मैन्युअल सदस्यता प्रबंधन की अनुमति दें (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=If this is checked, common dictionary words are allo
 allow-empty-searches=Allow Empty Searches (Automatic Copy)
 allow-empty-searches-help=When enabled, an empty search query returns all available assets. By default, an empty query returns no search results. (Automatic Copy)
 allow-flattened-navigation=Allow Flattened Navigation (Automatic Copy)
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=Allow Guest Users to Send Files (Automatic Copy)
 allow-localization-management=Allow Localization Management (Automatic Copy)
 allow-manual-membership-management=Dopusti ručno upravljanje članstvom

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr_BA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr_BA.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=If this is checked, common dictionary words are allo
 allow-empty-searches=Allow Empty Searches (Automatic Copy)
 allow-empty-searches-help=When enabled, an empty search query returns all available assets. By default, an empty query returns no search results. (Automatic Copy)
 allow-flattened-navigation=Allow Flattened Navigation (Automatic Copy)
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=Allow Guest Users to Send Files (Automatic Copy)
 allow-localization-management=Allow Localization Management (Automatic Copy)
 allow-manual-membership-management=Allow Manual Membership Management (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=Ha ez be van jelölve, a közös szótári szavak is
 allow-empty-searches=Üres keresések engedélyezése
 allow-empty-searches-help=Ha engedélyezi, egy üres keresési sor az összes elérhető tartalmat eredményezi. Alapértelmezésben egy üres keresés nem ad vissza semmilyen találatot.
 allow-flattened-navigation=Simított navigáció engedélyezése
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=Fájlok küldésének engedélyezése vendég felhasználók részére
 allow-localization-management=Lokalizációkezelés engedélyezése
 allow-manual-membership-management=Kézi tagság kezelés engedélyezése

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=Jika ini diperiksa, kata-kata kamus umum diizinkan s
 allow-empty-searches=Perbolehkan Pencarian Kosong (Automatic Translation)
 allow-empty-searches-help=Saat diaktifkan, kueri pencarian kosong mengembalikan semua aset yang tersedia. Secara default, kueri kosong tidak mengembalikan hasil pencarian. (Automatic Translation)
 allow-flattened-navigation=Perbolehkan Navigasi Rata (Automatic Translation)
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=Perbolehkan Pengguna Tamu Mengirim File (Automatic Translation)
 allow-localization-management=Allow Localization Management (Automatic Copy)
 allow-manual-membership-management=Perbolehkan Manajemen Keanggotaan Manual (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=Se selezionato, le password utente potranno contener
 allow-empty-searches=Consenti Ricerche Vuote
 allow-empty-searches-help=Se abilitata, una query di ricerca vuota restituisce tutte le risorse disponibili. Per impostazione predefinita, una query vuota non restituisce risultati di ricerca.
 allow-flattened-navigation=Consenti navigazione appiattita
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=Consenti agli Utenti Ospiti di Inviare Files
 allow-localization-management=Allow Localization Management (Automatic Copy)
 allow-manual-membership-management=Consenti Gestione Iscrizioni Manuale

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it_CH.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it_CH.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=Se selezionato, le password utente potranno contener
 allow-empty-searches=Consenti Ricerche Vuote
 allow-empty-searches-help=Se abilitata, una query di ricerca vuota restituisce tutte le risorse disponibili. Per impostazione predefinita, una query vuota non restituisce risultati di ricerca.
 allow-flattened-navigation=Consenti navigazione appiattita
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=Consenti agli Utenti Ospiti di Inviare Files
 allow-localization-management=Allow Localization Management (Automatic Copy)
 allow-manual-membership-management=Consenti Gestione Iscrizioni Manuale

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=אם אפשרות זו מסומנות, מילים נ
 allow-empty-searches=אפשר ביצוע חיפושים ריקים
 allow-empty-searches-help=כאשר היא מופעלת, שאילתת חיפוש ריקה מחזירה את כל הנכסים הזמינים. כברירת מחדל, שאילתה ריקה אינה מחזירה תוצאות חיפוש.
 allow-flattened-navigation=אפשר ניווט משוטח
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=אפשר למשתמשים אורחים לשלוח קבצים (Automatic Translation)
 allow-localization-management=Allow Localization Management (Automatic Copy)
 allow-manual-membership-management=אפשר ניהול חברות ידני

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=これにチェックがついている場合、共�
 allow-empty-searches=空の検索を許可する
 allow-empty-searches-help=有効にすると、空の検索クエリに対してすべての利用可能なアセットを返します。デフォルトでは、空の検索クエリに対して検索結果を返しません。
 allow-flattened-navigation=ナビゲーションのフラット化を許可する
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=ゲストユーザーのファイル送信を許可する
 allow-localization-management=ローカライズの管理を許可する
 allow-manual-membership-management=手動メンバーシップ管理を許可する

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=If this is checked, common dictionary words are allo
 allow-empty-searches=Allow Empty Searches (Automatic Copy)
 allow-empty-searches-help=When enabled, an empty search query returns all available assets. By default, an empty query returns no search results. (Automatic Copy)
 allow-flattened-navigation=Allow Flattened Navigation (Automatic Copy)
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=Allow Guest Users to Send Files (Automatic Copy)
 allow-localization-management=Allow Localization Management (Automatic Copy)
 allow-manual-membership-management=Allow Manual Membership Management (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_km.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_km.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=ប្រសិនបើវាត្រូវបា�
 allow-empty-searches=អនុញ្ញាតឱ្យស្វែងរកទទេ
 allow-empty-searches-help=នៅពេលបើកដំណើរការ search query ទទេនឹងបង្ហាញ​ assets ដែលមានទាំងអស់។ តាមលំនាំដើម empty query មិនបង្ហាញលទ្ធផលស្វែងរកទេ។
 allow-flattened-navigation=អនុញ្ញាត​ Flattened Navigation
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=អនុញ្ញាត​ឱ្យ​ភ្ញៀវ​ផ្ញើ​ឯកសារ
 allow-localization-management=Allow Localization Management (Automatic Copy)
 allow-manual-membership-management=អនុញ្ញាតការគ្រប់គ្រងសមាជិកភាពដោយដៃ

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=이것을 선택하면, 일반 단어를 사용자 �
 allow-empty-searches=빈 검색 허용
 allow-empty-searches-help=활성하면, 빈 검색 질의가 모든 사용가능 자산을 반환합니다. 기본으로 빈 질의는 검색 결과를 반환하지 않습니다.
 allow-flattened-navigation=수평 네비게이션 허용
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=익명 사용자 파일 전송 허용
 allow-localization-management=Allow Localization Management (Automatic Copy)
 allow-manual-membership-management=수동 회원관리 허용

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=ຖ້າເລືອກ, ຄຳສັບໃນວ�
 allow-empty-searches=ອະນຸຍາດການຄົ້ນຫາທີ່ຫວ່າງເປົ່າ
 allow-empty-searches-help=ເມື່ອເປີດໃຊ້, ຄຳຄົ້ນຫາທີ່ຫວ່າງເປົ່າຈະສົ່ງຄືນຊັບສິນທີ່ມີຢູ່ທັງໝົດ.
 allow-flattened-navigation=ອະນຸຍາດການນຳທາງແບບແບນ
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=ອະນຸຍາດໃຫ້ຜູ້ໃຊ້ທົ່ວໄປສົ່ງໄຟລ໌
 allow-localization-management=ອະນຸຍາດການຈັດການພາສາທ້ອງຖິ່ນ
 allow-manual-membership-management=ອະນຸຍາດການຈັດການສະມາຊິກດ້ວຍຕົນເອງ

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=Jei tai pažymėta, bendrieji žodyno žodžiai leid
 allow-empty-searches=Leisti tuščias ieškas (Automatic Translation)
 allow-empty-searches-help=Įgalinus tuščią ieškos užklausą grąžinamas visas galimas turtas. Pagal numatytuosius nustatymus tuščia užklausa nepateikia jokių ieškos rezultatų. (Automatic Translation)
 allow-flattened-navigation=Leisti suplotą naršymą (Automatic Translation)
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=Leisti kviestiniams vartotojams siųsti failus (Automatic Translation)
 allow-localization-management=Allow Localization Management (Automatic Copy)
 allow-manual-membership-management=Leisti neautomatinį narystės valdymą (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_mk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_mk.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=If this is checked, common dictionary words are allo
 allow-empty-searches=Allow Empty Searches (Automatic Copy)
 allow-empty-searches-help=When enabled, an empty search query returns all available assets. By default, an empty query returns no search results. (Automatic Copy)
 allow-flattened-navigation=Allow Flattened Navigation (Automatic Copy)
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=Allow Guest Users to Send Files (Automatic Copy)
 allow-localization-management=Allow Localization Management (Automatic Copy)
 allow-manual-membership-management=Allow Manual Membership Management (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=Jika ini disemak, perkataan kamus biasa dibenarkan s
 allow-empty-searches=Benarkan Gelintar Kosong (Automatic Translation)
 allow-empty-searches-help=Apabila didayakan, pertanyaan carian kosong mengembalikan semua aset yang ada. Secara lalai, pertanyaan kosong tidak mengembalikan hasil carian. (Automatic Translation)
 allow-flattened-navigation=Benarkan Navigasi Bertamadun (Automatic Translation)
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=Benarkan Pengguna Tetamu Untuk Menghantar Fail (Automatic Translation)
 allow-localization-management=Allow Localization Management (Automatic Copy)
 allow-manual-membership-management=Benarkan Pengurusan Keahlian Manual (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_my.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_my.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=If this is checked, common dictionary words are allo
 allow-empty-searches=Allow Empty Searches (Automatic Copy)
 allow-empty-searches-help=When enabled, an empty search query returns all available assets. By default, an empty query returns no search results. (Automatic Copy)
 allow-flattened-navigation=Allow Flattened Navigation (Automatic Copy)
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=Allow Guest Users to Send Files (Automatic Copy)
 allow-localization-management=Allow Localization Management (Automatic Copy)
 allow-manual-membership-management=Allow Manual Membership Management (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=Hvis det er merket av for dette alternativet, tillat
 allow-empty-searches=Tillat tomme søk (Automatic Translation)
 allow-empty-searches-help=Når den er aktivert, returnerer en tom søkespørring alle tilgjengelige ressurser. Som standard returnerer en tom spørring ingen søkeresultater. (Automatic Translation)
 allow-flattened-navigation=Tillat flat navigering
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=Tillat gjestebrukere å sende filer (Automatic Translation)
 allow-localization-management=Allow Localization Management (Automatic Copy)
 allow-manual-membership-management=Tillat manuell medlemskapsforvaltning

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=Als deze optie is ingeschakeld zijn gewone woordenbo
 allow-empty-searches=Lege Zoekopdrachten toestaan
 allow-empty-searches-help=Wanneer ingeschakeld, levert een lege zoekopdracht alle beschikbare assets op als resultaat. Standaard levert een lege query geen zoekresultaten op.
 allow-flattened-navigation=Platte navigatie toestaan
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=Gastgebruikers toestaan om bestanden te verzenden
 allow-localization-management=Lokalisatiebeheer toestaan
 allow-manual-membership-management=Handmatig beheer van lidmaatschappen toestaan

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=Als deze optie is ingeschakeld zijn gewone woordenbo
 allow-empty-searches=Lege Zoekopdrachten toestaan
 allow-empty-searches-help=Wanneer ingeschakeld, levert een lege zoekopdracht alle beschikbare assets op als resultaat. Standaard levert een lege query geen zoekresultaten op.
 allow-flattened-navigation=Platte navigatie toestaan
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=Gastgebruikers toestaan om bestanden te verzenden
 allow-localization-management=Lokalisatiebeheer toestaan
 allow-manual-membership-management=Handmatig beheer van lidmaatschappen toestaan

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_no.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_no.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=Hvis det er merket av for dette alternativet, tillat
 allow-empty-searches=Tillat tomme søk (Automatic Translation)
 allow-empty-searches-help=Når den er aktivert, returnerer en tom søkespørring alle tilgjengelige ressurser. Som standard returnerer en tom spørring ingen søkeresultater. (Automatic Translation)
 allow-flattened-navigation=Tillat flat navigering
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=Tillat gjestebrukere å sende filer (Automatic Translation)
 allow-localization-management=Allow Localization Management (Automatic Copy)
 allow-manual-membership-management=Tillat manuell medlemskapsforvaltning

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=Jeśli jest to zaznaczone, wspólne słowa słownika
 allow-empty-searches=Zezwalaj na puste wyszukiwania (Automatic Translation)
 allow-empty-searches-help=Gdy ta opcja jest włączona, puste zapytanie wyszukiwania zwraca wszystkie dostępne zasoby. Domyślnie pusta kwerenda nie zwraca żadnych wyników wyszukiwania. (Automatic Translation)
 allow-flattened-navigation=Zezwalaj na spłaszczone nawigacje (Automatic Translation)
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=Zezwalaj użytkownikom-gościom na wysyłanie plików (Automatic Translation)
 allow-localization-management=Allow Localization Management (Automatic Copy)
 allow-manual-membership-management=Pozwól na ręczne zarządzanie uczestnictwem

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=Se marcado, palavras comuns do dicionário serão pe
 allow-empty-searches=Permitir buscas vazias
 allow-empty-searches-help=Quando ativado, uma consulta de busca vazia retorna com todos os ativos disponíveis. Como padrão, uma consulta de busca vazia não mostra nenhum resultado.
 allow-flattened-navigation=Permitir Navegação Plana
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=Permitir que usuários convidados enviem arquivos
 allow-localization-management=Permitir gerenciamento de localização
 allow-manual-membership-management=Permitir Gerenciamento Manual de Inscrições

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=Se selecionado, palavras comuns do dicionário serã
 allow-empty-searches=Permitir buscas vazias
 allow-empty-searches-help=Quando ativado, uma consulta de busca vazia retorna com todos os ativos disponíveis. Como padrão, uma consulta de busca vazia não mostra nenhum resultado.
 allow-flattened-navigation=Permitir Navegação Plana
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=Permitir que usuários convidados enviem arquivos (Automatic Translation)
 allow-localization-management=Permitir gerenciamento de localização
 allow-manual-membership-management=Permitir Gestão Manual de Inscrições

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=Dacă acest lucru este bifat, cuvintele obișnuite d
 allow-empty-searches=Se permit căutări goale (Automatic Translation)
 allow-empty-searches-help=Când este activată, o interogare de căutare goală returnează toate activele disponibile. În mod implicit, o interogare goală nu returnează niciun rezultat al căutării. (Automatic Translation)
 allow-flattened-navigation=Se permite navigarea aplatizată (Automatic Translation)
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=Se permite utilizatorilor invitați să trimită fișiere (Automatic Translation)
 allow-localization-management=Allow Localization Management (Automatic Copy)
 allow-manual-membership-management=Se permite gestionarea manuală a apartenenței (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=Если это проверено, в качест�
 allow-empty-searches=Разрешить пустой поиск (Automatic Translation)
 allow-empty-searches-help=При включении пустой поисковый запрос возвращает все доступные ресурсы. По умолчанию пустой запрос не возвращает результатов поиска. (Automatic Translation)
 allow-flattened-navigation=Разрешить сровнявую навигацию (Automatic Translation)
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=Разрешить гостевым пользователям отправлять файлы (Automatic Translation)
 allow-localization-management=Allow Localization Management (Automatic Copy)
 allow-manual-membership-management=Разрешить ручное управление членства

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=Ak je toto zaškrtnuté, budá sa môť v hesle pou�
 allow-empty-searches=Povoliť prázdne vyhľadávania (Automatic Translation)
 allow-empty-searches-help=Ak je táto možnosť povolená, prázdny vyhľadávací dotaz vráti všetky dostupné zdroje. Prázdny dotaz predvolene nevráti žiadne výsledky vyhľadávania. (Automatic Translation)
 allow-flattened-navigation=Povoliť zlúčenú navigáciu (Automatic Translation)
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=Povoliť hosťovským používateľom odosielanie súborov (Automatic Translation)
 allow-localization-management=Allow Localization Management (Automatic Copy)
 allow-manual-membership-management=Povoliť manuálnu správu členstva

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=Če je to preverjanje, so kot uporabnikova gesla dov
 allow-empty-searches=Dovoli prazna iskanja (Automatic Translation)
 allow-empty-searches-help=Ko je omogočeno, prazna iskalna poizvedba vrne vsa razpoložljiva sredstva. Privzeto prazna poizvedba ne vrne rezultatov iskanja. (Automatic Translation)
 allow-flattened-navigation=Dovoli sploščeno krmarjenje (Automatic Translation)
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=Dovoli uporabnikom gostov, da pošiljajo datoteke (Automatic Translation)
 allow-localization-management=Allow Localization Management (Automatic Copy)
 allow-manual-membership-management=Dovoli ročno upravljanje članstva (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=If this is checked, common dictionary words are allo
 allow-empty-searches=Allow Empty Searches (Automatic Copy)
 allow-empty-searches-help=When enabled, an empty search query returns all available assets. By default, an empty query returns no search results. (Automatic Copy)
 allow-flattened-navigation=Allow Flattened Navigation (Automatic Copy)
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=Allow Guest Users to Send Files (Automatic Copy)
 allow-localization-management=Allow Localization Management (Automatic Copy)
 allow-manual-membership-management=Allow Manual Membership Management (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=If this is checked, common dictionary words are allo
 allow-empty-searches=Allow Empty Searches (Automatic Copy)
 allow-empty-searches-help=When enabled, an empty search query returns all available assets. By default, an empty query returns no search results. (Automatic Copy)
 allow-flattened-navigation=Allow Flattened Navigation (Automatic Copy)
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=Allow Guest Users to Send Files (Automatic Copy)
 allow-localization-management=Allow Localization Management (Automatic Copy)
 allow-manual-membership-management=Allow Manual Membership Management (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=Om detta markeras är vanliga ord från ordlistan ti
 allow-empty-searches=Tillåt tomma sökningar
 allow-empty-searches-help=När detta är aktiverat returnerar en tom sökfråga alla tillgängliga tillgångar. Som standard returnerar en tom sökfråga inga resultat.
 allow-flattened-navigation=Tillåt utplattad navigering
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=Tillåt gästanvändare att skicka filer
 allow-localization-management=Tillåt hantering av lokalisering
 allow-manual-membership-management=Tillåt manuell hantering av medlemskap

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=இது செலக்ட் செய்யப�
 allow-empty-searches=Allow Empty Searches (Automatic Copy)
 allow-empty-searches-help=இயக்கப்பட்டிருக்கும் போது, ​​ஒரு empty search-னது எல்லா assets-களையும் வழங்குகிறது. By default, ஒரு empty query எந்த தேடல் முடிவுகளையும் கொடுக்காது.
 allow-flattened-navigation=Flattened Navigation-ஐ அனுமதி
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=Allow Guest Users to Send Files (Automatic Copy)
 allow-localization-management=Allow Localization Management (Automatic Copy)
 allow-manual-membership-management=Manual Membership Management அனுமதி

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=ถ้าตรงนี้ถูกเช็คเ�
 allow-empty-searches=อนุญาตเสิร์จว่างๆ
 allow-empty-searches-help=เมื่อเปิดใช้งาน เสิร์จคิวรี่ว่างๆรีเทิร์นแอสเซทที่ใช้งานได้ทั้งหมด ซึ่งปกติแล้วเสิร์จคิวรี่ว่างๆจะรีเทิร์นเป็นไม่พบผลการค้นหา
 allow-flattened-navigation=อนุญาตการนำทางแบบราบ
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=อนุญาตให้ผู้ใช้งานที่ไม่ได้ล็อคอินหรือเกสท์ส่งไฟล์ได้
 allow-localization-management=Allow Localization Management (Automatic Copy)
 allow-manual-membership-management=อนุญาตการดูแลจัดการสมาชิกด้วยตัวเองหรือแมนนวล

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=Bu işaretlenirse, ortak sözlük sözcüklerine kul
 allow-empty-searches=Boş Aramalara İzin Ver (Automatic Translation)
 allow-empty-searches-help=Etkinleştirildiğinde, boş bir arama sorgusu kullanılabilir tüm varlıkları döndürür. Varsayılan olarak, boş bir sorgu arama sonucu döndürmez. (Automatic Translation)
 allow-flattened-navigation=Düzleştirilmiş Gezintiye İzin Ver (Automatic Translation)
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=Konuk Kullanıcıların Dosya Göndermesine İzin Ver (Automatic Translation)
 allow-localization-management=Allow Localization Management (Automatic Copy)
 allow-manual-membership-management=El ile Üyelik Yönetimine İzin Ver (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=Якщо буде позначено цей пунк
 allow-empty-searches=Дозволити пусті пошуки (Automatic Translation)
 allow-empty-searches-help=Якщо ввімкнено, пустий пошуковий запит повертає всі доступні об'єкти. За промовчанням пустий запит не повертає результатів пошуку. (Automatic Translation)
 allow-flattened-navigation=Дозволити зведення переходів (Automatic Translation)
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=Дозволити гостьовим користувачам надсилати файли (Automatic Translation)
 allow-localization-management=Allow Localization Management (Automatic Copy)
 allow-manual-membership-management=Дозволити керування членством вручну (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=Nếu điều này được chọn, các từ điể
 allow-empty-searches=Cho phép Tìm kiếm Trống (Automatic Translation)
 allow-empty-searches-help=Khi được bật, truy vấn tìm kiếm trống trả về tất cả các tài sản có sẵn. Theo mặc định, truy vấn trống không trả về kết quả tìm kiếm. (Automatic Translation)
 allow-flattened-navigation=Cho phép Dẫn hướng Phẳng (Automatic Translation)
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=Cho phép Người dùng Khách gửi Tệp (Automatic Translation)
 allow-localization-management=Allow Localization Management (Automatic Copy)
 allow-manual-membership-management=Cho phép tự quản trị quan hệ thành viên

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=如果选中该选项，将允许用户密码使用�
 allow-empty-searches=允许空搜索
 allow-empty-searches-help=启用后，空搜索查询将返回所有可用资产。默认情况下，空查询不会返回搜索结果。
 allow-flattened-navigation=允许平展导航
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=允许访客发送文件
 allow-localization-management=允许本地化管理
 allow-manual-membership-management=允许手动的成员管理

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
@@ -1589,6 +1589,7 @@ allow-dictionary-words-help=如果這被核選，一般字典字會允許用在�
 allow-empty-searches=允許空搜尋
 allow-empty-searches-help=啟用后，空搜索查詢將返回所有可用資產。默認情況下，空查詢不會返回搜尋結果。 (Automatic Translation)
 allow-flattened-navigation=允許平展式的導航
+allow-guest-access=Allow Guest Access (Automatic Copy)
 allow-guest-users-to-send-files=允許訪客寄送檔案
 allow-localization-management=Allow Localization Management (Automatic Copy)
 allow-manual-membership-management=允許手動會員資格管理


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-104441

## What Is Being Fixed

The AI Hub chatbot admin form (liferay-portal-ee) adds a new "allow guest access" toggle whose label key, `allow-guest-access`, does not exist yet in the shared language bundle.

Forwarded manually from https://github.com/liferay-ai-hub/liferay-portal/pull/725, which the AI Hub CI declined to forward automatically because its pr-check is recorded as skipped.

## How It Is Being Fixed

The first commit is Iliyan Peychev's original change, unmodified: `allow-guest-access=Allow Guest Access` added to `portal-language-lang`'s `Language.properties`, placed alphabetically immediately before `allow-guest-users-to-send-files`. The second commit is the `buildLang` output, which propagates the key to all 65 `Language_<locale>.properties` files as `Allow Guest Access (Automatic Copy)` pending translation.

The companion object field, server-side gate, and form toggle are in the liferay-ai-hub/liferay-portal-ee PR: https://github.com/liferay-ai-hub/liferay-portal-ee/pull/142.

## PR Check

**pr-check: SKIPPED** — language key addition plus its generated `buildLang` output, no code change

<!-- pr-check {"reason": "language key addition plus its generated buildLang output, no code change", "result": "skipped", "sha": "9f53dacb9de656be11437cd0f67f0c5c1daba051"} -->
