### PR TITLE
LPD-105636 Generate a localization add method that skips the lookup of the existing row

### DIFF
--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPDefinitionLocalService.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPDefinitionLocalService.java
@@ -119,6 +119,12 @@ public interface CPDefinitionLocalService
 			int status, ServiceContext serviceContext)
 		throws PortalException;
 
+	public CPDefinitionLocalization addCPDefinitionLocalization(
+			CPDefinition cpDefinition, String languageId, String description,
+			String metaDescription, String metaKeywords, String metaTitle,
+			String name, String shortDescription)
+		throws PortalException;
+
 	public CPDefinition addOrUpdateCPDefinition(
 			String externalReferenceCode, long userId, long groupId,
 			long cpDefinitionId, long cpTaxCategoryId,
@@ -721,4 +727,4 @@ public interface CPDefinitionLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-79398288
+// LIFERAY-SERVICE-BUILDER-HASH:927766104

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPDefinitionLocalServiceUtil.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPDefinitionLocalServiceUtil.java
@@ -105,6 +105,18 @@ public class CPDefinitionLocalServiceUtil {
 			serviceContext);
 	}
 
+	public static com.liferay.commerce.product.model.CPDefinitionLocalization
+			addCPDefinitionLocalization(
+				CPDefinition cpDefinition, String languageId,
+				String description, String metaDescription, String metaKeywords,
+				String metaTitle, String name, String shortDescription)
+		throws PortalException {
+
+		return getService().addCPDefinitionLocalization(
+			cpDefinition, languageId, description, metaDescription,
+			metaKeywords, metaTitle, name, shortDescription);
+	}
+
 	public static CPDefinition addOrUpdateCPDefinition(
 			String externalReferenceCode, long userId, long groupId,
 			long cpDefinitionId, long cpTaxCategoryId,
@@ -999,4 +1011,4 @@ public class CPDefinitionLocalServiceUtil {
 			CPDefinitionLocalServiceUtil.class, CPDefinitionLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:762569692
+// LIFERAY-SERVICE-BUILDER-HASH:496117148

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPDefinitionLocalServiceWrapper.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPDefinitionLocalServiceWrapper.java
@@ -104,6 +104,19 @@ public class CPDefinitionLocalServiceWrapper
 	}
 
 	@Override
+	public com.liferay.commerce.product.model.CPDefinitionLocalization
+			addCPDefinitionLocalization(
+				CPDefinition cpDefinition, String languageId,
+				String description, String metaDescription, String metaKeywords,
+				String metaTitle, String name, String shortDescription)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _cpDefinitionLocalService.addCPDefinitionLocalization(
+			cpDefinition, languageId, description, metaDescription,
+			metaKeywords, metaTitle, name, shortDescription);
+	}
+
+	@Override
 	public CPDefinition addOrUpdateCPDefinition(
 			String externalReferenceCode, long userId, long groupId,
 			long cpDefinitionId, long cpTaxCategoryId,
@@ -1162,4 +1175,4 @@ public class CPDefinitionLocalServiceWrapper
 	private CPDefinitionLocalService _cpDefinitionLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-628781409
+// LIFERAY-SERVICE-BUILDER-HASH:-1804334423

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/base/CPDefinitionLocalServiceBaseImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/base/CPDefinitionLocalServiceBaseImpl.java
@@ -592,6 +592,21 @@ public abstract class CPDefinitionLocalServiceBaseImpl
 	}
 
 	@Override
+	public CPDefinitionLocalization addCPDefinitionLocalization(
+			CPDefinition cpDefinition, String languageId, String description,
+			String metaDescription, String metaKeywords, String metaTitle,
+			String name, String shortDescription)
+		throws PortalException {
+
+		cpDefinition = cpDefinitionPersistence.findByPrimaryKey(
+			cpDefinition.getPrimaryKey());
+
+		return _updateCPDefinitionLocalization(
+			cpDefinition, null, languageId, description, metaDescription,
+			metaKeywords, metaTitle, name, shortDescription);
+	}
+
+	@Override
 	public CPDefinitionLocalization fetchCPDefinitionLocalization(
 		long CPDefinitionId, String languageId) {
 
@@ -943,4 +958,4 @@ public abstract class CPDefinitionLocalServiceBaseImpl
 		CPDefinitionLocalServiceBaseImpl.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-333298322
+// LIFERAY-SERVICE-BUILDER-HASH:-1907837699

--- a/modules/apps/commerce/commerce-term-api/bnd.bnd
+++ b/modules/apps/commerce/commerce-term-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Commerce Term API
 Bundle-SymbolicName: com.liferay.commerce.term.api
-Bundle-Version: 10.0.1
+Bundle-Version: 10.1.0
 Export-Package:\
 	com.liferay.commerce.term.configuration,\
 	com.liferay.commerce.term.constants,\

--- a/modules/apps/commerce/commerce-term-api/src/main/java/com/liferay/commerce/term/service/CommerceTermEntryLocalService.java
+++ b/modules/apps/commerce/commerce-term-api/src/main/java/com/liferay/commerce/term/service/CommerceTermEntryLocalService.java
@@ -92,6 +92,11 @@ public interface CommerceTermEntryLocalService
 			ServiceContext serviceContext)
 		throws PortalException;
 
