### PR TITLE
LPD-105630 Drop the language from getUniqueUrlTitle

### DIFF
--- a/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/model/listener/AssetCategoryFriendlyURLModelListener.java
+++ b/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/model/listener/AssetCategoryFriendlyURLModelListener.java
@@ -103,8 +103,7 @@ public class AssetCategoryFriendlyURLModelListener
 					_friendlyURLEntryLocalService.getUniqueUrlTitle(
 						assetCategory.getGroupId(), classNameId, parentClassPK,
 						assetCategory.getCategoryId(),
-						friendlyURLEntryLocalization.getUrlTitle(),
-						friendlyURLEntryLocalization.getLanguageId()));
+						friendlyURLEntryLocalization.getUrlTitle()));
 			}
 
 			_friendlyURLEntryLocalService.updateFriendlyURLEntry(

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/upgrade/v1_1_0/BlogsEntryUpgradeProcess.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/upgrade/v1_1_0/BlogsEntryUpgradeProcess.java
@@ -58,7 +58,7 @@ public class BlogsEntryUpgradeProcess extends UpgradeProcess {
 
 				if (existingFriendlyURLEntry != null) {
 					urlTitle = _friendlyURLEntryLocalService.getUniqueUrlTitle(
-						groupId, classNameId, classPK, urlTitle, null);
+						groupId, classNameId, classPK, urlTitle);
 				}
 
 				urlTitle = _getUniqueUrlTitle(classPK, groupId, urlTitle);
@@ -98,7 +98,7 @@ public class BlogsEntryUpgradeProcess extends UpgradeProcess {
 
 		return _friendlyURLEntryLocalService.getUniqueUrlTitle(
 			groupId, _classNameLocalService.getClassNameId(BlogsEntry.class),
-			entryId, urlTitle, null);
+			entryId, urlTitle);
 	}
 
 	private final ClassNameLocalService _classNameLocalService;

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/upgrade/v3_1_1/BlogsFriendlyURLFormatUpgradeProcess.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/upgrade/v3_1_1/BlogsFriendlyURLFormatUpgradeProcess.java
@@ -55,7 +55,6 @@ public class BlogsFriendlyURLFormatUpgradeProcess extends UpgradeProcess {
 			while (resultSet.next()) {
 				long classPK = resultSet.getLong("classPK");
 				long groupId = resultSet.getLong("groupId");
-				String languageId = resultSet.getString("languageId");
 
 				String urlTitle = resultSet.getString("urlTitle");
 
@@ -66,7 +65,7 @@ public class BlogsFriendlyURLFormatUpgradeProcess extends UpgradeProcess {
 				}
 
 				urlTitle = _friendlyURLEntryLocalService.getUniqueUrlTitle(
-					groupId, classNameId, classPK, urlTitle, languageId);
+					groupId, classNameId, classPK, urlTitle);
 
 				if (StringUtil.equals(originalUrlTitle, urlTitle)) {
 					continue;
@@ -77,8 +76,8 @@ public class BlogsFriendlyURLFormatUpgradeProcess extends UpgradeProcess {
 					updatePreparedStatement, urlTitle);
 
 				_updateFriendlyURLEntry(
-					resultSet.getLong("friendlyURLEntryId"), languageId,
-					urlTitle);
+					resultSet.getLong("friendlyURLEntryId"),
+					resultSet.getString("languageId"), urlTitle);
 			}
 
 			updatePreparedStatement.executeBatch();

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsEntryLocalServiceImpl.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsEntryLocalServiceImpl.java
@@ -1886,7 +1886,7 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 		return _friendlyURLEntryLocalService.getUniqueUrlTitle(
 			entry.getGroupId(),
 			_classNameLocalService.getClassNameId(BlogsEntry.class),
-			entry.getEntryId(), urlTitle, null);
+			entry.getEntryId(), urlTitle);
 	}
 
 	private String _getURLTitle(long entryId) {

--- a/modules/apps/commerce/commerce-initializer-util/src/main/java/com/liferay/commerce/initializer/util/AssetCategoriesImporter.java
+++ b/modules/apps/commerce/commerce-initializer-util/src/main/java/com/liferay/commerce/initializer/util/AssetCategoriesImporter.java
@@ -311,7 +311,7 @@ public class AssetCategoriesImporter {
 				companyGroup.getGroupId(),
 				_portal.getClassNameId(AssetCategory.class),
 				_getParentClassPK(assetCategory), assetCategory.getCategoryId(),
-				titleEntry.getValue(), null);
+				titleEntry.getValue());
 
 			urlTitleMap.put(
 				LocaleUtil.toLanguageId(titleEntry.getKey()), urlTitle);

