### PR TITLE
LPD-105655 Ask the object definition before querying object entry versions

### DIFF
--- a/modules/apps/object/object-info-api/src/main/java/com/liferay/object/info/item/util/ObjectEntryInfoItemUtil.java
+++ b/modules/apps/object/object-info-api/src/main/java/com/liferay/object/info/item/util/ObjectEntryInfoItemUtil.java
@@ -82,13 +82,15 @@ public class ObjectEntryInfoItemUtil {
 					serviceBuilderObjectEntry.getHeadObjectEntryId());
 		}
 
-		ObjectEntryVersion objectEntryVersion =
-			ObjectEntryVersionLocalServiceUtil.fetchObjectEntryVersion(
-				serviceBuilderObjectEntry.getObjectEntryId(), version);
+		if (objectDefinition.isEnableObjectEntryVersioning()) {
+			ObjectEntryVersion objectEntryVersion =
+				ObjectEntryVersionLocalServiceUtil.fetchObjectEntryVersion(
+					serviceBuilderObjectEntry.getObjectEntryId(), version);
 
-		if (objectEntryVersion != null) {
-			dtoConverterContext.setAttribute(
-				"objectEntryVersion", objectEntryVersion);
+			if (objectEntryVersion != null) {
+				dtoConverterContext.setAttribute(
+					"objectEntryVersion", objectEntryVersion);
+			}
 		}
 
 		try {

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -2527,12 +2527,14 @@ public class ObjectEntryLocalServiceImpl
 			(originalObjectEntry.isScheduled() &&
 			 (status == WorkflowConstants.STATUS_APPROVED))) {
 
-			int count = _objectEntryVersionPersistence.countByObjectEntryId(
-				objectEntry.getObjectEntryId());
+			if (objectDefinition.isEnableObjectEntryVersioning()) {
+				int count = _objectEntryVersionPersistence.countByObjectEntryId(
+					objectEntry.getObjectEntryId());
 
-			if (count > 0) {
-				_updateLatestObjectEntryVersion(
-					userId, objectDefinition, objectEntry);
+				if (count > 0) {
+					_updateLatestObjectEntryVersion(
+						userId, objectDefinition, objectEntry);
+				}
 			}
 		}
 		else if (!skipStatusChangeSideEffects && !objectEntry.isInTrash() &&


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-105655

Object entry versioning optimization tracked under LPD-65366 (LPD-98910 scenario: creating and editing object entries).

## What Is Being Fixed

An object entry only ever has version rows while its definition has versioning enabled, because both of the paths that write one, `_addObjectEntryVersion` and `_updateLatestObjectEntryVersion`, return immediately on that flag. Two callers queried the version tables without asking the definition first.

`ObjectEntryLocalServiceImpl.updateStatus` counted an entry's versions to decide whether to update the latest one, which is a query per created entry, since creating an entry starts a workflow instance whose status update lands there. `ObjectEntryInfoItemUtil.getObjectEntry` fetched the entry's version so the converter context could carry it, which is a query per rendered entry.

## How It Is Being Fixed

Both callers now ask `objectDefinition.isEnableObjectEntryVersioning()` first.

In `updateStatus` the count only decided whether to call `_updateLatestObjectEntryVersion`, which already returns immediately when versioning is disabled, so the guard cannot change the outcome.

In `getObjectEntry` the guard is a deliberate tightening in one case. A definition that once had versioning keeps its rows when the flag is turned off, because nothing deletes them, and after the change such a render no longer carries version data, which is what the flag asks for.

## Verification

Fork CI on this change reports `ci:test:stable` 11 of 11 and `ci:test:object` 49 of 49 jobs passed. `ci:test:relevant` reports 33 of 35, whose only unique failure is `HeadlessBuilderResourceTest#testGetOpenAPIInDifferentCompany`, a master regression that fails byte identically at the base commit in the upstream `ci:test:headless` run, and whose second failed job is the top level aggregator itself.

## PR Check

**pr-check: PASS** — tested on `ebe037efd9fa36084a39038e7b0254e9c951277d`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Service Registration | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS (compile and jar; deploy not exercised) |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS (baseline-all + seven Ant projects + 1 changed exporting module) |
| Java Unit Tests | PASS |

Per-Module Compile built `apps:object:object-info-api` and `apps:object:object-service` through `:compileJava --rerun` and `:jar` rather than `:deploy`, because the worktree it ran in resolves `app.server.parent.dir` to a bundle that is not the one under test, so the deploy half was deliberately not exercised. Both compiles executed, and both rebuilt classes carry the added `isEnableObjectEntryVersioning` guard around the call it wraps.

<!-- pr-check {"result": "success", "sha": "ebe037efd9fa36084a39038e7b0254e9c951277d"} -->
