### PR TITLE
LPD-105489 Build the input template node of an input fragment once per render

### DIFF
--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/processor/DefaultFragmentEntryProcessorContext.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/processor/DefaultFragmentEntryProcessorContext.java
@@ -7,6 +7,7 @@ package com.liferay.fragment.processor;
 
 import com.liferay.asset.kernel.model.AssetRendererFactory;
 import com.liferay.fragment.constants.FragmentEntryLinkConstants;
+import com.liferay.fragment.input.template.parser.InputTemplateNode;
 import com.liferay.info.form.InfoForm;
 import com.liferay.info.item.InfoItemIdentifier;
 import com.liferay.info.item.InfoItemReference;
@@ -86,6 +87,11 @@ public class DefaultFragmentEntryProcessorContext
 	@Override
 	public InfoForm getInfoForm() {
 		return _infoForm;
+	}
+
+	@Override
+	public InputTemplateNode getInputTemplateNode() {
+		return _inputTemplateNode;
 	}
 
 	@Override
@@ -183,6 +189,10 @@ public class DefaultFragmentEntryProcessorContext
 		_infoForm = infoForm;
 	}
 
+	public void setInputTemplateNode(InputTemplateNode inputTemplateNode) {
+		_inputTemplateNode = inputTemplateNode;
+	}
+
 	public void setPreviewClassNameId(long previewClassNameId) {
 		_previewClassNameId = previewClassNameId;
 	}
@@ -212,6 +222,7 @@ public class DefaultFragmentEntryProcessorContext
 	private final HttpServletResponse _httpServletResponse;
 	private InfoForm _infoForm;
 	private InfoItemReference _infoItemReference;
+	private InputTemplateNode _inputTemplateNode;
 	private final Locale _locale;
 	private final String _mode;
 	private long _previewClassNameId;

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/processor/FragmentEntryProcessorContext.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/processor/FragmentEntryProcessorContext.java
@@ -5,6 +5,7 @@
 
 package com.liferay.fragment.processor;
 