--- a/modules/apps/commerce/commerce-product-asset-categories-web/src/main/java/com/liferay/commerce/product/asset/categories/web/internal/portlet/action/EditAssetCategoryFriendlyURLMVCActionCommand.java
+++ b/modules/apps/commerce/commerce-product-asset-categories-web/src/main/java/com/liferay/commerce/product/asset/categories/web/internal/portlet/action/EditAssetCategoryFriendlyURLMVCActionCommand.java
@@ -98,7 +98,7 @@ public class EditAssetCategoryFriendlyURLMVCActionCommand
 				urlTitle = _friendlyURLEntryLocalService.getUniqueUrlTitle(
 					assetCategory.getGroupId(), classNameId,
 					_getParentClassPK(assetCategory),
-					assetCategory.getCategoryId(), urlTitle, null);
+					assetCategory.getCategoryId(), urlTitle);
 
 				newUrlTitleMap.put(LocaleUtil.toLanguageId(locale), urlTitle);
 			}

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPDefinitionLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPDefinitionLocalServiceImpl.java
@@ -3346,7 +3346,7 @@ public class CPDefinitionLocalServiceImpl
 				urlTitle = _friendlyURLEntryLocalService.getUniqueUrlTitle(
 					companyGroup.getGroupId(),
 					_classNameLocalService.getClassNameId(CProduct.class),
-					cpDefinition.getCProductId(), titleEntry.getValue(), null);
+					cpDefinition.getCProductId(), titleEntry.getValue());
 
 				newURLTitleMap.put(titleEntry.getKey(), urlTitle);
 			}

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/service/FriendlyURLDLFileEntryLocalServiceWrapper.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/service/FriendlyURLDLFileEntryLocalServiceWrapper.java
@@ -16,7 +16,6 @@ import com.liferay.friendly.url.service.FriendlyURLEntryLocalService;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.module.configuration.ConfigurationProviderUtil;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -24,7 +23,6 @@ import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.service.ServiceWrapper;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.FriendlyURLNormalizer;
-import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.io.File;
@@ -118,8 +116,7 @@ public class FriendlyURLDLFileEntryLocalServiceWrapper
 		String uniqueUrlTitle = _friendlyURLEntryLocalService.getUniqueUrlTitle(
 			dlFileEntry.getGroupId(),
 			_classNameLocalService.getClassNameId(FileEntry.class),
-			dlFileEntry.getFileEntryId(), urlTitle,
-			_language.getLanguageId(LocaleUtil.getSiteDefault()));
+			dlFileEntry.getFileEntryId(), urlTitle);
 
 		_friendlyURLEntryLocalService.addFriendlyURLEntry(
 			dlFileEntry.getGroupId(),
@@ -198,8 +195,5 @@ public class FriendlyURLDLFileEntryLocalServiceWrapper
 
 	@Reference
 	private FriendlyURLNormalizer _friendlyURLNormalizer;
-
-	@Reference
-	private Language _language;
 
 }

