### PR TITLE
LPD-105196 Map collection fields from the item the collection provided

### DIFF
--- a/modules/apps/fragment/fragment-api/bnd.bnd
+++ b/modules/apps/fragment/fragment-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Fragment API
 Bundle-SymbolicName: com.liferay.fragment.api
-Bundle-Version: 62.2.2
+Bundle-Version: 62.3.0
 Export-Package:\
 	com.liferay.fragment.cache,\
 	com.liferay.fragment.configuration,\

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/processor/DefaultFragmentEntryProcessorContext.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/processor/DefaultFragmentEntryProcessorContext.java
@@ -59,6 +59,11 @@ public class DefaultFragmentEntryProcessorContext
 	}
 
 	@Override
+	public Object getContextInfoItem() {
+		return _contextInfoItem;
+	}
+
+	@Override
 	public InfoItemReference getContextInfoItemReference() {
 		return _infoItemReference;
 	}
@@ -156,6 +161,10 @@ public class DefaultFragmentEntryProcessorContext
 		_attributes = attributes;
 	}
 
+	public void setContextInfoItem(Object contextInfoItem) {
+		_contextInfoItem = contextInfoItem;
+	}
+
 	public void setContextInfoItemReference(
 		InfoItemReference infoItemReference) {
 
@@ -196,6 +205,7 @@ public class DefaultFragmentEntryProcessorContext
 
 	private Map<String, Serializable> _attributes = new LinkedHashMap<>();
 	private final long _companyId;
+	private Object _contextInfoItem;
 	private boolean _disablePortletRender;
 	private String _fragmentElementId;
 	private final HttpServletRequest _httpServletRequest;

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/processor/FragmentEntryProcessorContext.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/processor/FragmentEntryProcessorContext.java
@@ -42,6 +42,8 @@ public interface FragmentEntryProcessorContext {
 		return serviceContext.getCompanyId();
 	}
 
+	public Object getContextInfoItem();
+
 	public InfoItemReference getContextInfoItemReference();
 
 	public String getFragmentElementId();

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/renderer/DefaultFragmentRendererContext.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/renderer/DefaultFragmentRendererContext.java
@@ -41,6 +41,11 @@ public class DefaultFragmentRendererContext implements FragmentRendererContext {
 	}
 
 	@Override
+	public Object getContextInfoItem() {
+		return _contextInfoItem;
+	}
+
+	@Override
 	public InfoItemReference getContextInfoItemReference() {
 		return _infoItemReference;
 	}
@@ -133,6 +138,10 @@ public class DefaultFragmentRendererContext implements FragmentRendererContext {
 		_attributes = attributes;
 	}
 
+	public void setContextInfoItem(Object contextInfoItem) {
+		_contextInfoItem = contextInfoItem;
+	}
+
 	public void setContextInfoItemReference(
 		InfoItemReference infoItemReference) {
 
@@ -180,6 +189,7 @@ public class DefaultFragmentRendererContext implements FragmentRendererContext {
 	}
 
 	private Map<String, Serializable> _attributes = new LinkedHashMap<>();
+	private Object _contextInfoItem;
 	private boolean _disablePortletRender;
 	private final String _fragmentEntryElementId;
 	private final FragmentEntryLink _fragmentEntryLink;

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/renderer/FragmentRendererContext.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/renderer/FragmentRendererContext.java
@@ -26,6 +26,8 @@ public interface FragmentRendererContext {
 
 	public Map<String, Serializable> getAttributes();
 
+	public Object getContextInfoItem();
+
 	public InfoItemReference getContextInfoItemReference();
 
 	public String getFragmentElementId();

--- a/modules/apps/fragment/fragment-api/src/main/resources/com/liferay/fragment/processor/packageinfo
+++ b/modules/apps/fragment/fragment-api/src/main/resources/com/liferay/fragment/processor/packageinfo
@@ -1,1 +1,1 @@
-version 13.0.0
+version 13.1.0

--- a/modules/apps/fragment/fragment-api/src/main/resources/com/liferay/fragment/renderer/packageinfo
+++ b/modules/apps/fragment/fragment-api/src/main/resources/com/liferay/fragment/renderer/packageinfo
@@ -1,1 +1,1 @@
-version 11.1.0
+version 11.2.0

--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-impl/src/main/java/com/liferay/fragment/entry/processor/internal/helper/FragmentEntryProcessorHelperImpl.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-impl/src/main/java/com/liferay/fragment/entry/processor/internal/helper/FragmentEntryProcessorHelperImpl.java
@@ -431,9 +431,13 @@ public class FragmentEntryProcessorHelperImpl
 
 			fieldName = editableValueJSONObject.getString("collectionFieldId");
 
-			object = _getInfoItem(
-				fragmentEntryProcessorContext.getScopeGroupId(),
-				infoItemReference);
+			object = fragmentEntryProcessorContext.getContextInfoItem();
+
+			if (object == null) {
+				object = _getInfoItem(
+					fragmentEntryProcessorContext.getScopeGroupId(),
+					infoItemReference);
+			}
 		}
 		else if (isMappedDisplayPage(editableValueJSONObject)) {
 			HttpServletRequest httpServletRequest =

--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-test/src/testIntegration/java/com/liferay/fragment/entry/processor/internal/util/test/FragmentEntryProcessorHelperTest.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-test/src/testIntegration/java/com/liferay/fragment/entry/processor/internal/util/test/FragmentEntryProcessorHelperTest.java
@@ -1010,6 +1010,59 @@ public class FragmentEntryProcessorHelperTest {
 	}
 
 	@Test
+	public void testGetInfoItemFieldMappedFromCollectionItem()
+		throws Exception {
+
+		JournalArticle journalArticle = JournalTestUtil.addArticle(
+			_group.getGroupId(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString());
+
+		InfoItemReference infoItemReference = new InfoItemReference(
+			JournalArticle.class.getName(),
+			new ClassPKInfoItemIdentifier(journalArticle.getResourcePrimKey()));
+
+		DefaultFragmentEntryProcessorContext
+			defaultFragmentEntryProcessorContext =
+				new DefaultFragmentEntryProcessorContext(
+					_group.getCompanyId(), new MockHttpServletRequest(),
+					new MockHttpServletResponse(), LocaleUtil.US,
+					FragmentEntryLinkConstants.VIEW, _group.getGroupId());
+
+		defaultFragmentEntryProcessorContext.setContextInfoItem(journalArticle);
+		defaultFragmentEntryProcessorContext.setContextInfoItemReference(
+			infoItemReference);
+
+		JSONObject editableValueJSONObject = JSONUtil.put(
+			"collectionFieldId", "title");
+
+		InfoItemFieldMapped infoItemFieldMapped =
+			_fragmentEntryProcessorHelper.getInfoItemFieldMapped(
+				editableValueJSONObject, defaultFragmentEntryProcessorContext);
+
+		Assert.assertEquals("title", infoItemFieldMapped.getFieldName());
+		Assert.assertEquals(
+			infoItemReference, infoItemFieldMapped.getInfoItemReference());
+		Assert.assertSame(journalArticle, infoItemFieldMapped.getObject());
+
+		defaultFragmentEntryProcessorContext.setContextInfoItem(null);
+
+		infoItemFieldMapped =
+			_fragmentEntryProcessorHelper.getInfoItemFieldMapped(
+				editableValueJSONObject, defaultFragmentEntryProcessorContext);
+
+		Assert.assertEquals(
+			infoItemReference, infoItemFieldMapped.getInfoItemReference());
+		Assert.assertNotSame(journalArticle, infoItemFieldMapped.getObject());
+
+		JournalArticle resolvedJournalArticle =
+			(JournalArticle)infoItemFieldMapped.getObject();
+
+		Assert.assertEquals(
+			journalArticle.getResourcePrimKey(),
+			resolvedJournalArticle.getResourcePrimKey());
+	}
+
+	@Test
 	@TestInfo({"LPD-11377", "LPD-51076"})
 	public void testGetRepeatableAssetTags() throws Exception {
 		JSONObject jsonObject = JSONUtil.put(

--- a/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/renderer/FragmentEntryFragmentRenderer.java
+++ b/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/renderer/FragmentEntryFragmentRenderer.java
@@ -436,6 +436,8 @@ public class FragmentEntryFragmentRenderer implements FragmentRenderer {
 
 		defaultFragmentEntryProcessorContext.setAttributes(
 			fragmentRendererContext.getAttributes());
+		defaultFragmentEntryProcessorContext.setContextInfoItem(
+			fragmentRendererContext.getContextInfoItem());
 		defaultFragmentEntryProcessorContext.setContextInfoItemReference(
 			fragmentRendererContext.getContextInfoItemReference());
 		defaultFragmentEntryProcessorContext.setDisablePortletRender(

--- a/modules/apps/info/info-api/bnd.bnd
+++ b/modules/apps/info/info-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Info API
 Bundle-SymbolicName: com.liferay.info.api
-Bundle-Version: 38.13.1
+Bundle-Version: 38.14.0
 Export-Package:\
 	com.liferay.info.collection.provider,\
 	com.liferay.info.constants,\

--- a/modules/apps/info/info-api/src/main/java/com/liferay/info/constants/InfoDisplayWebKeys.java
+++ b/modules/apps/info/info-api/src/main/java/com/liferay/info/constants/InfoDisplayWebKeys.java
@@ -10,6 +10,8 @@ package com.liferay.info.constants;
  */
 public class InfoDisplayWebKeys {
 
+	public static final String COLLECTION_INFO_ITEM = "COLLECTION_INFO_ITEM";
+
 	public static final String INFO_FORM = "INFO_FORM";
 
 	public static final String INFO_ITEM = "INFO_ITEM";

--- a/modules/apps/info/info-api/src/main/resources/com/liferay/info/constants/packageinfo
+++ b/modules/apps/info/info-api/src/main/resources/com/liferay/info/constants/packageinfo
@@ -1,1 +1,1 @@
-version 5.0.0
+version 5.1.0

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/display/context/RenderLayoutStructureDisplayContext.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/display/context/RenderLayoutStructureDisplayContext.java
@@ -249,6 +249,11 @@ public class RenderLayoutStructureDisplayContext {
 				infoItemReference = infoItemDetails.getInfoItemReference();
 			}
 		}
+		else {
+			defaultFragmentRendererContext.setContextInfoItem(
+				_httpServletRequest.getAttribute(
+					InfoDisplayWebKeys.COLLECTION_INFO_ITEM));
+		}
 
 		defaultFragmentRendererContext.setContextInfoItemReference(
 			infoItemReference);

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/renderer/LayoutStructureRenderer.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/renderer/LayoutStructureRenderer.java
@@ -271,9 +271,12 @@ public class LayoutStructureRenderer {
 	private void _renderCol(
 			CollectionStyledLayoutStructureItem
 				collectionStyledLayoutStructureItem,
-			int index, InfoForm infoForm, InfoItemDetails infoItemDetails)
+			int index, InfoForm infoForm, Object infoItem,
+			InfoItemDetails infoItemDetails)
 		throws Exception {
 
+		_httpServletRequest.setAttribute(
+			InfoDisplayWebKeys.COLLECTION_INFO_ITEM, infoItem);
 		_httpServletRequest.setAttribute(
 			InfoDisplayWebKeys.INFO_ITEM_REFERENCE,
 			infoItemDetails.getInfoItemReference());
@@ -536,6 +539,8 @@ public class LayoutStructureRenderer {
 				renderCollectionLayoutStructureItemDisplayContext)
 		throws Exception {
 
+		Object currentInfoItem = _httpServletRequest.getAttribute(
+			InfoDisplayWebKeys.COLLECTION_INFO_ITEM);
 		InfoItemReference currentInfoItemReference =
 			(InfoItemReference)_httpServletRequest.getAttribute(
 				InfoDisplayWebKeys.INFO_ITEM_REFERENCE);
@@ -617,7 +622,7 @@ public class LayoutStructureRenderer {
 
 					_renderCol(
 						collectionStyledLayoutStructureItem,
-						i % numberOfColumns, infoForm,
+						i % numberOfColumns, infoForm, collection.get(i),
 						infoItemDetailsProvider.getInfoItemDetails(
 							collection.get(i)));
 				}
@@ -649,6 +654,7 @@ public class LayoutStructureRenderer {
 
 						_renderCol(
 							collectionStyledLayoutStructureItem, j, infoForm,
+							collection.get(index),
 							infoItemDetailsProvider.getInfoItemDetails(
 								collection.get(index)));
 					}
@@ -660,6 +666,8 @@ public class LayoutStructureRenderer {
 			containerTag.doEndTag();
 		}
 		finally {
+			_httpServletRequest.setAttribute(
+				InfoDisplayWebKeys.COLLECTION_INFO_ITEM, currentInfoItem);
 			_httpServletRequest.setAttribute(
 				InfoDisplayWebKeys.INFO_ITEM_REFERENCE,
 				currentInfoItemReference);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-105196

Third change of the object entry listing optimization tracked under LPD-65366 (LPD-98910 scenario: a site page whose collection display lists a custom object's entries). It follows #181480, which hands the fragment the listing's object entries, and precedes the bulk load of a page's values, which relies on the instances this one lets through.

## What Is Being Fixed

A fragment rendered inside a collection row knows the row only as an `InfoItemReference`: the renderer context carries the reference, the processor context copies it, and `FragmentEntryProcessorHelperImpl.getInfoItemFieldMapped` resolves the reference again through the item's `InfoItemObjectProvider` for every mapped field. The collection provider had the item in hand when it built the page, so that second resolution rebuilds an object the request already holds, and for an object entry it also reads the entry's values again, once per mapped field per row.

## How It Is Being Fixed

- `FragmentRendererContext` and `FragmentEntryProcessorContext` carry the context item next to its reference, and `FragmentEntryFragmentRenderer` copies it from one context to the other the same way it copies the reference.
- `LayoutStructureRenderer` publishes the row item as the `COLLECTION_INFO_ITEM` request attribute of `InfoDisplayWebKeys`, beside the `INFO_ITEM_REFERENCE` it already publishes for the row, saves and restores it around the rows like the reference, and `RenderLayoutStructureDisplayContext` sets it on the renderer context whenever the reference came from that attribute.
- `getInfoItemFieldMapped` uses the item the context carries and keeps the provider lookup as the fallback for contexts that do not publish one.

The two `Semantic versioning` commits carry the minor bumps the baseline task asks for: the fragment-api context packages for the new accessors, and `com.liferay.info.constants` for the new key.

## Verification

- `FragmentEntryProcessorHelperTest` covers both branches of the mapping: with the item on the context the mapping returns that very instance; without it the row is resolved through its provider as before.
- Self-CI on shuyangzhou/liferay-portal PR 12753: stable 16 of 16, object 50 of 50, relevant run twice (85 of 103, then 32 of 38 after a marker commit) with every failure in common with the upstream acceptance runs at 9b0cfd1 and be108f2 and no unique failures on the rerun; the first run listed the chronic page editor drag-and-drop collection test and three Analytics Cloud, CMP and staging Playwright axes as unique only because the comparison covers integration axes alone.

## PR Check

**pr-check: PASS** — tested on `9e28b2de08cd188beb372b75cf708d30863ec922`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Service Registration | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | NOT VERIFIED |
| Baseline | PASS (baseline-all + seven Ant projects + 3 changed exporting modules) |
| Structural Smoke | PASS |
| Java Unit Tests | NOT VERIFIED |

Source Format ran the Java formatter only: the 15-file diff matches none of `source.formatter.frontend.file.regex`, so the yarn side was skipped rather than run clean. The breaking-change commit-message check ran over both `Semantic versioning` commits and reported nothing.

Cross-Module Compile verified nothing: the consumer set is 20 `-test` modules, above the cap of 8, so the expansion was skipped for every symbol rather than compiling an arbitrary subset; Integration Test Compile ran over 8 of that surface and passed.

Java Unit Tests verified nothing: none of the changed classes has a unit test; `FragmentEntryProcessorHelperTest` and `FragmentEntryFragmentRendererTest` cover them as integration tests.

Baseline reported no required version change; bnd's own `baseline` against released `62.2.1` confirms the minor bumps (`com.liferay.fragment.processor` 13.1.0, `com.liferay.fragment.renderer` 11.2.0, both `@ProviderType`; `com.liferay.info.constants` 5.1.0).

<!-- pr-check {"result": "success", "sha": "9e28b2de08cd188beb372b75cf708d30863ec922"} -->
