### PR TITLE
LPD-105641 Read the id of an attachment DTO without serializing it

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/field/business/type/AttachmentObjectFieldBusinessType.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/field/business/type/AttachmentObjectFieldBusinessType.java
@@ -480,6 +480,14 @@ public class AttachmentObjectFieldBusinessType
 	}
 
 	private Object _getFileEntryId(Object value) throws PortalException {
+		if (value instanceof FileEntry fileEntry) {
+			long fileEntryId = GetterUtil.getLong(fileEntry.getId());
+
+			if (fileEntryId > 0) {
+				return fileEntryId;
+			}
+		}
+
 		long fileEntryId = GetterUtil.getLong(value);
 
 		if (fileEntryId > 0) {

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/field/business/type/test/AttachmentObjectFieldBusinessTypeTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/field/business/type/test/AttachmentObjectFieldBusinessTypeTest.java
@@ -1,0 +1,76 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.internal.field.business.type.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.field.business.type.ObjectFieldBusinessType;
+import com.liferay.object.field.business.type.ObjectFieldBusinessTypeRegistry;
+import com.liferay.object.model.ObjectField;
+import com.liferay.object.rest.dto.v1_0.FileEntry;
+import com.liferay.object.service.ObjectFieldLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.Collections;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Shuyang Zhou
+ */
+@RunWith(Arquillian.class)
+public class AttachmentObjectFieldBusinessTypeTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testGetValueWithFileEntry() throws Exception {
+		ObjectField objectField = _objectFieldLocalService.createObjectField(0);
+
+		objectField.setName("attachment");
+
+		long fileEntryId = RandomTestUtil.randomLong();
+
+		FileEntry fileEntry = new FileEntry() {
+			{
+				setId(() -> fileEntryId);
+				setMetadata(
+					() -> {
+						throw new AssertionError(
+							"The metadata of the attachment was resolved");
+					});
+			}
+		};
+
+		ObjectFieldBusinessType objectFieldBusinessType =
+			_objectFieldBusinessTypeRegistry.getObjectFieldBusinessType(
+				ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT);
+
+		Assert.assertEquals(
+			fileEntryId,
+			objectFieldBusinessType.getValue(
+				null, objectField, TestPropsValues.getUserId(),
+				Collections.singletonMap("attachment", fileEntry)));
+	}
+
+	@Inject
+	private ObjectFieldBusinessTypeRegistry _objectFieldBusinessTypeRegistry;
+
+	@Inject
+	private ObjectFieldLocalService _objectFieldLocalService;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-105641

Object entry update optimization tracked under LPD-65366 (LPD-98910 scenario: editing an object entry that carries an attachment field without touching the attachment).

## What Is Being Fixed

A partial update of an object entry keeps the current value of every field it does not touch, and for an attachment field that current value is the `FileEntry` DTO the entry was read with. `AttachmentObjectFieldBusinessType._getFileEntryId` turned that DTO into a number by stringifying it, which ran `FileEntry.toString`, resolved every lazy supplier of the DTO, and read the file entry's `DLFileEntryMetadata` rows for a value the update was never going to store.

## How It Is Being Fixed

`_getFileEntryId` reads the id of a `FileEntry` DTO directly and falls through to the existing number, map and string handling for every other input.

## Verification

- `AttachmentObjectFieldBusinessTypeTest.testGetValueWithFileEntry` passes a `FileEntry` whose metadata supplier throws; it fails on the parent commit through `FileEntry.toString` and passes with the change, verified on an isolated bundle.
- Self-CI on shuyangzhou/liferay-portal PR 12773: `ci:test:object` 49 of 49. The `ci:test:stable` and `ci:test:relevant` runs of that night executed against the then-frozen upstream base; every one of their failures was attributed to that base or to infrastructure, none reaches the changed code, and both suites were re-fired on the synced base.

## PR Check

**pr-check: PASS** — tested on `5c81f3638901b4c3b1fcb77c075b132ea59f27d4`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Service Registration | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS (baseline-all + seven Ant projects; 0 changed exporting modules) |
| Java Unit Tests | NOT VERIFIED |

Per-Module Compile ran `compileJava` and `jar` in place of `deploy` (no bundle in the verification worktree); the built bundle carries the new `instanceof FileEntry` fast path. Baseline reported only the inherited `portal-test` `com.liferay.portal.kernel.test.util` excessive-increase finding, outside this diff, restored and not counted. Java Unit Tests: the changed class has no unit counterpart; it is covered by the new integration test `AttachmentObjectFieldBusinessTypeTest`.

<!-- pr-check {"result": "success", "sha": "5c81f3638901b4c3b1fcb77c075b132ea59f27d4"} -->