--- a/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/FriendlyURLEntryLocalService.java
+++ b/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/FriendlyURLEntryLocalService.java
@@ -419,12 +419,11 @@ public interface FriendlyURLEntryLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public String getUniqueUrlTitle(
 		long groupId, long classNameId, long parentClassPK, long classPK,
-		String urlTitle, String languageId);
+		String urlTitle);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public String getUniqueUrlTitle(
-		long groupId, long classNameId, long classPK, String urlTitle,
-		String languageId);
+		long groupId, long classNameId, long classPK, String urlTitle);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public Map<String, String> getUniqueUrlTitleMap(
@@ -530,4 +529,4 @@ public interface FriendlyURLEntryLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-550593190
+// LIFERAY-SERVICE-BUILDER-HASH:-134776500

--- a/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/FriendlyURLEntryLocalServiceUtil.java
+++ b/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/FriendlyURLEntryLocalServiceUtil.java
@@ -551,18 +551,17 @@ public class FriendlyURLEntryLocalServiceUtil {
 
 	public static String getUniqueUrlTitle(
 		long groupId, long classNameId, long parentClassPK, long classPK,
-		String urlTitle, String languageId) {
+		String urlTitle) {
 
 		return getService().getUniqueUrlTitle(
-			groupId, classNameId, parentClassPK, classPK, urlTitle, languageId);
+			groupId, classNameId, parentClassPK, classPK, urlTitle);
 	}
 
 	public static String getUniqueUrlTitle(
-		long groupId, long classNameId, long classPK, String urlTitle,
-		String languageId) {
+		long groupId, long classNameId, long classPK, String urlTitle) {
 
 		return getService().getUniqueUrlTitle(
-			groupId, classNameId, classPK, urlTitle, languageId);
+			groupId, classNameId, classPK, urlTitle);
 	}
 
 	public static Map<String, String> getUniqueUrlTitleMap(
@@ -734,4 +733,4 @@ public class FriendlyURLEntryLocalServiceUtil {
 			FriendlyURLEntryLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-556093448
+// LIFERAY-SERVICE-BUILDER-HASH:-1769455778

--- a/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/FriendlyURLEntryLocalServiceWrapper.java
+++ b/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/FriendlyURLEntryLocalServiceWrapper.java
@@ -617,19 +617,18 @@ public class FriendlyURLEntryLocalServiceWrapper
 	@Override
 	public String getUniqueUrlTitle(
 		long groupId, long classNameId, long parentClassPK, long classPK,
-		String urlTitle, String languageId) {
+		String urlTitle) {
 
 		return _friendlyURLEntryLocalService.getUniqueUrlTitle(
-			groupId, classNameId, parentClassPK, classPK, urlTitle, languageId);
+			groupId, classNameId, parentClassPK, classPK, urlTitle);
 	}
 
 	@Override
 	public String getUniqueUrlTitle(
-		long groupId, long classNameId, long classPK, String urlTitle,
-		String languageId) {
+		long groupId, long classNameId, long classPK, String urlTitle) {
 
 		return _friendlyURLEntryLocalService.getUniqueUrlTitle(
-			groupId, classNameId, classPK, urlTitle, languageId);
+			groupId, classNameId, classPK, urlTitle);
 	}
 
 	@Override
@@ -849,4 +848,4 @@ public class FriendlyURLEntryLocalServiceWrapper
 	private FriendlyURLEntryLocalService _friendlyURLEntryLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1715614355
+// LIFERAY-SERVICE-BUILDER-HASH:7069645

--- a/modules/apps/friendly-url/friendly-url-api/src/main/resources/com/liferay/friendly/url/service/packageinfo
+++ b/modules/apps/friendly-url/friendly-url-api/src/main/resources/com/liferay/friendly/url/service/packageinfo
@@ -1,1 +1,1 @@
-version 4.3.0
+version 5.0.0

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/change/tracking/spi/resolver/FriendlyURLEntryLocalizationConstraintResolver.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/change/tracking/spi/resolver/FriendlyURLEntryLocalizationConstraintResolver.java
@@ -101,8 +101,7 @@ public class FriendlyURLEntryLocalizationConstraintResolver
 				friendlyURLEntryLocalization.getClassNameId(),
 				friendlyURLEntryLocalization.getParentClassPK(),
 				friendlyURLEntryLocalization.getClassPK(),
