### PR TITLE
LPD-105490 Build the preview URL of an attachment only for an image file

### DIFF
--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/drag-and-drop-upload/index.js
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/drag-and-drop-upload/index.js
@@ -82,7 +82,7 @@ function showDropzone(dropzoneContainerType) {
 function showPreview(fileOrUrl, fileName) {
 	hasSelectedFile = true;
 
-	if (!fileOrUrl) {
+	if (!fileOrUrl && !fileName) {
 		showDropzone(DROP_ZONE_CONTAINER_TYPE.DEFAULT);
 
 		return;
@@ -90,8 +90,10 @@ function showPreview(fileOrUrl, fileName) {
 
 	let imageURL = null;
 
-	if (fileOrUrl instanceof File && fileOrUrl.type?.startsWith('image/')) {
-		imageURL = URL.createObjectURL(fileOrUrl);
+	if (fileOrUrl instanceof File) {
+		if (fileOrUrl.type?.startsWith('image/')) {
+			imageURL = URL.createObjectURL(fileOrUrl);
+		}
 	}
 	else {
 		imageURL = fileOrUrl;
@@ -256,7 +258,7 @@ else {
 					translationInput.dataset.previewURL = value.previewURL;
 				});
 
-				if (input.attributes?.previewURL) {
+				if (input.attributes?.fileName) {
 					showPreview(
 						input.attributes.previewURL,
 						input.attributes.fileName
@@ -281,13 +283,14 @@ else {
 							inputElement.id
 						);
 
-						let previewURL = translationInput?.dataset?.previewURL;
-
 						const fileName =
 							translationInput?.dataset?.fileName || '';
 
-						if (previewURL) {
-							showPreview(previewURL, fileName);
+						if (fileName) {
+							showPreview(
+								translationInput?.dataset?.previewURL,
+								fileName
+							);
 						}
 						else {
 							const defaultInput = getTranslationInput({
@@ -299,9 +302,7 @@ else {
 								namespace: fragmentElementId,
 							});
 
-							previewURL = defaultInput?.dataset?.previewURL;
-
-							if (previewURL) {
+							if (defaultInput?.dataset?.fileName) {
 								showPreview(
 									defaultInput?.dataset?.previewURL,
 									defaultInput?.dataset?.fileName
@@ -353,10 +354,7 @@ else {
 							fileInput.id
 						);
 
-						const previewURL =
-							defaultTranslationInput?.dataset?.previewURL;
-
-						if (previewURL) {
+						if (defaultTranslationInput?.dataset?.fileName) {
 							showPreview(
 								defaultTranslationInput?.dataset?.previewURL,
 								defaultTranslationInput?.dataset?.fileName
@@ -403,7 +401,9 @@ else {
 
 						translationInput.files = dataTransfer.files;
 						translationInput.dataset.previewURL =
-							URL.createObjectURL(dataTransfer.files[0]);
+							value.type?.startsWith('image/')
+								? URL.createObjectURL(dataTransfer.files[0])
+								: '';
 						translationInput.dataset.fileName = title;
 					}
 
@@ -473,6 +473,7 @@ else {
 					});
 
 					translationInput.value = '';
+					translationInput.dataset.fileName = '';
 					translationInput.dataset.previewURL = '';
 
 					if (currentLanguageId === defaultLanguageId) {
@@ -488,7 +489,7 @@ else {
 							namespace: fragmentElementId,
 						});
 
-						if (defaultInput.dataset?.previewURL) {
+						if (defaultInput.dataset?.fileName) {
 							showPreview(
 								defaultInput.dataset?.previewURL,
 								defaultInput.dataset.fileName
@@ -510,7 +511,7 @@ else {
 				const unlocalizedFieldsState =
 					input.attributes.unlocalizedFieldsState;
 
-				if (input.attributes?.previewURL) {
+				if (input.attributes?.fileName) {
 					showPreview(
 						input.attributes.previewURL,
 						input.attributes.fileName

--- a/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/input/template/parser/FragmentEntryInputTemplateNodeContextHelperImpl.java
+++ b/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/input/template/parser/FragmentEntryInputTemplateNodeContextHelperImpl.java
@@ -8,6 +8,8 @@ package com.liferay.fragment.internal.input.template.parser;
 import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.document.library.kernel.processor.ImageProcessor;
+import com.liferay.document.library.kernel.processor.ImageProcessorUtil;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.util.DLURLHelper;
 import com.liferay.fragment.constants.FragmentConfigurationFieldDataType;
@@ -1145,7 +1147,13 @@ public class FragmentEntryInputTemplateNodeContextHelperImpl
 
 		FileEntry fileEntry = _fetchFileEntry(GetterUtil.getLong(value));
 
-		if (fileEntry != null) {
+		if (fileEntry == null) {
+			return null;
+		}
+
+		ImageProcessor imageProcessor = ImageProcessorUtil.getImageProcessor();
+
+		if (imageProcessor.isImageSupported(fileEntry.getMimeType())) {
 			try {
 				return _dlURLHelper.getPreviewURL(
 					fileEntry, fileEntry.getFileVersion(),

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/input/template/parser/test/FragmentEntryInputTemplateNodeContextHelperTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/input/template/parser/test/FragmentEntryInputTemplateNodeContextHelperTest.java
@@ -74,6 +74,7 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.DateUtil;
+import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -222,6 +223,46 @@ public class FragmentEntryInputTemplateNodeContextHelperTest {
 		finally {
 			ServiceContextThreadLocal.popServiceContext();
 		}
+	}
+
+	@Test
+	public void testToInputTemplateNodeWithFileInfoFieldType()
+		throws Exception {
+
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				Collections.singletonList(
+					new AttachmentObjectFieldBuilder(
+					).labelMap(
+						LocalizedMapUtil.getLocalizedMap(
+							RandomTestUtil.randomString())
+					).name(
+						"myAttachment"
+					).objectFieldSettings(
+						Arrays.asList(
+							_createObjectFieldSetting(
+								ObjectFieldSettingConstants.
+									NAME_ACCEPTED_FILE_EXTENSIONS,
+								"png,txt"),
+							_createObjectFieldSetting(
+								ObjectFieldSettingConstants.NAME_FILE_SOURCE,
+								ObjectFieldSettingConstants.
+									VALUE_USER_COMPUTER_TO_DOCS_AND_MEDIA),
+							_createObjectFieldSetting(
+								ObjectFieldSettingConstants.NAME_MAX_FILE_SIZE,
+								"100"))
+					).build()),
+				ObjectDefinitionConstants.SCOPE_SITE);
+
+		Assert.assertNotNull(
+			_getPreviewURL(
+				_addDLFileEntry(
+					FileUtil.getBytes(
+						getClass(),
+						"/com/liferay/fragment/dependencies/liferay.png"),
+					"png"),
+				objectDefinition));
+		Assert.assertNull(_getPreviewURL(_addDLFileEntry(), objectDefinition));
 	}
 
 	@Test
@@ -690,15 +731,19 @@ public class FragmentEntryInputTemplateNodeContextHelperTest {
 	}
 
 	private DLFileEntry _addDLFileEntry() throws Exception {
-		byte[] bytes = TestDataConstants.TEST_BYTE_ARRAY;
+		return _addDLFileEntry(TestDataConstants.TEST_BYTE_ARRAY, "txt");
+	}
+
+	private DLFileEntry _addDLFileEntry(byte[] bytes, String extension)
+		throws Exception {
 
 		InputStream inputStream = new ByteArrayInputStream(bytes);
 
 		return _dlFileEntryLocalService.addFileEntry(
 			null, TestPropsValues.getUserId(), _group.getGroupId(),
 			_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-			RandomTestUtil.randomString() + ".txt",
-			MimeTypesUtil.getExtensionContentType("txt"),
+			RandomTestUtil.randomString() + StringPool.PERIOD + extension,
+			MimeTypesUtil.getExtensionContentType(extension),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			StringPool.BLANK, StringPool.BLANK,
 			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT, null,
@@ -959,6 +1004,29 @@ public class FragmentEntryInputTemplateNodeContextHelperTest {
 		return httpServletRequest;
 	}
 
+	private String _getPreviewURL(
+			DLFileEntry dlFileEntry, ObjectDefinition objectDefinition)
+		throws Exception {
+
+		ObjectEntry objectEntry = _objectEntryLocalService.addObjectEntry(
+			_group.getGroupId(), TestPropsValues.getUserId(),
+			objectDefinition.getObjectDefinitionId(),
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			null,
+			HashMapBuilder.<String, Serializable>put(
+				"myAttachment", dlFileEntry.getFileEntryId()
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		InputTemplateNode inputTemplateNode = _toInputTemplateNode(
+			objectDefinition.getClassName(), "ObjectField_myAttachment",
+			LocaleUtil.US, objectEntry);
+
+		Map<String, Object> attributes = inputTemplateNode.getAttributes();
+
+		return (String)attributes.get("previewURL");
+	}
+
 	private ThemeDisplay _getThemeDisplay() throws Exception {
 		ThemeDisplay themeDisplay = new ThemeDisplay();
 
@@ -978,9 +1046,39 @@ public class FragmentEntryInputTemplateNodeContextHelperTest {
 			Map<Locale, Object> valueI18nMap, Map<Locale, Object> values)
 		throws Exception {
 
+		for (Map.Entry<Locale, Object> entry : values.entrySet()) {
+			InputTemplateNode inputTemplateNode = _toInputTemplateNode(
+				className, inputFieldId, entry.getKey(), objectEntry);
+
+			Assert.assertEquals(
+				entry.getValue(), inputTemplateNode.getInputValue());
+
+			Map<String, String> actualValueI18nMap =
+				inputTemplateNode.getValueI18n();
+
+			Assert.assertEquals(
+				MapUtil.toString(actualValueI18nMap), valueI18nMap.size(),
+				actualValueI18nMap.size());
+
+			for (Map.Entry<Locale, Object> curEntry : valueI18nMap.entrySet()) {
+				Assert.assertEquals(
+					curEntry.getValue(),
+					actualValueI18nMap.get(
+						LocaleUtil.toLanguageId(curEntry.getKey())));
+			}
+		}
+	}
+
+	private InputTemplateNode _toInputTemplateNode(
+			String className, String inputFieldId, Locale locale,
+			ObjectEntry objectEntry)
+		throws Exception {
+
 		HttpServletRequest httpServletRequest = new MockHttpServletRequest();
 
 		ThemeDisplay themeDisplay = _getThemeDisplay();
+
+		themeDisplay.setLocale(locale);
 
 		httpServletRequest.setAttribute(WebKeys.THEME_DISPLAY, themeDisplay);
 
@@ -1008,40 +1106,14 @@ public class FragmentEntryInputTemplateNodeContextHelperTest {
 		try {
 			ServiceContextThreadLocal.pushServiceContext(serviceContext);
 
-			for (Map.Entry<Locale, Object> entry : values.entrySet()) {
-				Locale locale = entry.getKey();
-
-				themeDisplay.setLocale(locale);
-
-				InputTemplateNode inputTemplateNode =
-					_fragmentEntryInputTemplateNodeContextHelper.
-						toInputTemplateNode(
-							Collections.emptyMap(), "Default",
-							_addInputFragmentEntryLink(inputFieldId),
-							httpServletRequest,
-							infoItemFormProvider.getInfoForm(
-								StringPool.BLANK, _group.getGroupId()),
-							locale);
-
-				Assert.assertEquals(
-					entry.getValue(), inputTemplateNode.getInputValue());
-
-				Map<String, String> actualValueI18nMap =
-					inputTemplateNode.getValueI18n();
-
-				Assert.assertEquals(
-					MapUtil.toString(actualValueI18nMap), valueI18nMap.size(),
-					actualValueI18nMap.size());
-
-				for (Map.Entry<Locale, Object> curEntry :
-						valueI18nMap.entrySet()) {
-
-					Assert.assertEquals(
-						curEntry.getValue(),
-						actualValueI18nMap.get(
-							LocaleUtil.toLanguageId(curEntry.getKey())));
-				}
-			}
+			return _fragmentEntryInputTemplateNodeContextHelper.
+				toInputTemplateNode(
+					Collections.emptyMap(), "Default",
+					_addInputFragmentEntryLink(inputFieldId),
+					httpServletRequest,
+					infoItemFormProvider.getInfoForm(
+						StringPool.BLANK, _group.getGroupId()),
+					locale);
 		}
 		finally {
 			ServiceContextThreadLocal.popServiceContext();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-105490

Part of the object entry page optimization tracked under LPD-65366 (LPD-98910 scenario, the edit page of an object entry). Independent of the other in-flight changes.

## What Is Being Fixed

The Drag and Drop Upload fragment shows the preview URL of the attached file as an image, yet the input template node computed that URL for every attachment: it loaded the file entry and composed the friendly URL for a text or PDF document too, and the fragment then rendered a broken image for it. The File Upload fragment never reads the preview URL at all, so for it the URL was computed and discarded on every render.

## How It Is Being Fixed

- `FragmentEntryInputTemplateNodeContextHelperImpl` builds the preview URL only when the file's MIME type is a supported image.
- The Drag and Drop Upload fragment keys "a file is attached" on the file name instead of the preview URL, shows its no-preview dropzone with the file name when a value has no preview URL, which also covers a non-image file picked from the user's computer, and forgets the file name together with the preview URL when the file is removed.

## Verification

- `FragmentEntryInputTemplateNodeContextHelperTest.testToInputTemplateNodeWithFileInfoFieldType` asserts that a PNG attachment yields a preview URL and a text attachment yields none, through a node-building scaffold shared with the localized input test. 81 fragment integration tests pass on a fresh bundle built from the branch, and the fragment's before and after behaviour was checked by hand.
- Self-CI on shuyangzhou/liferay-portal PR 12761 (same content on the previous base 20f61d7): stable 16/16, object 49/49, relevant 30/38 where every failure is in the chronic common set or is one of four page editor Playwright tests that fail identically on plain master (verified by running master and the branch on the same clean bundle).

## PR Check

**pr-check: PASS** — tested on `ca88438b16e00aca76f2d206ee63214bcc6e3f10`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Service Registration | PASS |
| Transaction Usage | PASS |
| HTML Escaping | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS (baseline-all + seven Ant projects + zero changed exporting modules) |
| Java Unit Tests | NOT VERIFIED |
| JavaScript Unit Tests | NOT VERIFIED |

Source Format's node half ran on the changed fragment script (`Everything is correctly formatted`). Java Unit Tests verified nothing: the helper has no unit counterpart; `FragmentEntryInputTemplateNodeContextHelperTest`, including the new `testToInputTemplateNodeWithFileInfoFieldType`, passes on a fresh bundle built from this tree (81 fragment tests green). JavaScript Unit Tests verified nothing: the fragment collection module has no package.json or Jest setup; the script is a fragment resource shipped inside the bundle jar.

<!-- pr-check {"result": "success", "sha": "ca88438b16e00aca76f2d206ee63214bcc6e3f10"} -->
