### PR TITLE
LCD-53350 Retry a Liferay sync that raced the infrastructure provider

### DIFF
--- a/cloud/helm/default/templates/liferayenvironment.yaml
+++ b/cloud/helm/default/templates/liferayenvironment.yaml
@@ -2,6 +2,8 @@
 apiVersion: licensing.liferay.com/v1alpha1
 kind: LiferayEnvironment
 metadata:
+    annotations:
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     labels:
         app: {{ include "liferay.name" . }}
         {{- include "liferay.labels" . | nindent 8 }}

--- a/cloud/helm/default/tests/liferayenvironment_test.yaml
+++ b/cloud/helm/default/tests/liferayenvironment_test.yaml
@@ -40,3 +40,10 @@ tests:
         set:
             licensing.enabled: true
             licensing.offline: true
+    -   asserts:
+            -   equal:
+                    path: metadata.annotations["argocd.argoproj.io/sync-options"]
+                    value: SkipDryRunOnMissingResource=true
+        it: Tolerates its own custom resource definition arriving late
+        set:
+            licensing.enabled: true

--- a/cloud/terraform/aws/gitops/resources/argocd.tf
+++ b/cloud/terraform/aws/gitops/resources/argocd.tf
@@ -467,6 +467,14 @@ resource "kubernetes_manifest" "liferay_applicationset" {
 								"pod-security.kubernetes.io/enforce"="restricted"
 							}
 						}
+						retry={
+							backoff={
+								duration="15s"
+								factor=2
+								maxDuration="5m"
+							}
+							limit=10
+						}
 						syncOptions=[
 							"CreateNamespace=true",
 							"RespectIgnoreDifferences=true",

--- a/cloud/terraform/aws/gitops/resources/tests/argocd-applications.tftest.hcl
+++ b/cloud/terraform/aws/gitops/resources/tests/argocd-applications.tftest.hcl
@@ -75,6 +75,26 @@ run "should_include_required_prefixes_for_the_marketplace_chart_to_gateway_name"
 		liferay_helm_chart_name="liferay-aws-marketplace"
 	}
 }
+run "should_leave_the_operator_settings_to_the_chart_by_default" {
+	assert {
+		condition=length([
+			for p in kubernetes_manifest.infrastructure_provider_application.manifest.spec.sources[0].helm.parameters : p
+			if p.name == "liferay-dxp-operator.heartbeatInterval" || startswith(p.name, "liferay-dxp-operator.image.") || p.name == "liferay-dxp-operator.provisioning.baseURL" || p.name == "liferay-dxp-operator.retry.maxDelay"
+		]) == 0
+		error_message="The infrastructure provider Application must not override operator settings unless they are configured"
+	}
+	command=plan
+}
+run "should_leave_the_replica_count_to_the_operator" {
+	assert {
+		condition=length([
+			for difference in kubernetes_manifest.liferay_applicationset.manifest.spec.template.spec.ignoreDifferences : difference
+			if difference.kind == "StatefulSet" && contains(difference.managedFieldsManagers, "liferay-dxp-operator")
+		]) == 1
+		error_message="The Liferay ApplicationSet template must ignore spec.replicas on the workload, since the operator caps it against the licensed ceiling"
+	}
+	command=plan
+}
 run "should_name_the_appprojects" {
 	assert {
 		condition=kubernetes_manifest.infrastructure_applicationset.manifest.spec.template.spec.project == "liferay-infrastructure"
@@ -94,16 +114,6 @@ run "should_name_the_appprojects" {
 	}
 	command=plan
 }
-run "should_leave_the_replica_count_to_the_operator" {
-	assert {
-		condition=length([
-			for difference in kubernetes_manifest.liferay_applicationset.manifest.spec.template.spec.ignoreDifferences : difference
-			if difference.kind == "StatefulSet" && contains(difference.managedFieldsManagers, "liferay-dxp-operator")
-		]) == 1
-		error_message="The Liferay ApplicationSet template must ignore spec.replicas on the workload, since the operator caps it against the licensed ceiling"
-	}
-	command=plan
-}
 run "should_pass_cluster_identity_to_the_provider_application" {
 	assert {
 		condition=length([
@@ -118,16 +128,6 @@ run "should_pass_cluster_identity_to_the_provider_application" {
 			if p.name == "deploymentName" && p.value == "liferay-test"
 		]) == 1
 		error_message="The infrastructure provider Application must pass the deployment name as a Helm parameter"
-	}
-	command=plan
-}
-run "should_leave_the_operator_settings_to_the_chart_by_default" {
-	assert {
-		condition=length([
-			for p in kubernetes_manifest.infrastructure_provider_application.manifest.spec.sources[0].helm.parameters : p
-			if p.name == "liferay-dxp-operator.heartbeatInterval" || startswith(p.name, "liferay-dxp-operator.image.") || p.name == "liferay-dxp-operator.provisioning.baseURL" || p.name == "liferay-dxp-operator.retry.maxDelay"
-		]) == 0
-		error_message="The infrastructure provider Application must not override operator settings unless they are configured"
 	}
 	command=plan
 }
@@ -180,13 +180,18 @@ run "should_pass_the_configured_operator_settings_to_the_provider_application" {
 		}
 	}
 }
