### PR TITLE
LPD-105483 Skip the URL title when the resolver does not use it

### DIFF
--- a/modules/apps/asset/asset-display-page-api/src/main/java/com/liferay/asset/display/page/portlet/BaseAssetDisplayPageFriendlyURLResolver.java
+++ b/modules/apps/asset/asset-display-page-api/src/main/java/com/liferay/asset/display/page/portlet/BaseAssetDisplayPageFriendlyURLResolver.java
@@ -209,20 +209,23 @@ public abstract class BaseAssetDisplayPageFriendlyURLResolver
 			groupId, friendlyURL, layoutDisplayPageObjectProvider,
 			layoutDisplayPageProvider);
 
-		String originalFriendlyURL = _getOriginalFriendlyURL(friendlyURL);
-
-		String localizedFriendlyURL = originalFriendlyURL;
+		if (!useOriginalFriendlyURL()) {
+			return new LayoutFriendlyURLComposite(layout, friendlyURL, false);
+		}
 
 		String urlTitle = layoutDisplayPageObjectProvider.getURLTitle(
 			getLocale(requestContext));
 
-		if (useOriginalFriendlyURL() && Validator.isNotNull(urlTitle)) {
-			localizedFriendlyURL = getURLSeparator() + urlTitle;
-		}
+		if (Validator.isNotNull(urlTitle)) {
+			String localizedFriendlyURL = getURLSeparator() + urlTitle;
 
-		if (!isSameFriendlyURL(originalFriendlyURL, localizedFriendlyURL)) {
-			return new LayoutFriendlyURLComposite(
-				layout, localizedFriendlyURL, true);
+			if (!isSameFriendlyURL(
+					_getOriginalFriendlyURL(friendlyURL),
+					localizedFriendlyURL)) {
+
+				return new LayoutFriendlyURLComposite(
+					layout, localizedFriendlyURL, true);
+			}
 		}
 
 		return new LayoutFriendlyURLComposite(layout, friendlyURL, false);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-105483

Part of the object entry page optimization tracked under LPD-65366 (LPD-98910 scenario). It touches the same resolver as #181605 but a different method, and is independent of the other in-flight changes.

## What Is Being Fixed

`BaseAssetDisplayPageFriendlyURLResolver.getLayoutFriendlyURLComposite` asked the layout display page object provider for the item's URL title before checking whether the resolver uses the original friendly URL at all. `CustomAssetDisplayPageFriendlyURLResolver`, which serves object entry display pages, never does, and for an object entry that title is the entry's main friendly URL entry, fetched from the database for every resolution only to be discarded.

## How It Is Being Fixed

The title is read only when the resolver uses the original friendly URL. When it does not, or when the title is blank, the localized URL equalled the original one and the comparison always fell through to the same composite, which is now returned directly. One file, no API change.

## Verification

- The resolution is covered by the existing resolver integration tests in `asset-display-page-test`; `CustomAssetDisplayPageFriendlyURLResolverTest` passes on a fresh bundle built from the change. `BaseAssetDisplayPageFriendlyURLResolverTest.testGetLayoutFriendlyURLComposite` fails identically on master since 2026-09-04 in its fixture (Testray case 519459540) before the changed method is entered.
- Self-CI on shuyangzhou/liferay-portal PR 12757: stable 16/16, object 49/49, relevant 23/30 with no unique failures (every failure is in the chronic set shared with upstream master, including the two resolver tests named above).

## PR Check

**pr-check: PASS** — tested on `0ea909d31247c1fa32f8b1a89a37d94c96982787`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Service Registration | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS (baseline-all + seven Ant projects + 1 changed exporting module) |
| Java Unit Tests | NOT VERIFIED |

Baseline compared `com.liferay.asset.display.page.api-21.1.0` against the released `21.0.3` with no findings; the diff adds and removes no public or protected member, so no version bump is owed.

Java Unit Tests verified nothing: `asset-display-page-api` has no `src/test` tree. The resolver is covered by the integration tests in `asset-display-page-test`, run separately on a fresh bundle as described above.

<!-- pr-check {"result": "success", "sha": "0ea909d31247c1fa32f8b1a89a37d94c96982787"} -->
