### PR TITLE
LPD-105390 Resolve a display page URL without reading the item's field values

### DIFF
--- a/modules/apps/asset/asset-display-page-api/src/main/java/com/liferay/asset/display/page/portlet/BaseAssetDisplayPageFriendlyURLResolver.java
+++ b/modules/apps/asset/asset-display-page-api/src/main/java/com/liferay/asset/display/page/portlet/BaseAssetDisplayPageFriendlyURLResolver.java
@@ -134,22 +134,32 @@ public abstract class BaseAssetDisplayPageFriendlyURLResolver
 		}
 
 		Locale locale = portal.getLocale(httpServletRequest);
+
 		Layout layout = getLayoutDisplayPageObjectProviderLayout(
 			groupId, friendlyURL, layoutDisplayPageObjectProvider,
 			layoutDisplayPageProvider);
 
-		InfoItemFieldValuesProvider<Object> infoItemFieldValuesProvider =
-			infoItemServiceRegistry.getFirstInfoItemService(
-				InfoItemFieldValuesProvider.class,
-				layoutDisplayPageObjectProvider.getClassName());
+		String mappedDescription = layout.getTypeSettingsProperty(
+			"mapped-description");
+		String mappedTitle = layout.getTypeSettingsProperty("mapped-title");
 
-		InfoItemFieldValues infoItemFieldValues =
-			infoItemFieldValuesProvider.getInfoItemFieldValues(
-				layoutDisplayPageObjectProvider.getDisplayObject());
+		InfoItemFieldValues infoItemFieldValues = null;
+
+		if (Validator.isNotNull(mappedDescription) ||
+			Validator.isNotNull(mappedTitle)) {
+
+			InfoItemFieldValuesProvider<Object> infoItemFieldValuesProvider =
+				infoItemServiceRegistry.getFirstInfoItemService(
+					InfoItemFieldValuesProvider.class,
+					layoutDisplayPageObjectProvider.getClassName());
+
+			infoItemFieldValues =
+				infoItemFieldValuesProvider.getInfoItemFieldValues(
+					layoutDisplayPageObjectProvider.getDisplayObject());
+		}
 
 		String description = _getMappedValue(
-			layout.getTypeSettingsProperty("mapped-description"),
-			infoItemFieldValues, locale);
+			mappedDescription, infoItemFieldValues, locale);
 
 		if (description == null) {
 			description = layoutDisplayPageObjectProvider.getDescription(
@@ -165,8 +175,7 @@ public abstract class BaseAssetDisplayPageFriendlyURLResolver
 			httpServletRequest);
 
 		String title = _getMappedValue(
-			layout.getTypeSettingsProperty("mapped-title"), infoItemFieldValues,
-			locale);
+			mappedTitle, infoItemFieldValues, locale);
 
 		if (title == null) {
 			title = layoutDisplayPageObjectProvider.getTitle(locale);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-105390

Part of the object entry page optimization tracked under LPD-65366 (LPD-98910 scenario). Independent of the listing changes (#181480, #181510, #181560): one file in `asset-display-page-api`, no API change.

## What Is Being Fixed

Resolving the friendly URL of an asset display page builds the complete info item field values of the displayed item, so that a title or description template mapped on the layout can be filled from them. That renders every field of the item before the page has asked for a single value; for an object entry it reads the attachment fields, builds their download URLs and checks the view permission on each file entry, all to answer a URL request. A layout that maps neither a title nor a description template pays for it all the same.

## How It Is Being Fixed

`BaseAssetDisplayPageFriendlyURLResolver.getActualURL` reads the layout's `mapped-title` and `mapped-description` type settings first and builds the field values only when at least one of them is set. When neither is set, the title and description fall back to the display object's own, which is exactly what the empty templates already produced, and the item's fields, download URLs and permission checks behind them are not computed.

## Verification

- The resolution is covered by the existing resolver integration tests in `asset-display-page-test`; `CustomAssetDisplayPageFriendlyURLResolverTest` passes on a fresh bundle built from the change. `BaseAssetDisplayPageFriendlyURLResolverTest.testGetLayoutFriendlyURLComposite` fails identically on master since 2026-09-04 (its fixture adds a Design Library display page template without the LPD-57283 flag, Testray case 519459540), and the unit `CustomAssetDisplayPageFriendlyURLResolverTest.testGetActualURL` fails on master with `NoClassDefFoundError: DepotEntryLocalService` because `asset-display-page-service` does not declare `depot-api`; neither reaches the changed code.
- Self-CI on shuyangzhou/liferay-portal PR 12756 (same content on the previous base 468aa6c): stable 11/11, object 49/49, relevant 23/29 with no unique failures (all six in common with upstream master).

## PR Check

**pr-check: PASS** — tested on `c2fd74a743d7504b56e7835862e4eb0e62f9e2b5`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Service Registration | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS (baseline-all + seven Ant projects + 1 changed exporting module) |
| Java Unit Tests | NOT VERIFIED |

Baseline compared `asset-display-page-api` against the released `com.liferay.asset.display.page.api-21.0.3` with no findings; the diff adds and removes no public or protected member, so no version bump is owed.

Java Unit Tests verified nothing: `asset-display-page-api` has no `src/test` tree. The resolver is covered by the integration tests in `asset-display-page-test`, run separately as described above.

<!-- pr-check {"result": "success", "sha": "c2fd74a743d7504b56e7835862e4eb0e62f9e2b5"} -->