-run "should_scope_liferay_applicationset_helm_values_by_prefix" {
+run "should_retry_a_sync_that_lost_a_race_with_the_infrastructure_provider" {
 	assert {
-		condition=length([
-			for p in kubernetes_manifest.liferay_applicationset.manifest.spec.template.spec.sources[0].helm.parameters : p
-			if p.name == "liferay-default.network.gatewayName"
-		]) == 1
-		error_message="The liferay-aws chart must include prefix for liferay-default chart at gatewayName Helm parameter"
+		condition=kubernetes_manifest.liferay_applicationset.manifest.spec.template.spec.syncPolicy.retry.limit == 10
+		error_message="The Liferay ApplicationSet template must retry a failed sync, since ArgoCD does not retry a revision whose sync already failed"
+	}
+	assert {
+		condition=kubernetes_manifest.liferay_applicationset.manifest.spec.template.spec.syncPolicy.retry.backoff.maxDuration == "5m"
+		error_message="The Liferay ApplicationSet template must cap the retry backoff, so a custom resource definition that arrives late is still picked up"
+	}
+	assert {
+		condition=!contains(kubernetes_manifest.liferay_applicationset.manifest.spec.template.spec.syncPolicy.syncOptions, "SkipDryRunOnMissingResource=true")
+		error_message="The Liferay ApplicationSet template must keep the dry run for every resource, since tolerating a missing resource belongs on the one resource that needs it"
 	}
 	command=plan
 }
@@ -197,4 +202,14 @@ variables {
 	liferay_git_repo_url="https://github.com/example/liferay-gitops.git"
 	liferay_helm_chart_version="0.4.20"
 	region="us-east-1"
+}
+run "should_scope_liferay_applicationset_helm_values_by_prefix" {
+	assert {
+		condition=length([
+			for p in kubernetes_manifest.liferay_applicationset.manifest.spec.template.spec.sources[0].helm.parameters : p
+			if p.name == "liferay-default.network.gatewayName"
+		]) == 1
+		error_message="The liferay-aws chart must include prefix for liferay-default chart at gatewayName Helm parameter"
+	}
+	command=plan
 }

--- a/cloud/terraform/gcp/gitops/resources/argocd.tf
+++ b/cloud/terraform/gcp/gitops/resources/argocd.tf
@@ -446,6 +446,14 @@ resource "kubernetes_manifest" "liferay_applicationset" {
 								"pod-security.kubernetes.io/enforce"="restricted"
 							}
 						}
+						retry={
+							backoff={
+								duration="15s"
+								factor=2
+								maxDuration="5m"
+							}
+							limit=10
+						}
 						syncOptions=[
 							"CreateNamespace=true",
 							"RespectIgnoreDifferences=true",

--- a/cloud/terraform/gcp/gitops/resources/tests/argocd-applications.tftest.hcl
+++ b/cloud/terraform/gcp/gitops/resources/tests/argocd-applications.tftest.hcl
@@ -14,6 +14,26 @@ override_data {
 		number="1234567890"
 	}
 }
+run "should_leave_the_operator_settings_to_the_chart_by_default" {
+	assert {
+		condition=length([
+			for p in kubernetes_manifest.infrastructure_provider_application.manifest.spec.sources[0].helm.parameters : p
+			if p.name == "liferay-dxp-operator.heartbeatInterval" || startswith(p.name, "liferay-dxp-operator.image.") || p.name == "liferay-dxp-operator.provisioning.baseURL" || p.name == "liferay-dxp-operator.retry.maxDelay"
+		]) == 0
+		error_message="The infrastructure provider Application must not override operator settings unless they are configured"
+	}
+	command=plan
+}
+run "should_leave_the_replica_count_to_the_operator" {
+	assert {
+		condition=length([
+			for difference in kubernetes_manifest.liferay_applicationset.manifest.spec.template.spec.ignoreDifferences : difference
+			if difference.kind == "StatefulSet" && contains(difference.managedFieldsManagers, "liferay-dxp-operator")
+		]) == 1
+		error_message="The Liferay ApplicationSet template must ignore spec.replicas on the workload, since the operator caps it against the licensed ceiling"
+	}
+	command=plan
+}
 run "should_name_the_appprojects" {
 	assert {
 		condition=kubernetes_manifest.infrastructure_applicationset.manifest.spec.template.spec.project == "liferay-infrastructure"
@@ -47,16 +67,6 @@ run "should_pass_deployment_identity_to_the_provider_application" {
 			if p.name == "global.gcp.projectId" && p.value == "liferay-test-project"
 		]) == 1
 		error_message="The infrastructure provider Application must pass the GCP project id as a Helm parameter"
-	}
-	command=plan
-}
-run "should_leave_the_operator_settings_to_the_chart_by_default" {
-	assert {
-		condition=length([
-			for p in kubernetes_manifest.infrastructure_provider_application.manifest.spec.sources[0].helm.parameters : p
-			if p.name == "liferay-dxp-operator.heartbeatInterval" || startswith(p.name, "liferay-dxp-operator.image.") || p.name == "liferay-dxp-operator.provisioning.baseURL" || p.name == "liferay-dxp-operator.retry.maxDelay"
-		]) == 0
-		error_message="The infrastructure provider Application must not override operator settings unless they are configured"
 	}
 	command=plan
 }
