### PR TITLE
LPD-105482 Resolve system object external reference codes through the persisted model service

### DIFF
--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/object/system/AccountEntrySystemObjectDefinitionManager.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/object/system/AccountEntrySystemObjectDefinitionManager.java
@@ -89,16 +89,6 @@ public class AccountEntrySystemObjectDefinitionManager
 	}
 
 	@Override
-	public String getBaseModelExternalReferenceCode(long primaryKey)
-		throws PortalException {
-
-		AccountEntry accountEntry = _accountEntryLocalService.getAccountEntry(
-			primaryKey);
-
-		return accountEntry.getExternalReferenceCode();
-	}
-
-	@Override
 	public String getExternalReferenceCode() {
 		return "L_ACCOUNT";
 	}

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/object/system/CPDefinitionSystemObjectDefinitionManager.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/object/system/CPDefinitionSystemObjectDefinitionManager.java
@@ -41,9 +41,13 @@ import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
+import java.io.Serializable;
+
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -123,6 +127,42 @@ public class CPDefinitionSystemObjectDefinitionManager
 		}
 
 		return cProduct.getExternalReferenceCode();
+	}
+
+	@Override
+	public Map<Serializable, String> getBaseModelExternalReferenceCodes(
+		Set<Serializable> primaryKeys) {
+
+		Map<Serializable, CProduct> cProducts =
+			_cProductLocalService.fetchPersistedModels(primaryKeys);
+
+		Map<Serializable, String> externalReferenceCodes = new HashMap<>();
+
+		for (Serializable primaryKey : primaryKeys) {
+			CProduct cProduct = cProducts.get(primaryKey);
+
+			if (cProduct == null) {
+				CPDefinition cpDefinition =
+					_cpDefinitionLocalService.fetchCPDefinition(
+						(Long)primaryKey);
+
+				if (cpDefinition == null) {
+					continue;
+				}
+
+				cProduct = _cProductLocalService.fetchCProduct(
+					cpDefinition.getCProductId());
+
+				if (cProduct == null) {
+					continue;
+				}
+			}
+
+			externalReferenceCodes.put(
+				primaryKey, cProduct.getExternalReferenceCode());
+		}
+
+		return externalReferenceCodes;
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/object/system/CommerceOrderItemSystemObjectDefinitionManager.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/object/system/CommerceOrderItemSystemObjectDefinitionManager.java
@@ -96,16 +96,6 @@ public class CommerceOrderItemSystemObjectDefinitionManager
 	}
 
 	@Override
-	public String getBaseModelExternalReferenceCode(long primaryKey)
-		throws PortalException {
-
-		CommerceOrderItem commerceOrderItem =
-			_commerceOrderItemLocalService.getCommerceOrderItem(primaryKey);
-
-		return commerceOrderItem.getExternalReferenceCode();
-	}
-
-	@Override
 	public String getExternalReferenceCode() {
 		return "L_COMMERCE_ORDER_ITEM";
 	}

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/object/system/CommerceOrderNoteSystemObjectDefinitionManager.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/object/system/CommerceOrderNoteSystemObjectDefinitionManager.java
@@ -93,16 +93,6 @@ public class CommerceOrderNoteSystemObjectDefinitionManager
 	}
 
 	@Override
-	public String getBaseModelExternalReferenceCode(long primaryKey)
-		throws PortalException {
-
-		CommerceOrderNote commerceOrderNote =
-			_commerceOrderNoteLocalService.getCommerceOrderNote(primaryKey);
-
-		return commerceOrderNote.getExternalReferenceCode();
-	}
-
-	@Override
 	public String getExternalReferenceCode() {
 		return "L_COMMERCE_ORDER_NOTE";
 	}

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/object/system/CommerceOrderSystemObjectDefinitionManager.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/object/system/CommerceOrderSystemObjectDefinitionManager.java
@@ -97,16 +97,6 @@ public class CommerceOrderSystemObjectDefinitionManager
 	}
 
 	@Override
