### PR TITLE
LPD-105634 Mark the required translation query parameters in the object OpenAPI fixtures

### DIFF
--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi.json
@@ -7556,6 +7556,7 @@
 						"description": "The required language ID of the source text (e.g., \"en_US\").",
 						"in": "query",
 						"name": "sourceLanguageId",
+						"required": true,
 						"schema": {
 							"type": "string"
 						}
@@ -7564,6 +7565,7 @@
 						"description": "A required list of language IDs for the target translations (e.g., \"es_ES\", \"fr_FR\").",
 						"in": "query",
 						"name": "targetLanguageIds",
+						"required": true,
 						"schema": {
 							"type": "string"
 						}
@@ -7658,6 +7660,7 @@
 						"description": "The required language ID for the target translation (e.g., \"en_US\").",
 						"in": "query",
 						"name": "targetLanguageId",
+						"required": true,
 						"schema": {
 							"type": "string"
 						}

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions.json
@@ -3934,6 +3934,7 @@
 						"description": "The required language ID of the source text (e.g., \"en_US\").",
 						"in": "query",
 						"name": "sourceLanguageId",
+						"required": true,
 						"schema": {
 							"type": "string"
 						}
@@ -3942,6 +3943,7 @@
 						"description": "A required list of language IDs for the target translations (e.g., \"es_ES\", \"fr_FR\").",
 						"in": "query",
 						"name": "targetLanguageIds",
+						"required": true,
 						"schema": {
 							"type": "string"
 						}
@@ -4036,6 +4038,7 @@
 						"description": "The required language ID for the target translation (e.g., \"en_US\").",
 						"in": "query",
 						"name": "targetLanguageId",
+						"required": true,
 						"schema": {
 							"type": "string"
 						}

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions_object_action.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions_object_action.json
@@ -4016,6 +4016,7 @@
 						"description": "The required language ID of the source text (e.g., \"en_US\").",
 						"in": "query",
 						"name": "sourceLanguageId",
+						"required": true,
 						"schema": {
 							"type": "string"
 						}
@@ -4024,6 +4025,7 @@
 						"description": "A required list of language IDs for the target translations (e.g., \"es_ES\", \"fr_FR\").",
 						"in": "query",
 						"name": "targetLanguageIds",
+						"required": true,
 						"schema": {
 							"type": "string"
 						}
@@ -4118,6 +4120,7 @@
 						"description": "The required language ID for the target translation (e.g., \"en_US\").",
 						"in": "query",
 						"name": "targetLanguageId",
+						"required": true,
 						"schema": {
 							"type": "string"
 						}

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_categorization_disabled.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_categorization_disabled.json
@@ -3575,6 +3575,7 @@
 						"description": "The required language ID of the source text (e.g., \"en_US\").",
 						"in": "query",
 						"name": "sourceLanguageId",
+						"required": true,
 						"schema": {
 							"type": "string"
 						}
@@ -3583,6 +3584,7 @@
 						"description": "A required list of language IDs for the target translations (e.g., \"es_ES\", \"fr_FR\").",
 						"in": "query",
 						"name": "targetLanguageIds",
+						"required": true,
 						"schema": {
 							"type": "string"
 						}
@@ -3677,6 +3679,7 @@
 						"description": "The required language ID for the target translation (e.g., \"en_US\").",
 						"in": "query",
 						"name": "targetLanguageId",
+						"required": true,
 						"schema": {
 							"type": "string"
 						}

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_related.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_related.json
@@ -9713,6 +9713,7 @@
 						"description": "The required language ID of the source text (e.g., \"en_US\").",
 						"in": "query",
 						"name": "sourceLanguageId",
+						"required": true,
 						"schema": {
 							"type": "string"
 						}
@@ -9721,6 +9722,7 @@
 						"description": "A required list of language IDs for the target translations (e.g., \"es_ES\", \"fr_FR\").",
 						"in": "query",
 						"name": "targetLanguageIds",
+						"required": true,
 						"schema": {
 							"type": "string"
 						}
@@ -9815,6 +9817,7 @@
 						"description": "The required language ID for the target translation (e.g., \"en_US\").",
 						"in": "query",
 						"name": "targetLanguageId",
+						"required": true,
 						"schema": {
 							"type": "string"
 						}

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_site.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_site.json
@@ -3107,6 +3107,7 @@
 						"description": "The required language ID of the source text (e.g., \"en_US\").",
 						"in": "query",
 						"name": "sourceLanguageId",
