### PR TITLE
LPD-105586 Read the friendly URL paths of an object entry only when the definition lets users customize them

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -2150,6 +2150,7 @@ public class DefaultObjectEntryManagerImpl
 		return ServiceContextUtil.createServiceContext(
 			objectDefinition.getCompanyId(),
 			objectDefinition.isEnableCategorization(),
+			objectDefinition.isEnableFriendlyURLCustomization(),
 			getGroupId(objectDefinition, scopeKey),
 			dtoConverterContext.getLocale(), modelPermissions, objectEntry,
 			objectEntryComments, dtoConverterContext.getUserId());

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/util/ServiceContextUtil.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/util/ServiceContextUtil.java
@@ -73,21 +73,24 @@ public class ServiceContextUtil {
 	}
 
 	public static ServiceContext createServiceContext(
-			long companyId, boolean enableCategorization, long groupId,
-			Locale locale, ModelPermissions modelPermissions,
-			ObjectEntry objectEntry,
+			long companyId, boolean enableCategorization,
+			boolean enableFriendlyURLCustomization, long groupId, Locale locale,
+			ModelPermissions modelPermissions, ObjectEntry objectEntry,
 			List<ObjectEntryComment> objectEntryComments, long userId)
 		throws PortalException {
 
 		ServiceContext serviceContext = createServiceContext(
 			companyId, enableCategorization, groupId, objectEntry, userId);
 
-		serviceContext.setAttribute(
-			"friendlyUrlMap",
-			(Serializable)LocalizedMapUtil.populateI18nMap(
-				LocaleUtil.toLanguageId(locale),
-				objectEntry.getFriendlyUrlPath_i18n(),
-				objectEntry.getFriendlyUrlPath()));
+		if (enableFriendlyURLCustomization) {
+			serviceContext.setAttribute(
+				"friendlyUrlMap",
+				(Serializable)LocalizedMapUtil.populateI18nMap(
+					LocaleUtil.toLanguageId(locale),
+					objectEntry.getFriendlyUrlPath_i18n(),
+					objectEntry.getFriendlyUrlPath()));
+		}
+
 		serviceContext.setAttribute(
 			"objectEntryComments", (Serializable)objectEntryComments);
 		serviceContext.setCompanyId(companyId);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-105586

Part of the object entry page optimization tracked under LPD-65366 (LPD-98910 scenario, the edit page of an object entry). Independent of the other in-flight changes.

## What Is Being Fixed

The REST object entry manager builds the service context of every object entry add and update with a `friendlyUrlMap` attribute filled from the DTO's friendly URL path and its localized paths. For an entry that came out of the DTO converter, which is what the info item updater behind the edit page hands in, those two fields are lazy suppliers that resolve through the entry's `FriendlyURLEntryMapping`, its main `FriendlyURLEntry` and the entry's localizations, so a description-only edit read all of them. `ObjectEntryLocalService` consumes the attribute only when the object definition enables friendly URL customization; for every other definition the reads are wasted.

## How It Is Being Fixed

`ServiceContextUtil.createServiceContext` takes the definition's friendly URL customization flag and sets the `friendlyUrlMap` attribute only when it is enabled, so the suppliers are never invoked for the definitions that cannot use their result. `DefaultObjectEntryManagerImpl` passes `objectDefinition.isEnableFriendlyURLCustomization()`.

## Verification

- Existing coverage of both settings passes on a fresh bundle built from the branch: `ObjectEntryResourceTest.testGetObjectEntryWithFriendlyURL` and `testPatchObjectEntryWithFriendlyURLCustomizationEnabled`, `DefaultObjectEntryManagerImplTest.testAddOrUpdateObjectEntryWithFriendlyURL` and `testGetVersionedObjectEntries`, `ObjectEntryLocalServiceTest.testAddOrUpdateObjectEntryWithFriendlyURL`.
- Self-CI on shuyangzhou/liferay-portal PR 12763 (same content on the previous base 72316f2): stable 16/16, object 49/49, relevant 37/41, where the unique failures are `HeadlessBuilderResourceTest.testGetOpenAPIInDifferentCompany`, which fails on every pull this week, and two Playwright axes unrelated to objects that fail identically on a pull touching only the sample SQL builder.

## PR Check

**pr-check: PASS** — tested on `830b9cd066099feeef0429fab52e46534a444621`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Service Registration | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS (baseline-all + seven Ant projects + 0 changed exporting modules) |
| Java Unit Tests | NOT VERIFIED (no unit counterpart) |

Source Format ran `ant setup-sdk` (`BUILD SUCCESSFUL`, exit 0) and then `ant format-source-current-branch -Dvalidate.commit.messages=true`, which exited 0 with `BUILD SUCCESSFUL`; `SourceCheck:` and `ERROR: Dependency` both matched nothing. The yarn half never ran rather than running clean: the diff holds only `.java` files, none matching the frontend regex, so `skip.node.task` suppressed `downloadNode`, `yarnInstall` and `portalYarnFormatCurrentBranch`. The formatter left the tree untouched, so `git status --porcelain` was empty and no `SF` autocommit was warranted.

Service Registration selected the Unsatisfied Reference scan only; the Redeclared Interface scan did not apply, since neither changed file is a `*ResourceImpl.java` under a `resource/v<major>_<minor>` package. The risky-class collection came out empty: `DefaultObjectEntryManagerImpl` declares `@Component(property = "object.entry.manager.storage.type=" + ObjectDefinitionConstants.STORAGE_TYPE_DEFAULT, service = ObjectEntryManager.class)` rather than `service = {}`, `ServiceContextUtil` declares no `@Component`, and the diff adds no field declaration. An empty collection ends the scan, so nothing was reported.

Transaction Usage scanned both changed Java files (neither carries a `@generated` marker) and `${FINDINGS}` came back empty (`len=0`), so the branch adds no `@Transactional`, `Propagation.REQUIRES_NEW`, `REQUIRES_NEW_TRANSACTION`, `TransactionCallbackUtil`, `TransactionCommitCallbackUtil`, or `TransactionInvokerUtil`.

Per-Module Compile resolved both changed files to one module, `apps:object:object-rest-impl`. No consumer expansion fired: `git diff ... | grep -E '^-\s*(public|protected)\b'` matched nothing (the changed `createServiceContext` declaration line is diff context; only its parameter lines moved), and the diff touches no `modules/frontend-sdk/**` or `modules/node-scripts.config.js`. The lockfile check found no `package.json` dependency change and no lockfile to match. `:apps:object:object-rest-impl:deploy` reported `> Task :apps:object:object-rest-impl:compileJava` as executed rather than `UP-TO-DATE`, then `Files of project ':apps:object:object-rest-impl' deployed to /home/trunks/git/bundles-wt5/osgi/portal` and `BUILD SUCCESSFUL in 18s` / `222 actionable tasks: 91 executed, 131 up-to-date`.

Integration Test Compile derived five affected modules — the sibling `-test` modules under `modules/apps/object` holding a `src/testIntegration` tree (`object-admin-rest-test`, `object-rest-test`, `object-storage-salesforce-test`, `object-storage-sugarcrm-test`, `object-test`); no additional `-test` module declares `project(":apps:object:object-rest-impl")`. All five ran `compileTestIntegrationJava` with `--rerun` and each printed its own executed task line, ending `BUILD SUCCESSFUL in 26s` / `607 actionable tasks: 156 executed, 451 up-to-date`. No failure occurred, so no control compile was needed.

Cross-Module Compile searched the two changed simple type names, `DefaultObjectEntryManagerImpl` and `ServiceContextUtil`, across the two surfaces no other validation compiles, after asserting the `modules` search root exists. No module carrying `.lfrbuild-portal-deprecated` references either name. Two `-test` modules reference them from `src/testIntegration`: `apps:object:object-rest-test` and `apps:portal-workflow:portal-workflow-kaleo-test` (the latter on the unrelated `com.liferay.portal.kernel.service.ServiceContextUtil` of the same simple name). Two consumers is under the cap of 8, so both compiled with `--rerun`; each printed its own executed `compileTestIntegrationJava` task line and the run ended `BUILD SUCCESSFUL in 16s` / `479 actionable tasks: 8 executed, 471 up-to-date`. No `only showing the first`, `error:`, or `cannot access` line appeared.

Baseline ran `ant compile install-portal-snapshots` first (`BUILD SUCCESSFUL`, exit 0; `.m2/com/liferay/portal/com.liferay.portal.impl` present), then `ant baseline-all` from the worktree root, which exited 0 with `BUILD SUCCESSFUL` / `Total time: 1 minute 5 seconds` and printed no warning table, no `VERSION INCREASE`, no `PACKAGEINFO` row, and no `[Baseline Warning]` line. Each of the seven top-level Ant projects was then confirmed on its own with `baseline --rerun`, and every one printed `> Task :baseline`, `BUILD SUCCESSFUL` and `1 actionable task: 1 executed`, so each genuinely compared rather than reporting a cached verdict. The branch changes one module, `apps:object:object-rest-impl`, whose `bnd.bnd` carries no `Export-Package:` line, so the set of changed exporting modules is empty; running its baseline task anyway confirmed this, reporting `> Task :apps:object:object-rest-impl:baseline SKIPPED`. `git status --porcelain --untracked-files=all -- '*bnd.bnd' '*packageinfo'` was empty afterwards, so the task rewrote no `packageinfo` and no `bnd.bnd` and nothing had to be restored. The Local Version Check found nothing to check: neither changed `.java` file sits under an `*-api` module's `src/main/java`, `portal-impl/src`, or `portal-kernel/src`, the diff lowers no `packageinfo` or `Bundle-Version`, and it exports no new package.

Java Unit Tests verified nothing. Neither changed class has a `src/test` counterpart: `modules/apps/object/object-rest-impl/src/test` holds only `RelatedObjectEntryResourceImplTest.java`, and no `ServiceContextUtilTest.java` exists anywhere under `modules/apps/object`. `DefaultObjectEntryManagerImpl` is covered instead by the integration test `modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java`, which this validation does not run. The module's existing unit suite was run anyway as a cheap unrelated-break check after deleting its `test-results` tree: `TEST-com.liferay.object.rest.internal.resource.v1_0.RelatedObjectEntryResourceImplTest.xml` recorded `tests="2" skipped="0" failures="0" errors="0"`. That suite never loads either changed class, so it cannot move the verdict either way.

<!-- pr-check {"result": "success", "sha": "830b9cd066099feeef0429fab52e46534a444621"} -->
