### PR TITLE
LPD-105644 Resolve an attachment's file version only when a value needs it

### DIFF
--- a/modules/apps/object/object-info-api/src/main/java/com/liferay/object/info/item/provider/util/ObjectEntryInfoItemValuesProviderUtil.java
+++ b/modules/apps/object/object-info-api/src/main/java/com/liferay/object/info/item/provider/util/ObjectEntryInfoItemValuesProviderUtil.java
@@ -47,6 +47,8 @@ import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectEntryService;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.function.UnsafeSupplierValue;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -75,9 +77,11 @@ import java.time.format.DateTimeFormatter;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.function.Supplier;
 
 /**
  * @author Carolina Barbosa
@@ -410,11 +414,11 @@ public class ObjectEntryInfoItemValuesProviderUtil {
 				ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT)) {
 
 			try {
-				Object downloadURLInfoFieldValue = null;
+				Supplier<Object> downloadURLSupplier = null;
 				Object fileNameInfoFieldValue = null;
-				Object fileURLInfoFieldValue = null;
+				Supplier<Object> fileURLSupplier = null;
 				Object mimeTypeInfoFieldValue = null;
-				Object previewURLInfoFieldValue = null;
+				Supplier<Object> previewURLSupplier = null;
 				Object sizeInfoFieldValue = null;
 
 				if (infoFieldValue instanceof Long) {
@@ -423,50 +427,37 @@ public class ObjectEntryInfoItemValuesProviderUtil {
 					FileEntry fileEntry = dlAppLocalService.getFileEntry(
 						GetterUtil.getLong(fileEntryId));
 
-					downloadURLInfoFieldValue = _getAttachmentDownloadURL(
-						dlURLHelper, fileEntry, objectDefinition,
-						objectEntryService, objectField,
-						serviceBuilderObjectEntry, themeDisplay);
+					downloadURLSupplier = _toSupplier(
+						() -> _getAttachmentDownloadURL(
+							dlURLHelper, fileEntry, objectDefinition,
+							objectEntryService, objectField,
+							serviceBuilderObjectEntry, themeDisplay));
 					fileNameInfoFieldValue = fileEntry.getFileName();
 
 					String mimeType = fileEntry.getMimeType();
 
 					mimeTypeInfoFieldValue = mimeType;
 
-					WebImage fileURLWebImage = new WebImage(
-						dlURLHelper.getPreviewURL(
-							fileEntry, fileEntry.getFileVersion(), themeDisplay,
-							StringPool.BLANK),
-						new InfoItemReference(
-							FileEntry.class.getName(),
-							new ClassPKInfoItemIdentifier(
-								fileEntry.getFileEntryId())));
-
-					fileURLWebImage.setAlt(fileEntry.getDescription());
+					Supplier<Object> webImageSupplier = _toSupplier(
+						() -> _getWebImage(
+							dlURLHelper, fileEntry, themeDisplay));
 
 					if (mimeType.startsWith("image")) {
-						fileURLInfoFieldValue = fileURLWebImage;
+						fileURLSupplier = webImageSupplier;
 					}
 
-					previewURLInfoFieldValue = fileURLWebImage;
+					previewURLSupplier = webImageSupplier;
 					sizeInfoFieldValue = fileEntry.getSize();
 				}
 				else if (infoFieldValue instanceof InfoLocalizedValue) {
-					InfoLocalizedValue.Builder<Object>
-						downloadURLInfoFieldValueBuilder =
-							InfoLocalizedValue.builder();
+					Map<Locale, FileEntry> fileEntries = new LinkedHashMap<>();
 					InfoLocalizedValue.Builder<Object>
 						fileNameInfoFieldValueBuilder =
 							InfoLocalizedValue.builder();
-					InfoLocalizedValue.Builder<Object>
-						fileURLInfoFieldValueBuilder =
-							InfoLocalizedValue.builder();
-					boolean hasImage = false;
+					Map<Locale, FileEntry> imageFileEntries =
+						new LinkedHashMap<>();
 					InfoLocalizedValue.Builder<Object>
 						mimeTypeInfoFieldValueBuilder =
-							InfoLocalizedValue.builder();
-					InfoLocalizedValue.Builder<Object>
-						previewURLInfoFieldValueBuilder =
 							InfoLocalizedValue.builder();
 					InfoLocalizedValue.Builder<Object>
 						sizeInfoFieldValueBuilder =
@@ -485,62 +476,45 @@ public class ObjectEntryInfoItemValuesProviderUtil {
 							continue;
 						}
 
-						downloadURLInfoFieldValueBuilder.value(
-							entry.getKey(),
-							_getAttachmentDownloadURL(
-								dlURLHelper, fileEntry, objectDefinition,
-								objectEntryService, objectField,
-								serviceBuilderObjectEntry, themeDisplay));
+						fileEntries.put(entry.getKey(), fileEntry);
 						fileNameInfoFieldValueBuilder.value(
 							entry.getKey(), fileEntry.getFileName());
-						mimeTypeInfoFieldValueBuilder.value(
-							entry.getKey(), fileEntry.getMimeType());
 
 						String mimeType = fileEntry.getMimeType();
 
-						WebImage fileURLWebImage = new WebImage(
-							dlURLHelper.getPreviewURL(
-								fileEntry, fileEntry.getFileVersion(),
-								themeDisplay, StringPool.BLANK),
-							new InfoItemReference(
-								FileEntry.class.getName(),
-								new ClassPKInfoItemIdentifier(
-									fileEntry.getFileEntryId())));
-
-						fileURLWebImage.setAlt(fileEntry.getDescription());
-
 						if (mimeType.startsWith("image")) {
-							fileURLInfoFieldValueBuilder.value(
-								entry.getKey(), fileURLWebImage);
-
-							hasImage = true;
+							imageFileEntries.put(entry.getKey(), fileEntry);
 						}
 
-						previewURLInfoFieldValueBuilder.value(
-							entry.getKey(), fileURLWebImage);
+						mimeTypeInfoFieldValueBuilder.value(
+							entry.getKey(), mimeType);
 						sizeInfoFieldValueBuilder.value(
 							entry.getKey(), fileEntry.getSize());
 					}
 
-					downloadURLInfoFieldValue =
-						downloadURLInfoFieldValueBuilder.build();
-
+					downloadURLSupplier = _toSupplier(
+						() -> _getAttachmentDownloadURLInfoLocalizedValue(
+							dlURLHelper, fileEntries, objectDefinition,
+							objectEntryService, objectField,
+							serviceBuilderObjectEntry, themeDisplay));
 					fileNameInfoFieldValue =
 						fileNameInfoFieldValueBuilder.build();
 
-					if (hasImage) {
-						fileURLInfoFieldValue =
-							fileURLInfoFieldValueBuilder.build();
+					if (!imageFileEntries.isEmpty()) {
+						fileURLSupplier = _toSupplier(
+							() -> _getWebImageInfoLocalizedValue(
+								dlURLHelper, imageFileEntries, themeDisplay));
 					}
 
 					mimeTypeInfoFieldValue =
 						mimeTypeInfoFieldValueBuilder.build();
-					previewURLInfoFieldValue =
-						previewURLInfoFieldValueBuilder.build();
+					previewURLSupplier = _toSupplier(
+						() -> _getWebImageInfoLocalizedValue(
+							dlURLHelper, fileEntries, themeDisplay));
 					sizeInfoFieldValue = sizeInfoFieldValueBuilder.build();
 				}
 
-				if (fileURLInfoFieldValue != null) {
+				if (fileURLSupplier != null) {
 					infoFieldValues.add(
 						new InfoFieldValue<>(
 							InfoField.builder(
@@ -554,7 +528,7 @@ public class ObjectEntryInfoItemValuesProviderUtil {
 								InfoLocalizedValue.localize(
 									ObjectEntryInfoItemFields.class, "file-url")
 							).build(),
-							fileURLInfoFieldValue));
+							fileURLSupplier));
 				}
 
 				infoFieldValues.add(
@@ -570,7 +544,7 @@ public class ObjectEntryInfoItemValuesProviderUtil {
 							InfoLocalizedValue.localize(
 								ObjectEntryInfoItemFields.class, "download-url")
 						).build(),
-						downloadURLInfoFieldValue));
+						downloadURLSupplier));
 				infoFieldValues.add(
 					new InfoFieldValue<>(
 						InfoField.builder(
@@ -612,7 +586,7 @@ public class ObjectEntryInfoItemValuesProviderUtil {
 							InfoLocalizedValue.localize(
 								ObjectEntryInfoItemFields.class, "preview-url")
 						).build(),
-						previewURLInfoFieldValue));
+						previewURLSupplier));
 				infoFieldValues.add(
 					new InfoFieldValue<>(
 						InfoField.builder(
@@ -663,6 +637,30 @@ public class ObjectEntryInfoItemValuesProviderUtil {
 			PermissionThreadLocal.getPermissionChecker(), themeDisplay);
 	}
 
+	private static InfoLocalizedValue<Object>
+			_getAttachmentDownloadURLInfoLocalizedValue(
+				DLURLHelper dlURLHelper, Map<Locale, FileEntry> fileEntries,
+				ObjectDefinition objectDefinition,
+				ObjectEntryService objectEntryService, ObjectField objectField,
+				com.liferay.object.model.ObjectEntry serviceBuilderObjectEntry,
+				ThemeDisplay themeDisplay)
+		throws PortalException {
+
+		InfoLocalizedValue.Builder<Object> builder =
+			InfoLocalizedValue.builder();
+
+		for (Map.Entry<Locale, FileEntry> entry : fileEntries.entrySet()) {
+			builder.value(
+				entry.getKey(),
+				_getAttachmentDownloadURL(
+					dlURLHelper, entry.getValue(), objectDefinition,
+					objectEntryService, objectField, serviceBuilderObjectEntry,
+					themeDisplay));
+		}
+
+		return builder.build();
+	}
+
 	private static KeyLocalizedLabelPair _getKeyLocalizedLabelPair(
 		ListTypeEntryLocalService listTypeEntryLocalService, Object object,
 		ObjectField objectField) {
@@ -697,6 +695,41 @@ public class ObjectEntryInfoItemValuesProviderUtil {
 			).values(
 				listTypeEntry.getNameMap()
 			).build());
+	}
+
+	private static WebImage _getWebImage(
+			DLURLHelper dlURLHelper, FileEntry fileEntry,
+			ThemeDisplay themeDisplay)
+		throws PortalException {
+
+		WebImage webImage = new WebImage(
+			dlURLHelper.getPreviewURL(
+				fileEntry, fileEntry.getFileVersion(), themeDisplay,
+				StringPool.BLANK),
+			new InfoItemReference(
+				FileEntry.class.getName(),
+				new ClassPKInfoItemIdentifier(fileEntry.getFileEntryId())));
+
+		webImage.setAlt(fileEntry.getDescription());
+
+		return webImage;
+	}
+
+	private static InfoLocalizedValue<Object> _getWebImageInfoLocalizedValue(
+			DLURLHelper dlURLHelper, Map<Locale, FileEntry> fileEntries,
+			ThemeDisplay themeDisplay)
+		throws PortalException {
+
+		InfoLocalizedValue.Builder<Object> builder =
+			InfoLocalizedValue.builder();
+
+		for (Map.Entry<Locale, FileEntry> entry : fileEntries.entrySet()) {
+			builder.value(
+				entry.getKey(),
+				_getWebImage(dlURLHelper, entry.getValue(), themeDisplay));
+		}
+
+		return builder.build();
 	}
 
 	private static Object _parseValue(
@@ -845,6 +878,26 @@ public class ObjectEntryInfoItemValuesProviderUtil {
 		}
 
 		return value;
+	}
+
+	private static Supplier<Object> _toSupplier(
+		UnsafeSupplier<Object, Exception> unsafeSupplier) {
+
+		UnsafeSupplierValue<Object, Exception> unsafeSupplierValue =
+			new UnsafeSupplierValue<>(unsafeSupplier);
+
+		return () -> {
+			try {
+				return unsafeSupplierValue.getValue();
+			}
+			catch (Exception exception) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(exception);
+				}
+			}
+
+			return null;
+		};
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/field/business/type/AttachmentObjectFieldBusinessType.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/field/business/type/AttachmentObjectFieldBusinessType.java
@@ -158,11 +158,15 @@ public class AttachmentObjectFieldBusinessType
 
 		LiferayFileEntry liferayFileEntry = new LiferayFileEntry(dlFileEntry);
 
-		FileVersion fileVersion = liferayFileEntry.getFileVersion();
-
 		return new FileEntry() {
 			{
-				setAlternativeText(fileVersion::getDescription);
+				setAlternativeText(
+					() -> {
+						FileVersion fileVersion =
+							liferayFileEntry.getFileVersion();
+
+						return fileVersion.getDescription();
+					});
 				setExtension(dlFileEntry::getExtension);
 				setExternalReferenceCode(dlFileEntry::getExternalReferenceCode);
 				setFileBase64(() -> _getFileBase64(dlFileEntry, objectField));
@@ -178,8 +182,8 @@ public class AttachmentObjectFieldBusinessType
 						GuestOrUserUtil.getPermissionChecker(), _portal));
 				setMetadata(
 					() -> _getMetadata(
-						fileVersion, dtoConverterContext.getLocale(),
-						objectField));
+						liferayFileEntry.getFileVersion(),
+						dtoConverterContext.getLocale(), objectField));
 				setMimeType(dlFileEntry::getMimeType);
 				setName(dlFileEntry::getFileName);
 				setPreviewURL(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/info/item/provider/test/ObjectEntryInfoItemFieldValuesProviderTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/info/item/provider/test/ObjectEntryInfoItemFieldValuesProviderTest.java
@@ -9,8 +9,10 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.asset.kernel.model.AssetCategory;
 import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.asset.test.util.AssetTestUtil;
+import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
+import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
 import com.liferay.document.library.test.util.DLTestUtil;
 import com.liferay.document.library.util.DLURLHelper;
 import com.liferay.info.field.InfoFieldValue;
@@ -364,6 +366,68 @@ public class ObjectEntryInfoItemFieldValuesProviderTest {
 
 			Assert.assertNotNull(
 				downloadURLInfoFieldValue.getValue(LocaleUtil.US));
+		}
+		finally {
+			ServiceContextThreadLocal.popServiceContext();
+		}
+	}
+
+	@Test
+	public void testObjectEntryInfoItemFieldValuesProviderWithAttachmentObjectFieldWithoutFileVersion()
+		throws Exception {
+
+		FileEntry fileEntry = _dlAppLocalService.addFileEntry(
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, "test.png",
+			ContentTypes.IMAGE_PNG, DLTestUtil.getImageBytes("png"), null, null,
+			null,
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		ObjectEntry objectEntry = _objectEntryLocalService.addObjectEntry(
+			_group.getGroupId(), TestPropsValues.getUserId(),
+			_childObjectDefinition.getObjectDefinitionId(),
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			null,
+			HashMapBuilder.<String, Serializable>put(
+				"attachmentObjectFieldName", fileEntry.getFileEntryId()
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		DLFileEntry dlFileEntry = _dlFileEntryLocalService.getDLFileEntry(
+			fileEntry.getFileEntryId());
+
+		dlFileEntry.setVersion(RandomTestUtil.randomString());
+
+		_dlFileEntryLocalService.updateDLFileEntry(dlFileEntry);
+
+		_pushServiceContext(_getThemeDisplay(StringPool.BLANK, "UTC"));
+
+		try {
+			InfoItemFieldValuesProvider<ObjectEntry>
+				infoItemFieldValuesProvider =
+					_infoItemServiceRegistry.getFirstInfoItemService(
+						InfoItemFieldValuesProvider.class,
+						_childObjectDefinition.getClassName());
+
+			InfoItemFieldValues infoItemFieldValues =
+				infoItemFieldValuesProvider.getInfoItemFieldValues(objectEntry);
+
+			ObjectField objectField = _objectFieldLocalService.fetchObjectField(
+				_childObjectDefinition.getObjectDefinitionId(),
+				"attachmentObjectFieldName");
+
+			InfoFieldValue<Object> fileNameInfoFieldValue =
+				infoItemFieldValues.getInfoFieldValue(
+					objectField.getObjectFieldId() + "#fileName");
+
+			Assert.assertEquals(
+				fileEntry.getFileName(), fileNameInfoFieldValue.getValue());
+
+			InfoFieldValue<Object> downloadURLInfoFieldValue =
+				infoItemFieldValues.getInfoFieldValue(
+					objectField.getObjectFieldId() + "#downloadURL");
+
+			Assert.assertNull(downloadURLInfoFieldValue.getValue());
 		}
 		finally {
 			ServiceContextThreadLocal.popServiceContext();
@@ -895,6 +959,9 @@ public class ObjectEntryInfoItemFieldValuesProviderTest {
 
 	@Inject
 	private DLAppLocalService _dlAppLocalService;
+
+	@Inject
+	private DLFileEntryLocalService _dlFileEntryLocalService;
 
 	@Inject
 	private DLURLHelper _dlURLHelper;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-105644

Attachment field optimization tracked under LPD-65366 (LPD-98910 scenario: rendering and editing object entries that carry an attachment field).

## What Is Being Fixed

Every read of an object entry with an attachment paid a `DLFileVersion` select the reader never used. The attachment `FileEntry` DTO fetched the file version up front, although the version feeds only its `alternativeText` and `metadata` suppliers, and neither the page render nor a partial update reads them. The info item values util then built the download URL, the preview URL and the file URL of every attachment field eagerly for every rendered entry, fetching the version again and running the two download permission checks, whether or not any fragment maps those values.

## How It Is Being Fixed

- `AttachmentObjectFieldBusinessType.getDTOValue` resolves the file version inside the `alternativeText` and `metadata` suppliers.
- `ObjectEntryInfoItemValuesProviderUtil` builds the three URL values behind memoizing suppliers over `UnsafeSupplierValue`, keeping the eager block's behaviour of logging a failed resolution at debug level and leaving that value empty. The file name, the mime type and the size still come off the file entry, and the mime type still decides up front whether the file URL value is present, so the list of values does not change.

## Verification

- `ObjectEntryInfoItemFieldValuesProviderTest.testObjectEntryInfoItemFieldValuesProviderWithAttachmentObjectFieldWithoutFileVersion` points a file entry's version at a row that does not exist and asserts the file name still comes back while the download URL resolves to nothing. On the parent code the DTO conversion throws `NoSuchFileVersionException`; with the change the class passes 6 of 6 on an isolated bundle with no ERROR line, including the group teardown that deletes the file entry with the dangling version.
- Self-CI on shuyangzhou/liferay-portal PR 12775: `ci:test:object` 49 of 49, `ci:test:stable` 11 of 11, and `ci:test:relevant` 33 of 35 whose only test failure is `HeadlessBuilderResourceTest.testGetOpenAPIInDifferentCompany`, a master regression that appears on unrelated pull requests of the same night.

## PR Check

**pr-check: PASS** — tested on `64f38ee1bf771441d9603a38bb83f009e091f5c6`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Service Registration | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS (baseline-all + seven Ant projects + 1 changed exporting module) |
| Java Unit Tests | NOT VERIFIED |

<!-- pr-check {"result": "success", "sha": "64f38ee1bf771441d9603a38bb83f009e091f5c6"} -->
