### PR TITLE
LPD-105183 Drop superseded responses in the relationship autocomplete

### DIFF
--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/ObjectRelationship/ObjectRelationship.tsx
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/ObjectRelationship/ObjectRelationship.tsx
@@ -163,6 +163,8 @@ export default function ObjectRelationship({
 
 	const onChangeRef = useRef(onChange);
 
+	const latestURLRef = useRef<string | null>(null);
+
 	const parameterObjectFieldId = parameterObjectFieldName
 		? objectRelationships?.[parameterObjectFieldName]
 		: null;
@@ -202,11 +204,17 @@ export default function ObjectRelationship({
 				return;
 			}
 
+			latestURLRef.current = newURL;
+
 			setState((prevState) => ({...prevState, loading: true}));
 
 			try {
 				const items =
 					(await fetchOptions<Resource>(newURL))?.items ?? [];
+
+				if (latestURLRef.current !== newURL) {
+					return;
+				}
 
 				const state: State = {
 					list:
@@ -235,6 +243,10 @@ export default function ObjectRelationship({
 							`${baseAPIURL}/${value}${apiURLQueryString ? `?${apiURLQueryString}` : ''}`
 						);
 
+						if (latestURLRef.current !== newURL) {
+							return;
+						}
+
 						selected = matchesValue(item) ? item : undefined;
 					}
 
@@ -252,13 +264,18 @@ export default function ObjectRelationship({
 				}));
 			}
 			catch (error) {
+				console.error(error);
+
+				if (latestURLRef.current !== newURL) {
+					return;
+				}
+
 				setState(({active, searchTerm}) => ({
 					active,
 					loading: false,
 					searchTerm,
 					url,
 				}));
-				console.error(error);
 			}
 		};
 

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/tests/ObjectRelationship.spec.tsx
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/tests/ObjectRelationship.spec.tsx
@@ -4,7 +4,7 @@
  */
 
 import '@testing-library/jest-dom';
-import {fireEvent, render, waitFor} from '@testing-library/react';
+import {act, fireEvent, render, waitFor} from '@testing-library/react';
 import {fetch} from 'frontend-js-web';
 import React from 'react';
 
@@ -86,6 +86,50 @@ describe('fetchData', () => {
 		await waitFor(() =>
 			expect(onChange).toHaveBeenCalledWith({target: {value: null}})
 		);
+	});
+
+	it('ignores the response of a request the search term has superseded', async () => {
+		let resolveInitialFetch: (response: unknown) => void = () => {};
+
+		(fetch as jest.Mock)
+			.mockReset()
+			.mockReturnValueOnce(
+				new Promise((resolve) => {
+					resolveInitialFetch = resolve;
+				})
+			)
+			.mockResolvedValueOnce({
+				json: () => Promise.resolve({items: [{id: 2, label: 'Org B'}]}),
+			});
+
+		const {getAllByRole, getByRole} = render(
+			<ObjectRelationship {...DEFAULT_PROPS} apiURL={API_URL} />
+		);
+
+		fireEvent.focus(getByRole('textbox'));
+		fireEvent.change(getByRole('textbox'), {target: {value: 'Org B'}});
+
+		await waitFor(() =>
+			expect(getByRole('menu')).toHaveTextContent('Org B')
+		);
+
+		await act(async () => {
+			resolveInitialFetch({
+				json: () =>
+					Promise.resolve({
+						items: [
+							{id: 1, label: 'Org A'},
+							{id: 2, label: 'Org B'},
+						],
+					}),
+			});
+
+			await new Promise((resolve) => setTimeout(resolve, 0));
+		});
+
+		expect(getAllByRole('menuitem')).toHaveLength(1);
+		expect(getByRole('menu')).not.toHaveTextContent('Org A');
+		expect(fetch).toHaveBeenCalledTimes(2);
 	});
 
 	it('joins the search term with "&" when the apiURL already has a query string', async () => {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-105183

`ci:test:object` Playwright failure fix, under the Objects stabilization epic LPD-99314. Product fix in the relationship field of the object entry form.

## What Is Being Fixed

`object-web/entry/objectEntry.spec.ts`, "can view all entries related to an object in the relationship field using autocomplete", fails right after typing into the relationship field:

```
Error: expect.toContainText: Error: strict mode violation: getByRole('menuitem') resolved to 2 elements:
    1) <button role="menuitem" class="dropdown-item">…</button> aka getByRole('menuitem', { name: 'test 1' })
    2) <button role="menuitem" class="dropdown-item">test 2</button> aka getByRole('menuitem', { name: 'test 2' })
```

`ObjectRelationship.tsx` fetches its candidates when the field mounts (`GET /o/c/<plural>`, unfiltered) and again on every change of the search term (`?search=<term>`), and its data effect wrote the dropdown list from whichever response resolved. Nothing tied a response to the term it answered. In the CI trace (test-1-41 build 181, axis playwright 1/0) the main thread was still mounting the form when the test typed `t 1`, both fetch continuations queued, and the older unfiltered payload rendered first: the menu opened with both entries next to the typed term, the single-element assertion died on the spot (strict mode violations are not retried), and the stale URL the response stored re-ran the effect, which fetched the same search a second time. A user typing quickly sees the same flash of the previous list and pays the same redundant request.

## How It Is Being Fixed

The effect remembers the URL of the latest request it issued and drops a response, the follow-up by-id fetch, or a failure whose URL is no longer the latest, so the list only ever reflects the current search term and no stale URL is stored. A Jest test resolves the mount fetch after the filtered one has rendered and asserts the list keeps the single filtered item and no further request is made.

Root cause: 935d0266838f5 (LPS-157898, 2022-07-06) migrated the field to TypeScript and made it fetch per URL, writing the list from each response as it resolved with no check that the response still matched the current term; 4eed61eca990e (LPD-17930) restructured the effect for ESM and kept that shape.

## Verification

Local, on a clean bundle at brianchandotcom/master 0a79b7a (`--retries=0 --timeout=30000 --workers=1`):

- Amplifier: the unfiltered request held until the fill had completed, the filtered request held 1500 ms, and the page's CPU throttled 20x from right after the fill to right after the assertion (the wrong list lives only between React's commit and its passive-effect task, so an idle main thread never shows it to the poll; CI's saturated thread did). Control 5/5 failed with the CI signature, each run issuing the search request twice; fixed 5/5 passed, each run issuing it once.
- Fix alone, unamplified: 3/3. The whole spec file: 93 passed, 0 failed.
- Jest: the module's `ObjectRelationship.spec.tsx` passes 7/7 with the fix; the new test fails on the original component (three fetch calls instead of two).
- Self-CI on shuyangzhou/liferay-portal PR 12750: `ci:test:stable` 16/16, `ci:test:relevant` 13/13, and `ci:test:object` three times on the same tree with distinct SHAs so no run is a cached replay (fix head `35801bd` and two empty marker commits): 50/50, 50/50, 50/50.

The CI history of this signature: three occurrences in about two years (2025-01-27, 2025-04-11, 2026-09-08), always this test; the Page Templates variant never types into the field and never failed this way.

## PR Check

**pr-check: PASS** — tested on `7c0cd594fdb3352745ac94f3d64f1fb56f512b7f`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| HTML Escaping | PASS |
| Per-Module Compile | PASS |
| Baseline | PASS (baseline-all + seven Ant projects + 0 changed exporting modules) |
| JavaScript Unit Tests | PASS |

JavaScript Unit Tests ran the changed module's full suite (8 suites, 68 tests, including the new `ignores the response of a request the search term has superseded`) and the full suite of its one declared consumer, `site-cmp-site-initializer` (49 suites, 312 tests). Source Format's TypeScript check ran over both TypeScript projects, and Per-Module Compile confirmed the changed `.tsx` reached the deployed bundle rather than trusting an `UP-TO-DATE` task line. The module exports no package, so no version bump is required.

<!-- pr-check {"result": "success", "sha": "7c0cd594fdb3352745ac94f3d64f1fb56f512b7f"} -->