+	public CTermEntryLocalization addCTermEntryLocalization(
+			CommerceTermEntry commerceTermEntry, String languageId,
+			String description, String label)
+		throws PortalException;
+
 	public void checkCommerceTermEntries() throws PortalException;
 
 	/**
@@ -412,4 +417,4 @@ public interface CommerceTermEntryLocalService
 		throws PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-718948372
+// LIFERAY-SERVICE-BUILDER-HASH:1818086450

--- a/modules/apps/commerce/commerce-term-api/src/main/java/com/liferay/commerce/term/service/CommerceTermEntryLocalServiceUtil.java
+++ b/modules/apps/commerce/commerce-term-api/src/main/java/com/liferay/commerce/term/service/CommerceTermEntryLocalServiceUtil.java
@@ -75,6 +75,16 @@ public class CommerceTermEntryLocalServiceUtil {
 			serviceContext);
 	}
 
+	public static com.liferay.commerce.term.model.CTermEntryLocalization
+			addCTermEntryLocalization(
+				CommerceTermEntry commerceTermEntry, String languageId,
+				String description, String label)
+		throws PortalException {
+
+		return getService().addCTermEntryLocalization(
+			commerceTermEntry, languageId, description, label);
+	}
+
 	public static void checkCommerceTermEntries() throws PortalException {
 		getService().checkCommerceTermEntries();
 	}
@@ -534,4 +544,4 @@ public class CommerceTermEntryLocalServiceUtil {
 			CommerceTermEntryLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1961197734
+// LIFERAY-SERVICE-BUILDER-HASH:-965785376

--- a/modules/apps/commerce/commerce-term-api/src/main/java/com/liferay/commerce/term/service/CommerceTermEntryLocalServiceWrapper.java
+++ b/modules/apps/commerce/commerce-term-api/src/main/java/com/liferay/commerce/term/service/CommerceTermEntryLocalServiceWrapper.java
@@ -74,6 +74,18 @@ public class CommerceTermEntryLocalServiceWrapper
 	}
 
 	@Override
+	public com.liferay.commerce.term.model.CTermEntryLocalization
+			addCTermEntryLocalization(
+				com.liferay.commerce.term.model.CommerceTermEntry
+					commerceTermEntry,
+				String languageId, String description, String label)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _commerceTermEntryLocalService.addCTermEntryLocalization(
+			commerceTermEntry, languageId, description, label);
+	}
+
+	@Override
 	public void checkCommerceTermEntries()
 		throws com.liferay.portal.kernel.exception.PortalException {
 
@@ -631,4 +643,4 @@ public class CommerceTermEntryLocalServiceWrapper
 	private CommerceTermEntryLocalService _commerceTermEntryLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1400640575
+// LIFERAY-SERVICE-BUILDER-HASH:-2145785400

--- a/modules/apps/commerce/commerce-term-api/src/main/resources/com/liferay/commerce/term/service/packageinfo
+++ b/modules/apps/commerce/commerce-term-api/src/main/resources/com/liferay/commerce/term/service/packageinfo
@@ -1,1 +1,1 @@
-version 5.1.0
+version 5.2.0

--- a/modules/apps/commerce/commerce-term-service/src/main/java/com/liferay/commerce/term/service/base/CommerceTermEntryLocalServiceBaseImpl.java
+++ b/modules/apps/commerce/commerce-term-service/src/main/java/com/liferay/commerce/term/service/base/CommerceTermEntryLocalServiceBaseImpl.java
@@ -559,6 +559,19 @@ public abstract class CommerceTermEntryLocalServiceBaseImpl
 	}
 
 	@Override
+	public CTermEntryLocalization addCTermEntryLocalization(
+			CommerceTermEntry commerceTermEntry, String languageId,
+			String description, String label)
+		throws PortalException {
+
+		commerceTermEntry = commerceTermEntryPersistence.findByPrimaryKey(
+			commerceTermEntry.getPrimaryKey());
+
+		return _updateCTermEntryLocalization(
+			commerceTermEntry, null, languageId, description, label);
+	}
+
+	@Override
 	public CTermEntryLocalization fetchCTermEntryLocalization(
 		long commerceTermEntryId, String languageId) {
 
@@ -810,4 +823,4 @@ public abstract class CommerceTermEntryLocalServiceBaseImpl
 		CommerceTermEntryLocalServiceBaseImpl.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1031751550
+// LIFERAY-SERVICE-BUILDER-HASH:270300484

--- a/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/FriendlyURLEntryLocalService.java
+++ b/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/FriendlyURLEntryLocalService.java
@@ -102,6 +102,11 @@ public interface FriendlyURLEntryLocalService
 			ServiceContext serviceContext)
 		throws PortalException;
 
+	public FriendlyURLEntryLocalization addFriendlyURLEntryLocalization(
+			FriendlyURLEntry friendlyURLEntry, String languageId,
+			String urlTitle)
+		throws PortalException;
+
 	/**
 	 * Creates a new friendly url entry with the primary key. Does not add the friendly url entry to the database.
 	 *
@@ -525,4 +530,4 @@ public interface FriendlyURLEntryLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1021384353
+// LIFERAY-SERVICE-BUILDER-HASH:-550593190

--- a/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/FriendlyURLEntryLocalServiceUtil.java
+++ b/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/FriendlyURLEntryLocalServiceUtil.java
@@ -95,6 +95,16 @@ public class FriendlyURLEntryLocalServiceUtil {
 			groupId, classNameId, classPK, urlTitle, serviceContext);
 	}
 
+	public static com.liferay.friendly.url.model.FriendlyURLEntryLocalization
+			addFriendlyURLEntryLocalization(
+				FriendlyURLEntry friendlyURLEntry, String languageId,
+				String urlTitle)
+		throws PortalException {
+
+		return getService().addFriendlyURLEntryLocalization(
+			friendlyURLEntry, languageId, urlTitle);
+	}
+
 	/**
 	 * Creates a new friendly url entry with the primary key. Does not add the friendly url entry to the database.
 	 *
@@ -724,4 +734,4 @@ public class FriendlyURLEntryLocalServiceUtil {
 			FriendlyURLEntryLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1252061885
+// LIFERAY-SERVICE-BUILDER-HASH:-556093448

--- a/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/FriendlyURLEntryLocalServiceWrapper.java
+++ b/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/FriendlyURLEntryLocalServiceWrapper.java
@@ -95,6 +95,17 @@ public class FriendlyURLEntryLocalServiceWrapper
 			groupId, classNameId, classPK, urlTitle, serviceContext);
 	}
 
+	@Override
+	public com.liferay.friendly.url.model.FriendlyURLEntryLocalization
+			addFriendlyURLEntryLocalization(
+				FriendlyURLEntry friendlyURLEntry, String languageId,
+				String urlTitle)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _friendlyURLEntryLocalService.addFriendlyURLEntryLocalization(
+			friendlyURLEntry, languageId, urlTitle);
+	}
+
 	/**
 	 * Creates a new friendly url entry with the primary key. Does not add the friendly url entry to the database.
 	 *
@@ -838,4 +849,4 @@ public class FriendlyURLEntryLocalServiceWrapper
 	private FriendlyURLEntryLocalService _friendlyURLEntryLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:89411744
+// LIFERAY-SERVICE-BUILDER-HASH:1715614355

--- a/modules/apps/friendly-url/friendly-url-api/src/main/resources/com/liferay/friendly/url/service/packageinfo
+++ b/modules/apps/friendly-url/friendly-url-api/src/main/resources/com/liferay/friendly/url/service/packageinfo
@@ -1,1 +1,1 @@
-version 4.2.0
+version 4.3.0

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/base/FriendlyURLEntryLocalServiceBaseImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/base/FriendlyURLEntryLocalServiceBaseImpl.java
@@ -556,6 +556,19 @@ public abstract class FriendlyURLEntryLocalServiceBaseImpl
 	}
 
 	@Override
+	public FriendlyURLEntryLocalization addFriendlyURLEntryLocalization(
+			FriendlyURLEntry friendlyURLEntry, String languageId,
+			String urlTitle)
+		throws PortalException {
+
+		friendlyURLEntry = friendlyURLEntryPersistence.findByPrimaryKey(
+			friendlyURLEntry.getPrimaryKey());
+
+		return _updateFriendlyURLEntryLocalization(
+			friendlyURLEntry, null, languageId, urlTitle);
+	}
+
+	@Override
 	public FriendlyURLEntryLocalization fetchFriendlyURLEntryLocalization(
 		long friendlyURLEntryId, String languageId) {
 
@@ -838,4 +851,4 @@ public abstract class FriendlyURLEntryLocalServiceBaseImpl
 		FriendlyURLEntryLocalServiceBaseImpl.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1423515914
+// LIFERAY-SERVICE-BUILDER-HASH:-1197516012

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
@@ -135,7 +135,7 @@ public class FriendlyURLEntryLocalServiceImpl
 		friendlyURLEntry = friendlyURLEntryPersistence.update(friendlyURLEntry);
 
 		_updateFriendlyURLEntryLocalizations(
-			friendlyURLEntry, classNameId, parentClassPK,
+			friendlyURLEntry, classNameId, parentClassPK, true,
 			_merge(urlTitleMap, existingUrlTitleMap));
 
 		// Asset
@@ -569,7 +569,7 @@ public class FriendlyURLEntryLocalServiceImpl
 		friendlyURLEntry = friendlyURLEntryPersistence.update(friendlyURLEntry);
 
 		_updateFriendlyURLEntryLocalizations(
-			friendlyURLEntry, classNameId, parentClassPK, urlTitleMap);
+			friendlyURLEntry, classNameId, parentClassPK, false, urlTitleMap);
 
 		// Asset
 
@@ -947,7 +947,8 @@ public class FriendlyURLEntryLocalServiceImpl
 
 	private void _updateFriendlyURLEntryLocalizations(
 			FriendlyURLEntry friendlyURLEntry, long classNameId,
-			long parentClassPK, Map<String, String> urlTitleMap)
+			long parentClassPK, boolean newFriendlyURLEntry,
+			Map<String, String> urlTitleMap)
 		throws PortalException {
 
 		urlTitleMap = _sortUrlTitleMap(
@@ -980,6 +981,10 @@ public class FriendlyURLEntryLocalServiceImpl
 						updateFriendlyURLLocalization(
 							existingFriendlyURLEntryLocalization);
 					}
+				}
+				else if (newFriendlyURLEntry) {
+					addFriendlyURLEntryLocalization(
+						friendlyURLEntry, entry.getKey(), normalizedUrlTitle);
 				}
 				else {
 					updateFriendlyURLEntryLocalization(

--- a/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/service/LVEntryLocalService.java
+++ b/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/service/LVEntryLocalService.java
@@ -91,6 +91,11 @@ public interface LVEntryLocalService
 	@Indexable(type = IndexableType.REINDEX)
 	public LVEntry addLVEntry(LVEntry lvEntry);
 
+	public LVEntryLocalization addLVEntryLocalization(
+			LVEntry draftLVEntry, String languageId, String title,
+			String content)
+		throws PortalException;
+
 	@Indexable(type = IndexableType.REINDEX)
 	@Override
 	public LVEntry checkout(LVEntry publishedLVEntry, int version)
@@ -435,4 +440,4 @@ public interface LVEntryLocalService
 		throws PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1816798054
+// LIFERAY-SERVICE-BUILDER-HASH:429589222

--- a/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/service/LVEntryLocalServiceUtil.java
+++ b/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/service/LVEntryLocalServiceUtil.java
@@ -78,6 +78,17 @@ public class LVEntryLocalServiceUtil {
 		return getService().addLVEntry(lvEntry);
 	}
 
+	public static
+		com.liferay.portal.tools.service.builder.test.model.LVEntryLocalization
+				addLVEntryLocalization(
+					LVEntry draftLVEntry, String languageId, String title,
+					String content)
+			throws PortalException {
+
+		return getService().addLVEntryLocalization(
+			draftLVEntry, languageId, title, content);
+	}
+
 	public static LVEntry checkout(LVEntry publishedLVEntry, int version)
 		throws PortalException {
 
@@ -574,4 +585,4 @@ public class LVEntryLocalServiceUtil {
 	private static volatile LVEntryLocalService _service;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:972932743
+// LIFERAY-SERVICE-BUILDER-HASH:32172927

--- a/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/service/LVEntryLocalServiceWrapper.java
+++ b/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/service/LVEntryLocalServiceWrapper.java
@@ -82,6 +82,19 @@ public class LVEntryLocalServiceWrapper
 	}
 
 	@Override
+	public
+		com.liferay.portal.tools.service.builder.test.model.LVEntryLocalization
+				addLVEntryLocalization(
+					com.liferay.portal.tools.service.builder.test.model.LVEntry
+						draftLVEntry,
+					String languageId, String title, String content)
+			throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _lvEntryLocalService.addLVEntryLocalization(
+			draftLVEntry, languageId, title, content);
+	}
+
+	@Override
 	public com.liferay.portal.tools.service.builder.test.model.LVEntry checkout(
 			com.liferay.portal.tools.service.builder.test.model.LVEntry
 				publishedLVEntry,
@@ -730,4 +743,4 @@ public class LVEntryLocalServiceWrapper
 	private LVEntryLocalService _lvEntryLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-343039805
+// LIFERAY-SERVICE-BUILDER-HASH:1361996429

--- a/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/service/LocalizedEntryLocalService.java
+++ b/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/service/LocalizedEntryLocalService.java
@@ -74,6 +74,11 @@ public interface LocalizedEntryLocalService
 	@Indexable(type = IndexableType.REINDEX)
 	public LocalizedEntry addLocalizedEntry(LocalizedEntry localizedEntry);
 
+	public LocalizedEntryLocalization addLocalizedEntryLocalization(
+			LocalizedEntry localizedEntry, String languageId, String title,
+			String content)
+		throws PortalException;
+
 	/**
 	 * Creates a new localized entry with the primary key. Does not add the localized entry to the database.
 	 *
@@ -290,4 +295,4 @@ public interface LocalizedEntryLocalService
 		throws PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:606289772
+// LIFERAY-SERVICE-BUILDER-HASH:-1448690497

--- a/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/service/LocalizedEntryLocalServiceUtil.java
+++ b/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/service/LocalizedEntryLocalServiceUtil.java
@@ -53,6 +53,16 @@ public class LocalizedEntryLocalServiceUtil {
 		return getService().addLocalizedEntry(localizedEntry);
 	}
 
+	public static com.liferay.portal.tools.service.builder.test.model.
+		LocalizedEntryLocalization addLocalizedEntryLocalization(
+				LocalizedEntry localizedEntry, String languageId, String title,
+				String content)
+			throws PortalException {
+
+		return getService().addLocalizedEntryLocalization(
+			localizedEntry, languageId, title, content);
+	}
+
 	/**
 	 * Creates a new localized entry with the primary key. Does not add the localized entry to the database.
 	 *
@@ -346,4 +356,4 @@ public class LocalizedEntryLocalServiceUtil {
 	private static volatile LocalizedEntryLocalService _service;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1516670927
+// LIFERAY-SERVICE-BUILDER-HASH:-1643926355

--- a/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/service/LocalizedEntryLocalServiceWrapper.java
+++ b/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/service/LocalizedEntryLocalServiceWrapper.java
@@ -48,6 +48,18 @@ public class LocalizedEntryLocalServiceWrapper
 		return _localizedEntryLocalService.addLocalizedEntry(localizedEntry);
 	}
 
+	@Override
+	public com.liferay.portal.tools.service.builder.test.model.
+		LocalizedEntryLocalization addLocalizedEntryLocalization(
+				com.liferay.portal.tools.service.builder.test.model.
+					LocalizedEntry localizedEntry,
+				String languageId, String title, String content)
+			throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _localizedEntryLocalService.addLocalizedEntryLocalization(
+			localizedEntry, languageId, title, content);
+	}
+
 	/**
 	 * Creates a new localized entry with the primary key. Does not add the localized entry to the database.
 	 *
@@ -407,4 +419,4 @@ public class LocalizedEntryLocalServiceWrapper
 	private LocalizedEntryLocalService _localizedEntryLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:10117042
+// LIFERAY-SERVICE-BUILDER-HASH:-1138686657

--- a/modules/util/portal-tools-service-builder-test-compat710-api/src/main/java/com/liferay/portal/tools/service/builder/test/compat710/service/LocalizedEntryLocalService.java
+++ b/modules/util/portal-tools-service-builder-test-compat710-api/src/main/java/com/liferay/portal/tools/service/builder/test/compat710/service/LocalizedEntryLocalService.java
@@ -67,6 +67,11 @@ public interface LocalizedEntryLocalService
 	@Indexable(type = IndexableType.REINDEX)
 	public LocalizedEntry addLocalizedEntry(LocalizedEntry localizedEntry);
 
+	public LocalizedEntryLocalization addLocalizedEntryLocalization(
+			LocalizedEntry localizedEntry, String languageId, String title,
+			String content)
+		throws PortalException;
+
 	/**
 	 * Creates a new localized entry with the primary key. Does not add the localized entry to the database.
 	 *
@@ -271,4 +276,4 @@ public interface LocalizedEntryLocalService
 		throws PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1948478375
+// LIFERAY-SERVICE-BUILDER-HASH:677956710

--- a/modules/util/portal-tools-service-builder-test-compat710-api/src/main/java/com/liferay/portal/tools/service/builder/test/compat710/service/LocalizedEntryLocalServiceUtil.java
+++ b/modules/util/portal-tools-service-builder-test-compat710-api/src/main/java/com/liferay/portal/tools/service/builder/test/compat710/service/LocalizedEntryLocalServiceUtil.java
@@ -52,6 +52,16 @@ public class LocalizedEntryLocalServiceUtil {
 		return getService().addLocalizedEntry(localizedEntry);
 	}
 
+	public static com.liferay.portal.tools.service.builder.test.compat710.model.
+		LocalizedEntryLocalization addLocalizedEntryLocalization(
+				LocalizedEntry localizedEntry, String languageId, String title,
+				String content)
+			throws PortalException {
+
+		return getService().addLocalizedEntryLocalization(
+			localizedEntry, languageId, title, content);
+	}
+
 	/**
 	 * Creates a new localized entry with the primary key. Does not add the localized entry to the database.
 	 *
@@ -327,4 +337,4 @@ public class LocalizedEntryLocalServiceUtil {
 	private static volatile LocalizedEntryLocalService _service;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1377178715
+// LIFERAY-SERVICE-BUILDER-HASH:-459074787

--- a/modules/util/portal-tools-service-builder-test-compat710-api/src/main/java/com/liferay/portal/tools/service/builder/test/compat710/service/LocalizedEntryLocalServiceWrapper.java
+++ b/modules/util/portal-tools-service-builder-test-compat710-api/src/main/java/com/liferay/portal/tools/service/builder/test/compat710/service/LocalizedEntryLocalServiceWrapper.java
@@ -44,6 +44,18 @@ public class LocalizedEntryLocalServiceWrapper
 		return _localizedEntryLocalService.addLocalizedEntry(localizedEntry);
 	}
 
+	@Override
+	public com.liferay.portal.tools.service.builder.test.compat710.model.
+		LocalizedEntryLocalization addLocalizedEntryLocalization(
+				com.liferay.portal.tools.service.builder.test.compat710.model.
+					LocalizedEntry localizedEntry,
+				String languageId, String title, String content)
+			throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _localizedEntryLocalService.addLocalizedEntryLocalization(
+			localizedEntry, languageId, title, content);
+	}
+
 	/**
 	 * Creates a new localized entry with the primary key. Does not add the localized entry to the database.
 	 *
@@ -381,4 +393,4 @@ public class LocalizedEntryLocalServiceWrapper
 	private LocalizedEntryLocalService _localizedEntryLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1756126801
+// LIFERAY-SERVICE-BUILDER-HASH:727265364

--- a/modules/util/portal-tools-service-builder-test-compat710-service/src/main/java/com/liferay/portal/tools/service/builder/test/compat710/service/base/LocalizedEntryLocalServiceBaseImpl.java
+++ b/modules/util/portal-tools-service-builder-test-compat710-service/src/main/java/com/liferay/portal/tools/service/builder/test/compat710/service/base/LocalizedEntryLocalServiceBaseImpl.java
@@ -349,6 +349,19 @@ public abstract class LocalizedEntryLocalServiceBaseImpl
 	}
 
 	@Override
+	public LocalizedEntryLocalization addLocalizedEntryLocalization(
+			LocalizedEntry localizedEntry, String languageId, String title,
+			String content)
+		throws PortalException {
+
+		localizedEntry = localizedEntryPersistence.findByPrimaryKey(
+			localizedEntry.getPrimaryKey());
+
+		return _updateLocalizedEntryLocalization(
+			localizedEntry, null, languageId, title, content);
+	}
+
+	@Override
 	public LocalizedEntryLocalization fetchLocalizedEntryLocalization(
 		long localizedEntryId, String languageId) {
 
@@ -686,4 +699,4 @@ public abstract class LocalizedEntryLocalServiceBaseImpl
 		persistedModelLocalServiceRegistry;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1791705261
+// LIFERAY-SERVICE-BUILDER-HASH:183691167

--- a/modules/util/portal-tools-service-builder-test-compat720-api/src/main/java/com/liferay/portal/tools/service/builder/test/compat720/service/LocalizedEntryLocalService.java
+++ b/modules/util/portal-tools-service-builder-test-compat720-api/src/main/java/com/liferay/portal/tools/service/builder/test/compat720/service/LocalizedEntryLocalService.java
@@ -67,6 +67,11 @@ public interface LocalizedEntryLocalService
 	@Indexable(type = IndexableType.REINDEX)
 	public LocalizedEntry addLocalizedEntry(LocalizedEntry localizedEntry);
 
+	public LocalizedEntryLocalization addLocalizedEntryLocalization(
+			LocalizedEntry localizedEntry, String languageId, String title,
+			String content)
+		throws PortalException;
+
 	/**
 	 * Creates a new localized entry with the primary key. Does not add the localized entry to the database.
 	 *
@@ -271,4 +276,4 @@ public interface LocalizedEntryLocalService
 		throws PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:105919492
+// LIFERAY-SERVICE-BUILDER-HASH:1321725257

--- a/modules/util/portal-tools-service-builder-test-compat720-api/src/main/java/com/liferay/portal/tools/service/builder/test/compat720/service/LocalizedEntryLocalServiceUtil.java
+++ b/modules/util/portal-tools-service-builder-test-compat720-api/src/main/java/com/liferay/portal/tools/service/builder/test/compat720/service/LocalizedEntryLocalServiceUtil.java
@@ -52,6 +52,16 @@ public class LocalizedEntryLocalServiceUtil {
 		return getService().addLocalizedEntry(localizedEntry);
 	}
 
+	public static com.liferay.portal.tools.service.builder.test.compat720.model.
+		LocalizedEntryLocalization addLocalizedEntryLocalization(
+				LocalizedEntry localizedEntry, String languageId, String title,
+				String content)
+			throws PortalException {
+
+		return getService().addLocalizedEntryLocalization(
+			localizedEntry, languageId, title, content);
+	}
+
 	/**
 	 * Creates a new localized entry with the primary key. Does not add the localized entry to the database.
 	 *
@@ -327,4 +337,4 @@ public class LocalizedEntryLocalServiceUtil {
 	private static volatile LocalizedEntryLocalService _service;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-211696536
+// LIFERAY-SERVICE-BUILDER-HASH:-2050296314

--- a/modules/util/portal-tools-service-builder-test-compat720-api/src/main/java/com/liferay/portal/tools/service/builder/test/compat720/service/LocalizedEntryLocalServiceWrapper.java
+++ b/modules/util/portal-tools-service-builder-test-compat720-api/src/main/java/com/liferay/portal/tools/service/builder/test/compat720/service/LocalizedEntryLocalServiceWrapper.java
@@ -44,6 +44,18 @@ public class LocalizedEntryLocalServiceWrapper
 		return _localizedEntryLocalService.addLocalizedEntry(localizedEntry);
 	}
 
+	@Override
+	public com.liferay.portal.tools.service.builder.test.compat720.model.
+		LocalizedEntryLocalization addLocalizedEntryLocalization(
+				com.liferay.portal.tools.service.builder.test.compat720.model.
+					LocalizedEntry localizedEntry,
+				String languageId, String title, String content)
+			throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _localizedEntryLocalService.addLocalizedEntryLocalization(
+			localizedEntry, languageId, title, content);
+	}
+
 	/**
 	 * Creates a new localized entry with the primary key. Does not add the localized entry to the database.
 	 *
@@ -381,4 +393,4 @@ public class LocalizedEntryLocalServiceWrapper
 	private LocalizedEntryLocalService _localizedEntryLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2128825961
+// LIFERAY-SERVICE-BUILDER-HASH:-1026837314

--- a/modules/util/portal-tools-service-builder-test-compat720-service/src/main/java/com/liferay/portal/tools/service/builder/test/compat720/service/base/LocalizedEntryLocalServiceBaseImpl.java
+++ b/modules/util/portal-tools-service-builder-test-compat720-service/src/main/java/com/liferay/portal/tools/service/builder/test/compat720/service/base/LocalizedEntryLocalServiceBaseImpl.java
@@ -349,6 +349,19 @@ public abstract class LocalizedEntryLocalServiceBaseImpl
 	}
 
 	@Override
+	public LocalizedEntryLocalization addLocalizedEntryLocalization(
+			LocalizedEntry localizedEntry, String languageId, String title,
+			String content)
+		throws PortalException {
+
+		localizedEntry = localizedEntryPersistence.findByPrimaryKey(
+			localizedEntry.getPrimaryKey());
+
+		return _updateLocalizedEntryLocalization(
+			localizedEntry, null, languageId, title, content);
+	}
+
+	@Override
 	public LocalizedEntryLocalization fetchLocalizedEntryLocalization(
 		long localizedEntryId, String languageId) {
 
@@ -686,4 +699,4 @@ public abstract class LocalizedEntryLocalServiceBaseImpl
 		persistedModelLocalServiceRegistry;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1575222422
+// LIFERAY-SERVICE-BUILDER-HASH:1562908514

--- a/modules/util/portal-tools-service-builder-test-compat730-api/src/main/java/com/liferay/portal/tools/service/builder/test/compat730/service/LocalizedEntryLocalService.java
+++ b/modules/util/portal-tools-service-builder-test-compat730-api/src/main/java/com/liferay/portal/tools/service/builder/test/compat730/service/LocalizedEntryLocalService.java
@@ -67,6 +67,11 @@ public interface LocalizedEntryLocalService
 	@Indexable(type = IndexableType.REINDEX)
 	public LocalizedEntry addLocalizedEntry(LocalizedEntry localizedEntry);
 
+	public LocalizedEntryLocalization addLocalizedEntryLocalization(
+			LocalizedEntry localizedEntry, String languageId, String title,
+			String content)
+		throws PortalException;
+
 	/**
 	 * Creates a new localized entry with the primary key. Does not add the localized entry to the database.
 	 *
@@ -277,4 +282,4 @@ public interface LocalizedEntryLocalService
 		throws PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-554342706
+// LIFERAY-SERVICE-BUILDER-HASH:-1050104115

--- a/modules/util/portal-tools-service-builder-test-compat730-api/src/main/java/com/liferay/portal/tools/service/builder/test/compat730/service/LocalizedEntryLocalServiceUtil.java
+++ b/modules/util/portal-tools-service-builder-test-compat730-api/src/main/java/com/liferay/portal/tools/service/builder/test/compat730/service/LocalizedEntryLocalServiceUtil.java
@@ -52,6 +52,16 @@ public class LocalizedEntryLocalServiceUtil {
 		return getService().addLocalizedEntry(localizedEntry);
 	}
 
+	public static com.liferay.portal.tools.service.builder.test.compat730.model.
+		LocalizedEntryLocalization addLocalizedEntryLocalization(
+				LocalizedEntry localizedEntry, String languageId, String title,
+				String content)
+			throws PortalException {
+
+		return getService().addLocalizedEntryLocalization(
+			localizedEntry, languageId, title, content);
+	}
+
 	/**
 	 * Creates a new localized entry with the primary key. Does not add the localized entry to the database.
 	 *
@@ -337,4 +347,4 @@ public class LocalizedEntryLocalServiceUtil {
 	private static volatile LocalizedEntryLocalService _service;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-95094506
+// LIFERAY-SERVICE-BUILDER-HASH:1400831888

--- a/modules/util/portal-tools-service-builder-test-compat730-api/src/main/java/com/liferay/portal/tools/service/builder/test/compat730/service/LocalizedEntryLocalServiceWrapper.java
+++ b/modules/util/portal-tools-service-builder-test-compat730-api/src/main/java/com/liferay/portal/tools/service/builder/test/compat730/service/LocalizedEntryLocalServiceWrapper.java
@@ -45,6 +45,18 @@ public class LocalizedEntryLocalServiceWrapper
 		return _localizedEntryLocalService.addLocalizedEntry(localizedEntry);
 	}
 
+	@Override
+	public com.liferay.portal.tools.service.builder.test.compat730.model.
+		LocalizedEntryLocalization addLocalizedEntryLocalization(
+				com.liferay.portal.tools.service.builder.test.compat730.model.
+					LocalizedEntry localizedEntry,
+				String languageId, String title, String content)
+			throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _localizedEntryLocalService.addLocalizedEntryLocalization(
+			localizedEntry, languageId, title, content);
+	}
+
 	/**
 	 * Creates a new localized entry with the primary key. Does not add the localized entry to the database.
 	 *
@@ -398,4 +410,4 @@ public class LocalizedEntryLocalServiceWrapper
 	private LocalizedEntryLocalService _localizedEntryLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-195580891
+// LIFERAY-SERVICE-BUILDER-HASH:-1688979556

--- a/modules/util/portal-tools-service-builder-test-compat730-service/src/main/java/com/liferay/portal/tools/service/builder/test/compat730/service/base/LocalizedEntryLocalServiceBaseImpl.java
+++ b/modules/util/portal-tools-service-builder-test-compat730-service/src/main/java/com/liferay/portal/tools/service/builder/test/compat730/service/base/LocalizedEntryLocalServiceBaseImpl.java
@@ -359,6 +359,19 @@ public abstract class LocalizedEntryLocalServiceBaseImpl
 	}
 
 	@Override
+	public LocalizedEntryLocalization addLocalizedEntryLocalization(
+			LocalizedEntry localizedEntry, String languageId, String title,
+			String content)
+		throws PortalException {
+
+		localizedEntry = localizedEntryPersistence.findByPrimaryKey(
+			localizedEntry.getPrimaryKey());
+
+		return _updateLocalizedEntryLocalization(
+			localizedEntry, null, languageId, title, content);
+	}
+
+	@Override
 	public LocalizedEntryLocalization fetchLocalizedEntryLocalization(
 		long localizedEntryId, String languageId) {
 
@@ -696,4 +709,4 @@ public abstract class LocalizedEntryLocalServiceBaseImpl
 		persistedModelLocalServiceRegistry;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-170775475
+// LIFERAY-SERVICE-BUILDER-HASH:-1776313447

--- a/modules/util/portal-tools-service-builder-test-compat740-api/src/main/java/com/liferay/portal/tools/service/builder/test/compat740/service/LocalizedEntryLocalService.java
+++ b/modules/util/portal-tools-service-builder-test-compat740-api/src/main/java/com/liferay/portal/tools/service/builder/test/compat740/service/LocalizedEntryLocalService.java
@@ -68,6 +68,11 @@ public interface LocalizedEntryLocalService
 	@Indexable(type = IndexableType.REINDEX)
 	public LocalizedEntry addLocalizedEntry(LocalizedEntry localizedEntry);
 
+	public LocalizedEntryLocalization addLocalizedEntryLocalization(
+			LocalizedEntry localizedEntry, String languageId, String title,
+			String content)
+		throws PortalException;
+
 	/**
 	 * Creates a new localized entry with the primary key. Does not add the localized entry to the database.
 	 *
@@ -284,4 +289,4 @@ public interface LocalizedEntryLocalService
 		throws PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1549432738
+// LIFERAY-SERVICE-BUILDER-HASH:-870357389

--- a/modules/util/portal-tools-service-builder-test-compat740-api/src/main/java/com/liferay/portal/tools/service/builder/test/compat740/service/LocalizedEntryLocalServiceUtil.java
+++ b/modules/util/portal-tools-service-builder-test-compat740-api/src/main/java/com/liferay/portal/tools/service/builder/test/compat740/service/LocalizedEntryLocalServiceUtil.java
@@ -54,6 +54,16 @@ public class LocalizedEntryLocalServiceUtil {
 		return getService().addLocalizedEntry(localizedEntry);
 	}
 
+	public static com.liferay.portal.tools.service.builder.test.compat740.model.
+		LocalizedEntryLocalization addLocalizedEntryLocalization(
+				LocalizedEntry localizedEntry, String languageId, String title,
+				String content)
+			throws PortalException {
+
+		return getService().addLocalizedEntryLocalization(
+			localizedEntry, languageId, title, content);
+	}
+
 	/**
 	 * Creates a new localized entry with the primary key. Does not add the localized entry to the database.
 	 *
@@ -346,4 +356,4 @@ public class LocalizedEntryLocalServiceUtil {
 			LocalizedEntryLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1066130764
+// LIFERAY-SERVICE-BUILDER-HASH:-257675382

--- a/modules/util/portal-tools-service-builder-test-compat740-api/src/main/java/com/liferay/portal/tools/service/builder/test/compat740/service/LocalizedEntryLocalServiceWrapper.java
+++ b/modules/util/portal-tools-service-builder-test-compat740-api/src/main/java/com/liferay/portal/tools/service/builder/test/compat740/service/LocalizedEntryLocalServiceWrapper.java
@@ -49,6 +49,18 @@ public class LocalizedEntryLocalServiceWrapper
 		return _localizedEntryLocalService.addLocalizedEntry(localizedEntry);
 	}
 
+	@Override
+	public com.liferay.portal.tools.service.builder.test.compat740.model.
+		LocalizedEntryLocalization addLocalizedEntryLocalization(
+				com.liferay.portal.tools.service.builder.test.compat740.model.
+					LocalizedEntry localizedEntry,
+				String languageId, String title, String content)
+			throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _localizedEntryLocalService.addLocalizedEntryLocalization(
+			localizedEntry, languageId, title, content);
+	}
+
 	/**
 	 * Creates a new localized entry with the primary key. Does not add the localized entry to the database.
 	 *
@@ -414,4 +426,4 @@ public class LocalizedEntryLocalServiceWrapper
 	private LocalizedEntryLocalService _localizedEntryLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:533575112
+// LIFERAY-SERVICE-BUILDER-HASH:-61685433

--- a/modules/util/portal-tools-service-builder-test-compat740-service/src/main/java/com/liferay/portal/tools/service/builder/test/compat740/service/base/LocalizedEntryLocalServiceBaseImpl.java
+++ b/modules/util/portal-tools-service-builder-test-compat740-service/src/main/java/com/liferay/portal/tools/service/builder/test/compat740/service/base/LocalizedEntryLocalServiceBaseImpl.java
@@ -380,6 +380,19 @@ public abstract class LocalizedEntryLocalServiceBaseImpl
 	}
 
 	@Override
+	public LocalizedEntryLocalization addLocalizedEntryLocalization(
+			LocalizedEntry localizedEntry, String languageId, String title,
+			String content)
+		throws PortalException {
+
+		localizedEntry = localizedEntryPersistence.findByPrimaryKey(
+			localizedEntry.getPrimaryKey());
+
+		return _updateLocalizedEntryLocalization(
+			localizedEntry, null, languageId, title, content);
+	}
+
+	@Override
 	public LocalizedEntryLocalization fetchLocalizedEntryLocalization(
 		long localizedEntryId, String languageId) {
 
@@ -625,4 +638,4 @@ public abstract class LocalizedEntryLocalServiceBaseImpl
 		LocalizedEntryLocalServiceBaseImpl.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2131819832
+// LIFERAY-SERVICE-BUILDER-HASH:-168384492

--- a/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/service/base/LVEntryLocalServiceBaseImpl.java
+++ b/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/service/base/LVEntryLocalServiceBaseImpl.java
@@ -558,6 +558,25 @@ public abstract class LVEntryLocalServiceBaseImpl
 	}
 
 	@Override
+	public LVEntryLocalization addLVEntryLocalization(
+			LVEntry draftLVEntry, String languageId, String title,
+			String content)
+		throws PortalException {
+
+		draftLVEntry = lvEntryPersistence.findByPrimaryKey(
+			draftLVEntry.getPrimaryKey());
+
+		if (draftLVEntry.isHead()) {
+			throw new IllegalArgumentException(
+				"Can only update draft entries " +
+					draftLVEntry.getPrimaryKey());
+		}
+
+		return _updateLVEntryLocalization(
+			draftLVEntry, null, languageId, title, content);
+	}
+
+	@Override
 	public LVEntryLocalization fetchLVEntryLocalization(
 		long lvEntryId, String languageId) {
 
@@ -1514,4 +1533,4 @@ public abstract class LVEntryLocalServiceBaseImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1540283516
+// LIFERAY-SERVICE-BUILDER-HASH:-1420983648

--- a/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/service/base/LocalizedEntryLocalServiceBaseImpl.java
+++ b/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/service/base/LocalizedEntryLocalServiceBaseImpl.java
@@ -378,6 +378,19 @@ public abstract class LocalizedEntryLocalServiceBaseImpl
 	}
 
 	@Override
+	public LocalizedEntryLocalization addLocalizedEntryLocalization(
+			LocalizedEntry localizedEntry, String languageId, String title,
+			String content)
+		throws PortalException {
+
+		localizedEntry = localizedEntryPersistence.findByPrimaryKey(
+			localizedEntry.getPrimaryKey());
+
+		return _updateLocalizedEntryLocalization(
+			localizedEntry, null, languageId, title, content);
+	}
+
+	@Override
 	public LocalizedEntryLocalization fetchLocalizedEntryLocalization(
 		long localizedEntryId, String languageId) {
 
@@ -704,4 +717,4 @@ public abstract class LocalizedEntryLocalServiceBaseImpl
 		LocalizedEntryLocalServiceBaseImpl.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1033473168
+// LIFERAY-SERVICE-BUILDER-HASH:1120709084

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/LVEntryTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/LVEntryTest.java
@@ -46,6 +46,36 @@ public class LVEntryTest {
 		new LiferayIntegrationTestRule();
 
 	@Test
+	public void testAddLVEntryLocalization() throws Exception {
+		LVEntry draftLVEntry = _versionService.create();
+
+		draftLVEntry = _versionService.updateDraft(draftLVEntry);
+
+		LVEntryLocalization lvEntryLocalization =
+			_lvEntryLocalService.addLVEntryLocalization(
+				draftLVEntry, _LANGUAGE_ID_1, _TITLE_1, _CONTENT_1);
+
+		Assert.assertEquals(
+			lvEntryLocalization,
+			_lvEntryLocalService.fetchLVEntryLocalization(
+				draftLVEntry.getPrimaryKey(), _LANGUAGE_ID_1));
+
+		_lvEntry = _versionService.publishDraft(draftLVEntry);
+
+		try {
+			_lvEntryLocalService.addLVEntryLocalization(
+				_lvEntry, _LANGUAGE_ID_2, _TITLE_2, _CONTENT_2);
+
+			Assert.fail();
+		}
+		catch (IllegalArgumentException illegalArgumentException) {
+			Assert.assertEquals(
+				"Can only update draft entries " + _lvEntry.getPrimaryKey(),
+				illegalArgumentException.getMessage());
+		}
+	}
+
+	@Test
 	public void testCheckout() throws Exception {
 		LVEntry draftLVEntry = _versionService.create();
 

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/LocalizedEntryTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/LocalizedEntryTest.java
@@ -1,0 +1,59 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.tools.service.builder.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.tools.service.builder.test.model.LocalizedEntry;
+import com.liferay.portal.tools.service.builder.test.model.LocalizedEntryLocalization;
+import com.liferay.portal.tools.service.builder.test.service.LocalizedEntryLocalService;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Shuyang Zhou
+ */
+@RunWith(Arquillian.class)
+public class LocalizedEntryTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testAddLocalizedEntryLocalization() throws Exception {
+		_localizedEntry = _localizedEntryLocalService.addLocalizedEntry(
+			_localizedEntryLocalService.createLocalizedEntry(
+				RandomTestUtil.nextLong()));
+
+		LocalizedEntryLocalization localizedEntryLocalization =
+			_localizedEntryLocalService.addLocalizedEntryLocalization(
+				_localizedEntry, "en_US", "Title", "Content");
+
+		Assert.assertEquals(
+			localizedEntryLocalization,
+			_localizedEntryLocalService.fetchLocalizedEntryLocalization(
+				_localizedEntry.getLocalizedEntryId(), "en_US"));
+		Assert.assertEquals("Title", localizedEntryLocalization.getTitle());
+		Assert.assertEquals("Content", localizedEntryLocalization.getContent());
+	}
+
+	@DeleteAfterTestRun
+	private LocalizedEntry _localizedEntry;
+
+	@Inject
+	private LocalizedEntryLocalService _localizedEntryLocalService;
+
+}

