### PR TITLE
LPD-105314 Comment the related object entry test method

### DIFF
--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/info/item/provider/test/ObjectEntryInfoItemFieldValuesProviderTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/info/item/provider/test/ObjectEntryInfoItemFieldValuesProviderTest.java
@@ -528,6 +528,8 @@ public class ObjectEntryInfoItemFieldValuesProviderTest {
 	public void testObjectEntryInfoItemFieldValuesProviderWithObjectRelationship()
 		throws Exception {
 
+		// Publish a parent and a child object definition with a text field each
+
 		ObjectDefinition parentObjectDefinition = _addObjectDefinition(
 			new TextObjectFieldBuilder(
 			).labelMap(
@@ -554,6 +556,8 @@ public class ObjectEntryInfoItemFieldValuesProviderTest {
 				TestPropsValues.getUserId(),
 				childObjectDefinition.getObjectDefinitionId());
 
+		// Relate the child definition to the parent definition one to many
+
 		ObjectRelationship objectRelationship =
 			_objectRelationshipLocalService.addObjectRelationship(
 				null, TestPropsValues.getUserId(),
@@ -563,6 +567,8 @@ public class ObjectEntryInfoItemFieldValuesProviderTest {
 				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
 				"oneToManyRelationshipName", false,
 				ObjectRelationshipConstants.TYPE_ONE_TO_MANY, null);
+
+		// Add a parent entry and a child entry that points to it
 
 		ObjectEntry parentObjectEntry = _objectEntryLocalService.addObjectEntry(
 			_group.getGroupId(), TestPropsValues.getUserId(),
@@ -590,6 +596,9 @@ public class ObjectEntryInfoItemFieldValuesProviderTest {
 			).build(),
 			ServiceContextTestUtil.getServiceContext());
 
+		// Load the parent entry again, give that instance a title the database
+		// does not have, and let the child row carry it as its related entry
+
 		ObjectEntry relatedObjectEntry =
 			_objectEntryLocalService.getObjectEntry(
 				parentObjectEntry.getObjectEntryId());
@@ -607,6 +616,9 @@ public class ObjectEntryInfoItemFieldValuesProviderTest {
 			"r_oneToManyRelationshipName_" +
 				parentObjectDefinition.getPKObjectFieldName(),
 			relatedObjectEntry);
+
+		// The row renders the related entry it carries, not a fresh fetch, so
+		// the parent title is the one set on the carried instance
 
 		_pushServiceContext(_getThemeDisplay(StringPool.BLANK, "UTC"));
 
@@ -631,6 +643,9 @@ public class ObjectEntryInfoItemFieldValuesProviderTest {
 			parentTitleValue, parentTitleInfoFieldValue.getValue());
 
 		ServiceContextThreadLocal.popServiceContext();
+
+		// Clear the relationship's edge so it can be deleted, then delete it
+		// and both definitions
 
 		objectRelationship =
 			_objectRelationshipLocalService.updateObjectRelationship(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-105314

Follow-up to #181560 (comment https://github.com/brianchandotcom/liferay-portal/pull/181560#issuecomment-5619910488): the merge dropped the one comment in the related-entry test in favour of commenting the whole method.

## What Is Being Fixed

`ObjectEntryInfoItemFieldValuesProviderTest.testObjectEntryInfoItemFieldValuesProviderWithObjectRelationship` explained only the step that reloads the parent entry; the rest of the method, which sets up two definitions, a relationship and two entries, then checks that the row renders the related entry it carries rather than a fresh fetch, had no comments.

## How It Is Being Fixed

Each step of the test method now says what it sets up or checks: the two definitions, the relationship, the two entries, the carried instance with a title the database does not have, the render that reads it, and the cleanup. Comments only, no code change.

## Verification

- `ObjectEntryInfoItemFieldValuesProviderTest` compiles (`:apps:object:object-test:compileTestIntegrationJava`).

## PR Check

**pr-check: PASS** — tested on `fab0ad1267baeabcfe51da3cac0e4a91ba30fe79`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |

Comments-only change to one integration test file: no production source, exported package, `bnd.bnd`, `packageinfo` or build file changes, so Baseline, Per-Module Compile, Cross-Module Compile, Service Registration, Transaction Usage and Java Unit Tests have nothing to validate.

<!-- pr-check {"result": "success", "sha": "fab0ad1267baeabcfe51da3cac0e4a91ba30fe79"} -->
