### PR TITLE
LPD-105587 Keep an object entry's friendly URL entry when its source did not change

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -6611,6 +6611,58 @@ public class ObjectEntryLocalServiceImpl
 		return objectEntry;
 	}
 
+	private boolean _needAddFriendlyURLEntry(
+		ObjectDefinition objectDefinition, ObjectEntry objectEntry,
+		ObjectEntry originalObjectEntry, Map<String, Serializable> values) {
+
+		if (objectDefinition.isEnableFriendlyURLCustomization() ||
+			!Objects.equals(
+				objectEntry.getDefaultLanguageId(),
+				originalObjectEntry.getDefaultLanguageId()) ||
+			!Objects.equals(
+				objectEntry.getExternalReferenceCode(),
+				originalObjectEntry.getExternalReferenceCode())) {
+
+			return true;
+		}
+
+		if (objectDefinition.getTitleObjectFieldId() > 0) {
+			ObjectField objectField = _objectFieldPersistence.fetchByPrimaryKey(
+				objectDefinition.getTitleObjectFieldId());
+
+			if (!Objects.equals(
+					ObjectEntryValuesUtil.getValue(
+						objectEntry.getDefaultLanguageId(), objectField,
+						HashMapBuilder.<String, Object>putAll(
+							values
+						).putAll(
+							objectEntry.getModelAttributes()
+						).build()),
+					ObjectEntryValuesUtil.getValue(
+						originalObjectEntry.getDefaultLanguageId(), objectField,
+						HashMapBuilder.<String, Object>putAll(
+							originalObjectEntry.getValues()
+						).putAll(
+							originalObjectEntry.getModelAttributes()
+						).build()))) {
+
+				return true;
+			}
+		}
+
+		FriendlyURLEntry friendlyURLEntry =
+			_friendlyURLEntryLocalService.fetchMainFriendlyURLEntry(
+				_classNameLocalService.getClassNameId(
+					objectDefinition.getClassName()),
+				objectEntry.getObjectEntryId());
+
+		if (friendlyURLEntry == null) {
+			return true;
+		}
+
+		return false;
+	}
+
 	private void _performActions(
 			long objectDefinitionId,
 			ActionableDynamicQuery.PerformActionMethod<?> performActionMethod)
@@ -7644,8 +7696,12 @@ public class ObjectEntryLocalServiceImpl
 			return objectEntry;
 		}
 
