### PR TITLE
LPD-105314 Load the values of an object entry listing in one query per table

### DIFF
--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectEntry.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectEntry.java
@@ -64,6 +64,8 @@ public interface ObjectEntry
 
 	public java.util.Date getPublishDate();
 
+	public ObjectEntry getRelatedObjectEntry(String objectFieldName);
+
 	public java.util.Map<java.util.Locale, String> getTitleMap()
 		throws com.liferay.portal.kernel.exception.PortalException;
 
@@ -88,10 +90,13 @@ public interface ObjectEntry
 
 	public void setObjectDefinition(ObjectDefinition objectDefinition);
 
+	public void setRelatedObjectEntry(
+		String objectFieldName, ObjectEntry relatedObjectEntry);
+
 	public void setTransientValues(
 		java.util.Map<String, java.io.Serializable> values);
 
 	public void setValues(java.util.Map<String, java.io.Serializable> values);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1856044374
+// LIFERAY-SERVICE-BUILDER-HASH:1806780153

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectEntryWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectEntryWrapper.java
@@ -408,6 +408,11 @@ public class ObjectEntryWrapper
 		return model.getPublishDate();
 	}
 
+	@Override
+	public ObjectEntry getRelatedObjectEntry(String objectFieldName) {
+		return model.getRelatedObjectEntry(objectFieldName);
+	}
+
 	/**
 	 * Returns the review date of this object entry.
 	 *
@@ -851,6 +856,13 @@ public class ObjectEntryWrapper
 		model.setPrimaryKey(primaryKey);
 	}
 
+	@Override
+	public void setRelatedObjectEntry(
+		String objectFieldName, ObjectEntry relatedObjectEntry) {
+
+		model.setRelatedObjectEntry(objectFieldName, relatedObjectEntry);
+	}
+
 	/**
 	 * Sets the review date of this object entry.
 	 *
@@ -1012,4 +1024,4 @@ public class ObjectEntryWrapper
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-536486699
+// LIFERAY-SERVICE-BUILDER-HASH:-1478554619

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/model/bag/ObjectFieldBag.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/model/bag/ObjectFieldBag.java
@@ -59,6 +59,10 @@ public class ObjectFieldBag {
 		return _nameObjectFieldsMap.get(name);
 	}
 
+	public List<ObjectField> getObjectFields() {
+		return _objectFields;
+	}
+
 	private final Map<Long, ObjectField> _idObjectFieldsMap = new HashMap<>();
 	private final List<ObjectField> _indexedObjectFields = new ArrayList<>();
 	private final Map<String, ObjectField> _nameObjectFieldsMap =

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalService.java
@@ -531,6 +531,11 @@ public interface ObjectEntryLocalService
 			Map<String, Serializable> values)
 		throws PortalException;
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public void loadValues(
+			ObjectDefinition objectDefinition, List<ObjectEntry> objectEntries)
+		throws PortalException;
+
 	public void moveObjectEntriesToTrash(
 			long userId, ObjectEntryFolder objectEntryFolder,
 			ServiceContext serviceContext)
@@ -625,4 +630,4 @@ public interface ObjectEntryLocalService
 		throws PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:872444325
+// LIFERAY-SERVICE-BUILDER-HASH:-81508022

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalServiceUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalServiceUtil.java
@@ -731,6 +731,14 @@ public class ObjectEntryLocalServiceUtil {
 			userId, objectDefinitionId, primaryKey, values);
 	}
 
+	public static void loadValues(
+			com.liferay.object.model.ObjectDefinition objectDefinition,
+			List<ObjectEntry> objectEntries)
+		throws PortalException {
+
+		getService().loadValues(objectDefinition, objectEntries);
+	}
+
 	public static void moveObjectEntriesToTrash(
 			long userId,
 			com.liferay.object.model.ObjectEntryFolder objectEntryFolder,
@@ -910,4 +918,4 @@ public class ObjectEntryLocalServiceUtil {
 			ObjectEntryLocalServiceUtil.class, ObjectEntryLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:481668498
+// LIFERAY-SERVICE-BUILDER-HASH:-742764202

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalServiceWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalServiceWrapper.java
@@ -837,6 +837,15 @@ public class ObjectEntryLocalServiceWrapper
 	}
 
 	@Override
+	public void loadValues(
+			com.liferay.object.model.ObjectDefinition objectDefinition,
+			java.util.List<com.liferay.object.model.ObjectEntry> objectEntries)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		_objectEntryLocalService.loadValues(objectDefinition, objectEntries);
+	}
+
+	@Override
 	public void moveObjectEntriesToTrash(
 			long userId,
 			com.liferay.object.model.ObjectEntryFolder objectEntryFolder,
@@ -1050,4 +1059,4 @@ public class ObjectEntryLocalServiceWrapper
 	private ObjectEntryLocalService _objectEntryLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:660663488
+// LIFERAY-SERVICE-BUILDER-HASH:-262356575

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/model/bag/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/model/bag/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/model/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/model/packageinfo
@@ -1,1 +1,1 @@
-version 13.5.0
+version 13.6.0

--- a/modules/apps/object/object-info-api/src/main/java/com/liferay/object/info/item/provider/util/ObjectEntryInfoItemValuesProviderUtil.java
+++ b/modules/apps/object/object-info-api/src/main/java/com/liferay/object/info/item/provider/util/ObjectEntryInfoItemValuesProviderUtil.java
@@ -171,8 +171,18 @@ public class ObjectEntryInfoItemValuesProviderUtil {
 
 			com.liferay.object.model.ObjectEntry
 				serviceBuilderRelatedObjectEntry =
-					objectEntryLocalService.fetchObjectEntry(
-						GetterUtil.getLong(values.get(objectField.getName())));
+					serviceBuilderObjectEntry.getRelatedObjectEntry(
+						objectField.getName());
+
+			if (serviceBuilderRelatedObjectEntry == null) {
+				long objectEntryId = GetterUtil.getLong(
+					values.get(objectField.getName()));
+
+				if (objectEntryId != 0) {
+					serviceBuilderRelatedObjectEntry =
+						objectEntryLocalService.fetchObjectEntry(objectEntryId);
+				}
+			}
 
 			ObjectEntry objectEntry = ObjectEntryInfoItemUtil.getObjectEntry(
 				parentObjectDefinition, objectEntryManagerRegistry,

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -3069,6 +3069,9 @@ public class DefaultObjectEntryManagerImpl
 				WorkflowConstants.STATUS_ANY);
 		}
 
+		objectEntryLocalService.loadValues(
+			objectDefinition, serviceBuilderObjectEntries);
+
 		return Page.of(
 			serviceBuilderObjectEntries, pagination, objectEntriesCount);
 	}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectEntryImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectEntryImpl.java
@@ -154,6 +154,11 @@ public class ObjectEntryImpl extends ObjectEntryBaseImpl {
 	}
 
 	@Override
+	public ObjectEntry getRelatedObjectEntry(String objectFieldName) {
+		return _relatedObjectEntries.get(objectFieldName);
+	}
+
+	@Override
 	public StagedModelType getStagedModelType() {
 		return new StagedModelType(
 			PortalUtil.getClassNameId(getModelClassName()));
@@ -335,6 +340,13 @@ public class ObjectEntryImpl extends ObjectEntryBaseImpl {
 	}
 
 	@Override
+	public void setRelatedObjectEntry(
+		String objectFieldName, ObjectEntry relatedObjectEntry) {
+
+		_relatedObjectEntries.put(objectFieldName, relatedObjectEntry);
+	}
+
+	@Override
 	public void setTransientValues(Map<String, Serializable> values) {
 		_transientValues = values;
 	}
@@ -349,6 +361,8 @@ public class ObjectEntryImpl extends ObjectEntryBaseImpl {
 
 	private Map<String, Serializable> _indexedValues;
 	private ObjectDefinition _objectDefinition;
+	private final Map<String, ObjectEntry> _relatedObjectEntries =
+		new HashMap<>();
 	private Map<String, Serializable> _transientValues;
 	private Map<String, Serializable> _values;
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -1982,6 +1982,21 @@ public class ObjectEntryLocalServiceImpl
 	}
 
 	@Override
+	public void loadValues(
+			ObjectDefinition objectDefinition, List<ObjectEntry> objectEntries)
+		throws PortalException {
+
+		Map<ObjectDefinition, List<ObjectEntry>> relatedObjectEntriesMap =
+			_loadValues(objectDefinition, objectEntries);
+
+		for (Map.Entry<ObjectDefinition, List<ObjectEntry>> entry :
+				relatedObjectEntriesMap.entrySet()) {
+
+			_loadValues(entry.getKey(), entry.getValue());
+		}
+	}
+
+	@Override
 	public void moveObjectEntriesToTrash(
 			long userId, ObjectEntryFolder objectEntryFolder,
 			ServiceContext serviceContext)
@@ -2911,40 +2926,9 @@ public class ObjectEntryLocalServiceImpl
 			),
 			objectFieldBag, selectExpressions);
 
-		if (ListUtil.isEmpty(rows)) {
-			return;
-		}
-
-		List<Column<DynamicObjectDefinitionLocalizationTable, ?>>
-			objectFieldColumns =
-				dynamicObjectDefinitionLocalizationTable.
-					getObjectFieldColumns();
-
-		for (int i = 0; i < objectFieldColumns.size(); i++) {
-			Column<DynamicObjectDefinitionLocalizationTable, ?>
-				objectFieldColumn = objectFieldColumns.get(i);
-
-			Map<String, Serializable> localizedValues = new HashMap<>();
-
-			for (Object[] row : rows) {
-				Object localizedValue = row[i];
-
-				if (!(localizedValue instanceof Long) &&
-					Validator.isNull(localizedValue)) {
-
-					continue;
-				}
-
-				_putValue(
-					objectFieldColumn.getJavaType(),
-					String.valueOf(row[objectFieldColumns.size()]),
-					localizedValue, localizedValues);
-			}
-
-			_putLocalizedValues(
-				objectFieldColumn.getName(), defaultLanguageId, localizedValues,
-				values);
-		}
+		_putLocalizedObjectFieldValues(
+			defaultLanguageId, dynamicObjectDefinitionLocalizationTable, rows,
+			values);
 	}
 
 	private ObjectEntry _addObjectEntry(
@@ -3067,6 +3051,148 @@ public class ObjectEntryLocalServiceImpl
 			values.put(
 				objectRelationshipERCObjectFieldName, externalReferenceCode);
 		}
+	}
+
+	private Map<ObjectDefinition, List<ObjectEntry>>
+		_addObjectRelationshipERCFieldValues(
+			List<ObjectField> objectFields, List<ObjectEntry> objectEntries) {
+
+		Map<ObjectDefinition, List<ObjectEntry>> relatedObjectEntriesMap =
+			new HashMap<>();
+
+		for (ObjectField objectField : objectFields) {
+			if (!Objects.equals(
+					objectField.getRelationshipType(),
+					ObjectRelationshipConstants.TYPE_ONE_TO_MANY)) {
+
+				continue;
+			}
+
+			Set<Serializable> primaryKeys = new HashSet<>();
+
+			for (ObjectEntry objectEntry : objectEntries) {
+				Map<String, Serializable> values = objectEntry.getValues();
+
+				long primaryKey = GetterUtil.getLong(
+					values.get(objectField.getName()));
+
+				if (primaryKey != 0) {
+					primaryKeys.add(primaryKey);
+				}
+			}
+
+			if (primaryKeys.isEmpty()) {
+				continue;
+			}
+
+			ObjectRelationship objectRelationship =
+				_objectRelationshipPersistence.fetchByObjectFieldId2(
+					objectField.getObjectFieldId());
+
+			ObjectDefinition objectDefinition =
+				_objectDefinitionPersistence.fetchByPrimaryKey(
+					objectRelationship.getObjectDefinitionId1());
+
+			if (objectDefinition == null) {
+				continue;
+			}
+
+			String objectRelationshipERCObjectFieldName =
+				ObjectFieldSettingUtil.getValue(
+					ObjectFieldSettingConstants.
+						NAME_OBJECT_RELATIONSHIP_ERC_OBJECT_FIELD_NAME,
+					objectField);
+
+			if (objectDefinition.isUnmodifiableSystemObject()) {
+				SystemObjectDefinitionManager systemObjectDefinitionManager =
+					_systemObjectDefinitionManagerRegistry.
+						getSystemObjectDefinitionManager(
+							objectDefinition.getName());
+
+				for (ObjectEntry objectEntry : objectEntries) {
+					Map<String, Serializable> values = objectEntry.getValues();
+
+					long primaryKey = GetterUtil.getLong(
+						values.get(objectField.getName()));
+
+					if (primaryKey == 0) {
+						continue;
+					}
+
+					try {
+						values.put(
+							objectRelationshipERCObjectFieldName,
+							systemObjectDefinitionManager.
+								getBaseModelExternalReferenceCode(primaryKey));
+					}
+					catch (PortalException portalException) {
+						if (_log.isDebugEnabled()) {
+							_log.debug(portalException);
+						}
+					}
+				}
+
+				continue;
+			}
+
+			Map<Serializable, ObjectEntry> relatedObjectEntries =
+				new HashMap<>();
+
+			if (objectDefinition.getObjectDefinitionId() ==
+					objectField.getObjectDefinitionId()) {
+
+				for (ObjectEntry objectEntry : objectEntries) {
+					if (primaryKeys.remove(objectEntry.getObjectEntryId())) {
+						relatedObjectEntries.put(
+							objectEntry.getObjectEntryId(), objectEntry);
+					}
+				}
+			}
+
+			if (!primaryKeys.isEmpty()) {
+				Map<Serializable, ObjectEntry> fetchedRelatedObjectEntries =
+					objectEntryPersistence.fetchByPrimaryKeys(primaryKeys);
+
+				relatedObjectEntries.putAll(fetchedRelatedObjectEntries);
+
+				List<ObjectEntry> relatedObjectEntriesList =
+					relatedObjectEntriesMap.computeIfAbsent(
+						objectDefinition, key -> new ArrayList<>());
+
+				relatedObjectEntriesList.addAll(
+					fetchedRelatedObjectEntries.values());
+			}
+
+			for (ObjectEntry objectEntry : objectEntries) {
+				Map<String, Serializable> values = objectEntry.getValues();
+
+				long primaryKey = GetterUtil.getLong(
+					values.get(objectField.getName()));
+
+				if (primaryKey == 0) {
+					continue;
+				}
+
+				String externalReferenceCode = StringPool.BLANK;
+
+				ObjectEntry relatedObjectEntry = relatedObjectEntries.get(
+					primaryKey);
+
+				if (relatedObjectEntry != null) {
+					externalReferenceCode =
+						relatedObjectEntry.getExternalReferenceCode();
+
+					objectEntry.setRelatedObjectEntry(
+						objectField.getName(), relatedObjectEntry);
+				}
+
+				values.put(
+					objectRelationshipERCObjectFieldName,
+					externalReferenceCode);
+			}
+		}
+
+		return relatedObjectEntriesMap;
 	}
 
 	private void _addOrUpdateComments(
@@ -4731,6 +4857,46 @@ public class ObjectEntryLocalServiceImpl
 			locales, _language.getCompanyAvailableLocales(companyId));
 	}
 
+	private Map<Long, List<Object[]>> _getLocalizedRowsMap(
+			DynamicObjectDefinitionLocalizationTable
+				dynamicObjectDefinitionLocalizationTable,
+			ObjectFieldBag objectFieldBag, Long[] primaryKeys)
+		throws PortalException {
+
+		Column<DynamicObjectDefinitionLocalizationTable, Long>
+			foreignKeyColumn =
+				dynamicObjectDefinitionLocalizationTable.getForeignKeyColumn();
+
+		Expression<?>[] selectExpressions = ArrayUtil.append(
+			_getSelectExpressions(dynamicObjectDefinitionLocalizationTable),
+			new Expression<?>[] {
+				dynamicObjectDefinitionLocalizationTable.getLanguageIdColumn(),
+				foreignKeyColumn
+			});
+
+		List<Object[]> rows = _list(
+			DSLQueryFactoryUtil.select(
+				selectExpressions
+			).from(
+				dynamicObjectDefinitionLocalizationTable
+			).where(
+				foreignKeyColumn.in(primaryKeys)
+			),
+			objectFieldBag, selectExpressions);
+
+		Map<Long, List<Object[]>> localizedRowsMap = new HashMap<>();
+
+		for (Object[] row : rows) {
+			List<Object[]> localizedRows = localizedRowsMap.computeIfAbsent(
+				GetterUtil.getLong(row[selectExpressions.length - 1]),
+				key -> new ArrayList<>());
+
+			localizedRows.add(row);
+		}
+
+		return localizedRowsMap;
+	}
+
 	private Object _getLocalizedValue(
 		String languageId, Map<String, Object> localizedValues) {
 
@@ -5845,6 +6011,20 @@ public class ObjectEntryLocalServiceImpl
 			new ValidationError(objectEntryValuesException.getMessage()));
 	}
 
+	private boolean _hasFormulaObjectField(List<ObjectField> objectFields) {
+		for (ObjectField objectField : objectFields) {
+			if (objectField.compareBusinessType(
+					ObjectFieldConstants.BUSINESS_TYPE_FORMULA) &&
+				Validator.isNotNull(
+					ObjectFieldSettingUtil.getValue("script", objectField))) {
+
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 	private void _insertIntoLocalizationTable(
 			Map<String, Serializable> insertedValues,
 			ObjectDefinition objectDefinition, long objectEntryId,
@@ -6239,6 +6419,127 @@ public class ObjectEntryLocalServiceImpl
 		return results;
 	}
 
+	private Map<ObjectDefinition, List<ObjectEntry>> _loadValues(
+			ObjectDefinition objectDefinition, List<ObjectEntry> objectEntries)
+		throws PortalException {
+
+		if (objectEntries.isEmpty()) {
+			return Collections.emptyMap();
+		}
+
+		ObjectFieldBag objectFieldBag = objectDefinition.getObjectFieldBag();
+
+		List<ObjectField> objectFields = objectFieldBag.getObjectFields();
+
+		if (_hasFormulaObjectField(objectFields)) {
+			for (ObjectEntry objectEntry : objectEntries) {
+				objectEntry.setValues(getValues(objectEntry));
+			}
+
+			return Collections.emptyMap();
+		}
+
+		DynamicObjectDefinitionTable dynamicObjectDefinitionTable =
+			DynamicObjectDefinitionTableUtil.getDynamicObjectDefinitionTable(
+				false, objectDefinition, objectFields);
+
+		DynamicObjectDefinitionTable extensionDynamicObjectDefinitionTable =
+			DynamicObjectDefinitionTableUtil.getDynamicObjectDefinitionTable(
+				true, objectDefinition, objectFields);
+
+		Expression<?>[] extensionSelectExpressions = ArrayUtil.remove(
+			_getSelectExpressions(
+				extensionDynamicObjectDefinitionTable, 0, null, null),
+			extensionDynamicObjectDefinitionTable.getPrimaryKeyColumn());
+
+		Predicate innerJoinPredicate = null;
+
+		if (extensionSelectExpressions.length != 0) {
+			innerJoinPredicate =
+				dynamicObjectDefinitionTable.getPrimaryKeyColumn(
+				).eq(
+					extensionDynamicObjectDefinitionTable.getPrimaryKeyColumn()
+				);
+		}
+
+		Column<DynamicObjectDefinitionTable, Long> primaryKeyColumn =
+			dynamicObjectDefinitionTable.getPrimaryKeyColumn();
+		Expression<?>[] selectExpressions = ArrayUtil.append(
+			_getSelectExpressions(dynamicObjectDefinitionTable, 0, null, null),
+			extensionSelectExpressions);
+
+		Long[] primaryKeys = ListUtil.toArray(
+			objectEntries, ObjectEntry.OBJECT_ENTRY_ID_ACCESSOR);
+
+		Long[][] primaryKeysBatches = {primaryKeys};
+
+		int dbInMaxParameters = DBManagerUtil.getDBInMaxParameters();
+
+		if (primaryKeys.length > dbInMaxParameters) {
+			primaryKeysBatches = (Long[][])ArrayUtil.split(
+				primaryKeys, dbInMaxParameters);
+		}
+
+		DynamicObjectDefinitionLocalizationTable
+			dynamicObjectDefinitionLocalizationTable =
+				DynamicObjectDefinitionLocalizationTableFactory.create(
+					objectDefinition, objectFields);
+
+		Map<Long, List<Object[]>> localizedRowsMap = new HashMap<>();
+		Map<Long, Map<String, Serializable>> valuesMap = new HashMap<>();
+
+		for (Long[] primaryKeysBatch : primaryKeysBatches) {
+			List<Object[]> rows = _list(
+				DSLQueryFactoryUtil.select(
+					selectExpressions
+				).from(
+					dynamicObjectDefinitionTable
+				).innerJoinON(
+					extensionDynamicObjectDefinitionTable, innerJoinPredicate
+				).where(
+					primaryKeyColumn.in(primaryKeysBatch)
+				),
+				objectFieldBag, selectExpressions);
+
+			for (Object[] row : rows) {
+				valuesMap.put(
+					(Long)row[0],
+					_getValues(objectFieldBag, row, selectExpressions));
+			}
+
+			if (dynamicObjectDefinitionLocalizationTable != null) {
+				localizedRowsMap.putAll(
+					_getLocalizedRowsMap(
+						dynamicObjectDefinitionLocalizationTable,
+						objectFieldBag, primaryKeysBatch));
+			}
+		}
+
+		for (ObjectEntry objectEntry : objectEntries) {
+			Map<String, Serializable> values = valuesMap.get(
+				objectEntry.getObjectEntryId());
+
+			if (values == null) {
+				objectEntry.setValues(Collections.emptyMap());
+
+				continue;
+			}
+
+			if (dynamicObjectDefinitionLocalizationTable != null) {
+				_putLocalizedObjectFieldValues(
+					objectEntry.getDefaultLanguageId(),
+					dynamicObjectDefinitionLocalizationTable,
+					localizedRowsMap.get(objectEntry.getObjectEntryId()),
+					values);
+			}
+
+			objectEntry.setValues(values);
+		}
+
+		return _addObjectRelationshipERCFieldValues(
+			objectFields, objectEntries);
+	}
+
 	private ObjectEntry _moveObjectEntryToTrash(
 			ObjectEntry objectEntry, long objectEntryFolderId,
 			ServiceContext serviceContext, long userId)
@@ -6372,6 +6673,48 @@ public class ObjectEntryLocalServiceImpl
 		}
 
 		insertedValues.put(key, serializable);
+	}
+
+	private void _putLocalizedObjectFieldValues(
+		String defaultLanguageId,
+		DynamicObjectDefinitionLocalizationTable
+			dynamicObjectDefinitionLocalizationTable,
+		List<Object[]> rows, Map<String, Serializable> values) {
+
+		if (ListUtil.isEmpty(rows)) {
+			return;
+		}
+
+		List<Column<DynamicObjectDefinitionLocalizationTable, ?>>
+			objectFieldColumns =
+				dynamicObjectDefinitionLocalizationTable.
+					getObjectFieldColumns();
+
+		for (int i = 0; i < objectFieldColumns.size(); i++) {
+			Column<DynamicObjectDefinitionLocalizationTable, ?>
+				objectFieldColumn = objectFieldColumns.get(i);
+
+			Map<String, Serializable> localizedValues = new HashMap<>();
+
+			for (Object[] row : rows) {
+				Object localizedValue = row[i];
+
+				if (!(localizedValue instanceof Long) &&
+					Validator.isNull(localizedValue)) {
+
+					continue;
+				}
+
+				_putValue(
+					objectFieldColumn.getJavaType(),
+					String.valueOf(row[objectFieldColumns.size()]),
+					localizedValue, localizedValues);
+			}
+
+			_putLocalizedValues(
+				objectFieldColumn.getName(), defaultLanguageId, localizedValues,
+				values);
+		}
 	}
 
 	private void _putLocalizedValues(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -6509,6 +6509,230 @@ public class ObjectEntryLocalServiceTest {
 	}
 
 	@Test
+	public void testLoadValues() throws Exception {
+		ObjectEntry objectEntry1 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"emailAddressRequired", "peter@liferay.com"
+			).put(
+				"firstName", "Peter"
+			).put(
+				"listTypeEntryKeyRequired", "listTypeEntryKey1"
+			).build());
+		ObjectEntry objectEntry2 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"emailAddressRequired", "james@liferay.com"
+			).put(
+				"firstName", "James"
+			).put(
+				"listTypeEntryKeyRequired", "listTypeEntryKey2"
+			).build());
+
+		_assertLoadValues(_objectDefinition, objectEntry1, objectEntry2);
+	}
+
+	@Test
+	public void testLoadValuesWithFormulaObjectField() throws Exception {
+		_addCustomObjectField(
+			new FormulaObjectFieldBuilder(
+			).labelMap(
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString())
+			).name(
+				"formulaObjectFieldName"
+			).objectDefinitionId(
+				_objectDefinition.getObjectDefinitionId()
+			).objectFieldSettings(
+				Arrays.asList(
+					new ObjectFieldSettingBuilder(
+					).name(
+						"script"
+					).value(
+						"id + id"
+					).build(),
+					new ObjectFieldSettingBuilder(
+					).name(
+						"output"
+					).value(
+						ObjectFieldConstants.BUSINESS_TYPE_DECIMAL
+					).build())
+			).build());
+
+		ObjectEntry objectEntry1 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"emailAddressRequired", "peter@liferay.com"
+			).put(
+				"listTypeEntryKeyRequired", "listTypeEntryKey1"
+			).build());
+		ObjectEntry objectEntry2 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"emailAddressRequired", "james@liferay.com"
+			).put(
+				"listTypeEntryKeyRequired", "listTypeEntryKey2"
+			).build());
+
+		_assertLoadValues(_objectDefinition, objectEntry1, objectEntry2);
+	}
+
+	@Test
+	public void testLoadValuesWithLocalizedObjectField() throws Exception {
+		ObjectField objectField = ObjectFieldUtil.createObjectField(
+			ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+			ObjectFieldConstants.DB_TYPE_STRING, "Localized Text",
+			"localizedText");
+
+		objectField.setLocalized(true);
+
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				Collections.singletonList(objectField));
+
+		ObjectEntry objectEntry1 = _addObjectEntry(
+			objectDefinition,
+			HashMapBuilder.<String, Serializable>put(
+				"localizedText_i18n",
+				(Serializable)HashMapBuilder.<String, Serializable>put(
+					LocaleUtil.toLanguageId(LocaleUtil.US), "Able"
+				).build()
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+		ObjectEntry objectEntry2 = _addObjectEntry(
+			objectDefinition,
+			HashMapBuilder.<String, Serializable>put(
+				"localizedText_i18n",
+				(Serializable)HashMapBuilder.<String, Serializable>put(
+					LocaleUtil.toLanguageId(LocaleUtil.US), "Baker"
+				).build()
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		_assertLoadValues(objectDefinition, objectEntry1, objectEntry2);
+
+		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
+	}
+
+	@Test
+	public void testLoadValuesWithRelatedObjectEntries() throws Exception {
+		ObjectDefinition objectDefinition1 =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				Collections.singletonList(
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+						ObjectFieldConstants.DB_TYPE_STRING, "Name", "name")));
+		ObjectDefinition objectDefinition2 =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				Collections.emptyList());
+
+		ObjectRelationship objectRelationship =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				_objectRelationshipLocalService, objectDefinition1,
+				objectDefinition2);
+
+		ObjectField relationshipObjectField =
+			_objectFieldLocalService.fetchObjectField(
+				objectRelationship.getObjectFieldId2());
+
+		ObjectEntry relatedObjectEntry = _addObjectEntry(
+			objectDefinition1,
+			HashMapBuilder.<String, Serializable>put(
+				"name", RandomTestUtil.randomString()
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		ObjectEntry objectEntry = _addObjectEntry(
+			objectDefinition2,
+			HashMapBuilder.<String, Serializable>put(
+				relationshipObjectField.getName(),
+				relatedObjectEntry.getObjectEntryId()
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		List<ObjectEntry> objectEntries = Collections.singletonList(
+			_objectEntryLocalService.getObjectEntry(
+				objectEntry.getObjectEntryId()));
+
+		_objectEntryLocalService.loadValues(
+			_objectDefinitionLocalService.getObjectDefinition(
+				objectDefinition2.getObjectDefinitionId()),
+			objectEntries);
+
+		ObjectEntry loadedObjectEntry = objectEntries.get(0);
+
+		ObjectEntry loadedRelatedObjectEntry =
+			loadedObjectEntry.getRelatedObjectEntry(
+				relationshipObjectField.getName());
+
+		Assert.assertEquals(
+			relatedObjectEntry.getObjectEntryId(),
+			loadedRelatedObjectEntry.getObjectEntryId());
+
+		_assertValuesLoaded(relatedObjectEntry, loadedRelatedObjectEntry);
+
+		_objectRelationshipLocalService.deleteObjectRelationship(
+			objectRelationship);
+		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition2);
+		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition1);
+	}
+
+	@Test
+	public void testLoadValuesWithRelatedObjectEntryOnTheList()
+		throws Exception {
+
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				Collections.singletonList(
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+						ObjectFieldConstants.DB_TYPE_STRING, "Name", "name")));
+
+		ObjectRelationship objectRelationship =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				_objectRelationshipLocalService, objectDefinition,
+				objectDefinition);
+
+		ObjectField relationshipObjectField =
+			_objectFieldLocalService.fetchObjectField(
+				objectRelationship.getObjectFieldId2());
+
+		ObjectEntry relatedObjectEntry = _addObjectEntry(
+			objectDefinition,
+			HashMapBuilder.<String, Serializable>put(
+				"name", RandomTestUtil.randomString()
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		ObjectEntry objectEntry = _addObjectEntry(
+			objectDefinition,
+			HashMapBuilder.<String, Serializable>put(
+				"name", RandomTestUtil.randomString()
+			).put(
+				relationshipObjectField.getName(),
+				relatedObjectEntry.getObjectEntryId()
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		List<ObjectEntry> objectEntries = Arrays.asList(
+			_objectEntryLocalService.getObjectEntry(
+				objectEntry.getObjectEntryId()),
+			_objectEntryLocalService.getObjectEntry(
+				relatedObjectEntry.getObjectEntryId()));
+
+		_objectEntryLocalService.loadValues(
+			_objectDefinitionLocalService.getObjectDefinition(
+				objectDefinition.getObjectDefinitionId()),
+			objectEntries);
+
+		ObjectEntry loadedObjectEntry = objectEntries.get(0);
+
+		Assert.assertSame(
+			objectEntries.get(1),
+			loadedObjectEntry.getRelatedObjectEntry(
+				relationshipObjectField.getName()));
+
+		_objectRelationshipLocalService.deleteObjectRelationship(
+			objectRelationship);
+		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
+	}
+
+	@Test
 	public void testMoveObjectEntryToTrashWithComments() throws Exception {
 		Group group = GroupTestUtil.addGroup();
 
@@ -9621,6 +9845,28 @@ public class ObjectEntryLocalServiceTest {
 		Assert.assertEquals(count, baseModelSearchResult.getLength());
 	}
 
+	private void _assertLoadValues(
+			ObjectDefinition objectDefinition, ObjectEntry... objectEntries)
+		throws Exception {
+
+		List<ObjectEntry> loadedObjectEntries = new ArrayList<>();
+
+		for (ObjectEntry objectEntry : objectEntries) {
+			loadedObjectEntries.add(
+				_objectEntryLocalService.getObjectEntry(
+					objectEntry.getObjectEntryId()));
+		}
+
+		_objectEntryLocalService.loadValues(
+			_objectDefinitionLocalService.getObjectDefinition(
+				objectDefinition.getObjectDefinitionId()),
+			loadedObjectEntries);
+
+		for (int i = 0; i < objectEntries.length; i++) {
+			_assertValuesLoaded(objectEntries[i], loadedObjectEntries.get(i));
+		}
+	}
+
 	private void _assertObjectActionStatus(
 		int expectedStatus, ObjectAction objectAction) {
 
@@ -9718,6 +9964,31 @@ public class ObjectEntryLocalServiceTest {
 		Assert.assertEquals(
 			expectedObjectFieldName,
 			objectValidationRuleResult.getObjectFieldName());
+	}
+
+	private void _assertValuesLoaded(
+			ObjectEntry expectedObjectEntry, ObjectEntry objectEntry)
+		throws Exception {
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.object.model.impl.ObjectEntryImpl",
+				LoggerTestUtil.DEBUG)) {
+
+			Assert.assertEquals(
+				_objectEntryLocalService.getValues(expectedObjectEntry),
+				objectEntry.getValues());
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
+
+			LogEntry logEntry = logEntries.get(0);
+
+			Assert.assertEquals(
+				"Use cached values for object entry " +
+					objectEntry.getObjectEntryId(),
+				logEntry.getMessage());
+		}
 	}
 
 	private void _clearValidatedObjectEntryIds() {

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/info/item/provider/test/ObjectEntryInfoItemFieldValuesProviderTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/info/item/provider/test/ObjectEntryInfoItemFieldValuesProviderTest.java
@@ -590,6 +590,26 @@ public class ObjectEntryInfoItemFieldValuesProviderTest {
 			).build(),
 			ServiceContextTestUtil.getServiceContext());
 
+		// The row renders the related entry it carries, not a fresh fetch
+
+		ObjectEntry relatedObjectEntry =
+			_objectEntryLocalService.getObjectEntry(
+				parentObjectEntry.getObjectEntryId());
+
+		String parentTitleValue = RandomTestUtil.randomString();
+
+		relatedObjectEntry.setValues(
+			HashMapBuilder.<String, Serializable>putAll(
+				_objectEntryLocalService.getValues(relatedObjectEntry)
+			).put(
+				"parentTitle", parentTitleValue
+			).build());
+
+		childObjectEntry.setRelatedObjectEntry(
+			"r_oneToManyRelationshipName_" +
+				parentObjectDefinition.getPKObjectFieldName(),
+			relatedObjectEntry);
+
 		_pushServiceContext(_getThemeDisplay(StringPool.BLANK, "UTC"));
 
 		InfoItemFieldValuesProvider<ObjectEntry> infoItemFieldValuesProvider =
@@ -605,6 +625,12 @@ public class ObjectEntryInfoItemFieldValuesProviderTest {
 			infoItemFieldValues.getInfoFieldValue("childTitle");
 
 		Assert.assertEquals(childTitleValue, infoFieldValue.getValue());
+
+		InfoFieldValue<Object> parentTitleInfoFieldValue =
+			infoItemFieldValues.getInfoFieldValue("parentTitle");
+
+		Assert.assertEquals(
+			parentTitleValue, parentTitleInfoFieldValue.getValue());
 
 		ServiceContextThreadLocal.popServiceContext();
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-105314

Third change of the object entry listing optimization tracked under LPD-65366 (LPD-98910 scenario: a site page whose collection display lists a custom object's entries). It follows #181480 and #181510, which keep the listing's object entries and the collection item in hand while the rows render.

## What Is Being Fixed

Rendering a page of object entries loads the custom field values of every entry with its own SELECT on the definition's table, and resolves the related object entry of every relationship field with another lookup per row. On the benchmark page (100k entries, 50 rows per page) that is 50 identical single-row selects on the definition's table per page view, 52 statements in total with the listing count and the listing page query, plus the related entry lookups repeated per mapped field.

## How It Is Being Fixed

- `ObjectEntryLocalService.loadValues(objectDefinition, objectEntries)` loads the values of a list of object entries in one query per table: the definition table joined with its extension table, filtered by the primary keys in batches of the database IN-list limit, plus one query on the localization table for localized fields. Definitions with a formula field keep the per-entry read, since a formula needs the entry's own values to evaluate.
- The related object entries of the relationship fields are collected per relationship and loaded the same way, and an object entry now carries the related object entries loaded with it (`getRelatedObjectEntry`, `setRelatedObjectEntry`), so the renderer reads the related entry from the instance the row already holds. A related entry that is itself on the list is reused as the same instance.
- The collection providers call `loadValues` for the page they hand out. The `Semantic versioning` commit carries the bumps for the new service method and model accessors, and the two `buildService` commits carry their regeneration.

## Verification

- `ObjectEntryLocalServiceTest` covers the bulk load with five focused tests: plain fields, the formula fallback, a localized field, related entries with their own values loaded, and a related entry on the list reused as the same instance.
- Self-CI on shuyangzhou/liferay-portal PR 12754: stable 16/16, object 49/49, relevant 39/42 with every failure chronic on master (Testray: instance export 29/65, tags import report 23/65, Clarity site import 65/65, staging use cases 65-66/66).

## PR Check

**pr-check: PASS** — tested on `e7591a284a7fbfe21665018f0d9d5c0012e59770`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Service Registration | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | NOT VERIFIED |
| Baseline | PASS (baseline-all + seven Ant projects + 2 changed exporting modules; see note) |
| Java Unit Tests | NOT VERIFIED |

Baseline: the bnd baseline against the released `com.liferay.object.api-128.0.1` reported zero findings for the branch's bumps (`com.liferay.object.model` 13.5.0 -> 13.6.0, `com.liferay.object.model.bag` 2.0.0 -> 2.1.0) and left no repairs. The skill's Local Version Check flagged `com.liferay.object.service` because the branch adds `ObjectEntryLocalService.loadValues` without touching that package's `packageinfo`; that row is overruled here on evidence: the package already sits at 88.1.0 against the released 88.0.0 (raised by LPD-104797, unreleased), so the minor rise the addition needs is already in place, a further bump to 88.2.0 would be an excessive increase against the release, and the `semantic-versioning` job of `ci:test:relevant` passed on this content.

Cross-Module Compile verified nothing: the consumer set is 50 `-test` modules, above the cap of 8, so the expansion was skipped for every symbol; Integration Test Compile covered 8 of them and the deprecated surface is empty.

Java Unit Tests verified nothing beyond the three existing counterparts (4 tests, 0 failures), none of which reaches the added members; `ObjectEntryLocalServiceTest` in `object-test` covers them as integration tests.

Service Builder regenerated 527 entities with zero drift, so the two `buildService` commits are reproducible from the in-repo generator.

<!-- pr-check {"result": "success", "sha": "e7591a284a7fbfe21665018f0d9d5c0012e59770"} -->
