### PR TITLE
ENBT-4433 Clarity chart js example

### DIFF
--- a/workspaces/clarity-solution-workspace/client-extensions/clarity-solution-bar-chart/.gitignore
+++ b/workspaces/clarity-solution-workspace/client-extensions/clarity-solution-bar-chart/.gitignore
@@ -1,0 +1,25 @@
+# See https://help.github.com/ignore-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+
+# testing
+/coverage
+
+# production
+/build
+/dist
+/.settings
+
+# misc
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+.project

--- a/workspaces/clarity-solution-workspace/client-extensions/clarity-solution-bar-chart/@vite/refresh.ts
+++ b/workspaces/clarity-solution-workspace/client-extensions/clarity-solution-bar-chart/@vite/refresh.ts
@@ -1,0 +1,29 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+// @ts-ignore
+
+// eslint-disable-next-line @liferay/no-absolute-import
+import RefreshRuntime from '/@react-refresh';
+
+/**
+ * @description This file is used ONLY and EXCLUSIVE for development
+ * When setting up the remote app, add this import
+ * http://localhost:5173/@vite/refresh.ts
+ */
+
+RefreshRuntime.injectIntoGlobalHook(window);
+window.$RefreshReg$ = () => {};
+window.$RefreshSig$ = () => (type) => type;
+
+window.__vite_plugin_react_preamble_installed__ = true;
+
+declare global {
+	interface Window {
+		$RefreshReg$: () => void;
+		$RefreshSig$: () => (type: string) => string;
+		__vite_plugin_react_preamble_installed__: boolean;
+	}
+}

