### PR TITLE
LPD-95092 Add a sample CX for CKEditor 5 email editing plugins

### DIFF
--- a/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/env/client-extensions.list
+++ b/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/env/client-extensions.list
@@ -2,3 +2,5 @@ liferay-sample-editor-config-contributor-1
 liferay-sample-editor-config-contributor-2
 liferay-sample-editor-config-contributor-3
 liferay-sample-editor-config-contributor-4
+liferay-sample-editor-config-contributor-5
+liferay-sample-editor-config-contributor-6

--- a/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor5/react_cet_premium.spec.ts
+++ b/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor5/react_cet_premium.spec.ts
@@ -127,23 +127,23 @@ if (!process.env.CI) {
 			);
 		}
 	);
-}
 
-test(
-	'Email editing buttons added via client extension appear in the toolbar',
-	{tag: '@LPD-95092'},
-	async ({classicPage}) => {
-		const emailEditingButtons = [
-			{name: 'Insert merge field'},
-			{name: 'Insert template'},
-			{name: 'Merge fields preview'},
-			{exact: true, name: 'Preview with Inline Styles'},
-		];
+	test(
+		'Email editing buttons added via client extension appear in the toolbar',
+		{tag: '@LPD-95092'},
+		async ({classicPage}) => {
+			const emailEditingButtons = [
+				{name: 'Insert merge field'},
+				{name: 'Insert template'},
+				{name: 'Merge fields preview'},
+				{exact: true, name: 'Preview with Inline Styles'},
+			];
 
-		for (const options of emailEditingButtons) {
-			await expect(
-				classicPage.toolbar.container.getByRole('button', options)
-			).toBeVisible();
+			for (const options of emailEditingButtons) {
+				await expect(
+					classicPage.toolbar.container.getByRole('button', options)
+				).toBeVisible();
+			}
 		}
-	}
-);
+	);
+}

--- a/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor5/react_cet_premium.spec.ts
+++ b/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor5/react_cet_premium.spec.ts
@@ -128,3 +128,22 @@ if (!process.env.CI) {
 		}
 	);
 }
+
+test(
+	'Email editing buttons added via client extension appear in the toolbar',
+	{tag: '@LPD-95092'},
+	async ({classicPage}) => {
+		const emailEditingButtons = [
+			{name: 'Insert merge field'},
+			{name: 'Insert template'},
+			{name: 'Merge fields preview'},
+			{exact: true, name: 'Preview with Inline Styles'},
+		];
+
+		for (const options of emailEditingButtons) {
+			await expect(
+				classicPage.toolbar.container.getByRole('button', options)
+			).toBeVisible();
+		}
+	}
+);

--- a/workspaces/liferay-sample-workspace/README.md
+++ b/workspaces/liferay-sample-workspace/README.md
@@ -102,6 +102,10 @@ For `liferay-sample-etc-cron` and `liferay-sample-etc-spring-boot` the third typ
 
 	Add a document link selector button to the CKEditor 5 link dialog as an example of augmenting the link plugin for document browsing without portal dependencies.
 
+- *liferay-sample-editor-config-contributor-6*
+
+	Enable the CKEditor 5 email editing plugins (Email Configuration Helper, Merge Fields, Template, and Export with Inline Styles, plus the non-premium Layout Tables and Empty Block) as an example of registering premium and non-premium plugins via a client extension.
+
 - *liferay-sample-etc-cron*
 
 	Use Spring Boot and OAuth (server to server) to read from and write to Liferay in timed intervals.

--- a/workspaces/liferay-sample-workspace/README.md
+++ b/workspaces/liferay-sample-workspace/README.md
@@ -104,7 +104,7 @@ For `liferay-sample-etc-cron` and `liferay-sample-etc-spring-boot` the third typ
 
 - *liferay-sample-editor-config-contributor-6*
 