@@ -109,6 +119,31 @@ run "should_pass_the_configured_operator_settings_to_the_provider_application" {
 		}
 	}
 }
+run "should_retry_a_sync_that_lost_a_race_with_the_infrastructure_provider" {
+	assert {
+		condition=kubernetes_manifest.liferay_applicationset.manifest.spec.template.spec.syncPolicy.retry.limit == 10
+		error_message="The Liferay ApplicationSet template must retry a failed sync, since ArgoCD does not retry a revision whose sync already failed"
+	}
+	assert {
+		condition=kubernetes_manifest.liferay_applicationset.manifest.spec.template.spec.syncPolicy.retry.backoff.maxDuration == "5m"
+		error_message="The Liferay ApplicationSet template must cap the retry backoff, so a custom resource definition that arrives late is still picked up"
+	}
+	assert {
+		condition=!contains(kubernetes_manifest.liferay_applicationset.manifest.spec.template.spec.syncPolicy.syncOptions, "SkipDryRunOnMissingResource=true")
+		error_message="The Liferay ApplicationSet template must keep the dry run for every resource, since tolerating a missing resource belongs on the one resource that needs it"
+	}
+	command=plan
+}
+variables {
+	deployment_name="liferay-test"
+	infrastructure_helm_chart_version="0.4.9"
+	infrastructure_provider_helm_chart_version="0.3.12"
+	liferay_git_repo_url="https://github.com/example/liferay-gitops.git"
+	liferay_helm_chart_version="0.4.20"
+	observability_helm_chart_version="0.1.0"
+	project_id="liferay-test-project"
+	region="us-central1"
+}
 run "should_scope_liferay_applicationset_helm_values_by_prefix" {
 	assert {
 		condition=kubernetes_manifest.liferay_applicationset.manifest.spec.template.spec.sources[0].helm.parameters[0].name == "liferay-default.environmentId"
@@ -125,24 +160,4 @@ run "should_use_an_unscoped_prefix_for_the_liferay_default_chart" {
 	variables {
 		liferay_helm_chart_name="liferay-default"
 	}
-}
-variables {
-	deployment_name="liferay-test"
-	infrastructure_helm_chart_version="0.4.9"
-	infrastructure_provider_helm_chart_version="0.3.12"
-	liferay_git_repo_url="https://github.com/example/liferay-gitops.git"
-	liferay_helm_chart_version="0.4.20"
-	observability_helm_chart_version="0.1.0"
-	project_id="liferay-test-project"
-	region="us-central1"
-}
-run "should_leave_the_replica_count_to_the_operator" {
-	assert {
-		condition=length([
-			for difference in kubernetes_manifest.liferay_applicationset.manifest.spec.template.spec.ignoreDifferences : difference
-			if difference.kind == "StatefulSet" && contains(difference.managedFieldsManagers, "liferay-dxp-operator")
-		]) == 1
-		error_message="The Liferay ApplicationSet template must ignore spec.replicas on the workload, since the operator caps it against the licensed ceiling"
-	}
-	command=plan
 }


### PR DESCRIPTION
The LiferayEnvironment custom resource definition is installed by the infrastructure provider application, while the resource that needs it is rendered by the Liferay application. Those are separate ArgoCD applications, so sync waves impose no ordering between them, and on a fresh cluster the Liferay application can reach its first sync before the definition exists. Losing that race failed the whole sync rather than the one resource, and automated sync never recovered it, because ArgoCD will not retry a revision whose sync already failed.

The permanence is the part worth fixing, so the ApplicationSet now carries a retry policy. Ten attempts backing off from fifteen seconds to a five minute ceiling cover roughly half an hour, which is well past the eleven and a half minutes the provider application took on the deployment where this was found, and the policy applies whichever resource loses a race rather than only this one.

Tolerating a definition that is not installed yet belongs on the resource that needs it, so the LiferayEnvironment carries the sync option as an annotation. Setting it on the ApplicationSet instead would drop the dry run for every resource of every environment, which is how a typo in an apiVersion stops being caught at validation time.