+import com.liferay.fragment.input.template.parser.InputTemplateNode;
 import com.liferay.info.form.InfoForm;
 import com.liferay.info.item.InfoItemReference;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -53,6 +54,10 @@ public interface FragmentEntryProcessorContext {
 	public HttpServletResponse getHttpServletResponse();
 
 	public InfoForm getInfoForm();
+
+	public default InputTemplateNode getInputTemplateNode() {
+		return null;
+	}
 
 	public Locale getLocale();
 

--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-freemarker/src/main/java/com/liferay/fragment/entry/processor/freemarker/FreeMarkerFragmentEntryProcessor.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-freemarker/src/main/java/com/liferay/fragment/entry/processor/freemarker/FreeMarkerFragmentEntryProcessor.java
@@ -9,6 +9,7 @@ import com.liferay.fragment.entry.processor.freemarker.internal.configuration.Fr
 import com.liferay.fragment.exception.FragmentEntryContentException;
 import com.liferay.fragment.helper.FragmentEntryLinkHelper;
 import com.liferay.fragment.input.template.parser.FragmentEntryInputTemplateNodeContextHelper;
+import com.liferay.fragment.input.template.parser.InputTemplateNode;
 import com.liferay.fragment.model.FragmentEntryLink;
 import com.liferay.fragment.processor.FragmentEntryProcessor;
 import com.liferay.fragment.processor.FragmentEntryProcessorContext;
@@ -160,18 +161,25 @@ public class FreeMarkerFragmentEntryProcessor
 			).build());
 
 		if (fragmentEntryLink.isTypeInput()) {
-			template.put(
-				"input",
-				_fragmentEntryInputTemplateNodeContextHelper.
-					toInputTemplateNode(
-						fragmentEntryProcessorContext.getAttributes(),
-						_fragmentEntryLinkHelper.getFragmentEntryName(
+			InputTemplateNode inputTemplateNode =
+				fragmentEntryProcessorContext.getInputTemplateNode();
+
+			if (inputTemplateNode == null) {
+				inputTemplateNode =
+					_fragmentEntryInputTemplateNodeContextHelper.
+						toInputTemplateNode(
+							fragmentEntryProcessorContext.getAttributes(),
+							_fragmentEntryLinkHelper.getFragmentEntryName(
+								fragmentEntryLink,
+								fragmentEntryProcessorContext.getLocale()),
 							fragmentEntryLink,
-							fragmentEntryProcessorContext.getLocale()),
-						fragmentEntryLink,
-						fragmentEntryProcessorContext.getHttpServletRequest(),
-						fragmentEntryProcessorContext.getInfoForm(),
-						fragmentEntryProcessorContext.getLocale()));
+							fragmentEntryProcessorContext.
+								getHttpServletRequest(),
+							fragmentEntryProcessorContext.getInfoForm(),
+							fragmentEntryProcessorContext.getLocale());
+			}
+
+			template.put("input", inputTemplateNode);
 		}
 
 		template.prepareTaglib(

--- a/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/renderer/FragmentEntryFragmentRenderer.java
+++ b/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/renderer/FragmentEntryFragmentRenderer.java
@@ -8,6 +8,7 @@ package com.liferay.fragment.internal.renderer;
 import com.liferay.fragment.cache.FragmentEntryLinkCache;
 import com.liferay.fragment.configuration.FragmentJavaScriptConfiguration;
 import com.liferay.fragment.contributor.FragmentCollectionContributorRegistry;
+import com.liferay.fragment.helper.FragmentEntryLinkHelper;
 import com.liferay.fragment.input.template.parser.FragmentEntryInputTemplateNodeContextHelper;
 import com.liferay.fragment.input.template.parser.InputTemplateNode;
 import com.liferay.fragment.model.FragmentEntry;
@@ -161,24 +162,6 @@ public class FragmentEntryFragmentRenderer implements FragmentRenderer {
 		return fragmentEntryLink;
 	}
 
-	private String _getFragmentEntryName(FragmentEntryLink fragmentEntryLink) {
-		FragmentEntry fragmentEntry = fragmentEntryLink.fetchFragmentEntry();
-
-		if ((fragmentEntry == null) &&
-			Validator.isNotNull(fragmentEntryLink.getRendererKey())) {
-
-			fragmentEntry =
-				_fragmentCollectionContributorRegistry.getFragmentEntry(
-					fragmentEntryLink.getRendererKey());
-		}
-
-		if (fragmentEntry == null) {
-			return StringPool.BLANK;
-		}
-
-		return fragmentEntry.getName();
-	}
-
 	private JSONObject _getInputJSONObject(
 		FragmentEntryLink fragmentEntryLink,
 		FragmentRendererContext fragmentRendererContext,
@@ -187,8 +170,10 @@ public class FragmentEntryFragmentRenderer implements FragmentRenderer {
 		InputTemplateNode inputTemplateNode =
 			_fragmentEntryInputTemplateNodeContextHelper.toInputTemplateNode(
 				fragmentRendererContext.getAttributes(),
-				_getFragmentEntryName(fragmentEntryLink), fragmentEntryLink,
-				httpServletRequest, fragmentRendererContext.getInfoForm(),
+				_fragmentEntryLinkHelper.getFragmentEntryName(
+					fragmentEntryLink, fragmentRendererContext.getLocale()),
+				fragmentEntryLink, httpServletRequest,
+				fragmentRendererContext.getInfoForm(),
 				fragmentRendererContext.getLocale());
 
 		return inputTemplateNode.toJSONObject();
@@ -578,6 +563,9 @@ public class FragmentEntryFragmentRenderer implements FragmentRenderer {
 
 	@Reference
 	private FragmentEntryLinkCache _fragmentEntryLinkCache;
+
+	@Reference
+	private FragmentEntryLinkHelper _fragmentEntryLinkHelper;
 
 	@Reference
 	private FragmentEntryProcessorRegistry _fragmentEntryProcessorRegistry;

--- a/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/renderer/FragmentEntryFragmentRenderer.java
+++ b/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/renderer/FragmentEntryFragmentRenderer.java
@@ -162,23 +162,6 @@ public class FragmentEntryFragmentRenderer implements FragmentRenderer {
 		return fragmentEntryLink;
 	}
 
-	private JSONObject _getInputJSONObject(
-		FragmentEntryLink fragmentEntryLink,
-		FragmentRendererContext fragmentRendererContext,
-		HttpServletRequest httpServletRequest) {
-
-		InputTemplateNode inputTemplateNode =
-			_fragmentEntryInputTemplateNodeContextHelper.toInputTemplateNode(
-				fragmentRendererContext.getAttributes(),
-				_fragmentEntryLinkHelper.getFragmentEntryName(
-					fragmentEntryLink, fragmentRendererContext.getLocale()),
-				fragmentEntryLink, httpServletRequest,
-				fragmentRendererContext.getInfoForm(),
-				fragmentRendererContext.getLocale());
-
-		return inputTemplateNode.toJSONObject();
-	}
-
 	private boolean _isCacheable(
 		FragmentEntryLink fragmentEntryLink,
 		FragmentRendererContext fragmentRendererContext) {
@@ -245,7 +228,8 @@ public class FragmentEntryFragmentRenderer implements FragmentRenderer {
 	private String _renderFragmentEntry(
 		String configuration, String css,
 		FragmentRendererContext fragmentRendererContext, String html,
-		HttpServletRequest httpServletRequest, String nonce) {
+		HttpServletRequest httpServletRequest,
+		InputTemplateNode inputTemplateNode, String nonce) {
 
 		StringBundler sb = new StringBundler(35);
 
@@ -350,11 +334,7 @@ public class FragmentEntryFragmentRenderer implements FragmentRenderer {
 
 		if (fragmentEntryLink.isTypeInput()) {
 			sb.append("; const input = ");
-			sb.append(
-				JSONUtil.toString(
-					_getInputJSONObject(
-						fragmentEntryLink, fragmentRendererContext,
-						httpServletRequest)));
+			sb.append(JSONUtil.toString(inputTemplateNode.toJSONObject()));
 			sb.append("; input.value = Liferay.Util.unescapeHTML(input.value ");
 			sb.append("?? ''); Object.keys(input.valueI18n).forEach(");
 			sb.append("function(key){ input.valueI18n[key] = Liferay.Util.");
@@ -442,6 +422,24 @@ public class FragmentEntryFragmentRenderer implements FragmentRenderer {
 		defaultFragmentEntryProcessorContext.setSegmentsEntryIds(
 			fragmentRendererContext.getSegmentsEntryIds());
 
+		InputTemplateNode inputTemplateNode = null;
+
+		if (fragmentEntryLink.isTypeInput()) {
+			inputTemplateNode =
+				_fragmentEntryInputTemplateNodeContextHelper.
+					toInputTemplateNode(
+						fragmentRendererContext.getAttributes(),
+						_fragmentEntryLinkHelper.getFragmentEntryName(
+							fragmentEntryLink,
+							fragmentRendererContext.getLocale()),
+						fragmentEntryLink, httpServletRequest,
+						fragmentRendererContext.getInfoForm(),
+						fragmentRendererContext.getLocale());
+
+			defaultFragmentEntryProcessorContext.setInputTemplateNode(
+				inputTemplateNode);
+		}
+
 		String css = StringPool.BLANK;
 
 		if (Validator.isNotNull(fragmentEntryLink.getCss())) {
@@ -466,7 +464,8 @@ public class FragmentEntryFragmentRenderer implements FragmentRenderer {
 
 		content = _renderFragmentEntry(
 			_toConfiguration(fragmentEntryLink, fragmentRendererContext), css,
-			fragmentRendererContext, html, httpServletRequest, nonce);
+			fragmentRendererContext, html, httpServletRequest,
+			inputTemplateNode, nonce);
 
 		if (!cacheable) {
 			return content;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-105489

Part of the object entry page optimization tracked under LPD-65366 (LPD-98910 scenario, the edit page of an object entry). Independent of the other in-flight changes.

## What Is Being Fixed

Rendering an input fragment built the fragment's `InputTemplateNode` twice: the FreeMarker processor built it to expose `input` to the fragment template, and the renderer built it again to embed the same node as JSON in the fragment's module script. Each build resolves the field value through the info item values provider, loads the file entry of an attachment field once for its name and once more for its preview URL, and composes the preview URL through the friendly URL entry and group lookups, so every input fragment on an edit page paid for that work twice, once from each caller.

## How It Is Being Fixed

- A preparation commit makes the renderer name the fragment in the script the way the template already does, through `FragmentEntryLinkHelper.getFragmentEntryName`, so both builds of the node take the same arguments. The default label is visible only for an input fragment that maps no field and has no label typed in the editor; for that case the script now carries the same localized name as the template.
- The renderer then builds the node once for an input fragment entry link, carries it to the processors on `FragmentEntryProcessorContext` through a new default accessor, and embeds that same node in the script. The FreeMarker processor uses the node the context carries and keeps building its own for callers that process a fragment without one.
- No packageinfo change: `com.liferay.fragment.processor` is already raised to 13.1.0 in this cycle, which covers the new default method; bnd rejects a further bump as excessive.

## Verification

- `FragmentEntryFragmentRendererTest`, `FragmentEntryInputTemplateNodeContextHelperTest`, `FreeMarkerFragmentEntryProcessorTest`, `FragmentExportImportTest` and `FragmentEntryLinkLocalServiceTest` (80 tests) pass on a fresh bundle built from the branch.
- Self-CI on shuyangzhou/liferay-portal PR 12760 (same content on the previous base 20f61d7): stable 16/16, object 49/49, relevant 27/34 where every failure is in the chronic common set or is one of four page editor Playwright tests that fail identically on plain master (verified by running master and the branch on the same clean bundle).

## PR Check

**pr-check: PASS** — tested on `cff4b37902794e065e2f12b9d7f498ef9b380872`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Service Registration | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS (baseline-all + seven Ant projects + 1 changed exporting module) |
| Java Unit Tests | NOT VERIFIED |

Baseline compared `com.liferay.fragment.api-62.3.0` against the released `62.2.1` with no findings: `com.liferay.fragment.processor` is already 13.1.0 against the released 13.0.0, which covers the new default method, so no packageinfo change is in the diff. The skill's offline Local Version Check flags the package because the branch adds public members without a packageinfo line; that row is overruled on the bnd evidence, and CI's semantic versioning job rejected a 13.2.0 bump earlier as an excessive increase.

Java Unit Tests verified nothing: none of the four changed classes has a unit counterpart. `FragmentEntryFragmentRendererTest`, `FragmentEntryInputTemplateNodeContextHelperTest`, `FreeMarkerFragmentEntryProcessorTest`, `FragmentExportImportTest` and `FragmentEntryLinkLocalServiceTest` (80 tests) pass on a fresh bundle built from this tree.

<!-- pr-check {"result": "success", "sha": "cff4b37902794e065e2f12b9d7f498ef9b380872"} -->