-	Enable the CKEditor 5 email editing plugins (Email Configuration Helper, Merge Fields, Template, and Export with Inline Styles, plus the non-premium Layout Tables and Empty Block) as an example of registering premium and non-premium plugins via a client extension.
+	Enable the CKEditor 5 email editing plugins (Email Configuration Helper, Merge Fields, Template, and Export with Inline Styles, plus the nonpremium Layout Tables and Empty Block) as an example of registering premium and nonpremium plugins via a client extension.
 
 - *liferay-sample-etc-cron*
 

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-editor-config-contributor-6/client-extension.dev.yaml
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-editor-config-contributor-6/client-extension.dev.yaml
@@ -1,0 +1,2 @@
+liferay-sample-editor-config-contributor-6:
+    baseURL: http://localhost:3004/build

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-editor-config-contributor-6/client-extension.dev.yaml
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-editor-config-contributor-6/client-extension.dev.yaml
@@ -1,2 +1,2 @@
 liferay-sample-editor-config-contributor-6:
-    baseURL: http://localhost:3004/build
+    baseURL: http://localhost:3003/build

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-editor-config-contributor-6/client-extension.yaml
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-editor-config-contributor-6/client-extension.yaml
@@ -1,0 +1,9 @@
+assemble:
+    -   from: build
+        into: static
+liferay-sample-editor-config-contributor-6:
+    editorConfigKeys:
+        -   sampleReactCETPremiumEditor
+    name: Liferay Sample Editor Config Contributor CKEditor 5 Email Editing
+    type: editorConfigContributor
+    url: index.js

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-editor-config-contributor-6/package.json
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-editor-config-contributor-6/package.json
@@ -1,0 +1,27 @@
+{
+	"dependencies": {
+		"@ckeditor/ckeditor5-core": "46.0.3",
+		"@ckeditor/ckeditor5-email": "46.0.3",
+		"@ckeditor/ckeditor5-export-inline-styles": "46.0.3",
+		"@ckeditor/ckeditor5-html-support": "46.0.3",
+		"@ckeditor/ckeditor5-merge-fields": "46.0.3",
+		"@ckeditor/ckeditor5-table": "46.0.3",
+		"@ckeditor/ckeditor5-template": "46.0.3",
+		"@ckeditor/ckeditor5-ui": "46.0.3",
+		"@liferay/js-api": "0.8.0"
+	},
+	"description": "Liferay Sample Editor Config Contributor CKEditor 5 Email Editing",
+	"devDependencies": {
+		"serve": "^14.2.0",
+		"typescript": "^5.0.4"
+	},
+	"main": "./src/index.ts",
+	"name": "@liferay/liferay-sample-editor-config-contributor-6",
+	"scripts": {
+		"build": "esbuild src/index.ts --outdir=build --bundle --format=esm --external:@ckeditor/*",
+		"start": "PORT=3004 serve --cors",
+		"watch": "tsc --watch"
+	},
+	"type": "module",
+	"version": "0.0.0"
+}

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-editor-config-contributor-6/package.json
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-editor-config-contributor-6/package.json
@@ -4,6 +4,7 @@
 		"@ckeditor/ckeditor5-email": "46.0.3",
 		"@ckeditor/ckeditor5-export-inline-styles": "46.0.3",
 		"@ckeditor/ckeditor5-html-support": "46.0.3",