--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/service_base_impl.ftl
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/service_base_impl.ftl
@@ -1256,7 +1256,44 @@ import org.osgi.service.component.annotations.Reference;
 			localizedEntity = entity.localizedEntity
 			localizedEntityColumns = entity.localizedEntityColumns
 			pkEntityColumn = entity.PKEntityColumns?first
+
+			entityVariableName = entity.variableName
 		/>
+
+		<#if entity.versionEntity??>
+			<#assign entityVariableName = "draft" + entity.name />
+		</#if>
+
+		@Override
+		public ${localizedEntity.name} add${localizedEntity.name}(
+			${entity.name} ${entityVariableName}, String languageId,
+			<#list localizedEntityColumns as entityColumn>
+				String ${entityColumn.name}
+
+				<#if entityColumn?has_next>
+					,
+				</#if>
+			</#list>
+			) throws PortalException {
+
+			${entityVariableName} = ${entity.variableName}Persistence.findByPrimaryKey(${entityVariableName}.getPrimaryKey());
+
+			<#if entity.versionEntity??>
+				if (${entityVariableName}.isHead()) {
+					throw new IllegalArgumentException("Can only update draft entries " + ${entityVariableName}.getPrimaryKey());
+				}
+			</#if>
+
+			return _update${localizedEntity.name}(${entityVariableName}, null, languageId,
+				<#list localizedEntityColumns as entityColumn>
+					${entityColumn.name}
+
+					<#if entityColumn?has_next>
+						,
+					</#if>
+				</#list>
+			);
+		}
 
 		@Override
 		public ${localizedEntity.name} fetch${localizedEntity.name}(${entity.PKClassName} ${entity.PKVariableName}, String languageId) {
@@ -1272,12 +1309,6 @@ import org.osgi.service.component.annotations.Reference;
 		public List<${localizedEntity.name}> get${localizedEntity.pluralName}(${entity.PKClassName} ${entity.PKVariableName}) {
 			return ${localizedEntity.variableName}Persistence.findBy${pkEntityColumn.methodName}(${entity.PKVariableName});
 		}
-
-		<#assign entityVariableName = entity.variableName />
-
-		<#if entity.versionEntity??>
-			<#assign entityVariableName = "draft" + entity.name />
-		</#if>
 
 		@Override
 		public ${localizedEntity.name} update${localizedEntity.name}(

--- a/portal-impl/src/com/liferay/portal/service/base/CountryLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/CountryLocalServiceBaseImpl.java
@@ -489,6 +489,16 @@ public abstract class CountryLocalServiceBaseImpl
 	}
 
 	@Override
+	public CountryLocalization addCountryLocalization(
+			Country country, String languageId, String title)
+		throws PortalException {
+
+		country = countryPersistence.findByPrimaryKey(country.getPrimaryKey());
+
+		return _updateCountryLocalization(country, null, languageId, title);
+	}
+
+	@Override
 	public CountryLocalization fetchCountryLocalization(
 		long countryId, String languageId) {
 
@@ -796,4 +806,4 @@ public abstract class CountryLocalServiceBaseImpl
 		CountryLocalServiceBaseImpl.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-617478071
+// LIFERAY-SERVICE-BUILDER-HASH:-586058939

--- a/portal-impl/src/com/liferay/portal/service/base/RegionLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/RegionLocalServiceBaseImpl.java
@@ -485,6 +485,16 @@ public abstract class RegionLocalServiceBaseImpl
 	}
 
 	@Override
+	public RegionLocalization addRegionLocalization(
+			Region region, String languageId, String title)
+		throws PortalException {
+
+		region = regionPersistence.findByPrimaryKey(region.getPrimaryKey());
+
+		return _updateRegionLocalization(region, null, languageId, title);
+	}
+
+	@Override
 	public RegionLocalization fetchRegionLocalization(
 		long regionId, String languageId) {
 
@@ -790,4 +800,4 @@ public abstract class RegionLocalServiceBaseImpl
 		RegionLocalServiceBaseImpl.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1748132497
+// LIFERAY-SERVICE-BUILDER-HASH:833686909

--- a/portal-kernel/src/com/liferay/portal/kernel/service/CountryLocalService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/CountryLocalService.java
@@ -88,6 +88,10 @@ public interface CountryLocalService
 			boolean zipRequired, ServiceContext serviceContext)
 		throws PortalException;
 
+	public CountryLocalization addCountryLocalization(
+			Country country, String languageId, String title)
+		throws PortalException;
+
 	/**
 	 * Creates a new country with the primary key. Does not add the country to the database.
 	 *
@@ -431,4 +435,4 @@ public interface CountryLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2003063802
+// LIFERAY-SERVICE-BUILDER-HASH:987180304

--- a/portal-kernel/src/com/liferay/portal/kernel/service/CountryLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/CountryLocalServiceUtil.java
@@ -64,6 +64,14 @@ public class CountryLocalServiceUtil {
 			serviceContext);
 	}
 
+	public static com.liferay.portal.kernel.model.CountryLocalization
+			addCountryLocalization(
+				Country country, String languageId, String title)
+		throws PortalException {
+
+		return getService().addCountryLocalization(country, languageId, title);
+	}
+
 	/**
 	 * Creates a new country with the primary key. Does not add the country to the database.
 	 *
@@ -518,4 +526,4 @@ public class CountryLocalServiceUtil {
 	private static volatile CountryLocalService _service;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:429553285
+// LIFERAY-SERVICE-BUILDER-HASH:1629884040

--- a/portal-kernel/src/com/liferay/portal/kernel/service/CountryLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/CountryLocalServiceWrapper.java
@@ -57,6 +57,16 @@ public class CountryLocalServiceWrapper
 			serviceContext);
 	}
 
+	@Override
+	public com.liferay.portal.kernel.model.CountryLocalization
+			addCountryLocalization(
+				Country country, String languageId, String title)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _countryLocalService.addCountryLocalization(
+			country, languageId, title);
+	}
+
 	/**
 	 * Creates a new country with the primary key. Does not add the country to the database.
 	 *
@@ -608,4 +618,4 @@ public class CountryLocalServiceWrapper
 	private CountryLocalService _countryLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1975640055
+// LIFERAY-SERVICE-BUILDER-HASH:668921470

--- a/portal-kernel/src/com/liferay/portal/kernel/service/RegionLocalService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/RegionLocalService.java
@@ -88,6 +88,10 @@ public interface RegionLocalService
 			ServiceContext serviceContext)
 		throws PortalException;
 
+	public RegionLocalization addRegionLocalization(
+			Region region, String languageId, String title)
+		throws PortalException;
+
 	/**
 	 * @throws PortalException
 	 */
@@ -405,4 +409,4 @@ public interface RegionLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-751349059
+// LIFERAY-SERVICE-BUILDER-HASH:-402038845

--- a/portal-kernel/src/com/liferay/portal/kernel/service/RegionLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/RegionLocalServiceUtil.java
@@ -62,6 +62,14 @@ public class RegionLocalServiceUtil {
 			regionCode, serviceContext);
 	}
 
