### PR TITLE
LPD-105645 Skip the display page entry lookup of a class that has none in the group

### DIFF
--- a/modules/apps/asset/asset-display-page-api/src/main/java/com/liferay/asset/display/page/service/AssetDisplayPageEntryLocalService.java
+++ b/modules/apps/asset/asset-display-page-api/src/main/java/com/liferay/asset/display/page/service/AssetDisplayPageEntryLocalService.java
@@ -310,6 +310,9 @@ public interface AssetDisplayPageEntryLocalService
 	public int getAssetDisplayPageEntriesCount();
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public int getAssetDisplayPageEntriesCount(long groupId, long classNameId);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getAssetDisplayPageEntriesCount(
 		long classNameId, long classTypeId, long layoutPageTemplateEntryId,
 		boolean defaultTemplate);
@@ -400,4 +403,4 @@ public interface AssetDisplayPageEntryLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1674851509
+// LIFERAY-SERVICE-BUILDER-HASH:707038117

--- a/modules/apps/asset/asset-display-page-api/src/main/java/com/liferay/asset/display/page/service/AssetDisplayPageEntryLocalServiceUtil.java
+++ b/modules/apps/asset/asset-display-page-api/src/main/java/com/liferay/asset/display/page/service/AssetDisplayPageEntryLocalServiceUtil.java
@@ -358,6 +358,13 @@ public class AssetDisplayPageEntryLocalServiceUtil {
 	}
 
 	public static int getAssetDisplayPageEntriesCount(
+		long groupId, long classNameId) {
+
+		return getService().getAssetDisplayPageEntriesCount(
+			groupId, classNameId);
+	}
+
+	public static int getAssetDisplayPageEntriesCount(
 		long classNameId, long classTypeId, long layoutPageTemplateEntryId,
 		boolean defaultTemplate) {
 
@@ -473,4 +480,4 @@ public class AssetDisplayPageEntryLocalServiceUtil {
 			AssetDisplayPageEntryLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1933622741
+// LIFERAY-SERVICE-BUILDER-HASH:-712392838

--- a/modules/apps/asset/asset-display-page-api/src/main/java/com/liferay/asset/display/page/service/AssetDisplayPageEntryLocalServiceWrapper.java
+++ b/modules/apps/asset/asset-display-page-api/src/main/java/com/liferay/asset/display/page/service/AssetDisplayPageEntryLocalServiceWrapper.java
@@ -404,6 +404,12 @@ public class AssetDisplayPageEntryLocalServiceWrapper
 	}
 
 	@Override
+	public int getAssetDisplayPageEntriesCount(long groupId, long classNameId) {
+		return _assetDisplayPageEntryLocalService.
+			getAssetDisplayPageEntriesCount(groupId, classNameId);
+	}
+
+	@Override
 	public int getAssetDisplayPageEntriesCount(
 		long classNameId, long classTypeId, long layoutPageTemplateEntryId,
 		boolean defaultTemplate) {
@@ -565,4 +571,4 @@ public class AssetDisplayPageEntryLocalServiceWrapper
 		_assetDisplayPageEntryLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-741153119
+// LIFERAY-SERVICE-BUILDER-HASH:-217983123

--- a/modules/apps/asset/asset-display-page-api/src/main/java/com/liferay/asset/display/page/util/AssetDisplayPageUtil.java
+++ b/modules/apps/asset/asset-display-page-api/src/main/java/com/liferay/asset/display/page/util/AssetDisplayPageUtil.java
@@ -149,6 +149,14 @@ public class AssetDisplayPageUtil {
 		LayoutPageTemplateEntry defaultLayoutPageTemplateEntry,
 		LayoutDisplayPageProvider<?> layoutDisplayPageProvider) {
 
+		int assetDisplayPageEntriesCount =
+			AssetDisplayPageEntryLocalServiceUtil.
+				getAssetDisplayPageEntriesCount(groupId, classNameId);
+
+		if (assetDisplayPageEntriesCount == 0) {
+			return defaultLayoutPageTemplateEntry;
+		}
+
 		AssetDisplayPageEntry assetDisplayPageEntry =
 			AssetDisplayPageEntryLocalServiceUtil.fetchAssetDisplayPageEntry(
 				groupId, classNameId, classPK);

--- a/modules/apps/asset/asset-display-page-api/src/main/resources/com/liferay/asset/display/page/service/packageinfo
+++ b/modules/apps/asset/asset-display-page-api/src/main/resources/com/liferay/asset/display/page/service/packageinfo
@@ -1,1 +1,1 @@
-version 4.0.0
+version 4.1.0

--- a/modules/apps/asset/asset-display-page-service/src/main/java/com/liferay/asset/display/page/service/impl/AssetDisplayPageEntryLocalServiceImpl.java
+++ b/modules/apps/asset/asset-display-page-service/src/main/java/com/liferay/asset/display/page/service/impl/AssetDisplayPageEntryLocalServiceImpl.java
@@ -212,6 +212,12 @@ public class AssetDisplayPageEntryLocalServiceImpl
 	}
 
 	@Override
+	public int getAssetDisplayPageEntriesCount(long groupId, long classNameId) {
+		return assetDisplayPageEntryPersistence.countByG_CN(
+			groupId, classNameId);
+	}
+
+	@Override
 	public int getAssetDisplayPageEntriesCount(
 		long classNameId, long classTypeId, long layoutPageTemplateEntryId,
 		boolean defaultTemplate) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-105645

Display page lookup optimization tracked under LPD-65366 (LPD-98910 scenario: collection pages listing object entries, the entry edit page, and display page resolution).

## What Is Being Fixed

Every asset rendered on a collection page, every entry edit page and every display page resolution looks the asset's own `AssetDisplayPageEntry` up through the unique `groupId`, `classNameId`, `classPK` finder. Rows in that table are written only by the display page selector of the edit forms that render it; custom objects have no such selector, so for them the lookup is a guaranteed miss that costs one select per distinct entry.

## How It Is Being Fixed

- `AssetDisplayPageEntryLocalService` gains `getAssetDisplayPageEntriesCount(groupId, classNameId)`, backed by the existing `countByG_CN` finder, whose result the finder cache keeps until a row of that group and class name is written.
- `AssetDisplayPageUtil._getAssetDisplayPage` asks that count first and returns the default template when it is zero, which is where the miss ended before. When entries exist the per-asset fetch runs exactly as today.

## Verification

- The asset display page integration module passes on a bundle built from this change, 64 of 65, the exception being a resolver test that dies in its own fixture setup because the design library feature flag is off in that bundle, before any changed code runs. `AssetDisplayPageUtilTest`, which covers the specific, inherited and absent display page cases, passes in full.
- Self-CI on shuyangzhou/liferay-portal PR 12776: `ci:test:object` 49 of 49, `ci:test:stable` 11 of 11, and `ci:test:relevant` whose failures are the standing portal log assertor gate and tests that fail on master, plus one asset list upgrade method that does not reproduce in four local runs, two on a bundle without this change and two on a bundle with it.

## PR Check

**pr-check: PASS** — tested on `246f670a15e3345d7f1299503b39db3cf4c28090`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Service Registration | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS (compileJava + jar substituted for deploy) |
| Integration Test Compile | PASS (8 of 38 affected modules, cap bound) |
| Cross-Module Compile | NOT VERIFIED |
| Baseline | PASS (baseline-all + seven Ant projects + 1 changed exporting module) |
| Java Unit Tests | NOT VERIFIED |

<!-- pr-check {"result": "success", "sha": "246f670a15e3345d7f1299503b39db3cf4c28090"} -->