+						"required": true,
 						"schema": {
 							"type": "string"
 						}
@@ -3115,6 +3116,7 @@
 						"description": "A required list of language IDs for the target translations (e.g., \"es_ES\", \"fr_FR\").",
 						"in": "query",
 						"name": "targetLanguageIds",
+						"required": true,
 						"schema": {
 							"type": "string"
 						}
@@ -3225,6 +3227,7 @@
 						"description": "The required language ID for the target translation (e.g., \"en_US\").",
 						"in": "query",
 						"name": "targetLanguageId",
+						"required": true,
 						"schema": {
 							"type": "string"
 						}
@@ -4395,6 +4398,7 @@
 						"description": "The required language ID of the source text (e.g., \"en_US\").",
 						"in": "query",
 						"name": "sourceLanguageId",
+						"required": true,
 						"schema": {
 							"type": "string"
 						}
@@ -4403,6 +4407,7 @@
 						"description": "A required list of language IDs for the target translations (e.g., \"es_ES\", \"fr_FR\").",
 						"in": "query",
 						"name": "targetLanguageIds",
+						"required": true,
 						"schema": {
 							"type": "string"
 						}
@@ -4497,6 +4502,7 @@
 						"description": "The required language ID for the target translation (e.g., \"en_US\").",
 						"in": "query",
 						"name": "targetLanguageId",
+						"required": true,
 						"schema": {
 							"type": "string"
 						}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-105634

Test-failure fix under LPD-99314. cc @4lejandrito @ccorreagg, authors of LPD-101616, whose REST Builder change this fixture update follows.

## What Is Being Fixed

`OpenAPIResourceTest.testGetOpenAPI` and `testGetOpenAPIWithActions` fail on every `ci:test:object` run of master since LPD-101616 landed on 2026-09-11: JSONAssert reports an unexpected `required` key on the translation endpoints' query parameters (`/{object1Id}/translations` GET parameters 1 and 2, `/{object1Id}/translations/{languageId}` GET parameter 2). The bare-master baseline of the object suite went from 49/49 to 46/49 on it, and every object pull request since then carries the same two failures.

## How It Is Being Fixed

LPD-101616 (d87c617fccde2) makes the REST Builder emit `required` on generated `@Parameter` annotations, and 7f52e28412500 regenerated `BaseObjectEntryResourceImpl` with it, so the served document now carries `required: true` on `sourceLanguageId`, `targetLanguageIds` and `targetLanguageId`, which `rest-openapi.yaml` declares as required query parameters. The `expected_openapi*.json` fixtures in object-rest-test still lacked the flag. The six fixtures that describe the translation endpoints gain `"required": true` on those three parameters, 21 insertions and nothing else. LPD-101616 reached master through a forwarded pull request on which only `ci:test:sf` ran, so no integration suite executed this test before the merge.

## Verification

- `OpenAPIResourceTest` passes 5 of 5 on a bundle built from the failing master tip 9f1434e with this commit applied; without it the same bundle fails the two methods with the assertion above.
- Self-CI on shuyangzhou/liferay-portal PR 12768 (same content on the previous base ea70198): `ci:test:object` 49/49, the first fully green object run since the break; `ci:test:relevant` 199/282 no longer lists the two OpenAPI failures, its remaining failures being the chronic set (`HeadlessBuilderResourceTest`, `LayoutExportImportTest`, `SXPBlueprint*`, `IndexWriterHelperImplTest`, the page editor and site initializer Playwright specs) that fail on plain master; `ci:test:stable` 14/16, its only failure the smoke test's `PortalLogAssertorTest`, which a bare-master stable run fails identically.

## PR Check

**pr-check: PASS** — tested on `a69e64bf5bb57b337eba1c677c0eb78cf555f09f`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Baseline | PASS (baseline-all + seven Ant projects + 0 changed exporting modules) |

The diff is six JSON fixtures under `object-rest-test/src/testIntegration/resources`, so only these two validations fire. Source Format ran both halves: the Java formatter with commit message validation, and the node half over the six files (`Everything is correctly formatted`). Baseline found no warning row anywhere and rewrote nothing; the changed module exports no package. Integration Test Compile does not match JSON-only diffs; the fixtures are exercised by `OpenAPIResourceTest`, which passes 5 of 5 on a bundle built from the failing master tip with this commit applied, and by the fork's `ci:test:object` run (49/49).

<!-- pr-check {"result": "success", "sha": "a69e64bf5bb57b337eba1c677c0eb78cf555f09f"} -->