+	public static com.liferay.portal.kernel.model.RegionLocalization
+			addRegionLocalization(
+				Region region, String languageId, String title)
+		throws PortalException {
+
+		return getService().addRegionLocalization(region, languageId, title);
+	}
+
 	/**
 	 * @throws PortalException
 	 */
@@ -475,4 +483,4 @@ public class RegionLocalServiceUtil {
 	private static volatile RegionLocalService _service;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-710628756
+// LIFERAY-SERVICE-BUILDER-HASH:-1916021605

--- a/portal-kernel/src/com/liferay/portal/kernel/service/RegionLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/RegionLocalServiceWrapper.java
@@ -55,6 +55,16 @@ public class RegionLocalServiceWrapper
 			regionCode, serviceContext);
 	}
 
+	@Override
+	public com.liferay.portal.kernel.model.RegionLocalization
+			addRegionLocalization(
+				Region region, String languageId, String title)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _regionLocalService.addRegionLocalization(
+			region, languageId, title);
+	}
+
 	/**
 	 * @throws PortalException
 	 */
@@ -556,4 +566,4 @@ public class RegionLocalServiceWrapper
 	private RegionLocalService _regionLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:185711684
+// LIFERAY-SERVICE-BUILDER-HASH:-896386275

--- a/portal-kernel/src/com/liferay/portal/kernel/service/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/packageinfo
@@ -1,1 +1,1 @@
-version 54.1.0
+version 54.2.0


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-105636

