### PR TITLE
LPD-105503 Give sample object entries the friendly URL rows the service creates

### DIFF
--- a/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
@@ -4669,6 +4669,16 @@ public class DataFactory {
 		return friendlyURLEntryModel;
 	}
 
+	public FriendlyURLEntryModel newFriendlyURLEntryModel(
+		ObjectDefinitionModel objectDefinitionModel,
+		ObjectEntryModel objectEntryModel) {
+
+		return newFriendlyURLEntryModel(
+			_globalGroupId,
+			getClassNameId(objectDefinitionModel.getClassName()),
+			objectEntryModel.getObjectEntryId());
+	}
+
 	public GroupModel newGlobalGroupModel() {
 		_globalGroupId = _counter.get();
 
@@ -5759,7 +5769,7 @@ public class DataFactory {
 
 		String uuid = SequentialUUID.generate();
 
-		return newObjectDefinitionModel(
+		ObjectDefinitionModel objectDefinitionModel = newObjectDefinitionModel(
 			objectDefinitionId, objectFolderId, 0, className,
 			StringBundler.concat("O_", _companyId, StringPool.UNDERLINE, name),
 			true, false, true, label, true, name,
@@ -5767,6 +5777,11 @@ public class DataFactory {
 			"c_" + StringUtil.toLowerCase(name) + "_",
 			"c_" + StringUtil.toLowerCase(name), label, true, false, uuid,
 			uuid);
+
+		objectDefinitionModel.setFriendlyURLSeparator(
+			_friendlyURLNormalizer.normalizeWithPeriodsAndSlashes(name));
+
+		return objectDefinitionModel;
 	}
 
 	public List<ObjectDefinitionModel> newObjectDefinitionModels(

--- a/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/custom_object_definitions.ftl
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/resources/com/liferay/portal/tools/sample/sql/builder/dependencies/custom_object_definitions.ftl
@@ -39,6 +39,14 @@ ${dataFactory.getExtensionDynamicObjectDefinitionTableCreateSQL(objectDefinition
 
 	${dataFactory.toInsertSQL(objectEntryModel)}
 
+	<#assign friendlyURLEntryModel = dataFactory.newFriendlyURLEntryModel(objectDefinitionModel, objectEntryModel) />
+
+	${dataFactory.toInsertSQL(friendlyURLEntryModel)}
+
+	${dataFactory.toInsertSQL(dataFactory.newFriendlyURLEntryLocalizationModel(friendlyURLEntryModel, objectEntryModel.getExternalReferenceCode()))}
+
+	${dataFactory.toInsertSQL(dataFactory.newFriendlyURLEntryMapping(friendlyURLEntryModel))}
+
 	<@insertAssetEntry _entry = objectEntryModel />
 
 	<#list dataFactory.generateDynamicSQLs(objectDefinitionModel.getDBTableName(), dlFileEntryModel.getFileEntryId(), objectEntryModel.getObjectEntryId(), objectFieldModels, relatedTicketObjectEntryId, objectEntryModel.getUserId()) as dynamicSQL>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-105503

Benchmark data for the object entry page optimization tracked under LPD-65366 (LPD-98910 scenario). Generator only, no runtime change.

## What Is Being Fixed

The sample SQL builder's object data differs from data a person creates through the service in two ways that change what the edit step of the scenario measures. The custom object definition is inserted with an empty friendly URL separator, while the service derives one from the definition's name, and the object entries are inserted without the `FriendlyURLEntry`, `FriendlyURLEntryLocalization` and `FriendlyURLEntryMapping` rows the service writes at creation. The first edit of every sample entry therefore inserts those three rows and increments two counters, a cost no human-created entry pays on an edit, and with 100k entries almost every measured edit is a first edit.

## How It Is Being Fixed

- `DataFactory.newObjectDefinitionModel` gives the sample definition the separator the service derives from its name, through the same `normalizeWithPeriodsAndSlashes` normalization.
- `custom_object_definitions.ftl` writes the three friendly URL rows per object entry with the existing `newFriendlyURLEntryModel`, `newFriendlyURLEntryLocalizationModel` and `newFriendlyURLEntryMapping` helpers the blogs data already uses: the entry in the company group, its localization in the entry's default language with the external reference code as URL title, since the definition has no title field, and the mapping. A new `newFriendlyURLEntryModel(ObjectDefinitionModel, ObjectEntryModel)` overload resolves the group and the class name id.

## Verification

- Regenerated the 100k PostgreSQL data set: the definition carries the derived separator and every entry has exactly one friendly URL entry, localization and mapping in the company group. Against the same runtime, entries added through the service coexist with the generated ones, and edits reuse the existing rows instead of creating them.
- Self-CI on shuyangzhou/liferay-portal PR 12762: stable 16/16, object 49/49, relevant 150/217. The change is a build-time tool that no CI test executes, so none of the relevant failures can come from it: the failures CI marks unique are the chronic master set (the page editor form container Playwright specs, `HeadlessBuilderResourceTest.testGetOpenAPIInDifferentCompany`, `LayoutExportImportTest`, `IndexWriterHelperImplTest`, `SaveAuditConfigurationMVCActionCommandTest`, `SkuResourceTest`, all failing on other pulls this week per Testray) plus two single-occurrence flakes (`ResourceFileResourceTest.testPutSiteResourceFile` with a concurrent log failure, `SearchResponseResourceImplTest.testToSearchResponse`, which fails the same way on brianchandotcom master `72316f27576b1` without this change).

## PR Check

**pr-check: PASS** — tested on `137d97d08196d065b4656acd1569a04fb66be35a`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Service Registration | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS (baseline-all + module baseline skipped: the tool exports no packages) |
| Java Unit Tests | NOT VERIFIED |

Per-Module Compile confirmed the new `newFriendlyURLEntryModel(ObjectDefinitionModel, ObjectEntryModel)` and the three friendly URL inserts inside the built `com.liferay.portal.tools.sample.sql.builder.jar`. Integration Test Compile compiled the five `modules/util/*-test` modules, none of which depends on the generator; the generator has no integration test consumer. Baseline: `ant baseline-all` clean; `:util:portal-tools-sample-sql-builder:baseline` is skipped by bnd because the bundle exports no packages.

Java Unit Tests verified nothing about the change: `DataFactory` has no unit counterpart, and the module's `SampleSQLBuilderTest` is on the permanent exclusion list; `CharPipeTest` (21 tests) passes. The change was verified by regenerating the 100k PostgreSQL data set and inspecting the rows, as described above.

<!-- pr-check {"result": "success", "sha": "137d97d08196d065b4656acd1569a04fb66be35a"} -->