+		"@ckeditor/ckeditor5-mention": "46.0.3",
 		"@ckeditor/ckeditor5-merge-fields": "46.0.3",
 		"@ckeditor/ckeditor5-table": "46.0.3",
 		"@ckeditor/ckeditor5-template": "46.0.3",

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-editor-config-contributor-6/package.json
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-editor-config-contributor-6/package.json
@@ -20,7 +20,7 @@
 	"name": "@liferay/liferay-sample-editor-config-contributor-6",
 	"scripts": {
 		"build": "esbuild src/index.ts --outdir=build --bundle --format=esm --external:@ckeditor/*",
-		"start": "PORT=3004 serve --cors",
+		"start": "PORT=3003 serve --cors",
 		"watch": "tsc --watch"
 	},
 	"type": "module",

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-editor-config-contributor-6/src/index.ts
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-editor-config-contributor-6/src/index.ts
@@ -7,6 +7,7 @@ import {Plugin} from '@ckeditor/ckeditor5-core/dist/index.js';
 import {EmailConfigurationHelper} from '@ckeditor/ckeditor5-email/dist/index.js';
 import {ExportInlineStyles} from '@ckeditor/ckeditor5-export-inline-styles/dist/index.js';
 import {EmptyBlock} from '@ckeditor/ckeditor5-html-support/dist/index.js';
+import {Mention} from '@ckeditor/ckeditor5-mention/dist/index.js';
 import {MergeFields} from '@ckeditor/ckeditor5-merge-fields/dist/index.js';
 import {Table} from '@ckeditor/ckeditor5-table/dist/index.js';
 import {Template} from '@ckeditor/ckeditor5-template/dist/index.js';