Part of the object entry page optimization tracked under LPD-65366 (LPD-98910 scenario, adding object entries). Independent of the other in-flight changes; the Service Builder change is generic and the friendly URL service is its first user.

## What Is Being Fixed

For every entity with a `<localized-entity>`, Service Builder generates `update<Localized>(entity, languageId, values)` as the only way a service can write one localization row, and that method always looks the existing row up by entity id and language before deciding between create and update. A service that has just created the entity knows no row can exist, yet the lookup still runs against the database: a unique finder has nothing cached for an id nobody has seen. `FriendlyURLEntryLocalServiceImpl.addFriendlyURLEntry` takes that path for every new friendly URL entry, so every add of an object entry paid one select per language for nothing.

## How It Is Being Fixed

- `service_base_impl.ftl` emits `add<Localized>(entity, languageId, values)` next to the update method. It reloads the entity, rejects a head for versioned entities exactly like the update method, and goes straight to the shared private create.
- Every localized entity is regenerated: `FriendlyURLEntry`, `CPDefinition`, `CommerceTermEntry`, `Country`, `Region` and the builder's test beds, including the compat test beds that `ant build-services` skips. The regeneration is limited to the new method; a pre-existing hash-trailer drift of the compat720 and compat730 persistence classes from LPD-96060 is deliberately left out.
- `Semantic versioning` carries the minor bumps bnd asked for: commerce-term-api 10.1.0 with its service package 5.2.0, the friendly URL service package 4.3.0, and the portal-kernel service package 54.2.0.
- `addFriendlyURLEntry` uses the generated `addFriendlyURLEntryLocalization` for the localizations of a new entry through a flag on `_updateFriendlyURLEntryLocalizations`; the update path keeps the probing method, since an existing entry may already own a row for that language.