-	public String getBaseModelExternalReferenceCode(long primaryKey)
-		throws PortalException {
-
-		CommerceOrder commerceOrder =
-			_commerceOrderLocalService.getCommerceOrder(primaryKey);
-
-		return commerceOrder.getExternalReferenceCode();
-	}
-
-	@Override
 	public String getExternalReferenceCode() {
 		return "L_COMMERCE_ORDER";
 	}

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/object/system/CommercePricingClassSystemObjectDefinitionManager.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/object/system/CommercePricingClassSystemObjectDefinitionManager.java
@@ -91,17 +91,6 @@ public class CommercePricingClassSystemObjectDefinitionManager
 	}
 
 	@Override
-	public String getBaseModelExternalReferenceCode(long primaryKey)
-		throws PortalException {
-
-		CommercePricingClass commercePricingClass =
-			_commercePricingClassLocalService.getCommercePricingClass(
-				primaryKey);
-
-		return commercePricingClass.getExternalReferenceCode();
-	}
-
-	@Override
 	public String getExternalReferenceCode() {
 		return "L_COMMERCE_PRODUCT_GROUP";
 	}

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/system/SystemObjectDefinitionManager.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/system/SystemObjectDefinitionManager.java
@@ -15,6 +15,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.PersistedModel;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.search.Sort;
@@ -26,6 +27,8 @@ import com.liferay.portal.service.PersistedModelLocalServiceRegistryUtil;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.util.ObjectMapperUtil;
+
+import java.io.Serializable;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -68,8 +71,40 @@ public interface SystemObjectDefinitionManager {
 			String externalReferenceCode, long companyId)
 		throws PortalException;
 
-	public String getBaseModelExternalReferenceCode(long primaryKey)
-		throws PortalException;
+	public default String getBaseModelExternalReferenceCode(long primaryKey)
+		throws PortalException {
+
+		ExternalReferenceCodeModel externalReferenceCodeModel =
+			(ExternalReferenceCodeModel)getPersistedModel(primaryKey);
+
+		return externalReferenceCodeModel.getExternalReferenceCode();
+	}
+
+	public default Map<Serializable, String> getBaseModelExternalReferenceCodes(
+		Set<Serializable> primaryKeys) {
+
+		PersistedModelLocalService persistedModelLocalService =
+			PersistedModelLocalServiceRegistryUtil.
+				getPersistedModelLocalService(getModelClassName());
+
+		Map<Serializable, PersistedModel> persistedModels =
+			persistedModelLocalService.fetchPersistedModels(primaryKeys);
+
+		Map<Serializable, String> externalReferenceCodes = new HashMap<>();
+
+		for (Map.Entry<Serializable, PersistedModel> entry :
+				persistedModels.entrySet()) {
+
+			ExternalReferenceCodeModel externalReferenceCodeModel =
+				(ExternalReferenceCodeModel)entry.getValue();
+
+			externalReferenceCodes.put(
+				entry.getKey(),
+				externalReferenceCodeModel.getExternalReferenceCode());
+		}
+
+		return externalReferenceCodes;
+	}
 
 	public default long getBaseModelGroupId() {
 		return 0L;

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/system/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/system/packageinfo
@@ -1,1 +1,1 @@
-version 20.0.0
+version 20.1.0

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/system/AddressSystemObjectDefinitionManager.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/system/AddressSystemObjectDefinitionManager.java
@@ -83,15 +83,6 @@ public class AddressSystemObjectDefinitionManager
 	}
 
 	@Override
-	public String getBaseModelExternalReferenceCode(long primaryKey)
-		throws PortalException {
-
-		Address address = _addressLocalService.getAddress(primaryKey);
-
-		return address.getExternalReferenceCode();
-	}
-
-	@Override
 	public String getExternalReferenceCode() {
 		return "L_POSTAL_ADDRESS";
 	}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/system/UserSystemObjectDefinitionManager.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/system/UserSystemObjectDefinitionManager.java
@@ -87,15 +87,6 @@ public class UserSystemObjectDefinitionManager
 	}
 
 	@Override