@@ -18,6 +19,49 @@ import {
 
 const EXPORT_ICON =
 	'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M10 13.5 5.5 9l1.4-1.4L9 9.7V2h2v7.7l2.1-2.1L14.5 9z"/><path d="M4 15h12v2H4z"/></svg>';
+
+const MERGE_FIELDS_CONFIG = {
+	dataSets: [
+		{
+			id: 'sample-recipient',
+			label: 'Sample Recipient',
+			values: {
+				'company-name': 'Liferay',
+				'email': 'jane.doe@example.com',
+				'first-name': 'Jane',
+				'last-name': 'Doe',
+			},
+		},
+	],
+	definitions: [
+		{
+			definitions: [
+				{id: 'first-name', label: 'First Name'},
+				{id: 'last-name', label: 'Last Name'},
+				{id: 'email', label: 'Email Address'},
+			],
+			groupId: 'recipient',
+			groupLabel: 'Recipient',
+		},
+		{id: 'company-name', label: 'Company Name'},
+	],
+};
+
+const TEMPLATE_CONFIG = {
+	definitions: [
+		{
+			data: '<p>Hi {{first-name}},</p><p>Welcome to {{company-name}}! We are excited to have you on board.</p>',
+			description:
+				'A short welcome message with merge fields for the recipient name and company.',
+			title: 'Welcome Email',
+		},
+		{
+			data: '<p>Best regards,<br>The {{company-name}} Team</p>',
+			description: 'A simple email sign-off.',
+			title: 'Signature',
+		},
+	],
+};
 
 class ExportInlineStylesPreview extends Plugin {
 	init() {
@@ -60,6 +104,7 @@ const editorConfigTransformer: EditorConfigTransformer<any> = (config) => {
 		Table,
 		EmptyBlock,
 		EmailConfigurationHelper,
+		Mention,
 		MergeFields,
 		Template,
 		ExportInlineStyles,
@@ -79,6 +124,8 @@ const editorConfigTransformer: EditorConfigTransformer<any> = (config) => {
 	return {
 		...config,
 		extraPlugins,
+		mergeFields: MERGE_FIELDS_CONFIG,
+		template: TEMPLATE_CONFIG,
 		toolbar: {
 			items: toolbarItems,
 		},

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-editor-config-contributor-6/src/index.ts
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-editor-config-contributor-6/src/index.ts
@@ -1,0 +1,92 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Plugin} from '@ckeditor/ckeditor5-core/dist/index.js';
+import {EmailConfigurationHelper} from '@ckeditor/ckeditor5-email/dist/index.js';
+import {ExportInlineStyles} from '@ckeditor/ckeditor5-export-inline-styles/dist/index.js';
+import {EmptyBlock} from '@ckeditor/ckeditor5-html-support/dist/index.js';
+import {MergeFields} from '@ckeditor/ckeditor5-merge-fields/dist/index.js';
+import {Table} from '@ckeditor/ckeditor5-table/dist/index.js';
+import {Template} from '@ckeditor/ckeditor5-template/dist/index.js';
+import {ButtonView} from '@ckeditor/ckeditor5-ui/dist/index.js';
+import {
+	EditorConfigTransformer,
+	EditorTransformer,
+} from '@liferay/js-api/editor';
+
+const EXPORT_ICON =
+	'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M10 13.5 5.5 9l1.4-1.4L9 9.7V2h2v7.7l2.1-2.1L14.5 9z"/><path d="M4 15h12v2H4z"/></svg>';
+
+class ExportInlineStylesPreview extends Plugin {
+	init() {
+		const editor = this.editor;
+
+		editor.ui.componentFactory.add('exportInlineStylesPreview', () => {
+			const button = new ButtonView();
+
+			button.set({
+				icon: EXPORT_ICON,
+				label: 'Preview with Inline Styles',
+				tooltip: true,
+			});
+
+			button.on('execute', async () => {
+				const html = await editor.commands.execute(
+					'exportInlineStyles',
+					{}
+				);
+
+				window.open(
+					URL.createObjectURL(new Blob([html], {type: 'text/html'})),
+					'_blank'
+				);
+			});
+
+			return button;
+		});
+	}
+}
+
+const editorConfigTransformer: EditorConfigTransformer<any> = (config) => {
+	const toolbar = config.toolbar as any;
+	const existingItems = Array.isArray(toolbar)
+		? toolbar
+		: toolbar?.items ?? [];
+
+	const extraPlugins = [
+		...(config.extraPlugins ?? []),
+		Table,
+		EmptyBlock,
+		EmailConfigurationHelper,
+		MergeFields,
+		Template,
+		ExportInlineStyles,
+		ExportInlineStylesPreview,
+	];
+
+	const toolbarItems = [
+		...existingItems,
+		'|',
+		'insertTable',
+		'insertMergeField',
+		'previewMergeFields',
+		'insertTemplate',
+		'exportInlineStylesPreview',
+	];
+
+	return {
+		...config,
+		extraPlugins,
+		toolbar: {
+			items: toolbarItems,
+		},
+	};
+};
+
+const editorTransformer: EditorTransformer<any> = {
+	editorConfigTransformer,
+};
+
+export default editorTransformer;

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-editor-config-contributor-6/tsconfig.json
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-editor-config-contributor-6/tsconfig.json
@@ -1,0 +1,21 @@
+{
+	"compilerOptions": {
+		"esModuleInterop": true,
+		"jsx": "react",
+		"lib": [
+			"DOM",
+			"ES2020"
+		],
+		"module": "ES2020",
+		"moduleResolution": "node",
+		"outDir": "./build",
+		"resolveJsonModule": true,
+		"sourceMap": false,
+		"target": "ES2020",
+		"types": [
+		]
+	},
+	"include": [
+		"./src/**/*"
+	]
+}

--- a/workspaces/liferay-sample-workspace/package.json
+++ b/workspaces/liferay-sample-workspace/package.json
@@ -33,7 +33,8 @@
 			"client-extensions/liferay-sample-custom-element-7",
 			"client-extensions/liferay-sample-editor-config-contributor-3",
 			"client-extensions/liferay-sample-editor-config-contributor-4",
-			"client-extensions/liferay-sample-editor-config-contributor-5"
+			"client-extensions/liferay-sample-editor-config-contributor-5",
+			"client-extensions/liferay-sample-editor-config-contributor-6"
 		]
 	}
 }

--- a/workspaces/liferay-sample-workspace/yarn.lock
+++ b/workspaces/liferay-sample-workspace/yarn.lock
@@ -1502,6 +1502,20 @@
     "@ckeditor/ckeditor5-utils" "48.2.0"
     es-toolkit "1.45.1"
 
+"@ckeditor/ckeditor5-email@46.0.3":
+  version "46.0.3"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-email/-/ckeditor5-email-46.0.3.tgz#1212dc70d55c7c45e3d3c6fc4ed63e530efc3386"
+  integrity sha512-t3nypkORG9UPGIc61yUfd9zzRiDDArOn799fvnkzeJf7Nym6Fu0823pmbzyEebLszdVlkg+BJLLC4m0aVTqBUQ==
+  dependencies:
+    "@ckeditor/ckeditor5-core" "46.0.3"
+    "@ckeditor/ckeditor5-export-inline-styles" "46.0.3"
+    "@ckeditor/ckeditor5-font" "46.0.3"
+    "@ckeditor/ckeditor5-html-support" "46.0.3"
+    "@ckeditor/ckeditor5-list" "46.0.3"
+    "@ckeditor/ckeditor5-table" "46.0.3"
+    "@ckeditor/ckeditor5-utils" "46.0.3"
+    ckeditor5 "46.0.3"
+
 "@ckeditor/ckeditor5-emoji@46.0.3":
   version "46.0.3"
   resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-emoji/-/ckeditor5-emoji-46.0.3.tgz#e129445b3a078b19268482b55dd769449922d636"
@@ -1555,6 +1569,17 @@
     "@ckeditor/ckeditor5-ui" "46.0.3"
     "@ckeditor/ckeditor5-undo" "46.0.3"
     ckeditor5 "46.0.3"
+
+"@ckeditor/ckeditor5-export-inline-styles@46.0.3":
+  version "46.0.3"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-export-inline-styles/-/ckeditor5-export-inline-styles-46.0.3.tgz#48c92e88b5660ce72f3b088039130572f780def0"
+  integrity sha512-HPzm/reWMsdbyMoL3y0EeIxUoecKlBA4ZKp4UmPWWOgzvG1F1nh3OBYzzbU8Fc1YWL/KroAATWKmO6Dp2BTpWA==
+  dependencies:
+    "@ckeditor/ckeditor5-core" "46.0.3"
+    "@ckeditor/ckeditor5-engine" "46.0.3"
+    "@ckeditor/ckeditor5-utils" "46.0.3"
+    ckeditor5 "46.0.3"
+    specificity "0.4.1"
 
 "@ckeditor/ckeditor5-find-and-replace@46.0.3":
   version "46.0.3"
@@ -1797,6 +1822,21 @@
     ckeditor5 "46.0.3"
     es-toolkit "1.39.5"
 
+"@ckeditor/ckeditor5-merge-fields@46.0.3":
+  version "46.0.3"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-merge-fields/-/ckeditor5-merge-fields-46.0.3.tgz#d881cd0f23d19eb3b7ec0d41cf6db701e7ecd2b4"
+  integrity sha512-2ZUmQc3NsuF7yzYTYhZOGr1Mc8mHPkxhlTbE10v6eHnW0/FATku4riD+NuKs5GgASeHGkf28D37cjHV+ZFZSWQ==
+  dependencies:
+    "@ckeditor/ckeditor5-core" "46.0.3"
+    "@ckeditor/ckeditor5-icons" "46.0.3"
+    "@ckeditor/ckeditor5-image" "46.0.3"
+    "@ckeditor/ckeditor5-mention" "46.0.3"
+    "@ckeditor/ckeditor5-ui" "46.0.3"
+    "@ckeditor/ckeditor5-utils" "46.0.3"
+    "@ckeditor/ckeditor5-widget" "46.0.3"
+    ckeditor5 "46.0.3"
+    es-toolkit "1.39.5"
+
 "@ckeditor/ckeditor5-minimap@46.0.3":
   version "46.0.3"
   resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-minimap/-/ckeditor5-minimap-46.0.3.tgz#ba170968a44a87557319ea6efcf97eb3d8923e3a"
@@ -1939,6 +1979,17 @@
     "@ckeditor/ckeditor5-widget" "46.0.3"
     ckeditor5 "46.0.3"
     es-toolkit "1.39.5"
+
+"@ckeditor/ckeditor5-template@46.0.3":
+  version "46.0.3"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-template/-/ckeditor5-template-46.0.3.tgz#bb97e5c862c7744495fc9daba73963f4d968ec7b"
+  integrity sha512-ULcr/nJHU9wO6j4CIlvQkiUw9KPoqc4nedGIZVuIOn3pnEwmCRccZ6K0WrBroc8f6ZPsn8g+XqrwXceyJeufDw==
+  dependencies:
+    "@ckeditor/ckeditor5-core" "46.0.3"
+    "@ckeditor/ckeditor5-icons" "46.0.3"
+    "@ckeditor/ckeditor5-ui" "46.0.3"
+    "@ckeditor/ckeditor5-utils" "46.0.3"
+    ckeditor5 "46.0.3"
 
 "@ckeditor/ckeditor5-theme-lark@46.0.3":
   version "46.0.3"
@@ -10328,6 +10379,11 @@ spdy@^4.0.2:
     http-deceiver "^1.2.7"
     select-hose "^2.0.0"
     spdy-transport "^3.0.0"
+
+specificity@0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/specificity/-/specificity-0.4.1.tgz#aab5e645012db08ba182e151165738d00887b019"
+  integrity sha512-1klA3Gi5PD1Wv9Q0wUoOQN1IWAuPu0D1U03ThXTr0cJ20+/iq2tHSDnK7Kk/0LXJ1ztUB2/1Os0wKmfyNgUQfg==
 
 sprintf-js@~1.0.2:
   version "1.0.3"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95092

Follow up of https://github.com/brianchandotcom/liferay-portal/pull/181427, adding one new commit that drops the hyphen from `nonpremium` and changes the sample's dev port from `3004` to `3003`.

## What Is Being Fixed

The CKEditor 5 sample client extensions show how to enable individual plugins via an `editorConfigContributor`, but there was no example combining several CKEditor 5 premium plugins to demonstrate the email editing feature set (Email Configuration Helper, Merge Fields, Template, Export with Inline Styles) validated by the customer demo request in LPD-82684.

## How It Is Being Fixed

Adds a sixth `liferay-sample-editor-config-contributor` client extension that registers the four premium plugins alongside the nonpremium Layout Tables and Empty Block plugins on the React + CET Premium tab, which is the tab reserved for premium plugin coverage. The plugins are registered unconditionally: every `@ckeditor/ckeditor5-*` package, premium included, is served through the portal's import map regardless of licensing, and each premium package enforces its own entitlement at the SDK level, so a client side license check in the sample would only duplicate enforcement the packages already perform. Mention is also registered, since MergeFieldsUI soft-requires it for its insert dropdown. Sample merge field definitions, a data set, and two email templates are included so the dropdowns have real content to insert rather than staying empty.

Playwright coverage lands in `react_cet_premium.spec.ts` and asserts that the four email editing toolbar buttons are present on the live editor. It also registers the editor config contributor samples that the project environment was missing, so `client-extensions.list` now names all six. The new test is wrapped in `if (!process.env.CI)` in a separate commit, since CI has no CKEditor 5 license yet; dropping that commit is all that is needed to turn the coverage on once it does.

## PR Check

**pr-check: PASS** — tested on `3ece9c568987e4229c73d07ee85349b5405286d1`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Baseline | PASS |
| Workspace Build | PASS |

Per-Module Compile and JavaScript Unit Tests matched the diff mechanically (a changed `.ts` file under `modules/test/playwright/`), but were not run: that directory is the Playwright harness, not an OSGi deploy target (no `deploy` task) and not a Jest suite (its `test` script runs `playwright test`), and Playwright execution is out of scope for `pr-check`.

<!-- pr-check {"result": "success", "sha": "3ece9c568987e4229c73d07ee85349b5405286d1"} -->
