### PR TITLE
LPD-105587 Keep an object entry's friendly URL entry when its source did not change

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -7257,6 +7257,58 @@ public class ObjectEntryLocalServiceImpl
 			parentObjectEntry.getRootObjectEntryId());
 	}
 
+	private boolean _shouldAddFriendlyURLEntry(
+		ObjectDefinition objectDefinition, ObjectEntry objectEntry,
+		ObjectEntry originalObjectEntry, Map<String, Serializable> values) {
+
+		if (objectDefinition.isEnableFriendlyURLCustomization() ||
+			!Objects.equals(
+				objectEntry.getDefaultLanguageId(),
+				originalObjectEntry.getDefaultLanguageId()) ||
+			!Objects.equals(
+				objectEntry.getExternalReferenceCode(),
+				originalObjectEntry.getExternalReferenceCode())) {
+
+			return true;
+		}
+
+		if (objectDefinition.getTitleObjectFieldId() > 0) {
+			ObjectField objectField = _objectFieldPersistence.fetchByPrimaryKey(
+				objectDefinition.getTitleObjectFieldId());
+
+			if (!Objects.equals(
+					ObjectEntryValuesUtil.getValue(
+						objectEntry.getDefaultLanguageId(), objectField,
+						HashMapBuilder.<String, Object>putAll(
+							values
+						).putAll(
+							objectEntry.getModelAttributes()
+						).build()),
+					ObjectEntryValuesUtil.getValue(
+						originalObjectEntry.getDefaultLanguageId(), objectField,
+						HashMapBuilder.<String, Object>putAll(
+							originalObjectEntry.getValues()
+						).putAll(
+							originalObjectEntry.getModelAttributes()
+						).build()))) {
+
+				return true;
+			}
+		}
+
+		FriendlyURLEntry friendlyURLEntry =
+			_friendlyURLEntryLocalService.fetchMainFriendlyURLEntry(
+				_classNameLocalService.getClassNameId(
+					objectDefinition.getClassName()),
+				objectEntry.getObjectEntryId());
+
+		if (friendlyURLEntry == null) {
+			return true;
+		}
+
+		return false;
+	}
+
 	private void _startWorkflowInstance(
 			long userId, ObjectEntry objectEntry, ServiceContext serviceContext,
 			boolean skipModelListener)
@@ -7644,8 +7696,12 @@ public class ObjectEntryLocalServiceImpl
 			return objectEntry;
 		}
 