-		_addFriendlyURLEntry(
-			objectDefinition, objectEntry, serviceContext, values);
+		if (_needAddFriendlyURLEntry(
+				objectDefinition, objectEntry, originalObjectEntry, values)) {
+
+			_addFriendlyURLEntry(
+				objectDefinition, objectEntry, serviceContext, values);
+		}
 
 		_addOrUpdateComments(
 			objectEntry.getGroupId(), userId, objectDefinition, objectEntry,

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -8596,6 +8596,73 @@ public class ObjectEntryLocalServiceTest {
 	}
 
 	@Test
+	public void testUpdateObjectEntryWithUnchangedFriendlyURL()
+		throws Exception {
+
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition();
+
+		objectDefinition.setFriendlyURLSeparator("test3");
+
+		objectDefinition = _objectDefinitionLocalService.updateObjectDefinition(
+			objectDefinition);
+
+		ObjectField objectField = _objectFieldLocalService.fetchObjectField(
+			objectDefinition.getObjectDefinitionId(), "able");
+
+		objectDefinition =
+			_objectDefinitionLocalService.updateTitleObjectFieldId(
+				objectDefinition.getObjectDefinitionId(),
+				objectField.getObjectFieldId());
+
+		ObjectEntry objectEntry = _addObjectEntry(
+			0, objectDefinition.getObjectDefinitionId(),
+			HashMapBuilder.<String, Serializable>put(
+				"able", "Test URL"
+			).build());
+
+		FriendlyURLEntry friendlyURLEntry =
+			_friendlyURLEntryLocalService.fetchMainFriendlyURLEntry(
+				_classNameLocalService.getClassNameId(
+					objectDefinition.getClassName()),
+				objectEntry.getObjectEntryId());
+
+		objectEntry = _objectEntryLocalService.updateObjectEntry(
+			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
+			objectEntry.getObjectEntryFolderId(),
+			HashMapBuilder.<String, Serializable>put(
+				"able", "Other URL"
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		AssertUtils.assertEquals(
+			HashMapBuilder.put(
+				"en_US", "other-url"
+			).build(),
+			objectEntry.getURLTitleMap());
+
+		_friendlyURLEntryLocalService.setMainFriendlyURLEntry(friendlyURLEntry);
+
+		objectEntry = _objectEntryLocalService.updateObjectEntry(
+			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
+			objectEntry.getObjectEntryFolderId(),
+			HashMapBuilder.<String, Serializable>put(
+				"able", "Other URL"
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		AssertUtils.assertEquals(
+			HashMapBuilder.put(
+				"en_US", "test-url"
+			).build(),
+			objectEntry.getURLTitleMap());
+
+		_assertFriendlyURLEntries(2, objectDefinition, objectEntry);
+
+		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
+	}
+
+	@Test
 	public void testUpdateStatus() throws Exception {
 		PermissionChecker permissionChecker =
 			PermissionThreadLocal.getPermissionChecker();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-105587

Part of the object entry page optimization tracked under LPD-65366 (LPD-98910 scenario, the edit page of an object entry). Independent of the other in-flight changes.

## What Is Being Fixed

Every update of an object entry derives the URL title again from the title field, or from the external reference code when the definition has no title field, asks the friendly URL service for a unique variant of it, which probes the localization table twice, and then hands it to `addFriendlyURLEntry`, which loads the entry's mapping, its main friendly URL entry and the localizations only to find the title already there and return. A description-only edit pays five lookups to conclude that nothing changed.

## How It Is Being Fixed

`ObjectEntryLocalServiceImpl` runs the friendly URL step of an update only when `_needAddFriendlyURLEntry` says so: the definition lets users customize the URL, the default language or the external reference code changed, the title field's value differs between the incoming values and the original entry, or the entry has no main friendly URL entry yet. Otherwise the derived title cannot differ from the one derived at the previous write, so the step is skipped. Entries without a friendly URL entry and updates that change the title source keep taking the existing path.

One visible difference: an unrelated edit no longer replaces a URL a user restored from the history, or a URL derived before the definition's title field was switched, with a freshly derived one. The URL now follows the title source only when that source itself changes.

## Verification

- `ObjectEntryLocalServiceTest.testUpdateObjectEntryWithUnchangedFriendlyURL`: a title change moves the URL to the new title, a main friendly URL entry restored from the history survives a later update that leaves the title alone, and the entry ends with exactly the two friendly URL entries the two titles produced. `testAddOrUpdateObjectEntryWithFriendlyURL` keeps passing. Both green on a fresh bundle built from the branch.
- Self-CI on shuyangzhou/liferay-portal PR 12764 (same content on the previous base 72316f2): stable 16/16, object 49/49, relevant 33/35, where the only unique failure is `HeadlessBuilderResourceTest.testGetOpenAPIInDifferentCompany`, which fails on every pull this week.

## PR Check

**pr-check: PASS** — tested on `a312548952a1dff5bafaeddd25bc764d3cebdb5e`

| Validation | Result |
| --- | --- |
| Service Builder | PASS (zero drift) |
| Source Format | PASS |
| Service Registration | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS (1 module) |
| Integration Test Compile | PASS (5 affected modules + control) |
| Baseline | PASS (baseline-all + seven Ant projects + 0 changed exporting modules) |
| Java Unit Tests | PASS |

Service Builder regenerated the whole tree from `portal-impl` and left it untouched. `BUILD SUCCESSFUL` / `Total time: 31 seconds`, 529 `Building <Entity>` lines including `Building ObjectEntry`, `Building ObjectEntryFolder`, `Building ObjectEntryVersion`, and `git status --porcelain --untracked-files=all` empty afterwards with `git diff --quiet` exiting 0 — zero drift, so no `buildServices` commit was warranted.

Source Format ran `ant setup-sdk` (`BUILD SUCCESSFUL` / `Total time: 3 seconds`, exit 0) then `ant format-source-current-branch -Dvalidate.commit.messages=true` (`BUILD SUCCESSFUL` / `Total time: 33 seconds`, exit 0). Searching the full log: no `SourceCheck:` line and no `ERROR: Dependency` line. The working tree was still clean afterwards, so there was no fixable subset to commit. The yarn half of the formatter never ran rather than running clean: `build.properties:791` sets `source.formatter.frontend.file.regex=\.(js|json|jsp|jspf|scss|ts|tsx)(\R|$)`, this diff is `.java` only, so `portal-impl/build.xml:749` set `skip.node.task` and `downloadNode`, `yarnInstall` and `portalYarnFormatCurrentBranch` were skipped entirely — the empty yarn search is expected here and is not a failure.

Service Registration selected only the Unsatisfied Reference scan; the Redeclared Interface scan was not selected because no changed file is a `*ResourceImpl.java` under a `resource/v<major>_<minor>` package. The risky-class collection came out empty — the one `@Component` in the diff registers `service = AopService.class` rather than `service = {}`, and the diff adds no `<visibility> <Type> _<name>;` field declaration at all — so the scan ended with nothing to report.

Transaction Usage scanned both changed Java files (neither carries an `@generated` marker, so neither was excluded) and produced an empty `${FINDINGS}`, judged from the variable rather than from an exit status. The branch adds no `@Transactional`, `Propagation.REQUIRES_NEW`, `REQUIRES_NEW_TRANSACTION`, `TransactionCallbackUtil`, `TransactionCommitCallbackUtil` or `TransactionInvokerUtil`.

Per-Module Compile derived a deploy set of one module, `apps:object:object-service`. `apps:object:object-test` was excluded because its only change is under `src/testIntegration`. No consumer expansion applied: the diff removes no `public`/`protected` line and adds only a `private` method. No `package.json` or lockfile changed, so the lockfile check had no work. `../gradlew --parallel --project-dir modules :apps:object:object-service:deploy` reported `BUILD SUCCESSFUL in 24s` (exit 0) with `> Task :apps:object:object-service:compileJava` executed — no `UP-TO-DATE` and no `FROM-CACHE` suffix. Rather than trust the task line alone, I confirmed the change reached the artifact: `javap -p` on `com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.class` extracted from the jar this run deployed (timestamped 07:39) shows `private boolean _needAddFriendlyURLEntry(ObjectDefinition, ObjectEntry, ObjectEntry, Map<String, Serializable>)`.

Integration Test Compile ran the control first, `:apps:blogs:blogs-test:compileTestIntegrationJava --rerun`, which reported `> Task :apps:blogs:blogs-test:compileTestIntegrationJava` executed and `BUILD SUCCESSFUL in 14s`. The affected set is the five `-test` modules under `modules/apps/object` holding `src/testIntegration`: `object-test`, `object-rest-test`, `object-admin-rest-test`, `object-storage-salesforce-test`, `object-storage-sugarcrm-test` (under the cap of 8; no additional `-test` module declares `project(":apps:object:object-service")` or `project(":apps:object:object-test")`). All five printed their own `compileTestIntegrationJava` task line with no `UP-TO-DATE`/`FROM-CACHE` suffix and `BUILD SUCCESSFUL` (18s, 13s, 12s, 10s, 12s), each exiting 0.

Baseline ran after `ant compile install-portal-snapshots` (`BUILD SUCCESSFUL`, exit 0); the snapshot is present at `/home/trunks/git/worktree3/.m2/com/liferay/portal/com.liferay.portal.impl/131.1.2-SNAPSHOT`, so the module runs baselined against the branch's own portal core. `ant baseline-all` from the worktree root reported `BUILD SUCCESSFUL` / `Total time: 1 minute 14 seconds` (exit 0) with zero warning rows — no `VERSION INCREASE REQUIRED`, `VERSION INCREASE SUGGESTED`, `EXCESSIVE VERSION INCREASE`, `PACKAGE ADDED, MISSING PACKAGEINFO`, `PACKAGE REMOVED, UNNECESSARY PACKAGEINFO` or `Bundle Version Change Recommended`. Because the task repairs in place, I read the tree immediately afterwards: `git status --porcelain --untracked-files=all -- '*bnd.bnd' '*packageinfo'` was empty, so bnd rewrote nothing anywhere and there was no repair to classify, commit or restore. Each of the seven Ant projects was then confirmed individually with `baseline --rerun`; all seven printed `> Task :baseline` and `1 actionable task: 1 executed` with `BUILD SUCCESSFUL` and exit 0, none reporting `Could not resolve` or `UP-TO-DATE`. The count of changed exporting modules is 0: neither `modules/apps/object/object-service/bnd.bnd` nor `modules/apps/object/object-test/bnd.bnd` carries an `Export-Package:` header, so there was no branch-owned exporting module to confirm separately. The Local Version Check ran last and found nothing to fail — no changed `.java` sits under an `*-api` module's `src/main/java`, `portal-impl/src` or `portal-kernel/src` (the only added `public` line is a test method in the `object-test` integration module), the diff touches no `packageinfo` or `bnd.bnd` so there is no lowering to flag, and it exports no new package.

Java Unit Tests located the counterpart by parallel name: `modules/apps/object/object-service/src/test/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImplTest.java`. The second changed file is under `src/testIntegration` and so is out of scope here. After deleting the module's `test-results` tree, `../gradlew --continue --project-dir modules -Dtest.ignore.failures=false :apps:object:object-service:test --tests "com.liferay.object.service.impl.ObjectEntryLocalServiceImplTest"` reported `BUILD SUCCESSFUL in 21s` (exit 0), and the verdict is taken from the results XML rather than that marker: `TEST-com.liferay.object.service.impl.ObjectEntryLocalServiceImplTest.xml` reads `tests="1" skipped="0" failures="0" errors="0" time="0.587"` — one test executed, none failed.

<!-- pr-check {"result": "success", "sha": "a312548952a1dff5bafaeddd25bc764d3cebdb5e"} -->