## Verification

- Builder test bed: `LocalizedEntryTest.testAddLocalizedEntryLocalization` reads the row back through the existing fetch, and `LVEntryTest.testAddLVEntryLocalization` covers the draft path and the head rejection.
- On a fresh bundle built from this branch: the friendly-url test module (238), the builder test bed tests (18) and `ObjectEntryLocalServiceTest` (93) pass, 349 tests, no log errors; Service Builder regeneration of every module shows zero drift.
- Self-CI on shuyangzhou/liferay-portal PR 12766 (same content): `ci:test:object` 49/49; `ci:test:stable` 13/16 where all misses are the log assertor on master noise (the smoke test's `DesignLibraryFeatureFlagListener` `RoleSubtypeException` and design library "has no path" errors, and the demo data creator bundle's boot-order race), the same assertor a bare-master stable run fails; `ci:test:relevant` 185/264 on the previous base with the chronic set only (`HeadlessBuilderResourceTest`, `LayoutExportImportTest`, `SXPBlueprint*`, `IndexWriterHelperImplTest`, the page editor and site initializer Playwright specs), the rerun on this base still in flight.

## PR Check

**pr-check: PASS** — tested on `0ed18b54e051e85206a94775fc8bcc416f00fa71`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Service Registration | PASS |
| Transaction Usage | PASS |
| Full Portal Build | NOT VERIFIED |
| Per-Module Compile | PASS (17 modules, `assemble` in place of `deploy`) |
| Integration Test Compile | PASS (8 of 66 affected modules, cap) |
| Cross-Module Compile | NOT VERIFIED (39 consumers exceed the cap) |
| Baseline | PASS (baseline-all + portal-kernel + 3 changed exporting modules) |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