-	public String getBaseModelExternalReferenceCode(long primaryKey)
-		throws PortalException {
-
-		User user = _userLocalService.getUser(primaryKey);
-
-		return user.getExternalReferenceCode();
-	}
-
-	@Override
 	public String getExternalReferenceCode() {
 		return "L_USER";
 	}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -3109,26 +3109,20 @@ public class ObjectEntryLocalServiceImpl
 						getSystemObjectDefinitionManager(
 							objectDefinition.getName());
 
+				Map<Serializable, String> externalReferenceCodes =
+					systemObjectDefinitionManager.
+						getBaseModelExternalReferenceCodes(primaryKeys);
+
 				for (ObjectEntry objectEntry : objectEntries) {
 					Map<String, Serializable> values = objectEntry.getValues();
 
-					long primaryKey = GetterUtil.getLong(
-						values.get(objectField.getName()));
+					String externalReferenceCode = externalReferenceCodes.get(
+						GetterUtil.getLong(values.get(objectField.getName())));
 
-					if (primaryKey == 0) {
-						continue;
-					}
-
-					try {
+					if (externalReferenceCode != null) {
 						values.put(
 							objectRelationshipERCObjectFieldName,
-							systemObjectDefinitionManager.
-								getBaseModelExternalReferenceCode(primaryKey));
-					}
-					catch (PortalException portalException) {
-						if (_log.isDebugEnabled()) {
-							_log.debug(portalException);
-						}
+							externalReferenceCode);
 					}
 				}
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -97,6 +97,7 @@ import com.liferay.object.field.builder.PrecisionDecimalObjectFieldBuilder;
 import com.liferay.object.field.builder.RichTextObjectFieldBuilder;
 import com.liferay.object.field.builder.TextObjectFieldBuilder;
 import com.liferay.object.field.setting.builder.ObjectFieldSettingBuilder;
+import com.liferay.object.field.setting.util.ObjectFieldSettingUtil;
 import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.model.ObjectAction;
 import com.liferay.object.model.ObjectDefinition;
@@ -6726,6 +6727,55 @@ public class ObjectEntryLocalServiceTest {
 			objectEntries.get(1),
 			loadedObjectEntry.getRelatedObjectEntry(
 				relationshipObjectField.getName()));
+
+		_objectRelationshipLocalService.deleteObjectRelationship(
+			objectRelationship);
+		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
+	}
+
+	@Test
+	public void testLoadValuesWithRelatedSystemObjectEntries()
+		throws Exception {
+
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				Collections.emptyList());
+
+		ObjectRelationship objectRelationship =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				_objectRelationshipLocalService,
+				_objectDefinitionLocalService.fetchObjectDefinitionByClassName(
+					TestPropsValues.getCompanyId(), User.class.getName()),
+				objectDefinition);
+
+		ObjectField relationshipObjectField =
+			_objectFieldLocalService.fetchObjectField(
+				objectRelationship.getObjectFieldId2());
+
+		Map<String, Serializable> values =
+			HashMapBuilder.<String, Serializable>put(
+				relationshipObjectField.getName(), TestPropsValues.getUserId()
+			).build();
+
+		ObjectEntry objectEntry1 = _addObjectEntry(
+			0, objectDefinition.getObjectDefinitionId(), values);
+		ObjectEntry objectEntry2 = _addObjectEntry(
+			0, objectDefinition.getObjectDefinitionId(), values);
+
+		User user = TestPropsValues.getUser();
+
+		Map<String, Serializable> objectEntryValues =
+			_objectEntryLocalService.getValues(objectEntry1);
+
+		Assert.assertEquals(
+			user.getExternalReferenceCode(),
+			objectEntryValues.get(
+				ObjectFieldSettingUtil.getValue(
+					ObjectFieldSettingConstants.
+						NAME_OBJECT_RELATIONSHIP_ERC_OBJECT_FIELD_NAME,
+					relationshipObjectField)));
+
+		_assertLoadValues(objectDefinition, objectEntry1, objectEntry2);
 
 		_objectRelationshipLocalService.deleteObjectRelationship(
 			objectRelationship);

