### PR TITLE
LPD-105642 Skip the locale ordering of a single URL title

### DIFF
--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
@@ -902,6 +902,10 @@ public class FriendlyURLEntryLocalServiceImpl
 	private Map<String, String> _sortUrlTitleMap(
 		long groupId, Map<String, String> urlTitleMap) {
 
+		if (urlTitleMap.size() <= 1) {
+			return urlTitleMap;
+		}
+
 		Map<String, String> sortedUrlTitleMap = new LinkedHashMap<>();
 
 		for (Locale locale : _language.getAvailableLocales(groupId)) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-105642

Friendly URL optimization tracked under LPD-65366 (LPD-98910 scenario: saving an object entry, which writes its single-language friendly URL title).

## What Is Being Fixed

`FriendlyURLEntryLocalServiceImpl` reorders the URL title map by the group's available languages before writing its localizations, so that they are created in the site's language order. A map with a single entry has nothing to order, yet every single-language save still paid the group lookup, the inherit-locales check and the company or group locale set behind `Language.getAvailableLocales`, plus a rebuilt map.

## How It Is Being Fixed

`_sortUrlTitleMap` returns a map of at most one entry as is. Every caller places the default language in the map, so a single entry is always the default-language title, and the loop's side effect of dropping a language the site does not have cannot apply to it.

## Verification

- The existing `FriendlyURLEntryLocalServiceTest` single-title cases exercise the new branch; the whole friendly-url integration module passes, 238 of 238, on an isolated bundle carrying the change, and `FriendlyURLEntryLocalServiceImplTest` drives a one-entry map through it as a unit test.
- Self-CI on shuyangzhou/liferay-portal PR 12774: `ci:test:object` 49 of 49. The `ci:test:stable` and `ci:test:relevant` runs of that night executed against the then-frozen upstream base and failed only on the master noise shared by every pull request of that night; all three suites were re-fired on the synced base after the rebase onto the current brianchandotcom master.

## PR Check

**pr-check: PASS** — tested on `221e28e805dad36dbeaeadddd96117be3d210885`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Service Registration | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS (baseline-all + seven Ant projects + 0 changed exporting modules) |
| Java Unit Tests | PASS |

Service Builder regenerated friendly-url-service with zero drift. Per-Module Compile ran `compileJava` and `jar` in place of `deploy` (no bundle in the verification worktree). Java Unit Tests: `FriendlyURLEntryLocalServiceImplTest` passes and drives a one-entry title map through the new early return.

<!-- pr-check {"result": "success", "sha": "221e28e805dad36dbeaeadddd96117be3d210885"} -->
