### PR TITLE
LPD-103691 Expose the Process Builder screens to the filter

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-web/src/main/java/com/liferay/portal/workflow/web/internal/application/list/ControlPanelWorkflowPanelApp.java
+++ b/modules/apps/portal-workflow/portal-workflow-web/src/main/java/com/liferay/portal/workflow/web/internal/application/list/ControlPanelWorkflowPanelApp.java
@@ -7,18 +7,28 @@ package com.liferay.portal.workflow.web.internal.application.list;
 
 import com.liferay.application.list.BasePanelApp;
 import com.liferay.application.list.PanelApp;
+import com.liferay.application.list.PanelAppNavigationItem;
 import com.liferay.application.list.constants.PanelCategoryKeys;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Portlet;
+import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.workflow.constants.WorkflowPortletKeys;
+import com.liferay.portal.workflow.constants.WorkflowWebKeys;
 
 import jakarta.portlet.PortletRequest;
 import jakarta.portlet.PortletURL;
 
 import jakarta.servlet.http.HttpServletRequest;
+
+import java.util.Arrays;
+import java.util.List;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -38,6 +48,29 @@ public class ControlPanelWorkflowPanelApp extends BasePanelApp {
 	@Override
 	public String getIcon() {
 		return "process-builder";
+	}
+
+	@Override
+	public List<PanelAppNavigationItem> getPanelAppNavigationItems(
+			HttpServletRequest httpServletRequest)
+		throws PortalException {
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		return TransformUtil.unsafeTransform(
+			Arrays.asList(
+				WorkflowWebKeys.WORKFLOW_TAB_DEFINITION,
+				WorkflowWebKeys.WORKFLOW_TAB_DEFINITION_LINK),
+			tabName -> new PanelAppNavigationItem(
+				_language.get(LocaleUtil.ENGLISH, tabName),
+				PortletURLBuilder.create(
+					getPortletURL(httpServletRequest)
+				).setParameter(
+					"tab", tabName
+				).buildString(),
+				_language.get(themeDisplay.getLocale(), tabName)));
 	}
 
 	@Override
@@ -65,6 +98,9 @@ public class ControlPanelWorkflowPanelApp extends BasePanelApp {
 
 		return themeDisplay.getControlPanelGroup();
 	}
+
+	@Reference
+	private Language _language;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/portal-workflow/portal-workflow-web/src/test/java/com/liferay/portal/workflow/web/internal/application/list/ControlPanelWorkflowPanelAppTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-web/src/test/java/com/liferay/portal/workflow/web/internal/application/list/ControlPanelWorkflowPanelAppTest.java
@@ -5,9 +5,13 @@
 
 package com.liferay.portal.workflow.web.internal.application.list;
 
+import com.liferay.application.list.PanelAppNavigationItem;
+import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletURL;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
@@ -18,7 +22,10 @@ import jakarta.portlet.PortletURL;
 
 import jakarta.servlet.http.HttpServletRequest;
 
+import java.util.List;
+
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -34,6 +41,69 @@ public class ControlPanelWorkflowPanelAppTest {
 	@Rule
 	public static final LiferayUnitTestRule liferayUnitTestRule =
 		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		ReflectionTestUtil.setFieldValue(
+			_controlPanelWorkflowPanelApp, "_language", _language);
+
+		Mockito.when(
+			_httpServletRequest.getAttribute(WebKeys.THEME_DISPLAY)
+		).thenReturn(
+			_themeDisplay
+		);
+
+		Mockito.when(
+			_language.get(Mockito.eq(LocaleUtil.ENGLISH), Mockito.anyString())
+		).thenAnswer(
+			invocationOnMock -> invocationOnMock.getArgument(1)
+		);
+
+		Mockito.when(
+			_language.get(Mockito.eq(LocaleUtil.SPAIN), Mockito.anyString())
+		).thenAnswer(
+			invocationOnMock -> invocationOnMock.getArgument(1) + "-es"
+		);
+
+		Mockito.when(
+			_themeDisplay.getLocale()
+		).thenReturn(
+			LocaleUtil.SPAIN
+		);
+	}
+
+	@Test
+	public void testGetPanelAppNavigationItems() throws Exception {
+		List<PanelAppNavigationItem> panelAppNavigationItems =
+			_controlPanelWorkflowPanelApp.getPanelAppNavigationItems(
+				_httpServletRequest);
+
+		Assert.assertEquals(
+			panelAppNavigationItems.toString(), 2,
+			panelAppNavigationItems.size());
+
+		PanelAppNavigationItem panelAppNavigationItem =
+			panelAppNavigationItems.get(0);
+
+		Assert.assertEquals(
+			"workflows", panelAppNavigationItem.getCanonicalName());
+		Assert.assertEquals("workflows-es", panelAppNavigationItem.getLabel());
+
+		String href = panelAppNavigationItem.getHref();
+
+		Assert.assertTrue(href, href.contains("tab=workflows"));
+
+		panelAppNavigationItem = panelAppNavigationItems.get(1);
+
+		Assert.assertEquals(
+			"configuration", panelAppNavigationItem.getCanonicalName());
+		Assert.assertEquals(
+			"configuration-es", panelAppNavigationItem.getLabel());
+
+		href = panelAppNavigationItem.getHref();
+
+		Assert.assertTrue(href, href.contains("tab=configuration"));
+	}
 
 	@Test
 	public void testGetPortletURL() {
@@ -86,5 +156,24 @@ public class ControlPanelWorkflowPanelAppTest {
 			Mockito.eq(PortletRequest.RENDER_PHASE)
 		);
 	}
+
+	private final ControlPanelWorkflowPanelApp _controlPanelWorkflowPanelApp =
+		new ControlPanelWorkflowPanelApp() {
+
+			@Override
+			public PortletURL getPortletURL(
+				HttpServletRequest httpServletRequest) {
+
+				return _portletURL;
+			}
+
+			private final PortletURL _portletURL = new MockLiferayPortletURL();
+
+		};
+
+	private final HttpServletRequest _httpServletRequest = Mockito.mock(
+		HttpServletRequest.class);
+	private final Language _language = Mockito.mock(Language.class);
+	private final ThemeDisplay _themeDisplay = Mockito.mock(ThemeDisplay.class);
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103691

Resend of https://github.com/brianchandotcom/liferay-portal/pull/181516

Removed `WorkflowNavigationConstants` and duplicated the tab names in each consumer. `git ls-files **NavigationConstants.java` returns 42 files, 39 of them `*ScreenNavigationConstants` belonging to the screen navigation framework, so the name reads as that framework rather than as a portlet's navigation bar, and `dispatch-api` already ships a `DispatchScreenNavigationConstants` the new class would have sat beside. `ControlPanelWorkflowPortlet` keeps its inline `Arrays.asList`, which puts it back at its master state and drops it from the diff, so what remains is the `getPanelAppNavigationItems` override on `ControlPanelWorkflowPanelApp` and its test.