-				friendlyURLEntryLocalization.getUrlTitle(),
-				friendlyURLEntryLocalization.getLanguageId()));
+				friendlyURLEntryLocalization.getUrlTitle()));
 
 		friendlyURLEntryLocalization.setUrlTitle(uniqueUrlTitle);
 

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/exportimport/staged/model/repository/FriendlyURLEntryStagedModelRepository.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/exportimport/staged/model/repository/FriendlyURLEntryStagedModelRepository.java
@@ -142,7 +142,7 @@ public class FriendlyURLEntryStagedModelRepository
 					friendlyURLEntry.getClassNameId(),
 					friendlyURLEntry.getParentClassPK(),
 					friendlyURLEntry.getClassPK(),
-					friendlyURLEntryLocalization.getUrlTitle(), null));
+					friendlyURLEntryLocalization.getUrlTitle()));
 
 			_friendlyURLEntryLocalService.updateFriendlyURLLocalization(
 				friendlyURLEntryLocalization);
@@ -205,7 +205,7 @@ public class FriendlyURLEntryStagedModelRepository
 					friendlyURLEntry.getGroupId(),
 					friendlyURLEntry.getClassNameId(),
 					friendlyURLEntry.getParentClassPK(),
-					friendlyURLEntry.getClassPK(), urlTitle, null);
+					friendlyURLEntry.getClassPK(), urlTitle);
 			}
 
 			languageIdLocalizationMap.put(

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
@@ -452,7 +452,7 @@ public class FriendlyURLEntryLocalServiceImpl
 	@Override
 	public String getUniqueUrlTitle(
 		long groupId, long classNameId, long parentClassPK, long classPK,
-		String urlTitle, String languageId) {
+		String urlTitle) {
 
 		if (urlTitle.startsWith(StringPool.SLASH)) {
 			urlTitle = urlTitle.replaceAll("^/+", StringPool.SLASH);
@@ -488,14 +488,13 @@ public class FriendlyURLEntryLocalServiceImpl
 
 	@Override
 	public String getUniqueUrlTitle(
-		long groupId, long classNameId, long classPK, String urlTitle,
-		String languageId) {
+		long groupId, long classNameId, long classPK, String urlTitle) {
 
 		return getUniqueUrlTitle(
 			groupId, classNameId,
 			FriendlyURLEntryConstants.
 				FRIENDLY_URL_ENTRY_PARENT_CLASS_PK_DEFAULT,
-			classPK, urlTitle, languageId);
+			classPK, urlTitle);
 	}
 
 	@Override
@@ -513,7 +512,7 @@ public class FriendlyURLEntryLocalServiceImpl
 					languageId,
 					friendlyURLEntryLocalService.getUniqueUrlTitle(
 						groupId, classNameId, parentClassPK, classPK,
-						entry.getValue(), languageId));
+						entry.getValue()));
 			}
 		}
 

--- a/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/service/test/FriendlyURLEntryLocalServiceTest.java
+++ b/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/service/test/FriendlyURLEntryLocalServiceTest.java
@@ -613,7 +613,7 @@ public class FriendlyURLEntryLocalServiceTest {
 			_friendlyURLEntryLocalService.getUniqueUrlTitle(
 				_group.getGroupId(),
 				_classNameLocalService.getClassNameId(User.class),
-				TestPropsValues.getUserId(), urlTitle, null));
+				TestPropsValues.getUserId(), urlTitle));
 	}
 
 	@Test
@@ -628,8 +628,7 @@ public class FriendlyURLEntryLocalServiceTest {
 		Assert.assertEquals(
 			"existing-url-title-1",
 			_friendlyURLEntryLocalService.getUniqueUrlTitle(
-				_group.getGroupId(), classNameId, _user.getUserId(), urlTitle,
-				null));
+				_group.getGroupId(), classNameId, _user.getUserId(), urlTitle));
 	}
 
 	@Test