--- a/workspaces/clarity-solution-workspace/client-extensions/clarity-solution-bar-chart/README.md
+++ b/workspaces/clarity-solution-workspace/client-extensions/clarity-solution-bar-chart/README.md
@@ -1,0 +1,62 @@
+# Clarity Solution Bar Chart
+
+> **Pedagogical purpose of this module**
+>
+> - Integrate a third-party library (Chart.js via react-chartjs-2) into a Liferay client extension.
+> - Bundle this client extension with Vite.
+> - Run the module locally, standalone, via `yarn dev`, using a stub that simulates both `window.Liferay.Util.fetch` and the paginated API normally served by Liferay (see [index.html](index.html)).
+> - Illustrate how to handle client-side pagination of Liferay API calls (page size deliberately reduced to `2` so the progressive chart building is easy to see).
+> - Illustrate how to make a custom element configurable through a fragment, thanks to the `jsImportMapsEntry` client extension type.
+
+Liferay custom element (`clarity-solution-bar-chart`) that renders a bar chart (via [Chart.js](https://www.chartjs.org/) / [react-chartjs-2](https://react-chartjs-2.js.org/)) built from a live count aggregation over any Liferay REST endpoint (e.g. a custom Object's REST API) — no backend/aggregation code required, everything is fetched and aggregated client-side.
+
+## Usage
+
+```html
+<clarity-solution-bar-chart
+  title="Stores by tier"
+  dataset-label="Count by tier"
+  aggregation-field="tier.key"
+  aggregation-type="count"
+  rest-context-path="/o/c/stores"
+  color="#4C9AFF"
+></clarity-solution-bar-chart>
+```
+
+Attributes:
+
+- `title` — chart title.
+- `dataset-label` — label of the (single) dataset shown in the legend/tooltip.
+- `aggregation-field` — field to group/count by, read from each item returned by the REST endpoint; supports dot paths (e.g. `tier.key` reads `item.tier.key`).
+- `aggregation-type` — how values are aggregated. Only `"count"` is implemented today (see [src/components/LiferayChart.jsx](src/components/LiferayChart.jsx)); other types (sums, averages, ...) are not handled yet.
+- `rest-context-path` — the Liferay REST endpoint to fetch items from (e.g. `/o/c/myobjects`).
+- `color` — bar fill color.
+
+## How it works
+
+- [src/index.jsx](src/index.jsx) defines the custom element and mounts the React app directly on the element itself (no shadow DOM here), forwarding its attributes as props.
+- [src/App.jsx](src/App.jsx) passes those props down to `LiferayChart`.
+- [src/components/LiferayChart.jsx](src/components/LiferayChart.jsx) paginates through `restContextPath` with `window.Liferay.Util.fetch`, requesting only `aggregationField` (`?fields=...&page=...&pageSize=...`), counts occurrences per page and merges them into a running total, then re-renders the chart after every page — so the chart progressively fills in while older pages are being fetched — until `lastPage` is reached.
+- [src/components/BarChart.jsx](src/components/BarChart.jsx) renders the resulting `labels`/`values` as a Chart.js bar chart.
+
+### Progressive chart building
+
+Liferay REST APIs are paginated by design — a single call never returns the whole collection, only one page plus a `lastPage` indicator. `LiferayChart.jsx` embraces that instead of working around it: rather than waiting to fetch every page before drawing anything, it counts and re-renders after **each** page (`fetchData` calls itself for `page + 1` once a page's results are merged in, until `page >= lastPage`), so the bars appear and grow continuously as pages come in instead of popping in all at once at the end.
+
+> **Note:** `pageSize` is hardcoded to `2` in `LiferayChart.jsx`. That's deliberately tiny — a real deployment would use a much larger page size — chosen here purely so the page-by-page construction of the chart is easy to see with a handful of demo records instead of resolving in a single, instantaneous fetch.
+
+## Fragment
+
+[fragments/vertical-bar-chart](fragments/vertical-bar-chart) packages the element as a Liferay page fragment so editors can configure `title`, `restContextPath`, `aggregationField`, `datasetLabel` and the bar color (`chartColor`, a color-palette field) from the page/fragment editor instead of hand-writing HTML — see [configuration.json](fragments/vertical-bar-chart/configuration.json) and [fragment.html](fragments/vertical-bar-chart/fragment.html).
+
+## Development
+
+```bash
+yarn            # install dependencies
+yarn dev        # Vite dev server (index.html), standalone with the mocked Liferay runtime
+yarn build      # production build → build/vite
+```
+
+`yarn dev` above runs the element fully standalone against the stub described in the pedagogical note (no running Liferay portal needed). To instead run against a real Liferay instance and get hot reload while editing, deploy the client extension, start `yarn dev`, and let [client-extension.dev.yaml](client-extension.dev.yaml) proxy the module's URL to the local Vite dev server (`http://localhost:5173`).
+
+The build is packaged as a Liferay JS import map client extension (`jsImportMapsEntry`, bare specifier `clarity-solution-bar-chart`) by [client-extension.yaml](client-extension.yaml).

--- a/workspaces/clarity-solution-workspace/client-extensions/clarity-solution-bar-chart/client-extension.dev.yaml
+++ b/workspaces/clarity-solution-workspace/client-extensions/clarity-solution-bar-chart/client-extension.dev.yaml
@@ -1,0 +1,5 @@
+clarity-solution-bar-chart:
+    urls:
+        -   http://localhost:5173/@vite/client
+        -   http://localhost:5173/@vite/refresh.ts
+        -   http://localhost:5173/src/index.jsx

--- a/workspaces/clarity-solution-workspace/client-extensions/clarity-solution-bar-chart/client-extension.yaml
+++ b/workspaces/clarity-solution-workspace/client-extensions/clarity-solution-bar-chart/client-extension.yaml
@@ -1,0 +1,8 @@
+assemble:
+    -   from: build/vite
+        into: static
+clarity-solution-bar-chart:
+    bareSpecifier: clarity-solution-bar-chart
+    name: Clarity Solution Bar Chart
+    type: jsImportMapsEntry
+    url: /index.js

--- a/workspaces/clarity-solution-workspace/client-extensions/clarity-solution-bar-chart/fragments/vertical-bar-chart/configuration.json
+++ b/workspaces/clarity-solution-workspace/client-extensions/clarity-solution-bar-chart/fragments/vertical-bar-chart/configuration.json
@@ -1,0 +1,61 @@
+{
+	"fieldSets": [
+		{
+			"fields": [
+				{
+					"dataType": "string",
+					"defaultValue": "",
+					"description": "",
+					"label": "title",
+					"name": "title",
+					"type": "text",
+					"typeOptions": {
+						"placeholder": "Chart Title"
+					}
+				},
+				{
+					"dataType": "string",
+					"defaultValue": "",
+					"description": "",
+					"label": "REST Context Path",
+					"name": "restContextPath",
+					"type": "text",
+					"typeOptions": {
+						"placeholder": "eg. /o/c/myobjects"
+					}
+				},
+				{
+					"dataType": "string",
+					"defaultValue": "",
+					"description": "",
+					"label": "Aggregation Field",
+					"name": "aggregationField",
+					"type": "text",
+					"typeOptions": {
+						"placeholder": "eg. tier.key"
+					}
+				},
+				{
+					"dataType": "string",
+					"defaultValue": "",
+					"description": "",
+					"label": "Dataset label",
+					"name": "datasetLabel",
+					"type": "text",
+					"typeOptions": {
+						"placeholder": "eg. Count by tier"
+					}
+				},
+				{
+					"dataType": "object",
+					"defaultValue": {
+						"color": "black"
+					},
+					"label": "Chart color",
+					"name": "chartColor",
+					"type": "colorPalette"
+				}
+			]
+		}
+	]
+}

--- a/workspaces/clarity-solution-workspace/client-extensions/clarity-solution-bar-chart/fragments/vertical-bar-chart/fragment.html
+++ b/workspaces/clarity-solution-workspace/client-extensions/clarity-solution-bar-chart/fragments/vertical-bar-chart/fragment.html
@@ -1,0 +1,16 @@
+[#assign color="black" /]
+[#if configuration.chartColor??]
+	[#if configuration.chartColor.rgbValue??]
+		[#assign color=configuration.chartColor.rgbValue /]
+	[#elseif configuration.chartColor.color??]
+		[#assign color=configuration.chartColor.color /]
+	[/#if]
+[/#if]
+<clarity-solution-bar-chart
+	aggregation-field="${configuration.aggregationField}"
+	aggregation-type="count"
+	color="${color}"
+	dataset-label="${configuration.datasetLabel}"
+	rest-context-path="${configuration.restContextPath}"
+	title="${configuration.title}"
+/>

--- a/workspaces/clarity-solution-workspace/client-extensions/clarity-solution-bar-chart/fragments/vertical-bar-chart/fragment.js
+++ b/workspaces/clarity-solution-workspace/client-extensions/clarity-solution-bar-chart/fragments/vertical-bar-chart/fragment.js
@@ -1,0 +1,6 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import 'clarity-solution-bar-chart';

--- a/workspaces/clarity-solution-workspace/client-extensions/clarity-solution-bar-chart/index.html
+++ b/workspaces/clarity-solution-workspace/client-extensions/clarity-solution-bar-chart/index.html
@@ -1,0 +1,61 @@
+<!doctype html>
+
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<link href="/vite.svg" rel="icon" type="image/svg+xml" />
+<meta content="width=device-width, initial-scale=1.0" name="viewport" />
+	<title>Vite + React</title>
+</head>
+
+<body>
+	<script>
+	  // Local dev only: stubs the Liferay runtime + REST endpoint consumed by
+	  // LiferayChart.jsx (window.Liferay.Util.fetch), so the custom element's
+	  // own attribute contract below stays untouched.
+	  const MOCK_ITEMS = [
+		{ status: 'Open' },
+		{ status: 'Open' },
+		{ status: 'Closed' },
+		{ status: 'Open' },
+		{ status: 'Pending' },
+		{ status: 'Closed' },
+		{ status: 'Pending' },
+	  ];
+
+	  window.Liferay = {
+		Util: {
+		  fetch(url) {
+			const { searchParams } = new URL(url, window.location.origin);
+			const page = Number(searchParams.get('page')) || 1;
+			const pageSize = Number(searchParams.get('pageSize')) || MOCK_ITEMS.length;
+			const start = (page - 1) * pageSize;
+
+			return Promise.resolve(
+			  new Response(
+				JSON.stringify({
+				  items: MOCK_ITEMS.slice(start, start + pageSize),
+				  page,
+				  lastPage: Math.ceil(MOCK_ITEMS.length / pageSize),
+				}),
+				{ headers: { 'content-type': 'application/json' } }
+			  )
+			);
+		  },
+		},
+	  };
+	</script>
+
+	<clarity-solution-bar-chart
+		aggregation-field="status"
+		aggregation-type="count"
+		color="black"
+		dataset-label="Count"
+		rest-context-path="/mock/aggregation"
+		title="Sample Chart"
+	/>
+	</clarity-solution-bar-chart>
+	
+	<script src="/src/index.jsx" type="module"></script>
+</body>
+</html>

--- a/workspaces/clarity-solution-workspace/client-extensions/clarity-solution-bar-chart/package.json
+++ b/workspaces/clarity-solution-workspace/client-extensions/clarity-solution-bar-chart/package.json
@@ -1,0 +1,25 @@
+{
+	"dependencies": {
+		"chart.js": "^4.4.7",
+		"react": "18.2.0",
+		"react-chartjs-2": "^5.3.0",
+		"react-dom": "18.2.0"
+	},
+	"devDependencies": {
+		"@vitejs/plugin-react": "^4.2.1",
+		"vite": "^5.2.0"
+	},
+	"exports": {
+		".": {
+			"import": "./build/vite/index.js"
+		}
+	},
+	"name": "clarity-solution-bar-chart",
+	"private": true,
+	"scripts": {
+		"build": "vite build",
+		"dev": "vite",
+		"preview": "vite preview"
+	},
+	"version": "1.0.0"
+}

--- a/workspaces/clarity-solution-workspace/client-extensions/clarity-solution-bar-chart/src/App.jsx
+++ b/workspaces/clarity-solution-workspace/client-extensions/clarity-solution-bar-chart/src/App.jsx
@@ -1,0 +1,31 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import React from 'react';
+import LiferayChart from './components/LiferayChart.jsx';
+
+function App({
+	title,
+	datasetLabel,
+	aggregationField,
+	aggregationType,
+	restContextPath,
+	color,
+}) {
+	return (
+		<>
+			<LiferayChart
+				title={title}
+				datasetLabel={datasetLabel}
+				aggregationField={aggregationField}
+				aggregationType={aggregationType}
+				restContextPath={restContextPath}
+				color={color}
+			/>
+		</>
+	);
+}
+
+export default App;

--- a/workspaces/clarity-solution-workspace/client-extensions/clarity-solution-bar-chart/src/components/BarChart.jsx
+++ b/workspaces/clarity-solution-workspace/client-extensions/clarity-solution-bar-chart/src/components/BarChart.jsx
@@ -1,0 +1,69 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import React, {useState, useEffect} from 'react';
+import {Bar} from 'react-chartjs-2';
+import {
+	Chart as ChartJS,
+	BarElement,
+	CategoryScale,
+	LinearScale,
+	Tooltip,
+	Legend,
+	Title,
+} from 'chart.js';
+
+ChartJS.register(
+	BarElement,
+	CategoryScale,
+	LinearScale,
+	Tooltip,
+	Legend,
+	Title
+);
+
+const BarChart = ({title, datasetLabel, labels, values, color}) => {
+	const [chartData, setChartData] = useState(null);
+	const [options, setOptions] = useState(null);
+
+	useEffect(() => {
+		if (values.length > 0) {
+			setOptions({
+				responsive: true,
+				plugins: {
+					legend: {
+						position: 'top',
+					},
+					title: {
+						display: true,
+						text: title,
+					},
+				},
+			});
+			setChartData({
+				labels,
+				datasets: [
+					{
+						label: datasetLabel,
+						data: values,
+						backgroundColor: color,
+					},
+				],
+			});
+		}
+	}, [title, datasetLabel, labels, values, color]);
+
+	return (
+		<>
+			{chartData ? (
+				<Bar options={options} data={chartData} />
+			) : (
+				<p>No data to display</p>
+			)}
+		</>
+	);
+};
+
+export default BarChart;

--- a/workspaces/clarity-solution-workspace/client-extensions/clarity-solution-bar-chart/src/components/LiferayChart.jsx
+++ b/workspaces/clarity-solution-workspace/client-extensions/clarity-solution-bar-chart/src/components/LiferayChart.jsx
@@ -1,0 +1,107 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import React, {useRef, useState, useEffect} from 'react';
+import BarChart from './BarChart';
+
+const LiferayChart = ({
+	title,
+	datasetLabel,
+	aggregationField,
+	aggregationType,
+	restContextPath,
+	color,
+}) => {
+	const [labels, setLabels] = useState([]);
+	const [values, setValues] = useState([]);
+
+	const pageSize = 2;
+	const runIdRef = useRef(0);
+
+	function getValue(obj, path) {
+		if (!path.includes('.')) {
+			return obj?.[path];
+		}
+
+		return path.split('.').reduce((o, k) => o?.[k], obj);
+	}
+
+	function countBy(array, path) {
+		return array.reduce((acc, item) => {
+			const value = getValue(item, path);
+			if (!value) return acc;
+
+			acc[value] = (acc[value] || 0) + 1;
+			return acc;
+		}, {});
+	}
+
+	function mergeCounts(a = {}, b = {}) {
+		const result = {...a};
+
+		for (const [key, value] of Object.entries(b)) {
+			result[key] = (result[key] || 0) + value;
+		}
+
+		return result;
+	}
+
+	function fetchData(page, currentCountAggregation, runId) {
+		window.Liferay.Util.fetch(
+			`${restContextPath}?fields=${aggregationField}&page=${page}&pageSize=${pageSize}`
+		)
+			.then((response) => {
+				const contentType = response.headers.get('content-type');
+				if (!contentType || !contentType.includes('application/json')) {
+					throw new Error(
+						`Expected JSON but received: ${contentType}`
+					);
+				}
+				if (!response.ok) {
+					throw new Error(`HTTP error ${response.status}`);
+				}
+				return response.json();
+			})
+			.then((json) => {
+				if (runIdRef.current === runId) {
+					if (aggregationType == 'count') {
+						const countAggregation = mergeCounts(
+							currentCountAggregation,
+							countBy(json.items, aggregationField)
+						);
+						const keys = Object.keys(countAggregation);
+						setLabels(keys);
+						setValues(keys.map((k) => countAggregation[k]));
+
+						if (page < json.lastPage && runIdRef.current == runId) {
+							fetchData(page + 1, countAggregation, runId);
+						}
+					} // We could manage other aggregation types, like sums or averages...
+				}
+			})
+			.catch((error) => console.error(error));
+	}
+
+	useEffect(() => {
+		const runId = ++runIdRef.current;
+		if (restContextPath) {
+			fetchData(1, {}, runId);
+		}
+	}, [restContextPath, aggregationField, aggregationType]);
+
+	return (
+		<>
+			<BarChart
+				title={title}
+				datasetLabel={datasetLabel}
+				labels={labels}
+				values={values}
+				color={color}
+			/>
+		</>
+	);
+};
+
+export default LiferayChart;

--- a/workspaces/clarity-solution-workspace/client-extensions/clarity-solution-bar-chart/src/index.jsx
+++ b/workspaces/clarity-solution-workspace/client-extensions/clarity-solution-bar-chart/src/index.jsx
@@ -1,0 +1,40 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import React, {StrictMode} from 'react';
+import {createRoot} from 'react-dom/client';
+
+import App from './App.jsx';
+
+class WebComponent extends HTMLElement {
+	connectedCallback() {
+		this.root = createRoot(this);
+
+		this.root.render(
+			<StrictMode>
+				<App
+					title={this.getAttribute('title')}
+					datasetLabel={this.getAttribute('dataset-label')}
+					aggregationField={this.getAttribute('aggregation-field')}
+					aggregationType={this.getAttribute('aggregation-type')}
+					restContextPath={this.getAttribute('rest-context-path')}
+					color={this.getAttribute('color')}
+				/>
+			</StrictMode>
+		);
+	}
+
+	disconnectedCallback() {
+		this.root.unmount();
+
+		delete this.root;
+	}
+}
+
+const ELEMENT_ID = 'clarity-solution-bar-chart';
+
+if (!customElements.get(ELEMENT_ID)) {
+	customElements.define(ELEMENT_ID, WebComponent);
+}

--- a/workspaces/clarity-solution-workspace/client-extensions/clarity-solution-bar-chart/vite.config.js
+++ b/workspaces/clarity-solution-workspace/client-extensions/clarity-solution-bar-chart/vite.config.js
@@ -1,0 +1,35 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {resolve} from 'path';
+import {defineConfig} from 'vite';
+import react from '@vitejs/plugin-react';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+	plugins: [react()],
+	build: {
+		lib: {
+			entry: {
+				index: resolve(__dirname, 'src/index.jsx'),
+			},
+			formats: ['es'],
+		},
+		outDir: 'build/vite',
+		rollupOptions: {
+			external: ['react', 'react-dom'],
+			output: {
+				entryFileNames: '[name].js',
+				format: 'es', // Ensured format is consistent
+			},
+		},
+	},
+	define: {
+		'process.env.NODE_ENV': '"production"',
+	},
+	server: {
+		origin: 'http://localhost:5173',
+	},
+});


### PR DESCRIPTION
Hello Brian,

**Pedagogical purpose of this module**

- Integrate a third-party library (Chart.js via react-chartjs-2) into a Liferay client extension.
- Bundle this client extension with Vite.
- Run the module locally, standalone, via yarn dev, using a stub that simulates both window.Liferay.Util.fetch and the paginated API normally served by Liferay (see [index.html](https://github.com/liferay/liferay-course-library/blob/final/client-extensions/clarity-solution-bar-chart/index.html)).
- Illustrate how to handle client-side pagination of Liferay API calls (page size deliberately reduced to 2 so the progressive chart building is easy to see).
- Illustrate how to make a custom element configurable through a fragment, thanks to the jsImportMapsEntry client extension type.

Is it ok to skip /pr-check. That skill is completely recompiling liferay-portal although my changes are peripherical and only involve code samples in the clarity workspace.

I'm running code formatter against the code I'm sending to you.