### PR TITLE
LPD-100263 Restrict response fields per MCP server profile tool

### DIFF
--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/model/listener/DataMaskObjectEntryModelListener.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/model/listener/DataMaskObjectEntryModelListener.java
@@ -96,8 +96,11 @@ public class DataMaskObjectEntryModelListener
 					_log.warn(
 						StringBundler.concat(
 							"Unable to attach system mask \"",
-							values.get("name"), "\" to profile ",
-							mcpServerProfileObjectEntry.getObjectEntryId()),
+							objectEntry.getExternalReferenceCode(),
+							"\" to profile \"",
+							mcpServerProfileObjectEntry.
+								getExternalReferenceCode(),
+							"\""),
 						portalException);
 				}
 			}

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/model/listener/MCPServerProfileObjectEntryModelListener.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/model/listener/MCPServerProfileObjectEntryModelListener.java
@@ -133,7 +133,7 @@ public class MCPServerProfileObjectEntryModelListener
 						StringBundler.concat(
 							"Unable to delete profile data mask ",
 							mcpServerProfileDataMaskObjectEntry.
-								getObjectEntryId(),
+								getExternalReferenceCode(),
 							" for profile ", externalReferenceCode),
 						portalException);
 				}
@@ -202,8 +202,9 @@ public class MCPServerProfileObjectEntryModelListener
 					_log.warn(
 						StringBundler.concat(
 							"Unable to attach system mask \"",
-							values.get("name"), "\" to profile ",
-							objectEntry.getObjectEntryId()),
+							dataMaskObjectEntry.getExternalReferenceCode(),
+							"\" to profile \"",
+							objectEntry.getExternalReferenceCode(), "\""),
 						portalException);
 				}
 			}

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/model/listener/MCPServerProfileToolObjectEntryModelListener.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/model/listener/MCPServerProfileToolObjectEntryModelListener.java
@@ -9,12 +9,16 @@ import com.liferay.mcp.server.rest.internal.constants.MCPServerConstants;
 import com.liferay.mcp.server.rest.internal.servlet.MCPServerServlet;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.model.listener.RelevantObjectEntryModelListener;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.ModelListenerException;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -24,7 +28,10 @@ import jakarta.servlet.Servlet;
 
 import jakarta.validation.ValidationException;
 
+import java.io.Serializable;
+
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -67,6 +74,7 @@ public class MCPServerProfileToolObjectEntryModelListener
 		throws ModelListenerException {
 
 		_validateRestrictFields(objectEntry);
+		_validateTool(objectEntry);
 	}
 
 	@Override
@@ -82,6 +90,7 @@ public class MCPServerProfileToolObjectEntryModelListener
 		throws ModelListenerException {
 
 		_validateRestrictFields(objectEntry);
+		_validateTool(objectEntry);
 	}
 
 	private void _invalidateServlet(ObjectEntry objectEntry) {
@@ -176,6 +185,78 @@ public class MCPServerProfileToolObjectEntryModelListener
 		}
 	}
 
+	private void _validateTool(ObjectEntry objectEntry)
+		throws ModelListenerException {
+
+		try {
+			ObjectDefinition mcpServerProfileObjectDefinition =
+				_objectDefinitionLocalService.
+					fetchObjectDefinitionByExternalReferenceCode(
+						MCPServerConstants.
+							EXTERNAL_REFERENCE_CODE_MCP_SERVER_PROFILE,
+						objectEntry.getCompanyId());
+
+			ObjectRelationship objectRelationship =
+				_objectRelationshipLocalService.getObjectRelationship(
+					mcpServerProfileObjectDefinition.getObjectDefinitionId(),
+					"mcpServerProfileToTools");
+
+			Map<String, Serializable> values = objectEntry.getValues();
+
+			String toolName = MapUtil.getString(values, "toolName");
+			String toolSetName = MapUtil.getString(values, "toolSetName");
+
+			for (ObjectEntry mcpServerProfileToolObjectEntry :
+					_objectEntryLocalService.getOneToManyObjectEntries(
+						0, objectRelationship.getObjectRelationshipId(), null,
+						false,
+						MapUtil.getLong(
+							values,
+							"r_mcpServerProfileToTools_l_mcpServerProfileId"),
+						true, null, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+						null)) {
+
+				if (mcpServerProfileToolObjectEntry.getObjectEntryId() ==
+						objectEntry.getObjectEntryId()) {
+
+					continue;
+				}
+
+				Map<String, Serializable> mcpServerProfileToolValues =
+					mcpServerProfileToolObjectEntry.getValues();
+
+				if (!Objects.equals(
+						MapUtil.getString(
+							mcpServerProfileToolValues, "toolName"),
+						toolName) ||
+					!Objects.equals(
+						MapUtil.getString(
+							mcpServerProfileToolValues, "toolSetName"),
+						toolSetName)) {
+
+					continue;
+				}
+
+				String mcpServerProfileExternalReferenceCode =
+					MapUtil.getString(
+						values,
+						"r_mcpServerProfileToTools_l_mcpServerProfileERC");
+
+				throw new ModelListenerException(
+					new ValidationException(
+						StringBundler.concat(
+							"Unable to add tool \"", toolName,
+							"\" from tool set \"", toolSetName,
+							"\" to MCP server profile \"",
+							mcpServerProfileExternalReferenceCode,
+							"\" more than once")));
+			}
+		}
+		catch (PortalException portalException) {
+			throw new ModelListenerException(portalException);
+		}
+	}
+
 	private static final Pattern _restrictFieldNamePattern = Pattern.compile(
 		"[A-Za-z0-9_]+(\\.[A-Za-z0-9_]+)*");
 
@@ -184,6 +265,9 @@ public class MCPServerProfileToolObjectEntryModelListener
 
 	@Reference
 	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Reference
+	private ObjectRelationshipLocalService _objectRelationshipLocalService;
 
 	@Reference(
 		target = "(osgi.http.whiteboard.servlet.name=com.liferay.mcp.server.rest.internal.servlet.MCPServerServlet)"

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/model/listener/MCPServerProfileToolObjectEntryModelListener.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/model/listener/MCPServerProfileToolObjectEntryModelListener.java
@@ -23,7 +23,11 @@ import jakarta.servlet.Servlet;
 
 import jakarta.validation.ValidationException;
 
+import java.util.HashSet;
 import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -115,6 +119,8 @@ public class MCPServerProfileToolObjectEntryModelListener
 		String[] restrictFieldNames = StringUtil.split(
 			MapUtil.getString(objectEntry.getValues(), "restrictFields"));
 
+		Set<String> uniqueRestrictFieldNames = new HashSet<>();
+
 		for (String restrictFieldName : restrictFieldNames) {
 			if (restrictFieldName.isEmpty() ||
 				!Objects.equals(restrictFieldName, restrictFieldName.trim())) {
@@ -125,6 +131,26 @@ public class MCPServerProfileToolObjectEntryModelListener
 							"Unable to restrict field \"", restrictFieldName,
 							"\" because the name is blank or has surrounding ",
 							"whitespace")));
+			}
+
+			Matcher matcher = _restrictFieldNamePattern.matcher(
+				restrictFieldName);
+
+			if (!matcher.matches()) {
+				throw new ModelListenerException(
+					new ValidationException(
+						StringBundler.concat(
+							"Unable to restrict field \"", restrictFieldName,
+							"\" because the name is not a dotted path of ",
+							"letters, digits, and underscores")));
+			}
+
+			if (!uniqueRestrictFieldNames.add(restrictFieldName)) {
+				throw new ModelListenerException(
+					new ValidationException(
+						StringBundler.concat(
+							"Unable to restrict field \"", restrictFieldName,
+							"\" more than once")));
 			}
 
 			for (String ancestorFieldName : restrictFieldNames) {
@@ -142,6 +168,9 @@ public class MCPServerProfileToolObjectEntryModelListener
 			}
 		}
 	}
+
+	private static final Pattern _restrictFieldNamePattern = Pattern.compile(
+		"[A-Za-z0-9_]+(\\.[A-Za-z0-9_]+)*");
 
 	@Reference
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/model/listener/MCPServerProfileToolObjectEntryModelListener.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/model/listener/MCPServerProfileToolObjectEntryModelListener.java
@@ -23,6 +23,8 @@ import jakarta.servlet.Servlet;
 
 import jakarta.validation.ValidationException;
 
+import java.util.Objects;
+
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
@@ -114,6 +116,17 @@ public class MCPServerProfileToolObjectEntryModelListener
 			MapUtil.getString(objectEntry.getValues(), "restrictFields"));
 
 		for (String restrictFieldName : restrictFieldNames) {
+			if (restrictFieldName.isEmpty() ||
+				!Objects.equals(restrictFieldName, restrictFieldName.trim())) {
+
+				throw new ModelListenerException(
+					new ValidationException(
+						StringBundler.concat(
+							"Unable to restrict field \"", restrictFieldName,
+							"\" because the name is blank or has surrounding ",
+							"whitespace")));
+			}
+
 			for (String ancestorFieldName : restrictFieldNames) {
 				if (restrictFieldName.startsWith(
 						ancestorFieldName + StringPool.PERIOD)) {

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/model/listener/MCPServerProfileToolObjectEntryModelListener.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/model/listener/MCPServerProfileToolObjectEntryModelListener.java
@@ -12,11 +12,16 @@ import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.model.listener.RelevantObjectEntryModelListener;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 
 import jakarta.servlet.Servlet;
+
+import jakarta.validation.ValidationException;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -51,10 +56,25 @@ public class MCPServerProfileToolObjectEntryModelListener
 	}
 
 	@Override
+	public void onBeforeCreate(ObjectEntry objectEntry)
+		throws ModelListenerException {
+
+		_validateRestrictFields(objectEntry);
+	}
+
+	@Override
 	public void onBeforeRemove(ObjectEntry objectEntry)
 		throws ModelListenerException {
 
 		_invalidateServlet(objectEntry);
+	}
+
+	@Override
+	public void onBeforeUpdate(
+			ObjectEntry originalObjectEntry, ObjectEntry objectEntry)
+		throws ModelListenerException {
+
+		_validateRestrictFields(objectEntry);
 	}
 
 	private void _invalidateServlet(ObjectEntry objectEntry) {
@@ -85,6 +105,29 @@ public class MCPServerProfileToolObjectEntryModelListener
 		mcpServerServlet.invalidate(
 			objectEntry.getCompanyId(),
 			MapUtil.getString(mcpServerProfileObjectEntry.getValues(), "name"));
+	}
+
+	private void _validateRestrictFields(ObjectEntry objectEntry)
+		throws ModelListenerException {
+
+		String[] restrictFieldNames = StringUtil.split(
+			MapUtil.getString(objectEntry.getValues(), "restrictFields"));
+
+		for (String restrictFieldName : restrictFieldNames) {
+			for (String ancestorFieldName : restrictFieldNames) {
+				if (restrictFieldName.startsWith(
+						ancestorFieldName + StringPool.PERIOD)) {
+
+					throw new ModelListenerException(
+						new ValidationException(
+							StringBundler.concat(
+								"Unable to restrict field \"",
+								restrictFieldName,
+								"\" because restricted field \"",
+								ancestorFieldName, "\" already hides it")));
+				}
+			}
+		}
 	}
 
 	@Reference

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/model/listener/MCPServerProfileToolObjectEntryModelListener.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/model/listener/MCPServerProfileToolObjectEntryModelListener.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
 
 import jakarta.servlet.Servlet;
 
@@ -116,8 +117,14 @@ public class MCPServerProfileToolObjectEntryModelListener
 	private void _validateRestrictFields(ObjectEntry objectEntry)
 		throws ModelListenerException {
 
-		String[] restrictFieldNames = StringUtil.split(
-			MapUtil.getString(objectEntry.getValues(), "restrictFields"));
+		String restrictFields = MapUtil.getString(
+			objectEntry.getValues(), "restrictFields");
+
+		if (Validator.isNull(restrictFields)) {
+			return;
+		}
+
+		String[] restrictFieldNames = StringUtil.split(restrictFields);
 
 		Set<String> uniqueRestrictFieldNames = new HashSet<>();
 

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/model/listener/MCPServerProfileToolsObjectFieldModelListener.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/model/listener/MCPServerProfileToolsObjectFieldModelListener.java
@@ -147,10 +147,10 @@ public class MCPServerProfileToolsObjectFieldModelListener
 				throw new ModelListenerException(
 					StringBundler.concat(
 						"The tools object field cannot be deleted because the ",
-						"profile tool \"", tool, "\" of profile ",
-						mcpServerProfileObjectEntry.getObjectEntryId(),
-						" was not migrated to an MCPServerProfileTool object ",
-						"entry"));
+						"profile tool \"", tool, "\" of profile \"",
+						mcpServerProfileObjectEntry.getExternalReferenceCode(),
+						"\" was not migrated to an MCPServerProfileTool ",
+						"object entry"));
 			}
 		}
 	}

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/resource/v1_0/ToolResourceImpl.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/resource/v1_0/ToolResourceImpl.java
@@ -33,7 +33,7 @@ public class ToolResourceImpl extends BaseToolResourceImpl {
 		}
 
 		return ToolSetUtil.getTool(
-			contextHttpServletRequest, toolName, toolSetName);
+			contextHttpServletRequest, null, toolName, toolSetName);
 	}
 
 	@Override
