### PR TITLE
LPD-103976 Capture the design library error the file initializer logs

### DIFF
--- a/modules/test/portal-smoke-test/src/testIntegration/java/com/liferay/portal/smoke/test/BundleSiteInitializerTest.java
+++ b/modules/test/portal-smoke-test/src/testIntegration/java/com/liferay/portal/smoke/test/BundleSiteInitializerTest.java
@@ -516,13 +516,25 @@ public class BundleSiteInitializerTest {
 		File tempDir2 = _getTempDir(
 			"/com.liferay.site.initializer.extender.test.bundle.2.jar");
 
-		try {
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.site.initializer.extender.internal." +
+					"BundleSiteInitializer",
+				LoggerTestUtil.ERROR)) {
+
 			_test1(
 				_siteInitializerFactory.create(
 					new File(tempDir1, "site-initializer"), null));
 			_test2(
 				_siteInitializerFactory.create(
 					new File(tempDir2, "site-initializer"), null));
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertTrue(
+				logEntries.toString(),
+				_hasLogEntryMessage(
+					logEntries,
+					"Design library Test Design Library 1 has no path"));
 		}
 		finally {
 			FileUtil.deltree(tempDir1);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103976

## What Is Being Fixed

The stable upstream suite fails on the master range that carries LPD-103976: `modules-integration-postgresql163_stable` runs `portal-smoke-test`, and `PortalLogAssertorTest` finds this line in the portal log:

```
ERROR [com.liferay.portal.smoke.test-executor-thread][BundleSiteInitializer:5943] Design library Test Design Library 1 has no path
```

The line is logged while `BundleSiteInitializerTest#testInitializeFromFile` initializes the second test bundle. Its `fragments/design-libraries/design-libraries.json` deliberately carries a "Test Design Library 1" entry with an empty path (added by 958e7878824302eaa95ab68a8ab8c5dfcdf46004 to cover that branch), and `BundleSiteInitializer` logs it at ERROR and skips it. `testInitializeFromBundle` runs the same fixture inside a `LogCapture` on the `BundleSiteInitializer` logger, which turns off the logger's additivity and keeps the entry out of the portal log, but `testInitializeFromFile` ran without one, so the ERROR reached the log.

## How It Is Being Fixed

`testInitializeFromFile` now wraps the two file initializers in the same `LogCapture`, at ERROR, and asserts the "has no path" entry, which also makes the empty path coverage explicit. Test change only.

cc @jkappler, author of the fixture commit.

Fork CI: `ci:test:stable` on https://github.com/shuyangzhou/liferay-portal/pull/12772 passed 15 of 15 jobs on this head (build 1891 on test-1-46), with `modules-integration-postgresql163_stable/0/0` green and no ERROR or WARN in its portal log.

## PR Check

**pr-check: PASS** — tested on `0d0d04fa02db10dcdecf8466fc280753f0e1ce56`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Service Registration | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | NOT VERIFIED |
| Integration Test Compile | PASS |
| Baseline | NOT VERIFIED |
| Java Unit Tests | NOT VERIFIED |

Per-Module Compile verified nothing. The only changed module, `modules/test/portal-smoke-test`, changes Java under `src/testIntegration` alone, which the validation excludes from the deploy set because a `-test` module deploys no runtime bundle; Integration Test Compile covers it.

Baseline verified nothing locally, since `baseline-all` was not run. The diff changes no module with an `Export-Package`, no `bnd.bnd` and no `packageinfo`, and the Local Version Check finds no exported API change. The `semantic-versioning` batch of the fork `ci:test:stable` run on this SHA passed 597 of 597.

Java Unit Tests verified nothing. `BundleSiteInitializerTest` is itself the integration test of `portal-smoke-test`, which has no `src/test` tree, so no unit test exercises the change.

<!-- pr-check {"result": "success", "sha": "0d0d04fa02db10dcdecf8466fc280753f0e1ce56"} -->
