### PR TITLE
LPD-105653 Skip the sharing entry lookup when the company shares none

### DIFF
--- a/modules/apps/sharing/sharing-search/src/main/java/com/liferay/sharing/search/internal/service/SharingEntryObjectEntryLocalServiceWrapper.java
+++ b/modules/apps/sharing/sharing-search/src/main/java/com/liferay/sharing/search/internal/service/SharingEntryObjectEntryLocalServiceWrapper.java
@@ -66,6 +66,14 @@ public class SharingEntryObjectEntryLocalServiceWrapper
 			return objectEntry;
 		}
 
+		int companySharingEntriesCount =
+			_sharingEntryLocalService.getCompanySharingEntriesCount(
+				objectEntry.getCompanyId(), className.getClassNameId());
+
+		if (companySharingEntriesCount == 0) {
+			return objectEntry;
+		}
+
 		List<SharingEntry> sharingEntryList =
 			_sharingEntryLocalService.getSharingEntries(
 				className.getClassNameId(), objectEntry.getObjectEntryId());


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-105653

Sharing optimization tracked under LPD-65366 (LPD-98910 scenario: creating and editing object entries).

## What Is Being Fixed

Every object entry update asks for that entry's sharing entries so it can reindex them. That is one query per entry, and on an instance where nothing has ever been shared it runs against a table that holds nothing at all, so the work is paid on every write and never returns a row.

## How It Is Being Fixed

`SharingEntryObjectEntryLocalServiceWrapper` asks the existing `getCompanySharingEntriesCount(companyId, classNameId)` before the per entry `getSharingEntries(classNameId, classPK)` and returns early when the count is zero. The company count answers the same question from the finder cache, where it stays until a sharing entry of that company and class name is written.

The invariant holds because `addSharingEntry` stamps the sharer's company on the row, and `deleteCompanySharingEntries(companyId, classNameId)` already treats that company and class name pair as covering every sharing entry of the type. The per entry lookup therefore runs only where it can return something.

## Verification

Fork CI on this change is fully green: `ci:test:stable` 16 of 16, `ci:test:relevant` 15 of 15 and `ci:test:object` 49 of 49 jobs passed.

## PR Check

**pr-check: PASS** — tested on `05f3319257b3b8f00a5c6f5bb053c6584f0a1259`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Service Registration | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS (compile and jar; deploy not exercised) |
| Integration Test Compile | PASS |
| Baseline | PASS (baseline-all + seven Ant projects + 0 changed exporting modules) |
| Java Unit Tests | NOT VERIFIED |

Per-Module Compile built `apps:sharing:sharing-search` through `:compileJava --rerun` and `:jar` rather than `:deploy`, because the worktree it ran in resolves `app.server.parent.dir` to a bundle that is not the one under test, so the deploy half was deliberately not exercised. The compile and the bundling it covers both passed, and the rebuilt class references the added `getCompanySharingEntriesCount` call.

Java Unit Tests verified nothing. `SharingEntryObjectEntryLocalServiceWrapper` has no `SharingEntryObjectEntryLocalServiceWrapperTest`, and `sharing-search` carries no `src/test` tree at all, so there is no unit counterpart to run, and no integration test of that name exists either.

<!-- pr-check {"result": "success", "sha": "05f3319257b3b8f00a5c6f5bb053c6584f0a1259"} -->