-		_addFriendlyURLEntry(
-			objectDefinition, objectEntry, serviceContext, values);
+		if (_shouldAddFriendlyURLEntry(
+				objectDefinition, objectEntry, originalObjectEntry, values)) {
+
+			_addFriendlyURLEntry(
+				objectDefinition, objectEntry, serviceContext, values);
+		}
 
 		_addOrUpdateComments(
 			objectEntry.getGroupId(), userId, objectDefinition, objectEntry,

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -8596,6 +8596,73 @@ public class ObjectEntryLocalServiceTest {
 	}
 
 	@Test
+	public void testUpdateObjectEntryWithUnchangedFriendlyURL()
+		throws Exception {
+
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition();
+
+		objectDefinition.setFriendlyURLSeparator("test3");
+
+		objectDefinition = _objectDefinitionLocalService.updateObjectDefinition(
+			objectDefinition);
+
+		ObjectField objectField = _objectFieldLocalService.fetchObjectField(
+			objectDefinition.getObjectDefinitionId(), "able");
+
+		objectDefinition =
+			_objectDefinitionLocalService.updateTitleObjectFieldId(
+				objectDefinition.getObjectDefinitionId(),
+				objectField.getObjectFieldId());
+
+		ObjectEntry objectEntry = _addObjectEntry(
+			0, objectDefinition.getObjectDefinitionId(),
+			HashMapBuilder.<String, Serializable>put(
+				"able", "Test URL"
+			).build());
+
+		FriendlyURLEntry friendlyURLEntry =
+			_friendlyURLEntryLocalService.fetchMainFriendlyURLEntry(
+				_classNameLocalService.getClassNameId(
+					objectDefinition.getClassName()),
+				objectEntry.getObjectEntryId());
+
+		objectEntry = _objectEntryLocalService.updateObjectEntry(
+			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
+			objectEntry.getObjectEntryFolderId(),
+			HashMapBuilder.<String, Serializable>put(
+				"able", "Other URL"
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		AssertUtils.assertEquals(
+			HashMapBuilder.put(
+				"en_US", "other-url"
+			).build(),
+			objectEntry.getURLTitleMap());
+
+		_friendlyURLEntryLocalService.setMainFriendlyURLEntry(friendlyURLEntry);
+
+		objectEntry = _objectEntryLocalService.updateObjectEntry(
+			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
+			objectEntry.getObjectEntryFolderId(),
+			HashMapBuilder.<String, Serializable>put(
+				"able", "Other URL"
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		AssertUtils.assertEquals(
+			HashMapBuilder.put(
+				"en_US", "test-url"
+			).build(),
+			objectEntry.getURLTitleMap());
+
+		_assertFriendlyURLEntries(2, objectDefinition, objectEntry);
+
+		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
+	}
+
+	@Test
 	public void testUpdateStatus() throws Exception {
 		PermissionChecker permissionChecker =
 			PermissionThreadLocal.getPermissionChecker();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-105587

Part of the object entry page optimization tracked under LPD-65366 (LPD-98910 scenario, the edit page of an object entry). Independent of the other in-flight changes. Resend of #181689 with the gate helper renamed to `_shouldAddFriendlyURLEntry` per review; the content is otherwise unchanged and rebased onto the current master.

## What Is Being Fixed

Every update of an object entry derives the URL title again from the title field, or from the external reference code when the definition has no title field, asks the friendly URL service for a unique variant of it, which probes the localization table twice, and then hands it to `addFriendlyURLEntry`, which loads the entry's mapping, its main friendly URL entry and the localizations only to find the title already there and return. A description-only edit pays five lookups to conclude that nothing changed.

## How It Is Being Fixed

`ObjectEntryLocalServiceImpl` runs the friendly URL step of an update only when `_shouldAddFriendlyURLEntry` says so: the definition lets users customize the URL, the default language or the external reference code changed, the title field's value differs between the incoming values and the original entry, or the entry has no main friendly URL entry yet. Otherwise the derived title cannot differ from the one derived at the previous write, so the step is skipped. Entries without a friendly URL entry and updates that change the title source keep taking the existing path.

One visible difference: an unrelated edit no longer replaces a URL a user restored from the history, or a URL derived before the definition's title field was switched, with a freshly derived one. The URL now follows the title source only when that source itself changes.

## Verification

- `ObjectEntryLocalServiceTest.testUpdateObjectEntryWithUnchangedFriendlyURL`: a title change moves the URL to the new title, a main friendly URL entry restored from the history survives a later update that leaves the title alone, and the entry ends with exactly the two friendly URL entries the two titles produced. `testAddOrUpdateObjectEntryWithFriendlyURL` keeps passing. Both green on a fresh bundle built from the branch.
- Self-CI on shuyangzhou/liferay-portal PR 12764 (same logic under the previous helper name, on base 72316f2): stable 16/16, object 49/49, relevant 33/35, where the only unique failure is `HeadlessBuilderResourceTest.testGetOpenAPIInDifferentCompany`, which fails on every pull this week. The renamed head is under self-CI on PR 12767.

## PR Check

**pr-check: PASS** — tested on `7e932d4671deb99e1f933fd927d5e8265b2333e8`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Service Registration | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS (baseline-all + seven Ant projects + 0 changed exporting modules) |
| Java Unit Tests | PASS |

Baseline reported one inherited finding in a module the branch never changed: `com.liferay.portal.kernel.test.util` in `portal-test` (`EXCESSIVE VERSION INCREASE` 11.0.0 vs 10.10.0 required, new class `FIPSModeTestUtil`), pre-existing master debt; the rewrite was restored and nothing committed. Neither changed module exports a package, so no version bump applies. Java Unit Tests ran `ObjectEntryLocalServiceImplTest` (green), which does not reach the changed gate; the behaviour is covered by `ObjectEntryLocalServiceTest.testUpdateObjectEntryWithUnchangedFriendlyURL`, which passed on a fresh bundle built from the same content under the previous helper name.

<!-- pr-check {"result": "success", "sha": "7e932d4671deb99e1f933fd927d5e8265b2333e8"} -->
