### PR TITLE
LPD-104918 Keep the object entries of a listing in hand

### DIFF
--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryService.java
@@ -67,6 +67,11 @@ public interface ObjectEntryService extends BaseService {
 			long objectDefinitionId, long objectEntryId, String actionId)
 		throws PortalException;
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public void checkModelResourcePermission(
+			ObjectEntry objectEntry, String actionId)
+		throws PortalException;
+
 	public ObjectEntry copyObjectEntry(
 			long objectEntryId, long objectEntryFolderId,
 			Map<String, Serializable> values, ServiceContext serviceContext)
@@ -210,4 +215,4 @@ public interface ObjectEntryService extends BaseService {
 		throws PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:222530909
+// LIFERAY-SERVICE-BUILDER-HASH:-1873666262

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryServiceUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryServiceUtil.java
@@ -63,6 +63,13 @@ public class ObjectEntryServiceUtil {
 			objectDefinitionId, objectEntryId, actionId);
 	}
 
+	public static void checkModelResourcePermission(
+			ObjectEntry objectEntry, String actionId)
+		throws PortalException {
+
+		getService().checkModelResourcePermission(objectEntry, actionId);
+	}
+
 	public static ObjectEntry copyObjectEntry(
 			long objectEntryId, long objectEntryFolderId,
 			Map<String, Serializable> values,
@@ -318,4 +325,4 @@ public class ObjectEntryServiceUtil {
 		new Snapshot<>(ObjectEntryServiceUtil.class, ObjectEntryService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1024998454
+// LIFERAY-SERVICE-BUILDER-HASH:-812823718

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryServiceWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryServiceWrapper.java
@@ -61,6 +61,14 @@ public class ObjectEntryServiceWrapper
 	}
 
 	@Override
+	public void checkModelResourcePermission(
+			com.liferay.object.model.ObjectEntry objectEntry, String actionId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		_objectEntryService.checkModelResourcePermission(objectEntry, actionId);
+	}
+
+	@Override
 	public com.liferay.object.model.ObjectEntry copyObjectEntry(
 			long objectEntryId, long objectEntryFolderId,
 			java.util.Map<String, java.io.Serializable> values,
@@ -360,4 +368,4 @@ public class ObjectEntryServiceWrapper
 	private ObjectEntryService _objectEntryService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-786646980
+// LIFERAY-SERVICE-BUILDER-HASH:-2010359252

--- a/modules/apps/object/object-info-api/src/main/java/com/liferay/object/info/item/util/ObjectEntryInfoItemUtil.java
+++ b/modules/apps/object/object-info-api/src/main/java/com/liferay/object/info/item/util/ObjectEntryInfoItemUtil.java
@@ -90,35 +90,38 @@ public class ObjectEntryInfoItemUtil {
 		}
 
 		try {
-			if (serviceBuilderObjectEntry.isRootDescendantNode() &&
-				(objectEntryManager instanceof DefaultObjectEntryManager)) {
+			if (objectEntryManager instanceof
+					DefaultObjectEntryManager defaultObjectEntryManager) {
 
-				DefaultObjectEntryManager defaultObjectEntryManager =
-					(DefaultObjectEntryManager)objectEntryManager;
+				if (serviceBuilderObjectEntry.isRootDescendantNode()) {
+					for (ObjectRelationship objectRelationship :
+							ObjectRelationshipLocalServiceUtil.
+								getObjectRelationshipsByObjectDefinitionId2(
+									objectDefinition.getObjectDefinitionId(),
+									true)) {
 
-				for (ObjectRelationship objectRelationship :
-						ObjectRelationshipLocalServiceUtil.
-							getObjectRelationshipsByObjectDefinitionId2(
-								objectDefinition.getObjectDefinitionId(),
-								true)) {
+						ObjectField objectField =
+							ObjectFieldLocalServiceUtil.getObjectField(
+								objectRelationship.getObjectFieldId2());
 
-					ObjectField objectField =
-						ObjectFieldLocalServiceUtil.getObjectField(
-							objectRelationship.getObjectFieldId2());
+						long parentObjectEntryId = MapUtil.getLong(
+							serviceBuilderObjectEntry.getValues(),
+							objectField.getName());
 
-					long parentObjectEntryId = MapUtil.getLong(
-						serviceBuilderObjectEntry.getValues(),
-						objectField.getName());
+						if (parentObjectEntryId == 0) {
+							continue;
+						}
 
-					if (parentObjectEntryId == 0) {
-						continue;
+						return defaultObjectEntryManager.getRelatedObjectEntry(
+							dtoConverterContext,
+							serviceBuilderObjectEntry.getObjectEntryId(),
+							objectRelationship, parentObjectEntryId);
 					}
-
-					return defaultObjectEntryManager.getRelatedObjectEntry(
-						dtoConverterContext,
-						serviceBuilderObjectEntry.getObjectEntryId(),
-						objectRelationship, parentObjectEntryId);
 				}
+
+				return defaultObjectEntryManager.getObjectEntry(
+					dtoConverterContext, objectDefinition,
+					serviceBuilderObjectEntry);
 			}
 
 			return objectEntryManager.getObjectEntry(

--- a/modules/apps/object/object-info-api/src/main/java/com/liferay/object/info/item/util/ObjectEntryInfoItemUtil.java
+++ b/modules/apps/object/object-info-api/src/main/java/com/liferay/object/info/item/util/ObjectEntryInfoItemUtil.java
@@ -74,7 +74,9 @@ public class ObjectEntryInfoItemUtil {
 
 		int version = serviceBuilderObjectEntry.getVersion();
 
-		if (serviceBuilderObjectEntry.getHeadObjectEntryId() > 0) {
+		if ((serviceBuilderObjectEntry.getHeadObjectEntryId() > 0) &&
+			!serviceBuilderObjectEntry.isHead()) {
+
 			serviceBuilderObjectEntry =
 				ObjectEntryLocalServiceUtil.fetchObjectEntry(
 					serviceBuilderObjectEntry.getHeadObjectEntryId());

--- a/modules/apps/object/object-rest-api/bnd.bnd
+++ b/modules/apps/object/object-rest-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Object REST API
 Bundle-SymbolicName: com.liferay.object.rest.api
-Bundle-Version: 36.0.3
+Bundle-Version: 36.1.0
 Export-Package:\
 	com.liferay.object.rest.dto.v1_0,\
 	com.liferay.object.rest.dto.v1_0.util,\

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/manager/v1_0/BaseObjectEntryManager.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/manager/v1_0/BaseObjectEntryManager.java
@@ -113,20 +113,10 @@ public abstract class BaseObjectEntryManager {
 	}
 
 	protected long getGroupId(
-			ObjectDefinition objectDefinition, String scopeKey)
-		throws ObjectEntryScopeException {
-
-		return getGroupId(objectDefinition, scopeKey, false);
-	}
-
-	protected long getGroupId(
-			ObjectDefinition objectDefinition, String scopeKey,
+			ObjectDefinition objectDefinition,
+			ObjectScopeProvider objectScopeProvider, String scopeKey,
 			boolean useCompanyGroup)
 		throws ObjectEntryScopeException {
-
-		ObjectScopeProvider objectScopeProvider =
-			objectScopeProviderRegistry.getObjectScopeProvider(
-				objectDefinition.getScope());
 
 		if (objectScopeProvider.isGroupAware()) {
 			if (scopeKey == null) {
@@ -155,6 +145,25 @@ public abstract class BaseObjectEntryManager {
 		}
 
 		return 0;
+	}
+
+	protected long getGroupId(
+			ObjectDefinition objectDefinition, String scopeKey)
+		throws ObjectEntryScopeException {
+
+		return getGroupId(objectDefinition, scopeKey, false);
+	}
+
+	protected long getGroupId(
+			ObjectDefinition objectDefinition, String scopeKey,
+			boolean useCompanyGroup)
+		throws ObjectEntryScopeException {
+
+		return getGroupId(
+			objectDefinition,
+			objectScopeProviderRegistry.getObjectScopeProvider(
+				objectDefinition.getScope()),
+			scopeKey, useCompanyGroup);
 	}
 
 	protected PortletResourcePermission getPortletResourcePermission(

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/manager/v1_0/DefaultObjectEntryManager.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/manager/v1_0/DefaultObjectEntryManager.java
@@ -164,6 +164,12 @@ public interface DefaultObjectEntryManager extends ObjectEntryManager {
 			ObjectDefinition objectDefinition, long objectEntryId)
 		throws Exception;
 
+	public ObjectEntry getObjectEntry(
+			DTOConverterContext dtoConverterContext,
+			ObjectDefinition objectDefinition,
+			com.liferay.object.model.ObjectEntry serviceBuilderObjectEntry)
+		throws Exception;
+
 	public ObjectEntry getObjectEntryByVersion(
 			DTOConverterContext dtoConverterContext,
 			String externalReferenceCode, ObjectDefinition objectDefinition,

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/manager/v1_0/DefaultObjectEntryManager.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/manager/v1_0/DefaultObjectEntryManager.java
@@ -204,6 +204,14 @@ public interface DefaultObjectEntryManager extends ObjectEntryManager {
 			String objectRelationshipName, Pagination pagination)
 		throws Exception;
 
+	public Page<com.liferay.object.model.ObjectEntry>
+			getServiceBuilderObjectEntries(
+				long companyId, ObjectDefinition objectDefinition,
+				String scopeKey, DTOConverterContext dtoConverterContext,
+				String filterString, Pagination pagination, String search,
+				Sort[] sorts)
+		throws Exception;
+
 	public Object getSystemObjectEntry(
 			DTOConverterContext dtoConverterContext,
 			ObjectDefinition objectDefinition, long primaryKey)

--- a/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/manager/v1_0/packageinfo
+++ b/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/manager/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 23.2.0
+version 23.3.0

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -27,6 +27,7 @@ import com.liferay.object.entry.folder.subscription.util.ObjectEntryFolderSubscr
 import com.liferay.object.entry.scope.provider.ObjectEntryScopeProvider;
 import com.liferay.object.entry.scope.provider.ObjectEntryScopeProviderRegistry;
 import com.liferay.object.entry.util.ObjectEntryDTOConverterUtil;
+import com.liferay.object.entry.util.ObjectEntryThreadLocal;
 import com.liferay.object.exception.NoSuchObjectEntryException;
 import com.liferay.object.exception.ObjectEntryValuesException;
 import com.liferay.object.field.attachment.AttachmentManager;
@@ -1004,6 +1005,22 @@ public class DefaultObjectEntryManagerImpl
 		return _getObjectEntry(
 			dtoConverterContext, objectDefinition,
 			_objectEntryService.getObjectEntry(objectEntryId));
+	}
+
+	@Override
+	public ObjectEntry getObjectEntry(
+			DTOConverterContext dtoConverterContext,
+			ObjectDefinition objectDefinition,
+			com.liferay.object.model.ObjectEntry serviceBuilderObjectEntry)
+		throws Exception {
+
+		if (!ObjectEntryThreadLocal.isSkipObjectEntryResourcePermission()) {
+			_objectEntryService.checkModelResourcePermission(
+				serviceBuilderObjectEntry, ActionKeys.VIEW);
+		}
+
+		return _getObjectEntry(
+			dtoConverterContext, objectDefinition, serviceBuilderObjectEntry);
 	}
 
 	@Override
@@ -2290,8 +2307,7 @@ public class DefaultObjectEntryManagerImpl
 		throws Exception {
 
 		_objectEntryService.checkModelResourcePermission(
-			objectDefinition.getObjectDefinitionId(),
-			serviceBuilderObjectEntry.getObjectEntryId(), objectActionName);
+			serviceBuilderObjectEntry, objectActionName);
 
 		_objectActionEngine.executeObjectAction(
 			objectActionName, ObjectActionTriggerConstants.KEY_STANDALONE,

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -793,7 +793,8 @@ public class DefaultObjectEntryManagerImpl
 			_objectScopeProviderRegistry.getObjectScopeProvider(
 				objectDefinition.getScope());
 
-		long groupId = getGroupId(objectDefinition, scopeKey);
+		long groupId = getGroupId(
+			objectDefinition, objectScopeProvider, scopeKey, false);
 
 		if (objectScopeProvider.isValidGroupId(groupId)) {
 			groupIdsList.add(groupId);

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -787,8 +787,6 @@ public class DefaultObjectEntryManagerImpl
 			Sort[] sorts)
 		throws Exception {
 
-		List<Long> groupIdsList = new ArrayList<>();
-
 		ObjectScopeProvider objectScopeProvider =
 			_objectScopeProviderRegistry.getObjectScopeProvider(
 				objectDefinition.getScope());
@@ -796,69 +794,22 @@ public class DefaultObjectEntryManagerImpl
 		long groupId = getGroupId(
 			objectDefinition, objectScopeProvider, scopeKey, false);
 
-		if (objectScopeProvider.isValidGroupId(groupId)) {
-			groupIdsList.add(groupId);
-		}
-
-		if (StringUtil.equals(
-				objectDefinition.getScope(),
-				ObjectDefinitionConstants.SCOPE_DEPOT)) {
-
-			groupIdsList.addAll(
-				TransformUtil.transform(
-					_depotEntryLocalService.getGroupConnectedDepotEntries(
-						groupId, DepotConstants.TYPE_ANY, QueryUtil.ALL_POS,
-						QueryUtil.ALL_POS),
-					DepotEntryModel::getGroupId));
-		}
-
-		if (objectScopeProvider.isGroupAware() &&
-			ListUtil.isEmpty(groupIdsList)) {
-
-			throw new NoSuchGroupException();
-		}
-
-		Long[] groupIds = groupIdsList.toArray(new Long[0]);
+		Long[] groupIds = _getGroupIds(
+			groupId, objectDefinition, objectScopeProvider);
 
 		Predicate predicate = _filterFactory.create(
 			filterExpression, groupIds, objectDefinition);
 
-		boolean preferApproved = GetterUtil.getBoolean(
-			dtoConverterContext.getAttribute("preferApproved"));
-		int start = _getStartPosition(pagination);
-		int end = _getEndPosition(pagination);
+		Page<com.liferay.object.model.ObjectEntry>
+			serviceBuilderObjectEntriesPage = _getServiceBuilderObjectEntries(
+				companyId, objectDefinition, groupIds, dtoConverterContext,
+				predicate, pagination, search, sorts);
 
-		List<ObjectEntry> objectEntries = null;
-		int objectEntriesCount = 0;
-
-		if (_isUseComplexQuery(
-				groupIds, objectDefinition, predicate, preferApproved, search,
-				sorts)) {
-
-			objectEntries = TransformUtil.transform(
-				objectEntryLocalService.getPrimaryKeys(
-					groupIds, companyId, dtoConverterContext.getUserId(),
-					objectDefinition.getObjectDefinitionId(), predicate,
-					preferApproved, search, start, end, sorts),
-				primaryKey -> _getObjectEntry(
-					dtoConverterContext, objectDefinition, primaryKey));
-			objectEntriesCount = objectEntryLocalService.getValuesListCount(
-				groupIds, companyId, dtoConverterContext.getUserId(),
-				objectDefinition.getObjectDefinitionId(), predicate,
-				preferApproved, search);
-		}
-		else {
-			objectEntries = TransformUtil.transform(
-				_objectEntryService.getObjectEntries(
-					groupIds[0], objectDefinition.getObjectDefinitionId(),
-					WorkflowConstants.STATUS_ANY, start, end),
-				serviceBuilderObjectEntry -> _getObjectEntry(
-					dtoConverterContext, objectDefinition,
-					serviceBuilderObjectEntry));
-			objectEntriesCount = _objectEntryService.getObjectEntriesCount(
-				groupIds[0], objectDefinition.getObjectDefinitionId(),
-				WorkflowConstants.STATUS_ANY);
-		}
+		List<ObjectEntry> objectEntries = TransformUtil.transform(
+			new ArrayList<>(serviceBuilderObjectEntriesPage.getItems()),
+			serviceBuilderObjectEntry -> _getObjectEntry(
+				dtoConverterContext, objectDefinition,
+				serviceBuilderObjectEntry));
 
 		return Page.of(
 			HashMapBuilder.put(
@@ -905,7 +856,8 @@ public class DefaultObjectEntryManagerImpl
 					aggregationTerm, predicate,
 					GetterUtil.getBoolean(
 						dtoConverterContext.getAttribute("preferApproved")))),
-			objectEntries, pagination, objectEntriesCount);
+			objectEntries, pagination,
+			serviceBuilderObjectEntriesPage.getTotalCount());
 	}
 
 	@Override
@@ -1203,6 +1155,32 @@ public class DefaultObjectEntryManagerImpl
 				serviceBuilderObjectEntry.getGroupId(),
 				objectRelationship.getObjectRelationshipId(), null,
 				serviceBuilderObjectEntry.getPrimaryKey(), null));
+	}
+
+	@Override
+	public Page<com.liferay.object.model.ObjectEntry>
+			getServiceBuilderObjectEntries(
+				long companyId, ObjectDefinition objectDefinition,
+				String scopeKey, DTOConverterContext dtoConverterContext,
+				String filterString, Pagination pagination, String search,
+				Sort[] sorts)
+		throws Exception {
+
+		ObjectScopeProvider objectScopeProvider =
+			_objectScopeProviderRegistry.getObjectScopeProvider(
+				objectDefinition.getScope());
+
+		Long[] groupIds = _getGroupIds(
+			getGroupId(objectDefinition, objectScopeProvider, scopeKey, false),
+			objectDefinition, objectScopeProvider);
+
+		return _getServiceBuilderObjectEntries(
+			companyId, objectDefinition, groupIds, dtoConverterContext,
+			_filterFactory.create(
+				_objectDefinitionFilterParser.parse(
+					filterString, objectDefinition),
+				groupIds, objectDefinition),
+			pagination, search, sorts);
 	}
 
 	@Override
@@ -2442,6 +2420,38 @@ public class DefaultObjectEntryManagerImpl
 		return null;
 	}
 
+	private Long[] _getGroupIds(
+			long groupId, ObjectDefinition objectDefinition,
+			ObjectScopeProvider objectScopeProvider)
+		throws Exception {
+
+		List<Long> groupIdsList = new ArrayList<>();
+
+		if (objectScopeProvider.isValidGroupId(groupId)) {
+			groupIdsList.add(groupId);
+		}
+
+		if (StringUtil.equals(
+				objectDefinition.getScope(),
+				ObjectDefinitionConstants.SCOPE_DEPOT)) {
+
+			groupIdsList.addAll(
+				TransformUtil.transform(
+					_depotEntryLocalService.getGroupConnectedDepotEntries(
+						groupId, DepotConstants.TYPE_ANY, QueryUtil.ALL_POS,
+						QueryUtil.ALL_POS),
+					DepotEntryModel::getGroupId));
+		}
+
+		if (objectScopeProvider.isGroupAware() &&
+			ListUtil.isEmpty(groupIdsList)) {
+
+			throw new NoSuchGroupException();
+		}
+
+		return groupIdsList.toArray(new Long[0]);
+	}
+
 	private BaseModel<ExternalReferenceCodeModel> _getManyToOneRelatedModel(
 			ObjectRelationship objectRelationship, long primaryKey,
 			ObjectDefinition relatedObjectDefinition)
@@ -2498,26 +2508,6 @@ public class DefaultObjectEntryManagerImpl
 				return false;
 			},
 			value);
-	}
-
-	private ObjectEntry _getObjectEntry(
-			DTOConverterContext dtoConverterContext,
-			ObjectDefinition objectDefinition, long objectEntryId)
-		throws Exception {
-
-		com.liferay.object.model.ObjectEntry serviceBuilderObjectEntry =
-			_objectEntryService.getObjectEntry(objectEntryId);
-
-		_checkApprovedObjectEntry(
-			GetterUtil.getBoolean(
-				dtoConverterContext.getAttribute("preferApproved")),
-			serviceBuilderObjectEntry);
-		_checkObjectEntryObjectDefinitionId(
-			objectDefinition, serviceBuilderObjectEntry);
-
-		return _toObjectEntry(
-			dtoConverterContext, objectDefinition, serviceBuilderObjectEntry,
-			null);
 	}
 
 	private ObjectEntry _getObjectEntry(
@@ -3035,6 +3025,52 @@ public class DefaultObjectEntryManagerImpl
 		return _toObjectEntry(
 			dtoConverterContext, objectDefinition, serviceBuilderObjectEntry,
 			serviceBuilderParentObjectEntry);
+	}
+
+	private Page<com.liferay.object.model.ObjectEntry>
+			_getServiceBuilderObjectEntries(
+				long companyId, ObjectDefinition objectDefinition,
+				Long[] groupIds, DTOConverterContext dtoConverterContext,
+				Predicate predicate, Pagination pagination, String search,
+				Sort[] sorts)
+		throws Exception {
+
+		int start = _getStartPosition(pagination);
+		int end = _getEndPosition(pagination);
+
+		boolean preferApproved = GetterUtil.getBoolean(
+			dtoConverterContext.getAttribute("preferApproved"));
+
+		List<com.liferay.object.model.ObjectEntry> serviceBuilderObjectEntries =
+			null;
+		int objectEntriesCount = 0;
+
+		if (_isUseComplexQuery(
+				groupIds, objectDefinition, predicate, preferApproved, search,
+				sorts)) {
+
+			serviceBuilderObjectEntries = TransformUtil.transform(
+				objectEntryLocalService.getPrimaryKeys(
+					groupIds, companyId, dtoConverterContext.getUserId(),
+					objectDefinition.getObjectDefinitionId(), predicate,
+					preferApproved, search, start, end, sorts),
+				primaryKey -> _objectEntryService.getObjectEntry(primaryKey));
+			objectEntriesCount = objectEntryLocalService.getValuesListCount(
+				groupIds, companyId, dtoConverterContext.getUserId(),
+				objectDefinition.getObjectDefinitionId(), predicate,
+				preferApproved, search);
+		}
+		else {
+			serviceBuilderObjectEntries = _objectEntryService.getObjectEntries(
+				groupIds[0], objectDefinition.getObjectDefinitionId(),
+				WorkflowConstants.STATUS_ANY, start, end);
+			objectEntriesCount = _objectEntryService.getObjectEntriesCount(
+				groupIds[0], objectDefinition.getObjectDefinitionId(),
+				WorkflowConstants.STATUS_ANY);
+		}
+
+		return Page.of(
+			serviceBuilderObjectEntries, pagination, objectEntriesCount);
 	}
 
 	private int _getStartPosition(Pagination pagination) {

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -6947,6 +6947,57 @@ public class DefaultObjectEntryManagerImplTest
 	}
 
 	@Test
+	public void testGetObjectEntry() throws Exception {
+
+		// Company scope
+
+		ObjectEntry objectEntry = _addObjectEntry(
+			_objectDefinition1, WorkflowConstants.STATUS_APPROVED);
+
+		_assertObjectEntry(
+			objectEntry,
+			_defaultObjectEntryManager.getObjectEntry(
+				dtoConverterContext, _objectDefinition1,
+				_objectEntryLocalService.getObjectEntry(objectEntry.getId())));
+
+		// Site scope
+
+		ObjectEntry siteObjectEntry = _defaultObjectEntryManager.addObjectEntry(
+			_simpleDTOConverterContext, _objectDefinition4,
+			new ObjectEntry() {
+				{
+					properties = HashMapBuilder.<String, Object>put(
+						"textObjectFieldName", RandomTestUtil.randomString()
+					).build();
+				}
+			},
+			_group.getGroupKey());
+
+		com.liferay.object.model.ObjectEntry serviceBuilderObjectEntry =
+			_objectEntryLocalService.getObjectEntry(siteObjectEntry.getId());
+
+		_assertObjectEntry(
+			siteObjectEntry,
+			_defaultObjectEntryManager.getObjectEntry(
+				dtoConverterContext, _objectDefinition4,
+				serviceBuilderObjectEntry));
+
+		// Without view permission
+
+		_user = _addUser();
+
+		AssertUtils.assertFailure(
+			PrincipalException.MustHavePermission.class,
+			StringBundler.concat(
+				"User ", _user.getUserId(), " must have VIEW permission for ",
+				_objectDefinition4.getClassName(), StringPool.SPACE,
+				siteObjectEntry.getId()),
+			() -> _defaultObjectEntryManager.getObjectEntry(
+				dtoConverterContext, _objectDefinition4,
+				serviceBuilderObjectEntry));
+	}
+
+	@Test
 	public void testGetObjectEntryByVersion() throws Exception {
 
 		// Company scope

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -7642,6 +7642,50 @@ public class DefaultObjectEntryManagerImplTest
 	}
 
 	@Test
+	public void testGetServiceBuilderObjectEntries() throws Exception {
+		ObjectEntry objectEntry1 = _addObjectEntry(
+			_objectDefinition1, WorkflowConstants.STATUS_APPROVED);
+		ObjectEntry objectEntry2 = _addObjectEntry(
+			_objectDefinition1, WorkflowConstants.STATUS_APPROVED);
+
+		Page<com.liferay.object.model.ObjectEntry> page =
+			_defaultObjectEntryManager.getServiceBuilderObjectEntries(
+				TestPropsValues.getCompanyId(), _objectDefinition1, null,
+				dtoConverterContext, null, Pagination.of(1, 20), null, null);
+
+		Assert.assertEquals(2, page.getTotalCount());
+
+		List<com.liferay.object.model.ObjectEntry> serviceBuilderObjectEntries =
+			new ArrayList<>(page.getItems());
+
+		Assert.assertEquals(
+			serviceBuilderObjectEntries.toString(), 2,
+			serviceBuilderObjectEntries.size());
+
+		com.liferay.object.model.ObjectEntry serviceBuilderObjectEntry1 =
+			serviceBuilderObjectEntries.get(0);
+
+		Assert.assertEquals(
+			objectEntry1.getId(),
+			Long.valueOf(serviceBuilderObjectEntry1.getObjectEntryId()));
+		Assert.assertEquals(
+			_objectEntryLocalService.getValues(
+				serviceBuilderObjectEntry1.getObjectEntryId()),
+			serviceBuilderObjectEntry1.getValues());
+
+		com.liferay.object.model.ObjectEntry serviceBuilderObjectEntry2 =
+			serviceBuilderObjectEntries.get(1);
+
+		Assert.assertEquals(
+			objectEntry2.getId(),
+			Long.valueOf(serviceBuilderObjectEntry2.getObjectEntryId()));
+		Assert.assertEquals(
+			_objectEntryLocalService.getValues(
+				serviceBuilderObjectEntry2.getObjectEntryId()),
+			serviceBuilderObjectEntry2.getValues());
+	}
+
+	@Test
 	public void testGetVersionedObjectEntries() throws Exception {
 
 		// Company scope

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/security/permission/resource/ObjectEntryModelResourcePermission.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/security/permission/resource/ObjectEntryModelResourcePermission.java
@@ -155,9 +155,7 @@ public class ObjectEntryModelResourcePermission
 			objectEntry = rootObjectEntry;
 		}
 
-		ObjectDefinition objectDefinition =
-			_objectDefinitionLocalService.getObjectDefinition(
-				objectEntry.getObjectDefinitionId());
+		ObjectDefinition objectDefinition = objectEntry.getObjectDefinition();
 
 		if (Objects.equals(actionId, ActionKeys.DOWNLOAD) &&
 			Objects.equals(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/http/ObjectEntryServiceHttp.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/http/ObjectEntryServiceHttp.java
@@ -166,6 +166,43 @@ public class ObjectEntryServiceHttp {
 		}
 	}
 
+	public static void checkModelResourcePermission(
+			HttpPrincipal httpPrincipal,
+			com.liferay.object.model.ObjectEntry objectEntry, String actionId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				ObjectEntryServiceUtil.class, "checkModelResourcePermission",
+				_checkModelResourcePermissionParameterTypes3);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, objectEntry, actionId);
+
+			try {
+				TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
 	public static com.liferay.object.model.ObjectEntry copyObjectEntry(
 			HttpPrincipal httpPrincipal, long objectEntryId,
 			long objectEntryFolderId,
@@ -176,7 +213,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "copyObjectEntry",
-				_copyObjectEntryParameterTypes3);
+				_copyObjectEntryParameterTypes4);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, objectEntryId, objectEntryFolderId, values,
@@ -217,7 +254,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "deleteObjectEntry",
-				_deleteObjectEntryParameterTypes4);
+				_deleteObjectEntryParameterTypes5);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, objectEntryId);
@@ -258,7 +295,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "expireObjectEntry",
-				_expireObjectEntryParameterTypes5);
+				_expireObjectEntryParameterTypes6);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, objectEntryId, serviceContext);
@@ -300,7 +337,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "fetchManyToOneObjectEntry",
-				_fetchManyToOneObjectEntryParameterTypes6);
+				_fetchManyToOneObjectEntryParameterTypes7);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, objectRelationshipId, primaryKey);
@@ -340,7 +377,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "fetchObjectEntry",
-				_fetchObjectEntryParameterTypes7);
+				_fetchObjectEntryParameterTypes8);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, objectEntryId);
@@ -381,7 +418,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "fetchObjectEntry",
-				_fetchObjectEntryParameterTypes8);
+				_fetchObjectEntryParameterTypes9);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, externalReferenceCode, groupId, objectDefinitionId);
@@ -424,7 +461,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "getManyToManyObjectEntries",
-				_getManyToManyObjectEntriesParameterTypes9);
+				_getManyToManyObjectEntriesParameterTypes10);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, objectRelationshipId, primaryKey, related,
@@ -468,7 +505,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "getManyToManyObjectEntriesCount",
-				_getManyToManyObjectEntriesCountParameterTypes10);
+				_getManyToManyObjectEntriesCountParameterTypes11);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, objectRelationshipId, primaryKey, related,
@@ -511,7 +548,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "getModelResourcePermission",
-				_getModelResourcePermissionParameterTypes11);
+				_getModelResourcePermissionParameterTypes12);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, objectDefinitionId);
@@ -555,7 +592,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "getObjectEntries",
-				_getObjectEntriesParameterTypes12);
+				_getObjectEntriesParameterTypes13);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, objectDefinitionId, status, start, end);
@@ -596,7 +633,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "getObjectEntriesCount",
-				_getObjectEntriesCountParameterTypes13);
+				_getObjectEntriesCountParameterTypes14);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, objectDefinitionId, status);
@@ -629,7 +666,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "getObjectEntry",
-				_getObjectEntryParameterTypes14);
+				_getObjectEntryParameterTypes15);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, objectEntryId);
@@ -670,7 +707,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "getObjectEntry",
-				_getObjectEntryParameterTypes15);
+				_getObjectEntryParameterTypes16);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, externalReferenceCode, groupId, objectDefinitionId);
@@ -716,7 +753,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "getOneToManyObjectEntries",
-				_getOneToManyObjectEntriesParameterTypes16);
+				_getOneToManyObjectEntriesParameterTypes17);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, objectRelationshipId, predicate,
@@ -761,7 +798,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "getOneToManyObjectEntriesCount",
-				_getOneToManyObjectEntriesCountParameterTypes17);
+				_getOneToManyObjectEntriesCountParameterTypes18);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, objectRelationshipId, predicate, primaryKey,
@@ -803,7 +840,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "getOrAddEmptyObjectEntry",
-				_getOrAddEmptyObjectEntryParameterTypes18);
+				_getOrAddEmptyObjectEntryParameterTypes19);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, externalReferenceCode, groupId, objectDefinitionId);
@@ -844,7 +881,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "hasModelResourcePermission",
-				_hasModelResourcePermissionParameterTypes19);
+				_hasModelResourcePermissionParameterTypes20);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, objectDefinitionId, objectEntryId, actionId);
@@ -885,7 +922,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "hasModelResourcePermission",
-				_hasModelResourcePermissionParameterTypes20);
+				_hasModelResourcePermissionParameterTypes21);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, objectEntry, actionId);
@@ -927,7 +964,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "hasModelResourcePermission",
-				_hasModelResourcePermissionParameterTypes21);
+				_hasModelResourcePermissionParameterTypes22);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, user, objectEntryId, actionId);
@@ -968,7 +1005,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "hasPortletResourcePermission",
-				_hasPortletResourcePermissionParameterTypes22);
+				_hasPortletResourcePermissionParameterTypes23);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, objectDefinitionId, actionId);
@@ -1011,7 +1048,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "moveObjectEntry",
-				_moveObjectEntryParameterTypes23);
+				_moveObjectEntryParameterTypes24);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, objectEntryId, objectEntryFolderId, values,
@@ -1054,7 +1091,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "moveObjectEntryToTrash",
-				_moveObjectEntryToTrashParameterTypes24);
+				_moveObjectEntryToTrashParameterTypes25);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, objectEntry, serviceContext);
@@ -1097,7 +1134,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "partialUpdateObjectEntry",
-				_partialUpdateObjectEntryParameterTypes25);
+				_partialUpdateObjectEntryParameterTypes26);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, objectEntryId, objectEntryFolderId, values,
@@ -1141,7 +1178,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "restoreObjectEntryFromTrash",
-				_restoreObjectEntryFromTrashParameterTypes26);
+				_restoreObjectEntryFromTrashParameterTypes27);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, objectEntry, serviceContext);
@@ -1181,7 +1218,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "subscribeObjectEntry",
-				_subscribeObjectEntryParameterTypes27);
+				_subscribeObjectEntryParameterTypes28);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, objectEntryId);
@@ -1217,7 +1254,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "unsubscribeObjectEntry",
-				_unsubscribeObjectEntryParameterTypes28);
+				_unsubscribeObjectEntryParameterTypes29);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, objectEntryId);
@@ -1256,7 +1293,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "updateObjectEntry",
-				_updateObjectEntryParameterTypes29);
+				_updateObjectEntryParameterTypes30);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, objectEntryId, objectEntryFolderId, values,
@@ -1300,7 +1337,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "validate",
-				_validateParameterTypes30);
+				_validateParameterTypes31);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, objectEntry,
@@ -1349,44 +1386,48 @@ public class ObjectEntryServiceHttp {
 		_checkModelResourcePermissionParameterTypes2 = new Class[] {
 			long.class, long.class, String.class
 		};
-	private static final Class<?>[] _copyObjectEntryParameterTypes3 =
+	private static final Class<?>[]
+		_checkModelResourcePermissionParameterTypes3 = new Class[] {
+			com.liferay.object.model.ObjectEntry.class, String.class
+		};
+	private static final Class<?>[] _copyObjectEntryParameterTypes4 =
 		new Class[] {
 			long.class, long.class, java.util.Map.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _deleteObjectEntryParameterTypes4 =
+	private static final Class<?>[] _deleteObjectEntryParameterTypes5 =
 		new Class[] {long.class};
-	private static final Class<?>[] _expireObjectEntryParameterTypes5 =
+	private static final Class<?>[] _expireObjectEntryParameterTypes6 =
 		new Class[] {
 			long.class, com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _fetchManyToOneObjectEntryParameterTypes6 =
+	private static final Class<?>[] _fetchManyToOneObjectEntryParameterTypes7 =
 		new Class[] {long.class, long.class, long.class};
-	private static final Class<?>[] _fetchObjectEntryParameterTypes7 =
-		new Class[] {long.class};
 	private static final Class<?>[] _fetchObjectEntryParameterTypes8 =
+		new Class[] {long.class};
+	private static final Class<?>[] _fetchObjectEntryParameterTypes9 =
 		new Class[] {String.class, long.class, long.class};
-	private static final Class<?>[] _getManyToManyObjectEntriesParameterTypes9 =
-		new Class[] {
+	private static final Class<?>[]
+		_getManyToManyObjectEntriesParameterTypes10 = new Class[] {
 			long.class, long.class, long.class, boolean.class, boolean.class,
 			String.class, int.class, int.class
 		};
 	private static final Class<?>[]
-		_getManyToManyObjectEntriesCountParameterTypes10 = new Class[] {
+		_getManyToManyObjectEntriesCountParameterTypes11 = new Class[] {
 			long.class, long.class, long.class, boolean.class, boolean.class,
 			String.class
 		};
 	private static final Class<?>[]
-		_getModelResourcePermissionParameterTypes11 = new Class[] {long.class};
-	private static final Class<?>[] _getObjectEntriesParameterTypes12 =
+		_getModelResourcePermissionParameterTypes12 = new Class[] {long.class};
+	private static final Class<?>[] _getObjectEntriesParameterTypes13 =
 		new Class[] {long.class, long.class, int.class, int.class, int.class};
-	private static final Class<?>[] _getObjectEntriesCountParameterTypes13 =
+	private static final Class<?>[] _getObjectEntriesCountParameterTypes14 =
 		new Class[] {long.class, long.class, int.class};
-	private static final Class<?>[] _getObjectEntryParameterTypes14 =
-		new Class[] {long.class};
 	private static final Class<?>[] _getObjectEntryParameterTypes15 =
+		new Class[] {long.class};
+	private static final Class<?>[] _getObjectEntryParameterTypes16 =
 		new Class[] {String.class, long.class, long.class};
-	private static final Class<?>[] _getOneToManyObjectEntriesParameterTypes16 =
+	private static final Class<?>[] _getOneToManyObjectEntriesParameterTypes17 =
 		new Class[] {
 			long.class, long.class,
 			com.liferay.petra.sql.dsl.expression.Predicate.class, boolean.class,
@@ -1394,63 +1435,63 @@ public class ObjectEntryServiceHttp {
 			com.liferay.portal.kernel.search.Sort[].class
 		};
 	private static final Class<?>[]
-		_getOneToManyObjectEntriesCountParameterTypes17 = new Class[] {
+		_getOneToManyObjectEntriesCountParameterTypes18 = new Class[] {
 			long.class, long.class,
 			com.liferay.petra.sql.dsl.expression.Predicate.class, long.class,
 			boolean.class, String.class
 		};
-	private static final Class<?>[] _getOrAddEmptyObjectEntryParameterTypes18 =
+	private static final Class<?>[] _getOrAddEmptyObjectEntryParameterTypes19 =
 		new Class[] {String.class, long.class, long.class};
 	private static final Class<?>[]
-		_hasModelResourcePermissionParameterTypes19 = new Class[] {
-			long.class, long.class, String.class
-		};
-	private static final Class<?>[]
 		_hasModelResourcePermissionParameterTypes20 = new Class[] {
-			com.liferay.object.model.ObjectEntry.class, String.class
+			long.class, long.class, String.class
 		};
 	private static final Class<?>[]
 		_hasModelResourcePermissionParameterTypes21 = new Class[] {
+			com.liferay.object.model.ObjectEntry.class, String.class
+		};
+	private static final Class<?>[]
+		_hasModelResourcePermissionParameterTypes22 = new Class[] {
 			com.liferay.portal.kernel.model.User.class, long.class, String.class
 		};
 	private static final Class<?>[]
-		_hasPortletResourcePermissionParameterTypes22 = new Class[] {
+		_hasPortletResourcePermissionParameterTypes23 = new Class[] {
 			long.class, long.class, String.class
 		};
-	private static final Class<?>[] _moveObjectEntryParameterTypes23 =
+	private static final Class<?>[] _moveObjectEntryParameterTypes24 =
 		new Class[] {
 			long.class, long.class, java.util.Map.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _moveObjectEntryToTrashParameterTypes24 =
+	private static final Class<?>[] _moveObjectEntryToTrashParameterTypes25 =
 		new Class[] {
 			com.liferay.object.model.ObjectEntry.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _partialUpdateObjectEntryParameterTypes25 =
+	private static final Class<?>[] _partialUpdateObjectEntryParameterTypes26 =
 		new Class[] {
 			long.class, long.class, java.util.Map.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
 	private static final Class<?>[]
-		_restoreObjectEntryFromTrashParameterTypes26 = new Class[] {
+		_restoreObjectEntryFromTrashParameterTypes27 = new Class[] {
 			com.liferay.object.model.ObjectEntry.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _subscribeObjectEntryParameterTypes27 =
+	private static final Class<?>[] _subscribeObjectEntryParameterTypes28 =
 		new Class[] {long.class, long.class};
-	private static final Class<?>[] _unsubscribeObjectEntryParameterTypes28 =
+	private static final Class<?>[] _unsubscribeObjectEntryParameterTypes29 =
 		new Class[] {long.class};
-	private static final Class<?>[] _updateObjectEntryParameterTypes29 =
+	private static final Class<?>[] _updateObjectEntryParameterTypes30 =
 		new Class[] {
 			long.class, long.class, java.util.Map.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _validateParameterTypes30 = new Class[] {
+	private static final Class<?>[] _validateParameterTypes31 = new Class[] {
 		long.class, com.liferay.object.model.ObjectEntry.class,
 		java.util.List.class,
 		com.liferay.portal.kernel.service.ServiceContext.class
 	};
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2008799208
+// LIFERAY-SERVICE-BUILDER-HASH:145977417

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryServiceImpl.java
@@ -157,6 +157,21 @@ public class ObjectEntryServiceImpl extends ObjectEntryServiceBaseImpl {
 	}
 
 	@Override
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public void checkModelResourcePermission(
+			ObjectEntry objectEntry, String actionId)
+		throws PortalException {
+
+		ObjectDefinition objectDefinition = objectEntry.getObjectDefinition();
+
+		_checkPermission(
+			actionId,
+			ModelResourcePermissionRegistryUtil.getModelResourcePermission(
+				objectDefinition.getClassName()),
+			objectEntry);
+	}
+
+	@Override
 	public ObjectEntry copyObjectEntry(
 			long objectEntryId, long objectEntryFolderId,
 			Map<String, Serializable> values, ServiceContext serviceContext)
@@ -774,8 +789,16 @@ public class ObjectEntryServiceImpl extends ObjectEntryServiceBaseImpl {
 			String actionId, long objectDefinitionId, ObjectEntry objectEntry)
 		throws PortalException {
 
-		ModelResourcePermission<ObjectEntry> modelResourcePermission =
-			getModelResourcePermission(objectDefinitionId);
+		_checkPermission(
+			actionId, getModelResourcePermission(objectDefinitionId),
+			objectEntry);
+	}
+
+	private void _checkPermission(
+			String actionId,
+			ModelResourcePermission<ObjectEntry> modelResourcePermission,
+			ObjectEntry objectEntry)
+		throws PortalException {
 
 		if (objectEntry.isRootDescendantNode() &&
 			(actionId.equals(ActionKeys.DELETE) ||

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/collection/provider/ObjectEntrySingleFormVariationInfoCollectionProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/collection/provider/ObjectEntrySingleFormVariationInfoCollectionProvider.java
@@ -489,6 +489,29 @@ public class ObjectEntrySingleFormVariationInfoCollectionProvider
 
 		Group scopeGroup = themeDisplay.getScopeGroup();
 
+		if (objectEntryManager instanceof
+				DefaultObjectEntryManager defaultObjectEntryManager) {
+
+			Page<ObjectEntry> objectEntriesPage =
+				defaultObjectEntryManager.getServiceBuilderObjectEntries(
+					themeDisplay.getCompanyId(), _objectDefinition,
+					scopeGroup.getGroupKey(),
+					new DefaultDTOConverterContext(
+						false, null, null, null, null, themeDisplay.getLocale(),
+						null, themeDisplay.getUser()),
+					_getFilterString(collectionQuery),
+					ObjectEntryInfoCollectionProviderUtil.getPagination(
+						collectionQuery.getPagination()),
+					ObjectEntryInfoCollectionProviderUtil.getSearch(
+						collectionQuery),
+					_SORTS_DEFAULT_OBJECT_ENTRY);
+
+			return InfoPage.of(
+				new ArrayList<>(objectEntriesPage.getItems()),
+				collectionQuery.getPagination(),
+				(int)objectEntriesPage.getTotalCount());
+		}
+
 		Page<com.liferay.object.rest.dto.v1_0.ObjectEntry> objectEntriesPage =
 			objectEntryManager.getObjectEntries(
 				themeDisplay.getCompanyId(), _objectDefinition,

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/updater/ObjectEntryInfoItemFieldValuesUpdater.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/updater/ObjectEntryInfoItemFieldValuesUpdater.java
@@ -117,47 +117,55 @@ public class ObjectEntryInfoItemFieldValuesUpdater
 				objectEntry.getGroupId(), _objectDefinition,
 				_objectScopeProviderRegistry);
 
-			_deleteRelatedObjectEntries(
-				themeDisplay.getCompanyId(),
+			DTOConverterContext dtoConverterContext =
 				new DefaultDTOConverterContext(
 					false, null, null, null, null, themeDisplay.getLocale(),
-					null, themeDisplay.getUser()),
+					null, themeDisplay.getUser());
+
+			_deleteRelatedObjectEntries(
+				themeDisplay.getCompanyId(), dtoConverterContext,
 				infoItemFieldValues, scopeKey);
 
-			com.liferay.object.rest.dto.v1_0.ObjectEntry dtoObjectEntry =
-				ObjectEntryManagerUtil.partialUpdateObjectEntry(
-					objectEntryManager.getObjectEntry(
-						objectEntry.getCompanyId(),
-						new DefaultDTOConverterContext(
-							false, null, null, null, null,
-							themeDisplay.getLocale(), null,
-							themeDisplay.getUser()),
-						objectEntry.getExternalReferenceCode(),
-						_objectDefinition, scopeKey),
-					_objectDefinition.getObjectDefinitionId(),
-					new com.liferay.object.rest.dto.v1_0.ObjectEntry() {
-						{
-							setFriendlyUrlPath(
-								() -> GetterUtil.getString(
-									curProperties.get("objectEntryFriendlyURL"),
-									null));
-							setFriendlyUrlPath_i18n(
-								() -> (Map<String, String>)curProperties.get(
-									"objectEntryFriendlyURL_i18n"));
-							setKeywords(serviceContext::getAssetTagNames);
-							setProperties(() -> curProperties);
-							setStatus(
-								() -> new Status() {
-									{
-										setCode(() -> statusInt);
-									}
-								});
-							setTaxonomyCategoryBriefs(
-								() -> _toTaxonomyCategoryBriefs(
-									serviceContext.getAssetCategoryIds(),
-									themeDisplay.getLocale()));
-						}
-					});
+			com.liferay.object.rest.dto.v1_0.ObjectEntry dtoObjectEntry = null;
+
+			if (objectEntryManager instanceof
+					DefaultObjectEntryManager defaultObjectEntryManager) {
+
+				dtoObjectEntry = defaultObjectEntryManager.getObjectEntry(
+					dtoConverterContext, _objectDefinition, objectEntry);
+			}
+			else {
+				dtoObjectEntry = objectEntryManager.getObjectEntry(
+					objectEntry.getCompanyId(), dtoConverterContext,
+					objectEntry.getExternalReferenceCode(), _objectDefinition,
+					scopeKey);
+			}
+
+			dtoObjectEntry = ObjectEntryManagerUtil.partialUpdateObjectEntry(
+				dtoObjectEntry, _objectDefinition.getObjectDefinitionId(),
+				new com.liferay.object.rest.dto.v1_0.ObjectEntry() {
+					{
+						setFriendlyUrlPath(
+							() -> GetterUtil.getString(
+								curProperties.get("objectEntryFriendlyURL"),
+								null));
+						setFriendlyUrlPath_i18n(
+							() -> (Map<String, String>)curProperties.get(
+								"objectEntryFriendlyURL_i18n"));
+						setKeywords(serviceContext::getAssetTagNames);
+						setProperties(() -> curProperties);
+						setStatus(
+							() -> new Status() {
+								{
+									setCode(() -> statusInt);
+								}
+							});
+						setTaxonomyCategoryBriefs(
+							() -> _toTaxonomyCategoryBriefs(
+								serviceContext.getAssetCategoryIds(),
+								themeDisplay.getLocale()));
+					}
+				});
 
 			if (curProperties.containsKey("displayDate") ||
 				curProperties.containsKey("expirationDate") ||


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-104918

Second change of the object entry listing optimization tracked under LPD-65366 (LPD-98910 scenario: a site page whose collection display lists a custom object's entries). It follows #181419, #181421 and #181454, which serve a listing with no query from a finder. The next change, the bulk load of a page's values, builds on the instances this one lets flow.

## What Is Being Fixed

Every row of the collection page that reaches the info item layer is resolved again although the caller already holds it. `ObjectEntryInfoItemUtil` and `ObjectEntryInfoItemFieldValuesUpdater` ask the default object entry manager for the entry by external reference code, a unique finder lookup that can only return the row in hand, and get a new instance whose values are read again. The remote permission check, given the entry's primary key, loads the entry again, and the model resource permission asks the definition service for every entry's definition. The collection provider wraps DTOs in proxy shells, so the fragment never sees the entities the listing loaded. The listing resolves the scope provider twice.

## How It Is Being Fixed

- The permission check reads the definition the entry carries; the entry's own accessor loads it on demand when nothing has set it.
- `ObjectEntryService.checkModelResourcePermission(ObjectEntry, String)` checks the entry in hand and takes the model resource permission from the entry's definition.
- `DefaultObjectEntryManager.getObjectEntry(DTOConverterContext, ObjectDefinition, ObjectEntry)` converts the entry in hand: the same view check with the root descendant rule of the remote service and the skip flag of `ObjectEntryThreadLocal`, then the same approved, definition and root descendant checks and the same conversion as the lookup path. `ObjectEntryInfoItemUtil` and the updater use it, and a head entry is no longer refetched by its own id.
- `BaseObjectEntryManager.getGroupId` accepts the scope provider its caller already resolved, so a listing resolves it once.
- `DefaultObjectEntryManager.getServiceBuilderObjectEntries` exposes the page of entries the DTO listing is built from, and `ObjectEntrySingleFormVariationInfoCollectionProvider` hands those entities to the fragment instead of shells built from the DTOs.

The statement count of the page does not change with this PR; the per-row service calls and lookups above go, and the same instances now travel from the listing to the fragment.

## Verification

- `DefaultObjectEntryManagerImplTest.testGetObjectEntry` covers the conversion of the entry in hand and its view check; `testGetServiceBuilderObjectEntries` covers the entity page against the DTO listing in order and count; `ObjectEntryInfoItemFieldValuesProviderTest` covers the info item values from the entry in hand.
- Self-CI on shuyangzhou/liferay-portal PR 12751: `ci:test:stable` 16/16 and `ci:test:object` 50/50 on this exact head (`9c6a6a8`, 2026-09-08). `ci:test:relevant` twice: 100/125 on the head and 42/45 on an identical-tree marker commit. Its integration failures are in common with upstream. The Playwright axes unique to the pull are, on both runs, the export-import and staging tests (Clarity site initializer round trip, staging use cases, instance export, Tags import report), each a timeout waiting on a background task, with a chronic failure history on master; the first run also carried Analytics Cloud client and UI tests failing on a backend returning 500, the CMP task tests that failed identically in another run that morning, and two single occurrences (a page editor mapping toast, a layout change tracking DataGuard leftover) that did not recur on the rerun. Nothing in them touches the object modules this change edits.

## PR Check

**pr-check: PASS** — tested on `9c6a6a8f62e8f5b14eea6db751bd06c3327abd18`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Service Registration | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | NOT VERIFIED |
| Baseline | PASS (baseline-all + seven Ant projects + 3 changed exporting modules compared against Nexus) |
| Structural Smoke | PASS |
| Java Unit Tests | NOT VERIFIED |

Cross-Module Compile verified nothing: the by-type-name consumer scan found 9 test modules, above the validation's cap of 8; Integration Test Compile covers 5 of them, and the remaining four (`headless-admin-user-test`, `layout-page-template-test`, `mcp-server-rest-test`, `site-dsr-site-initializer-test`) are exercised by the object and relevant suites of the self-CI. Java Unit Tests verified nothing: none of the changed classes has a unit test; their coverage is the integration tests named above, which run in the object suite. The `object-api`, `object-info-api` and `object-rest-api` minor bumps in the branch's Semantic versioning commit are exactly what Baseline requires.

<!-- pr-check {"result": "success", "sha": "9c6a6a8f62e8f5b14eea6db751bd06c3327abd18"} -->
