### PR TITLE
LPD-105647 Create a new model's friendly URL entry without looking its mapping up

### DIFF
--- a/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/FriendlyURLEntryLocalService.java
+++ b/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/FriendlyURLEntryLocalService.java
@@ -437,6 +437,9 @@ public interface FriendlyURLEntryLocalService
 		long groupId, long classNameId, long parentClassPK, long classPK,
 		Map<Locale, String> titleMap);
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public boolean hasMainFriendlyURLEntry(long classNameId, long classPK);
+
 	public void setMainFriendlyURLEntry(FriendlyURLEntry friendlyURLEntry);
 
 	/**
@@ -536,4 +539,4 @@ public interface FriendlyURLEntryLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:252005818
+// LIFERAY-SERVICE-BUILDER-HASH:822434815

--- a/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/FriendlyURLEntryLocalService.java
+++ b/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/FriendlyURLEntryLocalService.java
@@ -83,6 +83,12 @@ public interface FriendlyURLEntryLocalService
 	public FriendlyURLEntry addFriendlyURLEntry(
 			long groupId, long classNameId, long parentClassPK, long classPK,
 			String defaultLanguageId, Map<String, String> urlTitleMap,
+			boolean newModel, ServiceContext serviceContext)
+		throws PortalException;
+
+	public FriendlyURLEntry addFriendlyURLEntry(
+			long groupId, long classNameId, long parentClassPK, long classPK,
+			String defaultLanguageId, Map<String, String> urlTitleMap,
 			ServiceContext serviceContext)
 		throws PortalException;
 
@@ -530,4 +536,4 @@ public interface FriendlyURLEntryLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-550593190
+// LIFERAY-SERVICE-BUILDER-HASH:252005818

--- a/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/FriendlyURLEntryLocalServiceUtil.java
+++ b/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/FriendlyURLEntryLocalServiceUtil.java
@@ -585,6 +585,12 @@ public class FriendlyURLEntryLocalServiceUtil {
 			groupId, classNameId, parentClassPK, classPK, titleMap);
 	}
 
+	public static boolean hasMainFriendlyURLEntry(
+		long classNameId, long classPK) {
+
+		return getService().hasMainFriendlyURLEntry(classNameId, classPK);
+	}
+
 	public static void setMainFriendlyURLEntry(
 		FriendlyURLEntry friendlyURLEntry) {
 
@@ -746,4 +752,4 @@ public class FriendlyURLEntryLocalServiceUtil {
 			FriendlyURLEntryLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-791135644
+// LIFERAY-SERVICE-BUILDER-HASH:-1417099476

--- a/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/FriendlyURLEntryLocalServiceUtil.java
+++ b/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/FriendlyURLEntryLocalServiceUtil.java
@@ -57,6 +57,18 @@ public class FriendlyURLEntryLocalServiceUtil {
 	public static FriendlyURLEntry addFriendlyURLEntry(
 			long groupId, long classNameId, long parentClassPK, long classPK,
 			String defaultLanguageId, Map<String, String> urlTitleMap,
+			boolean newModel,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws PortalException {
+
+		return getService().addFriendlyURLEntry(
+			groupId, classNameId, parentClassPK, classPK, defaultLanguageId,
+			urlTitleMap, newModel, serviceContext);
+	}
+
+	public static FriendlyURLEntry addFriendlyURLEntry(
+			long groupId, long classNameId, long parentClassPK, long classPK,
+			String defaultLanguageId, Map<String, String> urlTitleMap,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
@@ -734,4 +746,4 @@ public class FriendlyURLEntryLocalServiceUtil {
 			FriendlyURLEntryLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-556093448
+// LIFERAY-SERVICE-BUILDER-HASH:-791135644

--- a/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/FriendlyURLEntryLocalServiceWrapper.java
+++ b/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/FriendlyURLEntryLocalServiceWrapper.java
@@ -655,6 +655,12 @@ public class FriendlyURLEntryLocalServiceWrapper
 	}
 
 	@Override
+	public boolean hasMainFriendlyURLEntry(long classNameId, long classPK) {
+		return _friendlyURLEntryLocalService.hasMainFriendlyURLEntry(
+			classNameId, classPK);
+	}
+
+	@Override
 	public void setMainFriendlyURLEntry(FriendlyURLEntry friendlyURLEntry) {
 		_friendlyURLEntryLocalService.setMainFriendlyURLEntry(friendlyURLEntry);
 	}
@@ -862,4 +868,4 @@ public class FriendlyURLEntryLocalServiceWrapper
 	private FriendlyURLEntryLocalService _friendlyURLEntryLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-606007081
+// LIFERAY-SERVICE-BUILDER-HASH:311769961

--- a/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/FriendlyURLEntryLocalServiceWrapper.java
+++ b/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/FriendlyURLEntryLocalServiceWrapper.java
@@ -54,6 +54,19 @@ public class FriendlyURLEntryLocalServiceWrapper
 	public FriendlyURLEntry addFriendlyURLEntry(
 			long groupId, long classNameId, long parentClassPK, long classPK,
 			String defaultLanguageId, java.util.Map<String, String> urlTitleMap,
+			boolean newModel,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _friendlyURLEntryLocalService.addFriendlyURLEntry(
+			groupId, classNameId, parentClassPK, classPK, defaultLanguageId,
+			urlTitleMap, newModel, serviceContext);
+	}
+
+	@Override
+	public FriendlyURLEntry addFriendlyURLEntry(
+			long groupId, long classNameId, long parentClassPK, long classPK,
+			String defaultLanguageId, java.util.Map<String, String> urlTitleMap,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
@@ -849,4 +862,4 @@ public class FriendlyURLEntryLocalServiceWrapper
 	private FriendlyURLEntryLocalService _friendlyURLEntryLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1715614355
+// LIFERAY-SERVICE-BUILDER-HASH:-606007081

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
@@ -515,6 +515,19 @@ public class FriendlyURLEntryLocalServiceImpl
 	}
 
 	@Override
+	public boolean hasMainFriendlyURLEntry(long classNameId, long classPK) {
+		FriendlyURLEntryMapping friendlyURLEntryMapping =
+			_friendlyURLEntryMappingPersistence.fetchByC_C(
+				classNameId, classPK);
+
+		if (friendlyURLEntryMapping == null) {
+			return false;
+		}
+
+		return true;
+	}
+
+	@Override
 	public void setMainFriendlyURLEntry(FriendlyURLEntry friendlyURLEntry) {
 		FriendlyURLEntryMapping friendlyURLEntryMapping =
 			_friendlyURLEntryMappingPersistence.fetchByC_C(

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
@@ -71,12 +71,25 @@ public class FriendlyURLEntryLocalServiceImpl
 	public FriendlyURLEntry addFriendlyURLEntry(
 			long groupId, long classNameId, long parentClassPK, long classPK,
 			String defaultLanguageId, Map<String, String> urlTitleMap,
-			ServiceContext serviceContext)
+			boolean newModel, ServiceContext serviceContext)
 		throws PortalException {
 
 		validate(groupId, classNameId, parentClassPK, classPK, urlTitleMap);
 
 		_validateAssetCategories(urlTitleMap, serviceContext);
+
+		if (newModel) {
+			FriendlyURLEntryMapping friendlyURLEntryMapping =
+				_friendlyURLEntryMappingPersistence.create(
+					counterLocalService.increment());
+
+			friendlyURLEntryMapping.setClassNameId(classNameId);
+			friendlyURLEntryMapping.setClassPK(classPK);
+
+			return _addFriendlyURLEntry(
+				groupId, classNameId, parentClassPK, classPK, defaultLanguageId,
+				urlTitleMap, friendlyURLEntryMapping, serviceContext);
+		}
 
 		FriendlyURLEntryMapping friendlyURLEntryMapping =
 			_friendlyURLEntryMappingPersistence.fetchByC_C(
@@ -108,41 +121,22 @@ public class FriendlyURLEntryLocalServiceImpl
 			return friendlyURLEntry;
 		}
 
-		Group group = _groupLocalService.getGroup(groupId);
+		return _addFriendlyURLEntry(
+			groupId, classNameId, parentClassPK, classPK, defaultLanguageId,
+			_merge(urlTitleMap, existingUrlTitleMap), friendlyURLEntryMapping,
+			serviceContext);
+	}
 
-		long friendlyURLEntryId = counterLocalService.increment();
+	@Override
+	public FriendlyURLEntry addFriendlyURLEntry(
+			long groupId, long classNameId, long parentClassPK, long classPK,
+			String defaultLanguageId, Map<String, String> urlTitleMap,
+			ServiceContext serviceContext)
+		throws PortalException {
 
-		friendlyURLEntry = friendlyURLEntryPersistence.create(
-			friendlyURLEntryId);
-
-		friendlyURLEntry.setUuid(serviceContext.getUuid());
-		friendlyURLEntry.setDefaultLanguageId(defaultLanguageId);
-		friendlyURLEntry.setGroupId(groupId);
-		friendlyURLEntry.setCompanyId(group.getCompanyId());
-		friendlyURLEntry.setClassNameId(classNameId);
-		friendlyURLEntry.setParentClassPK(parentClassPK);
-		friendlyURLEntry.setClassPK(classPK);
-
-		if ((BatchEngineThreadLocal.isBatchImportInProcess() &&
-			 _isBatchPortletDataHandler(classNameId, group.getCompanyId())) ||
-			!ExportImportThreadLocal.isImportInProcess()) {
-
-			friendlyURLEntryMapping.setFriendlyURLEntryId(friendlyURLEntryId);
-
-			_friendlyURLEntryMappingPersistence.update(friendlyURLEntryMapping);
-		}
-
-		friendlyURLEntry = friendlyURLEntryPersistence.update(friendlyURLEntry);
-
-		_updateFriendlyURLEntryLocalizations(
-			friendlyURLEntry, classNameId, parentClassPK, true,
-			_merge(urlTitleMap, existingUrlTitleMap));
-
-		// Asset
-
-		_updateAssetEntry(friendlyURLEntry, serviceContext);
-
-		return friendlyURLEntry;
+		return addFriendlyURLEntry(
+			groupId, classNameId, parentClassPK, classPK, defaultLanguageId,
+			urlTitleMap, false, serviceContext);
 	}
 
 	@Override
@@ -738,6 +732,49 @@ public class FriendlyURLEntryLocalServiceImpl
 			FriendlyURLEntryConstants.
 				FRIENDLY_URL_ENTRY_PARENT_CLASS_PK_DEFAULT,
 			0, LocaleUtil.toLanguageId(LocaleUtil.getSiteDefault()), urlTitle);
+	}
+
+	private FriendlyURLEntry _addFriendlyURLEntry(
+			long groupId, long classNameId, long parentClassPK, long classPK,
+			String defaultLanguageId, Map<String, String> urlTitleMap,
+			FriendlyURLEntryMapping friendlyURLEntryMapping,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		Group group = _groupLocalService.getGroup(groupId);
+
+		long friendlyURLEntryId = counterLocalService.increment();
+
+		FriendlyURLEntry friendlyURLEntry = friendlyURLEntryPersistence.create(
+			friendlyURLEntryId);
+
+		friendlyURLEntry.setUuid(serviceContext.getUuid());
+		friendlyURLEntry.setDefaultLanguageId(defaultLanguageId);
+		friendlyURLEntry.setGroupId(groupId);
+		friendlyURLEntry.setCompanyId(group.getCompanyId());
+		friendlyURLEntry.setClassNameId(classNameId);
+		friendlyURLEntry.setParentClassPK(parentClassPK);
+		friendlyURLEntry.setClassPK(classPK);
+
+		if ((BatchEngineThreadLocal.isBatchImportInProcess() &&
+			 _isBatchPortletDataHandler(classNameId, group.getCompanyId())) ||
+			!ExportImportThreadLocal.isImportInProcess()) {
+
+			friendlyURLEntryMapping.setFriendlyURLEntryId(friendlyURLEntryId);
+
+			_friendlyURLEntryMappingPersistence.update(friendlyURLEntryMapping);
+		}
+
+		friendlyURLEntry = friendlyURLEntryPersistence.update(friendlyURLEntry);
+
+		_updateFriendlyURLEntryLocalizations(
+			friendlyURLEntry, classNameId, parentClassPK, true, urlTitleMap);
+
+		// Asset
+
+		_updateAssetEntry(friendlyURLEntry, serviceContext);
+
+		return friendlyURLEntry;
 	}
 
 	private boolean _containsAllURLTitles(

--- a/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/service/test/FriendlyURLEntryLocalServiceTest.java
+++ b/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/service/test/FriendlyURLEntryLocalServiceTest.java
@@ -120,6 +120,34 @@ public class FriendlyURLEntryLocalServiceTest {
 	}
 
 	@Test
+	public void testAddFriendlyURLEntryForNewModel() throws Exception {
+		long classNameId = _classNameLocalService.getClassNameId(User.class);
+		long classPK = RandomTestUtil.nextLong();
+		String languageId = _language.getLanguageId(LocaleUtil.getDefault());
+
+		FriendlyURLEntry friendlyURLEntry =
+			_friendlyURLEntryLocalService.addFriendlyURLEntry(
+				_group.getGroupId(), classNameId,
+				FriendlyURLEntryConstants.
+					FRIENDLY_URL_ENTRY_PARENT_CLASS_PK_DEFAULT,
+				classPK, languageId,
+				Collections.singletonMap(languageId, "first-url-title"), true,
+				_getServiceContext());
+
+		Assert.assertEquals(
+			friendlyURLEntry,
+			_friendlyURLEntryLocalService.fetchMainFriendlyURLEntry(
+				classNameId, classPK));
+
+		FriendlyURLEntryLocalization friendlyURLEntryLocalization =
+			_friendlyURLEntryLocalService.getFriendlyURLEntryLocalization(
+				friendlyURLEntry.getFriendlyURLEntryId(), languageId);
+
+		Assert.assertEquals(
+			"first-url-title", friendlyURLEntryLocalization.getUrlTitle());
+	}
+
+	@Test
 	public void testAddFriendlyURLEntryKeepsOldLocalizedValues()
 		throws Exception {
 

--- a/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/service/test/FriendlyURLEntryLocalServiceTest.java
+++ b/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/service/test/FriendlyURLEntryLocalServiceTest.java
@@ -762,6 +762,23 @@ public class FriendlyURLEntryLocalServiceTest {
 	}
 
 	@Test
+	public void testHasMainFriendlyURLEntry() throws Exception {
+		long classNameId = _classNameLocalService.getClassNameId(User.class);
+
+		Assert.assertFalse(
+			_friendlyURLEntryLocalService.hasMainFriendlyURLEntry(
+				classNameId, TestPropsValues.getUserId()));
+
+		_friendlyURLEntryLocalService.addFriendlyURLEntry(
+			_group.getGroupId(), classNameId, TestPropsValues.getUserId(),
+			_getRandomURLTitle(), _getServiceContext());
+
+		Assert.assertTrue(
+			_friendlyURLEntryLocalService.hasMainFriendlyURLEntry(
+				classNameId, TestPropsValues.getUserId()));
+	}
+
+	@Test
 	public void testValidateAllowsDuplicatesInDifferentLanguagesForDifferentClassPK()
 		throws Exception {
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -562,7 +562,7 @@ public class ObjectEntryLocalServiceImpl
 		}
 
 		_addFriendlyURLEntry(
-			objectDefinition, objectEntry, serviceContext, values);
+			objectDefinition, objectEntry, true, serviceContext, values);
 
 		try (SafeCloseable safeCloseable =
 				ObjectEntryThreadLocal.setObjectEntryFolderIdWithSafeCloseable(
@@ -2801,7 +2801,8 @@ public class ObjectEntryLocalServiceImpl
 
 	private void _addFriendlyURLEntry(
 			ObjectDefinition objectDefinition, ObjectEntry objectEntry,
-			ServiceContext serviceContext, Map<String, Serializable> values)
+			boolean newObjectEntry, ServiceContext serviceContext,
+			Map<String, Serializable> values)
 		throws PortalException {
 
 		if (ObjectDefinitionUtil.isDefaultFriendlyURLSeparator(
@@ -2867,8 +2868,11 @@ public class ObjectEntryLocalServiceImpl
 				).build()));
 
 		_friendlyURLEntryLocalService.addFriendlyURLEntry(
-			groupId, classNameId, objectEntry.getObjectEntryId(),
-			objectEntry.getDefaultLanguageId(), urlTitleMap, serviceContext);
+			groupId, classNameId,
+			FriendlyURLEntryConstants.
+				FRIENDLY_URL_ENTRY_PARENT_CLASS_PK_DEFAULT,
+			objectEntry.getObjectEntryId(), objectEntry.getDefaultLanguageId(),
+			urlTitleMap, newObjectEntry, serviceContext);
 	}
 
 	private JoinStep _addInnerJoinON(
@@ -7700,7 +7704,7 @@ public class ObjectEntryLocalServiceImpl
 				objectDefinition, objectEntry, originalObjectEntry, values)) {
 
 			_addFriendlyURLEntry(
-				objectDefinition, objectEntry, serviceContext, values);
+				objectDefinition, objectEntry, false, serviceContext, values);
 		}
 
 		_addOrUpdateComments(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -7300,17 +7300,10 @@ public class ObjectEntryLocalServiceImpl
 			}
 		}
 
-		FriendlyURLEntry friendlyURLEntry =
-			_friendlyURLEntryLocalService.fetchMainFriendlyURLEntry(
-				_classNameLocalService.getClassNameId(
-					objectDefinition.getClassName()),
-				objectEntry.getObjectEntryId());
-
-		if (friendlyURLEntry == null) {
-			return true;
-		}
-
-		return false;
+		return !_friendlyURLEntryLocalService.hasMainFriendlyURLEntry(
+			_classNameLocalService.getClassNameId(
+				objectDefinition.getClassName()),
+			objectEntry.getObjectEntryId());
 	}
 
 	private void _startWorkflowInstance(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-105647

Friendly URL optimization tracked under LPD-65366 (LPD-98910 scenario: adding and updating object entries).

## What Is Being Fixed

Creating the friendly URL entry of a model that has just been created looked its mapping up first, although a new model cannot have one, and the gate that decides whether to create the entry at all loaded the mapped entry by primary key only to test it for null. A save therefore paid two reads that could only confirm what the caller already knew.

## How It Is Being Fixed

- `addFriendlyURLEntry` gains an overload that takes the caller's knowledge that the model is new and, in that case, creates the mapping and the entry without the lookup. The existing overload delegates with that flag false, so a caller that does not know keeps today's behaviour.
- `FriendlyURLEntryLocalService` gains `hasMainFriendlyURLEntry`, which answers from the mapping alone, and the object entry gate uses it instead of loading the entry.

## Verification

- `FriendlyURLEntryLocalServiceTest` covers adding the friendly URL entry of a new model and asking whether a model has a main friendly URL entry.
- The friendly URL integration module passes on an isolated bundle carrying the change.
- Self-CI on shuyangzhou/liferay-portal PR 12771: `ci:test:object` 49 of 49, `ci:test:stable` 12 of 12, and `ci:test:relevant` 35 of 37 whose only test failure is `HeadlessBuilderResourceTest.testGetOpenAPIInDifferentCompany`, a master regression seen on unrelated pull requests of the same night.

## PR Check

**pr-check: PASS** — tested on `02ef108ba21a22e60da944b61c6cc653a3e18e51`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Service Registration | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | NOT VERIFIED |
| Baseline | PASS (baseline-all + seven Ant projects + 1 changed exporting module) |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "02ef108ba21a22e60da944b61c6cc653a3e18e51"} -->