@@ -48,7 +48,8 @@ public class ToolResourceImpl extends BaseToolResourceImpl {
 		}
 
 		return ToolSetUtil.invokeTool(
-			null, contextHttpServletRequest, object, toolName, toolSetName);
+			null, contextHttpServletRequest, object, null, toolName,
+			toolSetName);
 	}
 
 }

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/servlet/MCPServerServlet.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/servlet/MCPServerServlet.java
@@ -56,6 +56,7 @@ import java.io.Serializable;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -160,10 +161,15 @@ public class MCPServerServlet extends HttpServlet {
 						"/mcp/" + mcpServerProfileName : "/mcp"
 				).build();
 
+		List<ObjectEntry> mcpServerProfileToolObjectEntries =
+			_getMCPServerProfileToolObjectEntries(mcpServerProfileObjectEntry);
+
+		Map<String, String> restrictFieldsMap = _getRestrictFieldsMap(
+			mcpServerProfileToolObjectEntries);
+
 		List<McpStatelessServerFeatures.SyncToolSpecification>
 			syncToolSpecifications = TransformUtil.transform(
-				_getMCPServerProfileToolObjectEntries(
-					mcpServerProfileObjectEntry),
+				mcpServerProfileToolObjectEntries,
 				mcpServerProfileToolObjectEntry -> {
 					Map<String, Serializable> mcpServerProfileToolValues =
 						mcpServerProfileToolObjectEntry.getValues();
@@ -177,12 +183,13 @@ public class MCPServerServlet extends HttpServlet {
 						return new McpStatelessServerFeatures.
 							SyncToolSpecification(
 								_getTool(
-									httpServletRequest, toolName, toolSetName),
+									httpServletRequest, restrictFieldsMap,
+									toolName, toolSetName),
 								(mcpTransportContext, callToolRequest) -> _call(
 									mcpTransportContext,
 									callToolRequest.arguments(), companyId,
 									mcpServerProfileExternalReferenceCode,
-									toolName, toolSetName));
+									restrictFieldsMap, toolName, toolSetName));
 					}
 					catch (Exception exception) {
 						_log.error(
@@ -251,7 +258,8 @@ public class MCPServerServlet extends HttpServlet {
 	private McpSchema.CallToolResult _call(
 		McpTransportContext mcpTransportContext, Object inputObject,
 		long companyId, String mcpServerProfileExternalReferenceCode,
-		String toolName, String toolSetName) {
+		Map<String, String> restrictFieldsMap, String toolName,
+		String toolSetName) {
 
 		HttpServletRequest httpServletRequest =
 			(HttpServletRequest)mcpTransportContext.get("httpServletRequest");
@@ -260,7 +268,8 @@ public class MCPServerServlet extends HttpServlet {
 			Response response = ToolSetUtil.invokeTool(
 				_getDataMaskExternalReferenceCodes(
 					companyId, mcpServerProfileExternalReferenceCode),
-				httpServletRequest, inputObject, toolName, toolSetName);
+				httpServletRequest, inputObject, restrictFieldsMap, toolName,
+				toolSetName);
 
 			int responseCode = response.getStatus();
 			String content = (String)response.getEntity();
@@ -412,6 +421,33 @@ public class MCPServerServlet extends HttpServlet {
 		}
 	}
 
+	private Map<String, String> _getRestrictFieldsMap(
+		List<ObjectEntry> mcpServerProfileToolObjectEntries) {
+
+		Map<String, String> restrictFieldsMap = new HashMap<>();
+
+		for (ObjectEntry mcpServerProfileToolObjectEntry :
+				mcpServerProfileToolObjectEntries) {
+
+			Map<String, Serializable> values =
+				mcpServerProfileToolObjectEntry.getValues();
+
+			String restrictFields = MapUtil.getString(values, "restrictFields");
+
+			if (Validator.isNull(restrictFields)) {
+				continue;
+			}
+
+			restrictFieldsMap.put(
+				ToolSetUtil.getToolKey(
+					MapUtil.getString(values, "toolSetName"),
+					MapUtil.getString(values, "toolName")),
+				restrictFields);
+		}
+
+		return restrictFieldsMap;
+	}
+
 	private Servlet _getServlet(
 		HttpServletRequest httpServletRequest, long companyId,
 		ObjectEntry mcpServerProfileObjectEntry) {
@@ -475,12 +511,13 @@ public class MCPServerServlet extends HttpServlet {
 	}
 
 	private McpSchema.Tool _getTool(
-		HttpServletRequest httpServletRequest, String toolName,
+		HttpServletRequest httpServletRequest,
+		Map<String, String> restrictFieldsMap, String toolName,
 		String toolSetName) {
 
 		try {
 			Tool tool = ToolSetUtil.getTool(
-				httpServletRequest, toolName, toolSetName);
+				httpServletRequest, restrictFieldsMap, toolName, toolSetName);
 
 			return McpSchema.Tool.builder(
 			).description(

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/upgrade/MCPProfileToolUpgradeProcess.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/upgrade/MCPProfileToolUpgradeProcess.java
@@ -1,0 +1,109 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.mcp.server.rest.internal.upgrade;
+
+import com.liferay.mcp.server.rest.internal.constants.MCPServerConstants;
+import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.definition.util.ObjectDefinitionThreadLocal;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectField;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectFieldLocalService;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.LocaleUtil;
+
+import java.util.Collections;
+
+/**
+ * @author Alberto Javier Moreno Lage
+ */
+public class MCPProfileToolUpgradeProcess extends UpgradeProcess {
+
+	public MCPProfileToolUpgradeProcess(
+		CompanyLocalService companyLocalService,
+		ObjectDefinitionLocalService objectDefinitionLocalService,
+		ObjectFieldLocalService objectFieldLocalService) {
+
+		_companyLocalService = companyLocalService;
+		_objectDefinitionLocalService = objectDefinitionLocalService;
+		_objectFieldLocalService = objectFieldLocalService;
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		_companyLocalService.forEachCompanyId(this::_upgradeCompany);
+	}
+
+	private void _addRestrictFieldsObjectField(
+			ObjectDefinition objectDefinition)
+		throws PortalException {
+
+		ObjectField restrictFieldsObjectField =
+			_objectFieldLocalService.fetchObjectField(
+				objectDefinition.getObjectDefinitionId(), "restrictFields");
+
+		if (restrictFieldsObjectField != null) {
+			return;
+		}
+
+		try {
+			_objectFieldLocalService.addSystemObjectField(
+				null, objectDefinition.getUserId(), 0,
+				objectDefinition.getObjectDefinitionId(),
+				ObjectFieldConstants.BUSINESS_TYPE_LONG_TEXT, null, null,
+				ObjectFieldConstants.DB_TYPE_CLOB, true, false, "en_US",
+				Collections.singletonMap(LocaleUtil.US, "Restrict Fields"),
+				false, "restrictFields", ObjectFieldConstants.READ_ONLY_FALSE,
+				null, false, false, Collections.emptyList());
+		}
+		catch (PortalException portalException) {
+			restrictFieldsObjectField =
+				_objectFieldLocalService.fetchObjectField(
+					objectDefinition.getObjectDefinitionId(), "restrictFields");
+
+			if (restrictFieldsObjectField == null) {
+				throw portalException;
+			}
+
+			if (_log.isDebugEnabled()) {
+				_log.debug(portalException);
+			}
+		}
+	}
+
+	private void _upgradeCompany(long companyId) throws Exception {
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.
+				fetchObjectDefinitionByExternalReferenceCode(
+					MCPServerConstants.
+						EXTERNAL_REFERENCE_CODE_MCP_SERVER_PROFILE_TOOL,
+					companyId);
+
+		if (objectDefinition == null) {
+			return;
+		}
+
+		try (SafeCloseable safeCloseable =
+				ObjectDefinitionThreadLocal.
+					setSkipBundleAllowedCheckWithSafeCloseable(true)) {
+
+			_addRestrictFieldsObjectField(objectDefinition);
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		MCPProfileToolUpgradeProcess.class);
+
+	private final CompanyLocalService _companyLocalService;
+	private final ObjectDefinitionLocalService _objectDefinitionLocalService;
+	private final ObjectFieldLocalService _objectFieldLocalService;
+
+}

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/upgrade/registry/MCPServerRestUpgradeStepRegistrator.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/upgrade/registry/MCPServerRestUpgradeStepRegistrator.java
@@ -7,6 +7,7 @@ package com.liferay.mcp.server.rest.internal.upgrade.registry;
 
 import com.liferay.list.type.service.ListTypeDefinitionLocalService;
 import com.liferay.mcp.server.rest.internal.upgrade.MCPProfileDataMaskUpgradeProcess;
+import com.liferay.mcp.server.rest.internal.upgrade.MCPProfileToolUpgradeProcess;
 import com.liferay.mcp.server.rest.internal.upgrade.MCPProfileUpgradeProcess;
 import com.liferay.mcp.server.rest.internal.upgrade.MCPPromptUpgradeProcess;
 import com.liferay.object.constants.ObjectDefinitionConstants;
@@ -57,6 +58,12 @@ public class MCPServerRestUpgradeStepRegistrator
 				_objectDefinitionLocalService, _objectEntryLocalService,
 				_objectFieldLocalService, _objectFieldSettingLocalService,
 				_objectFolderLocalService, _objectRelationshipLocalService));
+
+		registry.register(
+			"1.2.0", "1.3.0",
+			new MCPProfileToolUpgradeProcess(
+				_companyLocalService, _objectDefinitionLocalService,
+				_objectFieldLocalService));
 	}
 
 	@Reference

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
@@ -56,7 +56,7 @@ public class OpenAPIUtil {
 	public static VulcanRequestForwarder.Request getRequest(
 			String basePath, Map<String, String> headers,
 			JSONObject inputJSONObject, JSONObject openAPIJSONObject,
-			String toolName, User user)
+			String restrictFields, String toolName, User user)
 		throws Exception {
 
 		byte[] body;
@@ -132,7 +132,7 @@ public class OpenAPIUtil {
 				String path = basePath + _getPath(inputJSONObject, operation);
 
 				String queryString = _getQueryString(
-					inputJSONObject, operation);
+					inputJSONObject, operation, restrictFields);
 
 				if (queryString.isEmpty()) {
 					return path;
@@ -151,7 +151,7 @@ public class OpenAPIUtil {
 
 	public static Tool getTool(
 		boolean injectVulcanParameters, JSONObject openAPIJSONObject,
-		String toolName) {
+		String restrictFields, String toolName) {
 
 		Operation operation = _getOperation(openAPIJSONObject, toolName);
 
@@ -165,7 +165,7 @@ public class OpenAPIUtil {
 					() -> _getInputSchema(
 						injectVulcanParameters, operation._method,
 						openAPIJSONObject, operation._operationJSONObject,
-						operation._pathParametersJSONArray));
+						operation._pathParametersJSONArray, restrictFields));
 
 				setName(() -> toolName);
 			}
@@ -571,7 +571,7 @@ public class OpenAPIUtil {
 	private static Map<String, Object> _getInputSchema(
 		boolean injectVulcanParameters, String method,
 		JSONObject openAPIJSONObject, JSONObject operationJSONObject,
-		JSONArray pathParametersJSONArray) {
+		JSONArray pathParametersJSONArray, String restrictFields) {
 
 		Map<String, Object> properties = new LinkedHashMap<>();
 		List<String> requiredPropertyNames = new ArrayList<>();
@@ -634,6 +634,11 @@ public class OpenAPIUtil {
 
 		Collection<String> responseFieldNames = _getResponseFieldNames(
 			openAPIJSONObject, operationJSONObject);
+
+		if (Validator.isNotNull(restrictFields)) {
+			responseFieldNames.removeAll(
+				Arrays.asList(StringUtil.split(restrictFields)));
+		}
 
 		Set<String> visitedParameterNames = new HashSet<>();
 
@@ -969,7 +974,8 @@ public class OpenAPIUtil {
 	}
 
 	private static String _getQueryString(
-		JSONObject inputJSONObject, Operation operation) {
+		JSONObject inputJSONObject, Operation operation,
+		String restrictFields) {
 
 		StringBundler sb = new StringBundler();
 
@@ -996,7 +1002,16 @@ public class OpenAPIUtil {
 		}
 
 		if (Objects.equals(operation._method, "get")) {
-			_appendQueryParameter("restrictFields", sb, "actions");
+			if (Validator.isNull(restrictFields)) {
+				restrictFields = "actions";
+			}
+			else {
+				restrictFields = "actions," + restrictFields;
+			}
+		}
+
+		if (Validator.isNotNull(restrictFields)) {
+			_appendQueryParameter("restrictFields", sb, restrictFields);
 		}
 
 		return sb.toString();

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/ToolSetUtil.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/ToolSetUtil.java
@@ -71,14 +71,20 @@ public class ToolSetUtil {
 	}
 
 	public static Tool getTool(
-		HttpServletRequest httpServletRequest, String toolName,
+		HttpServletRequest httpServletRequest,
+		Map<String, String> restrictFieldsMap, String toolName,
 		String toolSetName) {
 
 		return OpenAPIUtil.getTool(
 			!Objects.equals(toolSetName, _TOOL_SET_NAME),
 			_getOpenAPIJSONObject(
 				httpServletRequest, _getOpenAPIBrief(toolSetName)),
+			_getRestrictFields(restrictFieldsMap, toolName, toolSetName),
 			toolName);
+	}
+
+	public static String getToolKey(String toolSetName, String toolName) {
+		return toolSetName + StringPool.SPACE + toolName;
 	}
 
 	public static Page<ToolSet> getToolSetsPage() {
@@ -113,7 +119,8 @@ public class ToolSetUtil {
 	public static Response invokeTool(
 			List<String> dataMaskExternalReferenceCodes,
 			HttpServletRequest httpServletRequest, Object inputObject,
-			String toolName, String toolSetName)
+			Map<String, String> restrictFieldsMap, String toolName,
+			String toolSetName)
 		throws Exception {
 
 		JSONObject inputJSONObject = null;
@@ -133,7 +140,7 @@ public class ToolSetUtil {
 			if (Objects.equals(toolName, "getToolSetToolSetNameTool")) {
 				return _getResponse(
 					getTool(
-						httpServletRequest,
+						httpServletRequest, restrictFieldsMap,
 						inputJSONObject.getString("toolName"),
 						inputJSONObject.getString("toolSetName")));
 			}
@@ -154,7 +161,7 @@ public class ToolSetUtil {
 			if (Objects.equals(toolName, "postToolSetToolSetNameToolInvoke")) {
 				return invokeTool(
 					dataMaskExternalReferenceCodes, httpServletRequest,
-					inputJSONObject.opt("body"),
+					inputJSONObject.opt("body"), restrictFieldsMap,
 					inputJSONObject.getString("toolName"),
 					inputJSONObject.getString("toolSetName"));
 			}
@@ -177,6 +184,8 @@ public class ToolSetUtil {
 					).build(),
 					inputJSONObject,
 					_getOpenAPIJSONObject(httpServletRequest, openAPIBrief),
+					_getRestrictFields(
+						restrictFieldsMap, toolName, toolSetName),
 					toolName, _getUser(httpServletRequest)));
 
 		String content = response.getContent();
@@ -387,6 +396,17 @@ public class ToolSetUtil {
 		return Response.ok(
 			objectMapper.writeValueAsString(value), ContentTypes.TEXT_PLAIN_UTF8
 		).build();
+	}
+
+	private static String _getRestrictFields(
+		Map<String, String> restrictFieldsMap, String toolName,
+		String toolSetName) {
+
+		if (restrictFieldsMap == null) {
+			return null;
+		}
+
+		return restrictFieldsMap.get(getToolKey(toolSetName, toolName));
 	}
 
 	private static Map<String, String> _getToolSetDescriptions() {

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/ToolSetUtil.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/ToolSetUtil.java
@@ -84,7 +84,7 @@ public class ToolSetUtil {
 	}
 
 	public static String getToolKey(String toolSetName, String toolName) {
-		return toolSetName + StringPool.SPACE + toolName;
+		return toolSetName + StringPool.POUND + toolName;
 	}
 
 	public static Page<ToolSet> getToolSetsPage() {

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/resources/com/liferay/mcp/server/rest/internal/batch/04-object-definition.batch-engine-data.json
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/resources/com/liferay/mcp/server/rest/internal/batch/04-object-definition.batch-engine-data.json
@@ -23,6 +23,22 @@
 			"name": "MCPServerProfileTool",
 			"objectFields": [
 				{
+					"DBType": "Clob",
+					"businessType": "LongText",
+					"defaultValue": "null",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"indexedLanguageId": "en_US",
+					"label": {
+						"en_US": "Restrict Fields"
+					},
+					"name": "restrictFields",
+					"required": false,
+					"state": false,
+					"system": true,
+					"type": "String"
+				},
+				{
 					"DBType": "String",
 					"businessType": "Text",
 					"defaultValue": "null",

--- a/modules/apps/mcp/mcp-server-rest-impl/src/test/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtilTest.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/test/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtilTest.java
@@ -65,6 +65,47 @@ public class OpenAPIUtilTest {
 	@Test
 	public void testGetRequest() throws Exception {
 		_testGetRequest(
+			"{}", "application/json", "POST", "/v1.0/items",
+			JSONUtil.put("body", JSONFactoryUtil.createJSONObject()),
+			"postItem");
+		_testGetRequest(
+			"{}", "application/json", "POST", "/v1.0/items?restrictFields=name",
+			JSONUtil.put("body", JSONFactoryUtil.createJSONObject()), "name",
+			"postItem");
+		_testGetRequest(
+			JSONUtil.put(
+				"name", "Test"
+			).toString(),
+			"application/json", "PATCH", "/v1.0/items/123",
+			JSONUtil.put(
+				"body", JSONUtil.put("name", "Test")
+			).put(
+				"itemId", "123"
+			),
+			"patchItem");
+		_testGetRequest(
+			JSONUtil.put(
+				"name", "Test"
+			).toString(),
+			"application/json", "PATCH", "/v1.0/items/123?restrictFields=name",
+			JSONUtil.put(
+				"body", JSONUtil.put("name", "Test")
+			).put(
+				"itemId", "123"
+			),
+			"name", "patchItem");
+		_testGetRequest(
+			JSONUtil.put(
+				"name", "Test"
+			).toString(),
+			"application/json", "PUT", "/v1.0/items/123?restrictFields=name",
+			JSONUtil.put(
+				"body", JSONUtil.put("name", "Test")
+			).put(
+				"itemId", "123"
+			),
+			"name", "putItem");
+		_testGetRequest(
 			null, null, "GET",
 			"/v1.0/items/123?fields=name&restrictFields=actions",
 			JSONUtil.put(
@@ -101,58 +142,17 @@ public class OpenAPIUtilTest {
 			JSONFactoryUtil.createJSONObject(), "getItems");
 		_testGetRequest(
 			null, null, "GET", "/v1.0/items?restrictFields=actions",
+			JSONFactoryUtil.createJSONObject(), StringPool.BLANK, "getItems");
+		_testGetRequest(
+			null, null, "GET", "/v1.0/items?restrictFields=actions",
 			JSONUtil.put("fields", ""), "getItems");
 		_testGetRequest(
 			null, null, "GET", "/v1.0/items?restrictFields=actions",
 			JSONUtil.put("restrictFields", "name"), "getItems");
 		_testGetRequest(
-			null, null, "GET", "/v1.0/items?restrictFields=actions",
-			JSONFactoryUtil.createJSONObject(), StringPool.BLANK, "getItems");
-		_testGetRequest(
 			null, null, "GET",
 			"/v1.0/items?restrictFields=actions%2Cname%2Cparent.name",
 			JSONFactoryUtil.createJSONObject(), "name,parent.name", "getItems");
-		_testGetRequest(
-			JSONUtil.put(
-				"name", "Test"
-			).toString(),
-			"application/json", "PATCH", "/v1.0/items/123?restrictFields=name",
-			JSONUtil.put(
-				"body", JSONUtil.put("name", "Test")
-			).put(
-				"itemId", "123"
-			),
-			"name", "patchItem");
-		_testGetRequest(
-			"{}", "application/json", "POST", "/v1.0/items?restrictFields=name",
-			JSONUtil.put("body", JSONFactoryUtil.createJSONObject()), "name",
-			"postItem");
-		_testGetRequest(
-			JSONUtil.put(
-				"name", "Test"
-			).toString(),
-			"application/json", "PUT", "/v1.0/items/123?restrictFields=name",
-			JSONUtil.put(
-				"body", JSONUtil.put("name", "Test")
-			).put(
-				"itemId", "123"
-			),
-			"name", "putItem");
-		_testGetRequest(
-			JSONUtil.put(
-				"name", "Test"
-			).toString(),
-			"application/json", "PATCH", "/v1.0/items/123",
-			JSONUtil.put(
-				"body", JSONUtil.put("name", "Test")
-			).put(
-				"itemId", "123"
-			),
-			"patchItem");
-		_testGetRequest(
-			"{}", "application/json", "POST", "/v1.0/items",
-			JSONUtil.put("body", JSONFactoryUtil.createJSONObject()),
-			"postItem");
 
 		String fileContent = RandomTestUtil.randomString();
 		String fileName = RandomTestUtil.randomString();

--- a/modules/apps/mcp/mcp-server-rest-impl/src/test/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtilTest.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/test/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtilTest.java
@@ -106,6 +106,39 @@ public class OpenAPIUtilTest {
 			null, null, "GET", "/v1.0/items?restrictFields=actions",
 			JSONUtil.put("restrictFields", "name"), "getItems");
 		_testGetRequest(
+			null, null, "GET", "/v1.0/items?restrictFields=actions",
+			JSONFactoryUtil.createJSONObject(), StringPool.BLANK, "getItems");
+		_testGetRequest(
+			null, null, "GET",
+			"/v1.0/items?restrictFields=actions%2Cname%2Cparent.name",
+			JSONFactoryUtil.createJSONObject(), "name,parent.name", "getItems");
+		_testGetRequest(
+			JSONUtil.put(
+				"name", "Test"
+			).toString(),
+			"application/json", "PATCH", "/v1.0/items/123?restrictFields=name",
+			JSONUtil.put(
+				"body", JSONUtil.put("name", "Test")
+			).put(
+				"itemId", "123"
+			),
+			"name", "patchItem");
+		_testGetRequest(
+			"{}", "application/json", "POST", "/v1.0/items?restrictFields=name",
+			JSONUtil.put("body", JSONFactoryUtil.createJSONObject()), "name",
+			"postItem");
+		_testGetRequest(
+			JSONUtil.put(
+				"name", "Test"
+			).toString(),
+			"application/json", "PUT", "/v1.0/items/123?restrictFields=name",
+			JSONUtil.put(
+				"body", JSONUtil.put("name", "Test")
+			).put(
+				"itemId", "123"
+			),
+			"name", "putItem");
+		_testGetRequest(
 			JSONUtil.put(
 				"name", "Test"
 			).toString(),
@@ -144,7 +177,7 @@ public class OpenAPIUtilTest {
 			).put(
 				"name", name
 			),
-			_openAPIJSONObject, "postBinary", null);
+			_openAPIJSONObject, null, "postBinary", null);
 
 		Assert.assertEquals("POST", request.getMethod());
 		Assert.assertEquals("/v1.0/binaries", request.getPath());
@@ -175,7 +208,7 @@ public class OpenAPIUtilTest {
 			).put(
 				"string", fileContent
 			),
-			_openAPIJSONObject, "postUpload", null);
+			_openAPIJSONObject, null, "postUpload", null);
 
 		Assert.assertEquals("POST", request.getMethod());
 		Assert.assertEquals("/v1.0/uploads", request.getPath());
@@ -196,7 +229,7 @@ public class OpenAPIUtilTest {
 
 		request = OpenAPIUtil.getRequest(
 			StringPool.BLANK, headers, JSONUtil.put("itemId", "123"),
-			_openAPIJSONObject, "getItem", null);
+			_openAPIJSONObject, null, "getItem", null);
 
 		Assert.assertEquals(headers, request.getHeaders());
 
@@ -212,7 +245,7 @@ public class OpenAPIUtilTest {
 				JSONUtil.put(
 					RandomTestUtil.randomString(),
 					RandomTestUtil.randomString()),
-				_openAPIJSONObject, "postItem", null));
+				_openAPIJSONObject, null, "postItem", null));
 	}
 
 	@Test
@@ -220,12 +253,13 @@ public class OpenAPIUtilTest {
 		AssertUtils.assertFailure(
 			IllegalArgumentException.class,
 			"OpenAPI document has no tool with name \"missing\"",
-			() -> OpenAPIUtil.getTool(true, _openAPIJSONObject, "missing"));
+			() -> OpenAPIUtil.getTool(
+				true, _openAPIJSONObject, null, "missing"));
 		AssertUtils.assertFailure(
 			IllegalArgumentException.class,
 			"OpenAPI document has no \"paths\" object",
 			() -> OpenAPIUtil.getTool(
-				true, JSONFactoryUtil.createJSONObject(),
+				true, JSONFactoryUtil.createJSONObject(), null,
 				RandomTestUtil.randomString()));
 		AssertUtils.assertFailure(
 			IllegalArgumentException.class, "Request body has no content",
@@ -271,6 +305,25 @@ public class OpenAPIUtilTest {
 		_testGetTool(
 			"PUT /v1.0/items/{itemId}", "put_test_v1.0_items_itemId.json",
 			"putItem");
+
+		// Restricted fields
+
+		Tool tool = OpenAPIUtil.getTool(
+			true, _openAPIJSONObject, "boolean,object1.name", "getItems");
+
+		Map<String, ?> inputSchemaMap = tool.getInputSchema();
+
+		Map<String, ?> propertiesMap = (Map<String, ?>)inputSchemaMap.get(
+			"properties");
+
+		Map<String, ?> fieldsMap = (Map<String, ?>)propertiesMap.get("fields");
+
+		Map<String, ?> itemsMap = (Map<String, ?>)fieldsMap.get("items");
+
+		List<String> enumValues = (List<String>)itemsMap.get("enum");
+
+		Assert.assertFalse(enumValues.contains("boolean"));
+		Assert.assertTrue(enumValues.contains("object1"));
 	}
 
 	@Test
@@ -397,7 +450,8 @@ public class OpenAPIUtilTest {
 	private Map<String, ?> _getInputSchema(
 		JSONObject openAPIJSONObject, String toolName) {
 
-		Tool tool = OpenAPIUtil.getTool(true, openAPIJSONObject, toolName);
+		Tool tool = OpenAPIUtil.getTool(
+			true, openAPIJSONObject, null, toolName);
 
 		return tool.getInputSchema();
 	}
@@ -413,9 +467,20 @@ public class OpenAPIUtilTest {
 			JSONObject inputJSONObject, String toolName)
 		throws Exception {
 
+		_testGetRequest(
+			expectedBody, expectedContentType, expectedMethod,
+			expectedPathWithQuery, inputJSONObject, null, toolName);
+	}
+
+	private void _testGetRequest(
+			String expectedBody, String expectedContentType,
+			String expectedMethod, String expectedPathWithQuery,
+			JSONObject inputJSONObject, String restrictFields, String toolName)
+		throws Exception {
+
 		VulcanRequestForwarder.Request request = OpenAPIUtil.getRequest(
 			StringPool.BLANK, null, inputJSONObject, _openAPIJSONObject,
-			toolName, null);
+			restrictFields, toolName, null);
 
 		if (expectedBody == null) {
 			Assert.assertNull(request.getBody());
@@ -438,7 +503,7 @@ public class OpenAPIUtilTest {
 		throws Exception {
 
 		Tool tool = OpenAPIUtil.getTool(
-			injectVulcanParameters, _openAPIJSONObject, toolName);
+			injectVulcanParameters, _openAPIJSONObject, null, toolName);
 
 		Assert.assertEquals(expectedDescription, tool.getDescription());
 		Assert.assertEquals(toolName, tool.getName());

--- a/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/internal/model/listener/test/MCPServerProfileToolObjectEntryModelListenerTest.java
+++ b/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/internal/model/listener/test/MCPServerProfileToolObjectEntryModelListenerTest.java
@@ -1,0 +1,255 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.mcp.server.rest.internal.model.listener.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.mcp.server.rest.test.util.MCPServerTestUtil;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.exception.ModelListenerException;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.test.AssertUtils;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.HTTPTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Alberto Javier Moreno Lage
+ */
+@FeatureFlags(featureFlags = @FeatureFlag("LPD-63311"))
+@RunWith(Arquillian.class)
+public class MCPServerProfileToolObjectEntryModelListenerTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		MCPServerTestUtil.processBatchEngineUnits();
+
+		ObjectEntry mcpServerProfileObjectEntry =
+			MCPServerTestUtil.addMCPServerProfileObjectEntry(
+				RandomTestUtil.randomString(), RandomTestUtil.randomString());
+
+		_mcpServerProfileExternalReferenceCode =
+			mcpServerProfileObjectEntry.getExternalReferenceCode();
+	}
+
+	@Test
+	public void testOnBeforeCreate() throws Exception {
+
+		// Every level below a restricted ancestor
+
+		_assertRestrictFieldsFailure("actions,actions.get", "actions.get");
+		_assertRestrictFieldsFailure(
+			"actions,actions.get.method", "actions.get.method");
+		_assertRestrictFieldsFailure(
+			"actions.get.method,actions", "actions.get.method");
+
+		// Fields outside of the restricted subtree
+
+		_addMCPServerProfileToolObjectEntry(
+			"actions,actionsCount,creator.id,description");
+
+		// Blank names and surrounding whitespace never reach Vulcan intact
+
+		_assertBlankRestrictFieldFailure("actions,,description", "");
+		_assertBlankRestrictFieldFailure(
+			"actions, description", " description");
+		_assertBlankRestrictFieldFailure("actions ,description", "actions ");
+
+		// A translator splitting on dots needs every segment to be a name
+
+		_assertMalformedRestrictFieldFailure(
+			"actions.,description", "actions.");
+		_assertMalformedRestrictFieldFailure(
+			".actions,description", ".actions");
+		_assertMalformedRestrictFieldFailure(
+			"actions..get,description", "actions..get");
+		_assertMalformedRestrictFieldFailure(
+			"actions get,description", "actions get");
+		_assertMalformedRestrictFieldFailure(
+			"actions;get,description", "actions;get");
+
+		// The same field twice is not a canonical value
+
+		AssertUtils.assertFailure(
+			ModelListenerException.class,
+			"jakarta.validation.ValidationException: Unable to restrict " +
+				"field \"actions\" more than once",
+			() -> _addMCPServerProfileToolObjectEntry(
+				"actions,description,actions"));
+
+		// Relationship alias keys are valid names
+
+		_addMCPServerProfileToolObjectEntry(
+			"r_universityStudents_c_university.budget,name_i18n");
+	}
+
+	@Test
+	public void testOnBeforeUpdate() throws Exception {
+		ObjectEntry mcpServerProfileToolObjectEntry =
+			_addMCPServerProfileToolObjectEntry("creator.id");
+
+		AssertUtils.assertFailure(
+			ModelListenerException.class,
+			"jakarta.validation.ValidationException: Unable to restrict " +
+				"field \"creator.id\" because restricted field \"creator\" " +
+					"already hides it",
+			() -> MCPServerTestUtil.updateMCPServerProfileToolRestrictFields(
+				mcpServerProfileToolObjectEntry, "creator,creator.id"));
+
+		MCPServerTestUtil.updateMCPServerProfileToolRestrictFields(
+			mcpServerProfileToolObjectEntry, "creator");
+
+		Assert.assertEquals(
+			"creator",
+			MapUtil.getString(
+				_objectEntryLocalService.getValues(
+					mcpServerProfileToolObjectEntry.getObjectEntryId()),
+				"restrictFields"));
+	}
+
+	@Test
+	public void testRestrictFieldsOnPatch() throws Exception {
+		ObjectEntry mcpServerProfileToolObjectEntry =
+			_addMCPServerProfileToolObjectEntry("creator.id,description");
+
+		long objectEntryId = mcpServerProfileToolObjectEntry.getObjectEntryId();
+
+		Assert.assertEquals(
+			400,
+			HTTPTestUtil.invokeToHttpCode(
+				JSONUtil.put(
+					"restrictFields", "creator,creator.id"
+				).toString(),
+				"mcp/server-profile-tools/" + objectEntryId,
+				Http.Method.PATCH));
+
+		// Removing a restriction re-exposes the field
+
+		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				"restrictFields", "description"
+			).toString(),
+			"mcp/server-profile-tools/" + objectEntryId, Http.Method.PATCH);
+
+		Assert.assertEquals(
+			"description", jsonObject.getString("restrictFields"));
+
+		Assert.assertEquals(
+			"description",
+			MapUtil.getString(
+				_objectEntryLocalService.getValues(objectEntryId),
+				"restrictFields"));
+	}
+
+	@Test
+	public void testRestrictFieldsOnPost() throws Exception {
+		Assert.assertEquals(
+			400,
+			HTTPTestUtil.invokeToHttpCode(
+				_getMCPServerProfileToolJSONObject(
+					"creator,creator.id"
+				).toString(),
+				"mcp/server-profile-tools", Http.Method.POST));
+
+		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
+			_getMCPServerProfileToolJSONObject(
+				"creator,description"
+			).toString(),
+			"mcp/server-profile-tools", Http.Method.POST);
+
+		Assert.assertEquals(
+			"creator,description",
+			MapUtil.getString(
+				_objectEntryLocalService.getValues(jsonObject.getLong("id")),
+				"restrictFields"));
+	}
+
+	private ObjectEntry _addMCPServerProfileToolObjectEntry(
+			String restrictFields)
+		throws Exception {
+
+		return MCPServerTestUtil.addMCPServerProfileToolObjectEntry(
+			_mcpServerProfileExternalReferenceCode, restrictFields,
+			"getMCPServerProfilesPage", "mcp-server-profiles");
+	}
+
+	private void _assertBlankRestrictFieldFailure(
+		String restrictFields, String restrictFieldName) {
+
+		AssertUtils.assertFailure(
+			ModelListenerException.class,
+			StringBundler.concat(
+				"jakarta.validation.ValidationException: Unable to restrict ",
+				"field \"", restrictFieldName, "\" because the name is blank ",
+				"or has surrounding whitespace"),
+			() -> _addMCPServerProfileToolObjectEntry(restrictFields));
+	}
+
+	private void _assertMalformedRestrictFieldFailure(
+		String restrictFields, String restrictFieldName) {
+
+		AssertUtils.assertFailure(
+			ModelListenerException.class,
+			StringBundler.concat(
+				"jakarta.validation.ValidationException: Unable to restrict ",
+				"field \"", restrictFieldName, "\" because the name is not a ",
+				"dotted path of letters, digits, and underscores"),
+			() -> _addMCPServerProfileToolObjectEntry(restrictFields));
+	}
+
+	private void _assertRestrictFieldsFailure(
+		String restrictFields, String restrictFieldName) {
+
+		AssertUtils.assertFailure(
+			ModelListenerException.class,
+			StringBundler.concat(
+				"jakarta.validation.ValidationException: Unable to restrict ",
+				"field \"", restrictFieldName, "\" because restricted field ",
+				"\"actions\" already hides it"),
+			() -> _addMCPServerProfileToolObjectEntry(restrictFields));
+	}
+
+	private JSONObject _getMCPServerProfileToolJSONObject(
+		String restrictFields) {
+
+		return JSONUtil.put(
+			"r_mcpServerProfileToTools_l_mcpServerProfileERC",
+			_mcpServerProfileExternalReferenceCode
+		).put(
+			"restrictFields", restrictFields
+		).put(
+			"toolName", "getMCPServerProfilesPage"
+		).put(
+			"toolSetName", "mcp-server-profiles"
+		);
+	}
+
+	private String _mcpServerProfileExternalReferenceCode;
+
+	@Inject
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+}

--- a/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/internal/model/listener/test/MCPServerProfileToolObjectEntryModelListenerTest.java
+++ b/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/internal/model/listener/test/MCPServerProfileToolObjectEntryModelListenerTest.java
@@ -17,12 +17,15 @@ import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.HTTPTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.io.Serializable;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -66,11 +69,6 @@ public class MCPServerProfileToolObjectEntryModelListenerTest {
 		_assertRestrictFieldsFailure(
 			"actions.get.method,actions", "actions.get.method");
 
-		// Fields outside of the restricted subtree
-
-		_addMCPServerProfileToolObjectEntry(
-			"actions,actionsCount,creator.id,description");
-
 		// Blank names and surrounding whitespace never reach Vulcan intact
 
 		_assertBlankRestrictFieldFailure("actions,,description", "");
@@ -100,10 +98,38 @@ public class MCPServerProfileToolObjectEntryModelListenerTest {
 			() -> _addMCPServerProfileToolObjectEntry(
 				"actions,description,actions"));
 
-		// Relationship alias keys are valid names
+		// Fields outside of the restricted subtree
 
 		_addMCPServerProfileToolObjectEntry(
-			"r_universityStudents_c_university.budget,name_i18n");
+			"actions,actionsCount,creator.id,description");
+
+		// The same tool twice in one profile, whatever it restricts
+
+		AssertUtils.assertFailure(
+			ModelListenerException.class,
+			StringBundler.concat(
+				"jakarta.validation.ValidationException: Unable to add tool ",
+				"\"getMCPServerProfilesPage\" from tool set ",
+				"\"mcp-server-profiles\" to MCP server profile \"",
+				_mcpServerProfileExternalReferenceCode, "\" more than once"),
+			() -> _addMCPServerProfileToolObjectEntry("description"));
+
+		// The same tool in another profile
+
+		ObjectEntry mcpServerProfileObjectEntry =
+			MCPServerTestUtil.addMCPServerProfileObjectEntry(
+				RandomTestUtil.randomString(), RandomTestUtil.randomString());
+
+		MCPServerTestUtil.addMCPServerProfileToolObjectEntry(
+			mcpServerProfileObjectEntry.getExternalReferenceCode(), null,
+			"getMCPServerProfilesPage", "mcp-server-profiles");
+
+		// Relationship alias keys are valid names
+
+		MCPServerTestUtil.addMCPServerProfileToolObjectEntry(
+			_mcpServerProfileExternalReferenceCode,
+			"r_universityStudents_c_university.budget,name_i18n",
+			"postMCPServerProfile", "mcp-server-profiles");
 	}
 
 	@Test
@@ -128,6 +154,33 @@ public class MCPServerProfileToolObjectEntryModelListenerTest {
 				_objectEntryLocalService.getValues(
 					mcpServerProfileToolObjectEntry.getObjectEntryId()),
 				"restrictFields"));
+
+		// Renaming a tool into one the profile already has
+
+		ObjectEntry postMCPServerProfileToolObjectEntry =
+			MCPServerTestUtil.addMCPServerProfileToolObjectEntry(
+				_mcpServerProfileExternalReferenceCode, null,
+				"postMCPServerProfile", "mcp-server-profiles");
+
+		AssertUtils.assertFailure(
+			ModelListenerException.class,
+			StringBundler.concat(
+				"jakarta.validation.ValidationException: Unable to add tool ",
+				"\"getMCPServerProfilesPage\" from tool set ",
+				"\"mcp-server-profiles\" to MCP server profile \"",
+				_mcpServerProfileExternalReferenceCode, "\" more than once"),
+			() -> MCPServerTestUtil.updateMCPServerProfileToolObjectEntry(
+				postMCPServerProfileToolObjectEntry,
+				HashMapBuilder.<String, Serializable>put(
+					"toolName", "getMCPServerProfilesPage"
+				).build()));
+
+		Assert.assertEquals(
+			"postMCPServerProfile",
+			MapUtil.getString(
+				_objectEntryLocalService.getValues(
+					postMCPServerProfileToolObjectEntry.getObjectEntryId()),
+				"toolName"));
 	}
 
 	@Test

--- a/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/internal/servlet/test/MCPServerServletTest.java
+++ b/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/internal/servlet/test/MCPServerServletTest.java
@@ -25,6 +25,7 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.test.util.CompanyConfigurationTemporarySwapper;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
@@ -179,6 +180,7 @@ public class MCPServerServletTest {
 				_testServiceWithModifiedProfile(authorization);
 				_testServiceWithNoContentResponse(authorization);
 				_testServiceWithProfile(authorization);
+				_testServiceWithRestrictFields(authorization);
 				_testServiceWithoutAuthTokenCheck(authorization);
 				_testServiceWithoutProfile(authorization);
 				_testServiceWithoutSession(authorization);
@@ -555,6 +557,66 @@ public class MCPServerServletTest {
 		).getString(
 			"access_token"
 		);
+	}
+
+	private List<String> _getFieldsEnumValues(McpSyncClient mcpSyncClient)
+		throws Exception {
+
+		McpSchema.ListToolsResult listToolsResult = mcpSyncClient.listTools();
+
+		List<McpSchema.Tool> tools = listToolsResult.tools();
+
+		McpSchema.Tool tool = tools.get(0);
+
+		return JSONUtil.toStringList(
+			JSONUtil.getValueAsJSONArray(
+				JSONFactoryUtil.createJSONObject(
+					new ObjectMapper(
+					).writeValueAsString(
+						tool.inputSchema()
+					)),
+				"JSONObject/properties", "JSONObject/fields",
+				"JSONObject/items", "JSONArray/enum"));
+	}
+
+	private JSONObject _getMCPServerProfileItemJSONObject(
+			Map<String, Object> arguments, McpSyncClient mcpSyncClient,
+			String profileName)
+		throws Exception {
+
+		JSONObject mcpServerProfileItemJSONObject = null;
+
+		McpSchema.CallToolResult callToolResult = mcpSyncClient.callTool(
+			new McpSchema.CallToolRequest(
+				"getMCPServerProfilesPage", arguments));
+
+		List<McpSchema.Content> contents = callToolResult.content();
+
+		McpSchema.TextContent textContent = (McpSchema.TextContent)contents.get(
+			0);
+
+		Assert.assertFalse(textContent.text(), callToolResult.isError());
+
+		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
+			textContent.text());
+
+		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
+
+		for (int i = 0; i < itemsJSONArray.length(); i++) {
+			JSONObject itemJSONObject = itemsJSONArray.getJSONObject(i);
+
+			if (Objects.equals(itemJSONObject.getString("name"), profileName)) {
+				mcpServerProfileItemJSONObject = itemJSONObject;
+
+				break;
+			}
+		}
+
+		Assert.assertNotNull(
+			"MCP server profile \"" + profileName + "\" was not found",
+			mcpServerProfileItemJSONObject);
+
+		return mcpServerProfileItemJSONObject;
 	}
 
 	private McpSyncClient _getMcpSyncClient(
@@ -1103,6 +1165,137 @@ public class MCPServerServletTest {
 			).contains(
 				entryName
 			));
+
+		mcpSyncClient.closeGracefully();
+	}
+
+	private void _testServiceWithRestrictFields(String authorization)
+		throws Exception {
+
+		String description = RandomTestUtil.randomString();
+		String profileName = RandomTestUtil.randomString();
+
+		ObjectEntry mcpServerProfileObjectEntry =
+			MCPServerTestUtil.addMCPServerProfileObjectEntry(
+				description, profileName);
+
+		String mcpServerProfileExternalReferenceCode =
+			mcpServerProfileObjectEntry.getExternalReferenceCode();
+
+		ObjectEntry getMCPServerProfileToolObjectEntry =
+			MCPServerTestUtil.addMCPServerProfileToolObjectEntry(
+				mcpServerProfileExternalReferenceCode,
+				"creator.givenName,description", "getMCPServerProfilesPage",
+				"mcp-server-profiles");
+		ObjectEntry postMCPServerProfileToolObjectEntry =
+			MCPServerTestUtil.addMCPServerProfileToolObjectEntry(
+				mcpServerProfileExternalReferenceCode, "description",
+				"postMCPServerProfile", "mcp-server-profiles");
+
+		McpSyncClient mcpSyncClient = _getMcpSyncClient(
+			authorization, profileName);
+
+		mcpSyncClient.initialize();
+
+		List<String> fieldsEnumValues = _getFieldsEnumValues(mcpSyncClient);
+
+		Assert.assertTrue(fieldsEnumValues.contains("creator"));
+		Assert.assertFalse(fieldsEnumValues.contains("description"));
+		Assert.assertTrue(fieldsEnumValues.contains("name"));
+
+		JSONObject itemJSONObject = _getMCPServerProfileItemJSONObject(
+			HashMapBuilder.<String, Object>put(
+				"pageSize", "100"
+			).build(),
+			mcpSyncClient, profileName);
+
+		Assert.assertEquals(profileName, itemJSONObject.getString("name"));
+		Assert.assertFalse(itemJSONObject.has("description"));
+
+		JSONObject creatorJSONObject = itemJSONObject.getJSONObject("creator");
+
+		Assert.assertTrue(creatorJSONObject.has("familyName"));
+		Assert.assertFalse(creatorJSONObject.has("givenName"));
+
+		itemJSONObject = _getMCPServerProfileItemJSONObject(
+			HashMapBuilder.<String, Object>put(
+				"fields", "description,name"
+			).put(
+				"pageSize", "100"
+			).build(),
+			mcpSyncClient, profileName);
+
+		Assert.assertEquals(profileName, itemJSONObject.getString("name"));
+		Assert.assertFalse(itemJSONObject.has("description"));
+
+		String entryName = RandomTestUtil.randomString();
+
+		McpSchema.CallToolResult callToolResult = mcpSyncClient.callTool(
+			new McpSchema.CallToolRequest(
+				"postMCPServerProfile",
+				HashMapBuilder.<String, Object>put(
+					"body",
+					HashMapBuilder.<String, Object>put(
+						"description", RandomTestUtil.randomString()
+					).put(
+						"name", entryName
+					).build()
+				).build()));
+
+		List<McpSchema.Content> contents = callToolResult.content();
+
+		McpSchema.TextContent textContent = (McpSchema.TextContent)contents.get(
+			0);
+
+		Assert.assertFalse(textContent.text(), callToolResult.isError());
+
+		JSONObject postItemJSONObject = JSONFactoryUtil.createJSONObject(
+			textContent.text());
+
+		Assert.assertEquals(entryName, postItemJSONObject.getString("name"));
+		Assert.assertFalse(postItemJSONObject.has("description"));
+
+		// Restricting a compound node hides its whole subtree
+
+		MCPServerTestUtil.updateMCPServerProfileToolRestrictFields(
+			getMCPServerProfileToolObjectEntry, "creator,description");
+
+		fieldsEnumValues = _getFieldsEnumValues(mcpSyncClient);
+
+		Assert.assertFalse(fieldsEnumValues.contains("creator"));
+
+		itemJSONObject = _getMCPServerProfileItemJSONObject(
+			HashMapBuilder.<String, Object>put(
+				"pageSize", "100"
+			).build(),
+			mcpSyncClient, profileName);
+
+		Assert.assertEquals(profileName, itemJSONObject.getString("name"));
+		Assert.assertFalse(itemJSONObject.has("creator"));
+
+		// Lifting the restrictions exposes the fields again
+
+		MCPServerTestUtil.updateMCPServerProfileToolRestrictFields(
+			getMCPServerProfileToolObjectEntry, null);
+		MCPServerTestUtil.updateMCPServerProfileToolRestrictFields(
+			postMCPServerProfileToolObjectEntry, null);
+
+		itemJSONObject = _getMCPServerProfileItemJSONObject(
+			HashMapBuilder.<String, Object>put(
+				"pageSize", "100"
+			).build(),
+			mcpSyncClient, profileName);
+
+		Assert.assertEquals(
+			description, itemJSONObject.getString("description"));
+
+		creatorJSONObject = itemJSONObject.getJSONObject("creator");
+
+		Assert.assertTrue(creatorJSONObject.has("givenName"));
+
+		fieldsEnumValues = _getFieldsEnumValues(mcpSyncClient);
+
+		Assert.assertTrue(fieldsEnumValues.contains("description"));
 
 		mcpSyncClient.closeGracefully();
 	}

--- a/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/internal/upgrade/test/MCPProfileToolUpgradeProcessTest.java
+++ b/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/internal/upgrade/test/MCPProfileToolUpgradeProcessTest.java
@@ -1,0 +1,438 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.mcp.server.rest.internal.upgrade.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.batch.engine.unit.BatchEngineUnit;
+import com.liferay.batch.engine.unit.BatchEngineUnitConfiguration;
+import com.liferay.batch.engine.unit.BatchEngineUnitProcessor;
+import com.liferay.batch.engine.unit.BatchEngineUnitReader;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectField;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectFieldLocalService;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.cache.CacheRegistryUtil;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.module.util.BundleUtil;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.CompanyTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeStep;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.zip.ZipWriter;
+import com.liferay.portal.kernel.zip.ZipWriterFactory;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Serializable;
+
+import java.net.URL;
+
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+
+/**
+ * @author Alberto Javier Moreno Lage
+ */
+@FeatureFlags(featureFlags = @FeatureFlag("LPD-63311"))
+@RunWith(Arquillian.class)
+public class MCPProfileToolUpgradeProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_company = CompanyTestUtil.addCompany();
+		_originalCompanyId = CompanyThreadLocal.getCompanyId();
+		_originalName = PrincipalThreadLocal.getName();
+		_originalPermissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		CompanyThreadLocal.setCompanyId(_company.getCompanyId());
+
+		_user = UserTestUtil.getAdminUser(_company.getCompanyId());
+
+		UserTestUtil.setUser(_user);
+
+		_deleteObjectDefinition("L_MCP_SERVER_PROFILE");
+		_deleteObjectDefinition("L_MCP_SERVER_PROFILE_TOOL");
+
+		Bundle bundle = _installBundle();
+
+		try {
+			_processBatchEngineUnits(bundle);
+		}
+		finally {
+			bundle.uninstall();
+		}
+	}
+
+	@After
+	public void tearDown() {
+		CompanyThreadLocal.setCompanyId(_originalCompanyId);
+		PermissionThreadLocal.setPermissionChecker(_originalPermissionChecker);
+		PrincipalThreadLocal.setName(_originalName);
+	}
+
+	@Test
+	public void testUpgrade() throws Exception {
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_MCP_SERVER_PROFILE_TOOL", _company.getCompanyId());
+
+		Assert.assertNull(
+			_objectFieldLocalService.fetchObjectField(
+				objectDefinition.getObjectDefinitionId(), "restrictFields"));
+
+		ObjectEntry mcpServerProfileToolObjectEntry =
+			_addMCPServerProfileToolObjectEntry(objectDefinition);
+
+		_upgrade();
+
+		_assertUpgrade(mcpServerProfileToolObjectEntry, objectDefinition);
+
+		_upgrade();
+
+		_assertUpgrade(mcpServerProfileToolObjectEntry, objectDefinition);
+
+		// The batch provisioning of the current bundle must accept the field
+		// the upgrade added
+
+		_processBatchEngineUnits(_getMCPServerRestImplBundle());
+
+		_assertUpgrade(mcpServerProfileToolObjectEntry, objectDefinition);
+	}
+
+	private ObjectEntry _addMCPServerProfileToolObjectEntry(
+			ObjectDefinition objectDefinition)
+		throws Exception {
+
+		ObjectDefinition mcpServerProfileObjectDefinition =
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_MCP_SERVER_PROFILE", _company.getCompanyId());
+
+		ObjectEntry mcpServerProfileObjectEntry = _addObjectEntry(
+			mcpServerProfileObjectDefinition,
+			HashMapBuilder.<String, Serializable>put(
+				"description", RandomTestUtil.randomString()
+			).put(
+				"name", RandomTestUtil.randomString()
+			).put(
+				"profileStatus", "active"
+			).build());
+
+		return _addObjectEntry(
+			objectDefinition,
+			HashMapBuilder.<String, Serializable>put(
+				"r_mcpServerProfileToTools_l_mcpServerProfileId",
+				mcpServerProfileObjectEntry.getObjectEntryId()
+			).put(
+				"toolName", "getMCPServerProfilesPage"
+			).put(
+				"toolSetName", "mcp-server-profiles"
+			).build());
+	}
+
+	private ObjectEntry _addObjectEntry(
+			ObjectDefinition objectDefinition, Map<String, Serializable> values)
+		throws Exception {
+
+		return _objectEntryLocalService.addObjectEntry(
+			0, _user.getUserId(), objectDefinition.getObjectDefinitionId(),
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			null, values,
+			ServiceContextTestUtil.getServiceContext(
+				_company.getCompanyId(), _company.getGroupId(),
+				_user.getUserId()));
+	}
+
+	private void _assertUpgrade(
+			ObjectEntry mcpServerProfileToolObjectEntry,
+			ObjectDefinition objectDefinition)
+		throws Exception {
+
+		ObjectField restrictFieldsObjectField =
+			_objectFieldLocalService.getObjectField(
+				objectDefinition.getObjectDefinitionId(), "restrictFields");
+
+		Assert.assertEquals(
+			ObjectFieldConstants.BUSINESS_TYPE_LONG_TEXT,
+			restrictFieldsObjectField.getBusinessType());
+		Assert.assertEquals(
+			ObjectFieldConstants.DB_TYPE_CLOB,
+			restrictFieldsObjectField.getDBType());
+		Assert.assertFalse(restrictFieldsObjectField.isRequired());
+		Assert.assertTrue(restrictFieldsObjectField.isSystem());
+
+		Map<String, Serializable> values = _objectEntryLocalService.getValues(
+			mcpServerProfileToolObjectEntry.getObjectEntryId());
+
+		Assert.assertEquals("getMCPServerProfilesPage", values.get("toolName"));
+		Assert.assertEquals("mcp-server-profiles", values.get("toolSetName"));
+
+		String restrictFields = RandomTestUtil.randomString();
+
+		values.put("restrictFields", restrictFields);
+
+		_objectEntryLocalService.updateObjectEntry(
+			_user.getUserId(),
+			mcpServerProfileToolObjectEntry.getObjectEntryId(),
+			mcpServerProfileToolObjectEntry.getObjectEntryFolderId(), values,
+			ServiceContextTestUtil.getServiceContext(
+				_company.getCompanyId(), _company.getGroupId(),
+				_user.getUserId()));
+
+		values = _objectEntryLocalService.getValues(
+			mcpServerProfileToolObjectEntry.getObjectEntryId());
+
+		Assert.assertEquals(restrictFields, values.get("restrictFields"));
+	}
+
+	private void _deleteObjectDefinition(String externalReferenceCode)
+		throws Exception {
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.
+				fetchObjectDefinitionByExternalReferenceCode(
+					externalReferenceCode, _company.getCompanyId());
+
+		if (objectDefinition != null) {
+			_objectDefinitionLocalService.deleteObjectDefinition(
+				objectDefinition);
+		}
+	}
+
+	private Bundle _getMCPServerRestImplBundle() {
+		Bundle bundle = FrameworkUtil.getBundle(
+			MCPProfileToolUpgradeProcessTest.class);
+
+		return BundleUtil.getBundle(
+			bundle.getBundleContext(), "com.liferay.mcp.server.rest.impl");
+	}
+
+	private UpgradeStep _getVersionedUpgradeStep() {
+		List<UpgradeStep> versionedUpgradeSteps = new ArrayList<>();
+
+		_upgradeStepRegistrator.register(
+			new UpgradeStepRegistrator.Registry() {
+
+				@Override
+				public void register(
+					String fromSchemaVersionString,
+					String toSchemaVersionString, UpgradeStep... upgradeSteps) {
+
+					if (!Objects.equals(fromSchemaVersionString, "1.2.0") ||
+						!Objects.equals(toSchemaVersionString, "1.3.0")) {
+
+						return;
+					}
+
+					for (UpgradeStep upgradeStep : upgradeSteps) {
+						Class<?> clazz = upgradeStep.getClass();
+
+						if (Objects.equals(
+								clazz.getSimpleName(),
+								"MCPProfileToolUpgradeProcess")) {
+
+							versionedUpgradeSteps.add(upgradeStep);
+						}
+					}
+				}
+
+				@Override
+				public void registerReleaseCreationUpgradeSteps(
+					UpgradeStep... upgradeSteps) {
+				}
+
+			});
+
+		return versionedUpgradeSteps.get(0);
+	}
+
+	private Bundle _installBundle() throws Exception {
+		Bundle bundle = FrameworkUtil.getBundle(
+			MCPProfileToolUpgradeProcessTest.class);
+
+		String dirName =
+			"com/liferay/mcp/server/rest/internal/upgrade/test/dependencies" +
+				"/tool/";
+
+		Enumeration<URL> enumeration = bundle.findEntries(dirName, "*", true);
+
+		ZipWriter zipWriter = _zipWriterFactory.getZipWriter();
+
+		if (enumeration != null) {
+			while (enumeration.hasMoreElements()) {
+				URL url = enumeration.nextElement();
+
+				String urlString = url.getPath();
+
+				if (urlString.endsWith(StringPool.SLASH)) {
+					continue;
+				}
+
+				String name = urlString.substring(dirName.length());
+
+				if (name.startsWith(StringPool.SLASH)) {
+					name = name.substring(1);
+				}
+
+				try (InputStream inputStream = url.openStream()) {
+					zipWriter.addEntry(name, inputStream);
+				}
+			}
+		}
+
+		BundleContext bundleContext = bundle.getBundleContext();
+
+		return bundleContext.installBundle(
+			RandomTestUtil.randomString(),
+			new FileInputStream(zipWriter.getFile()));
+	}
+
+	private void _processBatchEngineUnits(Bundle bundle) throws Exception {
+		_batchEngineUnitProcessor.processBatchEngineUnits(
+			TransformUtil.transform(
+				_batchEngineUnitReader.getBatchEngineUnits(bundle),
+				batchEngineUnit -> _toCompanyBatchEngineUnit(batchEngineUnit)));
+	}
+
+	private BatchEngineUnit _toCompanyBatchEngineUnit(
+		BatchEngineUnit batchEngineUnit) {
+
+		return new BatchEngineUnit() {
+
+			@Override
+			public BatchEngineUnitConfiguration
+					getBatchEngineUnitConfiguration()
+				throws IOException {
+
+				BatchEngineUnitConfiguration batchEngineUnitConfiguration =
+					batchEngineUnit.getBatchEngineUnitConfiguration();
+
+				batchEngineUnitConfiguration.setCompanyId(
+					_company.getCompanyId());
+				batchEngineUnitConfiguration.setUserId(_user.getUserId());
+
+				return batchEngineUnitConfiguration;
+			}
+
+			@Override
+			public InputStream getConfigurationInputStream()
+				throws IOException {
+
+				return batchEngineUnit.getConfigurationInputStream();
+			}
+
+			@Override
+			public String getDataFileName() {
+				return batchEngineUnit.getDataFileName();
+			}
+
+			@Override
+			public InputStream getDataInputStream() throws IOException {
+				return batchEngineUnit.getDataInputStream();
+			}
+
+			@Override
+			public String getFileName() {
+				return batchEngineUnit.getFileName();
+			}
+
+			@Override
+			public boolean isValid() {
+				return batchEngineUnit.isValid();
+			}
+
+		};
+	}
+
+	private void _upgrade() throws Exception {
+		UpgradeStep upgradeStep = _getVersionedUpgradeStep();
+
+		upgradeStep.upgrade();
+
+		// UpgradeExecutor clears the caches after a bundle's upgrade steps
+
+		CacheRegistryUtil.clear();
+	}
+
+	@Inject
+	private BatchEngineUnitProcessor _batchEngineUnitProcessor;
+
+	@Inject
+	private BatchEngineUnitReader _batchEngineUnitReader;
+
+	@DeleteAfterTestRun
+	private Company _company;
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Inject
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Inject
+	private ObjectFieldLocalService _objectFieldLocalService;
+
+	private long _originalCompanyId;
+	private String _originalName;
+	private PermissionChecker _originalPermissionChecker;
+
+	@Inject(
+		filter = "component.name=com.liferay.mcp.server.rest.internal.upgrade.registry.MCPServerRestUpgradeStepRegistrator"
+	)
+	private UpgradeStepRegistrator _upgradeStepRegistrator;
+
+	private User _user;
+
+	@Inject
+	private ZipWriterFactory _zipWriterFactory;
+
+}

--- a/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/test/util/MCPServerTestUtil.java
+++ b/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/test/util/MCPServerTestUtil.java
@@ -132,6 +132,15 @@ public class MCPServerTestUtil {
 			String toolSetName)
 		throws Exception {
 
+		return addMCPServerProfileToolObjectEntry(
+			mcpServerProfileExternalReferenceCode, null, toolName, toolSetName);
+	}
+
+	public static ObjectEntry addMCPServerProfileToolObjectEntry(
+			String mcpServerProfileExternalReferenceCode, String restrictFields,
+			String toolName, String toolSetName)
+		throws Exception {
+
 		ObjectDefinition mcpServerProfileObjectDefinition =
 			ObjectDefinitionLocalServiceUtil.
 				fetchObjectDefinitionByExternalReferenceCode(
@@ -156,6 +165,8 @@ public class MCPServerTestUtil {
 			HashMapBuilder.<String, Serializable>put(
 				"r_mcpServerProfileToTools_l_mcpServerProfileId",
 				mcpServerProfileObjectEntry.getObjectEntryId()
+			).put(
+				"restrictFields", () -> restrictFields
 			).put(
 				"toolName", toolName
 			).put(
@@ -376,6 +387,21 @@ public class MCPServerTestUtil {
 				prefix + "01.list.type.definition",
 				prefix + "02.object.definition", prefix + "03.object.entry"
 			});
+	}
+
+	public static void updateMCPServerProfileToolRestrictFields(
+			ObjectEntry mcpServerProfileToolObjectEntry, String restrictFields)
+		throws Exception {
+
+		ObjectEntryLocalServiceUtil.updateObjectEntry(
+			TestPropsValues.getUserId(),
+			mcpServerProfileToolObjectEntry.getObjectEntryId(), 0,
+			HashMapBuilder.<String, Serializable>putAll(
+				mcpServerProfileToolObjectEntry.getValues()
+			).put(
+				"restrictFields", restrictFields
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
 	}
 
 	private static ObjectEntry _fetchObjectEntry(

--- a/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/test/util/MCPServerTestUtil.java
+++ b/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/test/util/MCPServerTestUtil.java
@@ -389,8 +389,9 @@ public class MCPServerTestUtil {
 			});
 	}
 
-	public static void updateMCPServerProfileToolRestrictFields(
-			ObjectEntry mcpServerProfileToolObjectEntry, String restrictFields)
+	public static void updateMCPServerProfileToolObjectEntry(
+			ObjectEntry mcpServerProfileToolObjectEntry,
+			Map<String, Serializable> values)
 		throws Exception {
 
 		ObjectEntryLocalServiceUtil.updateObjectEntry(
@@ -398,10 +399,21 @@ public class MCPServerTestUtil {
 			mcpServerProfileToolObjectEntry.getObjectEntryId(), 0,
 			HashMapBuilder.<String, Serializable>putAll(
 				mcpServerProfileToolObjectEntry.getValues()
-			).put(
-				"restrictFields", restrictFields
+			).putAll(
+				values
 			).build(),
 			ServiceContextTestUtil.getServiceContext());
+	}
+
+	public static void updateMCPServerProfileToolRestrictFields(
+			ObjectEntry mcpServerProfileToolObjectEntry, String restrictFields)
+		throws Exception {
+
+		updateMCPServerProfileToolObjectEntry(
+			mcpServerProfileToolObjectEntry,
+			HashMapBuilder.<String, Serializable>put(
+				"restrictFields", restrictFields
+			).build());
 	}
 
 	private static ObjectEntry _fetchObjectEntry(

--- a/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/resources/com/liferay/mcp/server/rest/internal/upgrade/test/dependencies/tool/META-INF/MANIFEST.MF
+++ b/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/resources/com/liferay/mcp/server/rest/internal/upgrade/test/dependencies/tool/META-INF/MANIFEST.MF
@@ -1,0 +1,5 @@
+Manifest-Version: 2
+Bundle-ManifestVersion: 2
+Bundle-SymbolicName: tool-batch
+Bundle-Version: 1.0.0
+Liferay-Client-Extension-Batch: batch

--- a/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/resources/com/liferay/mcp/server/rest/internal/upgrade/test/dependencies/tool/batch/00-object-definition.batch-engine-data.json
+++ b/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/resources/com/liferay/mcp/server/rest/internal/upgrade/test/dependencies/tool/batch/00-object-definition.batch-engine-data.json
@@ -1,0 +1,118 @@
+{
+	"configuration": {
+		"className": "com.liferay.object.admin.rest.dto.v1_0.ObjectDefinition",
+		"multiCompany": true,
+		"parameters": {
+			"containsHeaders": "true",
+			"createStrategy": "UPSERT",
+			"importStrategy": "ON_ERROR_FAIL",
+			"updateStrategy": "UPDATE"
+		},
+		"taskItemDelegateName": "DEFAULT"
+	},
+	"items": [
+		{
+			"active": true,
+			"className": "com.liferay.object.model.ObjectDefinition#K7M2",
+			"externalReferenceCode": "L_MCP_SERVER_PROFILE",
+			"label": {
+				"en_US": "MCP Server Profile"
+			},
+			"modifiable": true,
+			"name": "MCPServerProfile",
+			"objectFields": [
+				{
+					"DBType": "String",
+					"businessType": "Text",
+					"defaultValue": "null",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"indexedLanguageId": "en_US",
+					"label": {
+						"en_US": "Description"
+					},
+					"name": "description",
+					"required": true,
+					"state": false,
+					"system": true,
+					"type": "String"
+				},
+				{
+					"DBType": "String",
+					"businessType": "Text",
+					"defaultValue": "null",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"indexedLanguageId": "en_US",
+					"label": {
+						"en_US": "Name"
+					},
+					"name": "name",
+					"objectFieldSettings": [
+						{
+							"name": "uniqueValues",
+							"value": true
+						}
+					],
+					"required": true,
+					"state": false,
+					"system": true,
+					"type": "String"
+				},
+				{
+					"DBType": "String",
+					"businessType": "Picklist",
+					"defaultValue": "inactive",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"label": {
+						"en_US": "Status"
+					},
+					"listTypeDefinitionExternalReferenceCode": "L_MCP_STATUS",
+					"name": "profileStatus",
+					"required": true,
+					"state": false,
+					"system": true,
+					"type": "String"
+				}
+			],
+			"objectRelationships": [
+				{
+					"deletionType": "cascade",
+					"externalReferenceCode": "L_MCP_SERVER_PROFILE_TO_L_MCP_SERVER_PROFILE_TOOL",
+					"label": {
+						"en_US": "MCP Server Profile to MCP Server Profile Tools"
+					},
+					"name": "mcpServerProfileToTools",
+					"objectDefinitionExternalReferenceCode1": "L_MCP_SERVER_PROFILE",
+					"objectDefinitionExternalReferenceCode2": "L_MCP_SERVER_PROFILE_TOOL",
+					"objectDefinitionName2": "MCPServerProfileTool",
+					"objectDefinitionSystem2": true,
+					"objectField": {
+						"label": {
+							"en_US": "MCP Server Profile to MCP Server Profile Tools"
+						},
+						"required": true
+					},
+					"parameterObjectFieldId": 0,
+					"parameterObjectFieldName": "",
+					"reverse": false,
+					"system": true,
+					"type": "oneToMany"
+				}
+			],
+			"panelCategoryKey": "control_panel.object",
+			"pluralLabel": {
+				"en_US": "MCP Server Profiles"
+			},
+			"scope": "company",
+			"status": {
+				"code": 0,
+				"label": "approved",
+				"label_i18n": "Approved"
+			},
+			"system": true,
+			"titleObjectFieldName": "name"
+		}
+	]
+}

--- a/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/resources/com/liferay/mcp/server/rest/internal/upgrade/test/dependencies/tool/batch/01-object-definition.batch-engine-data.json
+++ b/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/resources/com/liferay/mcp/server/rest/internal/upgrade/test/dependencies/tool/batch/01-object-definition.batch-engine-data.json
@@ -1,0 +1,71 @@
+{
+	"configuration": {
+		"className": "com.liferay.object.admin.rest.dto.v1_0.ObjectDefinition",
+		"multiCompany": true,
+		"parameters": {
+			"containsHeaders": "true",
+			"createStrategy": "UPSERT",
+			"importStrategy": "ON_ERROR_FAIL",
+			"updateStrategy": "UPDATE"
+		},
+		"taskItemDelegateName": "DEFAULT"
+	},
+	"items": [
+		{
+			"active": true,
+			"className": "com.liferay.object.model.ObjectDefinition#T4L8",
+			"externalReferenceCode": "L_MCP_SERVER_PROFILE_TOOL",
+			"label": {
+				"en_US": "MCP Server Profile Tool"
+			},
+			"modifiable": true,
+			"name": "MCPServerProfileTool",
+			"objectFields": [
+				{
+					"DBType": "String",
+					"businessType": "Text",
+					"defaultValue": "null",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"indexedLanguageId": "en_US",
+					"label": {
+						"en_US": "Tool Name"
+					},
+					"name": "toolName",
+					"required": true,
+					"state": false,
+					"system": true,
+					"type": "String"
+				},
+				{
+					"DBType": "String",
+					"businessType": "Text",
+					"defaultValue": "null",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"indexedLanguageId": "en_US",
+					"label": {
+						"en_US": "Tool Set Name"
+					},
+					"name": "toolSetName",
+					"required": true,
+					"state": false,
+					"system": true,
+					"type": "String"
+				}
+			],
+			"panelCategoryKey": "control_panel.object",
+			"pluralLabel": {
+				"en_US": "MCP Server Profile Tools"
+			},
+			"scope": "company",
+			"status": {
+				"code": 0,
+				"label": "approved",
+				"label_i18n": "Approved"
+			},
+			"system": true,
+			"titleObjectFieldName": "toolName"
+		}
+	]
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100263

## What Is Being Fixed

An MCP server profile exposed every response field of each tool it published. There was no way to hide a field for one profile while keeping it for another, so a profile intended for a narrow audience still advertised and returned the full response shape. The tool's input schema compounded it by offering every response field as a selectable value, which invited an agent to ask for a field the profile was never meant to surface.

## How It Is Being Fixed

Each MCP server profile tool now carries its own set of restricted field names, stored as a single comma-separated column on the `MCPServerProfileTool` object and added to existing rows by an upgrade process.

The restriction is threaded through the two places a tool's shape is decided. When a tool is advertised, the restricted names are removed from the response field names that build the input schema, so a restricted field is never offered as a choice. When a tool is invoked, the same names are appended to the outgoing `restrictFields` query parameter, so the response comes back without them. The servlet resolves the restricted fields once per profile and keys them by tool, rather than re-reading them per call.

A model listener validates the column on create and update. It rejects a blank or whitespace-padded name, a malformed name, a name that repeats within the same entry, and a name already hidden by another restricted field, since hiding a parent and then its child is redundant rather than additive. The same listener rejects a tool that the profile already has, which previously produced two entries competing for one tool key.

The last commit applies the review feedback from https://github.com/brianchandotcom/liferay-portal/pull/181603#issuecomment-5623465970. The `_testGetRequest` calls in `OpenAPIUtilTest` had been case-sensitively sorted and the new cases broke that order, so every call was collapsed to one line, sorted case sensitively, and re-wrapped by the source formatter.

## PR Check

**pr-check: PASS** — tested on `61942397b96987965a202ee2b9d0c41f2050e9e7`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Service Registration | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS (baseline-all + seven Ant projects + 0 changed exporting modules) |
| Java Unit Tests | NOT VERIFIED |

Java Unit Tests verified only part of the branch. `OpenAPIUtilTest` ran green at `tests="3" skipped="0" failures="0" errors="0"`, which includes the `testGetRequest` method whose calls were re-sorted. Nine of the ten changed production classes have no unit test counterpart: six are covered by name in the sibling `mcp-server-rest-test` integration module, which this validation does not run, while `MCPServerProfileToolsObjectFieldModelListener`, `MCPServerRestUpgradeStepRegistrator`, and `ToolSetUtil` have no test bearing their name at either layer.

Baseline is a genuine but shallow pass. Every changed Java file sits in an `internal` package or a test tree, so the branch changes no exported API surface. Neither changed module declares `Export-Package`, and `baseline --rerun` on both returns `baseline SKIPPED`, which is what bnd returns for a bundle that exports nothing. No inherited drift appeared on master this pass.

Cross-Module Compile compiled three integration test consumers, all successful. Two of them matched only on the simple name `OpenAPIUtil` and in fact import `com.liferay.portal.vulcan.util.OpenAPIUtil`, not the MCP class this branch changed, so they were never real consumers.

<!-- pr-check {"result": "success", "sha": "61942397b96987965a202ee2b9d0c41f2050e9e7"} -->
