### PR TITLE
LPD-105646 Ask whether a group is a depot before looking its asset entry up

### DIFF
--- a/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/validator/CardinalityAssetEntryValidator.java
+++ b/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/validator/CardinalityAssetEntryValidator.java
@@ -141,9 +141,9 @@ public class CardinalityAssetEntryValidator implements AssetEntryValidator {
 
 		Group group = _groupLocalService.getGroup(groupId);
 
-		if (Validator.isNotNull(
-				_assetEntryLocalService.fetchEntry(className, classPK)) &&
-			group.isDepot()) {
+		if (group.isDepot() &&
+			Validator.isNotNull(
+				_assetEntryLocalService.fetchEntry(className, classPK))) {
 
 			return true;
 		}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-105646

Asset validation optimization tracked under LPD-65366 (LPD-98910 scenario: creating and editing object entries).

## What Is Being Fixed

Every asset entry update runs the cardinality validator, which first asks whether the entity is categorizable. That check called the asset entry service for the entity and only then asked whether the group is a depot, so every save into an ordinary site paid a service call through the advice chain and a finder lookup whose result the condition could not use. On a create the lookup also reaches the database, because `addObjectEntry` marks the service context strict and the entry update then skips its own lookup, leaving the validator's as the only one.

## How It Is Being Fixed

The two operands are swapped. `Group.isDepot` reads the type of a group the method already holds and is false for every ordinary site, so the lookup is left to the only case that consumes it.

## Verification

- Measured on an isolated bundle with the database general log capturing every statement across eighteen object entry creates: after the change no create issues the asset entry lookup, and the log shows the validator reaching the group query and the depot group query with nothing in between.
- The asset and asset categories integration modules pass on a bundle built from this commit: 145 of 145 and 253 of 255, the two exceptions being indexer tests that compare available locales against enabled locales, which fail the same way without this change.
- Self-CI on shuyangzhou/liferay-portal PR 12778: `ci:test:object` 49 of 49, `ci:test:stable` 16 of 16, and `ci:test:relevant` with eight test failures, each in a family that fails on master, including one whose classpath error I reproduced on plain master.

## PR Check

**pr-check: PASS** — tested on `e872c3d0f56df2f3fd615e6e0b75151079b640de`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Service Registration | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS (compileJava + jar substituted for deploy) |
| Integration Test Compile | NOT VERIFIED |
| Baseline | PASS (baseline-all + seven Ant projects + 0 changed exporting modules) |
| Java Unit Tests | NOT VERIFIED |

<!-- pr-check {"result": "success", "sha": "e872c3d0f56df2f3fd615e6e0b75151079b640de"} -->