@@ -649,8 +648,7 @@ public class FriendlyURLEntryLocalServiceTest {
 		Assert.assertEquals(
 			"existing-url-title-1",
 			_friendlyURLEntryLocalService.getUniqueUrlTitle(
-				_group.getGroupId(), classNameId, _user.getUserId(), urlTitle,
-				_language.getLanguageId(LocaleUtil.getDefault())));
+				_group.getGroupId(), classNameId, _user.getUserId(), urlTitle));
 	}
 
 	@Test
@@ -675,8 +673,7 @@ public class FriendlyURLEntryLocalServiceTest {
 			_group.getGroupId(), classNameId,
 			FriendlyURLEntryConstants.
 				FRIENDLY_URL_ENTRY_PARENT_CLASS_PK_DEFAULT,
-			_assetCategory.getCategoryId(), urlTitle,
-			_language.getLanguageId(LocaleUtil.getDefault()));
+			_assetCategory.getCategoryId(), urlTitle);
 
 		Assert.assertEquals(urlTitle, uniqueUrlTitle);
 	}
@@ -692,7 +689,7 @@ public class FriendlyURLEntryLocalServiceTest {
 
 		String uniqueUrlTitle = _friendlyURLEntryLocalService.getUniqueUrlTitle(
 			_group.getGroupId(), classNameId, TestPropsValues.getUserId(),
-			urlTitle, null);
+			urlTitle);
 
 		Assert.assertEquals(urlTitle, uniqueUrlTitle);
 	}
@@ -708,7 +705,7 @@ public class FriendlyURLEntryLocalServiceTest {
 
 		String uniqueUrlTitle = _friendlyURLEntryLocalService.getUniqueUrlTitle(
 			_group.getGroupId(), classNameId, TestPropsValues.getUserId(),
-			urlTitle, null);
+			urlTitle);
 
 		Assert.assertEquals(maxLength, uniqueUrlTitle.length());
 	}
@@ -728,7 +725,7 @@ public class FriendlyURLEntryLocalServiceTest {
 
 		String uniqueUrlTitle = _friendlyURLEntryLocalService.getUniqueUrlTitle(
 			_group.getGroupId(), classNameId, TestPropsValues.getUserId(),
-			urlTitle, null);
+			urlTitle);
 
 		Assert.assertEquals(maxLength - 1, uniqueUrlTitle.length());
 	}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyCategoryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyCategoryResourceImpl.java
@@ -1258,7 +1258,7 @@ public class TaxonomyCategoryResourceImpl
 				languageId,
 				_friendlyURLEntryLocalService.getUniqueUrlTitle(
 					assetCategory.getGroupId(), classNameId, parentClassPK,
-					assetCategory.getCategoryId(), urlTitle, languageId));
+					assetCategory.getCategoryId(), urlTitle));
 		}
 
 		_friendlyURLEntryLocalService.addFriendlyURLEntry(

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v6_1_3/JournalArticleFriendlyURLFormatUpgradeProcess.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v6_1_3/JournalArticleFriendlyURLFormatUpgradeProcess.java
@@ -59,7 +59,6 @@ public class JournalArticleFriendlyURLFormatUpgradeProcess
 			while (resultSet1.next()) {
 				long classPK = resultSet1.getLong("classPK");
 				long groupId = resultSet1.getLong("groupId");
-				String languageId = resultSet1.getString("languageId");
 
 				String urlTitle = resultSet1.getString("urlTitle");
 
@@ -70,7 +69,7 @@ public class JournalArticleFriendlyURLFormatUpgradeProcess
 				}
 
 				urlTitle = _friendlyURLEntryLocalService.getUniqueUrlTitle(
-					groupId, classNameId, classPK, urlTitle, languageId);
+					groupId, classNameId, classPK, urlTitle);
 
 				if (StringUtil.equals(urlTitle, originalUrlTitle)) {
 					continue;
@@ -81,6 +80,8 @@ public class JournalArticleFriendlyURLFormatUpgradeProcess
 				ResultSet resultSet2 = preparedStatement2.executeQuery();
 
 				if (resultSet2.next()) {
+					String languageId = resultSet1.getString("languageId");
+
 					String defaultLanguageId = resultSet2.getString(
 						"defaultLanguageId");
 

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -4740,8 +4740,7 @@ public class JournalArticleLocalServiceImpl
 						groupId,
 						_classNameLocalService.getClassNameId(
 							JournalArticle.class),
-						article.getResourcePrimKey(), title,
-						_language.getLanguageId(entry.getKey()));
+						article.getResourcePrimKey(), title);
 
 				friendlyURLMap.put(entry.getKey(), urlTitle);
 			}