--- a/modules/apps/organizations/organizations-service/src/main/java/com/liferay/organizations/internal/object/system/OrganizationSystemObjectDefinitionManager.java
+++ b/modules/apps/organizations/organizations-service/src/main/java/com/liferay/organizations/internal/object/system/OrganizationSystemObjectDefinitionManager.java
@@ -95,17 +95,6 @@ public class OrganizationSystemObjectDefinitionManager
 	}
 
 	@Override
-	public String getBaseModelExternalReferenceCode(long primaryKey)
-		throws PortalException {
-
-		com.liferay.portal.kernel.model.Organization
-			serviceBuilderOrganization =
-				_organizationLocalService.getOrganization(primaryKey);
-
-		return serviceBuilderOrganization.getExternalReferenceCode();
-	}
-
-	@Override
 	public String getExternalReferenceCode() {
 		return "L_ORGANIZATION";
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-105482

Fourth change of the object entry listing optimization tracked under LPD-65366 (LPD-98910 scenario). It follows the bulk values load (#181560) and is independent of the other in-flight changes.

## What Is Being Fixed

Every system object definition manager answered `getBaseModelExternalReferenceCode` the same way: load the model by primary key through its own local service and read the external reference code. The values load of an object entry listing whose relationship points at a system object definition, for example User, resolved that code once per entry, one service call per row, although the definition manager already knows how to load its model generically through the persisted model service of its model class.

## How It Is Being Fixed

- `SystemObjectDefinitionManager.getBaseModelExternalReferenceCode` becomes a default method over the generic persisted model load, and a bulk companion `getBaseModelExternalReferenceCodes` resolves the codes of a set of primary keys with one `fetchPersistedModels` call. The account, address, commerce order, commerce order item, commerce order note, commerce pricing class, organization and user managers drop their identical overrides; the product definition manager keeps its own logic, which reads the code from the product, and gains the bulk form.
- The bulk relationship step of `ObjectEntryLocalServiceImpl` uses the bulk method for relationships to system object definitions, so a page of entries pointing at users costs one lookup for the distinct users.
- The `Semantic versioning` commit carries the minor bump of `com.liferay.object.system` for the new default method.

## Verification

- `ObjectEntryLocalServiceTest.testLoadValuesWithRelatedSystemObjectEntries` relates two entries to a user, asserts that the single read resolves the user's external reference code through the default, and runs the bulk load of both entries through the shared helper.
- Self-CI on shuyangzhou/liferay-portal PR 12759 (same content on the previous base 378c67ef): stable 16/16, object 49/49, relevant 56/64 with the only failure outside the chronic common set being `HeadlessBuilderResourceTest.testGetOpenAPIInDifferentCompany`, which fails on every pull today including a comments-only one.

## PR Check

**pr-check: PASS** — tested on `6e7ca4b33f2ee33c1f88a9146fe9ac1fe2033959`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Service Registration | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS (baseline-all + seven Ant projects + 1 changed exporting module) |
| Java Unit Tests | NOT VERIFIED |

Service Builder regeneration produced no drift. Baseline compared `com.liferay.object.api-128.1.0` against the released `128.0.1`, which exports `com.liferay.object.system;version="20.0.0"` with the abstract `getBaseModelExternalReferenceCode(long)`; the branch's 20.1.0 covers turning it into a default method and adding the default bulk companion, with no findings and no bundle version change recommended.

Java Unit Tests verified nothing about the change: the only unit counterpart, `ObjectEntryLocalServiceImplTest`, passes but exercises another method. The default and bulk external reference code resolution are covered by `ObjectEntryLocalServiceTest.testLoadValuesWithRelatedSystemObjectEntries` in the branch and by the system object manager integration tests, run on a fresh bundle (129 tests green).

<!-- pr-check {"result": "success", "sha": "6e7ca4b33f2ee33c1f88a9146fe9ac1fe2033959"} -->
