### PR TITLE
LPD-105654 Skip the redirect entry lookup when the group has none

### DIFF
--- a/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/service/impl/RedirectEntryLocalServiceImpl.java
+++ b/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/service/impl/RedirectEntryLocalServiceImpl.java
@@ -200,6 +200,13 @@ public class RedirectEntryLocalServiceImpl
 	public RedirectEntry fetchRedirectEntry(
 		long groupId, String sourceURL, boolean updateLastOccurrenceDate) {
 
+		int redirectEntriesCount = redirectEntryPersistence.countByGroupId(
+			groupId);
+
+		if (redirectEntriesCount == 0) {
+			return null;
+		}
+
 		RedirectEntry redirectEntry = redirectEntryPersistence.fetchByG_S(
 			groupId, sourceURL);
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-105654

Redirect optimization tracked under LPD-65366 (LPD-98910 scenario: creating and editing object entries).

## What Is Being Fixed

The redirect filter asks for a redirect entry matching the requested URL on every request, and a single page render asks more than once, because the servlet path and the friendly URL are both offered as source URLs. On a site that has never defined a redirect, each of those lookups is a query against an empty table.

## How It Is Being Fixed

The three argument `RedirectEntryLocalServiceImpl.fetchRedirectEntry` asks the existing `countByGroupId(groupId)` first and returns `null` when the count is zero. The group count answers the same question from the finder cache, where it stays until a redirect entry of that group is written, so the lookup by source URL now runs only where it can return something.

## Verification

Fork CI on this change is fully green: `ci:test:stable` 11 of 11, `ci:test:relevant` 16 of 16 and `ci:test:object` 49 of 49 jobs passed.

## PR Check

**pr-check: PASS** — tested on `fc336b1a9d57a5fd65480958c4650aa22acbdd8a`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Service Registration | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS (compile and jar; deploy not exercised) |
| Integration Test Compile | PASS |
| Baseline | PASS (baseline-all + seven Ant projects + 0 changed exporting modules) |
| Java Unit Tests | NOT VERIFIED |

Per-Module Compile built `apps:redirect:redirect-service` through `:compileJava --rerun` and `:jar` rather than `:deploy`, because the worktree it ran in resolves `app.server.parent.dir` to a bundle that is not the one under test, so the deploy half was deliberately not exercised. The compile executed, and the class inside the module jar is byte identical to the one it produced and carries the added `countByGroupId` call.

Java Unit Tests verified nothing. `RedirectEntryLocalServiceImpl` has no `RedirectEntryLocalServiceImplTest` unit counterpart, so there is nothing here to run. `RedirectEntryLocalServiceTest` in `apps:redirect:redirect-test` covers the class as an integration test, which this validation does not run.

<!-- pr-check {"result": "success", "sha": "fc336b1a9d57a5fd65480958c4650aa22acbdd8a"} -->
