### PR TITLE
LPD-105652 Reattach an existing asset entry before updating it

### DIFF
--- a/modules/apps/asset/asset-test/src/testIntegration/java/com/liferay/asset/service/test/AssetEntryLocalServiceTest.java
+++ b/modules/apps/asset/asset-test/src/testIntegration/java/com/liferay/asset/service/test/AssetEntryLocalServiceTest.java
@@ -15,6 +15,7 @@ import com.liferay.asset.link.service.AssetLinkLocalService;
 import com.liferay.asset.test.util.AssetTestUtil;
 import com.liferay.exportimport.kernel.service.StagingLocalService;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.cache.CacheRegistryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.SystemEvent;
 import com.liferay.portal.kernel.model.SystemEventConstants;
@@ -25,14 +26,21 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.SystemEventLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
+import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -153,6 +161,47 @@ public class AssetEntryLocalServiceTest {
 
 		Assert.assertNotNull(
 			_assetTagLocalService.fetchTag(group.getGroupId(), "tag"));
+	}
+
+	@Test
+	public void testUpdateEntryIssuesNoSelect() throws Exception {
+		AssetEntry assetEntry = _addAssetEntryWithClassUUID(
+			TestPropsValues.getGroupId());
+
+		CacheRegistryUtil.clear();
+
+		_assetEntryLocalService.getEntry(
+			assetEntry.getClassName(), assetEntry.getClassPK());
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"org.hibernate.SQL", LoggerTestUtil.DEBUG)) {
+
+			_assetEntryLocalService.updateEntry(
+				TestPropsValues.getUserId(), assetEntry.getGroupId(), null,
+				null, assetEntry.getClassName(), assetEntry.getClassPK(),
+				assetEntry.getClassUuid(), assetEntry.getClassTypeId(), null,
+				null, true, true, null, null, null, null,
+				assetEntry.getMimeType(), RandomTestUtil.randomString(),
+				assetEntry.getDescription(), assetEntry.getSummary(),
+				assetEntry.getUrl(), assetEntry.getLayoutUuid(),
+				assetEntry.getHeight(), assetEntry.getWidth(),
+				assetEntry.getPriority(),
+				ServiceContextTestUtil.getServiceContext());
+
+			List<String> selectSQLs = new ArrayList<>();
+
+			for (LogEntry logEntry : logCapture.getLogEntries()) {
+				String message = logEntry.getMessage();
+
+				if (message.startsWith("select") &&
+					message.contains("AssetEntry")) {
+
+					selectSQLs.add(message);
+				}
+			}
+
+			Assert.assertTrue(selectSQLs.toString(), selectSQLs.isEmpty());
+		}
 	}
 
 	private AssetEntry _addAssetEntryWithClassUUID(long groupId) {

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
@@ -905,6 +905,8 @@ public class AssetEntryLocalServiceImpl extends AssetEntryLocalServiceBaseImpl {
 		}
 		else {
 			entry = assetEntryPersistence.findByPrimaryKey(entryId);
+
+			assetEntryPersistence.reassociateIfAbsent(entry);
 		}
 
 		entry.setGroupId(groupId);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-105652

Asset entry write optimization tracked under LPD-65366 (LPD-98910 scenario: creating and editing object entries).

## What Is Being Fixed

Updating an existing asset entry issues a select of that entry's own row that nothing in the service asked for. `AssetEntryLocalServiceImpl.updateEntry` hands the entry to `assetEntryPersistence.update`, whose `session.merge` has to load the row whenever the instance it is given is detached from the Hibernate session, and the instance is detached on every finder cache hit, because the entity cache materializes a new model from its cache model on each read. The select therefore lands on the common path, inside `merge`, where no caller would look for it.

Every asset bearing entity funnels through this method, so the cost is shared by journal articles, blogs entries, documents, wiki pages, message boards, commerce and object entries alike.

## How It Is Being Fixed

`assetEntryPersistence.reassociateIfAbsent(entry)` is called before the setters, so the instance is already in the persistence context when `update` runs. The merge finds it there, copies nothing, and the flush writes the row straight from the instance.

Two details are deliberate. The call sits before the setters because `AbstractReassociateEventListener.reassociate` snapshots the object's current values as its clean state, so reassociating after mutating would leave dirty checking with nothing to write. And the existing `findByPrimaryKey` is kept: it refreshes the row and its `mvccVersion` after the tags block, and removing it turns a concurrent update of the same row into an `OptimisticLockException` instead of the behaviour master has today.

The same API is already used this way in `KaleoInstanceTokenLocalServiceImpl`, and `ReassociateEntryTest` in `portal-tools-service-builder-test-test` pins the contract: a detached update logs `select` then `update`, while a reassociated one logs only `update`.

## Verification

- `AssetEntryLocalServiceTest.testUpdateEntryIssuesNoSelect` asserts that updating an existing asset entry logs no select of its own row. It fails on master for exactly that select and passes with the change.
- Six further tests written for local verification — persistence of the change, repeated updates, tag replacement, a model listener seeing saved tags, the strict add creation path, and a concurrent update of the same row from a second transaction — pass in this shape on an isolated bundle. The concurrent one is what rules out removing the `findByPrimaryKey` call.
- Self-CI on shuyangzhou/liferay-portal PR 12779: `ci:test:stable` 11 of 11 and `ci:test:object` 49 of 49 passed. `ci:test:relevant` reported 166 of 232, and every failure it listed as unique to the pull is pre-existing: six of them, including both export/import failures, reproduce on plain master at this branch's base commit in the upstream sync run of 2026-09-13, and the remaining ones have long failure histories on unrelated branches.

## PR Check

**pr-check: PASS** — tested on `85d44fc1d7ad37c56d5a9931ae9b373afa0f9847`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Service Registration | PASS |
| Transaction Usage | PASS |
| Full Portal Build | PASS (compile and jar only; deploy half not verified) |
| Per-Module Compile | NOT VERIFIED |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS (baseline-all + seven Ant projects + 0 changed exporting modules) |
| Java Unit Tests | NOT VERIFIED |

Source Format ran `ant format-source-current-branch -Dvalidate.commit.messages=true` and reported `BUILD SUCCESSFUL` with no `SourceCheck:` violations and no files modified. The run was made under `ant -v` to confirm the commit message rules actually executed: the SourceFormatter argv carries `'validate.commit.messages=true'` as a literal, while every unset property still shows as an unexpanded token. The yarn half never ran rather than running clean — the diff is Java only, matching none of `js|json|jsp|jspf|scss|ts|tsx`, so `skip.node.task` suppressed it; that is expected and is not a failure.

Full Portal Build's `ant all` was not run because `app.server.parent.dir` resolves to a live portal that has to stay up, and `ant all` is `clean` + `compile` + `deploy` whose deploy target writes into that bundle. The compile and jar half was run instead as `ant compile install-portal-snapshots`, which reported eight `BUILD SUCCESSFUL` markers, no `BUILD FAILED` and no `javac` errors, and rebuilt the changed class. The deploy half is not verified for that reason.

Per-Module Compile verified nothing. The diff's only module change is `modules/apps/asset/asset-test/src/testIntegration/java/com/liferay/asset/service/test/AssetEntryLocalServiceTest.java`, and this validation excludes a module whose only Java change is under `src/testIntegration`, since `deploy` never compiles those sources and a `-test` module deploys no runtime bundle. No consumer expansion applied either, because the diff removes no `public` or `protected` member. The lockfile check ran regardless and found no `package.json` or lockfile in the diff. The excluded surface is covered by Integration Test Compile and Cross-Module Compile, both of which passed.

Integration Test Compile compiled eight `-test` modules under `modules/apps/asset` carrying `src/testIntegration`, including `apps:asset:asset-test`, which holds the added test. The run reported `BUILD SUCCESSFUL in 22s` with `423 actionable tasks: 158 executed, 265 up-to-date`, and every `compileTestIntegrationJava` task line appeared bare, with no `UP-TO-DATE`, `FROM-CACHE`, `SKIPPED` or `NO-SOURCE` suffix, so `--rerun` genuinely recompiled rather than replaying a cached verdict.

Cross-Module Compile found one consumer and no truncation. The deprecated-module scan matched none of the changed type names across the 3 modules carrying `.lfrbuild-portal-deprecated`. The testIntegration scan returned `apps:asset:asset-test`, which compiled with `BUILD SUCCESSFUL in 14s` and printed no truncation marker.

Baseline reported `BUILD SUCCESSFUL` from `baseline-all` with no `VERSION INCREASE REQUIRED`, `VERSION INCREASE SUGGESTED`, `EXCESSIVE VERSION INCREASE`, `PACKAGE ADDED, MISSING PACKAGEINFO`, `PACKAGE REMOVED, UNNECESSARY PACKAGEINFO` or `Bundle Version Change Recommended` row, and left no repair in the tree. Each of the seven Ant projects was rerun standalone and each printed `1 actionable task: 1 executed`, so each genuinely compared rather than replaying `UP-TO-DATE`. The branch changes no exporting module. The Local Version Check passed — the only changed file under `portal-impl/src` adds and removes no `public` or `protected` line, so no `packageinfo` or `Bundle-Version` bump is owed.

Java Unit Tests verified nothing. `AssetEntryLocalServiceImpl` has no unit test counterpart anywhere in the repository, so nothing at this layer can exercise the change. The class is covered instead by the integration test in `modules/apps/asset/asset-test`, which this validation does not run and which is where the branch's new `testUpdateEntryIssuesNoSelect` was added.

<!-- pr-check {"result": "success", "sha": "85d44fc1d7ad37c56d5a9931ae9b373afa0f9847"} -->