@@ -8437,7 +8436,7 @@ public class JournalArticleLocalServiceImpl
 			String urlTitle = friendlyURLEntryLocalService.getUniqueUrlTitle(
 				groupId,
 				_classNameLocalService.getClassNameId(JournalArticle.class),
-				resourcePrimKey, friendlyURL, languageId);
+				resourcePrimKey, friendlyURL);
 
 			urlTitleMap.put(languageId, urlTitle);
 		}
@@ -8454,7 +8453,7 @@ public class JournalArticleLocalServiceImpl
 						groupId,
 						_classNameLocalService.getClassNameId(
 							JournalArticle.class),
-						resourcePrimKey, value, languageId);
+						resourcePrimKey, value);
 
 				urlTitleMap.put(languageId, urlTitle);
 			}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -2852,7 +2852,7 @@ public class ObjectEntryLocalServiceImpl
 				entry.getKey(),
 				_friendlyURLEntryLocalService.getUniqueUrlTitle(
 					groupId, classNameId, objectEntry.getObjectEntryId(),
-					friendlyURL, entry.getKey()));
+					friendlyURL));
 		}
 
 		urlTitleMap.computeIfAbsent(
@@ -5886,8 +5886,7 @@ public class ObjectEntryLocalServiceImpl
 		}
 
 		return _friendlyURLEntryLocalService.getUniqueUrlTitle(
-			groupId, classNameId, objectEntry.getObjectEntryId(), urlTitle,
-			languageId);
+			groupId, classNameId, objectEntry.getObjectEntryId(), urlTitle);
 	}
 
 	/**


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-105630

Friendly URL optimization tracked under LPD-65366 (LPD-98910 scenario: saving an object entry). Follow-up to #181718, which resolved these titles with unpaginated finders.

## What Is Being Fixed

`getUniqueUrlTitle` takes a language, and since that pull request resolved the title through the unpaginated finders the language is no longer read: the method looks for any localization of the group, class name, parent and title, whatever its language. Every caller still had to supply one, and the ones that had no language at hand invented it.

## How It Is Being Fixed

The parameter is dropped from both overloads, and the thirty callers pass what they know. The generated API follows, and the semantic versioning commit carries the breaking sections.

## Verification

- `FriendlyURLEntryLocalServiceTest.testGetUniqueUrlTitleResolvesConflictsAcrossLanguages` asserts that a title taken in one language is still resolved for another, which is the behaviour the parameter used to suggest and never had.
- The friendly URL integration module and `ObjectEntryLocalServiceTest` pass on an isolated bundle carrying the change.
- Self-CI on shuyangzhou/liferay-portal PR 12769: `ci:test:object` 49 of 49, `ci:test:stable` 13 of 13, and `ci:test:relevant` 100 of 127 whose failures were each matched to the master acceptance build CI compares against, with none attributable to this change. The portal log assertor gate fires on about fifty axes of plain master and none of its leaked lines mentions a friendly URL entry or a missing method.

## PR Check

**pr-check: PASS** — tested on `a64059b59b9358b917555bdff90f3f033cd79f48`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Service Registration | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS (baseline-all + seven Ant projects + 2 changed exporting modules) |
| Java Unit Tests | NOT VERIFIED |

<!-- pr-check {"result": "success", "sha": "a64059b59b9358b917555bdff90f3f033cd79f48"} -->