Service Builder: `ant build-services` regenerated 529 entities with a clean tree; the compat test beds regenerated with `-Pbuild.service.compat` show only the pre-existing LPD-96060 hash-trailer drift of compat720 and compat730, which is not part of this branch. Source Format ran with the commit message validation. Full Portal Build was not run because the worktree has no bundle of its own; its compile half is covered by `ant compile install-portal-snapshots` and by the 17 module compiles, whose outputs were checked with `javap` for the newly generated methods. Cross-Module Compile skipped its expansion by its own cap rule; the branch removes no public or protected member. Baseline's only finding is inherited master debt in `portal-test` (`com.liferay.portal.kernel.test.util` excessive increase); the branch's carried bumps (commerce-term-api 10.1.0 with its service package 5.2.0, the friendly URL service package 4.3.0, the portal-kernel service package 54.2.0) are exactly what bnd requires and nothing was rewritten. Java Unit Tests ran the one counterpart green; the behaviour is covered by the builder test bed's `LocalizedEntryTest` and `LVEntryTest`, the friendly-url module and `ObjectEntryLocalServiceTest`, 349 tests green on a fresh bundle built from this content.

<!-- pr-check {"result": "success", "sha": "0ed18b54e051e85206a94775fc8bcc416f00fa71"} -->
